### PR TITLE
feat: CI/CD pipeline + REST API layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check & Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --workspace
+      - name: cargo clippy
+        run: cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -- -D warnings
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    services:
+      valkey:
+        image: valkey/valkey:7.2
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      FF_HOST: localhost
+      FF_PORT: "6379"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Unit tests
+        run: cargo test -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server
+      - name: E2E tests (serial)
+        run: cargo test -p ff-test -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,14 +448,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -466,6 +466,39 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -486,6 +519,25 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -576,6 +628,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -925,6 +983,7 @@ dependencies = [
 name = "ff-server"
 version = "0.1.0"
 dependencies = [
+ "axum 0.8.9",
  "ferriskey",
  "ff-core",
  "ff-engine",
@@ -935,6 +994,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -943,6 +1003,7 @@ dependencies = [
 name = "ff-test"
 version = "0.1.0"
 dependencies = [
+ "axum 0.8.9",
  "ferriskey",
  "ff-core",
  "ff-engine",
@@ -950,6 +1011,7 @@ dependencies = [
  "ff-script",
  "ff-sdk",
  "ff-server",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -1123,8 +1185,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1134,9 +1198,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1348,6 +1414,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1700,6 +1767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lz4"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1805,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2104,6 +2183,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,16 +2382,21 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -2265,6 +2404,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2311,6 +2451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2487,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2365,6 +2512,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2528,6 +2676,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2833,6 +2992,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,7 +3116,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -2997,6 +3171,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3015,6 +3190,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3035,6 +3211,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3327,10 +3504,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,5 @@ tokio = { version = "1", features = ["rt", "net", "time", "sync", "macros"] }
 tracing = "0.1"
 thiserror = "2"
 crc16 = "0.4"
+axum = "0.8"
+tower-http = { version = "0.6", features = ["cors", "trace"] }

--- a/crates/ff-script/src/functions/lease.rs
+++ b/crates/ff-script/src/functions/lease.rs
@@ -12,7 +12,6 @@ use ff_core::error::ScriptError;
 use ff_core::keys::ExecKeyContext;
 use ff_core::types::TimestampMs;
 
-use crate::ff_function;
 use crate::result::{FcallResult, FromFcallResult};
 
 // ─── FromFcallResult implementations ───

--- a/crates/ff-server/Cargo.toml
+++ b/crates/ff-server/Cargo.toml
@@ -19,3 +19,5 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+axum = { workspace = true }
+tower-http = { workspace = true }

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -1,5 +1,6 @@
 //! REST API layer — thin axum handlers over Server methods.
 
+use std::fmt;
 use std::sync::Arc;
 
 use axum::{
@@ -10,7 +11,8 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use tower_http::cors::CorsLayer;
+use axum::http::{HeaderName, Method};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 
 use ff_core::contracts::*;
@@ -65,15 +67,9 @@ struct ErrorBody {
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let (status, message) = match &self.0 {
-            ServerError::Script(msg) if msg.contains("not found") => {
-                (StatusCode::NOT_FOUND, msg.clone())
-            }
-            ServerError::Script(msg) if msg.contains("invalid") => {
-                (StatusCode::BAD_REQUEST, msg.clone())
-            }
-            ServerError::Script(msg) if msg.contains("failed:") => {
-                (StatusCode::BAD_REQUEST, msg.clone())
-            }
+            ServerError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+            ServerError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            ServerError::OperationFailed(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             other => (StatusCode::INTERNAL_SERVER_ERROR, other.to_string()),
         };
         (status, Json(ErrorBody { error: message })).into_response()
@@ -82,7 +78,9 @@ impl IntoResponse for ApiError {
 
 // ── Router ──
 
-pub fn router(server: Arc<Server>) -> Router {
+pub fn router(server: Arc<Server>, cors_origins: &[String]) -> Router {
+    let cors = build_cors_layer(cors_origins);
+
     Router::new()
         // Executions
         .route("/v1/executions", post(create_execution))
@@ -104,8 +102,22 @@ pub fn router(server: Arc<Server>) -> Router {
         // Health
         .route("/healthz", get(healthz))
         .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive())
+        .layer(cors)
         .with_state(server)
+}
+
+fn build_cors_layer(origins: &[String]) -> CorsLayer {
+    if origins.iter().any(|o| o == "*") {
+        return CorsLayer::permissive();
+    }
+    let parsed: Vec<_> = origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(parsed))
+        .allow_methods([Method::GET, Method::POST, Method::PUT])
+        .allow_headers([HeaderName::from_static("content-type")])
 }
 
 // ── Execution handlers ──
@@ -143,7 +155,9 @@ async fn cancel_execution(
     Path(id): Path<String>,
     AppJson(mut args): AppJson<CancelExecutionArgs>,
 ) -> Result<Json<CancelExecutionResult>, ApiError> {
-    args.execution_id = parse_execution_id(&id)?;
+    let path_eid = parse_execution_id(&id)?;
+    check_id_match(&path_eid, &args.execution_id, "execution_id")?;
+    args.execution_id = path_eid;
     Ok(Json(server.cancel_execution(&args).await?))
 }
 
@@ -152,7 +166,9 @@ async fn deliver_signal(
     Path(id): Path<String>,
     AppJson(mut args): AppJson<DeliverSignalArgs>,
 ) -> Result<Json<DeliverSignalResult>, ApiError> {
-    args.execution_id = parse_execution_id(&id)?;
+    let path_eid = parse_execution_id(&id)?;
+    check_id_match(&path_eid, &args.execution_id, "execution_id")?;
+    args.execution_id = path_eid;
     Ok(Json(server.deliver_signal(&args).await?))
 }
 
@@ -197,7 +213,9 @@ async fn add_execution_to_flow(
     Path(id): Path<String>,
     AppJson(mut args): AppJson<AddExecutionToFlowArgs>,
 ) -> Result<Json<AddExecutionToFlowResult>, ApiError> {
-    args.flow_id = parse_flow_id(&id)?;
+    let path_fid = parse_flow_id(&id)?;
+    check_id_match(&path_fid, &args.flow_id, "flow_id")?;
+    args.flow_id = path_fid;
     Ok(Json(server.add_execution_to_flow(&args).await?))
 }
 
@@ -206,7 +224,9 @@ async fn cancel_flow(
     Path(id): Path<String>,
     AppJson(mut args): AppJson<CancelFlowArgs>,
 ) -> Result<Json<CancelFlowResult>, ApiError> {
-    args.flow_id = parse_flow_id(&id)?;
+    let path_fid = parse_flow_id(&id)?;
+    check_id_match(&path_fid, &args.flow_id, "flow_id")?;
+    args.flow_id = path_fid;
     Ok(Json(server.cancel_flow(&args).await?))
 }
 
@@ -265,17 +285,27 @@ async fn healthz(
 
 // ── ID parsing helpers ──
 
+/// Return 400 if the body contains an ID that differs from the path ID.
+fn check_id_match<T: PartialEq + fmt::Display>(path_id: &T, body_id: &T, id_name: &str) -> Result<(), ApiError> {
+    if body_id != path_id {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "path {id_name} does not match body {id_name}"
+        ))));
+    }
+    Ok(())
+}
+
 fn parse_execution_id(s: &str) -> Result<ExecutionId, ApiError> {
     ExecutionId::parse(s)
-        .map_err(|e| ApiError(ServerError::Script(format!("invalid execution_id: {e}"))))
+        .map_err(|e| ApiError(ServerError::InvalidInput(format!("invalid execution_id: {e}"))))
 }
 
 fn parse_flow_id(s: &str) -> Result<FlowId, ApiError> {
     FlowId::parse(s)
-        .map_err(|e| ApiError(ServerError::Script(format!("invalid flow_id: {e}"))))
+        .map_err(|e| ApiError(ServerError::InvalidInput(format!("invalid flow_id: {e}"))))
 }
 
 fn parse_budget_id(s: &str) -> Result<BudgetId, ApiError> {
     BudgetId::parse(s)
-        .map_err(|e| ApiError(ServerError::Script(format!("invalid budget_id: {e}"))))
+        .map_err(|e| ApiError(ServerError::InvalidInput(format!("invalid budget_id: {e}"))))
 }

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -1,0 +1,281 @@
+//! REST API layer — thin axum handlers over Server methods.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post, put},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+
+use ff_core::contracts::*;
+use ff_core::state::PublicState;
+use ff_core::types::*;
+
+use crate::server::{Server, ServerError};
+
+// ── Custom JSON extractor (uniform JSON error on malformed body) ──
+
+struct AppJson<T>(T);
+
+impl<S, T> axum::extract::FromRequest<S> for AppJson<T>
+where
+    T: serde::de::DeserializeOwned + Send,
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request(
+        req: axum::extract::Request,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(AppJson(value)),
+            Err(rejection) => {
+                let status = rejection.status();
+                let body = ErrorBody {
+                    error: rejection.body_text(),
+                };
+                Err((status, Json(body)).into_response())
+            }
+        }
+    }
+}
+
+// ── Error handling ──
+
+struct ApiError(ServerError);
+
+impl From<ServerError> for ApiError {
+    fn from(e: ServerError) -> Self {
+        Self(e)
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, message) = match &self.0 {
+            ServerError::Script(msg) if msg.contains("not found") => {
+                (StatusCode::NOT_FOUND, msg.clone())
+            }
+            ServerError::Script(msg) if msg.contains("invalid") => {
+                (StatusCode::BAD_REQUEST, msg.clone())
+            }
+            ServerError::Script(msg) if msg.contains("failed:") => {
+                (StatusCode::BAD_REQUEST, msg.clone())
+            }
+            other => (StatusCode::INTERNAL_SERVER_ERROR, other.to_string()),
+        };
+        (status, Json(ErrorBody { error: message })).into_response()
+    }
+}
+
+// ── Router ──
+
+pub fn router(server: Arc<Server>) -> Router {
+    Router::new()
+        // Executions
+        .route("/v1/executions", post(create_execution))
+        .route("/v1/executions/{id}", get(get_execution))
+        .route("/v1/executions/{id}/state", get(get_execution_state))
+        .route("/v1/executions/{id}/cancel", post(cancel_execution))
+        .route("/v1/executions/{id}/signal", post(deliver_signal))
+        .route("/v1/executions/{id}/priority", put(change_priority))
+        .route("/v1/executions/{id}/replay", post(replay_execution))
+        // Flows
+        .route("/v1/flows", post(create_flow))
+        .route("/v1/flows/{id}/members", post(add_execution_to_flow))
+        .route("/v1/flows/{id}/cancel", post(cancel_flow))
+        // Budgets
+        .route("/v1/budgets", post(create_budget))
+        .route("/v1/budgets/{id}", get(get_budget_status))
+        // Quotas
+        .route("/v1/quotas", post(create_quota_policy))
+        // Health
+        .route("/healthz", get(healthz))
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+        .with_state(server)
+}
+
+// ── Execution handlers ──
+
+async fn create_execution(
+    State(server): State<Arc<Server>>,
+    AppJson(args): AppJson<CreateExecutionArgs>,
+) -> Result<(StatusCode, Json<CreateExecutionResult>), ApiError> {
+    let result = server.create_execution(&args).await?;
+    let status = match &result {
+        CreateExecutionResult::Created { .. } => StatusCode::CREATED,
+        CreateExecutionResult::Duplicate { .. } => StatusCode::OK,
+    };
+    Ok((status, Json(result)))
+}
+
+async fn get_execution(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+) -> Result<Json<ExecutionInfo>, ApiError> {
+    let eid = parse_execution_id(&id)?;
+    Ok(Json(server.get_execution(&eid).await?))
+}
+
+async fn get_execution_state(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+) -> Result<Json<PublicState>, ApiError> {
+    let eid = parse_execution_id(&id)?;
+    Ok(Json(server.get_execution_state(&eid).await?))
+}
+
+async fn cancel_execution(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+    AppJson(mut args): AppJson<CancelExecutionArgs>,
+) -> Result<Json<CancelExecutionResult>, ApiError> {
+    args.execution_id = parse_execution_id(&id)?;
+    Ok(Json(server.cancel_execution(&args).await?))
+}
+
+async fn deliver_signal(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+    AppJson(mut args): AppJson<DeliverSignalArgs>,
+) -> Result<Json<DeliverSignalResult>, ApiError> {
+    args.execution_id = parse_execution_id(&id)?;
+    Ok(Json(server.deliver_signal(&args).await?))
+}
+
+#[derive(Deserialize)]
+struct ChangePriorityBody {
+    new_priority: i32,
+}
+
+async fn change_priority(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+    AppJson(body): AppJson<ChangePriorityBody>,
+) -> Result<Json<ChangePriorityResult>, ApiError> {
+    let eid = parse_execution_id(&id)?;
+    Ok(Json(server.change_priority(&eid, body.new_priority).await?))
+}
+
+async fn replay_execution(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+) -> Result<Json<ReplayExecutionResult>, ApiError> {
+    let eid = parse_execution_id(&id)?;
+    Ok(Json(server.replay_execution(&eid).await?))
+}
+
+// ── Flow handlers ──
+
+async fn create_flow(
+    State(server): State<Arc<Server>>,
+    AppJson(args): AppJson<CreateFlowArgs>,
+) -> Result<(StatusCode, Json<CreateFlowResult>), ApiError> {
+    let result = server.create_flow(&args).await?;
+    let status = match &result {
+        CreateFlowResult::Created { .. } => StatusCode::CREATED,
+        CreateFlowResult::AlreadySatisfied { .. } => StatusCode::OK,
+    };
+    Ok((status, Json(result)))
+}
+
+async fn add_execution_to_flow(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+    AppJson(mut args): AppJson<AddExecutionToFlowArgs>,
+) -> Result<Json<AddExecutionToFlowResult>, ApiError> {
+    args.flow_id = parse_flow_id(&id)?;
+    Ok(Json(server.add_execution_to_flow(&args).await?))
+}
+
+async fn cancel_flow(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+    AppJson(mut args): AppJson<CancelFlowArgs>,
+) -> Result<Json<CancelFlowResult>, ApiError> {
+    args.flow_id = parse_flow_id(&id)?;
+    Ok(Json(server.cancel_flow(&args).await?))
+}
+
+// ── Budget / Quota handlers ──
+
+async fn create_budget(
+    State(server): State<Arc<Server>>,
+    AppJson(args): AppJson<CreateBudgetArgs>,
+) -> Result<(StatusCode, Json<CreateBudgetResult>), ApiError> {
+    let result = server.create_budget(&args).await?;
+    let status = match &result {
+        CreateBudgetResult::Created { .. } => StatusCode::CREATED,
+        CreateBudgetResult::AlreadySatisfied { .. } => StatusCode::OK,
+    };
+    Ok((status, Json(result)))
+}
+
+async fn get_budget_status(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+) -> Result<Json<BudgetStatus>, ApiError> {
+    let bid = parse_budget_id(&id)?;
+    Ok(Json(server.get_budget_status(&bid).await?))
+}
+
+async fn create_quota_policy(
+    State(server): State<Arc<Server>>,
+    AppJson(args): AppJson<CreateQuotaPolicyArgs>,
+) -> Result<(StatusCode, Json<CreateQuotaPolicyResult>), ApiError> {
+    let result = server.create_quota_policy(&args).await?;
+    let status = match &result {
+        CreateQuotaPolicyResult::Created { .. } => StatusCode::CREATED,
+        CreateQuotaPolicyResult::AlreadySatisfied { .. } => StatusCode::OK,
+    };
+    Ok((status, Json(result)))
+}
+
+// ── Health check ──
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+}
+
+async fn healthz(
+    State(server): State<Arc<Server>>,
+) -> Result<Json<HealthResponse>, ApiError> {
+    let _: String = server
+        .client()
+        .cmd("PING")
+        .execute()
+        .await
+        .map_err(|e| ApiError(ServerError::Valkey(e.to_string())))?;
+    Ok(Json(HealthResponse { status: "ok" }))
+}
+
+// ── ID parsing helpers ──
+
+fn parse_execution_id(s: &str) -> Result<ExecutionId, ApiError> {
+    ExecutionId::parse(s)
+        .map_err(|e| ApiError(ServerError::Script(format!("invalid execution_id: {e}"))))
+}
+
+fn parse_flow_id(s: &str) -> Result<FlowId, ApiError> {
+    FlowId::parse(s)
+        .map_err(|e| ApiError(ServerError::Script(format!("invalid flow_id: {e}"))))
+}
+
+fn parse_budget_id(s: &str) -> Result<BudgetId, ApiError> {
+    BudgetId::parse(s)
+        .map_err(|e| ApiError(ServerError::Script(format!("invalid budget_id: {e}"))))
+}

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -23,6 +23,8 @@ pub struct ServerConfig {
     pub engine_config: EngineConfig,
     /// Skip library loading (for tests where TestCluster already loaded it).
     pub skip_library_load: bool,
+    /// Allowed CORS origins. `["*"]` means permissive (all origins).
+    pub cors_origins: Vec<String>,
 }
 
 impl ServerConfig {
@@ -40,6 +42,7 @@ impl ServerConfig {
     /// | `FF_FLOW_PARTITIONS` | `64` | Flow partition count |
     /// | `FF_BUDGET_PARTITIONS` | `32` | Budget partition count |
     /// | `FF_QUOTA_PARTITIONS` | `32` | Quota partition count |
+    /// | `FF_CORS_ORIGINS` | `*` | Comma-separated CORS origins (`*` = permissive) |
     /// | `FF_LEASE_EXPIRY_INTERVAL_MS` | `1500` | Lease expiry scanner interval |
     /// | `FF_DELAYED_PROMOTER_INTERVAL_MS` | `750` | Delayed promoter interval |
     /// | `FF_INDEX_RECONCILER_INTERVAL_S` | `45` | Index reconciler interval |
@@ -49,6 +52,11 @@ impl ServerConfig {
         let tls = env_bool("FF_TLS");
         let cluster = env_bool("FF_CLUSTER");
         let listen_addr = env_or("FF_LISTEN_ADDR", "0.0.0.0:9090");
+        let cors_origins: Vec<String> = env_or("FF_CORS_ORIGINS", "*")
+            .split(',')
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+            .collect();
 
         let lanes: Vec<LaneId> = env_or("FF_LANES", "default")
             .split(',')
@@ -127,6 +135,7 @@ impl ServerConfig {
             listen_addr,
             engine_config,
             skip_library_load: false,
+            cors_origins,
         })
     }
 }
@@ -149,6 +158,7 @@ impl Default for ServerConfig {
                 ..Default::default()
             },
             skip_library_load: false,
+            cors_origins: vec!["*".to_owned()],
         }
     }
 }

--- a/crates/ff-server/src/lib.rs
+++ b/crates/ff-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod config;
 pub mod server;
 

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -24,6 +24,7 @@ async fn main() {
     };
 
     let listen_addr = config.listen_addr.clone();
+    let cors_origins = config.cors_origins.clone();
 
     let server = match Server::start(config).await {
         Ok(s) => s,
@@ -34,7 +35,7 @@ async fn main() {
     };
 
     let server = Arc::new(server);
-    let app = api::router(server.clone());
+    let app = api::router(server.clone(), &cors_origins);
 
     let listener = tokio::net::TcpListener::bind(&listen_addr)
         .await

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -1,17 +1,20 @@
+use std::sync::Arc;
+
+use ff_server::api;
 use ff_server::config::ServerConfig;
 use ff_server::server::Server;
 
 #[tokio::main]
 async fn main() {
-    // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "ff_server=info,ff_engine=info,ff_script=info".into()),
+                .unwrap_or_else(|_| {
+                    "ff_server=info,ff_engine=info,ff_script=info,tower_http=debug".into()
+                }),
         )
         .init();
 
-    // Load config
     let config = match ServerConfig::from_env() {
         Ok(c) => c,
         Err(e) => {
@@ -20,7 +23,8 @@ async fn main() {
         }
     };
 
-    // Start server
+    let listen_addr = config.listen_addr.clone();
+
     let server = match Server::start(config).await {
         Ok(s) => s,
         Err(e) => {
@@ -29,15 +33,33 @@ async fn main() {
         }
     };
 
-    // Wait for shutdown signal
-    wait_for_shutdown_signal().await;
+    let server = Arc::new(server);
+    let app = api::router(server.clone());
 
-    // Graceful shutdown
-    server.shutdown().await;
+    let listener = tokio::net::TcpListener::bind(&listen_addr)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!(addr = %listen_addr, error = %e, "failed to bind listener");
+            std::process::exit(1);
+        });
+
+    tracing::info!(addr = %listen_addr, "HTTP API listening");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!(error = %e, "HTTP server error");
+        });
+
+    // Graceful engine shutdown after HTTP server stops
+    match Arc::try_unwrap(server) {
+        Ok(s) => s.shutdown().await,
+        Err(_) => tracing::warn!("could not take exclusive server ownership for shutdown"),
+    }
 }
 
-/// Wait for SIGTERM or SIGINT (Ctrl+C).
-async fn wait_for_shutdown_signal() {
+async fn shutdown_signal() {
     let ctrl_c = tokio::signal::ctrl_c();
 
     #[cfg(unix)]

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -41,6 +41,12 @@ pub enum ServerError {
     LibraryLoad(String),
     #[error("partition mismatch: {0}")]
     PartitionMismatch(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+    #[error("operation failed: {0}")]
+    OperationFailed(String),
     #[error("script: {0}")]
     Script(String),
 }
@@ -368,7 +374,7 @@ impl Server {
                     ))
                 })
             }
-            None => Err(ServerError::Script(format!(
+            None => Err(ServerError::NotFound(format!(
                 "execution not found: {execution_id}"
             ))),
         }
@@ -485,7 +491,7 @@ impl Server {
             .map_err(|e| ServerError::Valkey(format!("HGETALL budget_def: {e}")))?;
 
         if def.is_empty() {
-            return Err(ServerError::Script(format!(
+            return Err(ServerError::NotFound(format!(
                 "budget not found: {budget_id}"
             )));
         }
@@ -849,7 +855,7 @@ impl Server {
             .map_err(|e| ServerError::Valkey(format!("HGETALL exec_core: {e}")))?;
 
         if fields.is_empty() {
-            return Err(ServerError::Script(format!(
+            return Err(ServerError::NotFound(format!(
                 "execution not found: {execution_id}"
             )));
         }
@@ -1119,7 +1125,7 @@ fn parse_create_result(
                 _ => None,
             })
             .unwrap_or_else(|| "unknown".to_owned());
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_create_execution failed: {error_code}"
         )))
     }
@@ -1153,7 +1159,7 @@ fn parse_cancel_result(
                 _ => None,
             })
             .unwrap_or_else(|| "unknown".to_owned());
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_cancel_execution failed: {error_code}"
         )))
     }
@@ -1201,7 +1207,7 @@ fn parse_budget_create_result(
                 _ => None,
             })
             .unwrap_or_else(|| "unknown".to_owned());
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_create_budget failed: {error_code}"
         )))
     }
@@ -1249,7 +1255,7 @@ fn parse_quota_create_result(
                 _ => None,
             })
             .unwrap_or_else(|| "unknown".to_owned());
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_create_quota_policy failed: {error_code}"
         )))
     }
@@ -1282,7 +1288,7 @@ fn parse_create_flow_result(
         }
     } else {
         let error_code = fcall_field_str(arr, 1);
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_create_flow failed: {error_code}"
         )))
     }
@@ -1327,7 +1333,7 @@ fn parse_add_execution_to_flow_result(
         }
     } else {
         let error_code = fcall_field_str(arr, 1);
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_add_execution_to_flow failed: {error_code}"
         )))
     }
@@ -1361,7 +1367,7 @@ fn parse_cancel_flow_result(raw: &Value) -> Result<CancelFlowResult, ServerError
         })
     } else {
         let error_code = fcall_field_str(arr, 1);
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_cancel_flow failed: {error_code}"
         )))
     }
@@ -1398,7 +1404,7 @@ fn parse_deliver_signal_result(
         }
     } else {
         let error_code = fcall_field_str(arr, 1);
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_deliver_signal failed: {error_code}"
         )))
     }
@@ -1422,7 +1428,7 @@ fn parse_change_priority_result(
         })
     } else {
         let error_code = fcall_field_str(arr, 1);
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_change_priority failed: {error_code}"
         )))
     }
@@ -1448,7 +1454,7 @@ fn parse_replay_result(raw: &Value) -> Result<ReplayExecutionResult, ServerError
         Ok(ReplayExecutionResult::Replayed { public_state: ps })
     } else {
         let error_code = fcall_field_str(arr, 1);
-        Err(ServerError::Script(format!(
+        Err(ServerError::OperationFailed(format!(
             "ff_replay_execution failed: {error_code}"
         )))
     }

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -22,3 +22,5 @@ tracing = { workspace = true }
 [dev-dependencies]
 ff-server = { workspace = true }
 serial_test = "3"
+axum = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -1,0 +1,621 @@
+//! REST API integration tests for FlowFabric.
+//!
+//! Spins up a real Server + axum HTTP listener on a random port,
+//! then exercises the API with reqwest.
+//!
+//! Run with: cargo test -p ff-test --test e2e_api -- --test-threads=1
+
+use std::sync::Arc;
+
+use ff_core::contracts::*;
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use tokio::task::AbortHandle;
+
+// ─── Test constants ──
+
+const LANE: &str = "api-test-lane";
+const NS: &str = "api-ns";
+
+// ─── Test harness ──
+
+struct TestApi {
+    client: reqwest::Client,
+    base_url: String,
+    abort_handle: AbortHandle,
+}
+
+impl Drop for TestApi {
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
+impl TestApi {
+    async fn setup() -> Self {
+        // 1. Connect TestCluster (loads Lua library + flushes)
+        let tc = TestCluster::connect().await;
+        tc.cleanup().await;
+
+        // 2. Build Server (skip_library_load since TestCluster already loaded it)
+        let config = test_server_config();
+        let server = ff_server::server::Server::start(config)
+            .await
+            .expect("Server::start failed");
+
+        let server = Arc::new(server);
+        let app = ff_server::api::router(server.clone());
+
+        // 3. Bind to random port
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind test listener");
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{addr}");
+
+        // 4. Spawn axum in background
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        let abort_handle = handle.abort_handle();
+
+        let client = reqwest::Client::new();
+
+        TestApi {
+            client,
+            base_url,
+            abort_handle,
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+}
+
+fn test_server_config() -> ff_server::config::ServerConfig {
+    let config = ff_test::fixtures::TEST_PARTITION_CONFIG;
+    let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
+    let port: u16 = std::env::var("FF_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6379);
+    let tls = ff_test::fixtures::env_flag("FF_TLS");
+    let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
+    ff_server::config::ServerConfig {
+        host,
+        port,
+        tls,
+        cluster,
+        partition_config: config,
+        lanes: vec![LaneId::new(LANE)],
+        listen_addr: "127.0.0.1:0".into(),
+        engine_config: ff_engine::EngineConfig {
+            partition_config: config,
+            lanes: vec![LaneId::new(LANE)],
+            ..Default::default()
+        },
+        skip_library_load: true,
+    }
+}
+
+// ─── Helpers ──
+
+/// Create an execution via API, return the ExecutionId. Panics on failure.
+async fn api_create_execution(api: &TestApi, eid: &ExecutionId, priority: i32) {
+    let args = CreateExecutionArgs {
+        execution_id: eid.clone(),
+        namespace: Namespace::new(NS),
+        lane_id: LaneId::new(LANE),
+        execution_kind: "api_test".into(),
+        input_payload: b"{}".to_vec(),
+        payload_encoding: None,
+        priority,
+        creator_identity: "api-test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy_json: "{}".into(),
+        delay_until: None,
+        partition_id: ff_core::partition::execution_partition(eid, &ff_test::fixtures::TEST_PARTITION_CONFIG).index,
+        now: TimestampMs::now(),
+    };
+    let resp = api.client.post(api.url("/v1/executions")).json(&args).send().await
+        .expect("create execution failed");
+    assert!(resp.status().is_success(), "create returned {}", resp.status());
+}
+
+// ─── Tests ──
+
+/// GET /healthz returns 200 + {"status":"ok"}.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_healthz() {
+    let api = TestApi::setup().await;
+
+    let resp = api
+        .client
+        .get(api.url("/healthz"))
+        .send()
+        .await
+        .expect("healthz request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    #[derive(Deserialize)]
+    struct Health {
+        status: String,
+    }
+    let body: Health = resp.json().await.expect("healthz JSON parse failed");
+    assert_eq!(body.status, "ok");
+}
+
+/// POST /v1/executions creates, then GET /v1/executions/{id} reads it back.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_create_and_get_execution() {
+    let api = TestApi::setup().await;
+
+    let eid = ExecutionId::new();
+    let now = TimestampMs::now();
+    let args = CreateExecutionArgs {
+        execution_id: eid.clone(),
+        namespace: Namespace::new(NS),
+        lane_id: LaneId::new(LANE),
+        execution_kind: "llm_call".into(),
+        input_payload: b"{}".to_vec(),
+        payload_encoding: Some("json".into()),
+        priority: 5,
+        creator_identity: "api-test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy_json: "{}".into(),
+        delay_until: None,
+        partition_id: ff_core::partition::execution_partition(&eid, &ff_test::fixtures::TEST_PARTITION_CONFIG).index,
+        now,
+    };
+
+    // POST create
+    let resp = api
+        .client
+        .post(api.url("/v1/executions"))
+        .json(&args)
+        .send()
+        .await
+        .expect("create execution request failed");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let result: CreateExecutionResult = resp.json().await.expect("create result parse failed");
+    match &result {
+        CreateExecutionResult::Created { execution_id, .. } => {
+            assert_eq!(execution_id, &eid);
+        }
+        CreateExecutionResult::Duplicate { .. } => panic!("expected Created, got Duplicate"),
+    }
+
+    // GET execution by ID
+    let resp = api
+        .client
+        .get(api.url(&format!("/v1/executions/{eid}")))
+        .send()
+        .await
+        .expect("get execution request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let info: ExecutionInfo = resp.json().await.expect("execution info parse failed");
+    assert_eq!(info.execution_id, eid);
+    assert_eq!(info.namespace, NS);
+    assert_eq!(info.lane_id, LANE);
+    assert_eq!(info.priority, 5);
+    assert_eq!(info.execution_kind, "llm_call");
+}
+
+/// POST /v1/executions/{id}/cancel transitions to cancelled.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_cancel_execution() {
+    let api = TestApi::setup().await;
+
+    // Create first
+    let eid = ExecutionId::new();
+    let now = TimestampMs::now();
+    let create_args = CreateExecutionArgs {
+        execution_id: eid.clone(),
+        namespace: Namespace::new(NS),
+        lane_id: LaneId::new(LANE),
+        execution_kind: "cancellable".into(),
+        input_payload: b"{}".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "api-test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy_json: "{}".into(),
+        delay_until: None,
+        partition_id: ff_core::partition::execution_partition(&eid, &ff_test::fixtures::TEST_PARTITION_CONFIG).index,
+        now,
+    };
+
+    let resp = api
+        .client
+        .post(api.url("/v1/executions"))
+        .json(&create_args)
+        .send()
+        .await
+        .expect("create request failed");
+    assert!(resp.status().is_success());
+
+    // Cancel
+    let cancel_args = CancelExecutionArgs {
+        execution_id: eid.clone(), // will be overridden by path
+        reason: "api-test-cancel".into(),
+        source: Some("operator_override".into()),
+        lease_id: None,
+        lease_epoch: None,
+        attempt_id: None,
+        now: TimestampMs::now(),
+    };
+
+    let resp = api
+        .client
+        .post(api.url(&format!("/v1/executions/{eid}/cancel")))
+        .json(&cancel_args)
+        .send()
+        .await
+        .expect("cancel request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let result: CancelExecutionResult = resp.json().await.expect("cancel result parse failed");
+    match result {
+        CancelExecutionResult::Cancelled { execution_id, .. } => {
+            assert_eq!(execution_id, eid);
+        }
+    }
+
+    // Verify state via GET
+    let resp = api
+        .client
+        .get(api.url(&format!("/v1/executions/{eid}/state")))
+        .send()
+        .await
+        .expect("get state request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let state: ff_core::state::PublicState = resp.json().await.expect("state parse failed");
+    assert_eq!(state, ff_core::state::PublicState::Cancelled);
+}
+
+/// POST /v1/flows creates a flow.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_create_flow() {
+    let api = TestApi::setup().await;
+
+    let flow_id = FlowId::new();
+    let args = CreateFlowArgs {
+        flow_id: flow_id.clone(),
+        flow_kind: "pipeline".into(),
+        namespace: Namespace::new(NS),
+        now: TimestampMs::now(),
+    };
+
+    let resp = api
+        .client
+        .post(api.url("/v1/flows"))
+        .json(&args)
+        .send()
+        .await
+        .expect("create flow request failed");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let result: CreateFlowResult = resp.json().await.expect("flow result parse failed");
+    match result {
+        CreateFlowResult::Created { flow_id: fid } => {
+            assert_eq!(fid, flow_id);
+        }
+        CreateFlowResult::AlreadySatisfied { .. } => panic!("expected Created"),
+    }
+}
+
+/// GET /v1/executions/{random-uuid} returns 404.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_not_found() {
+    let api = TestApi::setup().await;
+
+    let fake_id = ExecutionId::new();
+    let resp = api
+        .client
+        .get(api.url(&format!("/v1/executions/{fake_id}")))
+        .send()
+        .await
+        .expect("not-found request failed");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    #[derive(Deserialize)]
+    struct ErrBody {
+        error: String,
+    }
+    let body: ErrBody = resp.json().await.expect("error body parse failed");
+    assert!(
+        body.error.contains("not found"),
+        "expected 'not found' in error, got: {}",
+        body.error
+    );
+}
+
+/// POST /v1/budgets creates a budget.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_create_budget() {
+    let api = TestApi::setup().await;
+
+    let budget_id = BudgetId::new();
+    let args = CreateBudgetArgs {
+        budget_id: budget_id.clone(),
+        scope_type: "lane".into(),
+        scope_id: "test-lane".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms: 3_600_000,
+        dimensions: vec!["tokens".into(), "cost".into()],
+        hard_limits: vec![1000, 50],
+        soft_limits: vec![800, 40],
+        now: TimestampMs::now(),
+    };
+
+    let resp = api.client.post(api.url("/v1/budgets")).json(&args).send().await
+        .expect("create budget request failed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let result: CreateBudgetResult = resp.json().await.expect("budget result parse failed");
+    match result {
+        CreateBudgetResult::Created { budget_id: bid } => assert_eq!(bid, budget_id),
+        CreateBudgetResult::AlreadySatisfied { .. } => panic!("expected Created"),
+    }
+}
+
+/// Create budget, then GET /v1/budgets/{id} and verify fields.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_get_budget_status() {
+    let api = TestApi::setup().await;
+
+    let budget_id = BudgetId::new();
+    let args = CreateBudgetArgs {
+        budget_id: budget_id.clone(),
+        scope_type: "namespace".into(),
+        scope_id: "prod".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms: 0,
+        dimensions: vec!["requests".into()],
+        hard_limits: vec![500],
+        soft_limits: vec![400],
+        now: TimestampMs::now(),
+    };
+
+    let resp = api.client.post(api.url("/v1/budgets")).json(&args).send().await
+        .expect("create budget failed");
+    assert!(resp.status().is_success());
+
+    // GET status
+    let resp = api.client.get(api.url(&format!("/v1/budgets/{budget_id}"))).send().await
+        .expect("get budget status failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let status: BudgetStatus = resp.json().await.expect("budget status parse failed");
+    assert_eq!(status.budget_id, budget_id.to_string());
+    assert_eq!(status.scope_type, "namespace");
+    assert_eq!(status.scope_id, "prod");
+    assert_eq!(status.enforcement_mode, "strict");
+    assert_eq!(status.hard_limits.get("requests"), Some(&500));
+    assert_eq!(status.soft_limits.get("requests"), Some(&400));
+    assert_eq!(status.breach_count, 0);
+}
+
+/// POST /v1/quotas creates a quota policy.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_create_quota_policy() {
+    let api = TestApi::setup().await;
+
+    let qid = QuotaPolicyId::new();
+    let args = CreateQuotaPolicyArgs {
+        quota_policy_id: qid.clone(),
+        window_seconds: 60,
+        max_requests_per_window: 100,
+        max_concurrent: 10,
+        now: TimestampMs::now(),
+    };
+
+    let resp = api.client.post(api.url("/v1/quotas")).json(&args).send().await
+        .expect("create quota request failed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let result: CreateQuotaPolicyResult = resp.json().await.expect("quota result parse failed");
+    match result {
+        CreateQuotaPolicyResult::Created { quota_policy_id } => assert_eq!(quota_policy_id, qid),
+        CreateQuotaPolicyResult::AlreadySatisfied { .. } => panic!("expected Created"),
+    }
+}
+
+// NOTE: test_api_deliver_signal skipped — requires claim → suspend → signal
+// chain via FCALL, which is covered by test_server_deliver_signal in e2e_lifecycle.rs.
+// Adding here would duplicate ~60 lines of FCALL setup for a thin HTTP wrapper test.
+
+/// PUT /v1/executions/{id}/priority changes priority.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_change_priority() {
+    let api = TestApi::setup().await;
+
+    let eid = ExecutionId::new();
+    api_create_execution(&api, &eid, 0).await;
+
+    // Change priority
+    let resp = api.client
+        .put(api.url(&format!("/v1/executions/{eid}/priority")))
+        .json(&serde_json::json!({ "new_priority": 500 }))
+        .send()
+        .await
+        .expect("change priority request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let result: ChangePriorityResult = resp.json().await.expect("priority result parse failed");
+    match result {
+        ChangePriorityResult::Changed { execution_id } => assert_eq!(execution_id, eid),
+    }
+
+    // Verify via GET
+    let resp = api.client.get(api.url(&format!("/v1/executions/{eid}"))).send().await
+        .expect("get execution failed");
+    let info: ExecutionInfo = resp.json().await.expect("info parse failed");
+    assert_eq!(info.priority, 500);
+}
+
+/// Create → cancel (terminal) → replay → verify back to Waiting.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_replay_execution() {
+    let api = TestApi::setup().await;
+
+    let eid = ExecutionId::new();
+    api_create_execution(&api, &eid, 0).await;
+
+    // Cancel to make terminal
+    let cancel_args = CancelExecutionArgs {
+        execution_id: eid.clone(),
+        reason: "setup-for-replay".into(),
+        source: Some("operator_override".into()),
+        lease_id: None,
+        lease_epoch: None,
+        attempt_id: None,
+        now: TimestampMs::now(),
+    };
+    let resp = api.client
+        .post(api.url(&format!("/v1/executions/{eid}/cancel")))
+        .json(&cancel_args)
+        .send()
+        .await
+        .expect("cancel request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Replay
+    let resp = api.client
+        .post(api.url(&format!("/v1/executions/{eid}/replay")))
+        .send()
+        .await
+        .expect("replay request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let result: ReplayExecutionResult = resp.json().await.expect("replay result parse failed");
+    match result {
+        ReplayExecutionResult::Replayed { public_state } => {
+            assert_eq!(public_state, ff_core::state::PublicState::Waiting);
+        }
+    }
+
+    // Verify state is back to Waiting
+    let resp = api.client
+        .get(api.url(&format!("/v1/executions/{eid}/state")))
+        .send()
+        .await
+        .expect("get state failed");
+    let state: ff_core::state::PublicState = resp.json().await.expect("state parse failed");
+    assert_eq!(state, ff_core::state::PublicState::Waiting);
+}
+
+/// Create flow + execution, POST /v1/flows/{id}/members, verify Added.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_add_execution_to_flow() {
+    let api = TestApi::setup().await;
+
+    // Create flow
+    let flow_id = FlowId::new();
+    let flow_args = CreateFlowArgs {
+        flow_id: flow_id.clone(),
+        flow_kind: "pipeline".into(),
+        namespace: Namespace::new(NS),
+        now: TimestampMs::now(),
+    };
+    let resp = api.client.post(api.url("/v1/flows")).json(&flow_args).send().await
+        .expect("create flow failed");
+    assert!(resp.status().is_success());
+
+    // Create execution
+    let eid = ExecutionId::new();
+    api_create_execution(&api, &eid, 0).await;
+
+    // Add to flow
+    let add_args = AddExecutionToFlowArgs {
+        flow_id: flow_id.clone(),
+        execution_id: eid.clone(),
+        now: TimestampMs::now(),
+    };
+    let resp = api.client
+        .post(api.url(&format!("/v1/flows/{flow_id}/members")))
+        .json(&add_args)
+        .send()
+        .await
+        .expect("add to flow request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let result: AddExecutionToFlowResult = resp.json().await.expect("add result parse failed");
+    match result {
+        AddExecutionToFlowResult::Added { execution_id, new_node_count } => {
+            assert_eq!(execution_id, eid);
+            assert_eq!(new_node_count, 1);
+        }
+        AddExecutionToFlowResult::AlreadyMember { .. } => panic!("expected Added"),
+    }
+}
+
+/// Create flow, POST /v1/flows/{id}/cancel, verify Cancelled.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_cancel_flow() {
+    let api = TestApi::setup().await;
+
+    let flow_id = FlowId::new();
+    let flow_args = CreateFlowArgs {
+        flow_id: flow_id.clone(),
+        flow_kind: "pipeline".into(),
+        namespace: Namespace::new(NS),
+        now: TimestampMs::now(),
+    };
+    let resp = api.client.post(api.url("/v1/flows")).json(&flow_args).send().await
+        .expect("create flow failed");
+    assert!(resp.status().is_success());
+
+    // Cancel flow
+    let cancel_args = CancelFlowArgs {
+        flow_id: flow_id.clone(),
+        reason: "api-test-cancel".into(),
+        cancellation_policy: "cancel_all".into(),
+        now: TimestampMs::now(),
+    };
+    let resp = api.client
+        .post(api.url(&format!("/v1/flows/{flow_id}/cancel")))
+        .json(&cancel_args)
+        .send()
+        .await
+        .expect("cancel flow request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let result: CancelFlowResult = resp.json().await.expect("cancel flow result parse failed");
+    match result {
+        CancelFlowResult::Cancelled { cancellation_policy, .. } => {
+            assert_eq!(cancellation_policy, "cancel_all");
+        }
+    }
+}

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -46,7 +46,7 @@ impl TestApi {
             .expect("Server::start failed");
 
         let server = Arc::new(server);
-        let app = ff_server::api::router(server.clone());
+        let app = ff_server::api::router(server.clone(), &["*".to_owned()]);
 
         // 3. Bind to random port
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -98,6 +98,7 @@ fn test_server_config() -> ff_server::config::ServerConfig {
             ..Default::default()
         },
         skip_library_load: true,
+        cors_origins: vec!["*".to_owned()],
     }
 }
 

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -5329,6 +5329,7 @@ async fn test_server() -> ff_server::server::Server {
             ..Default::default()
         },
         skip_library_load: true, // TestCluster::connect() already loaded it
+        cors_origins: vec!["*".to_owned()],
     };
     ff_server::server::Server::start(server_config)
         .await
@@ -6346,6 +6347,7 @@ async fn test_system_engine_with_concurrent_scanners() {
                 ..Default::default()
             },
             skip_library_load: true,
+            cors_origins: vec!["*".to_owned()],
         }
     };
     let server = ff_server::server::Server::start(server_config)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
## Summary

- **CI/CD**: GitHub Actions with two jobs — fast check/clippy + full test suite against Valkey 7.2 service container
- **REST API**: 14 axum HTTP endpoints exposing all 13 server methods + health check
- **Tests**: 12 new API e2e tests, 146 total (up from 134), zero regressions

## REST Endpoints

| Method | Endpoint | Operation | Status |
|--------|----------|-----------|--------|
| POST | /v1/executions | create_execution | 201/200 |
| GET | /v1/executions/{id} | get_execution | 200 |
| GET | /v1/executions/{id}/state | get_execution_state | 200 |
| POST | /v1/executions/{id}/cancel | cancel_execution | 200 |
| POST | /v1/executions/{id}/signal | deliver_signal | 200 |
| PUT | /v1/executions/{id}/priority | change_priority | 200 |
| POST | /v1/executions/{id}/replay | replay_execution | 200 |
| POST | /v1/flows | create_flow | 201/200 |
| POST | /v1/flows/{id}/members | add_execution_to_flow | 200 |
| POST | /v1/flows/{id}/cancel | cancel_flow | 200 |
| POST | /v1/budgets | create_budget | 201/200 |
| GET | /v1/budgets/{id} | get_budget_status | 200 |
| POST | /v1/quotas | create_quota_policy | 201/200 |
| GET | /healthz | Valkey ping | 200 |

## Key design decisions

- **AppJson<T>** custom extractor for uniform JSON error responses (no plain-text 422s)
- **Error mapping**: not_found→404, invalid/failed→400, infra→500
- **201 Created** for new resources, 200 OK for duplicates/already-satisfied
- **Graceful shutdown**: SIGTERM/SIGINT → stop HTTP → drain engine scanners
- **CI**: ferriskey excluded from clippy (pre-existing upstream warnings)

## Quality

- 3 cross-review rounds on all new code
- 6 findings caught and fixed:
  1. CI: removed valkey-cli wait step (not available on GitHub runners)
  2. CI: added ff-test to clippy targets
  3. API: 201 Created status codes for create endpoints
  4. API: refined error categorization (Script→400 was too broad)
  5. API: uniform JSON error format for malformed requests
  6. Tests: server shutdown via AbortHandle (no resource leaks)

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p ff-{core,script,engine,scheduler,sdk,server,test} -- -D warnings` — zero warnings
- [x] 12/12 API e2e tests pass
- [x] 66/66 lifecycle e2e tests pass (no regressions)
- [ ] CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public HTTP API surface (routing, error mapping, CORS, graceful shutdown) and upgrades/adds networking dependencies, which could affect runtime behavior and compatibility despite being covered by new e2e tests.
> 
> **Overview**
> Adds a new axum-based REST API layer (`ff-server::api`) exposing execution/flow/budget/quota operations plus `GET /healthz`, with uniform JSON error responses, basic status-code mapping, request tracing, and permissive CORS.
> 
> Updates the `ff-server` binary to run an HTTP listener with graceful shutdown and then cleanly stop the underlying engine.
> 
> Introduces new end-to-end API tests in `ff-test` using `reqwest`, adds `axum`/`tower-http` (and lockfile updates), pins the Rust toolchain to stable, and adds a GitHub Actions workflow that runs `cargo check`/`clippy` and the unit+serial e2e suites against a Valkey service container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd537ffd037a558c1a92773424bf46d339174e19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->