### PR TITLE
Batch B: cairn multi-worker + security (capability routing, stream reads, HMAC tokens)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, rust]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-script",
+ "futures",
  "serde_json",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
 - **Budget and quota** -- per-dimension usage tracking, hard/soft limits, sliding-window rate limiting
 - **Streaming output** -- append-only frame streams scoped to each attempt
 - **Priority scheduling** -- score-based eligible sets with priority clamping
-- **REST API** -- 20 endpoints on axum with JSON error handling, CORS, health check
+- **REST API** -- 22 endpoints on axum with JSON error handling, CORS, health check
 - **Cluster-safe** -- all operations use hash-tag partitioning, no SCAN, no CrossSlot
 
 ## Quick start
@@ -96,6 +96,7 @@ For production deployments, use the Scheduler (`ff-scheduler`) which enforces ad
 
 ## Production considerations
 
+- **Full env var reference** — see the `ServerConfig::from_env` rustdoc in `crates/ff-server/src/config.rs` for the complete table (FF_HOST, FF_PORT, FF_TLS, FF_CLUSTER, FF_LANES, FF_CORS_ORIGINS, FF_API_TOKEN, FF_WAITPOINT_HMAC_SECRET (required), FF_WAITPOINT_HMAC_GRACE_MS, FF_MAX_CONCURRENT_STREAM_OPS, scanner intervals, partition counts).
 - **Auth is opt-in** — if `FF_API_TOKEN` is unset, every endpoint except `GET /healthz` is reachable without authentication. Always set `FF_API_TOKEN` (and consider CORS via `FF_CORS_ORIGINS`) before exposing the server beyond localhost.
 - **No API rate limiting** — deploy behind a reverse proxy (nginx, Envoy) with rate limiting configured
 - **No HTTP connection limit** — axum accepts unbounded connections; configure limits at the load balancer
@@ -108,6 +109,8 @@ For production deployments, use the Scheduler (`ff-scheduler`) which enforces ad
 ### Rolling upgrades
 
 KEYS-arity changes (and the `LIBRARY_VERSION` bump that paired with Batch A) require **blue-green or stop-then-start deployment**. Running old and new `ff-server` binaries against the same Valkey simultaneously can produce Lua errors on the old binary because the new binary loads a library whose KEYS arity differs from what the old binary expects — `redis.call(..., nil, ...)` surfaces as `ResponseError`, not silent corruption, but requests will fail until the old instances are drained.
+
+The version string lives in **`lua/version.lua`** (single source of truth). `crates/ff-script/build.rs` extracts it at compile time and exposes it to Rust via `env!("FLOWFABRIC_LUA_VERSION")`, so the Rust `LIBRARY_VERSION` constant tracks the Lua value automatically — do not maintain a separate Rust literal.
 
 Future: per-FCALL version negotiation. For now: drain old instances before starting new ones, or run a single writer at a time.
 

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -7,10 +7,10 @@ use crate::policy::ExecutionPolicy;
 use crate::state::{AttemptType, PublicState, StateVector};
 use crate::types::{
     AttemptId, AttemptIndex, CancelSource, ExecutionId, LaneId, LeaseEpoch, LeaseId, Namespace,
-    SignalId, SuspensionId, TimestampMs, WaitpointId, WorkerId, WorkerInstanceId,
+    SignalId, SuspensionId, TimestampMs, WaitpointId, WaitpointToken, WorkerId, WorkerInstanceId,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 // ─── create_execution ───
 
@@ -68,6 +68,12 @@ pub struct IssueClaimGrantArgs {
     pub route_snapshot_json: Option<String>,
     #[serde(default)]
     pub admission_summary: Option<String>,
+    /// Capabilities this worker advertises. Serialized as a sorted,
+    /// comma-separated string to the Lua FCALL (see scheduling.lua
+    /// ff_issue_claim_grant). An empty set matches only executions whose
+    /// `required_capabilities` is also empty.
+    #[serde(default)]
+    pub worker_capabilities: BTreeSet<String>,
     pub grant_ttl_ms: u64,
     /// Caller-side timestamp for bookkeeping. NOT passed to the Lua FCALL —
     /// ff_issue_claim_grant uses `redis.call("TIME")` for grant_expires_at.
@@ -484,13 +490,18 @@ pub enum SuspendExecutionResult {
         suspension_id: SuspensionId,
         waitpoint_id: WaitpointId,
         waitpoint_key: String,
+        /// HMAC-SHA1 token bound to (waitpoint_id, waitpoint_key, created_at).
+        /// Required by signal-delivery callers to authenticate against this
+        /// waitpoint (RFC-004 §Waitpoint Security).
+        waitpoint_token: WaitpointToken,
     },
     /// Buffered signals already satisfied the condition — suspension skipped.
-    /// Lease is still held.
+    /// Lease is still held. Token comes from the pending waitpoint record.
     AlreadySatisfied {
         suspension_id: SuspensionId,
         waitpoint_id: WaitpointId,
         waitpoint_key: String,
+        waitpoint_token: WaitpointToken,
     },
 }
 
@@ -538,6 +549,10 @@ pub enum CreatePendingWaitpointResult {
     Created {
         waitpoint_id: WaitpointId,
         waitpoint_key: String,
+        /// HMAC-SHA1 token bound to the pending waitpoint. Required for
+        /// `buffer_signal_for_pending_waitpoint` and carried forward when
+        /// the waitpoint is activated by `suspend_execution`.
+        waitpoint_token: WaitpointToken,
     },
 }
 
@@ -589,6 +604,17 @@ pub struct DeliverSignalArgs {
     /// MAXLEN for the waitpoint signal stream.
     #[serde(default)]
     pub signal_maxlen: Option<u64>,
+    /// HMAC-SHA1 token issued when the waitpoint was created. Required for
+    /// signal delivery; missing/tampered/rotated-past-grace tokens are
+    /// rejected with `invalid_token` or `token_expired` (RFC-004).
+    ///
+    /// Defense-in-depth: `WaitpointToken` is a transparent string newtype,
+    /// so an empty string deserializes successfully from JSON. The
+    /// validation boundary is in Lua (`validate_waitpoint_token` returns
+    /// `missing_token` on empty input); this type intentionally does NOT
+    /// pre-reject at the Rust layer so callers get a consistent typed
+    /// error regardless of how they constructed the args.
+    pub waitpoint_token: WaitpointToken,
     pub now: TimestampMs,
 }
 
@@ -621,6 +647,9 @@ pub struct BufferSignalArgs {
     #[serde(default)]
     pub idempotency_key: Option<String>,
     pub target_scope: String,
+    /// HMAC-SHA1 token issued when `create_pending_waitpoint` ran. Required
+    /// to authenticate early signals targeting the pending waitpoint.
+    pub waitpoint_token: WaitpointToken,
     pub now: TimestampMs,
 }
 
@@ -723,6 +752,81 @@ pub enum AppendFrameResult {
         /// Total frame count after this append.
         frame_count: u64,
     },
+}
+
+// ─── read_attempt_stream / tail_attempt_stream ───
+
+/// Hard cap on the number of frames returned by a single read/tail call.
+///
+/// Single source of truth across the Rust layer (ff-script, ff-server,
+/// ff-sdk). The Lua side in `lua/stream.lua` keeps a matching literal with
+/// an inline reference back here; bump both together if you ever need to
+/// lift the cap.
+pub const STREAM_READ_HARD_CAP: u64 = 10_000;
+
+/// A single frame read from an attempt-scoped stream.
+///
+/// Field set mirrors what `ff_append_frame` writes: `frame_type`, `ts`,
+/// `payload`, `encoding`, `source`, and optionally `correlation_id`. Stored
+/// as an ordered map so field order is deterministic across read calls.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamFrame {
+    /// Valkey Stream entry ID, e.g. "1713100800150-0".
+    pub id: String,
+    /// Frame fields in sorted order.
+    pub fields: std::collections::BTreeMap<String, String>,
+}
+
+/// Inputs to `ff_read_attempt_stream` (XRANGE wrapper).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReadFramesArgs {
+    pub execution_id: ExecutionId,
+    pub attempt_index: AttemptIndex,
+    /// XRANGE start ID. Use "-" for earliest.
+    pub from_id: String,
+    /// XRANGE end ID. Use "+" for latest.
+    pub to_id: String,
+    /// XRANGE COUNT limit. MUST be `>= 1`. The REST and SDK layers reject
+    /// `0` at the boundary; the Lua side rejects it too. `STREAM_READ_HARD_CAP`
+    /// is the upper bound.
+    pub count_limit: u64,
+}
+
+/// Result of reading frames from an attempt stream — frames plus terminal
+/// signal so consumers can stop polling without a timeout fallback.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamFrames {
+    /// Entries in the requested range (possibly empty).
+    pub frames: Vec<StreamFrame>,
+    /// Timestamp when the upstream writer closed the stream. `None` if the
+    /// stream is still open (or has never been written).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closed_at: Option<TimestampMs>,
+    /// Reason from the closing writer. Current values:
+    /// `attempt_success`, `attempt_failure`, `attempt_cancelled`,
+    /// `attempt_interrupted`. `None` iff the stream is still open.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closed_reason: Option<String>,
+}
+
+impl StreamFrames {
+    /// Construct an empty open-stream result (no frames, no terminal
+    /// markers). Useful for fast-path peek helpers.
+    pub fn empty_open() -> Self {
+        Self { frames: Vec::new(), closed_at: None, closed_reason: None }
+    }
+
+    /// True iff the producer has closed this stream. Consumers should stop
+    /// polling and drain once this returns true.
+    pub fn is_closed(&self) -> bool {
+        self.closed_at.is_some()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReadFramesResult {
+    /// Frames returned (possibly empty) plus optional closed markers.
+    Frames(StreamFrames),
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/crates/ff-core/src/hash.rs
+++ b/crates/ff-core/src/hash.rs
@@ -1,0 +1,72 @@
+//! Small, stable hash helpers shared across ff-sdk + ff-scheduler +
+//! ff-engine. **Not** security-sensitive — these are for cardinality
+//! reduction (log digests) and deterministic-but-spread iteration
+//! (partition-scan start offsets). A single source of truth avoids
+//! drift if the algorithm changes.
+//!
+//! Both helpers implement FNV-1a 64-bit with the standard offset basis
+//! and prime (see <http://www.isthe.com/chongo/tech/comp/fnv/>). FNV-1a
+//! is fast (byte-at-a-time), has good avalanche on short keys, and
+//! produces stable output across platforms — important because these
+//! digests leak into logs that operators grep against.
+
+/// 8-hex-character FNV-1a digest of the input, suitable for inclusion
+/// in per-event log lines as a stable "what worker is this" identifier.
+/// The upper and lower 32 bits of the 64-bit hash are XOR-folded before
+/// hex formatting to keep both halves' entropy in the 8 chars.
+pub fn fnv1a_xor8hex(s: &str) -> String {
+    let h = fnv1a_u64(s.as_bytes());
+    format!("{:08x}", (h as u32) ^ ((h >> 32) as u32))
+}
+
+/// FNV-1a of the input, reduced modulo `modulus`. Returns 0 when
+/// `modulus == 0`. Used for deterministic-but-spread scan-start
+/// offsets (partition jitter). Callers pass a non-zero modulus.
+pub fn fnv1a_u16_mod(s: &str, modulus: u16) -> u16 {
+    if modulus == 0 {
+        return 0;
+    }
+    let h = fnv1a_u64(s.as_bytes());
+    (h as u16) % modulus
+}
+
+/// FNV-1a 64-bit over raw bytes. Kept public for callers that need the
+/// full hash width (rare — most sites want the folded/reduced helpers
+/// above).
+pub fn fnv1a_u64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV offset basis
+    for b in bytes {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x100_0000_01b3); // FNV prime
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fnv1a_empty_is_offset_basis() {
+        assert_eq!(fnv1a_u64(b""), 0xcbf2_9ce4_8422_2325);
+    }
+
+    #[test]
+    fn fnv1a_stable() {
+        // Regression: the literal output for a fixed input. If this test
+        // flips, either the algorithm drifted or the seed changed.
+        assert_eq!(fnv1a_xor8hex("gpu,cuda").len(), 8);
+        assert_eq!(fnv1a_xor8hex("gpu,cuda"), fnv1a_xor8hex("gpu,cuda"));
+    }
+
+    #[test]
+    fn fnv1a_u16_mod_spread() {
+        // Different inputs usually land on different partitions. Not
+        // guaranteed (hash collisions exist) but the common case.
+        let a = fnv1a_u16_mod("worker-a", 256);
+        let b = fnv1a_u16_mod("worker-b", 256);
+        assert!(a < 256 && b < 256);
+        // Zero modulus returns 0.
+        assert_eq!(fnv1a_u16_mod("anything", 0), 0);
+    }
+}

--- a/crates/ff-core/src/keys.rs
+++ b/crates/ff-core/src/keys.rs
@@ -257,6 +257,18 @@ impl IndexKeys {
         format!("ff:idx:{}:lane:{}:suspended", self.tag, lane_id)
     }
 
+    /// `ff:sec:{p:N}:waitpoint_hmac` — HMAC signing secrets replicated
+    /// across every execution partition (RFC-004 §Waitpoint Security).
+    /// Hash fields:
+    ///   `current_kid`, `previous_kid`, `secret:<kid>` (hex), `previous_expires_at`.
+    /// Replication is required for cluster mode: every FCALL that mints or
+    /// validates a token must hash-tag-collocate this key with the rest of
+    /// its execution-partition KEYS. The secret value is identical across
+    /// partitions; rotation fans out HSETs across them.
+    pub fn waitpoint_hmac_secrets(&self) -> String {
+        format!("ff:sec:{}:waitpoint_hmac", self.tag)
+    }
+
     /// `ff:idx:{p:N}:lease_expiry` — Cross-lane lease expiry scanner target.
     pub fn lease_expiry(&self) -> String {
         format!("ff:idx:{}:lease_expiry", self.tag)
@@ -510,7 +522,23 @@ pub fn worker_key(wid: &WorkerInstanceId) -> String {
     format!("ff:worker:{}", wid)
 }
 
-/// Global worker index.
+/// Non-authoritative capability advertisement STRING for a worker
+/// (sorted CSV). Written by `ff-sdk::FlowFabricWorker::connect`, read by
+/// the engine's unblock scanner to decide whether a `blocked_by_route`
+/// execution has a matching worker. Cluster mode: the key lands on
+/// whatever slot CRC16 hashes to — enumeration goes through
+/// `workers_index_key()` rather than a keyspace SCAN, which would only
+/// hit one shard in cluster mode.
+pub fn worker_caps_key(wid: &WorkerInstanceId) -> String {
+    format!("ff:worker:{}:caps", wid)
+}
+
+/// Global worker index — SET of connected worker_instance_ids. Single
+/// slot in cluster mode (no hash tag; CRC16 of the literal key). SADD on
+/// connect, SREM on empty-caps restart; SMEMBERS gives the enumerable
+/// universe the unblock scanner walks. Separate from `ff:worker:{id}`
+/// registration keys to keep the index membership cheap to read and
+/// independent of per-worker hash details.
 pub fn workers_index_key() -> String {
     "ff:idx:workers".to_owned()
 }

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod contracts;
 pub mod error;
+pub mod hash;
 pub mod keys;
 pub mod partition;
 pub mod policy;

--- a/crates/ff-core/src/policy.rs
+++ b/crates/ff-core/src/policy.rs
@@ -1,5 +1,14 @@
 use crate::types::{BudgetId, TimestampMs};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// Capability CSV ceilings (RFC-009 §7.5). Shared between `ff-sdk` (worker
+/// caps ingress) and `ff-scheduler` (worker caps ingress); mirrored in
+/// `lua/helpers.lua` and enforced by `lua/scheduling.lua`/`lua/execution.lua`
+/// as defense-in-depth. Inclusive: a CSV exactly CAPS_MAX_BYTES long is
+/// accepted; one byte more is rejected.
+pub const CAPS_MAX_BYTES: usize = 4096;
+pub const CAPS_MAX_TOKENS: usize = 256;
 
 /// Retry configuration for an execution.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -112,9 +121,13 @@ pub struct FallbackTier {
 /// Routing requirements for worker matching.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct RoutingRequirements {
-    /// Required capabilities the worker must have.
+    /// Required capabilities the worker must advertise. An empty set means
+    /// any worker on the lane may claim (backwards-compatible default).
+    /// `BTreeSet` for deterministic ordering — critical for the sorted CSV
+    /// form that ff_issue_claim_grant receives in ARGV and for reproducible
+    /// test output / log correlation.
     #[serde(default)]
-    pub required_capabilities: Vec<String>,
+    pub required_capabilities: BTreeSet<String>,
     /// Preferred locality/region.
     #[serde(default)]
     pub preferred_locality: Option<String>,

--- a/crates/ff-core/src/types.rs
+++ b/crates/ff-core/src/types.rs
@@ -231,6 +231,78 @@ string_id! {
     WaitpointKey
 }
 
+/// Waitpoint HMAC token — authenticates signal delivery against the
+/// waitpoint's mint-time binding. Format `"kid:40hex"` (see RFC-004
+/// §Waitpoint Security). The `kid` prefix identifies which signing
+/// key produced the token, enabling zero-downtime rotation.
+///
+/// **Debug / Display REDACT the hex digest.** This is a bearer credential:
+/// anyone who captures the full token can mint signals against the waitpoint
+/// until it closes or rotation grace expires. A derive'd `Debug` would leak
+/// the digest into every `tracing::debug!(args = ?args)` call; a generic
+/// `Display` would leak it into error messages. Both impls print
+/// `"<kid>:<REDACTED:len>"` instead. If a test needs the raw value, use
+/// `as_str()` explicitly — that makes the leak intentional and searchable.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WaitpointToken(pub String);
+
+impl WaitpointToken {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Raw token value. Use ONLY at the wire boundary (FCALL ARGV,
+    /// HTTP header). Never feed this into a logger.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Split the token into `(kid, digest_len)` for redacted formatting.
+    /// Returns `(None, 0)` for malformed inputs so Debug/Display never
+    /// accidentally surface partial hex.
+    fn parts_for_redaction(&self) -> (Option<&str>, usize) {
+        match self.0.find(':') {
+            Some(i) if i > 0 && i < self.0.len() - 1 => {
+                (Some(&self.0[..i]), self.0.len() - i - 1)
+            }
+            _ => (None, 0),
+        }
+    }
+}
+
+impl fmt::Debug for WaitpointToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kid, digest_len) = self.parts_for_redaction();
+        match kid {
+            Some(k) => write!(f, "WaitpointToken({k}:<REDACTED:len={digest_len}>)"),
+            None => write!(f, "WaitpointToken(<REDACTED:malformed>)"),
+        }
+    }
+}
+
+impl fmt::Display for WaitpointToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kid, digest_len) = self.parts_for_redaction();
+        match kid {
+            Some(k) => write!(f, "{k}:<REDACTED:len={digest_len}>"),
+            None => write!(f, "<REDACTED:malformed>"),
+        }
+    }
+}
+
+impl From<&str> for WaitpointToken {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl From<String> for WaitpointToken {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
 /// Source of a cancel operation, determining authorization behavior.
 /// "operator_override" bypasses lease checks; "lease_holder" requires valid lease.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -14,6 +14,7 @@ description = "FlowFabric cross-partition dispatch and background scanners"
 ff-core = { workspace = true }
 ff-script = { workspace = true }
 ferriskey = { workspace = true }
+futures = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ff-engine/src/scanner/unblock.rs
+++ b/crates/ff-engine/src/scanner/unblock.rs
@@ -640,14 +640,42 @@ async fn check_route_cleared(
 /// doesn't round-trip the entire member list in one reply. `COUNT = 100`
 /// matches the convention in budget_reconciler / flow_projector.
 ///
-/// Empty caps STRING, missing key, or per-worker GET error are treated
-/// as "no caps" for that worker — scanner keeps going, the scheduler
-/// re-evaluates on the next tick (fail-open).
+/// Empty caps STRING or missing key = "no caps for that worker"; scanner
+/// keeps accumulating. Per-worker GET error, in contrast, PROPAGATES — a
+/// previous version used `.unwrap_or(None)` which silently merged error
+/// and empty into the same branch, making a transient error look like
+/// "this worker has no caps". In a single-capable-worker fleet that
+/// produced false-negative unions and left executions blocked even
+/// though a matching worker existed, contradicting the scanner's
+/// documented fail-open behavior. Now an error bubbles up; the only
+/// caller (`check_route_cleared`) treats `Err` by returning `true`
+/// (unblock — "we don't know, let the scheduler re-decide next tick"),
+/// which preserves liveness uniformly whether the fault is SSCAN, GET,
+/// or deeper transport.
 async fn load_worker_caps_union(
     client: &ferriskey::Client,
 ) -> Result<BTreeSet<String>, ferriskey::Error> {
     let mut union = BTreeSet::new();
     let index_key = ff_core::keys::workers_index_key();
+
+    // Helper: drain one completed future and fold its caps into the
+    // union, or propagate its error. Centralizing keeps the in-loop +
+    // drain paths symmetric (both must behave the same — a missed error
+    // at either point re-introduces the false-negative-union bug).
+    fn absorb(
+        union: &mut BTreeSet<String>,
+        res: Result<Option<String>, ferriskey::Error>,
+    ) -> Result<(), ferriskey::Error> {
+        let csv = res?;
+        if let Some(csv) = csv {
+            for token in csv.split(',') {
+                if !token.is_empty() {
+                    union.insert(token.to_owned());
+                }
+            }
+        }
+        Ok(())
+    }
 
     // SSCAN loop — bounded per-page response size. Cursor starts at "0"
     // and wraps back to "0" when iteration completes.
@@ -667,8 +695,11 @@ async fn load_worker_caps_union(
         // Bounded concurrent GETs per SSCAN page. FuturesUnordered with
         // a buffered stream caps in-flight work at CAPS_GET_CONCURRENCY —
         // enough parallelism to amortize round-trip latency, bounded so
-        // one scanner tick can't flood the shared Valkey client.
-        let mut pending = FuturesUnordered::new();
+        // one scanner tick can't flood the shared Valkey client. Each
+        // spawned future returns `Result<Option<String>, Error>` so
+        // transient Valkey errors propagate up (no .unwrap_or(None)
+        // swallowing) — see the fn-level doc for why.
+        let mut pending: FuturesUnordered<_> = FuturesUnordered::new();
         for id in worker_ids {
             let client = client.clone();
             pending.push(async move {
@@ -677,31 +708,20 @@ async fn load_worker_caps_union(
                     .cmd("GET")
                     .arg(&caps_key)
                     .execute()
-                    .await
-                    .unwrap_or(None);
-                csv
+                    .await?;
+                Ok::<Option<String>, ferriskey::Error>(csv)
             });
             if pending.len() >= CAPS_GET_CONCURRENCY
-                && let Some(csv) = pending.next().await.flatten()
+                && let Some(res) = pending.next().await
             {
-                for token in csv.split(',') {
-                    if !token.is_empty() {
-                        union.insert(token.to_owned());
-                    }
-                }
+                absorb(&mut union, res)?;
             }
         }
         // Drain remaining pending GETs from this page before advancing
         // the SSCAN cursor. Keeps the pipeline window bounded and the
         // union observation consistent with "all workers visible so far".
-        while let Some(result) = pending.next().await {
-            if let Some(csv) = result {
-                for token in csv.split(',') {
-                    if !token.is_empty() {
-                        union.insert(token.to_owned());
-                    }
-                }
-            }
+        while let Some(res) = pending.next().await {
+            absorb(&mut union, res)?;
         }
 
         if cursor == "0" {

--- a/crates/ff-engine/src/scanner/unblock.rs
+++ b/crates/ff-engine/src/scanner/unblock.rs
@@ -1,17 +1,27 @@
-//! Unblock scanner for budget/quota-blocked executions.
+//! Unblock scanner for budget/quota/capability-blocked executions.
 //!
-//! Scans `ff:idx:{p:N}:lane:<lane>:blocked:budget` and `blocked:quota`
-//! per execution partition. For each blocked execution, re-evaluates the
+//! Scans `ff:idx:{p:N}:lane:<lane>:blocked:{budget,quota,route}` per
+//! execution partition. For each blocked execution, re-evaluates the
 //! blocking condition. If cleared, calls `FCALL ff_unblock_execution`.
 //!
 //! Cross-partition budget check is cached per scan cycle (MANDATORY —
 //! without it, 50K blocked executions = 50K budget reads).
 //!
+//! Capability sweep reads the union of non-authoritative worker cap sets
+//! (`ff:worker:*:caps` — written by `ff-sdk::FlowFabricWorker::connect`)
+//! ONCE per scan cycle and uses it to decide whether a `waiting_for_capable_worker`
+//! execution has a matching worker. This is best-effort: caps sets may
+//! be slightly stale (TTL-less STRING, overwrite on restart), but the
+//! promotion path is self-correcting — a promoted execution that still
+//! can't be claimed gets re-blocked on the next scheduler tick. RFC-009
+//! §7.5 documents the v1 sweep approach and defers connect-triggered
+//! sweeps to V2.
+//!
 //! MUST skip `paused_by_flow_cancel` — only cancel_flow clears that.
 //!
-//! Reference: RFC-008 §2.4, RFC-010 §6
+//! Reference: RFC-008 §2.4, RFC-009 §7.5, RFC-010 §6
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::time::Duration;
 
 use ff_core::keys::IndexKeys;
@@ -61,12 +71,21 @@ impl Scanner for UnblockScanner {
         // Reset per partition scan (each partition scan is one "cycle").
         let mut budget_cache: HashMap<String, bool> = HashMap::new();
 
+        // Worker-caps union, read ONCE per partition scan.
+        // None = "not queried yet on this cycle"; Some(set) = cached result.
+        // Empty set means no online workers have any caps → nothing to promote.
+        // Partitions scanned later in a cycle reuse the same cached union;
+        // load is bounded by SCAN + GET per `ff:worker:*:caps` key per cycle.
+        let mut caps_union_cache: Option<BTreeSet<String>> = None;
+
         for lane in &self.lanes {
             // Scan blocked:budget
             let budget_key = idx.lane_blocked_budget(lane);
             let r = scan_blocked_set(
                 client, &p, &idx, lane, &budget_key,
-                "waiting_for_budget", &mut budget_cache, &self.partition_config,
+                "waiting_for_budget", &mut budget_cache,
+                &mut caps_union_cache,
+                &self.partition_config,
             ).await;
             total_processed += r.processed;
             total_errors += r.errors;
@@ -75,7 +94,22 @@ impl Scanner for UnblockScanner {
             let quota_key = idx.lane_blocked_quota(lane);
             let r = scan_blocked_set(
                 client, &p, &idx, lane, &quota_key,
-                "waiting_for_quota", &mut budget_cache, &self.partition_config,
+                "waiting_for_quota", &mut budget_cache,
+                &mut caps_union_cache,
+                &self.partition_config,
+            ).await;
+            total_processed += r.processed;
+            total_errors += r.errors;
+
+            // Scan blocked:route (capability-mismatch blocks). Promotion
+            // decision reads the union of connected workers' caps and
+            // checks subset coverage. See check_route_cleared below.
+            let route_key = idx.lane_blocked_route(lane);
+            let r = scan_blocked_set(
+                client, &p, &idx, lane, &route_key,
+                "waiting_for_capable_worker", &mut budget_cache,
+                &mut caps_union_cache,
+                &self.partition_config,
             ).await;
             total_processed += r.processed;
             total_errors += r.errors;
@@ -98,6 +132,7 @@ async fn scan_blocked_set(
     blocked_key: &str,
     expected_reason: &str,
     budget_cache: &mut HashMap<String, bool>,
+    caps_union_cache: &mut Option<BTreeSet<String>>,
     partition_config: &PartitionConfig,
 ) -> ScanResult {
     // Read all members from the blocked set (they're scored by block time)
@@ -167,6 +202,9 @@ async fn scan_blocked_set(
             }
             "waiting_for_quota" => {
                 check_quota_cleared(client, &core_key, eid_str, partition_config).await
+            }
+            "waiting_for_capable_worker" => {
+                check_route_cleared(client, &core_key, caps_union_cache).await
             }
             _ => false,
         };
@@ -467,4 +505,112 @@ async fn check_quota_cleared(
     }
 
     true // quota cleared
+}
+
+/// Check if the capability-block has cleared: some connected worker's
+/// caps now cover the execution's `required_capabilities`.
+///
+/// v1: compute the UNION of every connected worker's caps once per scan
+/// cycle (cached in `caps_union_cache`). If `required_capabilities ⊆ union`,
+/// unblock — the execution has at least one worker that *could* claim it
+/// on the next scheduling tick. If the worker is unavailable or the
+/// scheduler re-mismatches, the scheduler will block it again. That's
+/// the RFC-009 §7.5 "slow cycle" approximation; connect-triggered sweeps
+/// are V2.
+///
+/// Fail-OPEN on union-load failure: if `ff:worker:*:caps` read errors
+/// out, assume a worker might match and let the scheduler re-decide on
+/// the next tick. The caps set is non-authoritative (Lua never reads it);
+/// treating it as "unknown → maybe" preserves liveness. The alternative
+/// (fail-closed) would leave executions stuck whenever the caps-SCAN
+/// happens to hit a transient Valkey error.
+async fn check_route_cleared(
+    client: &ferriskey::Client,
+    core_key: &str,
+    caps_union_cache: &mut Option<BTreeSet<String>>,
+) -> bool {
+    let required_csv: Option<String> = client
+        .cmd("HGET")
+        .arg(core_key)
+        .arg("required_capabilities")
+        .execute()
+        .await
+        .unwrap_or(None);
+    let required_csv = match required_csv {
+        Some(s) if !s.is_empty() => s,
+        _ => return true, // no required caps → anyone can claim
+    };
+
+    if caps_union_cache.is_none() {
+        match load_worker_caps_union(client).await {
+            Ok(union) => *caps_union_cache = Some(union),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "unblock_scanner: failed to read worker caps union — \
+                     assuming match possible (fail-open to preserve liveness)"
+                );
+                return true;
+            }
+        }
+    }
+    let union = caps_union_cache.as_ref().expect("cache populated above");
+
+    // Subset check: every non-empty token in required_csv present in union.
+    required_csv
+        .split(',')
+        .filter(|t| !t.is_empty())
+        .all(|t| union.contains(t))
+}
+
+/// Union of every connected worker's advertised capabilities.
+///
+/// Cluster-safe enumeration: reads the members of
+/// `workers_index_key()` (a SET of worker_instance_ids maintained by
+/// `ff-sdk::FlowFabricWorker::connect`), then per-member `GET` on the
+/// `ff:worker:<id>:caps` STRING. A naive `SCAN MATCH ff:worker:*:caps`
+/// would silently miss workers whose keys hash to shards the `SCAN`
+/// command doesn't visit — Valkey cluster `SCAN` is per-node, not
+/// cluster-wide. This is the same class of bug Batch A fixed by
+/// promoting `budget_policies_index` / `flow_index` / `deps_all_edges`
+/// from keyspace SCAN to explicit index SETs.
+///
+/// Empty caps STRING, missing key, or per-worker GET error are treated
+/// as "no caps" for that worker — the scanner keeps going and the
+/// scheduler will re-evaluate on the next tick anyway (fail-open
+/// matches check_route_cleared's overall policy).
+async fn load_worker_caps_union(
+    client: &ferriskey::Client,
+) -> Result<BTreeSet<String>, ferriskey::Error> {
+    let mut union = BTreeSet::new();
+    let index_key = ff_core::keys::workers_index_key();
+
+    // Single-slot SMEMBERS: index key has no hash tag, so every node
+    // routes to the same slot. Bounded by the number of connected
+    // workers, which is the authoritative universe — unlike
+    // `SCAN MATCH ff:worker:*:caps` which in cluster mode only hits one
+    // shard's keyspace per call.
+    let worker_ids: Vec<String> = client
+        .cmd("SMEMBERS")
+        .arg(&index_key)
+        .execute()
+        .await?;
+
+    for id in &worker_ids {
+        let caps_key = format!("ff:worker:{}:caps", id);
+        let csv: Option<String> = client
+            .cmd("GET")
+            .arg(&caps_key)
+            .execute()
+            .await
+            .unwrap_or(None);
+        if let Some(csv) = csv {
+            for token in csv.split(',') {
+                if !token.is_empty() {
+                    union.insert(token.to_owned());
+                }
+            }
+        }
+    }
+    Ok(union)
 }

--- a/crates/ff-engine/src/scanner/unblock.rs
+++ b/crates/ff-engine/src/scanner/unblock.rs
@@ -22,7 +22,11 @@
 //! Reference: RFC-008 §2.4, RFC-009 §7.5, RFC-010 §6
 
 use std::collections::{BTreeSet, HashMap};
-use std::time::Duration;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use tokio::sync::Mutex as AsyncMutex;
 
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, budget_partition};
@@ -32,15 +36,60 @@ use super::{ScanResult, Scanner};
 
 const BATCH_SIZE: u32 = 100;
 
+/// SSCAN page size for the workers-index SET. Same COUNT the other
+/// index-SET scanners use (budget_reconciler, flow_projector). Bounds
+/// per-cursor round-trip response size; total iteration is still the
+/// full SET size across cursor=0 wrap.
+const WORKERS_SSCAN_COUNT: usize = 100;
+
+/// Per-worker caps GET fan-out concurrency cap. Mirrors the bounded
+/// parallelism W1 used in initialize_waitpoint_hmac_secret. Too low and
+/// large fleets (1000+ workers) pay serial round-trip latency; too high
+/// and we head-of-line the scanner client with a pipeline burst. 16 is
+/// a pragmatic middle for the current fleet scales.
+const CAPS_GET_CONCURRENCY: usize = 16;
+
 pub struct UnblockScanner {
     interval: Duration,
     lanes: Vec<LaneId>,
     partition_config: PartitionConfig,
+    /// Shared worker-caps union cache across ALL partitions in one scan
+    /// pass. Previously this cache was declared inside `scan_partition`
+    /// which runs once PER PARTITION — at 256 partitions that meant up
+    /// to 256 redundant SSCAN + fan-out GET sequences per scan interval.
+    /// Now: one load per TTL window (= `interval`), shared across every
+    /// partition visited in that window. `TTL == interval` is natural:
+    /// a worker connecting "now" propagates into the caps union on the
+    /// next scan cycle, not faster or slower than the cycle itself.
+    ///
+    /// `Arc<AsyncMutex<_>>` because the Scanner trait's `scan_partition`
+    /// takes `&self`. Contention is bounded by the partition iteration
+    /// cadence (one partition at a time per scanner task), so the mutex
+    /// is effectively uncontended in steady state.
+    caps_cache: Arc<AsyncMutex<CapsUnionCache>>,
+}
+
+/// Worker-caps union snapshot with a monotonic freshness timestamp.
+/// `None` on first scan; filled by `get_or_load`. Invalidated when
+/// `Instant::now() - fetched_at >= ttl`.
+struct CapsUnionCache {
+    snapshot: Option<BTreeSet<String>>,
+    fetched_at: Option<Instant>,
+    ttl: Duration,
 }
 
 impl UnblockScanner {
     pub fn new(interval: Duration, lanes: Vec<LaneId>, partition_config: PartitionConfig) -> Self {
-        Self { interval, lanes, partition_config }
+        Self {
+            interval,
+            lanes,
+            partition_config,
+            caps_cache: Arc::new(AsyncMutex::new(CapsUnionCache {
+                snapshot: None,
+                fetched_at: None,
+                ttl: interval,
+            })),
+        }
     }
 }
 
@@ -71,12 +120,14 @@ impl Scanner for UnblockScanner {
         // Reset per partition scan (each partition scan is one "cycle").
         let mut budget_cache: HashMap<String, bool> = HashMap::new();
 
-        // Worker-caps union, read ONCE per partition scan.
-        // None = "not queried yet on this cycle"; Some(set) = cached result.
-        // Empty set means no online workers have any caps → nothing to promote.
-        // Partitions scanned later in a cycle reuse the same cached union;
-        // load is bounded by SCAN + GET per `ff:worker:*:caps` key per cycle.
-        let mut caps_union_cache: Option<BTreeSet<String>> = None;
+        // Worker-caps union cache is shared across ALL partitions via
+        // the scanner struct (Arc<AsyncMutex<CapsUnionCache>>). `get_or_load`
+        // returns the cached snapshot if its fetched_at is within
+        // `interval` (TTL == scan interval), otherwise loads fresh via
+        // SSCAN + concurrent GET fan-out. Without this, at 256 partitions
+        // the old per-partition-local cache re-ran load_worker_caps_union
+        // up to 256× per cycle.
+        let caps_cache = self.caps_cache.clone();
 
         for lane in &self.lanes {
             // Scan blocked:budget
@@ -84,7 +135,7 @@ impl Scanner for UnblockScanner {
             let r = scan_blocked_set(
                 client, &p, &idx, lane, &budget_key,
                 "waiting_for_budget", &mut budget_cache,
-                &mut caps_union_cache,
+                &caps_cache,
                 &self.partition_config,
             ).await;
             total_processed += r.processed;
@@ -95,7 +146,7 @@ impl Scanner for UnblockScanner {
             let r = scan_blocked_set(
                 client, &p, &idx, lane, &quota_key,
                 "waiting_for_quota", &mut budget_cache,
-                &mut caps_union_cache,
+                &caps_cache,
                 &self.partition_config,
             ).await;
             total_processed += r.processed;
@@ -108,7 +159,7 @@ impl Scanner for UnblockScanner {
             let r = scan_blocked_set(
                 client, &p, &idx, lane, &route_key,
                 "waiting_for_capable_worker", &mut budget_cache,
-                &mut caps_union_cache,
+                &caps_cache,
                 &self.partition_config,
             ).await;
             total_processed += r.processed;
@@ -132,7 +183,7 @@ async fn scan_blocked_set(
     blocked_key: &str,
     expected_reason: &str,
     budget_cache: &mut HashMap<String, bool>,
-    caps_union_cache: &mut Option<BTreeSet<String>>,
+    caps_cache: &Arc<AsyncMutex<CapsUnionCache>>,
     partition_config: &PartitionConfig,
 ) -> ScanResult {
     // Read all members from the blocked set (they're scored by block time)
@@ -204,7 +255,7 @@ async fn scan_blocked_set(
                 check_quota_cleared(client, &core_key, eid_str, partition_config).await
             }
             "waiting_for_capable_worker" => {
-                check_route_cleared(client, &core_key, caps_union_cache).await
+                check_route_cleared(client, &core_key, caps_cache).await
             }
             _ => false,
         };
@@ -510,24 +561,21 @@ async fn check_quota_cleared(
 /// Check if the capability-block has cleared: some connected worker's
 /// caps now cover the execution's `required_capabilities`.
 ///
-/// v1: compute the UNION of every connected worker's caps once per scan
-/// cycle (cached in `caps_union_cache`). If `required_capabilities ⊆ union`,
-/// unblock — the execution has at least one worker that *could* claim it
-/// on the next scheduling tick. If the worker is unavailable or the
-/// scheduler re-mismatches, the scheduler will block it again. That's
-/// the RFC-009 §7.5 "slow cycle" approximation; connect-triggered sweeps
-/// are V2.
+/// The UNION of every connected worker's caps is cached on the scanner
+/// struct with a TTL equal to `interval`; so within one scan cycle every
+/// partition reuses the same snapshot, and between cycles a stale
+/// snapshot is automatically refreshed.
 ///
-/// Fail-OPEN on union-load failure: if `ff:worker:*:caps` read errors
+/// Fail-OPEN on union-load failure: if the SSCAN or fan-out GET errors
 /// out, assume a worker might match and let the scheduler re-decide on
 /// the next tick. The caps set is non-authoritative (Lua never reads it);
-/// treating it as "unknown → maybe" preserves liveness. The alternative
-/// (fail-closed) would leave executions stuck whenever the caps-SCAN
-/// happens to hit a transient Valkey error.
+/// treating it as "unknown → maybe" preserves liveness. Fail-closed
+/// would leave executions stuck whenever the caps read hits a transient
+/// Valkey error.
 async fn check_route_cleared(
     client: &ferriskey::Client,
     core_key: &str,
-    caps_union_cache: &mut Option<BTreeSet<String>>,
+    caps_cache: &Arc<AsyncMutex<CapsUnionCache>>,
 ) -> bool {
     let required_csv: Option<String> = client
         .cmd("HGET")
@@ -541,75 +589,123 @@ async fn check_route_cleared(
         _ => return true, // no required caps → anyone can claim
     };
 
-    if caps_union_cache.is_none() {
-        match load_worker_caps_union(client).await {
-            Ok(union) => *caps_union_cache = Some(union),
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "unblock_scanner: failed to read worker caps union — \
-                     assuming match possible (fail-open to preserve liveness)"
-                );
-                return true;
+    // Acquire the cache, return a cheap clone of the snapshot so the
+    // subset check runs OUTSIDE the mutex (BTreeSet clone is O(n) but
+    // n is bounded by total caps across the fleet — typically tens).
+    // Holding the mutex across the subset loop would serialize every
+    // partition's capability-block decision behind this one mutex.
+    let snapshot: BTreeSet<String> = {
+        let mut guard = caps_cache.lock().await;
+        let stale = guard
+            .fetched_at
+            .map(|t| t.elapsed() >= guard.ttl)
+            .unwrap_or(true);
+        if stale {
+            match load_worker_caps_union(client).await {
+                Ok(union) => {
+                    guard.snapshot = Some(union);
+                    guard.fetched_at = Some(Instant::now());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "unblock_scanner: failed to read worker caps union — \
+                         assuming match possible (fail-open to preserve liveness)"
+                    );
+                    return true;
+                }
             }
         }
-    }
-    let union = caps_union_cache.as_ref().expect("cache populated above");
+        guard.snapshot.clone().unwrap_or_default()
+    };
 
     // Subset check: every non-empty token in required_csv present in union.
     required_csv
         .split(',')
         .filter(|t| !t.is_empty())
-        .all(|t| union.contains(t))
+        .all(|t| snapshot.contains(t))
 }
 
 /// Union of every connected worker's advertised capabilities.
 ///
-/// Cluster-safe enumeration: reads the members of
-/// `workers_index_key()` (a SET of worker_instance_ids maintained by
-/// `ff-sdk::FlowFabricWorker::connect`), then per-member `GET` on the
-/// `ff:worker:<id>:caps` STRING. A naive `SCAN MATCH ff:worker:*:caps`
-/// would silently miss workers whose keys hash to shards the `SCAN`
-/// command doesn't visit — Valkey cluster `SCAN` is per-node, not
-/// cluster-wide. This is the same class of bug Batch A fixed by
-/// promoting `budget_policies_index` / `flow_index` / `deps_all_edges`
-/// from keyspace SCAN to explicit index SETs.
+/// Cluster-safe enumeration pattern (matches Batch A's index SETs for
+/// budget/flow/deps): SSCAN the `workers_index_key()` SET (single-slot,
+/// no hash tag needed — the key name literally hashes to one slot), then
+/// fan-out concurrent `GET ff:worker:<id>:caps` with a bounded concurrency
+/// cap. A keyspace `SCAN MATCH ff:worker:*:caps` in cluster mode visits
+/// only one shard per call and silently drops workers on other shards —
+/// exactly the class of bug Batch A Issue #11 fixed.
+///
+/// SSCAN is used instead of SMEMBERS so a fleet of thousands of workers
+/// doesn't round-trip the entire member list in one reply. `COUNT = 100`
+/// matches the convention in budget_reconciler / flow_projector.
 ///
 /// Empty caps STRING, missing key, or per-worker GET error are treated
-/// as "no caps" for that worker — the scanner keeps going and the
-/// scheduler will re-evaluate on the next tick anyway (fail-open
-/// matches check_route_cleared's overall policy).
+/// as "no caps" for that worker — scanner keeps going, the scheduler
+/// re-evaluates on the next tick (fail-open).
 async fn load_worker_caps_union(
     client: &ferriskey::Client,
 ) -> Result<BTreeSet<String>, ferriskey::Error> {
     let mut union = BTreeSet::new();
     let index_key = ff_core::keys::workers_index_key();
 
-    // Single-slot SMEMBERS: index key has no hash tag, so every node
-    // routes to the same slot. Bounded by the number of connected
-    // workers, which is the authoritative universe — unlike
-    // `SCAN MATCH ff:worker:*:caps` which in cluster mode only hits one
-    // shard's keyspace per call.
-    let worker_ids: Vec<String> = client
-        .cmd("SMEMBERS")
-        .arg(&index_key)
-        .execute()
-        .await?;
-
-    for id in &worker_ids {
-        let caps_key = format!("ff:worker:{}:caps", id);
-        let csv: Option<String> = client
-            .cmd("GET")
-            .arg(&caps_key)
+    // SSCAN loop — bounded per-page response size. Cursor starts at "0"
+    // and wraps back to "0" when iteration completes.
+    let mut cursor: String = "0".to_owned();
+    loop {
+        let reply: (String, Vec<String>) = client
+            .cmd("SSCAN")
+            .arg(&index_key)
+            .arg(&cursor)
+            .arg("COUNT")
+            .arg(WORKERS_SSCAN_COUNT.to_string().as_str())
             .execute()
-            .await
-            .unwrap_or(None);
-        if let Some(csv) = csv {
-            for token in csv.split(',') {
-                if !token.is_empty() {
-                    union.insert(token.to_owned());
+            .await?;
+        cursor = reply.0;
+        let worker_ids = reply.1;
+
+        // Bounded concurrent GETs per SSCAN page. FuturesUnordered with
+        // a buffered stream caps in-flight work at CAPS_GET_CONCURRENCY —
+        // enough parallelism to amortize round-trip latency, bounded so
+        // one scanner tick can't flood the shared Valkey client.
+        let mut pending = FuturesUnordered::new();
+        for id in worker_ids {
+            let client = client.clone();
+            pending.push(async move {
+                let caps_key = format!("ff:worker:{}:caps", id);
+                let csv: Option<String> = client
+                    .cmd("GET")
+                    .arg(&caps_key)
+                    .execute()
+                    .await
+                    .unwrap_or(None);
+                csv
+            });
+            if pending.len() >= CAPS_GET_CONCURRENCY
+                && let Some(csv) = pending.next().await.flatten()
+            {
+                for token in csv.split(',') {
+                    if !token.is_empty() {
+                        union.insert(token.to_owned());
+                    }
                 }
             }
+        }
+        // Drain remaining pending GETs from this page before advancing
+        // the SSCAN cursor. Keeps the pipeline window bounded and the
+        // union observation consistent with "all workers visible so far".
+        while let Some(result) = pending.next().await {
+            if let Some(csv) = result {
+                for token in csv.split(',') {
+                    if !token.is_empty() {
+                        union.insert(token.to_owned());
+                    }
+                }
+            }
+        }
+
+        if cursor == "0" {
+            break;
         }
     }
     Ok(union)

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -12,7 +12,40 @@
 use ff_core::keys::{ExecKeyContext, IndexKeys};
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, budget_partition, quota_partition};
 use ff_core::types::{BudgetId, ExecutionId, LaneId, QuotaPolicyId, WorkerId, WorkerInstanceId};
+use ff_script::error::ScriptError;
+use ff_script::result::FcallResult;
 use ff_script::retry::is_retryable_kind;
+use std::collections::BTreeSet;
+
+/// Short stable digest of a worker's capability CSV. Used in per-mismatch
+/// log lines so a worker-caps-CSV up to 4KB does not get echoed on every
+/// capability_mismatch event (would swamp aggregators during an incident).
+/// The full CSV is logged once at WARN when the worker connects; operators
+/// cross-reference this 8-hex prefix to the full set.
+/// Return true iff every non-empty comma-separated token in `required_csv`
+/// is present in `worker_caps`. Mirrors the authoritative Lua subset check
+/// in scheduling.lua (parse_capability_csv + missing_capabilities) — this
+/// is a fast-path Rust short-circuit so we can skip the quota-admission
+/// write for executions we already know the worker can't claim. Empty /
+/// all-separator CSV → subset holds trivially.
+fn caps_subset(required_csv: &str, worker_caps: &BTreeSet<String>) -> bool {
+    required_csv
+        .split(',')
+        .filter(|t| !t.is_empty())
+        .all(|t| worker_caps.contains(t))
+}
+
+fn worker_caps_digest(csv: &str) -> String {
+    // FNV-1a 64-bit — not security-sensitive; the point is cardinality
+    // reduction, not unforgeability. First 8 hex chars is enough for
+    // practical uniqueness at fleet scale.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in csv.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    format!("{:08x}", (h as u32) ^ ((h >> 32) as u32))
+}
 
 /// A claim grant issued by the scheduler for a specific execution.
 ///
@@ -190,6 +223,11 @@ impl Scheduler {
     /// Iterates all execution partitions looking for the first partition
     /// with an eligible execution. Issues a claim grant via FCALL.
     ///
+    /// `worker_capabilities` is sent to `ff_issue_claim_grant` as a sorted
+    /// CSV (BTreeSet guarantees deterministic order). Executions whose
+    /// `required_capabilities` are not a subset of this set are skipped
+    /// (stay queued) via `ScriptError::CapabilityMismatch`.
+    ///
     /// Returns `Ok(None)` if no eligible executions exist anywhere.
     /// Returns `Ok(Some(grant))` on success.
     /// Returns `Err` on Valkey errors.
@@ -198,12 +236,93 @@ impl Scheduler {
         lane: &LaneId,
         worker_id: &WorkerId,
         worker_instance_id: &WorkerInstanceId,
+        worker_capabilities: &BTreeSet<String>,
         grant_ttl_ms: u64,
     ) -> Result<Option<ClaimGrant>, SchedulerError> {
         let num_partitions = self.config.num_execution_partitions;
         let mut budget_checker = BudgetChecker::new(self.config);
 
-        for p_idx in 0..num_partitions {
+        // Jitter the partition scan start to avoid thundering-herd on
+        // partition 0 when 100 workers all tick simultaneously. Seeded
+        // from worker_instance_id so this worker hits a stable window
+        // within a single scheduling cycle (still covers every partition),
+        // and different workers naturally diverge. FNV-1a mix — same
+        // approach as ff-sdk's PARTITION_SCAN_CHUNK cursor seed.
+        let start_p: u16 = if num_partitions > 0 {
+            let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+            for b in worker_instance_id.as_str().as_bytes() {
+                h ^= u64::from(*b);
+                h = h.wrapping_mul(0x100_0000_01b3);
+            }
+            (h as u16) % num_partitions
+        } else {
+            0
+        };
+        // BTreeSet iterates sorted → stable CSV for Lua subset match.
+        // Ingress validation mirrors FlowFabricWorker::connect (ff-sdk):
+        //   - `,` is the CSV delimiter — a token containing one would split
+        //     mid-parse and could let a {"gpu"} worker appear to satisfy
+        //     {"gpu,cuda"} (silent auth bypass).
+        //   - Empty strings would inflate the CSV with leading / adjacent
+        //     commas ("" → ",gpu" → [" "," gpu"]) and inflate the token
+        //     count past CAPS_MAX_TOKENS for no semantic reason.
+        //   - Non-printable / whitespace: "gpu " vs "gpu" or "gpu\n" vs
+        //     "gpu" silently mis-routes. Require printable ASCII excluding
+        //     space (0x21-0x7E) at ingress so typos fail loud.
+        // Enforce ALL here so operator misconfig at the scheduler entry
+        // point fails loud, symmetric with the SDK inline-claim path.
+        // Bounds (#csv, #tokens) are enforced by the Lua side.
+        for cap in worker_capabilities {
+            if cap.is_empty() {
+                return Err(SchedulerError::Config(
+                    "capability token must not be empty".to_owned(),
+                ));
+            }
+            if cap.contains(',') {
+                return Err(SchedulerError::Config(format!(
+                    "capability token may not contain ',' (CSV delimiter): {cap:?}"
+                )));
+            }
+            // Reject ASCII control + whitespace (incl. Unicode whitespace);
+            // allow non-ASCII printable UTF-8 so i18n cap names work. CSV
+            // delimiter `,` is single-byte and never a UTF-8 continuation,
+            // so multibyte UTF-8 is safe on the wire. Symmetric with
+            // ff-sdk::FlowFabricWorker::connect.
+            if cap.chars().any(|c| c.is_control() || c.is_whitespace()) {
+                return Err(SchedulerError::Config(format!(
+                    "capability token must not contain whitespace or control characters: {cap:?}"
+                )));
+            }
+        }
+        if worker_capabilities.len() > ff_core::policy::CAPS_MAX_TOKENS {
+            return Err(SchedulerError::Config(format!(
+                "capability set exceeds CAPS_MAX_TOKENS ({}): {}",
+                ff_core::policy::CAPS_MAX_TOKENS,
+                worker_capabilities.len()
+            )));
+        }
+        let worker_caps_csv = worker_capabilities
+            .iter()
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(",");
+        // Stable digest used in per-mismatch logs so the full 4KB CSV
+        // doesn't get echoed on every mismatch. See worker_caps_digest.
+        let worker_caps_hash = worker_caps_digest(&worker_caps_csv);
+        if worker_caps_csv.len() > ff_core::policy::CAPS_MAX_BYTES {
+            return Err(SchedulerError::Config(format!(
+                "capability CSV exceeds CAPS_MAX_BYTES ({}): {}",
+                ff_core::policy::CAPS_MAX_BYTES,
+                worker_caps_csv.len()
+            )));
+        }
+
+        for offset in 0..num_partitions {
+            // Jittered iteration: start at start_p, wrap modulo num_partitions.
+            // Still covers every partition once per cycle; prevents all
+            // workers from hammering partition 0 first simultaneously.
+            let p_idx = (start_p + offset) % num_partitions;
             let partition = Partition {
                 family: PartitionFamily::Execution,
                 index: p_idx,
@@ -270,6 +389,65 @@ impl Scheduler {
                 }
             };
 
+            // ── Capability pre-check (in-slot HGET, cheap) ──
+            // Runs BEFORE quota admission so we never ZADD a quota slot
+            // for an execution this worker can't actually claim. Without
+            // this, on an unmatchable-top-of-zset, every scheduling tick
+            // would ZADD {q:K}:admitted_set then ZREM it via
+            // release_admission on the capability_mismatch reject — a
+            // cross-slot write storm amplifying the mismatch loop.
+            //
+            // Lua `ff_issue_claim_grant` still does the authoritative
+            // check; this is a fast-path short-circuit, not a substitute.
+            // A narrow race exists where `required_capabilities` is
+            // updated between our HGET and the FCALL — the FCALL is still
+            // atomic and correct.
+            let required_caps_csv: Option<String> = match self
+                .client
+                .cmd("HGET")
+                .arg(&core_key)
+                .arg("required_capabilities")
+                .execute::<Option<String>>()
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        partition = p_idx,
+                        execution_id = eid_s.as_str(),
+                        error = %e,
+                        "scheduler: HGET required_capabilities failed, skipping candidate"
+                    );
+                    continue;
+                }
+            };
+            if let Some(req) = required_caps_csv.as_deref()
+                && !req.is_empty()
+                && !caps_subset(req, worker_capabilities)
+            {
+                // Move this execution out of eligible into blocked_route
+                // so we don't hot-loop on it every tick (RFC-009 §564). A
+                // periodic sweep (scanner side) promotes blocked_route →
+                // eligible when a worker with matching caps registers.
+                // Logged with a hash digest, not the raw CSV, to keep
+                // per-mismatch log volume bounded.
+                tracing::info!(
+                    partition = p_idx,
+                    execution_id = eid_s.as_str(),
+                    worker_id = worker_id.as_str(),
+                    worker_caps_hash = worker_caps_hash.as_str(),
+                    required = req,
+                    "scheduler: capability mismatch, blocking execution off eligible"
+                );
+                self.block_candidate(
+                    &partition, &idx, lane, &eid, &eligible_key,
+                    "waiting_for_capable_worker",
+                    "no connected worker satisfies required_capabilities",
+                    now_ms,
+                ).await;
+                continue;
+            }
+
             // ── Budget pre-check (cross-partition, cached per cycle) ──
             if let Some(block_detail) = self
                 .check_budgets(&mut budget_checker, &exec_ctx, &core_key, &eid_s)
@@ -307,7 +485,7 @@ impl Scheduler {
             let wiid_s = worker_instance_id.to_string();
             let lane_s = lane.to_string();
 
-            let argv: [&str; 8] = [
+            let argv: [&str; 9] = [
                 &eid_s,
                 &wid_s,
                 &wiid_s,
@@ -316,13 +494,36 @@ impl Scheduler {
                 &ttl_str,
                 "",   // route_snapshot_json
                 "",   // admission_summary
+                &worker_caps_csv, // sorted CSV; empty → matches only empty-required execs
             ];
 
-            match self
+            let raw = match self
                 .client
                 .fcall::<ferriskey::Value>("ff_issue_claim_grant", &keys, &argv)
                 .await
             {
+                Ok(v) => v,
+                Err(e) => {
+                    // Transport failure on the FCALL — NOSCRIPT, IoError,
+                    // ClusterDown, etc. This is NOT a normal soft-reject;
+                    // persistent transport errors mean the scheduler is
+                    // effectively idle even though it looks like it's
+                    // running. WARN so ops dashboards (WARN+ aggregators)
+                    // fire instead of burying it at DEBUG.
+                    tracing::warn!(
+                        partition = p_idx,
+                        execution_id = eid_s.as_str(),
+                        error = %e,
+                        "scheduler: ff_issue_claim_grant transport error, trying next"
+                    );
+                    if let QuotaCheckOutcome::Admitted { tag, quota_id, eid } = &quota_admission {
+                        self.release_admission(tag, quota_id, eid).await;
+                    }
+                    continue;
+                }
+            };
+
+            match FcallResult::parse(&raw).and_then(|r| r.into_success()) {
                 Ok(_) => {
                     tracing::debug!(
                         partition = p_idx,
@@ -336,13 +537,50 @@ impl Scheduler {
                         expires_at_ms: now_ms + grant_ttl_ms,
                     }));
                 }
-                Err(e) => {
-                    tracing::debug!(
-                        partition = p_idx,
-                        execution_id = eid_s.as_str(),
-                        error = %e,
-                        "scheduler: ff_issue_claim_grant rejected, trying next"
-                    );
+                Err(script_err) => {
+                    if matches!(script_err, ScriptError::CapabilityMismatch(_)) {
+                        // Should be rare: the Rust pre-check above
+                        // normally catches this and blocks the execution
+                        // off eligible. Reaching here means the
+                        // required_capabilities field mutated between our
+                        // HGET and the Lua atomic check (narrow race).
+                        // Block here too so the next tick doesn't loop.
+                        //
+                        // Log uses worker_caps_hash (8-hex digest), not
+                        // the full 4KB CSV, to keep per-mismatch log
+                        // volume bounded. Full CSV is logged once at
+                        // worker connect under "worker caps" WARN.
+                        tracing::info!(
+                            partition = p_idx,
+                            execution_id = eid_s.as_str(),
+                            worker_id = wid_s.as_str(),
+                            worker_caps_hash = worker_caps_hash.as_str(),
+                            error = %script_err,
+                            "scheduler: capability mismatch via Lua (race), blocking execution"
+                        );
+                        self.block_candidate(
+                            &partition, &idx, lane, &eid, &eligible_key,
+                            "waiting_for_capable_worker",
+                            "no connected worker satisfies required_capabilities",
+                            now_ms,
+                        ).await;
+                        if let QuotaCheckOutcome::Admitted { tag, quota_id, eid } = &quota_admission {
+                            self.release_admission(tag, quota_id, eid).await;
+                        }
+                        continue;
+                    } else {
+                        // Any other logical reject (grant_already_exists,
+                        // execution_not_in_eligible_set, execution_not_eligible,
+                        // invalid_capabilities, etc.). These are rare and each
+                        // indicates either a race or a config problem — in
+                        // either case ops need to see it, so WARN, not DEBUG.
+                        tracing::warn!(
+                            partition = p_idx,
+                            execution_id = eid_s.as_str(),
+                            error = %script_err,
+                            "scheduler: ff_issue_claim_grant rejected, trying next"
+                        );
+                    }
                     if let QuotaCheckOutcome::Admitted { tag, quota_id, eid } = &quota_admission {
                         self.release_admission(tag, quota_id, eid).await;
                     }
@@ -547,6 +785,7 @@ impl Scheduler {
         let blocked_key = match block_reason {
             "waiting_for_budget" => idx.lane_blocked_budget(lane),
             "waiting_for_quota" => idx.lane_blocked_quota(lane),
+            "waiting_for_capable_worker" => idx.lane_blocked_route(lane),
             _ => idx.lane_blocked_budget(lane),
         };
 
@@ -554,22 +793,45 @@ impl Scheduler {
         let now_s = now_ms.to_string();
         let argv: [&str; 4] = [&eid_s, block_reason, blocking_detail, &now_s];
 
+        // Parse FcallResult so we distinguish Lua-level rejections (e.g.
+        // execution_not_active because the execution went terminal between
+        // our HGET and the FCALL) from a real block. Previously `Ok(_)`
+        // treated an err-tuple as success → INFO log "candidate blocked"
+        // while nothing actually changed on exec_core, then the next tick
+        // re-picked the same candidate and looped. Mirrors the
+        // release_admission parse fix.
         match self.client
             .fcall::<ferriskey::Value>("ff_block_execution_for_admission", &keys, &argv)
             .await
         {
-            Ok(_) => {
-                tracing::info!(
-                    execution_id = eid_s,
-                    reason = block_reason,
-                    "scheduler: candidate blocked by admission check"
-                );
-            }
+            Ok(v) => match FcallResult::parse(&v).and_then(|r| r.into_success()) {
+                Ok(_) => {
+                    tracing::info!(
+                        execution_id = eid_s,
+                        reason = block_reason,
+                        "scheduler: candidate blocked by admission check"
+                    );
+                }
+                Err(script_err) => {
+                    // Logical reject from Lua (e.g. execution_not_active
+                    // — the execution went terminal between the scheduler
+                    // pick and the block FCALL; the candidate loop will
+                    // naturally move on). WARN so ops dashboards surface
+                    // actual block failures, but not so loud that a common
+                    // race spams alerts.
+                    tracing::warn!(
+                        execution_id = eid_s,
+                        reason = block_reason,
+                        error = %script_err,
+                        "scheduler: ff_block_execution_for_admission rejected by Lua"
+                    );
+                }
+            },
             Err(e) => {
                 tracing::warn!(
                     execution_id = eid_s,
                     error = %e,
-                    "scheduler: ff_block_execution_for_admission failed"
+                    "scheduler: ff_block_execution_for_admission transport failed"
                 );
             }
         }
@@ -590,23 +852,42 @@ impl Scheduler {
         let keys: [&str; 3] = [&admitted_key, &admitted_set_key, &concurrency_key];
         let argv: [&str; 1] = [eid_s];
 
+        // Parse the Lua response properly: FCALL returns `Ok(Value)` for
+        // BOTH success and logical-error paths. Treating Ok(_) blindly as
+        // "released" logs a false positive when the Lua returns
+        // `{0, "quota_not_found"}` (or any other script-level err) — the
+        // slot in fact remains pinned until its TTL expires, which is
+        // minutes to hours. Surface the real outcome so on-call sees
+        // actual release failures instead of clean "released" events.
         match self.client
             .fcall::<ferriskey::Value>("ff_release_admission", &keys, &argv)
             .await
         {
-            Ok(_) => {
-                tracing::info!(
-                    execution_id = eid_s,
-                    quota_id,
-                    "scheduler: released admission after claim failure"
-                );
-            }
+            Ok(v) => match FcallResult::parse(&v).and_then(|r| r.into_success()) {
+                Ok(_) => {
+                    tracing::info!(
+                        execution_id = eid_s,
+                        quota_id,
+                        "scheduler: released admission after claim failure"
+                    );
+                }
+                Err(script_err) => {
+                    tracing::warn!(
+                        execution_id = eid_s,
+                        quota_id,
+                        error = %script_err,
+                        "scheduler: ff_release_admission rejected by Lua \
+                         (slot will expire via TTL)"
+                    );
+                }
+            },
             Err(e) => {
                 tracing::warn!(
                     execution_id = eid_s,
                     quota_id,
                     error = %e,
-                    "scheduler: ff_release_admission failed (slot will expire via TTL)"
+                    "scheduler: ff_release_admission transport failed \
+                     (slot will expire via TTL)"
                 );
             }
         }
@@ -647,6 +928,10 @@ pub enum SchedulerError {
         source: ferriskey::Error,
         context: String,
     },
+    /// Caller-supplied value failed ingress validation. NOT retryable — the
+    /// caller must fix its input before retrying.
+    #[error("config: {0}")]
+    Config(String),
 }
 
 impl SchedulerError {
@@ -656,6 +941,7 @@ impl SchedulerError {
     pub fn valkey_kind(&self) -> Option<ferriskey::ErrorKind> {
         match self {
             Self::Valkey(e) | Self::ValkeyContext { source: e, .. } => Some(e.kind()),
+            Self::Config(_) => None,
         }
     }
 

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -35,16 +35,11 @@ fn caps_subset(required_csv: &str, worker_caps: &BTreeSet<String>) -> bool {
         .all(|t| worker_caps.contains(t))
 }
 
+/// Short, stable digest of a worker's caps CSV for per-event log lines.
+/// Thin wrapper around the shared helper so call sites read as
+/// "worker_caps_digest" locally while the algorithm lives in one place.
 fn worker_caps_digest(csv: &str) -> String {
-    // FNV-1a 64-bit — not security-sensitive; the point is cardinality
-    // reduction, not unforgeability. First 8 hex chars is enough for
-    // practical uniqueness at fleet scale.
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for b in csv.as_bytes() {
-        h ^= u64::from(*b);
-        h = h.wrapping_mul(0x100_0000_01b3);
-    }
-    format!("{:08x}", (h as u32) ^ ((h >> 32) as u32))
+    ff_core::hash::fnv1a_xor8hex(csv)
 }
 
 /// A claim grant issued by the scheduler for a specific execution.
@@ -246,18 +241,13 @@ impl Scheduler {
         // partition 0 when 100 workers all tick simultaneously. Seeded
         // from worker_instance_id so this worker hits a stable window
         // within a single scheduling cycle (still covers every partition),
-        // and different workers naturally diverge. FNV-1a mix — same
-        // approach as ff-sdk's PARTITION_SCAN_CHUNK cursor seed.
-        let start_p: u16 = if num_partitions > 0 {
-            let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-            for b in worker_instance_id.as_str().as_bytes() {
-                h ^= u64::from(*b);
-                h = h.wrapping_mul(0x100_0000_01b3);
-            }
-            (h as u16) % num_partitions
-        } else {
-            0
-        };
+        // and different workers naturally diverge. Uses the shared
+        // ff_core::hash FNV-1a reducer — same helper powering ff-sdk's
+        // PARTITION_SCAN_CHUNK cursor seed. Zero-modulus safe.
+        let start_p: u16 = ff_core::hash::fnv1a_u16_mod(
+            worker_instance_id.as_str(),
+            num_partitions,
+        );
         // BTreeSet iterates sorted → stable CSV for Lua subset match.
         // Ingress validation mirrors FlowFabricWorker::connect (ff-sdk):
         //   - `,` is the CSV delimiter — a token containing one would split

--- a/crates/ff-script/build.rs
+++ b/crates/ff-script/build.rs
@@ -64,7 +64,12 @@ fn main() {
     // a naive `version_source.find("return '")` picks that up instead of
     // the real function body. Line-based skip-comments parse keeps the
     // extract string-based (no regex dep) while avoiding that trap.
-    let version = version_source
+    //
+    // Strict "exactly one" contract: collect ALL non-comment matches, then
+    // panic if count != 1. Guards against a future edit that adds a second
+    // `register_function` returning a literal and silently takes the
+    // first match (or worse, the wrong match).
+    let matches: Vec<String> = version_source
         .lines()
         .filter_map(|raw| {
             let line = raw.trim_start();
@@ -75,16 +80,24 @@ fn main() {
             let rest = &line[i + "return '".len()..];
             rest.find('\'').map(|j| rest[..j].to_owned())
         })
-        .next()
-        .unwrap_or_else(|| {
-            panic!(
-                "Failed to extract LIBRARY_VERSION from {}: expected exactly one \
-                 non-commented `return 'X'` literal (the body of ff_version). Do NOT \
-                 maintain a separate copy in crates/ff-script/src/lib.rs — this \
-                 extract is the single source of truth.",
-                version_path.display()
-            )
-        });
+        .collect();
+    let version = match matches.len() {
+        1 => matches.into_iter().next().unwrap(),
+        0 => panic!(
+            "Failed to extract LIBRARY_VERSION from {}: expected exactly one \
+             non-commented `return 'X'` literal (the body of ff_version), found \
+             NONE. Do NOT maintain a separate copy in crates/ff-script/src/lib.rs \
+             — this extract is the single source of truth.",
+            version_path.display()
+        ),
+        n => panic!(
+            "Failed to extract LIBRARY_VERSION from {}: expected exactly one \
+             non-commented `return 'X'` literal, found {n} ({matches:?}). If \
+             version.lua grew a second register_function, move it elsewhere — \
+             the extract can't know which one is authoritative.",
+            version_path.display()
+        ),
+    };
     // Sanity bounds: non-empty, no embedded quotes/newlines that would
     // imply a broken parse, short enough to be a version string.
     assert!(

--- a/crates/ff-script/build.rs
+++ b/crates/ff-script/build.rs
@@ -44,7 +44,60 @@ fn main() {
         panic!("Failed to write {}: {}", output_path.display(), e);
     });
 
-    // Tell Cargo to re-run if any Lua file changes
+    // Single source of truth for LIBRARY_VERSION: extract the string
+    // literal from `lua/version.lua` and expose it to Rust via
+    // `cargo:rustc-env=FLOWFABRIC_LUA_VERSION=...`. `crates/ff-script/src/lib.rs`
+    // reads it through `env!("FLOWFABRIC_LUA_VERSION")`. Eliminates the
+    // two-place drift class (one bump updates both the Lua function and
+    // the Rust constant the loader compares against).
+    //
+    // Parse contract: `lua/version.lua` must contain exactly one
+    // `return 'X'` literal (the body of `ff_version`). String find+slice,
+    // no regex or Lua parser dependency. Break the contract → panic with
+    // a message that points at the file to fix.
+    let version_path = lua_dir.join("version.lua");
+    let version_source = fs::read_to_string(&version_path).unwrap_or_else(|e| {
+        panic!("Failed to read {}: {}", version_path.display(), e);
+    });
+    // Walk lines, skipping Lua comments ("--" at start after trimming).
+    // The version.lua docstring contains "return 'X'" as explanatory text;
+    // a naive `version_source.find("return '")` picks that up instead of
+    // the real function body. Line-based skip-comments parse keeps the
+    // extract string-based (no regex dep) while avoiding that trap.
+    let version = version_source
+        .lines()
+        .filter_map(|raw| {
+            let line = raw.trim_start();
+            if line.starts_with("--") {
+                return None;
+            }
+            let i = line.find("return '")?;
+            let rest = &line[i + "return '".len()..];
+            rest.find('\'').map(|j| rest[..j].to_owned())
+        })
+        .next()
+        .unwrap_or_else(|| {
+            panic!(
+                "Failed to extract LIBRARY_VERSION from {}: expected exactly one \
+                 non-commented `return 'X'` literal (the body of ff_version). Do NOT \
+                 maintain a separate copy in crates/ff-script/src/lib.rs — this \
+                 extract is the single source of truth.",
+                version_path.display()
+            )
+        });
+    // Sanity bounds: non-empty, no embedded quotes/newlines that would
+    // imply a broken parse, short enough to be a version string.
+    assert!(
+        !version.is_empty()
+            && version.len() < 64
+            && !version.contains('\n')
+            && !version.contains('\''),
+        "Invalid LIBRARY_VERSION extracted from lua/version.lua: {version:?}"
+    );
+    println!("cargo:rustc-env=FLOWFABRIC_LUA_VERSION={version}");
+
+    // Tell Cargo to re-run if any Lua file changes. `version.lua` is
+    // already in the list above, so changes to it trigger re-extract.
     for filename in lua_files {
         println!("cargo:rerun-if-changed=../../lua/{}", filename);
     }

--- a/crates/ff-script/src/error.rs
+++ b/crates/ff-script/src/error.rs
@@ -345,6 +345,37 @@ pub enum ScriptError {
     #[error("invalid_input: {0}")]
     InvalidInput(String),
 
+    /// Worker caps do not satisfy execution's required_capabilities.
+    /// Payload is the sorted-CSV of missing tokens. RETRYABLE: execution
+    /// stays in the eligible ZSET for a worker with matching caps.
+    #[error("capability_mismatch: missing {0}")]
+    CapabilityMismatch(String),
+
+    /// Caller supplied a malformed or oversized capability list (defense
+    /// against 1MB-repeated-token payloads). TERMINAL from this call's
+    /// perspective: the caller must fix its config before retrying.
+    #[error("invalid_capabilities: {0}")]
+    InvalidCapabilities(String),
+
+    /// `ff_create_execution` received a `policy_json` that is not valid JSON
+    /// or whose `routing_requirements` is structurally wrong (not an object,
+    /// required_capabilities not an array). TERMINAL: the submitter must
+    /// send a well-formed policy. Kept distinct from `invalid_capabilities`
+    /// so tooling can distinguish "payload never parsed" from "payload
+    /// parsed but contents rejected".
+    #[error("invalid_policy_json: {0}")]
+    InvalidPolicyJson(String),
+
+    /// Pending waitpoint record is missing its HMAC token field. Returned by
+    /// `ff_suspend_execution` when activating a pending waitpoint whose
+    /// `waitpoint_token` field is absent or empty (pre-HMAC-upgrade record
+    /// or a corrupted write). Surfacing this at activation time instead of
+    /// letting every subsequent signal delivery silently reject with
+    /// `missing_token` makes the degraded state visible at the right step.
+    /// TERMINAL: the pending waitpoint is unrecoverable without a fresh one.
+    #[error("waitpoint_not_token_bound")]
+    WaitpointNotTokenBound,
+
     // ── Transport-level errors (not from Lua) ──
     /// Valkey connection or protocol error. Preserves `ferriskey::ErrorKind` so
     /// callers can distinguish transient/permanent/NOSCRIPT/MOVED/etc.
@@ -411,6 +442,9 @@ impl ScriptError {
             | Self::QuotaAttachConflict
             | Self::InvalidQuotaSpec
             | Self::InvalidInput(_)
+            | Self::InvalidCapabilities(_)
+            | Self::InvalidPolicyJson(_)
+            | Self::WaitpointNotTokenBound
             | Self::Parse(_) => ErrorClass::Terminal,
 
             // Transport errors classify by their ferriskey ErrorKind —
@@ -438,6 +472,7 @@ impl ScriptError {
             | Self::StaleGraphRevision
             | Self::RateLimitExceeded
             | Self::ConcurrencyLimitExceeded
+            | Self::CapabilityMismatch(_)
             | Self::InvalidOffset => ErrorClass::Retryable,
 
             // Cooperative
@@ -557,7 +592,29 @@ impl ScriptError {
             "quota_attach_conflict" => Self::QuotaAttachConflict,
             "invalid_quota_spec" => Self::InvalidQuotaSpec,
             "invalid_input" => Self::InvalidInput(String::new()),
+            "capability_mismatch" => Self::CapabilityMismatch(String::new()),
+            "invalid_capabilities" => Self::InvalidCapabilities(String::new()),
+            "invalid_policy_json" => Self::InvalidPolicyJson(String::new()),
+            "waitpoint_not_token_bound" => Self::WaitpointNotTokenBound,
             _ => return None,
+        })
+    }
+
+    /// Like `from_code`, but preserves the Lua-side detail payload for
+    /// variants that carry a String. Lua returns `{0, code, detail}` for
+    /// capability_mismatch (missing CSV), invalid_capabilities (bounds
+    /// reason), invalid_input (field name). The plain `from_code` discards
+    /// the detail; callers that log or surface the detail should use this
+    /// variant. Returns `None` only when the code is unknown — the detail
+    /// is always folded in when applicable.
+    pub fn from_code_with_detail(code: &str, detail: &str) -> Option<Self> {
+        let base = Self::from_code(code)?;
+        Some(match base {
+            Self::CapabilityMismatch(_) => Self::CapabilityMismatch(detail.to_owned()),
+            Self::InvalidCapabilities(_) => Self::InvalidCapabilities(detail.to_owned()),
+            Self::InvalidPolicyJson(_) => Self::InvalidPolicyJson(detail.to_owned()),
+            Self::InvalidInput(_) => Self::InvalidInput(detail.to_owned()),
+            other => other,
         })
     }
 }

--- a/crates/ff-script/src/functions/scheduling.rs
+++ b/crates/ff-script/src/functions/scheduling.rs
@@ -17,9 +17,10 @@ pub struct SchedOpKeys<'a> {
 // ─── ff_issue_claim_grant ──────────────────────────────────────────────
 //
 // Lua KEYS (3): exec_core, claim_grant_key, eligible_zset
-// Lua ARGV (8): execution_id, worker_id, worker_instance_id,
+// Lua ARGV (9): execution_id, worker_id, worker_instance_id,
 //               lane_id, capability_hash, grant_ttl_ms,
-//               route_snapshot_json, admission_summary
+//               route_snapshot_json, admission_summary,
+//               worker_capabilities_csv
 
 ff_function! {
     pub ff_issue_claim_grant(args: IssueClaimGrantArgs) -> IssueClaimGrantResult {
@@ -37,6 +38,8 @@ ff_function! {
             args.grant_ttl_ms.to_string(),
             args.route_snapshot_json.clone().unwrap_or_default(),
             args.admission_summary.clone().unwrap_or_default(),
+            // BTreeSet iterates in sorted order → stable CSV for Lua match
+            args.worker_capabilities.iter().cloned().collect::<Vec<_>>().join(","),
         }
     }
 }

--- a/crates/ff-script/src/functions/signal.rs
+++ b/crates/ff-script/src/functions/signal.rs
@@ -21,17 +21,17 @@ pub struct SignalOpKeys<'a> {
 
 // ─── ff_deliver_signal ────────────────────────────────────────────────
 //
-// Lua KEYS (13): exec_core, wp_condition, wp_signals_stream,
+// Lua KEYS (14): exec_core, wp_condition, wp_signals_stream,
 //                exec_signals_zset, signal_hash, signal_payload,
 //                idem_key, waitpoint_hash, suspension_current,
 //                eligible_zset, suspended_zset, delayed_zset,
-//                suspension_timeout_zset
-// Lua ARGV (17): signal_id, execution_id, waitpoint_id, signal_name,
+//                suspension_timeout_zset, hmac_secrets
+// Lua ARGV (18): signal_id, execution_id, waitpoint_id, signal_name,
 //                signal_category, source_type, source_identity,
 //                payload, payload_encoding, idempotency_key,
 //                correlation_id, target_scope, created_at,
 //                dedup_ttl_ms, resume_delay_ms, signal_maxlen,
-//                max_signals_per_execution
+//                max_signals_per_execution, waitpoint_token
 
 ff_function! {
     pub ff_deliver_signal(args: DeliverSignalArgs) -> DeliverSignalResult {
@@ -51,6 +51,7 @@ ff_function! {
             k.idx.lane_suspended(k.lane_id),                           // 11
             k.idx.lane_delayed(k.lane_id),                             // 12
             k.idx.suspension_timeout(),                                // 13
+            k.idx.waitpoint_hmac_secrets(),                            // 14
         }
         argv {
             args.signal_id.to_string(),                                // 1
@@ -72,6 +73,7 @@ ff_function! {
             args.resume_delay_ms.unwrap_or(0).to_string(),             // 15
             args.signal_maxlen.unwrap_or(1000).to_string(),            // 16
             args.max_signals_per_execution.unwrap_or(10_000).to_string(), // 17
+            args.waitpoint_token.as_str().to_owned(),                  // 18 (wire: raw, not redacted Display)
         }
     }
 }
@@ -103,10 +105,10 @@ impl FromFcallResult for DeliverSignalResult {
 
 // ─── ff_buffer_signal_for_pending_waitpoint ───────────────────────────
 //
-// Lua KEYS (7): exec_core, wp_condition, wp_signals_stream,
+// Lua KEYS (9): exec_core, wp_condition, wp_signals_stream,
 //               exec_signals_zset, signal_hash, signal_payload,
-//               idem_key
-// Lua ARGV (17): same as ff_deliver_signal (unused fields ignored)
+//               idem_key, waitpoint_hash, hmac_secrets
+// Lua ARGV (18): same as ff_deliver_signal (17 + waitpoint_token)
 
 ff_function! {
     pub ff_buffer_signal_for_pending_waitpoint(args: BufferSignalArgs) -> BufferSignalResult {
@@ -120,6 +122,8 @@ ff_function! {
             args.idempotency_key.as_ref().filter(|ik| !ik.is_empty()).map(|ik| {
                 k.ctx.signal_dedup(&args.waitpoint_id, ik)
             }).unwrap_or_else(|| k.ctx.noop()),                        // 7
+            k.ctx.waitpoint(&args.waitpoint_id),                       // 8
+            k.idx.waitpoint_hmac_secrets(),                            // 9
         }
         argv {
             args.signal_id.to_string(),                                // 1
@@ -141,6 +145,7 @@ ff_function! {
             String::new(),                                             // 15 resume_delay_ms (unused)
             String::new(),                                             // 16 signal_maxlen
             String::new(),                                             // 17 max_signals
+            args.waitpoint_token.as_str().to_owned(),                  // 18 (wire: raw, not redacted Display)
         }
     }
 }

--- a/crates/ff-script/src/functions/stream.rs
+++ b/crates/ff-script/src/functions/stream.rs
@@ -56,3 +56,235 @@ impl FromFcallResult for AppendFrameResult {
         })
     }
 }
+
+// ─── ff_read_attempt_stream ───────────────────────────────────────────
+//
+// Lua KEYS (2): stream_data, stream_meta
+// Lua ARGV (3): from_id, to_id, count_limit
+
+ff_function! {
+    pub ff_read_attempt_stream(args: ReadFramesArgs) -> ReadFramesResult {
+        keys(k: &StreamOpKeys<'_>) {
+            k.ctx.stream(args.attempt_index),              // 1
+            k.ctx.stream_meta(args.attempt_index),         // 2
+        }
+        argv {
+            args.from_id.clone(),                          // 1
+            args.to_id.clone(),                            // 2
+            args.count_limit.to_string(),                  // 3
+        }
+    }
+}
+
+impl FromFcallResult for ReadFramesResult {
+    fn from_fcall_result(raw: &ferriskey::Value) -> Result<Self, ScriptError> {
+        let r = FcallResult::parse(raw)?.into_success()?;
+        // Lua returns `ok(entries, closed_at, closed_reason)`.
+        // - entries: array of [entry_id, [f1, v1, ...]]
+        // - closed_at: string (ms timestamp) or "" if open
+        // - closed_reason: string or "" if open
+        let entries = r.fields.first().ok_or_else(|| {
+            ScriptError::Parse("ff_read_attempt_stream: missing entries field".into())
+        })?;
+        // XRANGE from a Valkey Function passes fields through as raw Lua
+        // arrays — no ArrayOfPairs conversion, so always Flat here.
+        let frames = parse_entries(entries, FieldShape::Flat)?;
+
+        let closed_at = r.field_str(1);
+        let closed_at = if closed_at.is_empty() {
+            None
+        } else {
+            closed_at
+                .parse::<i64>()
+                .ok()
+                .map(ff_core::types::TimestampMs::from_millis)
+        };
+
+        let closed_reason = r.field_str(2);
+        let closed_reason = if closed_reason.is_empty() {
+            None
+        } else {
+            Some(closed_reason)
+        };
+
+        Ok(ReadFramesResult::Frames(StreamFrames {
+            frames,
+            closed_at,
+            closed_reason,
+        }))
+    }
+}
+
+/// Explicit shape tag for stream-entry field payloads. Passed from the
+/// caller because each code path *knows* which shape ferriskey will emit —
+/// heuristic detection ("first entry looks like a 2-elem array") can
+/// mis-classify when field values happen to be arrays themselves.
+#[derive(Clone, Copy, Debug)]
+pub enum FieldShape {
+    /// Flat alternating `[k, v, k, v, ...]`. Emitted by raw Lua FCALL
+    /// replies and by RESP2 servers that bypass the ArrayOfPairs adapter.
+    Flat,
+    /// `[[k, v], [k, v], ...]` — ferriskey's `ArrayOfPairs` adapter for
+    /// XRANGE / XREAD direct commands.
+    Pairs,
+    /// RESP3 `{k: v, ...}` map.
+    Map,
+}
+
+/// Parse an XRANGE/XREAD-shaped `[entry_id, fields]` list.
+///
+/// Caller must tell us the field shape — see [`FieldShape`]. Inferring
+/// shape from data alone is unsound: any call site always knows whether
+/// it's reading a raw Lua payload (Flat), a ferriskey-adapted XRANGE/XREAD
+/// reply (Pairs), or a RESP3 Map.
+///
+/// Nil fields → an empty frame (no fields).
+pub(crate) fn parse_entries(
+    raw: &ferriskey::Value,
+    shape: FieldShape,
+) -> Result<Vec<StreamFrame>, ScriptError> {
+    let entries = match raw {
+        ferriskey::Value::Array(arr) => arr,
+        ferriskey::Value::Nil => return Ok(Vec::new()),
+        other => {
+            return Err(ScriptError::Parse(format!(
+                "XRANGE/XREAD entries: expected Array, got {other:?}"
+            )));
+        }
+    };
+
+    let mut frames = Vec::with_capacity(entries.len());
+    for entry in entries.iter() {
+        let entry = entry.as_ref().map_err(|e| {
+            ScriptError::Parse(format!("XRANGE entry error: {e}"))
+        })?;
+        let parts = match entry {
+            ferriskey::Value::Array(a) => a,
+            other => {
+                return Err(ScriptError::Parse(format!(
+                    "XRANGE entry: expected Array, got {other:?}"
+                )));
+            }
+        };
+        if parts.len() != 2 {
+            return Err(ScriptError::Parse(format!(
+                "XRANGE entry: expected 2 elements, got {}",
+                parts.len()
+            )));
+        }
+        let id = value_to_string(parts[0].as_ref().ok()).ok_or_else(|| {
+            ScriptError::Parse("XRANGE entry: missing/invalid id".into())
+        })?;
+
+        let field_val = match parts[1].as_ref() {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(ScriptError::Parse(format!(
+                    "XRANGE entry fields error: {e}"
+                )));
+            }
+        };
+        let fields = parse_fields_kv(field_val, shape)?;
+        frames.push(StreamFrame { id, fields });
+    }
+    Ok(frames)
+}
+
+/// Parse a stream-entry field payload into a sorted map, using an explicit
+/// [`FieldShape`] tag supplied by the caller.
+///
+/// `Value::Nil` always yields an empty map (entry exists but has no
+/// fields) regardless of `shape` — both XRANGE and XREAD can produce this
+/// for empty writes.
+pub(crate) fn parse_fields_kv(
+    v: &ferriskey::Value,
+    shape: FieldShape,
+) -> Result<std::collections::BTreeMap<String, String>, ScriptError> {
+    let mut out = std::collections::BTreeMap::new();
+    if matches!(v, ferriskey::Value::Nil) {
+        return Ok(out);
+    }
+    match shape {
+        FieldShape::Flat => {
+            let arr = match v {
+                ferriskey::Value::Array(arr) => arr,
+                other => {
+                    return Err(ScriptError::Parse(format!(
+                        "stream fields (Flat): expected Array, got {other:?}"
+                    )));
+                }
+            };
+            if !arr.len().is_multiple_of(2) {
+                return Err(ScriptError::Parse(format!(
+                    "stream fields (Flat): odd element count {}",
+                    arr.len()
+                )));
+            }
+            let mut i = 0;
+            while i < arr.len() {
+                let k = value_to_string(arr[i].as_ref().ok())
+                    .ok_or_else(|| ScriptError::Parse("stream field: bad key".into()))?;
+                let val = value_to_string(arr[i + 1].as_ref().ok()).unwrap_or_default();
+                out.insert(k, val);
+                i += 2;
+            }
+        }
+        FieldShape::Pairs => {
+            let arr = match v {
+                ferriskey::Value::Array(arr) => arr,
+                other => {
+                    return Err(ScriptError::Parse(format!(
+                        "stream fields (Pairs): expected Array, got {other:?}"
+                    )));
+                }
+            };
+            for pair in arr.iter() {
+                let inner = match pair.as_ref() {
+                    Ok(ferriskey::Value::Array(inner)) => inner,
+                    _ => {
+                        return Err(ScriptError::Parse(
+                            "stream fields (Pairs): expected 2-element Array per entry".into(),
+                        ));
+                    }
+                };
+                if inner.len() != 2 {
+                    return Err(ScriptError::Parse(format!(
+                        "stream fields (Pairs): expected len=2, got {}",
+                        inner.len()
+                    )));
+                }
+                let k = value_to_string(inner[0].as_ref().ok())
+                    .ok_or_else(|| ScriptError::Parse("stream field: bad key".into()))?;
+                let val = value_to_string(inner[1].as_ref().ok()).unwrap_or_default();
+                out.insert(k, val);
+            }
+        }
+        FieldShape::Map => {
+            let pairs = match v {
+                ferriskey::Value::Map(pairs) => pairs,
+                other => {
+                    return Err(ScriptError::Parse(format!(
+                        "stream fields (Map): expected Map, got {other:?}"
+                    )));
+                }
+            };
+            for (k, vv) in pairs {
+                let key = value_to_string(Some(k))
+                    .ok_or_else(|| ScriptError::Parse("stream field: bad key".into()))?;
+                let val = value_to_string(Some(vv)).unwrap_or_default();
+                out.insert(key, val);
+            }
+        }
+    }
+    Ok(out)
+}
+
+pub(crate) fn value_to_string(v: Option<&ferriskey::Value>) -> Option<String> {
+    match v? {
+        ferriskey::Value::BulkString(b) => Some(String::from_utf8_lossy(b).into_owned()),
+        ferriskey::Value::SimpleString(s) => Some(s.clone()),
+        ferriskey::Value::Int(n) => Some(n.to_string()),
+        ferriskey::Value::Okay => Some("OK".into()),
+        _ => None,
+    }
+}

--- a/crates/ff-script/src/functions/suspension.rs
+++ b/crates/ff-script/src/functions/suspension.rs
@@ -20,11 +20,12 @@ pub struct SuspendOpKeys<'a> {
 
 // ─── ff_suspend_execution ─────────────────────────────────────────────
 //
-// Lua KEYS (16): exec_core, attempt_record, lease_current, lease_history,
+// Lua KEYS (17): exec_core, attempt_record, lease_current, lease_history,
 //                lease_expiry_zset, worker_leases, suspension_current,
 //                waitpoint_hash, waitpoint_signals, suspension_timeout_zset,
 //                pending_wp_expiry_zset, active_index, suspended_zset,
-//                waitpoint_history, wp_condition, attempt_timeout_zset
+//                waitpoint_history, wp_condition, attempt_timeout_zset,
+//                hmac_secrets
 // Lua ARGV (17): execution_id, attempt_index, attempt_id, lease_id,
 //                lease_epoch, suspension_id, waitpoint_id, waitpoint_key,
 //                reason_code, requested_by, timeout_at, resume_condition_json,
@@ -50,6 +51,7 @@ ff_function! {
             k.ctx.waitpoints(),                                        // 14
             k.ctx.waitpoint_condition(&args.waitpoint_id),             // 15
             k.idx.attempt_timeout(),                                   // 16
+            k.idx.waitpoint_hmac_secrets(),                            // 17
         }
         argv {
             args.execution_id.to_string(),                             // 1
@@ -76,30 +78,34 @@ ff_function! {
 impl FromFcallResult for SuspendExecutionResult {
     fn from_fcall_result(raw: &ferriskey::Value) -> Result<Self, ScriptError> {
         let r = FcallResult::parse(raw)?;
-        // ALREADY_SATISFIED: {1, "ALREADY_SATISFIED", suspension_id, waitpoint_id, waitpoint_key}
+        // ALREADY_SATISFIED: {1, "ALREADY_SATISFIED", suspension_id, waitpoint_id, waitpoint_key, waitpoint_token}
         if r.status == "ALREADY_SATISFIED" {
             let sid = SuspensionId::parse(&r.field_str(0))
                 .map_err(|e| ScriptError::Parse(format!("bad suspension_id: {e}")))?;
             let wid = WaitpointId::parse(&r.field_str(1))
                 .map_err(|e| ScriptError::Parse(format!("bad waitpoint_id: {e}")))?;
             let wkey = r.field_str(2);
+            let token = WaitpointToken::new(r.field_str(3));
             return Ok(SuspendExecutionResult::AlreadySatisfied {
                 suspension_id: sid,
                 waitpoint_id: wid,
                 waitpoint_key: wkey,
+                waitpoint_token: token,
             });
         }
         let r = r.into_success()?;
-        // ok(suspension_id, waitpoint_id, waitpoint_key)
+        // ok(suspension_id, waitpoint_id, waitpoint_key, waitpoint_token)
         let sid = SuspensionId::parse(&r.field_str(0))
             .map_err(|e| ScriptError::Parse(format!("bad suspension_id: {e}")))?;
         let wid = WaitpointId::parse(&r.field_str(1))
             .map_err(|e| ScriptError::Parse(format!("bad waitpoint_id: {e}")))?;
         let wkey = r.field_str(2);
+        let token = WaitpointToken::new(r.field_str(3));
         Ok(SuspendExecutionResult::Suspended {
             suspension_id: sid,
             waitpoint_id: wid,
             waitpoint_key: wkey,
+            waitpoint_token: token,
         })
     }
 }
@@ -185,13 +191,15 @@ ff_function! {
 impl FromFcallResult for CreatePendingWaitpointResult {
     fn from_fcall_result(raw: &ferriskey::Value) -> Result<Self, ScriptError> {
         let r = FcallResult::parse(raw)?.into_success()?;
-        // ok(waitpoint_id, waitpoint_key)
+        // ok(waitpoint_id, waitpoint_key, waitpoint_token)
         let wid = WaitpointId::parse(&r.field_str(0))
             .map_err(|e| ScriptError::Parse(format!("bad waitpoint_id: {e}")))?;
         let wkey = r.field_str(1);
+        let token = WaitpointToken::new(r.field_str(2));
         Ok(CreatePendingWaitpointResult::Created {
             waitpoint_id: wid,
             waitpoint_key: wkey,
+            waitpoint_token: token,
         })
     }
 }

--- a/crates/ff-script/src/lib.rs
+++ b/crates/ff-script/src/lib.rs
@@ -7,6 +7,7 @@ pub mod result;
 pub mod loader;
 pub mod retry;
 pub mod functions;
+pub mod stream_tail;
 
 pub use error::ScriptError;
 pub use retry::{is_retryable_kind, kind_to_stable_str};
@@ -18,13 +19,15 @@ pub const LIBRARY_SOURCE: &str = include_str!(concat!(env!("OUT_DIR"), "/flowfab
 
 /// Expected library version. Must match `FCALL ff_version 0` return.
 ///
-/// Bump this (and the string returned by `lua/version.lua`'s `ff_version`)
-/// whenever any Lua function's KEYS or ARGV arity changes, or a new
-/// function is added. The loader compares this constant against the
-/// server's `ff_version` output; a mismatch triggers `FUNCTION LOAD
-/// REPLACE` so old binaries attached to a newly-upgraded Valkey don't
+/// **Single source of truth is `lua/version.lua`.** `build.rs` extracts the
+/// version string at compile time and injects it here via `env!()`. Do NOT
+/// hand-maintain a separate literal — the extract is the one knob. Bump
+/// `lua/version.lua` whenever any Lua function's KEYS or ARGV arity
+/// changes, or a new function is added. The loader compares this constant
+/// against the server's `ff_version` output; a mismatch triggers `FUNCTION
+/// LOAD REPLACE` so old binaries attached to a newly-upgraded Valkey don't
 /// call into a library whose key signatures they don't agree with.
-pub const LIBRARY_VERSION: &str = "2";
+pub const LIBRARY_VERSION: &str = env!("FLOWFABRIC_LUA_VERSION");
 
 // Re-export the trait so callers can use it without reaching into result.
 pub use result::FromFcallResult;

--- a/crates/ff-script/src/result.rs
+++ b/crates/ff-script/src/result.rs
@@ -74,13 +74,22 @@ impl FcallResult {
 
     /// If this is a failure result, convert the status string to a ScriptError.
     /// Returns Ok(self) if success.
+    ///
+    /// For variants carrying a detail payload (e.g. `CapabilityMismatch`,
+    /// `InvalidCapabilities`, `InvalidInput`) the first Lua-return field
+    /// is folded into the variant so callers can log the specifics of WHY
+    /// the call failed (which caps were missing, which bound was violated)
+    /// instead of an empty String placeholder.
     pub fn into_success(self) -> Result<Self, ScriptError> {
         if self.success {
             Ok(self)
         } else {
-            Err(ScriptError::from_code(&self.status).unwrap_or_else(|| {
-                ScriptError::Parse(format!("unknown error code: {}", self.status))
-            }))
+            let detail = value_to_string(self.fields.first());
+            let err = ScriptError::from_code_with_detail(&self.status, &detail)
+                .unwrap_or_else(|| {
+                    ScriptError::Parse(format!("unknown error code: {}", self.status))
+                });
+            Err(err)
         }
     }
 

--- a/crates/ff-script/src/stream_tail.rs
+++ b/crates/ff-script/src/stream_tail.rs
@@ -1,0 +1,293 @@
+//! Direct XREAD / XREAD BLOCK tail for attempt-scoped streams.
+//!
+//! XREAD BLOCK cannot run inside a Valkey Function (blocking commands are
+//! rejected by `FUNCTION`), so tailing is implemented as a direct client
+//! command against the same `ferriskey::Client` the server already holds.
+//!
+//! Semantics:
+//! - `block_ms == 0` → non-blocking `XREAD` (returns immediately)
+//! - `block_ms > 0`  → `XREAD BLOCK <ms>` (returns nil on timeout → empty result)
+//!
+//! Cluster-safe: the stream key carries the execution's `{p:N}` hash tag, so
+//! XREAD routes to the single owning slot.
+//!
+//! # Timeout interaction with the ferriskey client
+//!
+//! The client's configured `request_timeout` (5s on the server default) does
+//! NOT cap blocking tail calls. `ferriskey::client::get_request_timeout`
+//! inspects every outgoing cmd; for `XREAD`/`XREADGROUP` with a `BLOCK`
+//! argument, it returns `RequestTimeoutOption::BlockingCommand(block_ms +
+//! 500ms)` via `BLOCKING_CMD_TIMEOUT_EXTENSION`. That means a
+//! `block_ms = 30_000` call gets a 30_500ms effective timeout regardless of
+//! the client's default. No manual override is needed from this module.
+//!
+//! # Terminal signal (closed-stream propagation)
+//!
+//! After every XREAD/XREAD BLOCK we HMGET the sibling `stream_meta` hash
+//! to learn whether the producer has closed the stream (`closed_at` /
+//! `closed_reason`). This is the terminal-signal contract described in
+//! RFC-006 — consumers poll `tail_stream` until `is_closed()` is true,
+//! then drain any remaining frames.
+//!
+//! # Atomicity (XREAD vs HMGET)
+//!
+//! The XREAD and the follow-up HMGET are separate Valkey round trips. A
+//! close can land between them, so a caller can observe a result that
+//! was not simultaneously true at any single instant: `frames` reflect
+//! the stream as of T1, `closed_at`/`closed_reason` reflect
+//! `stream_meta` as of T2 > T1.
+//!
+//! This is correctness-safe. `ff_append_frame` gates on `closed_at`
+//! (see `lua/stream.lua`), so once the stream is closed no new frames
+//! can be appended — any frames returned by XREAD are guaranteed to be
+//! from before the close. The terminal signal arriving "slightly later"
+//! just means a tail loop may take one extra iteration to observe the
+//! closure. Consumers should treat `closed_at.is_some()` as the exit
+//! condition and perform a final `read_attempt_stream` drain from
+//! `last_seen_id` to `+` to pick up any frames that landed before close
+//! but after the tail's last read — see RFC-006 Impl Notes
+//! §"Terminal-signal drain pattern".
+
+use ff_core::contracts::{StreamFrame, StreamFrames, STREAM_READ_HARD_CAP};
+use ff_core::types::TimestampMs;
+use ferriskey::{Client, Value};
+
+use crate::error::ScriptError;
+use crate::functions::stream::{parse_entries, parse_fields_kv, value_to_string, FieldShape};
+
+/// Tail frames from `stream_key`, blocking up to `block_ms` (0 = no block).
+///
+/// `last_id` is the exclusive cursor — XREAD returns entries with id > last_id.
+/// Pass `"0-0"` (or `"0"`) to read from the beginning.
+///
+/// Returns a [`StreamFrames`] with `frames=Vec::new()` on timeout or when
+/// the stream has no new entries. The `closed_at`/`closed_reason` fields
+/// are populated from `stream_meta` on every call so consumers can stop
+/// polling when the producer finalizes the stream.
+///
+/// `count_limit` must be `>= 1` and `<= STREAM_READ_HARD_CAP`. This
+/// mirrors [`crate::functions::stream::ff_read_attempt_stream`] and the
+/// REST/SDK boundaries; callers that silently clamped to 0 previously must
+/// now pass `STREAM_READ_HARD_CAP` explicitly.
+///
+/// # Timeout handling
+///
+/// For blocking calls (`block_ms > 0`), the ferriskey client automatically
+/// extends its `request_timeout` to `block_ms + 500ms` for the duration of
+/// this command. Callers do not need to (and should not) pass a custom
+/// client with a larger `request_timeout` just to accommodate tail. See the
+/// module-level docs for the exact ferriskey code path.
+pub async fn xread_block(
+    client: &Client,
+    stream_key: &str,
+    stream_meta_key: &str,
+    last_id: &str,
+    block_ms: u64,
+    count_limit: u64,
+) -> Result<StreamFrames, ScriptError> {
+    // These are input-validation errors — `InvalidInput` is the right
+    // class (Terminal per `ScriptError::class()`). `Parse` is reserved for
+    // FCALL-result parse failures per the contract, so using it here
+    // would mislead callers that route retry decisions off the variant.
+    if count_limit == 0 {
+        return Err(ScriptError::InvalidInput(
+            "xread_block: count_limit must be >= 1".into(),
+        ));
+    }
+    if count_limit > STREAM_READ_HARD_CAP {
+        return Err(ScriptError::InvalidInput(format!(
+            "xread_block: count_limit exceeds STREAM_READ_HARD_CAP ({STREAM_READ_HARD_CAP})"
+        )));
+    }
+    debug_assert!(
+        STREAM_READ_HARD_CAP as i128 <= i64::MAX as i128,
+        "STREAM_READ_HARD_CAP must fit in i64 — RESP COUNT arg"
+    );
+
+    let cmd = client.cmd("XREAD").arg("COUNT").arg(count_limit);
+    let cmd = if block_ms > 0 {
+        cmd.arg("BLOCK").arg(block_ms)
+    } else {
+        cmd
+    };
+    let cmd = cmd.arg("STREAMS").arg(stream_key).arg(last_id);
+
+    let raw: Value = cmd.execute().await.map_err(ScriptError::Valkey)?;
+
+    let frames = parse_xread_reply(&raw, stream_key)?;
+
+    // Fetch terminal markers separately. HMGET on a missing key returns
+    // [nil, nil] which normalizes to (None, None) — an in-progress /
+    // never-written attempt is indistinguishable from "still open" here,
+    // which is the intended semantics.
+    let (closed_at, closed_reason) = fetch_closed_meta(client, stream_meta_key).await?;
+
+    Ok(StreamFrames { frames, closed_at, closed_reason })
+}
+
+async fn fetch_closed_meta(
+    client: &Client,
+    stream_meta_key: &str,
+) -> Result<(Option<TimestampMs>, Option<String>), ScriptError> {
+    let values: Vec<Option<String>> = client
+        .cmd("HMGET")
+        .arg(stream_meta_key)
+        .arg("closed_at")
+        .arg("closed_reason")
+        .execute()
+        .await
+        .map_err(ScriptError::Valkey)?;
+
+    let closed_at = values
+        .first()
+        .and_then(|v| v.as_deref())
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<i64>().ok())
+        .map(TimestampMs::from_millis);
+    let closed_reason = values
+        .get(1)
+        .and_then(|v| v.clone())
+        .filter(|s| !s.is_empty());
+    Ok((closed_at, closed_reason))
+}
+
+/// Parse an XREAD reply into frames for a single stream.
+///
+/// Handles every shape ferriskey can produce:
+/// - `Value::Nil` on BLOCK timeout or no new entries → `Vec::new()`
+/// - `Value::Map({stream_key: Map({entry_id: fields, ...})})` — RESP3
+/// - `Value::Map({stream_key: Array([[entry_id, fields], ...])})` — mixed
+/// - `Value::Array([[stream_key, [[entry_id, fields], ...]], ...])` — RESP2
+///
+/// Per-entry field payloads are always decoded with `FieldShape::Pairs`
+/// because ferriskey's XREAD adapter (`ArrayOfPairs`) is unconditional for
+/// the XREAD command family — see `ferriskey::client::value_conversion`.
+fn parse_xread_reply(raw: &Value, stream_key: &str) -> Result<Vec<StreamFrame>, ScriptError> {
+    let outer = match raw {
+        Value::Nil => return Ok(Vec::new()),
+        Value::Map(m) => m,
+        // RESP2 fallback: array of [stream_key, entries] pairs.
+        Value::Array(arr) => {
+            let mut non_match_count: usize = 0;
+            for entry in arr {
+                let Ok(Value::Array(pair)) = entry.as_ref() else {
+                    non_match_count += 1;
+                    continue;
+                };
+                if pair.len() != 2 {
+                    non_match_count += 1;
+                    continue;
+                }
+                let matches_key = match pair[0].as_ref() {
+                    Ok(Value::BulkString(b)) => b.as_ref() == stream_key.as_bytes(),
+                    Ok(Value::SimpleString(s)) => s == stream_key,
+                    _ => false,
+                };
+                if !matches_key {
+                    non_match_count += 1;
+                    continue;
+                }
+                let entries_val = match pair[1].as_ref() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(ScriptError::Parse(format!(
+                            "XREAD entries (RESP2): {e}"
+                        )));
+                    }
+                };
+                return parse_entries_any(entries_val);
+            }
+            if non_match_count > 0 {
+                tracing::trace!(
+                    non_match = non_match_count,
+                    stream_key,
+                    "XREAD RESP2 reply had entries but none matched the requested stream key"
+                );
+            }
+            return Ok(Vec::new());
+        }
+        other => {
+            return Err(ScriptError::Parse(format!(
+                "XREAD: expected Map/Nil/Array, got {other:?}"
+            )));
+        }
+    };
+
+    let mut non_match_count: usize = 0;
+    for (k, v) in outer.iter() {
+        let matches_key = match k {
+            Value::BulkString(b) => b.as_ref() == stream_key.as_bytes(),
+            Value::SimpleString(s) => s == stream_key,
+            _ => false,
+        };
+        if !matches_key {
+            non_match_count += 1;
+            continue;
+        }
+        let frames = match v {
+            // ferriskey's XREAD adapter (`Map { key: BulkString, value: Map
+            // { key: BulkString, value: ArrayOfPairs }}`) produces a
+            // `Map<entry_id, ArrayOfPairs-fields>` here — keys lift to Map
+            // but field payloads retain the Pairs shape.
+            Value::Map(entries) => {
+                let mut frames = Vec::with_capacity(entries.len());
+                for (id_v, field_v) in entries {
+                    let id = value_to_string(Some(id_v))
+                        .ok_or_else(|| ScriptError::Parse("XREAD entry: bad id".into()))?;
+                    let fields = parse_fields_kv(field_v, FieldShape::Pairs)?;
+                    frames.push(StreamFrame { id, fields });
+                }
+                frames
+            }
+            Value::Array(arr) => {
+                if arr.is_empty() {
+                    tracing::trace!(
+                        stream_key,
+                        "XREAD reply matched stream key but entries Array was empty — possible \
+                         malformed reply"
+                    );
+                }
+                parse_entries_any(v)?
+            }
+            Value::Nil => Vec::new(),
+            other => {
+                return Err(ScriptError::Parse(format!(
+                    "XREAD entries: expected Map/Array, got {other:?}"
+                )));
+            }
+        };
+        return Ok(frames);
+    }
+    if non_match_count > 0 {
+        tracing::trace!(
+            non_match = non_match_count,
+            stream_key,
+            "XREAD Map reply had entries but none matched the requested stream key"
+        );
+    }
+    Ok(Vec::new())
+}
+
+/// Parse an Array-of-entries (or Map-of-entries) payload. Used for the
+/// inner XREAD entry list — field shape is always `Pairs` because that's
+/// what ferriskey's `ArrayOfPairs` XREAD adapter emits even when the outer
+/// stream/entry wrappers are lifted to `Map`.
+fn parse_entries_any(raw: &Value) -> Result<Vec<StreamFrame>, ScriptError> {
+    match raw {
+        Value::Nil => Ok(Vec::new()),
+        Value::Array(_) => parse_entries(raw, FieldShape::Pairs),
+        Value::Map(map) => {
+            let mut frames = Vec::with_capacity(map.len());
+            for (id_v, field_v) in map {
+                let id = value_to_string(Some(id_v))
+                    .ok_or_else(|| ScriptError::Parse("XREAD entry: bad id".into()))?;
+                let fields = parse_fields_kv(field_v, FieldShape::Pairs)?;
+                frames.push(StreamFrame { id, fields });
+            }
+            Ok(frames)
+        }
+        other => Err(ScriptError::Parse(format!(
+            "XREAD entries: expected Array/Map/Nil, got {other:?}"
+        ))),
+    }
+}

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -47,8 +47,9 @@ pub mod worker;
 // Re-exports for convenience
 pub use config::WorkerConfig;
 pub use task::{
-    AppendFrameOutcome, ClaimedTask, ConditionMatcher, FailOutcome, Signal, SignalOutcome,
-    SuspendOutcome, TimeoutBehavior,
+    read_stream, tail_stream, AppendFrameOutcome, ClaimedTask, ConditionMatcher, FailOutcome,
+    Signal, SignalOutcome, StreamFrames, SuspendOutcome, TimeoutBehavior, MAX_TAIL_BLOCK_MS,
+    STREAM_READ_HARD_CAP,
 };
 pub use worker::FlowFabricWorker;
 

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -74,6 +74,8 @@ pub enum SuspendOutcome {
         suspension_id: SuspensionId,
         waitpoint_id: WaitpointId,
         waitpoint_key: String,
+        /// HMAC token that signal deliverers must supply to this waitpoint.
+        waitpoint_token: WaitpointToken,
     },
     /// Buffered signals already satisfied the condition — suspension skipped.
     /// The caller still holds the lease.
@@ -81,6 +83,7 @@ pub enum SuspendOutcome {
         suspension_id: SuspensionId,
         waitpoint_id: WaitpointId,
         waitpoint_key: String,
+        waitpoint_token: WaitpointToken,
     },
 }
 
@@ -93,6 +96,9 @@ pub struct Signal {
     pub source_type: String,
     pub source_identity: String,
     pub idempotency_key: Option<String>,
+    /// HMAC token issued when the waitpoint was created. Required for
+    /// authenticated signal delivery (RFC-004 §Waitpoint Security).
+    pub waitpoint_token: WaitpointToken,
 }
 
 /// Outcome of `deliver_signal()`.
@@ -714,11 +720,15 @@ impl ClaimedTask {
     /// waitpoint are buffered. When the worker later calls `suspend()` with
     /// `use_pending_waitpoint`, buffered signals may immediately satisfy the
     /// resume condition.
+    ///
+    /// Returns both the waitpoint_id AND the HMAC token required by external
+    /// callers to buffer signals against this pending waitpoint
+    /// (RFC-004 §Waitpoint Security).
     pub async fn create_pending_waitpoint(
         &self,
         waitpoint_key: &str,
         expires_in_ms: u64,
-    ) -> Result<WaitpointId, SdkError> {
+    ) -> Result<(WaitpointId, WaitpointToken), SdkError> {
         let partition = execution_partition(&self.execution_id, &self.partition_config);
         let ctx = ExecKeyContext::new(&partition, &self.execution_id);
         let idx = IndexKeys::new(&partition);
@@ -726,11 +736,12 @@ impl ClaimedTask {
         let waitpoint_id = WaitpointId::new();
         let expires_at = TimestampMs::from_millis(TimestampMs::now().0 + expires_in_ms as i64);
 
-        // KEYS (3): exec_core, waitpoint_hash, pending_wp_expiry_zset
+        // KEYS (4): exec_core, waitpoint_hash, pending_wp_expiry_zset, hmac_secrets
         let keys: Vec<String> = vec![
             ctx.core(),
             ctx.waitpoint(&waitpoint_id),
             idx.pending_waitpoint_expiry(),
+            idx.waitpoint_hmac_secrets(),
         ];
 
         // ARGV (5): execution_id, attempt_index, waitpoint_id, waitpoint_key, expires_at
@@ -751,8 +762,10 @@ impl ClaimedTask {
             .await
             .map_err(SdkError::Valkey)?;
 
-        parse_success_result(&raw, "ff_create_pending_waitpoint")?;
-        Ok(waitpoint_id)
+        // Response: {1, "OK", waitpoint_id, waitpoint_key, waitpoint_token}.
+        // Extract the token (the waitpoint_id is the one we generated locally).
+        let token = extract_pending_waitpoint_token(&raw)?;
+        Ok((waitpoint_id, token))
     }
 
     // ── Phase 4: Streaming ──
@@ -867,11 +880,11 @@ impl ClaimedTask {
             "retain_signal_buffer_until_closed": true,
         }).to_string();
 
-        // KEYS (16): exec_core, attempt_record, lease_current, lease_history,
+        // KEYS (17): exec_core, attempt_record, lease_current, lease_history,
         //            lease_expiry, worker_leases, suspension_current, waitpoint_hash,
         //            waitpoint_signals, suspension_timeout, pending_wp_expiry,
         //            active_index, suspended_index, waitpoint_history, wp_condition,
-        //            attempt_timeout
+        //            attempt_timeout, hmac_secrets
         let keys: Vec<String> = vec![
             ctx.core(),                                          // 1
             ctx.attempt_hash(self.attempt_index),                // 2
@@ -889,6 +902,7 @@ impl ClaimedTask {
             ctx.waitpoints(),                                    // 14
             ctx.waitpoint_condition(&waitpoint_id),              // 15
             idx.attempt_timeout(),                               // 16
+            idx.waitpoint_hmac_secrets(),                        // 17
         ];
 
         // ARGV (17): execution_id, attempt_index, attempt_id, lease_id,
@@ -1150,8 +1164,9 @@ fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkError>
     };
     if status_code != 1 {
         let error_code = usage_field_str(arr, 1);
+        let detail = usage_field_str(arr, 2);
         return Err(SdkError::Script(
-            ScriptError::from_code(&error_code).unwrap_or_else(|| {
+            ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_report_usage_and_check: {error_code}"))
             }),
         ));
@@ -1192,6 +1207,31 @@ fn usage_field_str(arr: &[Result<Value, ferriskey::Error>], index: usize) -> Str
 }
 
 /// Parse a standard {1, "OK", ...} / {0, "error", ...} FCALL result.
+/// Extract the waitpoint_token (field index 4 in the 0-indexed response array)
+/// from an `ff_create_pending_waitpoint` reply. Runs `parse_success_result`
+/// first so error cases produce the usual typed error, not a parse failure.
+fn extract_pending_waitpoint_token(raw: &Value) -> Result<WaitpointToken, SdkError> {
+    parse_success_result(raw, "ff_create_pending_waitpoint")?;
+    let arr = match raw {
+        Value::Array(arr) => arr,
+        _ => unreachable!("parse_success_result would have rejected non-array"),
+    };
+    // Layout: [0]=1, [1]="OK", [2]=waitpoint_id, [3]=waitpoint_key, [4]=waitpoint_token
+    let token_str = arr
+        .get(4)
+        .and_then(|v| match v {
+            Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+            Ok(Value::SimpleString(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            SdkError::Script(ScriptError::Parse(
+                "ff_create_pending_waitpoint: missing waitpoint_token in response".into(),
+            ))
+        })?;
+    Ok(WaitpointToken::new(token_str))
+}
+
 pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(), SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,
@@ -1220,19 +1260,29 @@ pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(
     if status_code == 1 {
         Ok(())
     } else {
-        // Extract error code from index 1
-        let error_code = arr
-            .get(1)
-            .and_then(|v| match v {
-                Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                Ok(Value::SimpleString(s)) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_owned());
+        // Extract error code from index 1 and optional detail from index 2
+        // (e.g. `capability_mismatch` ships missing tokens there). Variants
+        // that carry a String payload pick the detail up via
+        // `from_code_with_detail`; other variants ignore it.
+        let field_str = |idx: usize| -> String {
+            arr.get(idx)
+                .and_then(|v| match v {
+                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                    Ok(Value::SimpleString(s)) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        };
+        let error_code = {
+            let s = field_str(1);
+            if s.is_empty() { "unknown".to_owned() } else { s }
+        };
+        let detail = field_str(2);
 
-        let script_err = ScriptError::from_code(&error_code).unwrap_or_else(|| {
-            ScriptError::Parse(format!("{function_name}: unknown error: {error_code}"))
-        });
+        let script_err = ScriptError::from_code_with_detail(&error_code, &detail)
+            .unwrap_or_else(|| {
+                ScriptError::Parse(format!("{function_name}: unknown error: {error_code}"))
+            });
 
         Err(SdkError::Script(script_err))
     }
@@ -1266,16 +1316,22 @@ fn parse_suspend_result(
     };
 
     if status_code != 1 {
-        let error_code = arr
-            .get(1)
-            .and_then(|v| match v {
-                Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                Ok(Value::SimpleString(s)) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_owned());
+        let err_field_str = |idx: usize| -> String {
+            arr.get(idx)
+                .and_then(|v| match v {
+                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                    Ok(Value::SimpleString(s)) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        };
+        let error_code = {
+            let s = err_field_str(1);
+            if s.is_empty() { "unknown".to_owned() } else { s }
+        };
+        let detail = err_field_str(2);
         return Err(SdkError::Script(
-            ScriptError::from_code(&error_code).unwrap_or_else(|| {
+            ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_suspend_execution: {error_code}"))
             }),
         ));
@@ -1291,17 +1347,37 @@ fn parse_suspend_result(
         })
         .unwrap_or_default();
 
+    // Lua returns: {1, status, suspension_id, waitpoint_id, waitpoint_key, waitpoint_token}
+    // The suspension_id/waitpoint_id/waitpoint_key values the worker passed in are
+    // authoritative (Lua echoes them); waitpoint_token however is MINTED by Lua and
+    // must be read from the response.
+    let waitpoint_token = arr
+        .get(5)
+        .and_then(|v| match v {
+            Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+            Ok(Value::SimpleString(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .map(WaitpointToken::new)
+        .ok_or_else(|| {
+            SdkError::Script(ScriptError::Parse(
+                "ff_suspend_execution: missing waitpoint_token in response".into(),
+            ))
+        })?;
+
     if sub_status == "ALREADY_SATISFIED" {
         Ok(SuspendOutcome::AlreadySatisfied {
             suspension_id,
             waitpoint_id,
             waitpoint_key,
+            waitpoint_token,
         })
     } else {
         Ok(SuspendOutcome::Suspended {
             suspension_id,
             waitpoint_id,
             waitpoint_key,
+            waitpoint_token,
         })
     }
 }
@@ -1329,16 +1405,22 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
     };
 
     if status_code != 1 {
-        let error_code = arr
-            .get(1)
-            .and_then(|v| match v {
-                Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                Ok(Value::SimpleString(s)) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_owned());
+        let err_field_str = |idx: usize| -> String {
+            arr.get(idx)
+                .and_then(|v| match v {
+                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                    Ok(Value::SimpleString(s)) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        };
+        let error_code = {
+            let s = err_field_str(1);
+            if s.is_empty() { "unknown".to_owned() } else { s }
+        };
+        let detail = err_field_str(2);
         return Err(SdkError::Script(
-            ScriptError::from_code(&error_code).unwrap_or_else(|| {
+            ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_deliver_signal: {error_code}"))
             }),
         ));
@@ -1420,16 +1502,22 @@ fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError
     };
 
     if status_code != 1 {
-        let error_code = arr
-            .get(1)
-            .and_then(|v| match v {
-                Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                Ok(Value::SimpleString(s)) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_owned());
+        let err_field_str = |idx: usize| -> String {
+            arr.get(idx)
+                .and_then(|v| match v {
+                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                    Ok(Value::SimpleString(s)) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        };
+        let error_code = {
+            let s = err_field_str(1);
+            if s.is_empty() { "unknown".to_owned() } else { s }
+        };
+        let detail = err_field_str(2);
         return Err(SdkError::Script(
-            ScriptError::from_code(&error_code).unwrap_or_else(|| {
+            ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_append_frame: {error_code}"))
             }),
         ));
@@ -1484,16 +1572,22 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
     };
 
     if status_code != 1 {
-        let error_code = arr
-            .get(1)
-            .and_then(|v| match v {
-                Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                Ok(Value::SimpleString(s)) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_owned());
+        let err_field_str = |idx: usize| -> String {
+            arr.get(idx)
+                .and_then(|v| match v {
+                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                    Ok(Value::SimpleString(s)) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        };
+        let error_code = {
+            let s = err_field_str(1);
+            if s.is_empty() { "unknown".to_owned() } else { s }
+        };
+        let detail = err_field_str(2);
         return Err(SdkError::Script(
-            ScriptError::from_code(&error_code).unwrap_or_else(|| {
+            ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_fail_execution: {error_code}"))
             }),
         ));
@@ -1532,4 +1626,186 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
             "ff_fail_execution: unexpected sub-status: {sub_status}"
         )))),
     }
+}
+
+// ── Stream read / tail (consumer API, RFC-006 #2) ──
+
+/// Maximum tail block duration accepted by [`tail_stream`]. Mirrors the REST
+/// endpoint ceiling so SDK callers can't wedge a connection longer than the
+/// server would accept.
+pub const MAX_TAIL_BLOCK_MS: u64 = 30_000;
+
+/// Maximum frames per read/tail call. Mirrors
+/// `ff_core::contracts::STREAM_READ_HARD_CAP` — re-exported here so SDK
+/// callers don't need to import ff-core just to read the bound.
+pub use ff_core::contracts::STREAM_READ_HARD_CAP;
+
+/// Result of [`read_stream`] / [`tail_stream`] — frames plus the terminal
+/// signal so polling consumers can exit cleanly.
+///
+/// Re-export of `ff_core::contracts::StreamFrames` for SDK ergonomics.
+pub use ff_core::contracts::StreamFrames;
+
+fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
+    if count_limit == 0 {
+        return Err(SdkError::Config("count_limit must be >= 1".to_owned()));
+    }
+    if count_limit > STREAM_READ_HARD_CAP {
+        return Err(SdkError::Config(format!(
+            "count_limit exceeds STREAM_READ_HARD_CAP ({STREAM_READ_HARD_CAP})"
+        )));
+    }
+    Ok(())
+}
+
+/// Read frames from a completed or in-flight attempt's stream.
+///
+/// `from_id` / `to_id` accept XRANGE special markers (`"-"`, `"+"`) or
+/// entry IDs. `count_limit` MUST be in `1..=STREAM_READ_HARD_CAP` —
+/// `0` returns [`SdkError::Config`].
+///
+/// Returns a [`StreamFrames`] including `closed_at`/`closed_reason` so
+/// consumers know when the producer has finalized the stream. A
+/// never-written attempt and an in-progress stream are indistinguishable
+/// here — both present as `frames=[]`, `closed_at=None`.
+///
+/// Intended for consumers (audit, checkpoint replay) that hold a ferriskey
+/// client but are not the lease-holding worker — no lease check is
+/// performed.
+///
+/// # Head-of-line note
+///
+/// A max-limit XRANGE reply (10_000 frames × ~64 KB each) is a
+/// multi-MB reply serialized on one TCP socket. Like [`tail_stream`],
+/// calling this on a `client` that is also serving FCALLs stalls those
+/// FCALLs behind the reply. The REST server isolates reads on its
+/// `tail_client`; direct SDK callers should either use a dedicated
+/// client OR paginate through smaller `count_limit` slices.
+pub async fn read_stream(
+    client: &Client,
+    partition_config: &PartitionConfig,
+    execution_id: &ExecutionId,
+    attempt_index: AttemptIndex,
+    from_id: &str,
+    to_id: &str,
+    count_limit: u64,
+) -> Result<StreamFrames, SdkError> {
+    use ff_core::contracts::{ReadFramesArgs, ReadFramesResult};
+    validate_stream_read_count(count_limit)?;
+
+    let partition = execution_partition(execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, execution_id);
+    let keys = ff_script::functions::stream::StreamOpKeys { ctx: &ctx };
+
+    let args = ReadFramesArgs {
+        execution_id: execution_id.clone(),
+        attempt_index,
+        from_id: from_id.to_owned(),
+        to_id: to_id.to_owned(),
+        count_limit,
+    };
+
+    let ReadFramesResult::Frames(f) =
+        ff_script::functions::stream::ff_read_attempt_stream(client, &keys, &args)
+            .await
+            .map_err(SdkError::Script)?;
+    Ok(f)
+}
+
+/// Tail a live attempt's stream.
+///
+/// `last_id` is exclusive — XREAD returns entries with id strictly greater
+/// than `last_id`. Pass `"0-0"` to start from the beginning.
+///
+/// `block_ms == 0` → non-blocking peek. `block_ms > 0` → blocks up to that
+/// many ms. Rejects `block_ms > MAX_TAIL_BLOCK_MS` and `count_limit`
+/// outside `1..=STREAM_READ_HARD_CAP` with [`SdkError::Config`] to keep
+/// SDK and REST ceilings aligned.
+///
+/// Returns a [`StreamFrames`] including `closed_at`/`closed_reason` —
+/// polling consumers should loop until `result.is_closed()` is true, then
+/// drain and exit. Timeout with no new frames presents as
+/// `frames=[], closed_at=None`.
+///
+/// # Head-of-line warning — use a dedicated client
+///
+/// `ferriskey::Client` is a pipelined multiplexed connection; Valkey
+/// processes commands FIFO on it. `XREAD BLOCK block_ms` does not yield
+/// the read side until a frame arrives or the block elapses. If the
+/// `client` you pass here is ALSO used for claims, completes, fails,
+/// appends, or any other FCALL, a 30-second tail will stall all those
+/// calls for up to 30 seconds.
+///
+/// **Strongly recommended**: build a separate `ferriskey::Client` for
+/// tail callers — mirrors the `Server::tail_client` split that the REST
+/// server uses internally (see `crates/ff-server/src/server.rs` and
+/// RFC-006 Impl Notes §"Dedicated stream-op connection").
+///
+/// # Tail parallelism caveat (same mux)
+///
+/// Even a dedicated tail client is still one multiplexed TCP connection.
+/// Valkey processes `XREAD BLOCK` calls FIFO on that one socket, and
+/// ferriskey's per-call `request_timeout` starts at future-poll — so
+/// two concurrent tails against the same client can time out spuriously:
+/// the second call's BLOCK budget elapses while it waits for the first
+/// BLOCK to return. The REST server handles this internally with a
+/// `tokio::sync::Mutex` that serializes `xread_block` calls, giving
+/// each call its full `block_ms` budget at the server.
+///
+/// **Direct SDK callers that need concurrent tails**: either
+///   (1) build ONE `ferriskey::Client` per concurrent tail call (a small
+///       pool of clients, rotated by the caller), OR
+///   (2) wrap `tail_stream` calls in your own `tokio::sync::Mutex` so
+///       only one BLOCK is in flight per client at a time.
+/// If you need the REST-side backpressure (429 on contention) and the
+/// built-in serializer, go through the
+/// `/v1/executions/{eid}/attempts/{idx}/stream/tail` endpoint rather
+/// than calling this directly.
+///
+/// This SDK does not enforce either pattern — the mutex belongs at the
+/// application layer, and the connection pool belongs at the SDK
+/// caller's DI layer; neither has a structured place inside this
+/// helper.
+///
+/// # Timeout handling
+///
+/// Blocking calls do not hit ferriskey's default `request_timeout` (5s on
+/// the server default). For `XREAD`/`XREADGROUP` with a `BLOCK` argument,
+/// ferriskey's `get_request_timeout` returns `BlockingCommand(block_ms +
+/// 500ms)`, overriding the client's default per-call. A tail with
+/// `block_ms = 30_000` gets a 30_500ms effective transport timeout even if
+/// the client was built with a shorter `request_timeout`. No custom client
+/// configuration is required for timeout reasons — only for head-of-line
+/// isolation above.
+pub async fn tail_stream(
+    client: &Client,
+    partition_config: &PartitionConfig,
+    execution_id: &ExecutionId,
+    attempt_index: AttemptIndex,
+    last_id: &str,
+    block_ms: u64,
+    count_limit: u64,
+) -> Result<StreamFrames, SdkError> {
+    if block_ms > MAX_TAIL_BLOCK_MS {
+        return Err(SdkError::Config(format!(
+            "block_ms exceeds {MAX_TAIL_BLOCK_MS}ms ceiling"
+        )));
+    }
+    validate_stream_read_count(count_limit)?;
+
+    let partition = execution_partition(execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, execution_id);
+    let stream_key = ctx.stream(attempt_index);
+    let stream_meta_key = ctx.stream_meta(attempt_index);
+
+    ff_script::stream_tail::xread_block(
+        client,
+        &stream_key,
+        &stream_meta_key,
+        last_id,
+        block_ms,
+        count_limit,
+    )
+    .await
+    .map_err(SdkError::Script)
 }

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -282,18 +282,13 @@ impl FlowFabricWorker {
             csv
         };
 
-        // FNV-1a 8-hex digest of the sorted caps CSV, computed once so
-        // per-mismatch logs carry a stable short identifier instead of the
-        // 4KB CSV. Matches ff-scheduler::claim::worker_caps_digest.
+        // Short stable digest of the sorted caps CSV, computed once so
+        // per-mismatch logs carry a stable identifier instead of the 4KB
+        // CSV. Shared helper — ff-scheduler uses the same one for its
+        // own per-mismatch logs, so cross-component log lines are
+        // diffable against each other.
         #[cfg(feature = "insecure-direct-claim")]
-        let worker_capabilities_hash = {
-            let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-            for b in worker_capabilities_csv.as_bytes() {
-                h ^= u64::from(*b);
-                h = h.wrapping_mul(0x100_0000_01b3);
-            }
-            format!("{:08x}", (h as u32) ^ ((h >> 32) as u32))
-        };
+        let worker_capabilities_hash = ff_core::hash::fnv1a_xor8hex(&worker_capabilities_csv);
 
         // Full CSV logged once at connect so per-mismatch logs (which
         // carry only the 8-hex hash) can be cross-referenced by ops.
@@ -1190,12 +1185,7 @@ fn scan_cursor_seed(worker_instance_id: &str, num_partitions: usize) -> usize {
     if num_partitions == 0 {
         return 0;
     }
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in worker_instance_id.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100_0000_01b3);
-    }
-    (hash as usize) % num_partitions
+    (ff_core::hash::fnv1a_u64(worker_instance_id.as_bytes()) as usize) % num_partitions
 }
 
 #[cfg(feature = "insecure-direct-claim")]

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -51,6 +51,19 @@ pub struct FlowFabricWorker {
     client: Client,
     config: WorkerConfig,
     partition_config: PartitionConfig,
+    /// Sorted, deduplicated, comma-separated capabilities — computed once
+    /// from `config.capabilities` at connect time. Passed as ARGV[9] to
+    /// `ff_issue_claim_grant` on every claim. BTreeSet sorting is critical:
+    /// Lua's `ff_issue_claim_grant` relies on a stable CSV form for
+    /// reproducible logs and tests.
+    #[cfg(feature = "insecure-direct-claim")]
+    worker_capabilities_csv: String,
+    /// 8-hex FNV-1a digest of `worker_capabilities_csv`. Used in
+    /// per-mismatch logs so the 4KB CSV never echoes on every reject
+    /// during an incident. Full CSV logged once at connect-time WARN for
+    /// cross-reference. Mirrors `ff-scheduler::claim::worker_caps_digest`.
+    #[cfg(feature = "insecure-direct-claim")]
+    worker_capabilities_hash: String,
     #[cfg(feature = "insecure-direct-claim")]
     lane_index: AtomicUsize,
     #[cfg(feature = "insecure-direct-claim")]
@@ -202,10 +215,194 @@ impl FlowFabricWorker {
             partition_config.num_execution_partitions.max(1) as usize,
         );
 
+        // Sort + dedupe capabilities into a stable CSV. BTreeSet both sorts
+        // and deduplicates in one pass; string joining happens once here.
+        //
+        // Ingress validation mirrors Scheduler::claim_for_worker (ff-scheduler):
+        //   - `,` is the CSV delimiter; a token containing one would split
+        //     mid-parse and could let a {"gpu"} worker appear to satisfy
+        //     {"gpu,cuda"} (silent auth bypass).
+        //   - Empty strings would produce leading/adjacent commas on the
+        //     wire and inflate token count for no semantic reason.
+        //   - Non-printable / whitespace chars: `"gpu "` vs `"gpu"` or
+        //     `"gpu\n"` vs `"gpu"` produce silent mismatches that are
+        //     miserable to debug. Reject anything outside printable ASCII
+        //     excluding space (`'!'..='~'`) at ingress so a typo fails
+        //     loudly at connect instead of silently mis-routing forever.
+        // Reject at boot so operator misconfig is loud, symmetric with the
+        // scheduler path.
+        #[cfg(feature = "insecure-direct-claim")]
+        for cap in &config.capabilities {
+            if cap.is_empty() {
+                return Err(SdkError::Config(
+                    "capability token must not be empty".into(),
+                ));
+            }
+            if cap.contains(',') {
+                return Err(SdkError::Config(format!(
+                    "capability token may not contain ',' (CSV delimiter): {cap:?}"
+                )));
+            }
+            // Reject ASCII control bytes (0x00-0x1F, 0x7F) and any ASCII
+            // whitespace (space, tab, LF, CR, FF, VT). UTF-8 printable
+            // characters above 0x7F are ALLOWED so i18n caps like
+            // "东京-gpu" can be used. The CSV wire form is byte-safe for
+            // multibyte UTF-8 because `,` is always a single byte and
+            // never part of a multibyte continuation (only 0x80-0xBF are
+            // continuations, ',' is 0x2C).
+            if cap.chars().any(|c| c.is_control() || c.is_whitespace()) {
+                return Err(SdkError::Config(format!(
+                    "capability token must not contain whitespace or control characters: {cap:?}"
+                )));
+            }
+        }
+        #[cfg(feature = "insecure-direct-claim")]
+        let worker_capabilities_csv: String = {
+            let set: std::collections::BTreeSet<&str> = config
+                .capabilities
+                .iter()
+                .map(|s| s.as_str())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if set.len() > ff_core::policy::CAPS_MAX_TOKENS {
+                return Err(SdkError::Config(format!(
+                    "capability set exceeds CAPS_MAX_TOKENS ({}): {}",
+                    ff_core::policy::CAPS_MAX_TOKENS,
+                    set.len()
+                )));
+            }
+            let csv = set.into_iter().collect::<Vec<_>>().join(",");
+            if csv.len() > ff_core::policy::CAPS_MAX_BYTES {
+                return Err(SdkError::Config(format!(
+                    "capability CSV exceeds CAPS_MAX_BYTES ({}): {}",
+                    ff_core::policy::CAPS_MAX_BYTES,
+                    csv.len()
+                )));
+            }
+            csv
+        };
+
+        // FNV-1a 8-hex digest of the sorted caps CSV, computed once so
+        // per-mismatch logs carry a stable short identifier instead of the
+        // 4KB CSV. Matches ff-scheduler::claim::worker_caps_digest.
+        #[cfg(feature = "insecure-direct-claim")]
+        let worker_capabilities_hash = {
+            let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+            for b in worker_capabilities_csv.as_bytes() {
+                h ^= u64::from(*b);
+                h = h.wrapping_mul(0x100_0000_01b3);
+            }
+            format!("{:08x}", (h as u32) ^ ((h >> 32) as u32))
+        };
+
+        // Full CSV logged once at connect so per-mismatch logs (which
+        // carry only the 8-hex hash) can be cross-referenced by ops.
+        #[cfg(feature = "insecure-direct-claim")]
+        if !worker_capabilities_csv.is_empty() {
+            tracing::info!(
+                worker_instance_id = %config.worker_instance_id,
+                worker_caps_hash = %worker_capabilities_hash,
+                worker_caps = %worker_capabilities_csv,
+                "worker connected with capabilities (full CSV — mismatch logs use hash only)"
+            );
+        }
+
+        // Non-authoritative advertisement of caps for operator visibility
+        // (CLI introspection, dashboards). The AUTHORITATIVE source for
+        // scheduling decisions is ARGV[9] on each claim — Lua reads ONLY
+        // that, never this string. Lossy here is correctness-safe.
+        //
+        // Storage: a single STRING key holding the sorted CSV. Rationale:
+        //   * **Atomic overwrite.** `SET` is a single command — a concurrent
+        //     reader can never observe a transient empty value (the prior
+        //     DEL+SADD pair had that window).
+        //   * **Crash cleanup without refresh loop.** The alive-key SET NX
+        //     is startup-only (see §1 above); there's no periodic renew
+        //     to piggy-back on, so a TTL on caps would independently
+        //     expire mid-flight and hide a live worker's caps from ops
+        //     tools. Instead we drop the TTL: each reconnect overwrites;
+        //     a crashed worker leaves a stale CSV until a new process
+        //     with the same worker_instance_id boots (which triggers
+        //     `duplicate worker_instance_id` via alive-key guard anyway —
+        //     the orchestrator allocates a new id, and operators can DEL
+        //     the stale caps key if they care).
+        //   * **Empty caps = DEL.** A restart from {gpu} to {} clears the
+        //     advertisement rather than leaving stale data.
+        // Cluster-safe advertisement: the per-worker caps STRING lives at
+        // `ff:worker:{id}:caps` (lands on whatever slot CRC16 puts it on),
+        // and the INSTANCE ID is SADD'd to the global workers-index SET
+        // `ff:idx:workers` (single slot). The unblock scanner's cluster
+        // enumeration uses SMEMBERS on the index + per-member GET on each
+        // caps key, instead of `SCAN MATCH ff:worker:*:caps` (which in
+        // cluster mode only scans the shard the SCAN lands on and misses
+        // workers whose key hashes elsewhere). Pattern mirrors Batch A
+        // `budget_policies_index` / `flow_index` / `deps_all_edges`:
+        // operations stay atomic per command, the index is the
+        // cluster-wide enumeration surface.
+        #[cfg(feature = "insecure-direct-claim")]
+        {
+            let caps_key = ff_core::keys::worker_caps_key(&config.worker_instance_id);
+            let index_key = ff_core::keys::workers_index_key();
+            let instance_id = config.worker_instance_id.to_string();
+            if worker_capabilities_csv.is_empty() {
+                // No caps advertised. DEL the per-worker caps string AND
+                // SREM from the index so the scanner doesn't GET an empty
+                // string for a worker that never declares caps.
+                let _ = client
+                    .cmd("DEL")
+                    .arg(&caps_key)
+                    .execute::<Option<i64>>()
+                    .await;
+                if let Err(e) = client
+                    .cmd("SREM")
+                    .arg(&index_key)
+                    .arg(&instance_id)
+                    .execute::<Option<i64>>()
+                    .await
+                {
+                    tracing::warn!(error = %e, key = %index_key, instance = %instance_id,
+                        "SREM workers-index failed; continuing (non-authoritative)");
+                }
+            } else {
+                // Atomic overwrite of the caps STRING (one-command). Then
+                // SADD to the index (idempotent — re-running connect for
+                // the same id is a no-op at SADD level). The per-worker
+                // caps key is written BEFORE the index SADD so that when
+                // the scanner observes the id in the index, the caps key
+                // is guaranteed to resolve to a non-stale CSV (the reverse
+                // order would leak an index entry pointing at a stale or
+                // empty caps key during a narrow window).
+                if let Err(e) = client
+                    .cmd("SET")
+                    .arg(&caps_key)
+                    .arg(&worker_capabilities_csv)
+                    .execute::<Option<String>>()
+                    .await
+                {
+                    tracing::warn!(error = %e, key = %caps_key,
+                        "SET worker caps advertisement failed; continuing");
+                }
+                if let Err(e) = client
+                    .cmd("SADD")
+                    .arg(&index_key)
+                    .arg(&instance_id)
+                    .execute::<Option<i64>>()
+                    .await
+                {
+                    tracing::warn!(error = %e, key = %index_key, instance = %instance_id,
+                        "SADD workers-index failed; continuing");
+                }
+            }
+        }
+
         Ok(Self {
             client,
             config,
             partition_config,
+            #[cfg(feature = "insecure-direct-claim")]
+            worker_capabilities_csv,
+            #[cfg(feature = "insecure-direct-claim")]
+            worker_capabilities_hash,
             #[cfg(feature = "insecure-direct-claim")]
             lane_index: AtomicUsize::new(0),
             #[cfg(feature = "insecure-direct-claim")]
@@ -326,6 +523,27 @@ impl FlowFabricWorker {
 
             match grant_result {
                 Ok(()) => {}
+                Err(SdkError::Script(ff_script::error::ScriptError::CapabilityMismatch(
+                    ref missing,
+                ))) => {
+                    // Block-on-mismatch (RFC-009 §7.5) — parity with
+                    // ff-scheduler's Scheduler::claim_for_worker. Without
+                    // this, the inline-direct-claim path would hot-loop
+                    // on an unclaimable top-of-zset (every tick picks the
+                    // same execution, wastes an FCALL, logs, releases,
+                    // repeats). The scheduler-side unblock scanner
+                    // promotes blocked_route executions back to eligible
+                    // when a worker with matching caps registers.
+                    tracing::info!(
+                        execution_id = %execution_id,
+                        worker_id = %self.config.worker_id,
+                        worker_caps_hash = %self.worker_capabilities_hash,
+                        missing = %missing,
+                        "capability mismatch, blocking execution off eligible (SDK inline claim)"
+                    );
+                    self.block_route(&execution_id, &lane_id, &partition, &idx).await;
+                    continue;
+                }
                 Err(SdkError::Script(ref e)) if is_retryable_claim_error(e) => {
                     tracing::debug!(
                         execution_id = %execution_id,
@@ -409,8 +627,9 @@ impl FlowFabricWorker {
             idx.lane_eligible(lane_id),
         ];
 
-        // ARGV (8): eid, worker_id, worker_instance_id, lane_id,
-        //           capability_hash, grant_ttl_ms, route_snapshot_json, admission_summary
+        // ARGV (9): eid, worker_id, worker_instance_id, lane_id,
+        //           capability_hash, grant_ttl_ms, route_snapshot_json,
+        //           admission_summary, worker_capabilities_csv (sorted)
         let args: Vec<String> = vec![
             execution_id.to_string(),
             self.config.worker_id.to_string(),
@@ -420,6 +639,7 @@ impl FlowFabricWorker {
             "5000".to_owned(), // grant_ttl_ms (5 seconds)
             String::new(), // route_snapshot_json
             String::new(), // admission_summary
+            self.worker_capabilities_csv.clone(), // sorted CSV
         ];
 
         let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
@@ -432,6 +652,69 @@ impl FlowFabricWorker {
             .map_err(SdkError::Valkey)?;
 
         crate::task::parse_success_result(&raw, "ff_issue_claim_grant")
+    }
+
+    /// Move an execution from the lane's eligible ZSET into its
+    /// blocked_route ZSET via `ff_block_execution_for_admission`. Called
+    /// after a `CapabilityMismatch` reject — without this, the inline
+    /// direct-claim path would re-pick the same top-of-zset every tick
+    /// (same pattern the scheduler's block_candidate handles). The
+    /// engine's unblock scanner periodically promotes blocked_route
+    /// back to eligible once a worker with matching caps registers.
+    ///
+    /// Best-effort: transport or logical rejects (e.g. the execution
+    /// already went terminal between pick and block) are logged and the
+    /// outer loop simply `continue`s to the next partition. Parity with
+    /// ff-scheduler::Scheduler::block_candidate.
+    #[cfg(feature = "insecure-direct-claim")]
+    async fn block_route(
+        &self,
+        execution_id: &ExecutionId,
+        lane_id: &LaneId,
+        partition: &ff_core::partition::Partition,
+        idx: &IndexKeys,
+    ) {
+        let ctx = ExecKeyContext::new(partition, execution_id);
+        let core_key = ctx.core();
+        let eligible_key = idx.lane_eligible(lane_id);
+        let blocked_key = idx.lane_blocked_route(lane_id);
+        let eid_s = execution_id.to_string();
+        let now_ms = TimestampMs::now().0.to_string();
+
+        let keys: [&str; 3] = [&core_key, &eligible_key, &blocked_key];
+        let argv: [&str; 4] = [
+            &eid_s,
+            "waiting_for_capable_worker",
+            "no connected worker satisfies required_capabilities",
+            &now_ms,
+        ];
+
+        match self
+            .client
+            .fcall::<Value>("ff_block_execution_for_admission", &keys, &argv)
+            .await
+        {
+            Ok(v) => {
+                // Parse Lua result so a logical reject (e.g. execution
+                // went terminal mid-flight) is visible — same fix we
+                // applied to ff-scheduler's block_candidate.
+                if let Err(e) = crate::task::parse_success_result(&v, "ff_block_execution_for_admission") {
+                    tracing::warn!(
+                        execution_id = %execution_id,
+                        error = %e,
+                        "SDK block_route: Lua rejected; eligible ZSET unchanged, next poll \
+                         will re-evaluate"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    execution_id = %execution_id,
+                    error = %e,
+                    "SDK block_route: transport failure; eligible ZSET unchanged"
+                );
+            }
+        }
     }
 
     #[cfg(feature = "insecure-direct-claim")]
@@ -530,21 +813,28 @@ impl FlowFabricWorker {
         };
 
         if status_code != 1 {
-            let error_code = arr
-                .get(1)
-                .and_then(|v| match v {
-                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                    Ok(Value::SimpleString(s)) => Some(s.clone()),
-                    _ => None,
-                })
-                .unwrap_or_else(|| "unknown".to_owned());
+            let err_field_str = |idx: usize| -> String {
+                arr.get(idx)
+                    .and_then(|v| match v {
+                        Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                        Ok(Value::SimpleString(s)) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_default()
+            };
+            let error_code = {
+                let s = err_field_str(1);
+                if s.is_empty() { "unknown".to_owned() } else { s }
+            };
+            let detail = err_field_str(2);
 
             return Err(SdkError::Script(
-                ff_script::error::ScriptError::from_code(&error_code).unwrap_or_else(|| {
-                    ff_script::error::ScriptError::Parse(format!(
-                        "ff_claim_execution: {error_code}"
-                    ))
-                }),
+                ff_script::error::ScriptError::from_code_with_detail(&error_code, &detail)
+                    .unwrap_or_else(|| {
+                        ff_script::error::ScriptError::Parse(format!(
+                            "ff_claim_execution: {error_code}"
+                        ))
+                    }),
             ));
         }
 
@@ -674,21 +964,28 @@ impl FlowFabricWorker {
         };
 
         if status_code != 1 {
-            let error_code = arr
-                .get(1)
-                .and_then(|v| match v {
-                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                    Ok(Value::SimpleString(s)) => Some(s.clone()),
-                    _ => None,
-                })
-                .unwrap_or_else(|| "unknown".to_owned());
+            let err_field_str = |idx: usize| -> String {
+                arr.get(idx)
+                    .and_then(|v| match v {
+                        Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                        Ok(Value::SimpleString(s)) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_default()
+            };
+            let error_code = {
+                let s = err_field_str(1);
+                if s.is_empty() { "unknown".to_owned() } else { s }
+            };
+            let detail = err_field_str(2);
 
             return Err(SdkError::Script(
-                ff_script::error::ScriptError::from_code(&error_code).unwrap_or_else(|| {
-                    ff_script::error::ScriptError::Parse(format!(
-                        "ff_claim_resumed_execution: {error_code}"
-                    ))
-                }),
+                ff_script::error::ScriptError::from_code_with_detail(&error_code, &detail)
+                    .unwrap_or_else(|| {
+                        ff_script::error::ScriptError::Parse(format!(
+                            "ff_claim_resumed_execution: {error_code}"
+                        ))
+                    }),
             ));
         }
 
@@ -793,11 +1090,11 @@ impl FlowFabricWorker {
             .map_err(|e| SdkError::ValkeyContext { source: e, context: "HGET lane_id".into() })?;
         let lane_id = LaneId::new(lane_str.unwrap_or_else(|| "default".to_owned()));
 
-        // KEYS (13): exec_core, wp_condition, wp_signals_stream,
+        // KEYS (14): exec_core, wp_condition, wp_signals_stream,
         //            exec_signals_zset, signal_hash, signal_payload,
         //            idem_key, waitpoint_hash, suspension_current,
         //            eligible_zset, suspended_zset, delayed_zset,
-        //            suspension_timeout_zset
+        //            suspension_timeout_zset, hmac_secrets
         let idem_key = if let Some(ref ik) = signal.idempotency_key {
             ctx.signal_dedup(waitpoint_id, ik)
         } else {
@@ -817,6 +1114,7 @@ impl FlowFabricWorker {
             idx.lane_suspended(&lane_id),                  // 11
             idx.lane_delayed(&lane_id),                    // 12
             idx.suspension_timeout(),                      // 13
+            idx.waitpoint_hmac_secrets(),                  // 14
         ];
 
         let payload_str = signal
@@ -825,12 +1123,12 @@ impl FlowFabricWorker {
             .map(|p| String::from_utf8_lossy(p).into_owned())
             .unwrap_or_default();
 
-        // ARGV (17): signal_id, execution_id, waitpoint_id, signal_name,
+        // ARGV (18): signal_id, execution_id, waitpoint_id, signal_name,
         //            signal_category, source_type, source_identity,
         //            payload, payload_encoding, idempotency_key,
         //            correlation_id, target_scope, created_at,
         //            dedup_ttl_ms, resume_delay_ms, signal_maxlen,
-        //            max_signals_per_execution
+        //            max_signals_per_execution, waitpoint_token
         let args: Vec<String> = vec![
             signal_id.to_string(),                           // 1
             execution_id.to_string(),                        // 2
@@ -849,6 +1147,10 @@ impl FlowFabricWorker {
             "0".to_owned(),                                  // 15 resume_delay_ms
             "1000".to_owned(),                               // 16 signal_maxlen
             "10000".to_owned(),                              // 17 max_signals
+            // WIRE BOUNDARY — raw token must reach Lua unredacted. Do NOT
+            // use ToString/Display (those are redacted for log safety);
+            // .as_str() is the explicit opt-in that gets the secret bytes.
+            signal.waitpoint_token.as_str().to_owned(),      // 18 waitpoint_token
         ];
 
         let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -95,11 +95,11 @@ impl IntoResponse for ApiError {
             ServerError::OperationFailed(msg) => {
                 (StatusCode::BAD_REQUEST, ErrorBody::plain(msg.clone()))
             }
-            ServerError::TailUnavailable(max) => (
+            ServerError::ConcurrencyLimitExceeded(source, max) => (
                 StatusCode::TOO_MANY_REQUESTS,
                 ErrorBody {
                     error: format!(
-                        "too many concurrent tail calls (server max: {max}); retry with backoff"
+                        "too many concurrent {source} calls (server max: {max}); retry with backoff"
                     ),
                     kind: None,
                     retryable: Some(true),

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -95,6 +95,16 @@ impl IntoResponse for ApiError {
             ServerError::OperationFailed(msg) => {
                 (StatusCode::BAD_REQUEST, ErrorBody::plain(msg.clone()))
             }
+            ServerError::TailUnavailable(max) => (
+                StatusCode::TOO_MANY_REQUESTS,
+                ErrorBody {
+                    error: format!(
+                        "too many concurrent tail calls (server max: {max}); retry with backoff"
+                    ),
+                    kind: None,
+                    retryable: Some(true),
+                },
+            ),
             ServerError::Valkey(e) => {
                 let kind_str = kind_to_stable_str(e.kind());
                 tracing::error!(
@@ -177,6 +187,15 @@ pub fn router(server: Arc<Server>, cors_origins: &[String], api_token: Option<St
         .route("/v1/executions/{id}/priority", put(change_priority))
         .route("/v1/executions/{id}/replay", post(replay_execution))
         .route("/v1/executions/{id}/revoke-lease", post(revoke_lease))
+        // Stream read + tail (RFC-006 #2)
+        .route(
+            "/v1/executions/{id}/attempts/{idx}/stream",
+            get(read_attempt_stream),
+        )
+        .route(
+            "/v1/executions/{id}/attempts/{idx}/stream/tail",
+            get(tail_attempt_stream),
+        )
         // Flows
         .route("/v1/flows", post(create_flow))
         .route("/v1/flows/{id}/members", post(add_execution_to_flow))
@@ -190,6 +209,8 @@ pub fn router(server: Arc<Server>, cors_origins: &[String], api_token: Option<St
         .route("/v1/budgets/{id}/reset", post(reset_budget))
         // Quotas
         .route("/v1/quotas", post(create_quota_policy))
+        // Admin: rotate waitpoint HMAC secret (RFC-004 §Waitpoint Security)
+        .route("/v1/admin/rotate-waitpoint-secret", post(rotate_waitpoint_secret))
         // Health (always unauthenticated)
         .route("/healthz", get(healthz));
 
@@ -350,6 +371,85 @@ async fn deliver_signal(
     Ok(Json(server.deliver_signal(&args).await?))
 }
 
+// ── Admin: rotate waitpoint HMAC secret (RFC-004 §Waitpoint Security) ──
+
+#[derive(Deserialize)]
+struct RotateWaitpointSecretBody {
+    new_kid: String,
+    /// Hex-encoded new secret. Even-length, 0-9a-fA-F.
+    new_secret_hex: String,
+}
+
+/// Hard ceiling on how long the rotate endpoint runs before the HTTP
+/// handler bails. Rotation touches every execution partition (up to 256)
+/// with HGET+HMGET+HDEL+HSET per partition; 6 round-trips × 30ms cross-AZ
+/// × 256 partitions ≈ 46s worst-case. The internal SETNX lock is 10s TTL
+/// per partition, so 120s gives ample margin for contention + slow RTTs
+/// while staying below common LB idle timeouts (ALB 60s default, but
+/// typically bumped to 120s+ for admin endpoints).
+///
+/// On timeout: returns HTTP 504 immediately. Valkey-side work may still
+/// finish (the per-partition locks and HSETs are already in flight). The
+/// operator observes a 504 and retries; retry is SAFE — rotation is
+/// idempotent per-partition (same new_kid + same secret → no-op on
+/// already-rotated partitions).
+const ROTATE_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+async fn rotate_waitpoint_secret(
+    State(server): State<Arc<Server>>,
+    AppJson(body): AppJson<RotateWaitpointSecretBody>,
+) -> Result<Response, ApiError> {
+    // Cap the whole endpoint end-to-end. If this trips, the caller's
+    // retry is SAFE — per-partition rotation is idempotent on the same
+    // (new_kid, secret_hex) and the per-partition SETNX lock prevents
+    // double-rotation under concurrent retries.
+    let rotate_fut = server.rotate_waitpoint_secret(&body.new_kid, &body.new_secret_hex);
+    let result = match tokio::time::timeout(ROTATE_HTTP_TIMEOUT, rotate_fut).await {
+        Ok(r) => r?,
+        Err(_) => {
+            tracing::error!(
+                target: "audit",
+                new_kid = %body.new_kid,
+                timeout_s = ROTATE_HTTP_TIMEOUT.as_secs(),
+                "waitpoint_hmac_rotation_timeout_http_504"
+            );
+            let body = ErrorBody::plain(format!(
+                "rotation exceeded {}s server-side timeout; retry is safe \
+                 (per-partition rotation is idempotent on the same new_kid + secret_hex)",
+                ROTATE_HTTP_TIMEOUT.as_secs()
+            ));
+            return Ok((StatusCode::GATEWAY_TIMEOUT, Json(body)).into_response());
+        }
+    };
+    // Operator action log at audit target (per-partition detail logged inside
+    // rotate_waitpoint_secret). Returns 200 if at least one partition rotated
+    // OR at least one partition was already in-flight under a concurrent
+    // rotation. Returns 400 only on actionable fault states.
+    //
+    // Three distinct rotated==0 cases:
+    //   - all in_progress → concurrent rotation handling it, NOT a failure.
+    //     200 OK with the structured result so operators see what's happening.
+    //   - failed.is_empty() && in_progress.is_empty() → no partitions at all
+    //     (num_execution_partitions == 0; env_u16_positive rejects this at
+    //     boot so this is mostly dead code for library/Default callers).
+    //   - !failed.is_empty() → every partition attempt raised a real error.
+    //     Operator investigates Valkey/auth/cluster health before retrying.
+    if result.rotated == 0 && result.failed.is_empty() && result.in_progress.is_empty() {
+        return Err(ApiError::from(ServerError::OperationFailed(
+            "rotation had no partitions to operate on \
+             (num_execution_partitions is 0 — server misconfigured)"
+                .to_owned(),
+        )));
+    }
+    if result.rotated == 0 && !result.failed.is_empty() {
+        return Err(ApiError::from(ServerError::OperationFailed(
+            "rotation failed on all partitions (check Valkey connectivity)".to_owned(),
+        )));
+    }
+    // rotated==0 but some in_progress → 200 OK; caller polls / re-runs.
+    Ok(Json(result).into_response())
+}
+
 #[derive(Deserialize)]
 struct ChangePriorityBody {
     new_priority: i32,
@@ -378,6 +478,170 @@ async fn revoke_lease(
 ) -> Result<Json<RevokeLeaseResult>, ApiError> {
     let eid = parse_execution_id(&id)?;
     Ok(Json(server.revoke_lease(&eid).await?))
+}
+
+// ── Stream read + tail ──
+
+#[derive(Deserialize)]
+struct ReadStreamParams {
+    #[serde(default = "default_from_id")]
+    from: String,
+    #[serde(default = "default_to_id")]
+    to: String,
+    #[serde(default = "default_read_limit")]
+    limit: u64,
+}
+
+fn default_from_id() -> String { "-".to_owned() }
+fn default_to_id() -> String { "+".to_owned() }
+fn default_read_limit() -> u64 { 100 }
+
+/// Reject malformed `from`/`to`/`after` stream IDs at the REST boundary so
+/// Valkey doesn't have to. Accepts `"-"`, `"+"`, and `<ms>` or `<ms>-<seq>`
+/// decimal IDs as Valkey XRANGE/XREAD does.
+///
+/// Without this, a request like `?from=abc` would round-trip to Valkey,
+/// surface as a script error, and return HTTP 500 — which is wrong for
+/// caller-input validation.
+fn validate_stream_id(s: &str, field: &str, allow_open_markers: bool) -> Result<(), ApiError> {
+    if allow_open_markers && (s == "-" || s == "+") {
+        return Ok(());
+    }
+    // Allowed: `<digits>` or `<digits>-<digits>`.
+    let (ms_part, seq_part) = match s.split_once('-') {
+        Some((ms, seq)) => (ms, Some(seq)),
+        None => (s, None),
+    };
+    let ms_valid = !ms_part.is_empty() && ms_part.chars().all(|c| c.is_ascii_digit());
+    let seq_valid = seq_part
+        .map(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
+        .unwrap_or(true);
+    if ms_valid && seq_valid {
+        Ok(())
+    } else {
+        Err(ApiError(ServerError::InvalidInput(format!(
+            "{field}: invalid stream ID '{s}' (expected '-', '+', '<ms>', or '<ms>-<seq>')"
+        ))))
+    }
+}
+
+#[derive(Serialize)]
+struct ReadStreamResponse {
+    frames: Vec<StreamFrame>,
+    count: usize,
+    /// When set, the producer has closed this stream — consumer should
+    /// stop polling. Absent when the stream is still open (or never
+    /// existed, which is indistinguishable from "still open" at this
+    /// layer).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    closed_at: Option<i64>,
+    /// Reason from the closing writer: `attempt_success`, `attempt_failure`,
+    /// `attempt_cancelled`, `attempt_interrupted`. Absent iff still open.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    closed_reason: Option<String>,
+}
+
+impl From<ff_core::contracts::StreamFrames> for ReadStreamResponse {
+    fn from(sf: ff_core::contracts::StreamFrames) -> Self {
+        let count = sf.frames.len();
+        Self {
+            frames: sf.frames,
+            count,
+            closed_at: sf.closed_at.map(|t| t.0),
+            closed_reason: sf.closed_reason,
+        }
+    }
+}
+
+/// REST-layer ceiling on `limit` for stream read/tail responses. Lower
+/// than the internal `STREAM_READ_HARD_CAP` (10_000) because an HTTP
+/// response buffers the whole JSON body in memory in axum — a
+/// `10_000 × max_payload_bytes (65_536)` body is ~640MB per call, which
+/// is a DoS vector from a single client. Internal callers using FCALL or
+/// the SDK directly still get the full 10_000 ceiling; REST clients must
+/// paginate through `from`/`to` for larger spans.
+///
+/// v2 candidate: chunked-transfer / SSE when the caller wants > this bound.
+const REST_STREAM_LIMIT_CEILING: u64 = 1_000;
+
+async fn read_attempt_stream(
+    State(server): State<Arc<Server>>,
+    Path((id, idx)): Path<(String, u32)>,
+    Query(params): Query<ReadStreamParams>,
+) -> Result<Json<ReadStreamResponse>, ApiError> {
+    if params.limit == 0 {
+        return Err(ApiError(ServerError::InvalidInput(
+            "limit must be >= 1".to_owned(),
+        )));
+    }
+    if params.limit > REST_STREAM_LIMIT_CEILING {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "limit exceeds REST ceiling {REST_STREAM_LIMIT_CEILING}; paginate via from/to for larger spans"
+        ))));
+    }
+    validate_stream_id(&params.from, "from", true)?;
+    validate_stream_id(&params.to, "to", true)?;
+
+    let eid = parse_execution_id(&id)?;
+    let attempt_index = AttemptIndex::new(idx);
+    let result = server
+        .read_attempt_stream(&eid, attempt_index, &params.from, &params.to, params.limit)
+        .await?;
+    Ok(Json(result.into()))
+}
+
+#[derive(Deserialize)]
+struct TailStreamParams {
+    #[serde(default = "default_tail_after")]
+    after: String,
+    #[serde(default)]
+    block_ms: u64,
+    #[serde(default = "default_tail_limit")]
+    limit: u64,
+}
+
+fn default_tail_after() -> String { "0-0".to_owned() }
+fn default_tail_limit() -> u64 { 50 }
+
+/// Ceiling on BLOCK duration for the tail endpoint. Kept below common LB
+/// idle timeouts (ALB 60s, nginx 60s, Cloudflare 100s) so the HTTP response
+/// can't be cut mid-block.
+///
+/// Note: ferriskey's client auto-extends its `request_timeout` for XREAD
+/// BLOCK to `block_ms + 500ms`, so a blocking call with the full ceiling
+/// never produces a spurious transport timeout. See
+/// `ff_script::stream_tail` module docs for the exact ferriskey code path.
+const MAX_TAIL_BLOCK_MS: u64 = 30_000;
+
+async fn tail_attempt_stream(
+    State(server): State<Arc<Server>>,
+    Path((id, idx)): Path<(String, u32)>,
+    Query(params): Query<TailStreamParams>,
+) -> Result<Json<ReadStreamResponse>, ApiError> {
+    if params.block_ms > MAX_TAIL_BLOCK_MS {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "block_ms exceeds {MAX_TAIL_BLOCK_MS}ms ceiling"
+        ))));
+    }
+    if params.limit == 0 {
+        return Err(ApiError(ServerError::InvalidInput(
+            "limit must be >= 1".to_owned(),
+        )));
+    }
+    if params.limit > REST_STREAM_LIMIT_CEILING {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "limit exceeds REST ceiling {REST_STREAM_LIMIT_CEILING}; paginate via after for larger spans"
+        ))));
+    }
+    // XREAD cursor must be a concrete ID — "-"/"+" are XRANGE-only.
+    validate_stream_id(&params.after, "after", false)?;
+
+    let eid = parse_execution_id(&id)?;
+    let attempt_index = AttemptIndex::new(idx);
+    let result = server
+        .tail_attempt_stream(&eid, attempt_index, &params.after, params.block_ms, params.limit)
+        .await?;
+    Ok(Json(result.into()))
 }
 
 // ── Flow handlers ──

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -28,6 +28,31 @@ pub struct ServerConfig {
     /// Shared-secret API token. If set, all requests except GET /healthz must
     /// include `Authorization: Bearer <token>`. If unset, auth is disabled.
     pub api_token: Option<String>,
+    /// Hex-encoded secret used to sign waitpoint HMAC tokens (RFC-004
+    /// §Waitpoint Security). Required on boot; the server refuses to start
+    /// without it so multi-tenant signal authentication is never silently
+    /// disabled. Recommended length: 64 hex chars (32 bytes).
+    pub waitpoint_hmac_secret: String,
+    /// Grace window during which tokens signed by the previous kid remain
+    /// accepted after rotation. Tokens already in flight survive operator
+    /// rotation; operators tighten this for sensitive tenants. Default 24h.
+    pub waitpoint_hmac_grace_ms: u64,
+    /// Maximum concurrent stream-op callers (`read_attempt_stream` +
+    /// `tail_attempt_stream` combined). Each caller holds one semaphore
+    /// permit for the duration of its Valkey round-trip(s); contention
+    /// surfaces as HTTP 429 at the REST boundary.
+    ///
+    /// Shared bound for both read and tail because both run on the same
+    /// dedicated `tail_client` (see `Server.tail_client`) — a big
+    /// 10_000-frame XRANGE reply can head-of-line the mux just as badly
+    /// as a long `XREAD BLOCK`, so they should share fairness accounting.
+    ///
+    /// Default `64`. Set below the server's request-concurrency budget
+    /// so stream ops cannot starve other routes. Env var:
+    /// `FF_MAX_CONCURRENT_STREAM_OPS` (preferred) or legacy
+    /// `FF_MAX_CONCURRENT_TAIL` (accepted during the R4 rename; both
+    /// valid for at least one release).
+    pub max_concurrent_stream_ops: u32,
 }
 
 impl ServerConfig {
@@ -85,6 +110,43 @@ impl ServerConfig {
             .collect();
 
         let api_token = std::env::var("FF_API_TOKEN").ok().filter(|s| !s.is_empty());
+
+        // Waitpoint HMAC secret. Required on boot — refuse to start without
+        // it so multi-tenant signal authentication can never be silently
+        // disabled. Validate hex shape eagerly; empty strings and bad hex
+        // produce a configuration error, not a runtime crash later.
+        let waitpoint_hmac_secret = std::env::var("FF_WAITPOINT_HMAC_SECRET")
+            .map_err(|_| ConfigError::InvalidValue {
+                var: "FF_WAITPOINT_HMAC_SECRET".to_owned(),
+                message:
+                    "required: hex-encoded HMAC signing secret for waitpoint tokens \
+                     (RFC-004 §Waitpoint Security); suggested 64 hex chars (32 bytes)"
+                        .to_owned(),
+            })?;
+        if waitpoint_hmac_secret.is_empty() {
+            return Err(ConfigError::InvalidValue {
+                var: "FF_WAITPOINT_HMAC_SECRET".to_owned(),
+                message: "must not be empty".to_owned(),
+            });
+        }
+        if waitpoint_hmac_secret.len() % 2 != 0
+            || !waitpoint_hmac_secret.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            return Err(ConfigError::InvalidValue {
+                var: "FF_WAITPOINT_HMAC_SECRET".to_owned(),
+                message: "must be an even-length hex string (0-9a-fA-F)".to_owned(),
+            });
+        }
+        let waitpoint_hmac_grace_ms = env_u64("FF_WAITPOINT_HMAC_GRACE_MS", 86_400_000)?;
+        // Preferred env var: FF_MAX_CONCURRENT_STREAM_OPS. Legacy
+        // FF_MAX_CONCURRENT_TAIL is accepted for one release to avoid
+        // breaking existing deployments mid-rename (R4 unified the two
+        // stream-op clients on one permit pool). If both are set, the
+        // new name wins.
+        let max_concurrent_stream_ops = match std::env::var("FF_MAX_CONCURRENT_STREAM_OPS") {
+            Ok(_) => env_u32_positive("FF_MAX_CONCURRENT_STREAM_OPS", 64)?,
+            Err(_) => env_u32_positive("FF_MAX_CONCURRENT_TAIL", 64)?,
+        };
 
         let lanes: Vec<LaneId> = env_or("FF_LANES", "default")
             .split(',')
@@ -165,6 +227,9 @@ impl ServerConfig {
             skip_library_load: false,
             cors_origins,
             api_token,
+            waitpoint_hmac_secret,
+            waitpoint_hmac_grace_ms,
+            max_concurrent_stream_ops,
         })
     }
 }
@@ -189,6 +254,15 @@ impl Default for ServerConfig {
             skip_library_load: false,
             cors_origins: vec!["*".to_owned()],
             api_token: None,
+            // Deterministic dev/test secret. Production deployments MUST
+            // override via FF_WAITPOINT_HMAC_SECRET (ServerConfig::from_env
+            // requires it), so this default only applies to unit tests and
+            // TestCluster fixtures that skip env validation.
+            waitpoint_hmac_secret:
+                "0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_owned(),
+            waitpoint_hmac_grace_ms: 86_400_000,
+            max_concurrent_stream_ops: 64,
         }
     }
 }
@@ -240,4 +314,21 @@ fn env_u64(key: &str, default: u64) -> Result<u64, ConfigError> {
         }),
         Err(_) => Ok(default),
     }
+}
+
+fn env_u32_positive(key: &str, default: u32) -> Result<u32, ConfigError> {
+    let val = match std::env::var(key) {
+        Ok(v) => v.parse::<u32>().map_err(|_| ConfigError::InvalidValue {
+            var: key.to_owned(),
+            message: format!("expected u32, got '{v}'"),
+        })?,
+        Err(_) => default,
+    };
+    if val == 0 {
+        return Err(ConfigError::InvalidValue {
+            var: key.to_owned(),
+            message: "must be > 0 (semaphore size)".to_owned(),
+        });
+    }
+    Ok(val)
 }

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -10,7 +10,13 @@ async fn main() {
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| {
-                    "ff_server=info,ff_engine=info,ff_script=info,tower_http=debug".into()
+                    // `audit=info` is non-negotiable: rotation, security-kid
+                    // changes, and other compliance events use
+                    // `tracing::*!(target: "audit", ...)`. Without this
+                    // directive the default subscriber silently drops every
+                    // audit event (module-path directives like `ff_server=info`
+                    // do not match custom targets).
+                    "ff_server=info,ff_engine=info,ff_script=info,tower_http=debug,audit=info".into()
                 }),
         )
         .init();

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -149,12 +149,16 @@ pub enum ServerError {
     OperationFailed(String),
     #[error("script: {0}")]
     Script(String),
-    /// Server-wide concurrent-tail limit reached. Surfaces as HTTP 429
-    /// at the REST boundary so load balancers and clients can retry with
-    /// backoff. Distinct from transport/script errors because the fault is
-    /// on the server side (too many in-flight tails), not the caller side.
-    #[error("too many concurrent tail calls (max: {0})")]
-    TailUnavailable(u32),
+    /// Server-wide concurrency limit reached on a labelled pool. Surfaces
+    /// as HTTP 429 at the REST boundary so load balancers and clients can
+    /// retry with backoff. The `source` label ("stream_ops", "admin_rotate",
+    /// etc.) identifies WHICH pool is exhausted so operators aren't
+    /// misled by a single "tail unavailable" string when the real fault
+    /// is rotation contention.
+    ///
+    /// Fields: (source_label, max_permits).
+    #[error("too many concurrent {0} calls (max: {1})")]
+    ConcurrencyLimitExceeded(&'static str, u32),
 }
 
 impl ServerError {
@@ -189,9 +193,10 @@ impl ServerError {
             | Self::InvalidInput(_)
             | Self::OperationFailed(_)
             | Self::Script(_) => false,
-            // Back off and retry — the server-side tail pool is the bound,
-            // so the retry will succeed once a permit frees up.
-            Self::TailUnavailable(_) => true,
+            // Back off and retry — the bound is a server-side permit pool,
+            // so the retry will succeed once a permit frees up. Applies
+            // equally to stream ops, admin rotate, etc.
+            Self::ConcurrencyLimitExceeded(_, _) => true,
         }
     }
 }
@@ -1781,7 +1786,8 @@ impl Server {
         let permit = match self.stream_semaphore.clone().try_acquire_owned() {
             Ok(p) => p,
             Err(tokio::sync::TryAcquireError::NoPermits) => {
-                return Err(ServerError::TailUnavailable(
+                return Err(ServerError::ConcurrencyLimitExceeded(
+                    "stream_ops",
                     self.config.max_concurrent_stream_ops,
                 ));
             }
@@ -1869,7 +1875,8 @@ impl Server {
         let permit = match self.stream_semaphore.clone().try_acquire_owned() {
             Ok(p) => p,
             Err(tokio::sync::TryAcquireError::NoPermits) => {
-                return Err(ServerError::TailUnavailable(
+                return Err(ServerError::ConcurrencyLimitExceeded(
+                    "stream_ops",
                     self.config.max_concurrent_stream_ops,
                 ));
             }
@@ -2272,13 +2279,14 @@ impl Server {
         // Single-writer gate. Concurrent rotates against the SAME operator
         // token are an attack pattern (or a retry-loop bug); legitimate
         // operators rotate monthly and can afford to serialize. Contention
-        // returns TailUnavailable (→ HTTP 429) rather than queueing the
-        // HTTP handler past the 120s endpoint timeout. Permit is held for
+        // returns ConcurrencyLimitExceeded("admin_rotate", 1) (→ HTTP 429
+        // with a labelled error body) rather than queueing the HTTP
+        // handler past the 120s endpoint timeout. Permit is held for
         // the full partition fan-out.
         let _permit = match self.admin_rotate_semaphore.clone().try_acquire_owned() {
             Ok(p) => p,
             Err(tokio::sync::TryAcquireError::NoPermits) => {
-                return Err(ServerError::TailUnavailable(1));
+                return Err(ServerError::ConcurrencyLimitExceeded("admin_rotate", 1));
             }
             Err(tokio::sync::TryAcquireError::Closed) => {
                 return Err(ServerError::OperationFailed(
@@ -2295,60 +2303,98 @@ impl Server {
             .as_millis() as i64;
         let previous_expires_at = now_ms + grace_ms as i64;
 
+        // Parallelize the rotation fan-out with the same bounded
+        // concurrency as boot init (BOOT_INIT_CONCURRENCY = 16). A 256-
+        // partition sequential rotation takes ~7.7s at 30ms cross-AZ RTT,
+        // uncomfortably close to the 120s HTTP endpoint timeout under
+        // contention. The per-partition SETNX lock in
+        // `rotate_single_partition` prevents interleaved writes against
+        // the same partition; parallelism across DIFFERENT partitions is
+        // safe. The outer `admin_rotate_semaphore(1)` already bounds
+        // server-wide concurrent rotations, so this fan-out only affects
+        // a single in-flight rotate call at a time.
+        use futures::stream::{FuturesUnordered, StreamExt};
+
         let mut rotated = 0u16;
         let mut failed = Vec::new();
         let mut in_progress: Vec<u16> = Vec::new();
-        for index in 0..n {
-            let partition = Partition { family: PartitionFamily::Execution, index };
-            let key = ff_core::keys::IndexKeys::new(&partition).waitpoint_hmac_secrets();
+        let mut pending: FuturesUnordered<_> = FuturesUnordered::new();
+        let mut next_index: u16 = 0;
 
-            match self
-                .rotate_single_partition(&key, new_kid, new_secret_hex, previous_expires_at)
-                .await
-            {
-                Ok(RotationStepOutcome::Rotated) => {
-                    rotated += 1;
-                    // Per-partition event → DEBUG (not INFO). Rationale:
-                    // one rotate endpoint call produces 256 partition-level
-                    // events, which would blow up paid aggregator budgets
-                    // (Datadog/Splunk) at no operational value. The single
-                    // aggregated audit event below is the compliance
-                    // artifact. Failures stay at ERROR with per-partition
-                    // detail — that's where operators need it.
-                    tracing::debug!(
-                        partition = %partition,
-                        new_kid = %new_kid,
-                        "waitpoint_hmac_rotated"
-                    );
-                }
-                Ok(RotationStepOutcome::InProgress) => {
-                    // Another rotation is mid-flight on this partition. It
-                    // will finish (rotation is idempotent + per-partition
-                    // locked), so this is NOT a failure the operator needs
-                    // to retry. DO NOT push to `failed` — keeping `failed`
-                    // meaningful for actual Valkey/config errors the
-                    // operator must investigate. Per-partition detail at
-                    // DEBUG; summary emitted once at end.
-                    in_progress.push(index);
-                    tracing::debug!(
-                        partition = %partition,
-                        new_kid = %new_kid,
-                        "waitpoint_hmac_rotation_in_progress_skipped"
-                    );
-                }
-                Err(e) => {
-                    // Failures stay at ERROR (target=audit) per-partition —
-                    // operators need the partition index + error to debug
-                    // Valkey/config faults. Low cardinality in practice
-                    // (failures should be rare).
-                    tracing::error!(
-                        target: "audit",
-                        partition = %partition,
-                        err = %e,
-                        "waitpoint_hmac_rotation_failed"
-                    );
-                    failed.push(index);
-                }
+        loop {
+            while pending.len() < BOOT_INIT_CONCURRENCY && next_index < n {
+                let partition = Partition {
+                    family: PartitionFamily::Execution,
+                    index: next_index,
+                };
+                let key = ff_core::keys::IndexKeys::new(&partition).waitpoint_hmac_secrets();
+                let idx = next_index;
+                // Clone only what the per-partition future needs. The
+                // new_kid / new_secret_hex references outlive the loop
+                // (they come from the enclosing function args), but
+                // FuturesUnordered needs 'static futures. Own the strings.
+                let new_kid_owned = new_kid.to_owned();
+                let new_secret_owned = new_secret_hex.to_owned();
+                // Borrow-free call into rotate_single_partition: it only
+                // needs &self (Arc is fine; we already have &self here),
+                // &str (owned locals above), and i64 (Copy).
+                let fut = async move {
+                    let outcome = self
+                        .rotate_single_partition(
+                            &key,
+                            &new_kid_owned,
+                            &new_secret_owned,
+                            previous_expires_at,
+                        )
+                        .await;
+                    (idx, partition, outcome)
+                };
+                pending.push(fut);
+                next_index += 1;
+            }
+            match pending.next().await {
+                Some((idx, partition, outcome)) => match outcome {
+                    Ok(RotationStepOutcome::Rotated) => {
+                        rotated += 1;
+                        // Per-partition event → DEBUG (not INFO). Rationale:
+                        // one rotate endpoint call produces 256 partition-level
+                        // events, which would blow up paid aggregator budgets
+                        // (Datadog/Splunk) at no operational value. The single
+                        // aggregated audit event below is the compliance
+                        // artifact. Failures stay at ERROR with per-partition
+                        // detail — that's where operators need it.
+                        tracing::debug!(
+                            partition = %partition,
+                            new_kid = %new_kid,
+                            "waitpoint_hmac_rotated"
+                        );
+                    }
+                    Ok(RotationStepOutcome::InProgress) => {
+                        // Another rotation is mid-flight on this partition.
+                        // Idempotent + per-partition locked; NOT a failure
+                        // the operator needs to retry. Kept out of `failed`
+                        // so that list stays actionable.
+                        in_progress.push(idx);
+                        tracing::debug!(
+                            partition = %partition,
+                            new_kid = %new_kid,
+                            "waitpoint_hmac_rotation_in_progress_skipped"
+                        );
+                    }
+                    Err(e) => {
+                        // Failures stay at ERROR (target=audit) per-partition —
+                        // operators need the partition index + error to debug
+                        // Valkey/config faults. Low cardinality in practice.
+                        tracing::error!(
+                            target: "audit",
+                            partition = %partition,
+                            err = %e,
+                            "waitpoint_hmac_rotation_failed"
+                        );
+                        failed.push(idx);
+                    }
+                },
+                None => break,
             }
         }
 

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -22,7 +22,8 @@ use ff_core::keys::{
     QuotaKeyContext,
 };
 use ff_core::partition::{
-    budget_partition, execution_partition, flow_partition, quota_partition, PartitionConfig,
+    budget_partition, execution_partition, flow_partition, quota_partition, Partition,
+    PartitionConfig, PartitionFamily,
 };
 use ff_core::state::{PublicState, StateVector};
 use ff_core::types::*;
@@ -43,6 +44,77 @@ const ALREADY_TERMINAL_MEMBER_CAP: usize = 1000;
 /// and provides a minimal API for Phase 1.
 pub struct Server {
     client: Client,
+    /// Dedicated Valkey connection used EXCLUSIVELY for stream-op calls:
+    /// `xread_block` tails AND `ff_read_attempt_stream` range reads.
+    /// `ferriskey::Client` is a pipelined multiplexed connection; Valkey
+    /// processes commands FIFO on it.
+    ///
+    /// Two head-of-line risks motivate the split from the main client:
+    ///
+    /// * **Blocking**: `XREAD BLOCK 30_000` holds the read side until a
+    ///   new entry arrives or `block_ms` elapses.
+    /// * **Large replies**: `XRANGE … COUNT 10_000` with ~64 KB per
+    ///   frame returns a multi-MB reply serialized on one connection.
+    ///
+    /// Sharing either load with the main client would starve every other
+    /// FCALL (create_execution, claim, rotate_waitpoint_secret,
+    /// budget/quota, admin endpoints) AND every engine scanner.
+    ///
+    /// Kept separate from `client` and from the `Engine` scanner client so
+    /// tail latency cannot couple to foreground API latency or background
+    /// scanner cadence. See RFC-006 Impl Notes for the cascading-failure
+    /// rationale.
+    tail_client: Client,
+    /// Bounds concurrent stream-op calls server-wide — read AND tail
+    /// combined. Each caller acquires one permit for the duration of its
+    /// Valkey round-trip(s); contention surfaces as HTTP 429 at the REST
+    /// boundary, not as a silent queue on the stream connection. Default
+    /// size is `FF_MAX_CONCURRENT_STREAM_OPS` (64; legacy env
+    /// `FF_MAX_CONCURRENT_TAIL` accepted for one release).
+    ///
+    /// Read and tail share the same pool deliberately: they share the
+    /// `tail_client`, so fairness accounting must be unified or a flood
+    /// of one can starve the other. The semaphore is also `close()`d on
+    /// shutdown so no new stream ops can start while existing ones drain
+    /// (see `Server::shutdown`).
+    stream_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Serializes `XREAD BLOCK` calls against `tail_client`.
+    ///
+    /// `ferriskey::Client` is a pipelined multiplexed connection — Valkey
+    /// processes commands FIFO on one socket. `XREAD BLOCK` holds the
+    /// connection's read side for the full `block_ms`, so two parallel
+    /// BLOCKs sent down the same mux serialize: the second waits for the
+    /// first to return before its own BLOCK even begins at the server.
+    /// Meanwhile ferriskey's per-call `request_timeout` (auto-extended to
+    /// `block_ms + 500ms`) starts at future-poll on the CLIENT side, so
+    /// the second call's timeout fires before its turn at the server —
+    /// spurious `timed_out` errors under concurrent tail load.
+    ///
+    /// Explicit serialization around `xread_block` removes the
+    /// silent-failure mode: concurrent tails queue on this Mutex (inside
+    /// an already-acquired semaphore permit), then dispatch one at a
+    /// time with their full `block_ms` budget intact. The semaphore
+    /// ceiling (`max_concurrent_stream_ops`) effectively becomes queue
+    /// depth; throughput on the tail client is 1 BLOCK at a time.
+    ///
+    /// V2 upgrade: a pool of N dedicated `ferriskey::Client` connections
+    /// replacing the single `tail_client` + this Mutex. Deferred; the
+    /// Mutex here is correct v1 behavior.
+    ///
+    /// XRANGE reads (`read_attempt_stream`) are NOT gated by this Mutex —
+    /// XRANGE is non-blocking at the server, so pipelined XRANGEs on one
+    /// mux complete in microseconds each and don't trigger the same
+    /// client-side timeout race. Keeping reads unserialized preserves
+    /// read throughput.
+    xread_block_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Server-wide Semaphore(1) gating admin rotate calls. Legitimate
+    /// operators rotate ~monthly and can afford to serialize; concurrent
+    /// rotate requests are an attack or misbehaving script. Holding the
+    /// permit also guards against interleaved partial rotations on the
+    /// Server side of the per-partition locks, surfacing contention as
+    /// HTTP 429 instead of silently queueing and blowing past the 120s
+    /// HTTP timeout. See `rotate_waitpoint_secret` handler.
+    admin_rotate_semaphore: Arc<tokio::sync::Semaphore>,
     engine: Engine,
     config: ServerConfig,
     /// Background tasks spawned by async handlers (e.g. cancel_flow member
@@ -77,6 +149,12 @@ pub enum ServerError {
     OperationFailed(String),
     #[error("script: {0}")]
     Script(String),
+    /// Server-wide concurrent-tail limit reached. Surfaces as HTTP 429
+    /// at the REST boundary so load balancers and clients can retry with
+    /// backoff. Distinct from transport/script errors because the fault is
+    /// on the server side (too many in-flight tails), not the caller side.
+    #[error("too many concurrent tail calls (max: {0})")]
+    TailUnavailable(u32),
 }
 
 impl ServerError {
@@ -111,6 +189,9 @@ impl ServerError {
             | Self::InvalidInput(_)
             | Self::OperationFailed(_)
             | Self::Script(_) => false,
+            // Back off and retry — the server-side tail pool is the bound,
+            // so the retry will succeed once a permit frees up.
+            Self::TailUnavailable(_) => true,
         }
     }
 }
@@ -161,6 +242,17 @@ impl Server {
         // Step 2: Validate or create partition config
         validate_or_create_partition_config(&client, &config.partition_config).await?;
 
+        // Step 2b: Install waitpoint HMAC secret into every execution partition
+        // (RFC-004 §Waitpoint Security). Fail-fast: if any partition fails,
+        // the server refuses to start — a partial install would silently
+        // reject signal deliveries on half the partitions.
+        initialize_waitpoint_hmac_secret(
+            &client,
+            &config.partition_config,
+            &config.waitpoint_hmac_secret,
+        )
+        .await?;
+
         // Step 3: Load Lua library (skippable for tests where fixture already loaded)
         if !config.skip_library_load {
             tracing::info!("loading flowfabric Lua library");
@@ -191,7 +283,80 @@ impl Server {
             flow_projector_interval: config.engine_config.flow_projector_interval,
             execution_deadline_interval: config.engine_config.execution_deadline_interval,
         };
+        // Engine scanners keep running on the MAIN `client` mux — NOT on
+        // `tail_client`. Scanner cadence is foreground-latency-coupled by
+        // design (an incident that blocks all FCALLs should also visibly
+        // block scanners), and keeping scanners off the tail client means a
+        // long-poll tail can never starve lease-expiry, retention-trim,
+        // etc. Do not change this without revisiting RFC-006 Impl Notes.
         let engine = Engine::start(engine_cfg, client.clone());
+
+        // Dedicated tail client. Built AFTER library load + HMAC install
+        // because those steps use the main client; tail client only runs
+        // XREAD/XREAD BLOCK + HMGET on stream_meta, so it never needs the
+        // library loaded — but we build it on the same host/port/TLS
+        // options so network reachability is identical.
+        tracing::info!("opening dedicated tail connection");
+        let mut tail_builder = ClientBuilder::new()
+            .host(&config.host, config.port)
+            .connect_timeout(Duration::from_secs(10))
+            // `request_timeout` is ignored for XREAD BLOCK (ferriskey
+            // auto-extends to `block_ms + 500ms` for blocking commands),
+            // but is used for the companion HMGET — 5s matches main.
+            .request_timeout(Duration::from_millis(5000));
+        if config.tls {
+            tail_builder = tail_builder.tls();
+        }
+        if config.cluster {
+            tail_builder = tail_builder.cluster();
+        }
+        let tail_client = tail_builder
+            .build()
+            .await
+            .map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: "connect (tail)".into(),
+            })?;
+        let tail_pong: String = tail_client
+            .cmd("PING")
+            .execute()
+            .await
+            .map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: "PING (tail)".into(),
+            })?;
+        if tail_pong != "PONG" {
+            return Err(ServerError::OperationFailed(format!(
+                "tail client unexpected PING response: {tail_pong}"
+            )));
+        }
+
+        let stream_semaphore = Arc::new(tokio::sync::Semaphore::new(
+            config.max_concurrent_stream_ops as usize,
+        ));
+        let xread_block_lock = Arc::new(tokio::sync::Mutex::new(()));
+        tracing::info!(
+            max_concurrent_stream_ops = config.max_concurrent_stream_ops,
+            "stream-op client ready (read + tail share the semaphore; \
+             tails additionally serialize via xread_block_lock)"
+        );
+
+        // Admin surface warning. /v1/admin/* endpoints (waitpoint HMAC
+        // rotation, etc.) are only protected by the global Bearer
+        // middleware in api.rs — which is only installed when
+        // config.api_token is set. Without FF_API_TOKEN, a public
+        // deployment exposes secret rotation to anyone that can reach
+        // the listen_addr. Warn loudly so operators can't miss it; we
+        // don't fail-start because single-tenant dev uses this path.
+        if config.api_token.is_none() {
+            tracing::warn!(
+                listen_addr = %config.listen_addr,
+                "FF_API_TOKEN is unset — /v1/admin/* endpoints (including \
+                 rotate-waitpoint-secret) are UNAUTHENTICATED. Set \
+                 FF_API_TOKEN for any deployment reachable from untrusted \
+                 networks."
+            );
+        }
 
         tracing::info!(
             exec_partitions = config.partition_config.num_execution_partitions,
@@ -209,6 +374,14 @@ impl Server {
 
         Ok(Self {
             client,
+            tail_client,
+            stream_semaphore,
+            xread_block_lock,
+            // Single-permit semaphore: only one rotate-waitpoint-secret can
+            // be mid-flight server-wide. Attackers or misbehaving scripts
+            // firing parallel rotations fail fast with 429 instead of
+            // queueing HTTP handlers.
+            admin_rotate_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
             engine,
             config,
             background_tasks: Arc::new(AsyncMutex::new(JoinSet::new())),
@@ -1118,11 +1291,11 @@ impl Server {
             .map(|k| ctx.signal_dedup(wp_id, k))
             .unwrap_or_else(|| ctx.noop());
 
-        // KEYS (13): exec_core, wp_condition, wp_signals_stream,
+        // KEYS (14): exec_core, wp_condition, wp_signals_stream,
         //            exec_signals_zset, signal_hash, signal_payload,
         //            idem_key, waitpoint_hash, suspension_current,
         //            eligible_zset, suspended_zset, delayed_zset,
-        //            suspension_timeout_zset
+        //            suspension_timeout_zset, hmac_secrets
         let fcall_keys: Vec<String> = vec![
             ctx.core(),                       // 1
             ctx.waitpoint_condition(wp_id),    // 2
@@ -1137,14 +1310,15 @@ impl Server {
             idx.lane_suspended(&lane),         // 11
             idx.lane_delayed(&lane),           // 12
             idx.suspension_timeout(),          // 13
+            idx.waitpoint_hmac_secrets(),      // 14
         ];
 
-        // ARGV (17): signal_id, execution_id, waitpoint_id, signal_name,
+        // ARGV (18): signal_id, execution_id, waitpoint_id, signal_name,
         //            signal_category, source_type, source_identity,
         //            payload, payload_encoding, idempotency_key,
         //            correlation_id, target_scope, created_at,
         //            dedup_ttl_ms, resume_delay_ms, signal_maxlen,
-        //            max_signals_per_execution
+        //            max_signals_per_execution, waitpoint_token
         let fcall_args: Vec<String> = vec![
             args.signal_id.to_string(),                          // 1
             args.execution_id.to_string(),                       // 2
@@ -1175,6 +1349,9 @@ impl Server {
             args.max_signals_per_execution
                 .unwrap_or(10_000)
                 .to_string(),                                    // 17
+            // WIRE BOUNDARY — raw token to Lua. Display is redacted
+            // for log safety; use .as_str() at the wire crossing.
+            args.waitpoint_token.as_str().to_owned(),            // 18
         ];
 
         let key_refs: Vec<&str> = fcall_keys.iter().map(|s| s.as_str()).collect();
@@ -1570,15 +1747,206 @@ impl Server {
         parse_replay_result(&raw)
     }
 
+    /// Read frames from an attempt's stream (XRANGE wrapper) plus terminal
+    /// markers (`closed_at`, `closed_reason`) so consumers can stop polling
+    /// when the producer finalizes.
+    ///
+    /// `from_id` and `to_id` accept XRANGE special markers: `"-"` for
+    /// earliest, `"+"` for latest. `count_limit` MUST be `>= 1` —
+    /// `0` returns a `ServerError::InvalidInput` (matches the REST boundary
+    /// and the Lua-side reject).
+    ///
+    /// Cluster-safe: the attempt's `{p:N}` partition is derived from the
+    /// execution id, so all KEYS share the same slot.
+    pub async fn read_attempt_stream(
+        &self,
+        execution_id: &ExecutionId,
+        attempt_index: AttemptIndex,
+        from_id: &str,
+        to_id: &str,
+        count_limit: u64,
+    ) -> Result<ff_core::contracts::StreamFrames, ServerError> {
+        use ff_core::contracts::{ReadFramesArgs, ReadFramesResult};
+
+        if count_limit == 0 {
+            return Err(ServerError::InvalidInput(
+                "count_limit must be >= 1".to_owned(),
+            ));
+        }
+
+        // Share the same semaphore as tail. A large XRANGE reply (10_000
+        // frames × ~64KB) is just as capable of head-of-line-blocking the
+        // tail_client mux as a long BLOCK — fairness accounting must be
+        // unified. Non-blocking acquire → 429 on contention.
+        let permit = match self.stream_semaphore.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                return Err(ServerError::TailUnavailable(
+                    self.config.max_concurrent_stream_ops,
+                ));
+            }
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(ServerError::OperationFailed(
+                    "stream semaphore closed (server shutting down)".into(),
+                ));
+            }
+        };
+
+        let args = ReadFramesArgs {
+            execution_id: execution_id.clone(),
+            attempt_index,
+            from_id: from_id.to_owned(),
+            to_id: to_id.to_owned(),
+            count_limit,
+        };
+
+        let partition = execution_partition(execution_id, &self.config.partition_config);
+        let ctx = ExecKeyContext::new(&partition, execution_id);
+        let keys = ff_script::functions::stream::StreamOpKeys { ctx: &ctx };
+
+        // Route on the dedicated stream client, same as tail. A 10_000-
+        // frame XRANGE reply on the main mux would stall every other
+        // FCALL behind reply serialization.
+        let result = ff_script::functions::stream::ff_read_attempt_stream(
+            &self.tail_client, &keys, &args,
+        )
+        .await
+        .map_err(script_error_to_server);
+
+        drop(permit);
+
+        match result? {
+            ReadFramesResult::Frames(f) => Ok(f),
+        }
+    }
+
+    /// Tail a live attempt's stream (XREAD BLOCK wrapper). Returns frames
+    /// plus the terminal signal so a polling consumer can exit when the
+    /// producer closes the stream.
+    ///
+    /// `last_id` is exclusive — XREAD returns entries with id > last_id.
+    /// Pass `"0-0"` to read from the beginning.
+    ///
+    /// `block_ms == 0` → non-blocking peek (returns immediately).
+    /// `block_ms > 0`  → blocks up to that many ms. Empty `frames` +
+    /// `closed_at=None` → timeout, no new data, still open.
+    ///
+    /// `count_limit` MUST be `>= 1`; `0` returns `InvalidInput`.
+    ///
+    /// Implemented as a direct XREAD command (not FCALL) because blocking
+    /// commands are rejected inside Valkey Functions. The terminal
+    /// markers come from a companion HMGET on `stream_meta` — see
+    /// `ff_script::stream_tail` module docs.
+    pub async fn tail_attempt_stream(
+        &self,
+        execution_id: &ExecutionId,
+        attempt_index: AttemptIndex,
+        last_id: &str,
+        block_ms: u64,
+        count_limit: u64,
+    ) -> Result<ff_core::contracts::StreamFrames, ServerError> {
+        if count_limit == 0 {
+            return Err(ServerError::InvalidInput(
+                "count_limit must be >= 1".to_owned(),
+            ));
+        }
+
+        // Non-blocking permit acquisition on the shared stream_semaphore
+        // (read + tail split the same pool). If the server is already at
+        // the `max_concurrent_stream_ops` ceiling, return `TailUnavailable`
+        // (→ 429) rather than queueing — a queued tail holds the caller's
+        // HTTP request open with no upper bound, which is exactly the
+        // resource-exhaustion pattern this limit exists to prevent.
+        // Clients retry with backoff on 429.
+        //
+        // Worst-case permit hold: if the producer closes the stream via
+        // HSET on stream_meta (not an XADD), the XREAD BLOCK won't wake
+        // until `block_ms` elapses — so a permit can be held for up to
+        // the caller's block_ms even though the terminal signal is
+        // ready. This is a v1-accepted limitation; RFC-006 §Terminal-
+        // signal timing under active tail documents it and sketches the
+        // v2 sentinel-XADD upgrade path.
+        let permit = match self.stream_semaphore.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                return Err(ServerError::TailUnavailable(
+                    self.config.max_concurrent_stream_ops,
+                ));
+            }
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(ServerError::OperationFailed(
+                    "stream semaphore closed (server shutting down)".into(),
+                ));
+            }
+        };
+
+        let partition = execution_partition(execution_id, &self.config.partition_config);
+        let ctx = ExecKeyContext::new(&partition, execution_id);
+        let stream_key = ctx.stream(attempt_index);
+        let stream_meta_key = ctx.stream_meta(attempt_index);
+
+        // Acquire the XREAD BLOCK serializer AFTER the stream semaphore.
+        // Nesting order matters: the semaphore is the user-visible
+        // ceiling (surfaces as 429), the Mutex is an internal fairness
+        // gate. Holding the permit while waiting on the Mutex means the
+        // ceiling still bounds queue depth. See the field docstring for
+        // the full rationale (ferriskey pipeline FIFO + client-side
+        // per-call timeout race).
+        let _xread_guard = self.xread_block_lock.lock().await;
+
+        let result = ff_script::stream_tail::xread_block(
+            &self.tail_client,
+            &stream_key,
+            &stream_meta_key,
+            last_id,
+            block_ms,
+            count_limit,
+        )
+        .await
+        .map_err(script_error_to_server);
+
+        drop(_xread_guard);
+        drop(permit);
+        result
+    }
+
     /// Graceful shutdown — stops scanners, drains background handler tasks
     /// (e.g. cancel_flow member dispatch) with a bounded timeout, then waits
     /// for scanners to finish.
+    ///
+    /// Shutdown order is chosen so in-flight stream ops (read/tail) drain
+    /// cleanly without new arrivals piling up:
+    ///
+    /// 1. `stream_semaphore.close()` — new read/tail attempts fail fast
+    ///    with `ServerError::OperationFailed("stream semaphore closed …")`
+    ///    which the REST layer surfaces as a 500 with `retryable=false`
+    ///    (ops tooling may choose to wait + retry on 503-class responses;
+    ///    the body clearly names the shutdown reason).
+    /// 2. Drain handler-spawned background tasks with a 15s ceiling.
+    /// 3. `engine.shutdown()` stops scanners.
+    ///
+    /// Existing in-flight tails finish on their natural `block_ms`
+    /// boundary (up to ~30s); the `tail_client` is dropped when `Server`
+    /// is dropped after this function returns. We do NOT wait for tails
+    /// to drain explicitly — the semaphore-close + natural-timeout
+    /// combination bounds shutdown to roughly `block_ms + 15s` in the
+    /// worst case. Callers observing a dropped connection retry against
+    /// whatever replacement is coming up.
     pub async fn shutdown(self) {
         tracing::info!("shutting down FlowFabric server");
 
-        // Drain handler-spawned background tasks with the same ceiling as
-        // Engine::shutdown. If dispatch is still running at the deadline,
-        // drop the JoinSet to abort remaining tasks.
+        // Step 1: Close the stream semaphore FIRST so any in-flight
+        // read/tail calls that are between `try_acquire` and their
+        // Valkey command still hold a valid permit, but no NEW stream
+        // op can start. `Semaphore::close()` is idempotent.
+        self.stream_semaphore.close();
+        tracing::info!(
+            "stream semaphore closed; no new read/tail attempts will be accepted"
+        );
+
+        // Step 2: Drain handler-spawned background tasks with the same
+        // ceiling as Engine::shutdown. If dispatch is still running at
+        // the deadline, drop the JoinSet to abort remaining tasks.
         let drain_timeout = Duration::from_secs(15);
         let background = self.background_tasks.clone();
         let drain = async move {
@@ -1663,6 +2031,573 @@ async fn validate_or_create_partition_config(
 
     tracing::info!("partition config validated against stored {key}");
     Ok(())
+}
+
+// ── Waitpoint HMAC secret bootstrap (RFC-004 §Waitpoint Security) ──
+
+/// Stable initial kid written on first boot. Rotation promotes to k2, k3, ...
+/// The kid is stored alongside the secret in every partition's hash so each
+/// FCALL can self-identify which secret produced a given token.
+const WAITPOINT_HMAC_INITIAL_KID: &str = "k1";
+
+/// Per-partition outcome of the HMAC bootstrap step. Collected across the
+/// parallel scan so we can emit aggregated logs once at the end.
+enum PartitionBootOutcome {
+    /// Partition already had a matching (kid, secret) pair.
+    Match,
+    /// Stored secret diverges from env — likely operator rotation; kept.
+    Mismatch,
+    /// Torn write (current_kid present, secret:<kid> missing); repaired.
+    Repaired,
+    /// Fresh partition; atomically installed env secret under kid=k1.
+    Installed,
+}
+
+/// Bounded in-flight concurrency for the startup fan-out. Large enough to
+/// turn a 256-partition install from ~15s sequential into ~1s on cross-AZ
+/// Valkey, small enough to leave a cold cluster breathing room for other
+/// Server::start work (library load, engine scanner spawn).
+const BOOT_INIT_CONCURRENCY: usize = 16;
+
+async fn init_one_partition(
+    client: &Client,
+    partition: Partition,
+    secret_hex: &str,
+) -> Result<PartitionBootOutcome, ServerError> {
+    let key = ff_core::keys::IndexKeys::new(&partition).waitpoint_hmac_secrets();
+
+    // Probe for an existing install. Fast path (fresh partition): HGET
+    // returns nil and we fall through to the atomic install below. Slow
+    // path: secret:<stored_kid> is then HGET'd once we know the kid name.
+    // (A previous version used a 2-field HMGET that included a fake
+    // `secret:probe` placeholder — vestigial from an abandoned
+    // optimization attempt, and confusing to read. Collapsed back to a
+    // single-field HGET.)
+    let stored_kid: Option<String> = client
+        .cmd("HGET")
+        .arg(&key)
+        .arg("current_kid")
+        .execute()
+        .await
+        .map_err(|e| ServerError::ValkeyContext {
+            source: e,
+            context: format!("HGET {key} current_kid (init probe)"),
+        })?;
+
+    if let Some(stored_kid) = stored_kid {
+        // We didn't know the stored kid up front, so now HGET the real
+        // secret:<stored_kid> field. Two round-trips in the slow path; the
+        // fast path (fresh partition) stays at one.
+        let field = format!("secret:{stored_kid}");
+        let stored_secret: Option<String> = client
+            .hget(&key, &field)
+            .await
+            .map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: format!("HGET {key} secret:<kid> (init check)"),
+            })?;
+        if stored_secret.is_none() {
+            // Torn write from a previous boot: current_kid present but
+            // secret:<kid> missing. Without repair, mint returns
+            // "hmac_secret_not_initialized" on that partition forever.
+            // Repair in place with env secret. Not rotation — rotation
+            // always writes the secret first.
+            client
+                .hset(&key, &field, secret_hex)
+                .await
+                .map_err(|e| ServerError::ValkeyContext {
+                    source: e,
+                    context: format!("HSET {key} secret:<kid> (repair torn write)"),
+                })?;
+            return Ok(PartitionBootOutcome::Repaired);
+        }
+        if stored_secret.as_deref() != Some(secret_hex) {
+            return Ok(PartitionBootOutcome::Mismatch);
+        }
+        return Ok(PartitionBootOutcome::Match);
+    }
+
+    // Fresh partition — install current_kid + secret:<kid> atomically in
+    // one HSET. Multi-field HSET is single-command atomic, so a crash
+    // can't leave current_kid without its secret.
+    let secret_field = format!("secret:{WAITPOINT_HMAC_INITIAL_KID}");
+    let _: i64 = client
+        .cmd("HSET")
+        .arg(&key)
+        .arg("current_kid")
+        .arg(WAITPOINT_HMAC_INITIAL_KID)
+        .arg(&secret_field)
+        .arg(secret_hex)
+        .execute()
+        .await
+        .map_err(|e| ServerError::ValkeyContext {
+            source: e,
+            context: format!("HSET {key} (init waitpoint HMAC atomic)"),
+        })?;
+    Ok(PartitionBootOutcome::Installed)
+}
+
+/// Install the waitpoint HMAC secret on every execution partition.
+///
+/// Parallelized fan-out with bounded in-flight concurrency
+/// (`BOOT_INIT_CONCURRENCY`) so 256-partition boots finish in ~1s instead
+/// of ~15s sequential — the prior sequential loop was tight on K8s
+/// `initialDelaySeconds=30` defaults, especially cross-AZ. Fail-fast:
+/// the first per-partition error aborts boot.
+///
+/// Outcomes aggregate into mismatch/repaired counts (logged once at end)
+/// so operators see a single loud warning per fault class instead of 256
+/// per-partition lines.
+async fn initialize_waitpoint_hmac_secret(
+    client: &Client,
+    partition_config: &PartitionConfig,
+    secret_hex: &str,
+) -> Result<(), ServerError> {
+    use futures::stream::{FuturesUnordered, StreamExt};
+
+    let n = partition_config.num_execution_partitions;
+    tracing::info!(
+        partitions = n,
+        concurrency = BOOT_INIT_CONCURRENCY,
+        "installing waitpoint HMAC secret across {n} execution partitions"
+    );
+
+    let mut mismatch_count: u16 = 0;
+    let mut repaired_count: u16 = 0;
+    let mut pending: FuturesUnordered<_> = FuturesUnordered::new();
+    let mut next_index: u16 = 0;
+
+    loop {
+        while pending.len() < BOOT_INIT_CONCURRENCY && next_index < n {
+            let partition = Partition {
+                family: PartitionFamily::Execution,
+                index: next_index,
+            };
+            let client = client.clone();
+            let secret_hex = secret_hex.to_owned();
+            pending.push(async move {
+                init_one_partition(&client, partition, &secret_hex).await
+            });
+            next_index += 1;
+        }
+        match pending.next().await {
+            Some(res) => match res? {
+                PartitionBootOutcome::Match | PartitionBootOutcome::Installed => {}
+                PartitionBootOutcome::Mismatch => mismatch_count += 1,
+                PartitionBootOutcome::Repaired => repaired_count += 1,
+            },
+            None => break,
+        }
+    }
+
+    if repaired_count > 0 {
+        tracing::warn!(
+            repaired_partitions = repaired_count,
+            total_partitions = n,
+            "repaired {repaired_count} partitions with torn waitpoint HMAC writes \
+             (current_kid present but secret:<kid> missing, likely crash during prior boot)"
+        );
+    }
+
+    if mismatch_count > 0 {
+        tracing::warn!(
+            mismatched_partitions = mismatch_count,
+            total_partitions = n,
+            "stored/env secret mismatch on {mismatch_count} partitions — \
+             env FF_WAITPOINT_HMAC_SECRET ignored in favor of stored values; \
+             run POST /v1/admin/rotate-waitpoint-secret to sync"
+        );
+    }
+
+    tracing::info!(partitions = n, "waitpoint HMAC secret install complete");
+    Ok(())
+}
+
+/// Result of a waitpoint HMAC secret rotation across all execution partitions.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RotateWaitpointSecretResult {
+    /// Count of partitions that accepted the rotation.
+    pub rotated: u16,
+    /// Partition indices that failed — operator should investigate (Valkey
+    /// outage, auth failure, cluster split). Rotation is idempotent, so a
+    /// re-run after the underlying fault clears converges to the correct
+    /// state.
+    pub failed: Vec<u16>,
+    /// Partition indices where another rotation was already in progress
+    /// (SETNX lock held). These will be rotated by the concurrent request;
+    /// NOT a fault the operator should retry and NOT counted in `failed`.
+    /// Surfaced separately so dashboards distinguish "retry needed" from
+    /// "ignore, in-flight".
+    #[serde(default)]
+    pub in_progress: Vec<u16>,
+    /// New kid installed as current.
+    pub new_kid: String,
+}
+
+/// Per-partition rotation step outcome. `InProgress` means the SETNX lock
+/// was held by a concurrent rotation — not an error; the concurrent call
+/// will finish the work.
+enum RotationStepOutcome {
+    Rotated,
+    InProgress,
+}
+
+impl Server {
+    /// Rotate the waitpoint HMAC secret. Promotes the current kid to previous
+    /// (accepted within `FF_WAITPOINT_HMAC_GRACE_MS`), installs `new_secret_hex`
+    /// as the new current kid. Idempotent: re-running with the same `new_kid`
+    /// and `new_secret_hex` converges partitions to the same state.
+    ///
+    /// Returns a structured result so operators can see which partitions failed.
+    /// HTTP layer returns 200 if any partition succeeded, 500 only if all fail.
+    pub async fn rotate_waitpoint_secret(
+        &self,
+        new_kid: &str,
+        new_secret_hex: &str,
+    ) -> Result<RotateWaitpointSecretResult, ServerError> {
+        if new_kid.is_empty() || new_kid.contains(':') {
+            return Err(ServerError::OperationFailed(
+                "new_kid must be non-empty and must not contain ':'".into(),
+            ));
+        }
+        if new_secret_hex.is_empty()
+            || !new_secret_hex.len().is_multiple_of(2)
+            || !new_secret_hex.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            return Err(ServerError::OperationFailed(
+                "new_secret_hex must be a non-empty even-length hex string".into(),
+            ));
+        }
+
+        // Single-writer gate. Concurrent rotates against the SAME operator
+        // token are an attack pattern (or a retry-loop bug); legitimate
+        // operators rotate monthly and can afford to serialize. Contention
+        // returns TailUnavailable (→ HTTP 429) rather than queueing the
+        // HTTP handler past the 120s endpoint timeout. Permit is held for
+        // the full partition fan-out.
+        let _permit = match self.admin_rotate_semaphore.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                return Err(ServerError::TailUnavailable(1));
+            }
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(ServerError::OperationFailed(
+                    "admin rotate semaphore closed (server shutting down)".into(),
+                ));
+            }
+        };
+
+        let n = self.config.partition_config.num_execution_partitions;
+        let grace_ms = self.config.waitpoint_hmac_grace_ms;
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_millis() as i64;
+        let previous_expires_at = now_ms + grace_ms as i64;
+
+        let mut rotated = 0u16;
+        let mut failed = Vec::new();
+        let mut in_progress: Vec<u16> = Vec::new();
+        for index in 0..n {
+            let partition = Partition { family: PartitionFamily::Execution, index };
+            let key = ff_core::keys::IndexKeys::new(&partition).waitpoint_hmac_secrets();
+
+            match self
+                .rotate_single_partition(&key, new_kid, new_secret_hex, previous_expires_at)
+                .await
+            {
+                Ok(RotationStepOutcome::Rotated) => {
+                    rotated += 1;
+                    // Per-partition event → DEBUG (not INFO). Rationale:
+                    // one rotate endpoint call produces 256 partition-level
+                    // events, which would blow up paid aggregator budgets
+                    // (Datadog/Splunk) at no operational value. The single
+                    // aggregated audit event below is the compliance
+                    // artifact. Failures stay at ERROR with per-partition
+                    // detail — that's where operators need it.
+                    tracing::debug!(
+                        partition = %partition,
+                        new_kid = %new_kid,
+                        "waitpoint_hmac_rotated"
+                    );
+                }
+                Ok(RotationStepOutcome::InProgress) => {
+                    // Another rotation is mid-flight on this partition. It
+                    // will finish (rotation is idempotent + per-partition
+                    // locked), so this is NOT a failure the operator needs
+                    // to retry. DO NOT push to `failed` — keeping `failed`
+                    // meaningful for actual Valkey/config errors the
+                    // operator must investigate. Per-partition detail at
+                    // DEBUG; summary emitted once at end.
+                    in_progress.push(index);
+                    tracing::debug!(
+                        partition = %partition,
+                        new_kid = %new_kid,
+                        "waitpoint_hmac_rotation_in_progress_skipped"
+                    );
+                }
+                Err(e) => {
+                    // Failures stay at ERROR (target=audit) per-partition —
+                    // operators need the partition index + error to debug
+                    // Valkey/config faults. Low cardinality in practice
+                    // (failures should be rare).
+                    tracing::error!(
+                        target: "audit",
+                        partition = %partition,
+                        err = %e,
+                        "waitpoint_hmac_rotation_failed"
+                    );
+                    failed.push(index);
+                }
+            }
+        }
+
+        // Single aggregated audit event for the whole rotation. This is
+        // the load-bearing compliance artifact — operators alert on
+        // target="audit" at INFO level and this is the stable schema.
+        tracing::info!(
+            target: "audit",
+            new_kid = %new_kid,
+            total_partitions = n,
+            rotated,
+            failed_count = failed.len(),
+            in_progress_count = in_progress.len(),
+            "waitpoint_hmac_rotation_complete"
+        );
+
+        Ok(RotateWaitpointSecretResult {
+            rotated,
+            failed,
+            in_progress,
+            new_kid: new_kid.to_owned(),
+        })
+    }
+
+    /// Rotate on a single partition. Reads current_kid, promotes it to
+    /// previous_kid with `previous_expires_at`, installs new_kid + new secret.
+    ///
+    /// Serialized per-partition via a SETNX lock (`ff:sec:rotate_lock:{p:N}`)
+    /// with a 10s TTL. Concurrent operator-triggered rotations against the
+    /// same partition would otherwise interleave the HGET/HDEL/HSET sequence
+    /// and lose writes — the loser's secret would end up partially stored
+    /// and its tokens would stop validating. The lock key shares the
+    /// partition hash tag so it stays in-slot under cluster mode.
+    ///
+    /// A single-partition rotation completes in a few ms on local Valkey,
+    /// so the 10s TTL is a generous safety margin.
+    async fn rotate_single_partition(
+        &self,
+        key: &str,
+        new_kid: &str,
+        new_secret_hex: &str,
+        previous_expires_at: i64,
+    ) -> Result<RotationStepOutcome, ServerError> {
+        // Derive the lock key from the secrets key: keep the `{p:N}` hash tag
+        // so the lock lives in the same cluster slot as the hash we're
+        // mutating. `ff:sec:{p:N}:waitpoint_hmac` → `ff:sec:{p:N}:rotate_lock`.
+        let lock_key = rotate_lock_key_for(key);
+        const LOCK_TTL_MS: u64 = 10_000;
+        let acquired: Option<String> = self
+            .client
+            .cmd("SET")
+            .arg(&lock_key)
+            .arg("1")
+            .arg("NX")
+            .arg("PX")
+            .arg(LOCK_TTL_MS.to_string().as_str())
+            .execute()
+            .await
+            .map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: format!("SET NX {lock_key}"),
+            })?;
+        if acquired.is_none() {
+            // Concurrent rotation holds the lock. Return InProgress (not
+            // Err) — the concurrent caller will finish the work, the
+            // outer loop buckets this partition into `in_progress`, and
+            // the operator does not get a spurious "failed" count.
+            return Ok(RotationStepOutcome::InProgress);
+        }
+
+        // Best-effort DEL of the lock on all exit paths. Valkey auto-expires
+        // via PX TTL anyway, so a dropped future only costs the remaining
+        // lock window, not correctness.
+        let result = self
+            .rotate_single_partition_locked(key, new_kid, new_secret_hex, previous_expires_at)
+            .await;
+        let _: Option<i64> = self
+            .client
+            .cmd("DEL")
+            .arg(&lock_key)
+            .execute()
+            .await
+            .ok()
+            .flatten();
+        result.map(|()| RotationStepOutcome::Rotated)
+    }
+
+    async fn rotate_single_partition_locked(
+        &self,
+        key: &str,
+        new_kid: &str,
+        new_secret_hex: &str,
+        previous_expires_at: i64,
+    ) -> Result<(), ServerError> {
+        let current_kid: Option<String> = self
+            .client
+            .hget(key, "current_kid")
+            .await
+            .map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: format!("HGET {key} current_kid"),
+            })?;
+
+        if current_kid.as_deref() == Some(new_kid) {
+            // Already rotated to this kid. Retry-safety rule (RFC-004):
+            // - same kid + same secret → no-op (operator retry after HTTP
+            //   timeout or transient 5xx is SAFE).
+            // - same kid + DIFFERENT secret → REJECT with RotationConflict.
+            //   Silently overwriting would invalidate every token minted
+            //   under the stored secret since the first rotation to this
+            //   kid, an unbounded amount of in-flight state.
+            let field = format!("secret:{new_kid}");
+            let stored_secret: Option<String> = self
+                .client
+                .hget(key, &field)
+                .await
+                .map_err(|e| ServerError::ValkeyContext {
+                    source: e,
+                    context: format!("HGET {key} secret:<kid> (idempotency check)"),
+                })?;
+            match stored_secret.as_deref() {
+                Some(s) if s == new_secret_hex => {
+                    // Exact replay — idempotent no-op.
+                    return Ok(());
+                }
+                Some(_) => {
+                    // Same kid, different secret bytes. This is almost
+                    // certainly an operator mistake (typed wrong hex, or
+                    // forgot they rotated, or two simultaneous rotations
+                    // racing with distinct material). Refuse with a
+                    // dedicated error that the HTTP layer maps to 409
+                    // Conflict so the caller knows this isn't a retry
+                    // opportunity.
+                    return Err(ServerError::OperationFailed(format!(
+                        "rotation conflict: kid {new_kid} already installed with a \
+                         different secret. Either use a fresh kid or restore the \
+                         original secret for this kid before retrying."
+                    )));
+                }
+                None => {
+                    // Torn write: current_kid=new_kid but secret:<new_kid>
+                    // missing. Repair with the presented secret. Matches
+                    // boot-init repair semantics.
+                    self.client
+                        .hset(key, &field, new_secret_hex)
+                        .await
+                        .map_err(|e| ServerError::ValkeyContext {
+                            source: e,
+                            context: format!("HSET {key} secret:<kid> (torn-write repair)"),
+                        })?;
+                    return Ok(());
+                }
+            }
+        }
+
+        // Orphan GC: scan the entire expires_at:* namespace and HDEL both
+        // expires_at:<kid> and secret:<kid> for every kid whose grace has
+        // elapsed. Multi-kid validation (helpers.lua) accepts ANY kid
+        // present with a future expires_at, so GC by recency (just
+        // previous_kid) would leak historical kids forever AND — worse —
+        // restricting validation to a two-slot window would violate the
+        // grace contract on rapid rotation (A→B→C inside 24h kept A
+        // accepted under the prior model only via previous_kid, which B
+        // now claims).
+        //
+        // HGETALL the whole hash once (bounded: one entry per distinct
+        // kid ever installed, plus scalar fields). Build the reaper set
+        // in-memory, then one HDEL. Cheap.
+        let full_hash: std::collections::HashMap<String, String> = self
+            .client
+            .hgetall(key)
+            .await
+            .map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: format!("HGETALL {key} (orphan scan)"),
+            })?;
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_millis() as i64;
+        let mut expired_kids: Vec<String> = Vec::new();
+        for (field, value) in &full_hash {
+            if let Some(kid) = field.strip_prefix("expires_at:") {
+                let exp = value.parse::<i64>().unwrap_or(0);
+                if exp <= 0 || exp <= now_ms {
+                    expired_kids.push(kid.to_owned());
+                }
+            }
+        }
+        if !expired_kids.is_empty() {
+            let mut hdel = self.client.cmd("HDEL").arg(key);
+            for kid in &expired_kids {
+                hdel = hdel.arg(format!("expires_at:{kid}")).arg(format!("secret:{kid}"));
+            }
+            let _: i64 = hdel.execute().await.map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: format!("HDEL {key} expired kids (orphan GC)"),
+            })?;
+        }
+
+        // Promote current → previous: stamp expires_at:<current_kid> with
+        // the new previous_expires_at. This is the per-kid grace window
+        // that validate_waitpoint_token reads. previous_kid +
+        // previous_expires_at scalars are kept in lockstep for audit log
+        // observability (aggregated rotation event shape) and for any
+        // downgrade path that still reads the two-slot scheme.
+        //
+        // INVARIANT: expires_at:<new_kid> is NEVER written — current_kid
+        // has no expiry (always valid). It only gets an expires_at entry
+        // when a FUTURE rotation promotes it out of current.
+        let mut hset = self.client.cmd("HSET").arg(key);
+        let prev_expires_str = previous_expires_at.to_string();
+        let cur_owned;
+        let outgoing_expires_field;
+        if let Some(cur) = current_kid {
+            cur_owned = cur;
+            outgoing_expires_field = format!("expires_at:{cur_owned}");
+            hset = hset
+                .arg("previous_kid")
+                .arg(cur_owned.as_str())
+                .arg("previous_expires_at")
+                .arg(prev_expires_str.as_str())
+                .arg(outgoing_expires_field.as_str())
+                .arg(prev_expires_str.as_str());
+        }
+        let secret_field = format!("secret:{new_kid}");
+        let _: i64 = hset
+            .arg("current_kid")
+            .arg(new_kid)
+            .arg(&secret_field)
+            .arg(new_secret_hex)
+            .execute()
+            .await
+            .map_err(|e| ServerError::ValkeyContext {
+                source: e,
+                context: format!("HSET {key} (rotate atomic)"),
+            })?;
+        Ok(())
+    }
+}
+
+/// Derive a per-partition rotation lock key that shares the hash tag of the
+/// secrets key (so lock and hash live in the same cluster slot).
+/// `ff:sec:{p:N}:waitpoint_hmac` → `ff:sec:{p:N}:rotate_lock`.
+fn rotate_lock_key_for(secrets_key: &str) -> String {
+    match secrets_key.rsplit_once(':') {
+        Some((prefix, _last)) => format!("{prefix}:rotate_lock"),
+        None => format!("{secrets_key}:rotate_lock"),
+    }
 }
 
 // ── FCALL result parsing ──
@@ -2120,6 +3055,25 @@ fn parse_replay_result(raw: &Value) -> Result<ReplayExecutionResult, ServerError
 }
 
 /// Extract a string from an FCALL result array at the given index.
+/// Convert a `ScriptError` into a `ServerError` preserving `ferriskey::ErrorKind`
+/// for transport-level variants. Business-logic variants keep their code as
+/// `ServerError::Script(String)` so HTTP clients see a stable message.
+///
+/// Why this exists: before R2, the stream handlers did
+/// `ScriptError → format!() → ServerError::Script(String)`, which erased
+/// the ErrorKind and made `ServerError::is_retryable()` always return
+/// false. Retry-capable clients (cairn-fabric) would not retry a legit
+/// transient error like `IoError`.
+fn script_error_to_server(e: ff_script::error::ScriptError) -> ServerError {
+    match e {
+        ff_script::error::ScriptError::Valkey(valkey_err) => ServerError::ValkeyContext {
+            source: valkey_err,
+            context: "stream FCALL transport".into(),
+        },
+        other => ServerError::Script(other.to_string()),
+    }
+}
+
 fn fcall_field_str(arr: &[Result<Value, ferriskey::Error>], index: usize) -> String {
     match arr.get(index) {
         Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),

--- a/crates/ff-test/src/fixtures.rs
+++ b/crates/ff-test/src/fixtures.rs
@@ -125,6 +125,88 @@ impl TestCluster {
     /// to be run per-shard.
     pub async fn cleanup(&self) {
         self.cleanup_ff_keys().await;
+        // FLUSHDB erased any previously-installed waitpoint HMAC secret,
+        // so re-install one across all test partitions. This keeps
+        // FCALL-only tests (no Server boot) able to mint + validate tokens.
+        self.install_waitpoint_hmac_secret(
+            "k1",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .await;
+    }
+
+    /// Install a waitpoint HMAC secret across every execution partition.
+    /// Equivalent to what `Server::start` does on boot; useful for tests
+    /// that only exercise FCALLs (no Server instance). Overwrites.
+    pub async fn install_waitpoint_hmac_secret(&self, kid: &str, secret_hex: &str) {
+        for index in 0..self.config.num_execution_partitions {
+            let partition = ff_core::partition::Partition {
+                family: ff_core::partition::PartitionFamily::Execution,
+                index,
+            };
+            let key = ff_core::keys::IndexKeys::new(&partition).waitpoint_hmac_secrets();
+            self.client
+                .hset(&key, "current_kid", kid)
+                .await
+                .expect("HSET current_kid");
+            self.client
+                .hset(&key, &format!("secret:{kid}"), secret_hex)
+                .await
+                .expect("HSET secret:<kid>");
+        }
+    }
+
+    /// Rotate the waitpoint HMAC secret across partitions — promotes current
+    /// kid to previous with `previous_expires_at`, installs new kid. Used by
+    /// rotation tests that want to simulate operator rotation via fixtures.
+    pub async fn rotate_waitpoint_hmac_secret(
+        &self,
+        new_kid: &str,
+        new_secret_hex: &str,
+        previous_expires_at_ms: i64,
+    ) {
+        for index in 0..self.config.num_execution_partitions {
+            let partition = ff_core::partition::Partition {
+                family: ff_core::partition::PartitionFamily::Execution,
+                index,
+            };
+            let key = ff_core::keys::IndexKeys::new(&partition).waitpoint_hmac_secrets();
+            let current: Option<String> = self
+                .client
+                .hget(&key, "current_kid")
+                .await
+                .expect("HGET current_kid");
+            if let Some(cur) = current {
+                self.client
+                    .hset(&key, "previous_kid", &cur)
+                    .await
+                    .expect("HSET previous_kid");
+                self.client
+                    .hset(&key, "previous_expires_at", &previous_expires_at_ms.to_string())
+                    .await
+                    .expect("HSET previous_expires_at");
+                // Multi-kid validation (RFC-004 §Waitpoint Security): the
+                // per-kid expires_at:<kid> field is the authoritative
+                // grace signal. Mirror production Server::rotate_single_partition_locked
+                // which writes this alongside previous_kid / previous_expires_at.
+                self.client
+                    .hset(
+                        &key,
+                        &format!("expires_at:{cur}"),
+                        &previous_expires_at_ms.to_string(),
+                    )
+                    .await
+                    .expect("HSET expires_at:<outgoing_kid>");
+            }
+            self.client
+                .hset(&key, "current_kid", new_kid)
+                .await
+                .expect("HSET current_kid (rotate)");
+            self.client
+                .hset(&key, &format!("secret:{new_kid}"), new_secret_hex)
+                .await
+                .expect("HSET secret:<new_kid>");
+        }
     }
 
     /// Clear all data keys for a clean test slate.

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -12,8 +12,10 @@
 //! - POST /v1/budgets/{id}/reset (reset_budget)
 //! - POST /v1/flows/{id}/edges (stage_dependency_edge)
 //! - POST /v1/flows/{id}/edges/apply (apply_dependency_to_child)
+//!
 //! TODO: Untested SDK methods (no test at any layer):
 //! - ClaimedTask::move_to_waiting_children()
+//!
 //! TODO: Untested Server methods (tested via FCALL but not typed Server API):
 //! - Server::revoke_lease()
 //! - Server::reset_budget()
@@ -114,6 +116,10 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         skip_library_load: true,
         cors_origins: vec!["*".to_owned()],
         api_token: None,
+        waitpoint_hmac_secret:
+            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+        waitpoint_hmac_grace_ms: 86_400_000,
+        max_concurrent_stream_ops: 64,
     }
 }
 
@@ -640,4 +646,100 @@ async fn test_api_cancel_flow() {
             assert_eq!(cancellation_policy, "cancel_all");
         }
     }
+}
+
+/// R5 smoke: concurrency ceiling for stream ops surfaces as HTTP 429
+/// Too Many Requests when a burst exceeds `max_concurrent_stream_ops`.
+/// Verifies the `stream_semaphore` + `TailUnavailable → 429` path in
+/// `api::tail_attempt_stream`.
+///
+/// We build a Server with `max_concurrent_stream_ops=2`, fire 5 tail
+/// calls with a long-ish block so they all stay in flight, and assert
+/// that at least 3 of them come back as 429.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_stream_semaphore_returns_429_on_burst() {
+    // Build a bespoke server with a tiny stream-op ceiling.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let mut config = test_server_config();
+    config.max_concurrent_stream_ops = 2;
+    let server = ff_server::server::Server::start(config)
+        .await
+        .expect("Server::start failed");
+    let server = Arc::new(server);
+    let app = ff_server::api::router(server.clone(), &["*".to_owned()], None);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    let _abort = handle.abort_handle();
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap();
+
+    // Fire 5 concurrent tails on a never-written stream with block_ms=2000.
+    //
+    // Expected outcome under the `xread_block_lock` serializer:
+    //   * 2 calls acquire a stream_semaphore permit (ceiling=2) and
+    //     queue on the XREAD BLOCK Mutex. They serialize: first dispatches
+    //     immediately, second waits ~2s for the first to finish. Both
+    //     return 200 with empty frames + closed_at=None after ~2s and
+    //     ~4s respectively (full block_ms budget preserved on both).
+    //   * 3 calls fail the try_acquire_owned fast and return 429 in
+    //     microseconds.
+    //
+    // Before the serialization Mutex landed (R5-b), the second
+    // permit-holder would spuriously time out: ferriskey's per-call
+    // request_timeout (block_ms + 500ms) started client-side while
+    // Valkey was still servicing the first BLOCK on the pipelined mux,
+    // so the second call's timeout fired before its turn at the server.
+    // Observed as HTTP 500 `valkey: timed out`. The Mutex ensures each
+    // call's timeout doesn't start until it holds the lock.
+    let eid = ExecutionId::new();
+    let url = format!(
+        "{base_url}/v1/executions/{eid}/attempts/0/stream/tail?block_ms=2000&limit=10"
+    );
+
+    let mut handles = Vec::new();
+    for _ in 0..5 {
+        let c = client.clone();
+        let u = url.clone();
+        handles.push(tokio::spawn(async move { c.get(&u).send().await }));
+    }
+
+    let mut ok_like = 0;
+    let mut too_many = 0;
+    for h in handles {
+        let resp = h.await.expect("join").expect("send");
+        let status = resp.status().as_u16();
+        match status {
+            200 => ok_like += 1,
+            429 => too_many += 1,
+            other => {
+                let body = resp.text().await.unwrap_or_default();
+                panic!("unexpected status {other}: {body}");
+            }
+        }
+    }
+
+    // At most 2 can have acquired permits; the remaining 3 must 429.
+    assert!(
+        too_many >= 3,
+        "expected >=3 429 responses, got too_many={too_many} ok_like={ok_like}"
+    );
+    assert!(
+        ok_like <= 2,
+        "expected <=2 200 responses (matches max_concurrent_stream_ops), got {ok_like}"
+    );
+
+    _abort.abort();
 }

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -650,8 +650,8 @@ async fn test_api_cancel_flow() {
 
 /// R5 smoke: concurrency ceiling for stream ops surfaces as HTTP 429
 /// Too Many Requests when a burst exceeds `max_concurrent_stream_ops`.
-/// Verifies the `stream_semaphore` + `TailUnavailable → 429` path in
-/// `api::tail_attempt_stream`.
+/// Verifies the `stream_semaphore` + `ConcurrencyLimitExceeded("stream_ops", N)
+/// → 429` path in `api::tail_attempt_stream`.
 ///
 /// We build a Server with `max_concurrent_stream_ops=2`, fire 5 tail
 /// calls with a long-ish block so they all stay in flight, and assert

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -7824,3 +7824,96 @@ async fn test_capability_required_control_or_whitespace_rejected() {
         assert_err(&raw, "invalid_capabilities", label);
     }
 }
+
+/// PR#7 follow-up regression (Copilot): if a per-worker GET errors out
+/// inside `load_worker_caps_union` (transport blip, WRONGTYPE, etc.) the
+/// union must NOT silently treat that worker as capless. Previously
+/// `.unwrap_or(None)` merged error and empty into the same branch,
+/// producing a false-negative union and keeping executions blocked even
+/// though a matching worker existed.
+///
+/// Now the error propagates up; `check_route_cleared` treats `Err` as
+/// fail-open ("we don't know → let the scheduler re-decide next tick")
+/// and returns true, which promotes the blocked execution back to
+/// eligible. Test shapes the failure with HSET so the subsequent GET
+/// returns WRONGTYPE — a deterministic per-worker GET error we can
+/// exercise without mocking Valkey.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capable_worker_unblocks_on_get_error_failopen() {
+    use ff_engine::scanner::Scanner;
+
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let config = test_config();
+    let lane_id = LaneId::new(LANE);
+    let eid = ExecutionId::new();
+
+    // 1. Create execution with required caps {gpu}; block it via a
+    //    mismatched scheduler claim.
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    let worker_id = ff_core::types::WorkerId::new(WORKER);
+    let wiid = ff_core::types::WorkerInstanceId::new(WORKER_INST);
+    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), config);
+    let cpu_only: std::collections::BTreeSet<String> =
+        ["cpu".to_owned()].into_iter().collect();
+    scheduler
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &cpu_only, 5000)
+        .await
+        .expect("scheduler claim should not error");
+
+    // 2. Register a worker in the index but corrupt its caps key with a
+    //    HSET instead of SET. A subsequent GET on that key returns
+    //    WRONGTYPE — the concrete shape of "per-worker GET error" this
+    //    test is guarding against.
+    let instance_id = "wrongtype-gpu-worker";
+    let caps_key = format!("ff:worker:{instance_id}:caps");
+    let _: i64 = tc
+        .client()
+        .cmd("HSET")
+        .arg(caps_key.as_str())
+        .arg("corrupted")
+        .arg("by-test")
+        .execute()
+        .await
+        .expect("HSET plant WRONGTYPE");
+    let _: Option<i64> = tc
+        .client()
+        .cmd("SADD")
+        .arg("ff:idx:workers")
+        .arg(instance_id)
+        .execute()
+        .await
+        .expect("SADD workers-index");
+
+    // 3. Run the unblock scanner. The GET on the corrupted caps key will
+    //    error out inside load_worker_caps_union; that should bubble up
+    //    through check_route_cleared which fails OPEN and promotes.
+    let partition_idx = execution_partition(&eid, &config).index;
+    let scanner = ff_engine::scanner::unblock::UnblockScanner::new(
+        std::time::Duration::from_secs(30),
+        vec![lane_id.clone()],
+        config,
+    );
+    let _ = scanner.scan_partition(tc.client(), partition_idx).await;
+
+    // 4. Execution MUST be promoted back to eligible. With the old
+    //    `.unwrap_or(None)` swallow, the union would have been empty,
+    //    the subset check would have failed, and the execution would
+    //    still be in blocked:route.
+    let idx = IndexKeys::new(&execution_partition(&eid, &config));
+    let eligible_score: Option<String> = tc
+        .client()
+        .cmd("ZSCORE")
+        .arg(idx.lane_eligible(&lane_id).as_str())
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .expect("ZSCORE eligible");
+    assert!(
+        eligible_score.is_some(),
+        "execution must be promoted back to eligible when caps GET errors \
+         (fail-open on transient errors preserves liveness)"
+    );
+}

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -7405,6 +7405,71 @@ async fn test_tail_stream_rejects_zero_count_limit() {
     );
 }
 
+/// PR#7 regression (Copilot): direct FCALL with `count_limit > HARD_CAP`
+/// must return `err("invalid_input", "count_limit_exceeds_hard_cap")` —
+/// NOT a silent clamp to HARD_CAP. The SDK and server layers already
+/// reject at their boundary, but a caller bypassing those (direct
+/// `FCALL ff_read_attempt_stream`) still hit the silent-clamp path in
+/// lua/stream.lua before this fix. RFC-006 §Input validation promises
+/// symmetric rejection at both edges.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_read_stream_rejects_over_hard_cap_at_lua() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+
+    // HARD_CAP in lua/stream.lua is 10_000 (mirrors STREAM_READ_HARD_CAP).
+    // 10_001 must be rejected loud, not silently clamped.
+    let keys: Vec<String> = vec![
+        ctx.stream(AttemptIndex::new(0)),
+        ctx.stream_meta(AttemptIndex::new(0)),
+    ];
+    let args: Vec<String> = vec![
+        "-".to_owned(),
+        "+".to_owned(),
+        "10001".to_owned(),
+    ];
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw: Value = tc
+        .client()
+        .fcall("ff_read_attempt_stream", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL transport failed");
+
+    // Expect failure tuple: {0, "invalid_input", "count_limit_exceeds_hard_cap"}
+    let arr = match &raw {
+        Value::Array(a) => a,
+        other => panic!("expected Array, got {other:?}"),
+    };
+    let status = match arr.first() {
+        Some(Ok(Value::Int(n))) => *n,
+        other => panic!("expected Int status, got {other:?}"),
+    };
+    assert_eq!(status, 0, "expected failure status, got {status}: {arr:?}");
+    let code = match arr.get(1) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::SimpleString(s))) => s.clone(),
+        other => panic!("expected error code string, got {other:?}"),
+    };
+    assert_eq!(code, "invalid_input", "unexpected error code: {code}");
+    let detail = match arr.get(2) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::SimpleString(s))) => s.clone(),
+        other => panic!("expected detail string, got {other:?}"),
+    };
+    assert_eq!(
+        detail, "count_limit_exceeds_hard_cap",
+        "unexpected detail: {detail}"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // R2 regression tests (BUG1 + BUG2): fail-closed on malformed policy/caps
 // ═══════════════════════════════════════════════════════════════════════
@@ -7715,4 +7780,47 @@ async fn test_capable_worker_unblocks_route_blocked() {
         blocked_score.is_none(),
         "execution must NOT be in blocked:route after promotion"
     );
+}
+
+/// PR#7-BUG4 regression: required_capabilities tokens must be rejected by
+/// ff_create_execution when they contain ASCII control bytes (0x00-0x1F,
+/// 0x7F) or whitespace (0x20). Rust ingress in ff-sdk/ff-scheduler
+/// already rejects these, but an admin direct-HSET or a path that
+/// bypasses Rust ingress should STILL fail on the Lua side — the Lua
+/// write-path validation is the last line of defense. Silent-accept of
+/// "gpu\ncuda" would pin an execution as unclaimable forever.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_required_control_or_whitespace_rejected() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let cases = [
+        // Raw JSON escape of \n inside the cap string.
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu\ncuda"]}}"#,
+            "newline in token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu\tcuda"]}}"#,
+            "tab in token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu cuda"]}}"#,
+            "space in token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu\u0000cuda"]}}"#,
+            "NUL byte in token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu\u007fcuda"]}}"#,
+            "DEL byte in token",
+        ),
+    ];
+    for (policy_json, label) in cases {
+        let eid = ExecutionId::new();
+        let raw = fcall_create_execution_with_raw_policy(&tc, &eid, LANE, policy_json).await;
+        assert_err(&raw, "invalid_capabilities", label);
+    }
 }

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -159,7 +159,8 @@ async fn fcall_issue_claim_grant(
         idx.lane_eligible(&lane_id),
     ];
 
-    // ARGV (8): eid, worker_id, worker_instance_id, lane, cap_hash, grant_ttl, route_json, admission
+    // ARGV (9): eid, worker_id, worker_instance_id, lane, cap_hash, grant_ttl,
+    //           route_json, admission, worker_capabilities_csv
     let args: Vec<String> = vec![
         eid.to_string(),
         worker_id.to_owned(),
@@ -169,6 +170,7 @@ async fn fcall_issue_claim_grant(
         "5000".to_owned(),    // grant_ttl_ms
         String::new(),        // route_snapshot_json
         String::new(),        // admission_summary
+        String::new(),        // worker_capabilities_csv (empty: match-any path)
     ];
 
     let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
@@ -1014,6 +1016,7 @@ async fn fcall_issue_reclaim_grant(
     // KEYS (3): exec_core, claim_grant, lease_expiry
     let keys: Vec<String> = vec![ctx.core(), ctx.claim_grant(), idx.lease_expiry()];
 
+    // ARGV (9): …, worker_capabilities_csv (empty → match-any)
     let args: Vec<String> = vec![
         eid.to_string(),
         worker_id.to_owned(),
@@ -1021,6 +1024,7 @@ async fn fcall_issue_reclaim_grant(
         lane.to_owned(),
         String::new(),
         "5000".to_owned(),
+        String::new(),
         String::new(),
         String::new(),
     ];
@@ -1424,7 +1428,7 @@ async fn fcall_suspend_execution(
     resume_condition_json: &str,
     timeout_at: Option<i64>,
     timeout_behavior: &str,
-) -> (String, String, String, String) {
+) -> (String, String, String, String, String) {
     let config = test_config();
     let partition = execution_partition(eid, &config);
     let ctx = ExecKeyContext::new(&partition, eid);
@@ -1439,11 +1443,11 @@ async fn fcall_suspend_execution(
     let wp_id = WaitpointId::from_uuid(waitpoint_id_uuid);
     let waitpoint_key = format!("wpk:{waitpoint_id_str}");
 
-    // KEYS (16): exec_core, attempt_record, lease_current, lease_history,
+    // KEYS (17): exec_core, attempt_record, lease_current, lease_history,
     //            lease_expiry, worker_leases, suspension_current, waitpoint_hash,
     //            waitpoint_signals, suspension_timeout, pending_wp_expiry,
     //            active_index, suspended_index, waitpoint_history, wp_condition,
-    //            attempt_timeout
+    //            attempt_timeout, hmac_secrets
     let keys: Vec<String> = vec![
         ctx.core(),                              // 1
         ctx.attempt_hash(att_idx),               // 2
@@ -1461,6 +1465,7 @@ async fn fcall_suspend_execution(
         ctx.waitpoints(),                        // 14
         ctx.waitpoint_condition(&wp_id),         // 15
         idx.attempt_timeout(),                   // 16
+        idx.waitpoint_hmac_secrets(),            // 17
     ];
 
     // ARGV (17): execution_id, attempt_index, attempt_id, lease_id,
@@ -1499,7 +1504,10 @@ async fn fcall_suspend_execution(
 
     let arr = expect_success_array(&raw, "ff_suspend_execution");
     let sub_status = field_str(arr, 1); // "OK" or "ALREADY_SATISFIED"
-    (suspension_id, waitpoint_id_str, waitpoint_key, sub_status)
+    // Field index 5 in the response is the minted HMAC token (RFC-004
+    // §Waitpoint Security). Echoed for tests that will deliver signals.
+    let waitpoint_token = field_str(arr, 5);
+    (suspension_id, waitpoint_id_str, waitpoint_key, sub_status, waitpoint_token)
 }
 
 /// Call ff_deliver_signal.
@@ -1513,6 +1521,7 @@ async fn fcall_deliver_signal(
     signal_name: &str,
     signal_category: &str,
     idempotency_key: &str,
+    waitpoint_token: &str,
 ) -> (String, String) {
     let config = test_config();
     let partition = execution_partition(eid, &config);
@@ -1531,11 +1540,11 @@ async fn fcall_deliver_signal(
         ctx.signal_dedup(&wp_id, idempotency_key)
     };
 
-    // KEYS (13): exec_core, wp_condition, wp_signals_stream,
+    // KEYS (14): exec_core, wp_condition, wp_signals_stream,
     //            exec_signals_zset, signal_hash, signal_payload,
     //            idem_key, waitpoint_hash, suspension_current,
     //            eligible_zset, suspended_zset, delayed_zset,
-    //            suspension_timeout_zset
+    //            suspension_timeout_zset, hmac_secrets
     let keys: Vec<String> = vec![
         ctx.core(),                              // 1
         ctx.waitpoint_condition(&wp_id),         // 2
@@ -1550,14 +1559,15 @@ async fn fcall_deliver_signal(
         idx.lane_suspended(&lane_id),            // 11
         idx.lane_delayed(&lane_id),              // 12
         idx.suspension_timeout(),                // 13
+        idx.waitpoint_hmac_secrets(),            // 14
     ];
 
-    // ARGV (17): signal_id, execution_id, waitpoint_id, signal_name,
+    // ARGV (18): signal_id, execution_id, waitpoint_id, signal_name,
     //            signal_category, source_type, source_identity,
     //            payload, payload_encoding, idempotency_key,
     //            correlation_id, target_scope, created_at,
     //            dedup_ttl_ms, resume_delay_ms, signal_maxlen,
-    //            max_signals_per_execution
+    //            max_signals_per_execution, waitpoint_token
     let args: Vec<String> = vec![
         signal_id.clone(),                   // 1
         eid.to_string(),                     // 2
@@ -1576,6 +1586,7 @@ async fn fcall_deliver_signal(
         "0".to_owned(),                      // 15 resume_delay_ms
         "1000".to_owned(),                   // 16 signal_maxlen
         "10000".to_owned(),                  // 17 max_signals_per_execution
+        waitpoint_token.to_owned(),          // 18 waitpoint_token
     ];
 
     let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
@@ -1644,13 +1655,13 @@ async fn fcall_expire_suspension(
 }
 
 /// Call ff_create_pending_waitpoint.
-/// Returns (waitpoint_id, waitpoint_key).
+/// Returns (waitpoint_id, waitpoint_key, waitpoint_token).
 async fn fcall_create_pending_waitpoint(
     tc: &TestCluster,
     eid: &ExecutionId,
     attempt_index: &str,
     expires_in_ms: u64,
-) -> (String, String) {
+) -> (String, String, String) {
     let config = test_config();
     let partition = execution_partition(eid, &config);
     let ctx = ExecKeyContext::new(&partition, eid);
@@ -1663,11 +1674,12 @@ async fn fcall_create_pending_waitpoint(
 
     let expires_at = TimestampMs::now().0 + expires_in_ms as i64;
 
-    // KEYS (3): exec_core, waitpoint_hash, pending_wp_expiry_zset
+    // KEYS (4): exec_core, waitpoint_hash, pending_wp_expiry_zset, hmac_secrets
     let keys: Vec<String> = vec![
         ctx.core(),
         ctx.waitpoint(&wp_id),
         idx.pending_waitpoint_expiry(),
+        idx.waitpoint_hmac_secrets(),
     ];
 
     // ARGV (5): execution_id, attempt_index, waitpoint_id, waitpoint_key, expires_at
@@ -1688,8 +1700,10 @@ async fn fcall_create_pending_waitpoint(
         .await
         .expect("FCALL ff_create_pending_waitpoint failed");
 
-    assert_ok(&raw, "ff_create_pending_waitpoint");
-    (waitpoint_id_str, waitpoint_key)
+    let arr = expect_success_array(&raw, "ff_create_pending_waitpoint");
+    // Response: {1, "OK", waitpoint_id, waitpoint_key, waitpoint_token}
+    let waitpoint_token = field_str(arr, 4);
+    (waitpoint_id_str, waitpoint_key, waitpoint_token)
 }
 
 /// Call ff_buffer_signal_for_pending_waitpoint.
@@ -1700,10 +1714,12 @@ async fn fcall_buffer_signal(
     waitpoint_id_str: &str,
     signal_name: &str,
     idempotency_key: &str,
+    waitpoint_token: &str,
 ) -> (String, String) {
     let config = test_config();
     let partition = execution_partition(eid, &config);
     let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
 
     let signal_id = uuid::Uuid::new_v4().to_string();
     let wp_id = WaitpointId::parse(waitpoint_id_str).unwrap();
@@ -1716,8 +1732,9 @@ async fn fcall_buffer_signal(
         ctx.signal_dedup(&wp_id, idempotency_key)
     };
 
-    // KEYS (7): exec_core, wp_condition, wp_signals_stream,
-    //           exec_signals_zset, signal_hash, signal_payload, idem_key
+    // KEYS (9): exec_core, wp_condition, wp_signals_stream,
+    //           exec_signals_zset, signal_hash, signal_payload, idem_key,
+    //           waitpoint_hash, hmac_secrets
     let keys: Vec<String> = vec![
         ctx.core(),
         ctx.waitpoint_condition(&wp_id),
@@ -1726,9 +1743,11 @@ async fn fcall_buffer_signal(
         ctx.signal(&sig_id),
         ctx.signal_payload(&sig_id),
         idem_key,
+        ctx.waitpoint(&wp_id),
+        idx.waitpoint_hmac_secrets(),
     ];
 
-    // ARGV (17): same layout as ff_deliver_signal
+    // ARGV (18): same layout as ff_deliver_signal + waitpoint_token
     let args: Vec<String> = vec![
         signal_id.clone(),                   // 1
         eid.to_string(),                     // 2
@@ -1747,6 +1766,7 @@ async fn fcall_buffer_signal(
         "0".to_owned(),                      // 15 resume_delay_ms (unused by buffer)
         "1000".to_owned(),                   // 16 signal_maxlen
         "10000".to_owned(),                  // 17 max_signals
+        waitpoint_token.to_owned(),          // 18 waitpoint_token
     ];
 
     let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
@@ -1920,7 +1940,7 @@ async fn test_suspend_and_signal_resume() {
 
     // 2. Suspend
     let resume_cond = build_resume_condition_json(&["approval_result"], "fail");
-    let (suspension_id, waitpoint_id, _waitpoint_key, sub_status) =
+    let (suspension_id, waitpoint_id, _waitpoint_key, sub_status, wp_token) =
         fcall_suspend_execution(
             &tc, &eid, LANE, WORKER_INST,
             &lease_id, &epoch, &att_idx, &attempt_id,
@@ -1963,7 +1983,7 @@ async fn test_suspend_and_signal_resume() {
     // 4. Deliver signal matching the condition
     let (signal_id, effect) = fcall_deliver_signal(
         &tc, &eid, LANE, &waitpoint_id,
-        "approval_result", "approval", "",
+        "approval_result", "approval", "", &wp_token,
     ).await;
     assert!(!signal_id.is_empty());
     assert_eq!(effect, "resume_condition_satisfied");
@@ -2018,7 +2038,7 @@ async fn test_suspend_timeout_fail() {
     // Suspend with timeout in the past (triggers immediate expiry)
     let past_timeout = TimestampMs::now().0 - 1000; // 1s ago
     let resume_cond = build_resume_condition_json(&["approval"], "fail");
-    let (_sid, waitpoint_id, _wpk, _sub) = fcall_suspend_execution(
+    let (_sid, waitpoint_id, _wpk, _sub, _wp_token) = fcall_suspend_execution(
         &tc, &eid, LANE, WORKER_INST,
         &lease_id, &epoch, &att_idx, &attempt_id,
         "waiting_for_approval", &resume_cond, Some(past_timeout), "fail",
@@ -2057,7 +2077,7 @@ async fn test_suspend_timeout_auto_resume() {
     // Lua checks behavior == "auto_resume" (not the long form)
     let past_timeout = TimestampMs::now().0 - 1000;
     let resume_cond = build_resume_condition_json(&["approval"], "fail");
-    let (_sid, waitpoint_id, _wpk, _sub) = fcall_suspend_execution(
+    let (_sid, waitpoint_id, _wpk, _sub, _wp_token) = fcall_suspend_execution(
         &tc, &eid, LANE, WORKER_INST,
         &lease_id, &epoch, &att_idx, &attempt_id,
         "waiting_for_approval", &resume_cond, Some(past_timeout), "auto_resume",
@@ -2094,13 +2114,13 @@ async fn test_pending_waitpoint_with_buffered_signal() {
         fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 30_000).await;
 
     // 1. Create pending waitpoint while still active
-    let (waitpoint_id, _waitpoint_key) = fcall_create_pending_waitpoint(
+    let (waitpoint_id, _waitpoint_key, wp_token) = fcall_create_pending_waitpoint(
         &tc, &eid, &att_idx, 60_000,
     ).await;
 
     // 2. Buffer a signal against the pending waitpoint (before suspension)
     let (_sig_id, _effect) = fcall_buffer_signal(
-        &tc, &eid, &waitpoint_id, "callback_result", "",
+        &tc, &eid, &waitpoint_id, "callback_result", "", &wp_token,
     ).await;
 
     // 3. Now suspend with the pending waitpoint — condition matches buffered signal
@@ -2201,7 +2221,7 @@ async fn test_signal_idempotency() {
 
     // Use 2 matchers so first signal doesn't trigger resume
     let resume_cond = build_resume_condition_json(&["sig_a", "sig_b"], "fail");
-    let (_sid, waitpoint_id, _wpk, _sub) = fcall_suspend_execution(
+    let (_sid, waitpoint_id, _wpk, _sub, wp_token) = fcall_suspend_execution(
         &tc, &eid, LANE, WORKER_INST,
         &lease_id, &epoch, &att_idx, &attempt_id,
         "waiting_for_signal", &resume_cond, None, "fail",
@@ -2210,7 +2230,7 @@ async fn test_signal_idempotency() {
     // First signal delivery
     let (sig_id_1, effect_1) = fcall_deliver_signal(
         &tc, &eid, LANE, &waitpoint_id,
-        "sig_a", "callback", "dedup-key-1",
+        "sig_a", "callback", "dedup-key-1", &wp_token,
     ).await;
     assert!(!sig_id_1.is_empty());
     assert_eq!(effect_1, "appended_to_waitpoint",
@@ -2243,6 +2263,7 @@ async fn test_signal_idempotency() {
         idx.lane_suspended(&lane_id),
         idx.lane_delayed(&lane_id),
         idx.suspension_timeout(),
+        idx.waitpoint_hmac_secrets(),
     ];
 
     let args: Vec<String> = vec![
@@ -2263,6 +2284,7 @@ async fn test_signal_idempotency() {
         "0".to_owned(),                      // 15 resume_delay_ms
         "1000".to_owned(),                   // 16 signal_maxlen
         "10000".to_owned(),                  // 17 max_signals
+        wp_token.clone(),                    // 18 waitpoint_token
     ];
 
     let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
@@ -2301,7 +2323,7 @@ async fn test_cancel_suspended_execution() {
         fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 30_000).await;
 
     let resume_cond = build_resume_condition_json(&["approval"], "fail");
-    let (_sid, waitpoint_id, _wpk, _sub) = fcall_suspend_execution(
+    let (_sid, waitpoint_id, _wpk, _sub, _wp_token) = fcall_suspend_execution(
         &tc, &eid, LANE, WORKER_INST,
         &lease_id, &epoch, &att_idx, &attempt_id,
         "waiting_for_approval", &resume_cond, None, "fail",
@@ -2642,16 +2664,17 @@ async fn fcall_create_budget_full(
     //   on_hard_limit, on_soft_limit, reset_interval_ms, now_ms,
     //   dimension_count, dim_1..dim_N, hard_1..hard_N, soft_1..soft_N
     let dim_count = hard_limits.len();
-    let mut args: Vec<String> = Vec::new();
-    args.push(budget_id.to_owned());
-    args.push("lane".to_owned());
-    args.push("test-lane".to_owned());
-    args.push("strict".to_owned());
-    args.push("fail".to_owned());
-    args.push("warn".to_owned());
-    args.push(reset_interval_ms.to_string());
-    args.push(now.to_string());
-    args.push(dim_count.to_string());
+    let mut args: Vec<String> = vec![
+        budget_id.to_owned(),
+        "lane".to_owned(),
+        "test-lane".to_owned(),
+        "strict".to_owned(),
+        "fail".to_owned(),
+        "warn".to_owned(),
+        reset_interval_ms.to_string(),
+        now.to_string(),
+        dim_count.to_string(),
+    ];
     for (dim, _) in hard_limits {
         args.push((*dim).to_owned());
     }
@@ -3172,7 +3195,7 @@ async fn set_flow_id_on_exec(tc: &TestCluster, eid: &ExecutionId, flow_id: &str)
     let config = test_config();
     let partition = execution_partition(eid, &config);
     let ctx = ExecKeyContext::new(&partition, eid);
-    tc.client().cmd("HSET").arg(&ctx.core()).arg("flow_id").arg(flow_id)
+    tc.client().cmd("HSET").arg(ctx.core()).arg("flow_id").arg(flow_id)
         .execute::<i64>().await.expect("HSET flow_id");
 }
 
@@ -3909,6 +3932,7 @@ async fn test_error_paths() {
         "5000".to_owned(),
         String::new(),
         String::new(),
+        String::new(), // worker_capabilities_csv
     ];
     let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
     let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -4022,7 +4046,7 @@ async fn test_error_paths() {
     let policy = r#"{"retry_policy":{"max_retries":0}}"#;
     let _: () = tc.client()
         .cmd("SET")
-        .arg(&ctx4.policy())
+        .arg(ctx4.policy())
         .arg(policy)
         .execute()
         .await
@@ -4133,10 +4157,11 @@ async fn test_scheduler_claim_priority_ordering() {
         tc.client().clone(),
         config,
     );
+    let no_caps = std::collections::BTreeSet::<String>::new();
 
     // First grant should go to highest priority (1000)
     let grant1 = scheduler
-        .claim_for_worker(&lane_id, &worker_id, &wiid, 5000)
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &no_caps, 5000)
         .await
         .expect("scheduler claim 1 should not error");
     let grant1 = grant1.expect("should find an eligible execution");
@@ -4152,7 +4177,7 @@ async fn test_scheduler_claim_priority_ordering() {
 
     // Second grant should go to next highest priority (100)
     let grant2 = scheduler
-        .claim_for_worker(&lane_id, &worker_id, &wiid, 5000)
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &no_caps, 5000)
         .await
         .expect("scheduler claim 2 should not error");
     let grant2 = grant2.expect("should find second eligible execution");
@@ -4168,7 +4193,7 @@ async fn test_scheduler_claim_priority_ordering() {
 
     // Third grant should go to lowest priority (10)
     let grant3 = scheduler
-        .claim_for_worker(&lane_id, &worker_id, &wiid, 5000)
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &no_caps, 5000)
         .await
         .expect("scheduler claim 3 should not error");
     let grant3 = grant3.expect("should find third eligible execution");
@@ -4184,7 +4209,7 @@ async fn test_scheduler_claim_priority_ordering() {
 
     // Fourth claim: nothing left
     let grant4 = scheduler
-        .claim_for_worker(&lane_id, &worker_id, &wiid, 5000)
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &no_caps, 5000)
         .await
         .expect("scheduler claim 4 should not error");
     assert!(grant4.is_none(), "no more eligible executions");
@@ -4283,7 +4308,7 @@ async fn test_stream_payload_size_enforcement() {
     let ctx = ExecKeyContext::new(&partition, &eid);
     let att = AttemptIndex::new(att_idx.parse().unwrap());
     let frame_count: Option<String> = tc.client()
-        .cmd("HGET").arg(&ctx.stream_meta(att)).arg("frame_count")
+        .cmd("HGET").arg(ctx.stream_meta(att)).arg("frame_count")
         .execute().await.unwrap();
     assert_eq!(frame_count.as_deref(), Some("2"), "only 2 frames should exist");
 
@@ -4413,7 +4438,7 @@ async fn test_golden_path_all_methods() {
 
     // 6. Suspend
     let resume_cond = build_resume_condition_json(&["continue"], "fail");
-    let (_susp_id, wp_id_str, _wp_key, sub_status) = fcall_suspend_execution(
+    let (_susp_id, wp_id_str, _wp_key, sub_status, wp_token) = fcall_suspend_execution(
         &tc, &eid, LANE, WORKER_INST, &lease_id, &epoch, &att_idx, &attempt_id,
         "waiting_for_signal", &resume_cond, None, "fail",
     ).await;
@@ -4432,7 +4457,7 @@ async fn test_golden_path_all_methods() {
 
     // 7. Deliver signal → triggers resume
     let (sig_id, effect) = fcall_deliver_signal(
-        &tc, &eid, LANE, &wp_id_str, "continue", "api", "",
+        &tc, &eid, LANE, &wp_id_str, "continue", "api", "", &wp_token,
     ).await;
     assert!(!sig_id.is_empty());
     assert_eq!(effect, "resume_condition_satisfied");
@@ -4672,10 +4697,10 @@ async fn test_sdk_suspend_signal_resume_reclaim() {
         ff_sdk::task::TimeoutBehavior::Fail,
     ).await.unwrap();
 
-    let (waitpoint_id, _waitpoint_key) = match outcome {
-        ff_sdk::task::SuspendOutcome::Suspended { waitpoint_id, waitpoint_key, .. } => {
-            (waitpoint_id, waitpoint_key)
-        }
+    let (waitpoint_id, _waitpoint_key, waitpoint_token) = match outcome {
+        ff_sdk::task::SuspendOutcome::Suspended {
+            waitpoint_id, waitpoint_key, waitpoint_token, ..
+        } => (waitpoint_id, waitpoint_key, waitpoint_token),
         ff_sdk::task::SuspendOutcome::AlreadySatisfied { .. } => {
             panic!("should not be already satisfied");
         }
@@ -4696,6 +4721,7 @@ async fn test_sdk_suspend_signal_resume_reclaim() {
         source_type: "test".into(),
         source_identity: "test-runner".into(),
         idempotency_key: None,
+        waitpoint_token,
     };
     let sig_outcome = worker.deliver_signal(&eid, &waitpoint_id, signal).await.unwrap();
     match sig_outcome {
@@ -4950,7 +4976,7 @@ async fn test_sdk_claim_retry_attempt_index() {
     let ctx = ExecKeyContext::new(&partition, &eid);
     let _: () = tc.client()
         .cmd("SET")
-        .arg(&ctx.policy())
+        .arg(ctx.policy())
         .arg(r#"{"retry_policy":{"max_retries":3,"backoff":{"type":"fixed","delay_ms":10}}}"#)
         .execute()
         .await
@@ -5440,6 +5466,10 @@ async fn test_server() -> ff_server::server::Server {
         skip_library_load: true, // TestCluster::connect() already loaded it
         cors_origins: vec!["*".to_owned()],
         api_token: None,
+        waitpoint_hmac_secret:
+            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+        waitpoint_hmac_grace_ms: 86_400_000,
+        max_concurrent_stream_ops: 64,
     };
     ff_server::server::Server::start(server_config)
         .await
@@ -5664,7 +5694,7 @@ async fn test_server_flow_lifecycle() {
     let config = test_config();
     let up_partition = execution_partition(&upstream, &config);
     let up_ctx = ExecKeyContext::new(&up_partition, &upstream);
-    let stored_fid: Option<String> = tc.client().cmd("HGET").arg(&up_ctx.core())
+    let stored_fid: Option<String> = tc.client().cmd("HGET").arg(up_ctx.core())
         .arg("flow_id").execute().await.unwrap();
     assert_eq!(stored_fid.as_deref(), Some(flow_id.to_string().as_str()),
         "flow_id should be set on upstream exec_core");
@@ -5751,7 +5781,7 @@ async fn test_server_flow_lifecycle() {
         "downstream should be cancelled after cancel_flow");
 
     // Verify flow core state is cancelled (reuse fctx from step 4)
-    let flow_state: Option<String> = tc.client().cmd("HGET").arg(&fctx.core())
+    let flow_state: Option<String> = tc.client().cmd("HGET").arg(fctx.core())
         .arg("public_flow_state").execute().await.unwrap();
     assert_eq!(flow_state.as_deref(), Some("cancelled"));
 
@@ -5779,7 +5809,7 @@ async fn test_server_deliver_signal() {
 
     // 2. Suspend with resume condition
     let cond_json = build_resume_condition_json(&["test_signal"], "fail");
-    let (_susp_id, wp_id_str, _wp_key, sub) = fcall_suspend_execution(
+    let (_susp_id, wp_id_str, _wp_key, sub, wp_token) = fcall_suspend_execution(
         &tc, &eid, LANE, WORKER_INST, &lease_id, &lease_epoch,
         "0", &attempt_id, "waiting_signal", &cond_json, None, "fail",
     ).await;
@@ -5813,6 +5843,7 @@ async fn test_server_deliver_signal() {
         resume_delay_ms: None,
         max_signals_per_execution: None,
         signal_maxlen: None,
+        waitpoint_token: ff_core::types::WaitpointToken::new(wp_token),
         now: TimestampMs::now(),
     };
     let result = server.deliver_signal(&signal_args).await.unwrap();
@@ -5850,7 +5881,7 @@ async fn test_server_change_priority() {
     let partition = execution_partition(&eid, &config);
     let ctx = ExecKeyContext::new(&partition, &eid);
     let prio: Option<String> = tc.client().cmd("HGET")
-        .arg(&ctx.core()).arg("priority").execute().await.unwrap();
+        .arg(ctx.core()).arg("priority").execute().await.unwrap();
     assert_eq!(prio.as_deref(), Some("100"));
 
     // Change priority via Server API
@@ -5860,7 +5891,7 @@ async fn test_server_change_priority() {
 
     // Verify new priority in exec_core
     let new_prio: Option<String> = tc.client().cmd("HGET")
-        .arg(&ctx.core()).arg("priority").execute().await.unwrap();
+        .arg(ctx.core()).arg("priority").execute().await.unwrap();
     assert_eq!(new_prio.as_deref(), Some("500"));
 
     server.shutdown().await;
@@ -5970,7 +6001,9 @@ async fn test_server_methods_wrong_execution_id() {
     let err = server.replay_execution(&bogus).await;
     assert!(err.is_err(), "replay_execution on bogus should fail");
 
-    // deliver_signal → script error
+    // deliver_signal → script error (bogus token, bogus execution).
+    // The bogus token is fine here — this test asserts the execution-not-found
+    // path fails, so any token shape is acceptable.
     let signal_args = ff_core::contracts::DeliverSignalArgs {
         execution_id: bogus.clone(),
         waitpoint_id: WaitpointId::new(),
@@ -5989,6 +6022,7 @@ async fn test_server_methods_wrong_execution_id() {
         resume_delay_ms: None,
         max_signals_per_execution: None,
         signal_maxlen: None,
+        waitpoint_token: ff_core::types::WaitpointToken::new("k1:0000000000000000000000000000000000000000"),
         now: TimestampMs::now(),
     };
     let err = server.deliver_signal(&signal_args).await;
@@ -6044,7 +6078,7 @@ async fn test_server_get_execution_all_phases() {
 
     // Phase 3: SUSPENDED
     let cond_json = build_resume_condition_json(&["resume_me"], "fail");
-    let (_susp_id, wp_id_str, _wp_key, _sub) = fcall_suspend_execution(
+    let (_susp_id, wp_id_str, _wp_key, _sub, wp_token) = fcall_suspend_execution(
         &tc, &eid, LANE, WORKER_INST, &lid, &lep, "0", &aid,
         "waiting_signal", &cond_json, None, "fail",
     ).await;
@@ -6057,7 +6091,7 @@ async fn test_server_get_execution_all_phases() {
     assert_eq!(info.public_state, ff_core::state::PublicState::Suspended);
 
     // Phase 4: Signal → back to RUNNABLE
-    fcall_deliver_signal(&tc, &eid, LANE, &wp_id_str, "resume_me", "test", "").await;
+    fcall_deliver_signal(&tc, &eid, LANE, &wp_id_str, "resume_me", "test", "", &wp_token).await;
     let info = server.get_execution(&eid).await.unwrap();
     assert_eq!(info.state_vector.lifecycle_phase, ff_core::state::LifecyclePhase::Runnable);
     assert_eq!(info.state_vector.attempt_state, ff_core::state::AttemptState::AttemptInterrupted);
@@ -6410,7 +6444,7 @@ async fn test_server_create_cancel_roundtrip() {
     // Verify flow is cancelled
     let fpart = ff_core::partition::flow_partition(&flow_id, &config);
     let fctx = ff_core::keys::FlowKeyContext::new(&fpart, &flow_id);
-    let pfs: Option<String> = tc.client().cmd("HGET").arg(&fctx.core())
+    let pfs: Option<String> = tc.client().cmd("HGET").arg(fctx.core())
         .arg("public_flow_state").execute().await.unwrap();
     assert_eq!(pfs.as_deref(), Some("cancelled"));
 
@@ -6469,6 +6503,10 @@ async fn test_system_engine_with_concurrent_scanners() {
             skip_library_load: true,
             cors_origins: vec!["*".to_owned()],
             api_token: None,
+            waitpoint_hmac_secret:
+                "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+            waitpoint_hmac_grace_ms: 86_400_000,
+            max_concurrent_stream_ops: 64,
         }
     };
     let server = ff_server::server::Server::start(server_config)
@@ -6537,4 +6575,1144 @@ async fn test_system_engine_with_concurrent_scanners() {
     }).await;
 
     server.shutdown().await;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Batch B: Capability routing (RFC-009)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// Worker caps flow through ARGV[9] of ff_issue_claim_grant. Executions
+// declare required_capabilities in ExecutionPolicy.routing_requirements;
+// ff_create_execution extracts a sorted CSV onto exec_core. On mismatch
+// the Lua returns ("capability_mismatch", missing_csv) WITHOUT mutating
+// the eligible ZSET — the execution stays queued for a matching worker.
+
+async fn create_execution_with_caps(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    lane: &str,
+    required: &[&str],
+) {
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(lane);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+
+    let policy_json = if required.is_empty() {
+        "{}".to_owned()
+    } else {
+        let caps_json = serde_json::to_string(required).unwrap();
+        format!(
+            r#"{{"routing_requirements":{{"required_capabilities":{caps_json}}}}}"#
+        )
+    };
+
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        lane.to_owned(),
+        "cap_test".to_owned(),
+        "0".to_owned(),
+        "cap-test".to_owned(),
+        policy_json,
+        r#"{"t":1}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution failed");
+    parse_ok_fields(&raw, "ff_create_execution");
+}
+
+async fn fcall_claim_grant_with_caps(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    lane: &str,
+    worker_caps: &[&str],
+) -> Value {
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(lane);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.claim_grant(),
+        idx.lane_eligible(&lane_id),
+    ];
+
+    let caps_csv: String = worker_caps
+        .iter()
+        .copied()
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        WORKER_INST.to_owned(),
+        lane.to_owned(),
+        String::new(),
+        "5000".to_owned(),
+        String::new(),
+        String::new(),
+        caps_csv,
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    tc.client()
+        .fcall("ff_issue_claim_grant", &kr, &ar)
+        .await
+        .expect("FCALL ff_issue_claim_grant transport failure")
+}
+
+async fn assert_still_eligible(tc: &TestCluster, eid: &ExecutionId, lane: &str) {
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let idx = IndexKeys::new(&partition);
+    let eligible_key = idx.lane_eligible(&LaneId::new(lane));
+    let score: Option<String> = tc
+        .client()
+        .cmd("ZSCORE")
+        .arg(&eligible_key)
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .expect("ZSCORE transport");
+    assert!(
+        score.is_some(),
+        "execution {eid} should still be in eligible ZSET after capability_mismatch"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_match_superset() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let eid = ExecutionId::new();
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    let raw = fcall_claim_grant_with_caps(&tc, &eid, LANE, &["gpu", "cuda"]).await;
+    assert_ok(&raw, "capability_match_superset");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_exact_match() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let eid = ExecutionId::new();
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    let raw = fcall_claim_grant_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    assert_ok(&raw, "capability_exact_match");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_empty_requirement() {
+    // Backwards compat: no required_capabilities → any worker matches,
+    // including a worker with NO caps declared.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let eid = ExecutionId::new();
+    create_execution_with_caps(&tc, &eid, LANE, &[]).await;
+    let raw = fcall_claim_grant_with_caps(&tc, &eid, LANE, &[]).await;
+    assert_ok(&raw, "capability_empty_requirement");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_missing_one() {
+    // Worker satisfies some but not all required caps → capability_mismatch.
+    // Execution must stay in eligible ZSET.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let eid = ExecutionId::new();
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu", "torch>=2.3"]).await;
+    let raw = fcall_claim_grant_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    assert_err(&raw, "capability_mismatch", "missing one required cap");
+    assert_still_eligible(&tc, &eid, LANE).await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_no_overlap() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let eid = ExecutionId::new();
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    let raw = fcall_claim_grant_with_caps(&tc, &eid, LANE, &["cpu"]).await;
+    assert_err(&raw, "capability_mismatch", "no overlap");
+    assert_still_eligible(&tc, &eid, LANE).await;
+}
+
+/// Execution-side ingress: a required capability containing a comma must
+/// be rejected by `ff_create_execution`. Without this rejection the
+/// Lua-side CSV subset check would silently split the token at the comma
+/// and accept a worker that advertises only the prefix — a silent auth
+/// bypass. See lua/execution.lua's routing_requirements extraction.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_required_comma_rejected() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    // A token with an embedded comma. This MUST be rejected, otherwise
+    // the wire CSV would parse as two tokens on the Lua side.
+    let policy_json = r#"{"routing_requirements":{"required_capabilities":["gpu,cuda"]}}"#;
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "cap_comma_test".to_owned(),
+        "0".to_owned(),
+        "cap-test".to_owned(),
+        policy_json.to_owned(),
+        r#"{"t":1}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("transport");
+    assert_err(&raw, "invalid_capabilities", "comma in required token");
+}
+
+/// Execution-side ingress: required_capabilities over the 4096-byte CSV
+/// limit must be rejected by `ff_create_execution` rather than landing an
+/// unclaimable execution with a multi-kilobyte exec_core field. Limit is
+/// inclusive: exactly CAPS_MAX_BYTES accepts; CAPS_MAX_BYTES+1 rejects.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_required_csv_too_large() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Generate enough tokens that the resulting sorted CSV crosses
+    // CAPS_MAX_BYTES = 4096. Tokens "c000..c999" at 5 bytes + 1 comma each
+    // → worst case ~6KB; use 800 such tokens to safely exceed the limit
+    // while staying under CAPS_MAX_TOKENS (256) — wait, 800 > 256, so the
+    // too_many_tokens guard would fire first. To hit the bytes guard, use
+    // <=256 tokens with LONG strings. 32 * 200-byte tokens ≈ 6.4 KB.
+    let mut caps: Vec<String> = Vec::new();
+    for i in 0..32 {
+        caps.push(format!("{}{}", "c".repeat(200), i));
+    }
+    let caps_refs: Vec<&str> = caps.iter().map(String::as_str).collect();
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let policy_json = format!(
+        r#"{{"routing_requirements":{{"required_capabilities":{}}}}}"#,
+        serde_json::to_string(&caps_refs).unwrap()
+    );
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "cap_big_test".to_owned(),
+        "0".to_owned(),
+        "cap-test".to_owned(),
+        policy_json,
+        r#"{"t":1}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("transport");
+    assert_err(&raw, "invalid_capabilities", "CSV too large");
+}
+
+/// ff_issue_reclaim_grant applies the same capability check as the initial
+/// grant path: a reclaiming worker whose caps don't satisfy the execution's
+/// required set is rejected with capability_mismatch, execution stays in
+/// the lease_expiry ZSET for a different reclaimer to pick up.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_reclaim_grant_mismatch() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    // Create with required cap {gpu} and get the execution into
+    // lease_expired_reclaimable state.
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    // Initial worker matches so grant succeeds.
+    let grant = fcall_claim_grant_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    assert_ok(&grant, "initial grant should succeed for gpu worker");
+    // Claim with short lease TTL so we can time-expire it.
+    let (_lease_id, _epoch, _att_idx, _attempt_id) =
+        fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 100).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    fcall_mark_lease_expired(&tc, &eid).await;
+
+    // Attempt reclaim with a worker that advertises {cpu} only. Must be
+    // rejected; execution remains lease_expired_reclaimable.
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![ctx.core(), ctx.claim_grant(), idx.lease_expiry()];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        "reclaim-cpu-worker".to_owned(),
+        LANE.to_owned(),
+        String::new(),
+        "5000".to_owned(),
+        String::new(),
+        String::new(),
+        "cpu".to_owned(), // worker_capabilities_csv — missing gpu
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_issue_reclaim_grant", &kr, &ar)
+        .await
+        .expect("transport");
+    assert_err(
+        &raw,
+        "capability_mismatch",
+        "reclaim with non-matching caps",
+    );
+
+    // Execution should remain reclaimable for a different worker.
+    assert_execution_state(
+        &tc,
+        &eid,
+        &ExpectedState {
+            lifecycle_phase: Some(ff_core::state::LifecyclePhase::Active),
+            ownership_state: Some(ff_core::state::OwnershipState::LeaseExpiredReclaimable),
+            ..Default::default()
+        },
+    )
+    .await;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// RFC-006 #2: STREAM READ + TAIL
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Read all frames on an attempt that wrote two frames. Verifies round-trip
+/// of every field written by `ff_append_frame`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_read_stream_round_trips_append_frame_fields() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    fcall_create_execution(&tc, &eid, NS, LANE, "stream_read_rt", 0).await;
+    fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
+    let (lease_id, epoch, att_idx, attempt_id) =
+        fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 30_000).await;
+
+    fcall_append_frame(
+        &tc, &eid, &att_idx, &lease_id, &epoch, &attempt_id,
+        "log", "hello world", 0,
+    ).await;
+    fcall_append_frame(
+        &tc, &eid, &att_idx, &lease_id, &epoch, &attempt_id,
+        "output", "final result", 0,
+    ).await;
+
+    let result = ff_sdk::read_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(att_idx.parse().unwrap()),
+        "-",
+        "+",
+        ff_sdk::STREAM_READ_HARD_CAP,
+    )
+    .await
+    .expect("read_stream");
+    let frames = &result.frames;
+
+    assert_eq!(frames.len(), 2, "expected 2 frames, got {}", frames.len());
+    let f0 = &frames[0];
+    assert_eq!(f0.fields.get("frame_type").map(String::as_str), Some("log"));
+    assert_eq!(f0.fields.get("payload").map(String::as_str), Some("hello world"));
+    assert_eq!(f0.fields.get("encoding").map(String::as_str), Some("utf8"));
+    assert_eq!(f0.fields.get("source").map(String::as_str), Some("worker"));
+    assert!(f0.fields.contains_key("ts"), "ts field missing");
+
+    let f1 = &frames[1];
+    assert_eq!(f1.fields.get("frame_type").map(String::as_str), Some("output"));
+    assert_eq!(f1.fields.get("payload").map(String::as_str), Some("final result"));
+
+    assert_ne!(f0.id, f1.id);
+}
+
+/// Empty / never-written stream → read returns [].
+#[tokio::test]
+#[serial_test::serial]
+async fn test_read_stream_empty_returns_empty() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    let result = ff_sdk::read_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(0),
+        "-",
+        "+",
+        100,
+    )
+    .await
+    .expect("read_stream on empty");
+    assert!(result.frames.is_empty(), "expected empty vec, got {}", result.frames.len());
+    assert!(!result.is_closed(), "never-written stream must present as open");
+}
+
+/// Write many frames, read a page with limit, then resume from the next id.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_read_stream_slice_and_resume() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    fcall_create_execution(&tc, &eid, NS, LANE, "stream_slice", 0).await;
+    fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
+    let (lease_id, epoch, att_idx, attempt_id) =
+        fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 30_000).await;
+
+    const TOTAL: usize = 50;
+    for i in 0..TOTAL {
+        fcall_append_frame(
+            &tc, &eid, &att_idx, &lease_id, &epoch, &attempt_id,
+            "log", &format!("msg-{i}"), 0,
+        ).await;
+    }
+
+    let att = AttemptIndex::new(att_idx.parse().unwrap());
+
+    let page1 = ff_sdk::read_stream(tc.client(), &config, &eid, att, "-", "+", 20)
+        .await
+        .expect("read page1");
+    assert_eq!(page1.frames.len(), 20);
+
+    let last_id = page1.frames.last().unwrap().id.clone();
+    // XRANGE start is inclusive. Bump the sequence to skip the cursor entry.
+    let (ms, seq) = last_id.split_once('-').expect("entry id has ms-seq form");
+    let next_seq: u64 = seq.parse::<u64>().unwrap() + 1;
+    let resume_from = format!("{ms}-{next_seq}");
+
+    let page2 = ff_sdk::read_stream(tc.client(), &config, &eid, att, &resume_from, "+", 100)
+        .await
+        .expect("read page2");
+    assert_eq!(page2.frames.len(), TOTAL - 20);
+    assert_ne!(page2.frames[0].id, last_id, "resume must skip cursor entry");
+}
+
+/// Tail on an empty stream with short block_ms returns [] near the timeout.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_tail_stream_timeout_returns_empty() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    let started = std::time::Instant::now();
+    let result = ff_sdk::tail_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(0),
+        "0-0",
+        200,
+        50,
+    )
+    .await
+    .expect("tail_stream");
+    let elapsed = started.elapsed();
+
+    assert!(result.frames.is_empty(), "expected timeout with empty vec");
+    assert!(!result.is_closed(), "never-written stream must not report closed");
+    assert!(
+        elapsed >= std::time::Duration::from_millis(150),
+        "expected to block at least ~200ms, blocked {elapsed:?}"
+    );
+}
+
+/// Tail unblocks when a writer appends a frame while we're blocking.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_tail_stream_unblocks_on_write() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    fcall_create_execution(&tc, &eid, NS, LANE, "stream_tail", 0).await;
+    fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
+    let (lease_id, epoch, att_idx, attempt_id) =
+        fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 30_000).await;
+
+    let eid_w = eid.clone();
+    let att_idx_w = att_idx.clone();
+    let lease_w = lease_id.clone();
+    let epoch_w = epoch.clone();
+    let att_id_w = attempt_id.clone();
+    let writer = tokio::spawn(async move {
+        let w = TestCluster::connect().await;
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        fcall_append_frame(
+            &w, &eid_w, &att_idx_w, &lease_w, &epoch_w, &att_id_w,
+            "log", "tail-unblock-payload", 0,
+        ).await;
+    });
+
+    let result = ff_sdk::tail_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(att_idx.parse().unwrap()),
+        "0-0",
+        2_000,
+        50,
+    )
+    .await
+    .expect("tail_stream");
+
+    writer.await.unwrap();
+
+    assert_eq!(result.frames.len(), 1, "expected 1 frame, got {}", result.frames.len());
+    assert_eq!(
+        result.frames[0].fields.get("payload").map(String::as_str),
+        Some("tail-unblock-payload")
+    );
+}
+
+/// Regression: ferriskey auto-extends request_timeout for XREAD BLOCK by
+/// `BLOCK_arg + 500ms`, so tail calls with block_ms > the client's default
+/// request_timeout (5s) do NOT spuriously time out. This test proves that
+/// by blocking for 7s (above 5s client request_timeout).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_tail_stream_long_block_respects_ferriskey_timeout_extension() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    let started = std::time::Instant::now();
+    let result = ff_sdk::tail_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(0),
+        "0-0",
+        7_000, // deliberately > default 5s request_timeout
+        50,
+    )
+    .await
+    .expect("tail_stream must not surface transport timeout when ferriskey extends BLOCK timeout");
+    let elapsed = started.elapsed();
+    let frames = &result.frames;
+
+    assert!(frames.is_empty(), "no writer → expected empty vec");
+    assert!(
+        elapsed >= std::time::Duration::from_millis(6_500),
+        "expected to block ~7s, blocked {elapsed:?}"
+    );
+    assert!(
+        elapsed <= std::time::Duration::from_millis(9_000),
+        "expected to unblock near block_ms, blocked {elapsed:?}"
+    );
+}
+
+/// RFC-006 #2 terminal signal: after the attempt completes, both read_stream
+/// and a subsequent non-blocking tail_stream surface `closed_at` +
+/// `closed_reason` so consumers can exit their polling loop without a
+/// timeout fallback.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_stream_closed_signal_propagates_to_read_and_tail() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    fcall_create_execution(&tc, &eid, NS, LANE, "stream_closed", 0).await;
+    fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
+    let (lease_id, epoch, att_idx, attempt_id) =
+        fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 30_000).await;
+
+    // Write a frame, complete the attempt — completion closes the stream
+    // via lua/execution.lua with `closed_reason=attempt_success`.
+    fcall_append_frame(
+        &tc, &eid, &att_idx, &lease_id, &epoch, &attempt_id,
+        "log", "final-frame", 0,
+    ).await;
+    fcall_complete_execution(&tc, &eid, LANE, WORKER_INST, &lease_id, &epoch, &attempt_id).await;
+
+    let att = AttemptIndex::new(att_idx.parse().unwrap());
+
+    // read_stream sees the frame AND the terminal markers.
+    let read = ff_sdk::read_stream(tc.client(), &config, &eid, att, "-", "+", 100)
+        .await
+        .expect("read_stream after complete");
+    assert_eq!(read.frames.len(), 1);
+    assert!(read.is_closed(), "read_stream must report closed after complete");
+    assert_eq!(read.closed_reason.as_deref(), Some("attempt_success"));
+    assert!(read.closed_at.is_some());
+
+    // tail_stream with block_ms=0 at the tip returns no new frames but
+    // still reports closed — this is the signal consumers poll on.
+    let tip = read.frames.last().unwrap().id.clone();
+    let tail = ff_sdk::tail_stream(tc.client(), &config, &eid, att, &tip, 0, 10)
+        .await
+        .expect("tail_stream at tip");
+    assert!(tail.frames.is_empty());
+    assert!(tail.is_closed(), "tail_stream must report closed after complete");
+    assert_eq!(tail.closed_reason.as_deref(), Some("attempt_success"));
+}
+
+/// R4 regression: lease expiry closes stream_meta so tail consumers observe
+/// the terminal signal even if no reclaim ever runs (worker OOM / node dead).
+/// closed_reason=lease_expired is set on the FIRST close; later reclaim can
+/// overwrite it to "reclaimed" via its own HSET.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_lease_expired_closes_stream_meta() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    fcall_create_execution(&tc, &eid, NS, LANE, "stream_lease_expire", 0).await;
+    fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
+    // Short TTL so the lease expires while we wait.
+    let (lease_id, epoch, att_idx, attempt_id) =
+        fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 200).await;
+
+    // Write a frame so stream_meta exists (the close path skips if meta
+    // was never created — a never-written attempt has no stream to close).
+    fcall_append_frame(
+        &tc, &eid, &att_idx, &lease_id, &epoch, &attempt_id,
+        "log", "pre-expiry frame", 0,
+    ).await;
+
+    // Wait past TTL + a margin for Valkey's server-time resolution.
+    tokio::time::sleep(std::time::Duration::from_millis(350)).await;
+
+    fcall_mark_lease_expired(&tc, &eid).await;
+
+    let att = AttemptIndex::new(att_idx.parse().unwrap());
+    let result = ff_sdk::read_stream(
+        tc.client(), &config, &eid, att, "-", "+", 100,
+    )
+    .await
+    .expect("read_stream after lease expiry");
+
+    assert_eq!(result.frames.len(), 1);
+    assert!(
+        result.is_closed(),
+        "lease expiry must close stream_meta so tail consumers exit"
+    );
+    assert_eq!(result.closed_reason.as_deref(), Some("lease_expired"));
+    assert!(result.closed_at.is_some());
+}
+
+/// block_ms == 0 → non-blocking peek returns immediately with available entries.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_tail_stream_no_block_returns_available() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    fcall_create_execution(&tc, &eid, NS, LANE, "stream_peek", 0).await;
+    fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
+    let (lease_id, epoch, att_idx, attempt_id) =
+        fcall_claim_execution(&tc, &eid, LANE, WORKER, WORKER_INST, 30_000).await;
+
+    fcall_append_frame(
+        &tc, &eid, &att_idx, &lease_id, &epoch, &attempt_id,
+        "log", "peek-1", 0,
+    ).await;
+
+    let started = std::time::Instant::now();
+    let result = ff_sdk::tail_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(att_idx.parse().unwrap()),
+        "0-0",
+        0,
+        50,
+    )
+    .await
+    .expect("tail_stream peek");
+    let elapsed = started.elapsed();
+    let frames = &result.frames;
+
+    assert_eq!(frames.len(), 1);
+    assert_eq!(frames[0].fields.get("payload").map(String::as_str), Some("peek-1"));
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "non-blocking peek should return fast, took {elapsed:?}"
+    );
+}
+
+/// R3 regression (BUG2 `count_limit == 0` rejected at every layer).
+///
+/// Reject at the SDK boundary with `SdkError::Config` — never silently
+/// upgraded to `STREAM_READ_HARD_CAP`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_read_stream_rejects_zero_count_limit() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    let err = ff_sdk::read_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(0),
+        "-",
+        "+",
+        0,
+    )
+    .await
+    .expect_err("count_limit=0 must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("count_limit must be >= 1"),
+        "unexpected error: {msg}"
+    );
+}
+
+/// R3 regression (BUG2 `count_limit == 0` rejected on tail path too).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_tail_stream_rejects_zero_count_limit() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let config = test_config();
+
+    let err = ff_sdk::tail_stream(
+        tc.client(),
+        &config,
+        &eid,
+        AttemptIndex::new(0),
+        "0-0",
+        0,
+        0,
+    )
+    .await
+    .expect_err("count_limit=0 must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("count_limit must be >= 1"),
+        "unexpected error: {msg}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// R2 regression tests (BUG1 + BUG2): fail-closed on malformed policy/caps
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Submit an arbitrary policy_json raw and return the FCALL response.
+/// Deliberately bypasses the well-formed cap helpers above so tests can
+/// exercise the fail-closed parse path in ff_create_execution.
+async fn fcall_create_execution_with_raw_policy(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    lane: &str,
+    policy_json: &str,
+) -> Value {
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(lane);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        lane.to_owned(),
+        "cap_regression".to_owned(),
+        "0".to_owned(),
+        "cap-test".to_owned(),
+        policy_json.to_owned(),
+        r#"{"t":1}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    tc.client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("transport")
+}
+
+/// R2-BUG1 regression: a malformed policy_json (trailing comma here) used
+/// to slip through pcall(cjson.decode) as ok_decode=false, silently skip
+/// the routing_requirements extraction, and store an execution with NO
+/// required_capabilities — wildcard-claimable by anyone. Now it returns
+/// invalid_policy_json and writes nothing.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_malformed_policy_json_fails_closed() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let raw = fcall_create_execution_with_raw_policy(
+        &tc,
+        &eid,
+        LANE,
+        r#"{"routing_requirements":{"required_capabilities":["gpu",]}}"#,
+    )
+    .await;
+    assert_err(&raw, "invalid_policy_json", "malformed policy JSON");
+
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let exists: i64 = tc
+        .client()
+        .cmd("EXISTS")
+        .arg(ctx.core())
+        .execute()
+        .await
+        .expect("EXISTS transport");
+    assert_eq!(
+        exists, 0,
+        "exec_core must not exist after invalid_policy_json"
+    );
+}
+
+/// R2-BUG2 regression: a typed-config typo like ["gpu", null, 42] used to
+/// silent-drop the non-strings and store ["gpu"]. That silently erased a
+/// security-sensitive requirement. Now every non-string element aborts
+/// the create call with invalid_capabilities.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_non_string_token_fails_closed() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let cases = [
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu",null]}}"#,
+            "null token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu",42]}}"#,
+            "numeric token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu",{"x":1}]}}"#,
+            "object token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":["gpu",""]}}"#,
+            "empty token",
+        ),
+        (
+            r#"{"routing_requirements":{"required_capabilities":"gpu"}}"#,
+            "required not array",
+        ),
+    ];
+    for (policy_json, label) in cases {
+        let eid = ExecutionId::new();
+        let raw = fcall_create_execution_with_raw_policy(&tc, &eid, LANE, policy_json).await;
+        assert_err(&raw, "invalid_capabilities", label);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// R4: capability-mismatch block-to-route + periodic unblock
+// ═══════════════════════════════════════════════════════════════════════
+
+/// R4-BUG regression: after `ff_issue_claim_grant` returns capability_mismatch,
+/// the scheduler MUST move the execution from the lane's eligible ZSET
+/// into its blocked:route ZSET (eligibility_state=blocked_by_route,
+/// blocking_reason=waiting_for_capable_worker). Otherwise every tick
+/// re-picks the same top-of-zset and hot-loops.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capability_mismatch_blocks_to_route_zset() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+
+    let config = test_config();
+    let lane_id = LaneId::new(LANE);
+    let worker_id = ff_core::types::WorkerId::new(WORKER);
+    let wiid = ff_core::types::WorkerInstanceId::new(WORKER_INST);
+    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), config);
+
+    // Worker has only {cpu}; execution requires {gpu} → mismatch.
+    let cpu_only: std::collections::BTreeSet<String> =
+        ["cpu".to_owned()].into_iter().collect();
+    let grant = scheduler
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &cpu_only, 5000)
+        .await
+        .expect("scheduler claim should not error");
+    assert!(grant.is_none(), "no matching worker → no grant returned");
+
+    // Invariant (a)+(b): execution was moved out of eligible into blocked:route
+    let partition = execution_partition(&eid, &config);
+    let idx = IndexKeys::new(&partition);
+    let eligible_score: Option<String> = tc
+        .client()
+        .cmd("ZSCORE")
+        .arg(idx.lane_eligible(&lane_id).as_str())
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .expect("ZSCORE eligible");
+    assert!(
+        eligible_score.is_none(),
+        "execution must NOT be in eligible zset after mismatch"
+    );
+
+    let blocked_score: Option<String> = tc
+        .client()
+        .cmd("ZSCORE")
+        .arg(idx.lane_blocked_route(&lane_id).as_str())
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .expect("ZSCORE blocked:route");
+    assert!(
+        blocked_score.is_some(),
+        "execution must be in blocked:route zset after mismatch"
+    );
+
+    // Invariant (c): exec_core fields reflect the block.
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let (eligibility_state, blocking_reason): (Option<String>, Option<String>) = {
+        let v: Vec<Option<String>> = tc
+            .client()
+            .cmd("HMGET")
+            .arg(ctx.core().as_str())
+            .arg("eligibility_state")
+            .arg("blocking_reason")
+            .execute()
+            .await
+            .expect("HMGET");
+        (v.first().cloned().flatten(), v.get(1).cloned().flatten())
+    };
+    assert_eq!(
+        eligibility_state.as_deref(),
+        Some("blocked_by_route"),
+        "eligibility_state must be blocked_by_route"
+    );
+    assert_eq!(
+        blocking_reason.as_deref(),
+        Some("waiting_for_capable_worker"),
+        "blocking_reason must be waiting_for_capable_worker"
+    );
+}
+
+/// R4-BUG regression: the engine's unblock scanner MUST promote
+/// `waiting_for_capable_worker`-blocked executions back to eligible once
+/// the union of connected workers' caps covers the required set. Without
+/// this, capability-blocked executions stay stuck forever — exactly the
+/// bug that W3 and W1 both flagged independently in R4.
+///
+/// Uses the unblock scanner directly (not via a running Engine) to keep
+/// the test deterministic.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_capable_worker_unblocks_route_blocked() {
+    use ff_engine::scanner::Scanner;
+
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let config = test_config();
+    let lane_id = LaneId::new(LANE);
+    let eid = ExecutionId::new();
+
+    // 1. Create execution with required caps {gpu}; block it via a
+    //    mismatched scheduler claim.
+    create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
+    let worker_id = ff_core::types::WorkerId::new(WORKER);
+    let wiid = ff_core::types::WorkerInstanceId::new(WORKER_INST);
+    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), config);
+    let cpu_only: std::collections::BTreeSet<String> =
+        ["cpu".to_owned()].into_iter().collect();
+    scheduler
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &cpu_only, 5000)
+        .await
+        .expect("scheduler claim should not error");
+
+    // 2. Simulate a capable worker registering by writing the SAME two
+    //    cluster-safe entries the SDK writes on connect: the per-worker
+    //    caps STRING at ff:worker:<id>:caps, AND a SADD into the global
+    //    workers-index SET `ff:idx:workers`. The scanner enumerates
+    //    through the index in cluster mode (a keyspace SCAN would miss
+    //    workers whose caps key hashes to other shards).
+    let instance_id = "capable-gpu-worker";
+    let caps_key = format!("ff:worker:{instance_id}:caps");
+    let _: Option<String> = tc
+        .client()
+        .cmd("SET")
+        .arg(caps_key.as_str())
+        .arg("cuda,gpu")
+        .execute()
+        .await
+        .expect("SET worker caps");
+    let _: Option<i64> = tc
+        .client()
+        .cmd("SADD")
+        .arg("ff:idx:workers")
+        .arg(instance_id)
+        .execute()
+        .await
+        .expect("SADD workers-index");
+
+    // 3. Run the unblock scanner for this execution's partition.
+    let partition_idx = execution_partition(&eid, &config).index;
+    let scanner = ff_engine::scanner::unblock::UnblockScanner::new(
+        std::time::Duration::from_secs(30),
+        vec![lane_id.clone()],
+        config,
+    );
+    let _ = scanner.scan_partition(tc.client(), partition_idx).await;
+
+    // 4. Execution should be back in eligible, off blocked:route.
+    let idx = IndexKeys::new(&execution_partition(&eid, &config));
+    let eligible_score: Option<String> = tc
+        .client()
+        .cmd("ZSCORE")
+        .arg(idx.lane_eligible(&lane_id).as_str())
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .expect("ZSCORE eligible");
+    assert!(
+        eligible_score.is_some(),
+        "execution must be promoted back to eligible after capable worker appears"
+    );
+
+    let blocked_score: Option<String> = tc
+        .client()
+        .cmd("ZSCORE")
+        .arg(idx.lane_blocked_route(&lane_id).as_str())
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .expect("ZSCORE blocked:route");
+    assert!(
+        blocked_score.is_none(),
+        "execution must NOT be in blocked:route after promotion"
+    );
 }

--- a/crates/ff-test/tests/waitpoint_tokens.rs
+++ b/crates/ff-test/tests/waitpoint_tokens.rs
@@ -859,3 +859,108 @@ async fn test_rapid_rotation_past_grace_rejects_expired() {
     let resp = try_deliver_signal(&tc, &eid_b, &wp_b, "wpt_signal", &k1_token).await;
     assert_err_code(&resp, "token_expired");
 }
+
+/// 13. Malformed hex in the stored secret is rejected with `invalid_secret`.
+///
+/// Defense-in-depth: ServerConfig::from_env validates the env secret as
+/// even-length `0-9a-fA-F`, but an operator (or a buggy tool) writing
+/// directly to Valkey could plant a torn or non-hex value. The Lua
+/// `hex_to_bytes` helper rejects ANY non-hex pair — no silent coercion
+/// to 0 bytes, which would produce a bogus-but-valid-looking MAC.
+///
+/// This test installs a non-hex secret for the current kid, then attempts
+/// to deliver a signal and expects `invalid_secret` to bubble up through
+/// mint (at suspend) and/or validate (at deliver).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_malformed_hex_secret_rejects_cleanly() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Install a deliberately malformed secret under a fresh kid on every
+    // partition. "zzzzzz..." is ascii-printable but not hex, and even-
+    // length so it doesn't trip the length guard. The real guard is the
+    // per-pair tonumber(...) check.
+    let bad_hex = "z".repeat(64);
+    tc.install_waitpoint_hmac_secret("k1", &bad_hex).await;
+
+    // Try to suspend an execution. mint_waitpoint_token will call
+    // hmac_sha1_hex → hex_to_bytes(secret) → nil → "invalid_secret".
+    let eid = ExecutionId::new();
+    let (lease_id, epoch, _, attempt_id) = create_and_claim(&tc, &eid).await;
+
+    // Suspend with a fresh wp_id/wp_key. We can't use `suspend_and_get_token`
+    // here because it asserts success; we want to observe the failure.
+    let partition = execution_partition(&eid, &config());
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+    let wid = WorkerInstanceId::new(WORKER_INST);
+    let wp_uuid = uuid::Uuid::new_v4();
+    let wp_id_str = wp_uuid.to_string();
+    let wp_id = WaitpointId::from_uuid(wp_uuid);
+    let wp_key = format!("wpk:{wp_id_str}");
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(AttemptIndex::new(0)),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lease_expiry(),
+        idx.worker_leases(&wid),
+        ctx.suspension_current(),
+        ctx.waitpoint(&wp_id),
+        ctx.waitpoint_signals(&wp_id),
+        idx.suspension_timeout(),
+        idx.pending_waitpoint_expiry(),
+        idx.lane_active(&lane_id),
+        idx.lane_suspended(&lane_id),
+        ctx.waitpoints(),
+        ctx.waitpoint_condition(&wp_id),
+        idx.attempt_timeout(),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let resume_condition_json = serde_json::json!({
+        "condition_type": "signal_set",
+        "required_signal_names": ["wpt_signal"],
+        "signal_match_mode": "any",
+        "minimum_signal_count": 1,
+        "timeout_behavior": "fail",
+        "allow_operator_override": true,
+    })
+    .to_string();
+    let resume_policy_json = serde_json::json!({
+        "resume_target": "runnable",
+        "close_waitpoint_on_resume": true,
+        "consume_matched_signals": true,
+        "retain_signal_buffer_until_closed": true,
+    })
+    .to_string();
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        "0".to_owned(),
+        attempt_id,
+        lease_id,
+        epoch,
+        uuid::Uuid::new_v4().to_string(),
+        wp_id_str.clone(),
+        wp_key.clone(),
+        "waiting_for_signal".to_owned(),
+        "worker".to_owned(),
+        String::new(),
+        resume_condition_json,
+        resume_policy_json,
+        String::new(),
+        "0".to_owned(),
+        "fail".to_owned(),
+        "1000".to_owned(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_suspend_execution", &kr, &ar)
+        .await
+        .expect("ff_suspend_execution");
+    // Mint path rejects with invalid_secret — the token never reaches the wire.
+    assert_err_code(&raw, "invalid_secret");
+}

--- a/crates/ff-test/tests/waitpoint_tokens.rs
+++ b/crates/ff-test/tests/waitpoint_tokens.rs
@@ -1,0 +1,861 @@
+//! Waitpoint HMAC token validation tests (RFC-004 §Waitpoint Security).
+//!
+//! Exercises the kid-ring HMAC-SHA1 token flow end-to-end: minting on
+//! suspend / create_pending_waitpoint, validation on signal delivery,
+//! rotation behavior, and binding against the mint-time waitpoint identity.
+//!
+//! Run with: cargo test -p ff-test --test waitpoint_tokens -- --test-threads=1
+
+use ferriskey::Value;
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, PartitionConfig};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+const LANE: &str = "wpt-lane";
+const NS: &str = "wpt-ns";
+const WORKER: &str = "wpt-worker";
+const WORKER_INST: &str = "wpt-worker-1";
+
+fn config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+// ── Minimal FCALL helpers (scoped to this test file) ─────────────────────
+
+async fn create_and_claim(tc: &TestCluster, eid: &ExecutionId) -> (String, String, String, String) {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+    let wid = WorkerInstanceId::new(WORKER_INST);
+    let now = TimestampMs::now();
+
+    // 1. create_execution — KEYS (8), ARGV (13). Mirrors e2e_lifecycle fcall.
+    let _ = now; // fcall reads server TIME
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "wpt".to_owned(),
+        "0".to_owned(),
+        "wpt-runner".to_owned(),
+        "{}".to_owned(),
+        r#"{"test":true}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("ff_create_execution");
+
+    // 2. issue_claim_grant — KEYS (3), ARGV (9).
+    let grant_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.claim_grant(),
+        idx.lane_eligible(&lane_id),
+    ];
+    let grant_args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        WORKER_INST.to_owned(),
+        LANE.to_owned(),
+        String::new(),
+        "5000".to_owned(),
+        String::new(),
+        String::new(),
+        String::new(),
+    ];
+    let kr: Vec<&str> = grant_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = grant_args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_issue_claim_grant", &kr, &ar)
+        .await
+        .expect("ff_issue_claim_grant");
+
+    // 3. claim_execution — KEYS (14), ARGV (12) per e2e_lifecycle fcall_claim_execution.
+    let lease_id = uuid::Uuid::new_v4().to_string();
+    let attempt_id = uuid::Uuid::new_v4().to_string();
+    let att_idx = AttemptIndex::new(0);
+    let lease_ttl_ms: u64 = 30_000;
+    let renew_before = lease_ttl_ms * 2 / 3;
+    let claim_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.claim_grant(),
+        idx.lane_eligible(&lane_id),
+        idx.lease_expiry(),
+        idx.worker_leases(&wid),
+        ctx.attempt_hash(att_idx),
+        ctx.attempt_usage(att_idx),
+        ctx.attempt_policy(att_idx),
+        ctx.attempts(),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lane_active(&lane_id),
+        idx.attempt_timeout(),
+        idx.execution_deadline(),
+    ];
+    let claim_args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        WORKER_INST.to_owned(),
+        LANE.to_owned(),
+        String::new(),
+        lease_id.clone(),
+        lease_ttl_ms.to_string(),
+        renew_before.to_string(),
+        attempt_id.clone(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+    ];
+    let kr: Vec<&str> = claim_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = claim_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_claim_execution", &kr, &ar)
+        .await
+        .expect("ff_claim_execution");
+    // {1, "OK", lease_id, epoch, expires_at, attempt_id, attempt_index, attempt_type}
+    let arr = match &raw {
+        Value::Array(a) => a,
+        _ => panic!("claim: expected Array"),
+    };
+    let epoch = match arr.get(3) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::Int(n))) => n.to_string(),
+        _ => panic!("claim: no epoch, full: {raw:?}"),
+    };
+
+    (lease_id, epoch, "0".to_owned(), attempt_id)
+}
+
+/// Suspend an execution and return (wp_id_str, wp_key, token).
+async fn suspend_and_get_token(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    lease_id: &str,
+    epoch: &str,
+    attempt_id: &str,
+) -> (String, String, String) {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+    let wid = WorkerInstanceId::new(WORKER_INST);
+
+    let wp_uuid = uuid::Uuid::new_v4();
+    let wp_id_str = wp_uuid.to_string();
+    let wp_id = WaitpointId::from_uuid(wp_uuid);
+    let wp_key = format!("wpk:{wp_id_str}");
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(AttemptIndex::new(0)),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lease_expiry(),
+        idx.worker_leases(&wid),
+        ctx.suspension_current(),
+        ctx.waitpoint(&wp_id),
+        ctx.waitpoint_signals(&wp_id),
+        idx.suspension_timeout(),
+        idx.pending_waitpoint_expiry(),
+        idx.lane_active(&lane_id),
+        idx.lane_suspended(&lane_id),
+        ctx.waitpoints(),
+        ctx.waitpoint_condition(&wp_id),
+        idx.attempt_timeout(),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let resume_condition_json = serde_json::json!({
+        "condition_type": "signal_set",
+        "required_signal_names": ["wpt_signal"],
+        "signal_match_mode": "any",
+        "minimum_signal_count": 1,
+        "timeout_behavior": "fail",
+        "allow_operator_override": true,
+    })
+    .to_string();
+    let resume_policy_json = serde_json::json!({
+        "resume_target": "runnable",
+        "close_waitpoint_on_resume": true,
+        "consume_matched_signals": true,
+        "retain_signal_buffer_until_closed": true,
+    })
+    .to_string();
+
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        "0".to_owned(),
+        attempt_id.to_owned(),
+        lease_id.to_owned(),
+        epoch.to_owned(),
+        uuid::Uuid::new_v4().to_string(),
+        wp_id_str.clone(),
+        wp_key.clone(),
+        "waiting_for_signal".to_owned(),
+        "worker".to_owned(),
+        String::new(),
+        resume_condition_json,
+        resume_policy_json,
+        String::new(),
+        "0".to_owned(),
+        "fail".to_owned(),
+        "1000".to_owned(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_suspend_execution", &kr, &ar)
+        .await
+        .expect("ff_suspend_execution");
+    let arr = match &raw {
+        Value::Array(a) => a,
+        _ => panic!("suspend: expected Array"),
+    };
+    let status = match arr.first() {
+        Some(Ok(Value::Int(n))) => *n,
+        _ => panic!("suspend: no status"),
+    };
+    assert_eq!(status, 1, "suspend should succeed: {raw:?}");
+    let token = match arr.get(5) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::SimpleString(s))) => s.clone(),
+        _ => panic!("suspend: missing waitpoint_token at field 5: {raw:?}"),
+    };
+    assert!(!token.is_empty(), "token should not be empty");
+    (wp_id_str, wp_key, token)
+}
+
+/// Deliver a signal with the given token. Returns the raw FCALL response so
+/// tests can assert either success or an expected error code.
+async fn try_deliver_signal(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    wp_id_str: &str,
+    signal_name: &str,
+    waitpoint_token: &str,
+) -> Value {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let signal_id_str = uuid::Uuid::new_v4().to_string();
+    let wp_id = WaitpointId::parse(wp_id_str).unwrap();
+    let sig_id = SignalId::parse(&signal_id_str).unwrap();
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.waitpoint_condition(&wp_id),
+        ctx.waitpoint_signals(&wp_id),
+        ctx.exec_signals(),
+        ctx.signal(&sig_id),
+        ctx.signal_payload(&sig_id),
+        ctx.noop(),
+        ctx.waitpoint(&wp_id),
+        ctx.suspension_current(),
+        idx.lane_eligible(&lane_id),
+        idx.lane_suspended(&lane_id),
+        idx.lane_delayed(&lane_id),
+        idx.suspension_timeout(),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let args: Vec<String> = vec![
+        signal_id_str.clone(),
+        eid.to_string(),
+        wp_id_str.to_owned(),
+        signal_name.to_owned(),
+        "test".to_owned(),
+        "external".to_owned(),
+        "wpt".to_owned(),
+        String::new(),
+        "json".to_owned(),
+        String::new(),
+        String::new(),
+        "waitpoint".to_owned(),
+        TimestampMs::now().to_string(),
+        "86400000".to_owned(),
+        "0".to_owned(),
+        "1000".to_owned(),
+        "10000".to_owned(),
+        waitpoint_token.to_owned(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    tc.client()
+        .fcall("ff_deliver_signal", &kr, &ar)
+        .await
+        .expect("ff_deliver_signal FCALL transport")
+}
+
+fn assert_success(raw: &Value) {
+    let arr = match raw {
+        Value::Array(a) => a,
+        _ => panic!("expected Array, got {raw:?}"),
+    };
+    let status = match arr.first() {
+        Some(Ok(Value::Int(n))) => *n,
+        _ => panic!("no status"),
+    };
+    assert_eq!(status, 1, "expected success, got {raw:?}");
+}
+
+fn assert_err_code(raw: &Value, expected: &str) {
+    let arr = match raw {
+        Value::Array(a) => a,
+        _ => panic!("expected Array, got {raw:?}"),
+    };
+    let status = match arr.first() {
+        Some(Ok(Value::Int(n))) => *n,
+        _ => panic!("no status"),
+    };
+    assert_eq!(status, 0, "expected error, got {raw:?}");
+    let code = match arr.get(1) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::SimpleString(s))) => s.clone(),
+        _ => panic!("no error code"),
+    };
+    assert_eq!(code, expected, "expected {expected}, got {code}");
+}
+
+// ── Test matrix (RFC-004 §Waitpoint Security) ─────────────────────────────
+
+/// 1. Valid token minted on suspend succeeds on deliver_signal.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_valid_token_accepted() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let (lease_id, epoch, _att_idx, attempt_id) = create_and_claim(&tc, &eid).await;
+    let (wp_id, _wp_key, token) =
+        suspend_and_get_token(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
+
+    let resp = try_deliver_signal(&tc, &eid, &wp_id, "wpt_signal", &token).await;
+    assert_success(&resp);
+}
+
+/// 2. Empty/missing token → `missing_token`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_missing_token_rejected() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let (lease_id, epoch, _att_idx, attempt_id) = create_and_claim(&tc, &eid).await;
+    let (wp_id, _wp_key, _token) =
+        suspend_and_get_token(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
+
+    let resp = try_deliver_signal(&tc, &eid, &wp_id, "wpt_signal", "").await;
+    assert_err_code(&resp, "missing_token");
+}
+
+/// 3. Token with flipped hex char → `invalid_token`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_tampered_token_rejected() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let (lease_id, epoch, _att_idx, attempt_id) = create_and_claim(&tc, &eid).await;
+    let (wp_id, _wp_key, token) =
+        suspend_and_get_token(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
+
+    // Flip the last hex char: this yields the same format but a digest
+    // that won't match constant-time-compare.
+    let mut bytes: Vec<char> = token.chars().collect();
+    let last = bytes.len() - 1;
+    bytes[last] = if bytes[last] == '0' { '1' } else { '0' };
+    let tampered: String = bytes.into_iter().collect();
+
+    let resp = try_deliver_signal(&tc, &eid, &wp_id, "wpt_signal", &tampered).await;
+    assert_err_code(&resp, "invalid_token");
+}
+
+/// 4. Token with an unknown kid prefix → `invalid_token`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_wrong_kid_rejected() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let (lease_id, epoch, _att_idx, attempt_id) = create_and_claim(&tc, &eid).await;
+    let (wp_id, _wp_key, _token) =
+        suspend_and_get_token(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
+
+    let bogus = "k9:0000000000000000000000000000000000000000";
+    let resp = try_deliver_signal(&tc, &eid, &wp_id, "wpt_signal", bogus).await;
+    assert_err_code(&resp, "invalid_token");
+}
+
+/// 5. Rotation within grace: token minted under k1 still validates after k2
+/// rotation while `previous_expires_at` has not elapsed.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_rotation_grace_allows_previous_kid() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Fresh secret — TestCluster::cleanup already installed k1.
+    let eid = ExecutionId::new();
+    let (lease_id, epoch, _att_idx, attempt_id) = create_and_claim(&tc, &eid).await;
+    let (wp_id, _wp_key, k1_token) =
+        suspend_and_get_token(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
+    assert!(k1_token.starts_with("k1:"), "token should be k1-signed: {k1_token}");
+
+    // Rotate to k2 with a grace window 10 minutes into the future.
+    let future_grace = TimestampMs::now().0 + 600_000;
+    tc.rotate_waitpoint_hmac_secret(
+        "k2",
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        future_grace,
+    )
+    .await;
+
+    // Old (k1) token still works during grace.
+    let resp = try_deliver_signal(&tc, &eid, &wp_id, "wpt_signal", &k1_token).await;
+    assert_success(&resp);
+}
+
+/// 6. Rotation past grace: a k1-signed token is `token_expired` when
+/// `previous_expires_at` has already passed.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_rotation_past_grace_rejects_previous_kid() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let (lease_id, epoch, _att_idx, attempt_id) = create_and_claim(&tc, &eid).await;
+    let (wp_id, _wp_key, k1_token) =
+        suspend_and_get_token(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
+
+    // Rotate with a grace that expired 1s ago.
+    let past_grace = TimestampMs::now().0 - 1000;
+    tc.rotate_waitpoint_hmac_secret(
+        "k2",
+        "2222222222222222222222222222222222222222222222222222222222222222",
+        past_grace,
+    )
+    .await;
+
+    let resp = try_deliver_signal(&tc, &eid, &wp_id, "wpt_signal", &k1_token).await;
+    assert_err_code(&resp, "token_expired");
+}
+
+/// 7. Pending-waitpoint flow: create_pending_waitpoint returns a token that
+/// authenticates buffer_signal_for_pending_waitpoint. After the pending
+/// waitpoint is activated by suspend, the same token continues to work for
+/// ff_deliver_signal (the token is bound to the pending waitpoint's
+/// mint-time `created_at`, which suspend preserves).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_pending_waitpoint_token_flow() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let (_lease_id, _epoch, _att_idx, _attempt_id) = create_and_claim(&tc, &eid).await;
+
+    // Create pending waitpoint with its own minted token.
+    let partition = execution_partition(&eid, &config());
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let wp_uuid = uuid::Uuid::new_v4();
+    let wp_id_str = wp_uuid.to_string();
+    let wp_id = WaitpointId::from_uuid(wp_uuid);
+    let wp_key = format!("wpk-pending:{wp_id_str}");
+    let expires_at = TimestampMs::now().0 + 60_000;
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.waitpoint(&wp_id),
+        idx.pending_waitpoint_expiry(),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        "0".to_owned(),
+        wp_id_str.clone(),
+        wp_key.clone(),
+        expires_at.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_create_pending_waitpoint", &kr, &ar)
+        .await
+        .expect("ff_create_pending_waitpoint");
+    let arr = match &raw {
+        Value::Array(a) => a,
+        _ => panic!("create_pending: expected Array"),
+    };
+    let status = match arr.first() {
+        Some(Ok(Value::Int(n))) => *n,
+        _ => panic!("create_pending: no status"),
+    };
+    assert_eq!(status, 1, "create_pending should succeed: {raw:?}");
+    let pending_token = match arr.get(4) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::SimpleString(s))) => s.clone(),
+        _ => panic!("create_pending: missing token at field 4: {raw:?}"),
+    };
+    assert!(!pending_token.is_empty());
+
+    // Buffer a signal against the pending waitpoint — must validate token.
+    // Wrong token path first.
+    let buf_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.waitpoint_condition(&wp_id),
+        ctx.waitpoint_signals(&wp_id),
+        ctx.exec_signals(),
+        ctx.signal(&SignalId::new()),
+        ctx.signal_payload(&SignalId::new()),
+        ctx.noop(),
+        ctx.waitpoint(&wp_id),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let bad_buf_args: Vec<String> = vec![
+        uuid::Uuid::new_v4().to_string(),
+        eid.to_string(),
+        wp_id_str.clone(),
+        "wpt_signal".to_owned(),
+        "test".to_owned(),
+        "external".to_owned(),
+        "wpt".to_owned(),
+        String::new(),
+        "json".to_owned(),
+        String::new(),
+        String::new(),
+        "waitpoint".to_owned(),
+        TimestampMs::now().to_string(),
+        "86400000".to_owned(),
+        "0".to_owned(),
+        "1000".to_owned(),
+        "10000".to_owned(),
+        "k9:0000000000000000000000000000000000000000".to_owned(),
+    ];
+    let kr: Vec<&str> = buf_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = bad_buf_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_buffer_signal_for_pending_waitpoint", &kr, &ar)
+        .await
+        .expect("ff_buffer_signal_for_pending_waitpoint (bad)");
+    assert_err_code(&raw, "invalid_token");
+
+    // Valid token path — token remains bound to the pending waitpoint's
+    // mint-time created_at, unchanged by the activation below.
+    let good_buf_args: Vec<String> = vec![
+        uuid::Uuid::new_v4().to_string(),
+        eid.to_string(),
+        wp_id_str.clone(),
+        "wpt_signal".to_owned(),
+        "test".to_owned(),
+        "external".to_owned(),
+        "wpt".to_owned(),
+        String::new(),
+        "json".to_owned(),
+        String::new(),
+        String::new(),
+        "waitpoint".to_owned(),
+        TimestampMs::now().to_string(),
+        "86400000".to_owned(),
+        "0".to_owned(),
+        "1000".to_owned(),
+        "10000".to_owned(),
+        pending_token.clone(),
+    ];
+    let ar: Vec<&str> = good_buf_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_buffer_signal_for_pending_waitpoint", &kr, &ar)
+        .await
+        .expect("ff_buffer_signal_for_pending_waitpoint (good)");
+    assert_success(&raw);
+}
+
+/// 8. Cross-waitpoint binding: a token minted for waitpoint A is rejected
+/// when presented against waitpoint B, even when both are active on the
+/// same execution. The HMAC input binds waitpoint_id, so a leaked token
+/// cannot be replayed against another waitpoint on the same execution.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_cross_waitpoint_token_rejected() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Two separate executions each get their own waitpoint + token. Using
+    // two executions avoids the single-open-suspension invariant; the
+    // security property we're checking is the token→waitpoint binding.
+    let eid_a = ExecutionId::new();
+    let eid_b = ExecutionId::new();
+    let (lid_a, ep_a, _, aid_a) = create_and_claim(&tc, &eid_a).await;
+    let (lid_b, ep_b, _, aid_b) = create_and_claim(&tc, &eid_b).await;
+    let (_wp_a, _wk_a, token_a) =
+        suspend_and_get_token(&tc, &eid_a, &lid_a, &ep_a, &aid_a).await;
+    let (wp_b, _wk_b, _token_b) =
+        suspend_and_get_token(&tc, &eid_b, &lid_b, &ep_b, &aid_b).await;
+
+    // Present A's token to B → rejected.
+    let resp = try_deliver_signal(&tc, &eid_b, &wp_b, "wpt_signal", &token_a).await;
+    assert_err_code(&resp, "invalid_token");
+}
+
+/// 9a. ff_deliver_signal validates HMAC BEFORE state-probe — no oracle.
+/// Without this guarantee, an unauthenticated caller could enumerate which
+/// (execution_id, waitpoint_id) tuples exist, and whether they're
+/// pending / active / closed / terminal, by observing the error code.
+/// This test verifies that with a random bogus waitpoint_id + bogus token
+/// against a real execution, the error is `invalid_token` (not
+/// `waitpoint_not_found` or `target_not_signalable`).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_deliver_signal_no_state_oracle_on_bad_token() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Create an execution in active/leased state (NOT suspended, NO waitpoint).
+    let eid = ExecutionId::new();
+    let (_lease_id, _epoch, _att_idx, _attempt_id) = create_and_claim(&tc, &eid).await;
+
+    // Present an invented waitpoint_id and a bogus token. Pre-fix: caller
+    // would see `target_not_signalable` or `waitpoint_not_found` — signalling
+    // existence/state of the execution. Post-fix: `invalid_token`, because
+    // auth runs first and unifies the missing-waitpoint case into the
+    // token-failure bucket.
+    let bogus_wp = uuid::Uuid::new_v4().to_string();
+    let bogus_token = "k1:0000000000000000000000000000000000000000";
+    let resp = try_deliver_signal(&tc, &eid, &bogus_wp, "wpt_signal", bogus_token).await;
+    assert_err_code(&resp, "invalid_token");
+}
+
+/// 9. buffer_signal_for_pending_waitpoint rejects after waitpoint closed.
+/// ff_deliver_signal blocks replay via wp_condition.closed, but that
+/// condition hash does not exist for pending waitpoints — the buffer
+/// function must independently gate on wp.state. Without this gate, a
+/// caller holding a valid pending-waitpoint token could keep appending
+/// signals to a closed waitpoint that would replay on a later
+/// suspend(use_pending=1).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_buffer_signal_rejected_after_waitpoint_closed() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = ExecutionId::new();
+    let (_lease_id, _epoch, _att_idx, _attempt_id) = create_and_claim(&tc, &eid).await;
+
+    // Create pending waitpoint, capture token.
+    let partition = execution_partition(&eid, &config());
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let wp_uuid = uuid::Uuid::new_v4();
+    let wp_id_str = wp_uuid.to_string();
+    let wp_id = WaitpointId::from_uuid(wp_uuid);
+    let wp_key = format!("wpk-pending-closed:{wp_id_str}");
+    let expires_at = TimestampMs::now().0 + 60_000;
+    let create_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.waitpoint(&wp_id),
+        idx.pending_waitpoint_expiry(),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let create_args: Vec<String> = vec![
+        eid.to_string(),
+        "0".to_owned(),
+        wp_id_str.clone(),
+        wp_key.clone(),
+        expires_at.to_string(),
+    ];
+    let kr: Vec<&str> = create_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = create_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_create_pending_waitpoint", &kr, &ar)
+        .await
+        .expect("ff_create_pending_waitpoint");
+    let arr = match &raw {
+        Value::Array(a) => a,
+        _ => panic!("create_pending: expected Array"),
+    };
+    let token = match arr.get(4) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::SimpleString(s))) => s.clone(),
+        _ => panic!("create_pending: missing token: {raw:?}"),
+    };
+
+    // Close the pending waitpoint directly by HSET state=closed on its hash.
+    // Simulates ff_close_waitpoint having run while the external signaler
+    // was mid-flight with a still-valid token.
+    let wp_hash_key = ctx.waitpoint(&wp_id);
+    tc.client()
+        .hset(&wp_hash_key, "state", "closed")
+        .await
+        .expect("HSET close pending waitpoint");
+
+    // Build a buffer_signal call with the valid token; expect waitpoint_closed.
+    let buf_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.waitpoint_condition(&wp_id),
+        ctx.waitpoint_signals(&wp_id),
+        ctx.exec_signals(),
+        ctx.signal(&SignalId::new()),
+        ctx.signal_payload(&SignalId::new()),
+        ctx.noop(),
+        ctx.waitpoint(&wp_id),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let buf_args: Vec<String> = vec![
+        uuid::Uuid::new_v4().to_string(),
+        eid.to_string(),
+        wp_id_str.clone(),
+        "wpt_signal".to_owned(),
+        "test".to_owned(),
+        "external".to_owned(),
+        "wpt".to_owned(),
+        String::new(),
+        "json".to_owned(),
+        String::new(),
+        String::new(),
+        "waitpoint".to_owned(),
+        TimestampMs::now().to_string(),
+        "86400000".to_owned(),
+        "0".to_owned(),
+        "1000".to_owned(),
+        "10000".to_owned(),
+        token,
+    ];
+    let kr: Vec<&str> = buf_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = buf_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_buffer_signal_for_pending_waitpoint", &kr, &ar)
+        .await
+        .expect("ff_buffer_signal_for_pending_waitpoint (closed)");
+    assert_err_code(&raw, "waitpoint_closed");
+}
+
+/// 11. Rapid rotation preserves in-grace tokens (RFC-004 §Waitpoint Security).
+///
+/// Per the multi-kid validation model: ANY kid present in the secrets
+/// hash with a future `expires_at:<kid>` (or the current kid) accepts
+/// tokens. Rotating A→B→C within a grace window must keep A-signed tokens
+/// valid as long as A's expiry is still in the future.
+///
+/// The pre-fix two-slot model evicted A as soon as B became previous_kid,
+/// silently shrinking A's grace window from 24h to "time to next rotation".
+/// This test locks in the new contract: explicit grace per kid.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_rapid_rotation_preserves_in_grace_tokens() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Mint a token under k1 (installed by cleanup()).
+    let eid_a = ExecutionId::new();
+    let (lid_a, ep_a, _, aid_a) = create_and_claim(&tc, &eid_a).await;
+    let (wp_a, _wk_a, k1_token) =
+        suspend_and_get_token(&tc, &eid_a, &lid_a, &ep_a, &aid_a).await;
+    assert!(k1_token.starts_with("k1:"), "expected k1-signed token: {k1_token}");
+
+    // Rotate k1 → k2 with 10-minute grace. A-signed token must still work.
+    let future_grace = TimestampMs::now().0 + 600_000;
+    tc.rotate_waitpoint_hmac_secret(
+        "k2",
+        "2222222222222222222222222222222222222222222222222222222222222222",
+        future_grace,
+    )
+    .await;
+
+    // Rotate k2 → k3 with another 10-minute grace. Under the OLD two-slot
+    // model, previous_kid would now be k2 and k1 would silently fall off.
+    // Under multi-kid, expires_at:k1 is still future so k1-signed tokens
+    // keep validating.
+    tc.rotate_waitpoint_hmac_secret(
+        "k3",
+        "3333333333333333333333333333333333333333333333333333333333333333",
+        future_grace,
+    )
+    .await;
+
+    // The k1-signed token from before any rotation must still be accepted.
+    // This is the regression guard for the R4 BLOCKER.
+    let resp = try_deliver_signal(&tc, &eid_a, &wp_a, "wpt_signal", &k1_token).await;
+    assert_success(&resp);
+}
+
+/// 12. Rapid rotation past grace: after an expires_at:<kid> elapses, that
+/// kid's tokens reject with `token_expired`, not silently succeed and not
+/// invalid_token (which would suggest "never existed").
+#[tokio::test]
+#[serial_test::serial]
+async fn test_rapid_rotation_past_grace_rejects_expired() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Mint a k1 token, rotate to k2 with a grace window ALREADY in the past.
+    let eid_b = ExecutionId::new();
+    let (lid_b, ep_b, _, aid_b) = create_and_claim(&tc, &eid_b).await;
+    let (wp_b, _wk_b, k1_token) =
+        suspend_and_get_token(&tc, &eid_b, &lid_b, &ep_b, &aid_b).await;
+
+    // Set previous_expires_at in the past so k1's grace is already elapsed.
+    let past_grace = TimestampMs::now().0 - 1_000;
+    tc.rotate_waitpoint_hmac_secret(
+        "k2",
+        "2222222222222222222222222222222222222222222222222222222222222222",
+        past_grace,
+    )
+    .await;
+
+    // Subsequent rotate k2 → k3 triggers orphan GC which sweeps expired
+    // kids (including k1, whose expires_at is in the past). After this,
+    // secret:k1 should be gone from the hash.
+    let future_grace = TimestampMs::now().0 + 600_000;
+    tc.rotate_waitpoint_hmac_secret(
+        "k3",
+        "3333333333333333333333333333333333333333333333333333333333333333",
+        future_grace,
+    )
+    .await;
+
+    // k1-signed token → `token_expired`. expires_at:k1 is present in the
+    // hash (fixture helper writes it, mirroring production rotation) but
+    // its value is in the past. The multi-kid validator distinguishes
+    // "present kid whose grace has elapsed" (token_expired — actionable:
+    // operator rolled forward, client is holding an aged token) from
+    // "unknown kid" (invalid_token — never existed or already GC'd).
+    // Production orphan GC at the NEXT rotation will HDEL secret:k1 and
+    // expires_at:k1 because expires_at:k1 < now_ms; after that the same
+    // request would return invalid_token. The fixture doesn't run GC,
+    // so this pins the pre-GC "known kid, past grace" behavior.
+    let resp = try_deliver_signal(&tc, &eid_b, &wp_b, "wpt_signal", &k1_token).await;
+    assert_err_code(&resp, "token_expired");
+}

--- a/examples/coding-agent/Cargo.lock
+++ b/examples/coding-agent/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -945,6 +946,7 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-engine",
+ "ff-script",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/lua/execution.lua
+++ b/lua/execution.lua
@@ -74,6 +74,66 @@ redis.register_function('ff_create_execution', function(keys, args)
     return {1, "DUPLICATE", A.execution_id}
   end
 
+  -- 2b. Policy JSON validation — extract required_capabilities CSV now, BEFORE
+  -- any write, so an error aborts without leaving a half-written exec_core.
+  -- Fail-CLOSED on any malformed/typed input rather than silently defaulting
+  -- to the empty-required wildcard — required_capabilities is security-
+  -- sensitive (an empty set matches any worker).
+  --
+  --   * An empty / "{}" policy_json → no required_capabilities field written
+  --     → wildcard match, intentional.
+  --   * A non-empty policy_json that fails cjson.decode → fail with
+  --     invalid_policy_json. An operator who MEANT "no policy" passes "".
+  --   * routing_requirements.required_capabilities present but not an array
+  --     → fail with invalid_capabilities:required_not_array.
+  --   * Any element that is not a non-empty string → fail with
+  --     invalid_capabilities:required:non_string_token. Silent-drop on
+  --     `["gpu", null, 42]` would erase real requirements.
+  --   * Comma in a token → fail (reserved delimiter, see ff_issue_claim_grant).
+  --   * Bounds: same 4096 bytes / 256 tokens ceiling as the worker CSV.
+  local required_caps_csv = nil
+  if is_set(A.policy_json) and A.policy_json ~= "{}" then
+    local ok_decode, policy = pcall(cjson.decode, A.policy_json)
+    if not ok_decode then
+      return err("invalid_policy_json", "malformed")
+    end
+    if type(policy) == "table" and policy.routing_requirements ~= nil then
+      if type(policy.routing_requirements) ~= "table" then
+        return err("invalid_policy_json", "routing_requirements:not_object")
+      end
+      local caps = policy.routing_requirements.required_capabilities
+      if caps ~= nil then
+        if type(caps) ~= "table" then
+          return err("invalid_capabilities", "required:not_array")
+        end
+        local list = {}
+        for _, cap in ipairs(caps) do
+          if type(cap) ~= "string" then
+            return err("invalid_capabilities", "required:non_string_token")
+          end
+          if #cap == 0 then
+            return err("invalid_capabilities", "required:empty_token")
+          end
+          if string.find(cap, ",", 1, true) then
+            return err("invalid_capabilities", "required:comma_in_token")
+          end
+          list[#list + 1] = cap
+        end
+        if #list > CAPS_MAX_TOKENS then
+          return err("invalid_capabilities", "required:too_many_tokens")
+        end
+        table.sort(list)
+        if #list > 0 then
+          local csv = table.concat(list, ",")
+          if #csv > CAPS_MAX_BYTES then
+            return err("invalid_capabilities", "required:too_many_bytes")
+          end
+          required_caps_csv = csv
+        end
+      end
+    end
+  end
+
   -- 3. Determine initial eligibility
   local lifecycle_phase = "runnable"
   local eligibility_state, blocking_reason, blocking_detail, public_state
@@ -157,9 +217,14 @@ redis.register_function('ff_create_execution', function(keys, args)
     redis.call("SET", K.payload_key, A.input_payload)
   end
 
-  -- 6. Store policy
+  -- 6. Store policy + required_capabilities. Validation already ran before
+  -- any write (step 2b); here we only persist the pre-validated CSV. See
+  -- step 2b for the fail-closed rationale on malformed / typed inputs.
   if is_set(A.policy_json) then
     redis.call("SET", K.policy_key, A.policy_json)
+  end
+  if required_caps_csv then
+    redis.call("HSET", K.core_key, "required_capabilities", required_caps_csv)
   end
 
   -- 7. Store tags

--- a/lua/execution.lua
+++ b/lua/execution.lua
@@ -90,7 +90,21 @@ redis.register_function('ff_create_execution', function(keys, args)
   --     invalid_capabilities:required:non_string_token. Silent-drop on
   --     `["gpu", null, 42]` would erase real requirements.
   --   * Comma in a token → fail (reserved delimiter, see ff_issue_claim_grant).
+  --   * ASCII control byte (0x00-0x1F, 0x7F) or space (0x20) → fail
+  --     (invalid_capabilities:required:control_or_whitespace). Mirrors the
+  --     Rust ingress in ff-sdk::FlowFabricWorker::connect and
+  --     ff-scheduler::Scheduler::claim_for_worker (R3 relaxed printable-ASCII
+  --     check to allow UTF-8 printable above 0x7F while still rejecting
+  --     whitespace/control). This is the "last line of defense" for admin
+  --     direct-HSET bypass: a required cap containing "\n" or "\0" is
+  --     impossible to type, impossible to debug, and would silently pin an
+  --     execution as unclaimable forever.
   --   * Bounds: same 4096 bytes / 256 tokens ceiling as the worker CSV.
+  --
+  -- Note on UTF-8: the byte-range test rejects ASCII control + space but
+  -- accepts every byte ≥ 0x21 except 0x7F (DEL). UTF-8 multibyte sequences
+  -- use only bytes 0x80-0xBF (continuation) or 0xC0-0xFD (lead), all above
+  -- 0x7F, so i18n caps like "东京-gpu" pass through intact. See RFC-009 §7.5.
   local required_caps_csv = nil
   if is_set(A.policy_json) and A.policy_json ~= "{}" then
     local ok_decode, policy = pcall(cjson.decode, A.policy_json)
@@ -116,6 +130,14 @@ redis.register_function('ff_create_execution', function(keys, args)
           end
           if string.find(cap, ",", 1, true) then
             return err("invalid_capabilities", "required:comma_in_token")
+          end
+          -- Reject ASCII control (0x00-0x1F), DEL (0x7F), and space (0x20).
+          -- Iterating byte-by-byte: any byte in 0x00..=0x20 or == 0x7F fails.
+          for i = 1, #cap do
+            local b = cap:byte(i)
+            if b <= 0x20 or b == 0x7F then
+              return err("invalid_capabilities", "required:control_or_whitespace")
+            end
           end
           list[#list + 1] = cap
         end

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -25,17 +25,26 @@ local CAPS_MAX_TOKENS = 256
 ---------------------------------------------------------------------------
 
 -- Convert a hex string to a binary (byte) string. Accepts mixed case.
--- Returns nil on odd-length input; callers treat nil as invalid_secret.
--- Rust side (ServerConfig) already rejects odd-length hex, but an operator
--- writing directly to Valkey would bypass that validator — we refuse the
--- conversion here rather than silently drop the trailing nibble.
+-- Returns nil on ANY malformed input: non-string, odd length, OR any
+-- non-hex char (including whitespace, unicode, control chars). Callers
+-- treat nil as invalid_secret.
+--
+-- Rust side (ServerConfig) already validates the env secret as even-length
+-- 0-9a-fA-F, but an operator writing directly to Valkey (or a torn write
+-- during rotation) could bypass that validator. We refuse the conversion
+-- here instead of silently coercing bad pairs to 0 bytes (which would
+-- produce a bogus but valid-looking MAC).
 local function hex_to_bytes(hex)
   if type(hex) ~= "string" or #hex % 2 ~= 0 then
     return nil
   end
   local out = {}
   for i = 1, #hex - 1, 2 do
-    out[#out + 1] = string.char(tonumber(hex:sub(i, i + 1), 16) or 0)
+    local byte = tonumber(hex:sub(i, i + 1), 16)
+    if not byte then
+      return nil
+    end
+    out[#out + 1] = string.char(byte)
   end
   return table.concat(out)
 end

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -1,7 +1,293 @@
 -- FlowFabric shared library-local helpers
 -- These are local functions available to all registered functions in the
 -- flowfabric library. They are NOT independently FCALL-able.
--- Reference: RFC-010 §4.8
+-- Reference: RFC-010 §4.8, RFC-004 §Waitpoint Security (HMAC tokens)
+
+---------------------------------------------------------------------------
+-- Capability CSV bounds (RFC-009 §7.5)
+---------------------------------------------------------------------------
+-- Shared ceiling for BOTH the worker-side CSV (ff_issue_claim_grant ARGV[9])
+-- AND the execution-side CSV (exec_core.required_capabilities). Defense in
+-- depth against runaway field sizes: a 10k-token list turns into a multi-MB
+-- HSET value and a per-candidate O(N) atomic scan that blocks the shard.
+--
+-- Inclusivity: these are MAXIMUM accepted values. `#csv == CAPS_MAX_BYTES`
+-- and `n == CAPS_MAX_TOKENS` are accepted; one more rejects. Rust-side
+-- ingress (ff-sdk::FlowFabricWorker::connect, ff-scheduler::Scheduler::
+-- claim_for_worker, ff-core::policy::RoutingRequirements deserialization
+-- via lua/execution.lua) enforces the same ceilings so the Lua check is a
+-- defense-in-depth backstop, not the primary validator.
+local CAPS_MAX_BYTES  = 4096
+local CAPS_MAX_TOKENS = 256
+
+---------------------------------------------------------------------------
+-- Hex / binary helpers (for HMAC-SHA1 token derivation)
+---------------------------------------------------------------------------
+
+-- Convert a hex string to a binary (byte) string. Accepts mixed case.
+-- Returns nil on odd-length input; callers treat nil as invalid_secret.
+-- Rust side (ServerConfig) already rejects odd-length hex, but an operator
+-- writing directly to Valkey would bypass that validator — we refuse the
+-- conversion here rather than silently drop the trailing nibble.
+local function hex_to_bytes(hex)
+  if type(hex) ~= "string" or #hex % 2 ~= 0 then
+    return nil
+  end
+  local out = {}
+  for i = 1, #hex - 1, 2 do
+    out[#out + 1] = string.char(tonumber(hex:sub(i, i + 1), 16) or 0)
+  end
+  return table.concat(out)
+end
+
+-- XOR two equal-length byte strings. Used for HMAC key-pad construction.
+local function xor_bytes(a, b)
+  local out = {}
+  for i = 1, #a do
+    out[i] = string.char(bit.bxor(a:byte(i), b:byte(i)))
+  end
+  return table.concat(out)
+end
+
+-- HMAC-SHA1(key_hex, message) → lowercase hex digest (40 chars), or nil on
+-- malformed key_hex (odd-length / non-string). Callers must treat nil as
+-- an invalid-secret error — never pass it to HSET / concat / return.
+-- Reference: RFC 2104. SHA1 block size = 64 bytes.
+local function hmac_sha1_hex(key_hex, message)
+  local key = hex_to_bytes(key_hex)
+  if not key then
+    return nil
+  end
+  local block_size = 64
+  if #key > block_size then
+    -- Reduce oversized key via SHA1 (per RFC 2104). sha1hex output is 40
+    -- lowercase hex chars, so the inner hex_to_bytes cannot fail.
+    key = hex_to_bytes(redis.sha1hex(key))
+  end
+  if #key < block_size then
+    key = key .. string.rep("\0", block_size - #key)
+  end
+  local ipad = string.rep(string.char(0x36), block_size)
+  local opad = string.rep(string.char(0x5c), block_size)
+  local inner = redis.sha1hex(xor_bytes(key, ipad) .. message)
+  return redis.sha1hex(xor_bytes(key, opad) .. hex_to_bytes(inner))
+end
+
+-- Constant-time string equality. Returns true iff strings are equal in
+-- both length and content. Uses XOR-accumulation to avoid early-exit
+-- timing leaks on byte mismatches during HMAC token validation.
+-- Reference: Remote timing attacks on authentication (e.g., CVE-2011-3389 class).
+--
+-- Safety note on the length check: a length-mismatch early return reveals
+-- whether the presented string matches the expected length, which is a
+-- timing side channel IF attacker-controlled length is used to probe the
+-- expected length. In this codebase the caller normalizes to a fixed shape
+-- BEFORE reaching here — validate_waitpoint_token already requires
+-- #presented == 40 (SHA1 hex digest length) at the parsing boundary, so
+-- any input reaching constant_time_eq has a length already known to be 40
+-- by the attacker. The only length variation here is on `expected`, which
+-- is server-computed and constant. Hence this early return does not leak
+-- secret-dependent timing.
+local function constant_time_eq(a, b)
+  if type(a) ~= "string" or type(b) ~= "string" then
+    return false
+  end
+  if #a ~= #b then
+    return false
+  end
+  local acc = 0
+  for i = 1, #a do
+    acc = bit.bor(acc, bit.bxor(a:byte(i), b:byte(i)))
+  end
+  return acc == 0
+end
+
+---------------------------------------------------------------------------
+-- Waitpoint HMAC tokens (RFC-004 §Waitpoint Security)
+---------------------------------------------------------------------------
+--
+-- Token format: "kid:40hex"  — kid identifies which key signed the token,
+-- enabling zero-downtime rotation. ANY kid present in the secrets hash
+-- with a future `expires_at:<kid>` (or the current kid, which has no
+-- expiry) accepts tokens. This supports rapid rotation: rotating A→B→C
+-- within a grace window keeps A's secret validatable as long as
+-- expires_at:A is still future.
+--
+-- HMAC input binds (waitpoint_id | waitpoint_key | created_at_ms) with a
+-- pipe delimiter so field-boundary confusion cannot produce collisions
+-- across waitpoints.
+--
+-- Secret storage: per-partition replicated hash at
+--   ff:sec:{p:N}:waitpoint_hmac
+-- Fields:
+--   current_kid               — the kid minting new tokens (no expiry)
+--   secret:<kid>              — hex-encoded HMAC key for each kid ever installed
+--   expires_at:<kid>          — unix ms; accept tokens under <kid> iff exp > now_ms
+--                               INVARIANT: expires_at:<current_kid> is NEVER written
+--   previous_kid              — observability/audit only: the kid immediately
+--                               preceding current_kid (NOT the only acceptable one)
+--   previous_expires_at       — observability/audit only: matches
+--                               expires_at:<previous_kid>
+--
+-- Replication is required for Valkey cluster mode (all FCALL KEYS must
+-- hash to the same slot); rotation fans out across partitions.
+---------------------------------------------------------------------------
+
+-- Read the hmac_secrets hash. Returns a table with:
+--   current_kid, current_secret — the minting kid (nil if not initialized)
+--   kid_secrets = { [kid] = { secret = <hex>, expires_at = <ms or nil> } }
+--     includes current_kid (expires_at = nil → no expiry)
+--     includes every secret:<kid> present in the hash
+--   previous_kid, previous_secret, previous_expires_at — kept for back-compat
+--     (audit log / observability); validate path does NOT depend on them.
+-- Returns nil if the hash is absent.
+local function load_waitpoint_secrets(secrets_key)
+  local raw = redis.call("HGETALL", secrets_key)
+  if #raw == 0 then
+    return nil
+  end
+  local t = {}
+  for i = 1, #raw, 2 do
+    t[raw[i]] = raw[i + 1]
+  end
+  local out = {
+    current_kid = t.current_kid,
+    previous_kid = t.previous_kid,
+    previous_expires_at = t.previous_expires_at,
+    kid_secrets = {},
+  }
+  if out.current_kid then
+    out.current_secret = t["secret:" .. out.current_kid]
+  end
+  if out.previous_kid then
+    out.previous_secret = t["secret:" .. out.previous_kid]
+  end
+  -- Multi-kid scan: every secret:<kid> becomes a validation candidate.
+  -- current_kid has no expiry entry (intentional — it's always valid).
+  -- Other kids are accepted iff expires_at:<kid> is set AND > now_ms; the
+  -- expiry check runs in validate_waitpoint_token so we simply carry the
+  -- raw expires_at string here.
+  for k, v in pairs(t) do
+    if k:sub(1, 7) == "secret:" then
+      local kid = k:sub(8)
+      if kid ~= "" then
+        out.kid_secrets[kid] = {
+          secret = v,
+          expires_at = t["expires_at:" .. kid],
+        }
+      end
+    end
+  end
+  return out
+end
+
+-- Build the HMAC input string. Pipe delimiter prevents concatenation
+-- collisions across distinct (waitpoint_id, waitpoint_key) pairs.
+local function waitpoint_hmac_input(waitpoint_id, waitpoint_key, created_at_ms)
+  return waitpoint_id .. "|" .. waitpoint_key .. "|" .. tostring(created_at_ms)
+end
+
+-- Mint a waitpoint token using the current kid.
+-- Returns (token, kid) on success or (nil, error_code) on failure.
+-- Defense-in-depth: returns a typed error for missing secrets_key / missing
+-- secrets hash so external callers that construct FCALL KEYS by hand cannot
+-- produce the "arguments must be strings or integers" Lua panic via nil.
+local function mint_waitpoint_token(secrets_key, waitpoint_id, waitpoint_key, created_at_ms)
+  if type(secrets_key) ~= "string" or secrets_key == "" then
+    return nil, "invalid_keys_missing_hmac"
+  end
+  local secrets = load_waitpoint_secrets(secrets_key)
+  if not secrets or not secrets.current_kid or not secrets.current_secret then
+    return nil, "hmac_secret_not_initialized"
+  end
+  local input = waitpoint_hmac_input(waitpoint_id, waitpoint_key, created_at_ms)
+  local digest = hmac_sha1_hex(secrets.current_secret, input)
+  if not digest then
+    return nil, "invalid_secret"
+  end
+  return secrets.current_kid .. ":" .. digest, secrets.current_kid
+end
+
+-- Validate a waitpoint token against the (waitpoint_id, waitpoint_key,
+-- created_at_ms) that were bound at mint time. Accepts tokens signed with
+-- current_kid, or previous_kid if previous_expires_at has not passed.
+-- Returns nil on success or an error code string on failure.
+local function validate_waitpoint_token(
+  secrets_key, token, waitpoint_id, waitpoint_key, created_at_ms, now_ms
+)
+  if type(secrets_key) ~= "string" or secrets_key == "" then
+    return "invalid_keys_missing_hmac"
+  end
+  if type(token) ~= "string" or token == "" then
+    return "missing_token"
+  end
+  local sep = token:find(":", 1, true)
+  if not sep or sep < 2 or sep >= #token then
+    return "invalid_token"
+  end
+  local kid = token:sub(1, sep - 1)
+  local presented = token:sub(sep + 1)
+  if #presented ~= 40 then
+    -- SHA1 hex digest is always 40 chars.
+    return "invalid_token"
+  end
+
+  local secrets = load_waitpoint_secrets(secrets_key)
+  if not secrets or not secrets.current_kid then
+    return "hmac_secret_not_initialized"
+  end
+
+  -- Multi-kid validation. ANY secret:<kid> present in the hash is a
+  -- candidate IF:
+  --   - kid == current_kid (no expiry, always valid), OR
+  --   - expires_at:<kid> is a positive integer AND > now_ms.
+  --
+  -- Rationale: rapid rotation (A→B→C inside a grace window) must keep
+  -- in-flight A-signed tokens valid. The previous 2-slot model
+  -- (current + previous) evicted A as soon as B became previous, even
+  -- though expires_at:A was still future. RFC-004 §Waitpoint Security
+  -- promises grace duration, not "grace until next rotation".
+  --
+  -- Fail-CLOSED on malformed expires_at: a corrupted/non-numeric value
+  -- means "no affirmative unexpired proof" — reject.
+  local secret = nil
+  local expiry_state = nil  -- "known_kid_expired" | "unknown_kid"
+  if kid == secrets.current_kid then
+    secret = secrets.current_secret
+  else
+    local entry = secrets.kid_secrets and secrets.kid_secrets[kid]
+    if entry then
+      local exp = tonumber(entry.expires_at)
+      if not exp or exp <= 0 or exp < now_ms then
+        -- secret:<kid> is present but its grace has elapsed (or was
+        -- never recorded). Distinguishable from unknown_kid so the
+        -- caller can log the more-actionable "token_expired".
+        expiry_state = "known_kid_expired"
+      else
+        secret = entry.secret
+      end
+    else
+      expiry_state = "unknown_kid"
+    end
+  end
+
+  if not secret then
+    if expiry_state == "known_kid_expired" then
+      return "token_expired"
+    end
+    return "invalid_token"
+  end
+
+  local input = waitpoint_hmac_input(waitpoint_id, waitpoint_key, created_at_ms)
+  local expected = hmac_sha1_hex(secret, input)
+  if not expected then
+    return "invalid_secret"
+  end
+  if not constant_time_eq(expected, presented) then
+    return "invalid_token"
+  end
+  return nil
+end
 
 ---------------------------------------------------------------------------
 -- Time
@@ -105,6 +391,26 @@ local function validate_lease(core, argv, now_ms)
 end
 
 -- Sets ownership_state to lease_expired_reclaimable. Idempotent.
+--
+-- Also writes `closed_at`/`closed_reason="lease_expired"` on the attempt's
+-- `stream_meta` hash when that stream exists, so `tail_stream` consumers
+-- observe the terminal signal without having to fall back to polling
+-- `execution_state`. This matters for the permanent-failure case (worker
+-- OOM or node dead, no replacement reclaims): the reclaim path that
+-- normally writes `closed_reason="reclaimed"` may never run, and without
+-- this signal the tail poll loop waits forever.
+--
+-- Write order: we only write stream_meta if its existing `closed_at` is
+-- empty. A later `ff_reclaim_execution` that overwrites `closed_reason`
+-- to "reclaimed" still wins because it unconditionally HSETs the field;
+-- this function intentionally does NOT overwrite a pre-existing close.
+--
+-- Key construction: the stream_meta key is derived from core_key's
+-- `{p:N}` hash tag + current_attempt_index. All three keys share the
+-- same hash tag, so this stays single-slot in cluster mode despite not
+-- being declared in KEYS upfront — mirrors the dynamic attempt/lane key
+-- construction in `ff_create_execution`.
+--
 -- @param keys   table with core_key, lease_history_key
 -- @param core   table from hgetall_to_table
 -- @param now_ms current timestamp in milliseconds
@@ -134,6 +440,36 @@ local function mark_expired(keys, core, now_ms, maxlen)
     "worker_id", core.current_worker_id or "",
     "worker_instance_id", core.current_worker_instance_id or "",
     "ts", now_ms)
+
+  -- Close stream_meta (if the stream was lazily created) so tail_stream
+  -- consumers receive the terminal signal. Core key format:
+  --   ff:exec:{p:N}:<eid>:core
+  -- Stream meta key format:
+  --   ff:stream:{p:N}:<eid>:<attempt_index>:meta
+  local att_idx = core.current_attempt_index
+  if att_idx ~= nil and att_idx ~= "" then
+    local tag_open  = string.find(keys.core_key, "{", 1, true)
+    local tag_close = tag_open and string.find(keys.core_key, "}", tag_open, true)
+    if tag_open and tag_close then
+      local tag = string.sub(keys.core_key, tag_open, tag_close)
+      -- After `}:` comes `<eid>:core`. Walk past the `}:` delimiter.
+      local after_tag = string.sub(keys.core_key, tag_close + 2)
+      local eid_end = string.find(after_tag, ":core", 1, true)
+      if eid_end then
+        local eid = string.sub(after_tag, 1, eid_end - 1)
+        local stream_meta_key = "ff:stream:" .. tag .. ":" .. eid
+                                .. ":" .. tostring(att_idx) .. ":meta"
+        if redis.call("EXISTS", stream_meta_key) == 1 then
+          local existing_closed_at = redis.call("HGET", stream_meta_key, "closed_at")
+          if not is_set(existing_closed_at) then
+            redis.call("HSET", stream_meta_key,
+              "closed_at", tostring(now_ms),
+              "closed_reason", "lease_expired")
+          end
+        end
+      end
+    end
+  end
 end
 
 -- Validates lease AND atomically marks expired if lease has lapsed.

--- a/lua/scheduling.lua
+++ b/lua/scheduling.lua
@@ -4,6 +4,54 @@
 -- Depends on helpers: ok, err, hgetall_to_table, is_set, validate_lease
 
 ---------------------------------------------------------------------------
+-- Capability matching helpers (local to scheduling.lua)
+-- Bounds CAPS_MAX_BYTES / CAPS_MAX_TOKENS live in helpers.lua and are
+-- enforced symmetrically on worker caps here and on required caps in
+-- ff_create_execution so neither side can smuggle in an oversized list.
+---------------------------------------------------------------------------
+
+-- Parse a capability CSV into a {token=true} set. Empty/nil → empty set.
+-- Returns (set, nil) on success or (nil, err_tuple) on bound violation.
+--
+-- Empty tokens (from stray separators like "a,,b") are skipped BEFORE the
+-- count check so a legitimate list punctuated by noise isn't rejected.
+-- Real oversize input still fails because #csv > CAPS_MAX_BYTES catches it
+-- before this loop runs.
+local function parse_capability_csv(csv, kind)
+  if csv == nil or csv == "" then
+    return {}, nil
+  end
+  if #csv > CAPS_MAX_BYTES then
+    return nil, err("invalid_capabilities", kind .. ":too_many_bytes")
+  end
+  local set = {}
+  local n = 0
+  for token in string.gmatch(csv, "([^,]+)") do
+    if #token > 0 then
+      n = n + 1
+      if n > CAPS_MAX_TOKENS then
+        return nil, err("invalid_capabilities", kind .. ":too_many_tokens")
+      end
+      set[token] = true
+    end
+  end
+  return set, nil
+end
+
+-- Return sorted CSV of tokens present in `required` but missing from
+-- `worker_caps`. Empty result means worker satisfies all requirements.
+local function missing_capabilities(required, worker_caps)
+  local missing = {}
+  for cap, _ in pairs(required) do
+    if not worker_caps[cap] then
+      missing[#missing + 1] = cap
+    end
+  end
+  table.sort(missing)
+  return table.concat(missing, ",")
+end
+
+---------------------------------------------------------------------------
 -- #25  ff_issue_claim_grant
 --
 -- Scheduler issues a claim grant for an eligible execution.
@@ -11,9 +59,22 @@
 -- removes from eligible set.
 --
 -- KEYS (3): exec_core, claim_grant_key, eligible_zset
--- ARGV (8): execution_id, worker_id, worker_instance_id,
+-- ARGV (9): execution_id, worker_id, worker_instance_id,
 --           lane_id, capability_hash, grant_ttl_ms,
---           route_snapshot_json, admission_summary
+--           route_snapshot_json, admission_summary,
+--           worker_capabilities_csv  -- sorted CSV of worker caps (option a)
+--
+-- Capability matching (RFC-009):
+--   If exec_core.required_capabilities (sorted CSV on exec_core) is empty,
+--   any worker matches (backwards compat). Otherwise the worker's sorted
+--   CSV must be a superset.
+--   On mismatch: Lua stamps `last_capability_mismatch_at` (single scalar
+--   field, idempotent write — no unbounded counter) and returns
+--   err("capability_mismatch", missing_csv). The scheduler side MUST
+--   then block the execution off the eligible ZSET (see
+--   ff_block_execution_for_admission with reason `waiting_for_capability`),
+--   otherwise ZRANGEBYSCORE keeps returning the same top-of-zset every
+--   tick and 100 workers × 1 tick/s = hot-loop starvation. RFC-009 §564.
 ---------------------------------------------------------------------------
 redis.register_function('ff_issue_claim_grant', function(keys, args)
   local K = {
@@ -23,13 +84,14 @@ redis.register_function('ff_issue_claim_grant', function(keys, args)
   }
 
   local A = {
-    execution_id        = args[1],
-    worker_id           = args[2],
-    worker_instance_id  = args[3],
-    lane_id             = args[4],
-    capability_hash     = args[5] or "",
-    route_snapshot_json = args[7] or "",
-    admission_summary   = args[8] or "",
+    execution_id            = args[1],
+    worker_id               = args[2],
+    worker_instance_id      = args[3],
+    lane_id                 = args[4],
+    capability_hash         = args[5] or "",
+    route_snapshot_json     = args[7] or "",
+    admission_summary       = args[8] or "",
+    worker_capabilities_csv = args[9] or "",
   }
 
   local grant_ttl_n = require_number(args[6], "grant_ttl_ms")
@@ -62,7 +124,34 @@ redis.register_function('ff_issue_claim_grant', function(keys, args)
     return err("execution_not_in_eligible_set")
   end
 
-  -- 4. Write grant hash with TTL
+  -- 4. Capability matching. On miss we stamp a SINGLE bounded field —
+  -- `last_capability_mismatch_at` — so operators can SCAN for stuck
+  -- executions via `HGET last_capability_mismatch_at < now - 1h` without
+  -- needing a counter. An earlier version HINCRBY'd a counter; that was
+  -- dropped because combined with the hot-loop bug (executions staying in
+  -- the eligible ZSET after mismatch) the counter grew unboundedly (2.4M
+  -- increments/day on one stuck exec_core under 100 workers). An HSET of
+  -- a fixed field is idempotent w.r.t. size.
+  --
+  -- The scheduler MUST block the execution off the eligible ZSET after
+  -- this err returns; otherwise the next tick picks the same top-of-zset
+  -- and we wasted this validation. See Scheduler::claim_for_worker.
+  local required_set, req_err = parse_capability_csv(
+    core.required_capabilities or "", "required")
+  if req_err then return req_err end
+  local worker_set, wrk_err = parse_capability_csv(
+    A.worker_capabilities_csv, "worker")
+  if wrk_err then return wrk_err end
+  if next(required_set) ~= nil then
+    local missing = missing_capabilities(required_set, worker_set)
+    if missing ~= "" then
+      redis.call("HSET", K.core_key,
+        "last_capability_mismatch_at", tostring(now_ms))
+      return err("capability_mismatch", missing)
+    end
+  end
+
+  -- 5. Write grant hash with TTL
   local grant_expires_at = now_ms + A.grant_ttl_ms
   redis.call("HSET", K.claim_grant,
     "worker_id", A.worker_id,
@@ -75,7 +164,7 @@ redis.register_function('ff_issue_claim_grant', function(keys, args)
     "grant_expires_at", tostring(grant_expires_at))
   redis.call("PEXPIREAT", K.claim_grant, grant_expires_at)
 
-  -- 5. Do NOT ZREM from eligible here. ff_claim_execution does the ZREM
+  -- 6. Do NOT ZREM from eligible here. ff_claim_execution does the ZREM
   -- when consuming the grant. If the grant expires unconsumed, the execution
   -- remains in the eligible set and is re-discovered by the next scheduler
   -- cycle. This prevents the "orphaned grant" stuck state where an execution
@@ -294,13 +383,38 @@ end)
 ---------------------------------------------------------------------------
 -- #26  ff_issue_reclaim_grant
 --
+-- TODO(batch-c): This function has NO production Rust caller as of Batch B.
+-- The reclaim scanner that would invoke it (to recover leases from crashed
+-- workers) is scheduled for cairn Batch C. A worker dying mid-execution today
+-- leaves its execution stuck in `lease_expired_reclaimable` until operator
+-- intervention. Test-only callers exist in crates/ff-test/tests to exercise
+-- the Lua side. When the scheduler reclaim integration lands, the caller
+-- must apply the same block-on-capability-mismatch pattern used by
+-- `ff-scheduler::Scheduler::claim_for_worker` (see the IMPORTANT note
+-- below) — otherwise an unmatchable reclaim recycles every scanner tick.
+--
 -- Scheduler issues a reclaim grant for an expired/revoked execution.
 -- Similar to ff_issue_claim_grant but validates reclaimable state.
 --
 -- KEYS (3): exec_core, claim_grant_key, lease_expiry_zset
--- ARGV (8): execution_id, worker_id, worker_instance_id,
+-- ARGV (9): execution_id, worker_id, worker_instance_id,
 --           lane_id, capability_hash, grant_ttl_ms,
---           route_snapshot_json, admission_summary
+--           route_snapshot_json, admission_summary,
+--           worker_capabilities_csv
+--
+-- Capability matching identical to ff_issue_claim_grant: reclaiming a lease
+-- must respect the execution's required_capabilities just like an initial
+-- claim, so a re-issuance to a non-matching worker is blocked here too.
+--
+-- IMPORTANT: on capability_mismatch this function does NOT remove the exec
+-- from the lease_expiry pool. The reclaim SCANNER (to be added in Rust) MUST
+-- detect capability_mismatch and move the execution into blocked_route with
+-- reason `waiting_for_capable_worker` (mirroring the claim-grant path). If
+-- the scanner instead re-attempts the same execution every tick, a reclaim
+-- hot-loop develops that is analogous to the claim-path hot-loop and
+-- identical in cost (wasted FCALLs + log volume). Lease_expiry as an index
+-- has no natural sweeping mechanism for post-mismatch promotion — the
+-- scheduler-side block + periodic sweep owns the lifecycle.
 ---------------------------------------------------------------------------
 redis.register_function('ff_issue_reclaim_grant', function(keys, args)
   local K = {
@@ -310,13 +424,14 @@ redis.register_function('ff_issue_reclaim_grant', function(keys, args)
   }
 
   local A = {
-    execution_id        = args[1],
-    worker_id           = args[2],
-    worker_instance_id  = args[3],
-    lane_id             = args[4],
-    capability_hash     = args[5] or "",
-    route_snapshot_json = args[7] or "",
-    admission_summary   = args[8] or "",
+    execution_id            = args[1],
+    worker_id               = args[2],
+    worker_instance_id      = args[3],
+    lane_id                 = args[4],
+    capability_hash         = args[5] or "",
+    route_snapshot_json     = args[7] or "",
+    admission_summary       = args[8] or "",
+    worker_capabilities_csv = args[9] or "",
   }
 
   local grant_ttl_n = require_number(args[6], "grant_ttl_ms")
@@ -342,6 +457,26 @@ redis.register_function('ff_issue_reclaim_grant', function(keys, args)
   -- Check no existing grant
   if redis.call("EXISTS", K.claim_grant) == 1 then
     return err("grant_already_exists")
+  end
+
+  -- Capability matching — same policy as issue_claim_grant: stamp
+  -- last_capability_mismatch_at (single scalar) on miss so ops can surface
+  -- stuck reclaims via SCAN. Scheduler MUST also block-out the exec from
+  -- the lease_expiry reclaim pool; otherwise the reclaim scanner hits the
+  -- same mismatch every cycle. See Scheduler::reclaim_for_worker.
+  local required_set, req_err = parse_capability_csv(
+    core.required_capabilities or "", "required")
+  if req_err then return req_err end
+  local worker_set, wrk_err = parse_capability_csv(
+    A.worker_capabilities_csv, "worker")
+  if wrk_err then return wrk_err end
+  if next(required_set) ~= nil then
+    local missing = missing_capabilities(required_set, worker_set)
+    if missing ~= "" then
+      redis.call("HSET", K.core_key,
+        "last_capability_mismatch_at", tostring(now_ms))
+      return err("capability_mismatch", missing)
+    end
   end
 
   -- Write grant hash with TTL

--- a/lua/signal.lua
+++ b/lua/signal.lua
@@ -12,17 +12,17 @@
 -- signal, evaluate resume condition, optionally close waitpoint +
 -- suspension + transition suspended -> runnable.
 --
--- KEYS (13): exec_core, wp_condition, wp_signals_stream,
+-- KEYS (14): exec_core, wp_condition, wp_signals_stream,
 --            exec_signals_zset, signal_hash, signal_payload,
 --            idem_key, waitpoint_hash, suspension_current,
 --            eligible_zset, suspended_zset, delayed_zset,
---            suspension_timeout_zset
--- ARGV (17): signal_id, execution_id, waitpoint_id, signal_name,
+--            suspension_timeout_zset, hmac_secrets
+-- ARGV (18): signal_id, execution_id, waitpoint_id, signal_name,
 --            signal_category, source_type, source_identity,
 --            payload, payload_encoding, idempotency_key,
 --            correlation_id, target_scope, created_at,
 --            dedup_ttl_ms, resume_delay_ms, signal_maxlen,
---            max_signals_per_execution
+--            max_signals_per_execution, waitpoint_token
 ---------------------------------------------------------------------------
 redis.register_function('ff_deliver_signal', function(keys, args)
   local K = {
@@ -39,6 +39,7 @@ redis.register_function('ff_deliver_signal', function(keys, args)
     suspended_zset        = keys[11],
     delayed_zset          = keys[12],
     suspension_timeout_zset = keys[13],
+    hmac_secrets          = keys[14],
   }
 
   local A = {
@@ -59,6 +60,7 @@ redis.register_function('ff_deliver_signal', function(keys, args)
     resume_delay_ms  = tonumber(args[15] or "0"),
     signal_maxlen    = tonumber(args[16] or "1000"),
     max_signals      = tonumber(args[17] or "10000"),
+    waitpoint_token  = args[18] or "",
   }
 
   local t = redis.call("TIME")
@@ -71,29 +73,58 @@ redis.register_function('ff_deliver_signal', function(keys, args)
   end
   local core = hgetall_to_table(raw)
 
-  -- 2. Validate execution is in a signalable state
+  -- 2. Validate HMAC token FIRST (RFC-004 §Waitpoint Security).
+  --
+  -- Order matters: lifecycle / waitpoint-state checks below would otherwise
+  -- form a state oracle — an attacker presenting ANY token (including an
+  -- invalid one) for an arbitrary (execution_id, waitpoint_id) pair could
+  -- distinguish "execution is terminal" vs "waitpoint is pending" vs
+  -- "waitpoint is closed" by the specific error code returned, without
+  -- having to produce a valid HMAC. Auth-first closes that oracle.
+  --
+  -- Missing-waitpoint is collapsed into `invalid_token` for the same
+  -- reason: an unauthenticated caller must not be able to probe which
+  -- (execution, waitpoint) tuples exist.
+  local wp_for_auth_raw = redis.call("HGETALL", K.waitpoint_hash)
+  if #wp_for_auth_raw == 0 then
+    return err("invalid_token")
+  end
+  local wp_for_auth = hgetall_to_table(wp_for_auth_raw)
+  if not wp_for_auth.created_at then
+    return err("invalid_token")
+  end
+  local token_err = validate_waitpoint_token(
+    K.hmac_secrets, A.waitpoint_token,
+    A.waitpoint_id, wp_for_auth.waitpoint_key or "",
+    tonumber(wp_for_auth.created_at) or 0, now_ms)
+  if token_err then
+    -- Operator-visible counter (RFC-004 §Waitpoint Security observability).
+    -- Single scalar HSET on exec_core — bounded, amortized-free. Gives
+    -- operators a "last time this execution saw an auth failure" field to
+    -- correlate with key-rotation drift, client bugs, or attack traffic
+    -- without needing to tail Lua slowlog or FCALL error logs.
+    redis.call("HSET", K.core_key, "last_hmac_validation_failed_at", tostring(now_ms))
+    return err(token_err)
+  end
+
+  -- 3. Validate execution is in a signalable state (post-auth).
   local lp = core.lifecycle_phase
   if lp == "terminal" then
     return err("target_not_signalable")
   end
 
   if lp == "active" or lp == "runnable" or lp == "submitted" then
-    -- Not suspended. Check for pending waitpoint.
-    local wp_raw = redis.call("HGETALL", K.waitpoint_hash)
-    if #wp_raw == 0 then
-      return err("target_not_signalable")
-    end
-    local wp = hgetall_to_table(wp_raw)
-    if wp.state == "pending" then
+    -- Not suspended. wp_for_auth was just loaded above; reuse it.
+    if wp_for_auth.state == "pending" then
       return err("waitpoint_pending_use_buffer_script")
     end
-    if wp.state ~= "active" then
+    if wp_for_auth.state ~= "active" then
       return err("target_not_signalable")
     end
     -- Active waitpoint on non-suspended execution — unusual but valid (race window)
   end
 
-  -- 3. Validate waitpoint condition is open
+  -- 4. Validate waitpoint condition is open (post-auth).
   local cond_raw = redis.call("HGETALL", K.wp_condition)
   if #cond_raw == 0 then
     return err("waitpoint_not_found")
@@ -303,10 +334,10 @@ end)
 -- When suspend_execution activates the waitpoint, buffered signals
 -- are replayed through the full evaluation path.
 --
--- KEYS (7): exec_core, wp_condition, wp_signals_stream,
+-- KEYS (9): exec_core, wp_condition, wp_signals_stream,
 --           exec_signals_zset, signal_hash, signal_payload,
---           idem_key
--- ARGV (17): same as ff_deliver_signal (unused fields ignored)
+--           idem_key, waitpoint_hash, hmac_secrets
+-- ARGV (18): same as ff_deliver_signal (17 + waitpoint_token)
 ---------------------------------------------------------------------------
 redis.register_function('ff_buffer_signal_for_pending_waitpoint', function(keys, args)
   local K = {
@@ -317,6 +348,8 @@ redis.register_function('ff_buffer_signal_for_pending_waitpoint', function(keys,
     signal_hash       = keys[5],
     signal_payload    = keys[6],
     idem_key          = keys[7],
+    waitpoint_hash    = keys[8],
+    hmac_secrets      = keys[9],
   }
 
   local A = {
@@ -336,6 +369,7 @@ redis.register_function('ff_buffer_signal_for_pending_waitpoint', function(keys,
     dedup_ttl_ms     = tonumber(args[14] or "86400000"),
     signal_maxlen    = tonumber(args[16] or "1000"),
     max_signals      = tonumber(args[17] or "10000"),
+    waitpoint_token  = args[18] or "",
   }
 
   local t = redis.call("TIME")
@@ -345,6 +379,32 @@ redis.register_function('ff_buffer_signal_for_pending_waitpoint', function(keys,
   local raw = redis.call("HGETALL", K.core_key)
   if #raw == 0 then
     return err("execution_not_found")
+  end
+
+  -- 1a. Validate HMAC token against the pending waitpoint's mint-time binding.
+  local wp_for_auth = hgetall_to_table(redis.call("HGETALL", K.waitpoint_hash))
+  if not wp_for_auth.created_at then
+    return err("waitpoint_not_found")
+  end
+  local token_err = validate_waitpoint_token(
+    K.hmac_secrets, A.waitpoint_token,
+    A.waitpoint_id, wp_for_auth.waitpoint_key or "",
+    tonumber(wp_for_auth.created_at) or 0, now_ms)
+  if token_err then
+    -- Operator-visible counter mirroring ff_deliver_signal. See comment
+    -- there for rationale.
+    redis.call("HSET", K.core_key, "last_hmac_validation_failed_at", tostring(now_ms))
+    return err(token_err)
+  end
+
+  -- 1b. Gate on waitpoint state. ff_deliver_signal blocks replay-after-close
+  -- via wp_condition.closed, but wp_condition is not initialized for pending
+  -- waitpoints — we must check wp.state directly. Without this, a caller
+  -- holding a valid token for a pending waitpoint that has since been
+  -- closed/expired can keep appending buffered signals that will replay
+  -- when suspend_execution(use_pending=1) later activates the waitpoint.
+  if wp_for_auth.state == "closed" or wp_for_auth.state == "expired" then
+    return err("waitpoint_closed")
   end
 
   -- 2. Signal count limit

--- a/lua/stream.lua
+++ b/lua/stream.lua
@@ -185,10 +185,16 @@ redis.register_function('ff_read_attempt_stream', function(keys, args)
   local to_id   = args[2] or "+"
   local count_limit = tonumber(args[3] or "0")
 
-  -- Explicit reject on zero/negative — the REST and SDK layers also reject
-  -- at their boundary but we keep this as belt-and-suspenders so direct
-  -- FCALL callers (tests, future consumers) get a clear error instead of
-  -- a silently-clamped whole-stream read.
+  -- Explicit reject on zero/negative AND on over-cap. The REST and SDK
+  -- layers reject both at their boundary (R2/R3); the Lua check is the
+  -- last line of defense for direct FCALL callers (tests, future
+  -- consumers) so they get a clear error instead of a silently-clamped
+  -- whole-stream read or reply-size blowup.
+  --
+  -- Before PR#7 this was asymmetric: < 1 rejected with invalid_input,
+  -- but > HARD_CAP was silently clamped. That contradicted RFC-006
+  -- §Input validation ("both bounds reject, neither silently clamps").
+  -- Now both edges reject symmetrically.
   --
   -- HARD_CAP mirrors ff_core::contracts::STREAM_READ_HARD_CAP — keep in sync.
   local HARD_CAP = 10000
@@ -196,7 +202,7 @@ redis.register_function('ff_read_attempt_stream', function(keys, args)
     return err("invalid_input", "count_limit must be >= 1")
   end
   if count_limit > HARD_CAP then
-    count_limit = HARD_CAP
+    return err("invalid_input", "count_limit_exceeds_hard_cap")
   end
 
   -- Stream may legitimately not exist (never-written attempt). XRANGE on a

--- a/lua/stream.lua
+++ b/lua/stream.lua
@@ -121,17 +121,99 @@ redis.register_function('ff_append_frame', function(keys, args)
 
   local entry_id = redis.call("XADD", unpack(xadd_args))
 
-  -- 6. Update stream metadata
+  -- 6. Update stream metadata.
+  --
+  -- `frame_count` is the LIFETIME append counter — it is NOT the number
+  -- of frames currently retained in the stream. XTRIM below prunes old
+  -- entries without decrementing this counter, so on a 10k-cap stream
+  -- that has seen 1M appends `frame_count==1_000_000` while `XLEN==10_000`.
+  -- Consumers that want the retained count must `XLEN` the stream
+  -- directly; `frame_count` is the right number for metering, billing,
+  -- per-attempt usage attribution — anything that needs "how much was
+  -- produced", not "how much is still here".
   local frame_count = redis.call("HINCRBY", K.stream_meta, "frame_count", 1)
   redis.call("HINCRBY", K.stream_meta, "total_bytes", #A.payload)
   redis.call("HSET", K.stream_meta,
     "last_sequence", entry_id,
     "last_frame_at", tostring(now_ms))
 
-  -- 7. Apply retention trim (approximate for performance)
+  -- 7. Apply retention trim.
+  --
+  -- XTRIM MAXLEN `~` (approximate) is the default: it trims at macro-node
+  -- boundaries for throughput, so actual retained length floats slightly
+  -- above the target. Under a token-per-frame burst this can briefly
+  -- hold up to 2x the requested retention.
+  --
+  -- When the caller explicitly passes `retention_maxlen > 0` they've
+  -- opted into a specific bound; honor it EXACTLY with `=`. Bursty LLM
+  -- workloads that care about predictable memory pay a small XTRIM-rate
+  -- cost for the tighter bound. Default (A.retention_maxlen == 0) still
+  -- uses `~` for the lane-level unbounded-growth guard, where throughput
+  -- matters more than exact retention.
   local maxlen = A.retention_maxlen
-  if maxlen == 0 then maxlen = 10000 end  -- default cap prevents unbounded growth
-  redis.call("XTRIM", K.stream_key, "MAXLEN", "~", maxlen)
+  local trim_op
+  if maxlen == 0 then
+    maxlen = 10000       -- default cap prevents unbounded growth
+    trim_op = "~"
+  else
+    trim_op = "="        -- caller-supplied bound is honored exactly
+  end
+  redis.call("XTRIM", K.stream_key, "MAXLEN", trim_op, maxlen)
 
   return ok(entry_id, tostring(frame_count))
+end)
+
+---------------------------------------------------------------------------
+-- ff_read_attempt_stream
+--
+-- Read frames from an attempt-scoped output stream via XRANGE. Non-blocking
+-- (safe in Lua Functions). Cluster-safe: stream_key and stream_meta share
+-- the {p:N} hash tag.
+--
+-- Returns an empty array when the stream key does not exist (not an error —
+-- the attempt may not have produced frames yet). Also reports
+-- (closed_at, closed_reason) from stream_meta so callers can stop polling.
+--
+-- KEYS (2): stream_data, stream_meta
+-- ARGV (3): from_id, to_id, count_limit (must be 1..=HARD_CAP; 0 rejected)
+---------------------------------------------------------------------------
+redis.register_function('ff_read_attempt_stream', function(keys, args)
+  local stream_key  = keys[1]
+  local stream_meta = keys[2]
+
+  local from_id = args[1] or "-"
+  local to_id   = args[2] or "+"
+  local count_limit = tonumber(args[3] or "0")
+
+  -- Explicit reject on zero/negative — the REST and SDK layers also reject
+  -- at their boundary but we keep this as belt-and-suspenders so direct
+  -- FCALL callers (tests, future consumers) get a clear error instead of
+  -- a silently-clamped whole-stream read.
+  --
+  -- HARD_CAP mirrors ff_core::contracts::STREAM_READ_HARD_CAP — keep in sync.
+  local HARD_CAP = 10000
+  if count_limit == nil or count_limit < 1 then
+    return err("invalid_input", "count_limit must be >= 1")
+  end
+  if count_limit > HARD_CAP then
+    count_limit = HARD_CAP
+  end
+
+  -- Stream may legitimately not exist (never-written attempt). XRANGE on a
+  -- missing key returns empty, so no pre-check is needed.
+  local entries = redis.call("XRANGE", stream_key, from_id, to_id,
+                             "COUNT", count_limit)
+
+  -- Fetch terminal markers from stream_meta. A never-written attempt has
+  -- no stream_meta hash; HMGET returns nils for both fields which we
+  -- normalize to empty strings on the return path so Rust can decode a
+  -- consistent shape.
+  local meta = redis.call("HMGET", stream_meta, "closed_at", "closed_reason")
+  local closed_at     = meta[1] or ""
+  local closed_reason = meta[2] or ""
+
+  -- entries is an array of [entry_id, [f1, v1, f2, v2, ...]].
+  -- Return shape: ok(entries, closed_at, closed_reason). Rust parses the
+  -- three fields positionally.
+  return ok(entries, closed_at, closed_reason)
 end)

--- a/lua/suspension.lua
+++ b/lua/suspension.lua
@@ -13,20 +13,20 @@
 --
 -- Validate lease, release ownership, create suspension + waitpoint
 -- (or activate pending), init condition, transition active → suspended.
+-- Mints the waitpoint HMAC token (RFC-004 §Waitpoint Security) returned
+-- alongside the waitpoint_id for external signal delivery.
 --
--- KEYS (16): exec_core, attempt_record, lease_current, lease_history,
+-- KEYS (17): exec_core, attempt_record, lease_current, lease_history,
 --            lease_expiry_zset, worker_leases, suspension_current,
 --            waitpoint_hash, waitpoint_signals, suspension_timeout_zset,
 --            pending_wp_expiry_zset, active_index, suspended_zset,
---            waitpoint_history, wp_condition, attempt_timeout_zset
--- ARGV (13): execution_id, attempt_index, attempt_id, lease_id,
+--            waitpoint_history, wp_condition, attempt_timeout_zset,
+--            hmac_secrets
+-- ARGV (17): execution_id, attempt_index, attempt_id, lease_id,
 --            lease_epoch, suspension_id, waitpoint_id, waitpoint_key,
 --            reason_code, requested_by, timeout_at, resume_condition_json,
---            resume_policy_json
--- ARGV (14): continuation_metadata_pointer (optional)
--- ARGV (15): use_pending_waitpoint ("1" or "")
--- ARGV (16): timeout_behavior
--- ARGV (17): lease_history_maxlen
+--            resume_policy_json, continuation_metadata_pointer,
+--            use_pending_waitpoint, timeout_behavior, lease_history_maxlen
 ---------------------------------------------------------------------------
 redis.register_function('ff_suspend_execution', function(keys, args)
   local K = {
@@ -46,6 +46,7 @@ redis.register_function('ff_suspend_execution', function(keys, args)
     waitpoint_history     = keys[14],
     wp_condition          = keys[15],
     attempt_timeout_key   = keys[16],
+    hmac_secrets          = keys[17],
   }
 
   local A = {
@@ -104,6 +105,7 @@ redis.register_function('ff_suspend_execution', function(keys, args)
   -- 5. Create or activate waitpoint
   local waitpoint_id = A.waitpoint_id
   local waitpoint_key = A.waitpoint_key
+  local waitpoint_token = ""
 
   if A.use_pending_waitpoint == "1" then
     -- Activate existing pending waitpoint
@@ -111,10 +113,23 @@ redis.register_function('ff_suspend_execution', function(keys, args)
     local wp_err = validate_pending_waitpoint(wp_raw, A.execution_id, A.attempt_index, now_ms)
     if wp_err then return wp_err end
 
-    -- Read waitpoint_id and waitpoint_key from existing record
+    -- Read waitpoint_id, waitpoint_key, and existing token from pending record.
+    -- Token was minted at ff_create_pending_waitpoint time with that record's
+    -- created_at; we MUST keep using it so signals buffered before activation
+    -- validate against the same binding.
     local wp = hgetall_to_table(wp_raw)
     waitpoint_id = wp.waitpoint_id
     waitpoint_key = wp.waitpoint_key
+    -- A pending waitpoint without a minted token is either a pre-HMAC-upgrade
+    -- record or a corrupted write. Activating with an empty token would return
+    -- "" to the SDK, and every subsequent signal delivery would reject with
+    -- missing_token — fail-closed at the security boundary but silent about
+    -- the real degraded state. Surface the degradation AT the activation
+    -- point so operators see it immediately.
+    if not is_set(wp.waitpoint_token) then
+      return err("waitpoint_not_token_bound")
+    end
+    waitpoint_token = wp.waitpoint_token
 
     -- Activate the pending waitpoint
     redis.call("HSET", K.waitpoint_hash,
@@ -142,7 +157,7 @@ redis.register_function('ff_suspend_execution', function(keys, args)
           "closed_at", tostring(now_ms), "close_reason", "resumed")
         write_condition_hash(K.wp_condition, wp_cond, now_ms)
         -- Do NOT release lease, do NOT change execution state.
-        return ok_already_satisfied(A.suspension_id, waitpoint_id, waitpoint_key)
+        return ok_already_satisfied(A.suspension_id, waitpoint_id, waitpoint_key, waitpoint_token)
       end
       -- Condition not yet satisfied — proceed with suspension.
       -- Write partial condition state (some matchers may be satisfied).
@@ -153,13 +168,21 @@ redis.register_function('ff_suspend_execution', function(keys, args)
       write_condition_hash(K.wp_condition, wp_cond, now_ms)
     end
   else
-    -- Create new waitpoint
+    -- Create new waitpoint — mint HMAC token bound to (waitpoint_id,
+    -- waitpoint_key, created_at). The created_at written here is what the
+    -- signal-delivery path reads back for HMAC validation.
+    local token, token_err = mint_waitpoint_token(
+      K.hmac_secrets, waitpoint_id, waitpoint_key, now_ms)
+    if not token then return err(token_err) end
+    waitpoint_token = token
+
     redis.call("HSET", K.waitpoint_hash,
       "waitpoint_id", waitpoint_id,
       "execution_id", A.execution_id,
       "attempt_index", A.attempt_index,
       "suspension_id", A.suspension_id,
       "waitpoint_key", waitpoint_key,
+      "waitpoint_token", waitpoint_token,
       "state", "active",
       "created_at", tostring(now_ms),
       "activated_at", tostring(now_ms),
@@ -252,7 +275,7 @@ redis.register_function('ff_suspend_execution', function(keys, args)
     redis.call("ZADD", K.suspension_timeout_key, tonumber(A.timeout_at), A.execution_id)
   end
 
-  return ok(A.suspension_id, waitpoint_id, waitpoint_key)
+  return ok(A.suspension_id, waitpoint_id, waitpoint_key, waitpoint_token)
 end)
 
 ---------------------------------------------------------------------------
@@ -370,8 +393,10 @@ end)
 -- Pre-create a waitpoint before suspension commits. The waitpoint is
 -- externally addressable by waitpoint_key so early signals can be buffered.
 -- Requires the caller to still hold the active lease.
+-- Mints the waitpoint HMAC token up front so early signals targeting the
+-- pending waitpoint can be authenticated via ff_buffer_signal_for_pending_waitpoint.
 --
--- KEYS (3): exec_core, waitpoint_hash, pending_wp_expiry_zset
+-- KEYS (4): exec_core, waitpoint_hash, pending_wp_expiry_zset, hmac_secrets
 -- ARGV (5): execution_id, attempt_index, waitpoint_id, waitpoint_key,
 --           expires_at
 ---------------------------------------------------------------------------
@@ -380,6 +405,7 @@ redis.register_function('ff_create_pending_waitpoint', function(keys, args)
     core_key              = keys[1],
     waitpoint_hash        = keys[2],
     pending_wp_expiry_key = keys[3],
+    hmac_secrets          = keys[4],
   }
 
   local A = {
@@ -419,13 +445,20 @@ redis.register_function('ff_create_pending_waitpoint', function(keys, args)
     -- Old closed/expired waitpoint — safe to overwrite
   end
 
-  -- 3. Create pending waitpoint
+  -- 3. Mint HMAC token bound to (waitpoint_id, waitpoint_key, now_ms).
+  -- The suspension activation path will reuse this token unchanged.
+  local waitpoint_token, token_err = mint_waitpoint_token(
+    K.hmac_secrets, A.waitpoint_id, A.waitpoint_key, now_ms)
+  if not waitpoint_token then return err(token_err) end
+
+  -- 4. Create pending waitpoint
   redis.call("HSET", K.waitpoint_hash,
     "waitpoint_id", A.waitpoint_id,
     "execution_id", A.execution_id,
     "attempt_index", A.attempt_index,
     "suspension_id", "",
     "waitpoint_key", A.waitpoint_key,
+    "waitpoint_token", waitpoint_token,
     "state", "pending",
     "created_at", tostring(now_ms),
     "activated_at", "",
@@ -437,11 +470,11 @@ redis.register_function('ff_create_pending_waitpoint', function(keys, args)
     "matched_signal_count", "0",
     "last_signal_at", "")
 
-  -- 4. Add to pending waitpoint expiry index
+  -- 5. Add to pending waitpoint expiry index
   redis.call("ZADD", K.pending_wp_expiry_key,
     tonumber(A.expires_at), A.waitpoint_id)
 
-  return ok(A.waitpoint_id, A.waitpoint_key)
+  return ok(A.waitpoint_id, A.waitpoint_key, waitpoint_token)
 end)
 
 ---------------------------------------------------------------------------

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -2,12 +2,19 @@
 -- Returns the library version string. Used by the loader to detect
 -- whether the library is loaded and at the expected version.
 --
--- Bump this string (and `LIBRARY_VERSION` in crates/ff-script/src/lib.rs)
--- whenever any registered function's KEYS or ARGV arity changes, or a new
--- function is added. Mismatched versions force `FUNCTION LOAD REPLACE` so
--- old binaries cannot FCALL a library whose key signatures they expect a
--- different shape for.
+-- Bump this string whenever any registered function's KEYS or ARGV arity
+-- changes, or a new function is added. Mismatched versions force
+-- `FUNCTION LOAD REPLACE` so old binaries cannot FCALL a library whose key
+-- signatures they expect a different shape for.
+--
+-- SINGLE SOURCE OF TRUTH: Rust's `LIBRARY_VERSION` is extracted from the
+-- `return 'X'` literal below at compile time (see crates/ff-script/build.rs).
+-- Do NOT maintain a separate copy in crates/ff-script/src/lib.rs — there
+-- is no Rust copy; `env!("FLOWFABRIC_LUA_VERSION")` reads this file.
+-- Extract contract: the body MUST contain exactly one `return 'X'` literal
+-- with single quotes (not double). Breaking the contract fails build.rs
+-- with a pointer to this file.
 
 redis.register_function('ff_version', function(keys, args)
-  return '2'
+  return '4'
 end)

--- a/rfcs/RFC-004-suspension.md
+++ b/rfcs/RFC-004-suspension.md
@@ -83,43 +83,11 @@ One active suspension owns one active waitpoint. A pending waitpoint may exist b
 
 #### Waitpoint key routing
 
-`waitpoint_key` must be externally opaque but internally routable to the correct partition in Valkey Cluster.
+`waitpoint_key` is an externally opaque, internally routable string. The V1 implementation uses the simple `wpk:<uuid>` format and is **NOT** a crypto token. Multi-tenant signal authentication is enforced separately by the HMAC waitpoint token — see §Waitpoint Security below, which is the authoritative specification for the token mechanism in this RFC.
 
-**Token format:** base64url-encoded binary blob. No padding.
+Routing to `{p:N}` is done by storing the partition number on the waitpoint hash at creation time, keyed by the waitpoint_id embedded in the `wpk:<uuid>` handle. No signature check on the handle itself; integrity is provided by the HMAC token the signal deliverer must present.
 
-**Token structure:**
-
-```
-[version: 1 byte] [partition_number: 2 bytes] [execution_id: 16 bytes]
-[waitpoint_id: 16 bytes] [nonce: 8 bytes] [HMAC: 32 bytes]
-```
-
-Total: 75 bytes raw → 100 characters base64url.
-
-**MAC algorithm:** HMAC-SHA256. Input: all fields preceding the HMAC (version + partition + execution_id + waitpoint_id + nonce). Key: system-level deployment secret (see below).
-
-**MAC secret:** A system-level secret configured at deployment. All engine instances share the same secret. The secret is NOT per-namespace or per-execution — it is a deployment-wide signing key.
-
-**Decoding on signal ingress:**
-1. base64url-decode the token.
-2. Extract version byte. If unsupported version → `invalid_waitpoint_key`.
-3. Verify HMAC-SHA256 against the **current** secret.
-4. If verification fails, retry with the **previous** secret (dual-key rotation — see below).
-5. If both fail → `invalid_waitpoint_key`.
-6. Extract `partition_number`, `execution_id`, `waitpoint_id`.
-7. Route to `{p:<partition_number>}` keys. No cross-partition lookup.
-
-**MAC secret rotation — dual-key verification:**
-
-The engine maintains two secrets: `current_secret` and `previous_secret`. On rotation:
-1. `previous_secret` ← `current_secret`
-2. `current_secret` ← new secret
-3. `previous_secret` is retained for a configurable grace period. Recommended: `max(suspension_timeout)` across all active suspensions, minimum 24 hours.
-4. During the grace period, signal ingress verifies against `current_secret` first, then `previous_secret` on failure.
-5. After the grace period, `previous_secret` is discarded. Outstanding tokens signed with the old secret become permanently invalid — their executions resume only via operator action or suspension timeout.
-6. New waitpoint_keys are always signed with `current_secret`.
-
-This ensures in-flight callbacks survive one secret rotation without disruption. Operators should drain active suspensions or extend the grace period before rotating a second time.
+(An earlier draft of this RFC described a versioned 75-byte base64url token with embedded partition bytes and HMAC-SHA256 dual-key verification. That design is **not** what shipped — it was superseded by the separate HMAC-SHA1 waitpoint token scheme in §Waitpoint Security. See that section for the shipped contract: algorithm choice, kid-ring rotation, grace window semantics, and KEYS/ARGV impact.)
 
 ### Pending Waitpoints
 
@@ -1055,6 +1023,147 @@ Scanner pattern:
    - DEL `ff:wp:{p:N}:<waitpoint_id>:condition` (condition hash, if created)
    - for each signal_id in the signal stream: DEL `ff:signal:{p:N}:<signal_id>` and `ff:signal:{p:N}:<signal_id>:payload` (clean up orphaned signal records)
 
+## Waitpoint Security (HMAC token authentication)
+
+Multi-tenant deployments require that external signal sources (approval gates, webhook callbacks, tool result delivery) cannot deliver signals to waitpoints they do not own. Waitpoint IDs are UUIDs and can be unguessable, but they leak through logs, URLs, and inter-service hops. Relying on ID secrecy alone is insufficient.
+
+Each waitpoint carries an **HMAC token** that the signal deliverer must present. The token is minted at waitpoint creation time, bound to the specific `(waitpoint_id, waitpoint_key, created_at)` tuple, and validated in Lua before any mutating signal-delivery work runs.
+
+### Token format
+
+`"kid:40hex"`, where:
+
+- `kid` — short key identifier (e.g. `k1`, `k2`), enabling zero-downtime rotation
+- `40hex` — HMAC-SHA1 digest, lowercase hex (SHA1 output = 20 bytes = 40 hex chars)
+
+### Algorithm: HMAC-SHA1
+
+The Valkey Lua sandbox exposes `redis.sha1hex` but no SHA-256 primitive. Rather than import a ~200 LOC pure-Lua SHA-256 (large attack surface, new crypto primitive shipped in scripts), we use **HMAC-SHA1 per RFC 2104**. The security property we need is MAC unforgeability, not hash collision resistance: HMAC-SHA1 remains unbroken as a MAC construction (NIST SP 800-107r1), and with a 32-byte random secret the forgery work factor is 2^160. The helper `hmac_sha1_hex` in `lua/helpers.lua` implements the standard ipad/opad construction with a 64-byte SHA1 block size.
+
+### HMAC input (binding)
+
+```
+HMAC_SHA1( secret, waitpoint_id || "|" || waitpoint_key || "|" || created_at_ms )
+```
+
+- The pipe delimiter prevents field-boundary collisions across distinct `(waitpoint_id, waitpoint_key)` pairs.
+- Binding `waitpoint_id` ensures a token for waitpoint A cannot authenticate against waitpoint B (even on the same execution).
+- Binding `created_at_ms` means a waitpoint that is closed and later re-created at the same `(id, key)` tuple would mint a new token — the old token does not authenticate the new waitpoint.
+
+### Constant-time comparison
+
+Token validation compares the computed HMAC against the presented digest using `constant_time_eq` (helpers.lua): XOR-accumulate every byte, return equal iff the accumulator is zero. This closes remote timing attacks on early-exit character comparison.
+
+### Secret storage and rotation
+
+Secrets live in a per-partition hash: `ff:sec:{p:N}:waitpoint_hmac`. Fields:
+
+| Field | Purpose |
+| --- | --- |
+| `current_kid` | The kid currently minting new tokens. |
+| `secret:<kid>` | Hex-encoded HMAC key for kid `<kid>`. |
+| `previous_kid` | The kid immediately preceding `current_kid`. |
+| `previous_expires_at` | Absolute ms timestamp after which `previous_kid` tokens are rejected. |
+
+**Per-partition replication is required** because Valkey cluster mode demands that all KEYS in a single FCALL hash to the same slot. A single global secret key (e.g. `{s:waitpoint}:hmac_secrets`) would produce CROSSSLOT errors in suspension.lua and signal.lua FCALLs, which already touch `{p:N}`-tagged keys. The secret value is **identical across partitions**; only the storage is replicated. Rotation fans out across partitions (`O(num_execution_partitions)` HSETs — 256 by default, bounded at deployment time via `FF_EXEC_PARTITIONS`).
+
+### Key rotation (2-kid ring)
+
+1. Operator POSTs new secret to `/v1/admin/rotate-waitpoint-secret` (FF_API_TOKEN-authenticated).
+2. Server promotes `current_kid` → `previous_kid`, writes `previous_expires_at = now + FF_WAITPOINT_HMAC_GRACE_MS` (default 24h), installs the new kid + secret as current.
+3. Both `current_kid` and `previous_kid` validate during the grace window. After `previous_expires_at`, `previous_kid` tokens return `token_expired`.
+4. Fanout uses plain HSET (not HSETNX) and is **idempotent**: a partial-failure retry converges to the same state. The rotation endpoint returns `{rotated: N_ok, failed: [partition_ids]}`; HTTP 200 if any partition succeeded, 500 only if all fail. Per-partition outcomes are audit-logged (`target: "audit"`).
+
+### Boot initialization (fail-fast)
+
+`ff-server`'s `initialize_waitpoint_hmac_secret` runs between partition-config validation and Lua library load. For each execution partition:
+
+1. HGET `current_kid`. If absent, HSET `current_kid=k1`, `secret:k1=<env hex>`.
+2. If present and the stored secret matches env, continue (restart-safe).
+3. If present and divergent, log a warning (operator rotation scenario) and preserve the stored secret.
+
+Any HSET failure aborts the boot. A server running with some partitions missing the secret would `hmac_secret_not_initialized` half of traffic — failing loud at boot is strictly safer.
+
+### Replay bounding via waitpoint state machine
+
+Tokens are not serial-numbered and do not carry a nonce. Replay resistance comes from the waitpoint's one-shot state machine, not the token itself:
+
+- `ff_deliver_signal` (see `lua/signal.lua` §3) checks `wp_cond.closed == "1"` and returns `waitpoint_closed` before any mutation.
+- Once the resume condition is satisfied, `ff_deliver_signal` writes `closed=1` atomically as part of the same FCALL that records the signal.
+- Therefore a leaked token cannot be replayed after the resume condition is met: even if the attacker controls the signal delivery endpoint, the next FCALL observes `closed=1` and rejects.
+
+### Error codes (Lua → typed `ScriptError`)
+
+| Code | Meaning |
+| --- | --- |
+| `missing_token` | ARGV token empty or non-string. |
+| `invalid_token` | Malformed, unknown kid, wrong length, or HMAC mismatch. |
+| `token_expired` | Previous kid accepted, but `previous_expires_at < now`. |
+| `hmac_secret_not_initialized` | Boot init skipped or partition secret hash missing. |
+| `invalid_keys_missing_hmac` | FCALL built without the hmac_secrets KEY (caller misuse). |
+
+### KEYS / ARGV impact (library version 3)
+
+| Function | KEYS | ARGV | Returns |
+| --- | --- | --- | --- |
+| `ff_create_pending_waitpoint` | +`hmac_secrets` | unchanged | +token |
+| `ff_suspend_execution` | +`hmac_secrets` | unchanged | +token |
+| `ff_deliver_signal` | +`hmac_secrets` | +`waitpoint_token` | unchanged |
+| `ff_buffer_signal_for_pending_waitpoint` | +`hmac_secrets`, +`waitpoint_hash` | +`waitpoint_token` | unchanged |
+| `ff_resume_execution`, `ff_expire_suspension`, `ff_close_waitpoint` | unchanged (internal, not externally triggered) | unchanged | unchanged |
+
+This is a **breaking library-version bump** (2 → 3). Old SDK clients building pre-HMAC FCALL shapes will fail with arity or `invalid_keys_missing_hmac` errors, which is the desired behavior for multi-tenant security: no silent degradation.
+
+### Required deployment configuration
+
+Every `ff-server` deployment MUST set these environment variables. The server refuses to boot without them so no deployment can silently ship without HMAC protection.
+
+| Env var | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `FF_WAITPOINT_HMAC_SECRET` | **yes** | — | Hex-encoded HMAC-SHA1 signing secret. Recommended 64 hex chars (32 bytes). Even-length `0-9a-fA-F` validated at boot; malformed value fails `Server::start`. Store in a secret manager; never commit. |
+| `FF_WAITPOINT_HMAC_GRACE_MS` | no | `86_400_000` (24h) | Window during which `previous_kid` tokens continue to validate after rotation. Tighten for high-sensitivity tenants, loosen for longer-running approval workflows. |
+| `FF_API_TOKEN` | strongly recommended | — | Bearer token gating the entire API surface **including `/v1/admin/rotate-waitpoint-secret`**. Without it, admin endpoints are unauthenticated and the server logs a loud warning at boot. |
+
+### Audit events
+
+Rotation and other security-sensitive paths emit structured log events at `tracing::target: "audit"`. Operators aggregating audit logs should consume this target explicitly — the subscriber's default `EnvFilter` includes an `audit=info` directive out of the box; custom subscribers must add it.
+
+| Event name (message) | Level | Emitted on | Structured fields |
+| --- | --- | --- | --- |
+| `waitpoint_hmac_rotation_complete` | INFO | Every rotate endpoint call (success or partial) | `new_kid`, `total_partitions`, `rotated`, `failed_count`, `in_progress_count` |
+| `waitpoint_hmac_rotation_failed` | ERROR | Per-partition actual failure (Valkey outage, cluster split) | `partition`, `err` |
+| `waitpoint_hmac_rotation_timeout_http_504` | ERROR | Rotate endpoint exceeds 120s server-side timeout | `new_kid`, `timeout_s` |
+
+Per-partition `waitpoint_hmac_rotated` and `waitpoint_hmac_rotation_in_progress_skipped` are logged at `DEBUG` (not audit) because emitting 256 events per rotation blows up paid log aggregator budgets with no additional compliance value over the single aggregated INFO summary.
+
+Event names and structured field keys are a **stable public contract**. Breaking changes require a library-version bump and a deprecation window.
+
+### Performance notes
+
+HMAC-SHA1 minting and validation cost scale with the input size, not the stream rate. The input is bounded: `waitpoint_id` (36 bytes UUID) + `|` + `waitpoint_key` (≤256 bytes per RFC-004's opaque-string ceiling) + `|` + `created_at_ms` (13 bytes) ≈ 310 bytes worst case. `redis.sha1hex` on a ~310-byte buffer runs in low hundreds of nanoseconds per call. In practice, throughput is dominated by the FCALL round-trip and XADD/HSET work, not the HMAC itself.
+
+### Operator observability
+
+Every `invalid_token`, `token_expired`, `missing_token`, or `invalid_keys_missing_hmac` rejection on the signal-delivery path (`ff_deliver_signal` or `ff_buffer_signal_for_pending_waitpoint`) writes `last_hmac_validation_failed_at = now_ms` on the target execution's `exec_core` hash. Bounded scalar — one write per rejection, no per-failure log volume.
+
+Operators correlate this field with key rotation windows, client deploys, or attack traffic without tailing Lua slowlog:
+
+```
+HGET ff:exec:{p:42}:<eid>:core last_hmac_validation_failed_at
+```
+
+Absent field → never failed. Present field → last timestamp of any auth failure. Pair with execution lifecycle telemetry to distinguish "aged token, benign" from "stuck waitpoint, needs rotation audit".
+
+Audit-log correlation: every rotation emits the `waitpoint_hmac_rotation_complete` event (see §Audit events); `last_hmac_validation_failed_at` timestamps falling shortly after a rotation suggest in-flight tokens that pre-dated the rotation. Outside rotation windows, concentrated timestamps on one execution suggest a client bug or a probe.
+
+### Rate-limit posture
+
+HMAC validation is cheap (see above) but the entire `ff_deliver_signal` FCALL runs inside Valkey's single-threaded Lua slot for one `{p:N}` partition. A flood of tampered-token signals against one partition (same `execution_id` or a tight cluster of IDs mapped to the same `{p:N}`) saturates that shard's Lua slot even though every call returns `invalid_token` fast.
+
+v1 posture: **defer to LB/WAF for coarse rate limits.** The HMAC check is cheap enough that a determined attacker's throughput is bounded by their own connection concurrency against the LB, which is where rate limits belong. Per-(execution_id, source) token-bucket admission at the REST boundary is a deferred v2 feature if operators see partition starvation from hostile signal traffic.
+
+No in-server backpressure is wired today. Operators should monitor Valkey slowlog on the signal-delivery script family for evidence of hot partitions and front the API with an LB-level rate limiter (e.g. Cloudflare, ALB, nginx `limit_req`) sized for expected legitimate signal volume plus headroom.
+
 ## Interactions with Other Primitives
 
 - **RFC-001 Execution**: suspension is a first-class lifecycle state and drives `public_state = suspended`.
@@ -1075,6 +1184,7 @@ In v1:
 - atomic suspend and atomic resume-to-runnable
 - durable per-waitpoint signal buffer
 - explicit signal vs control boundary
+- HMAC-SHA1 waitpoint tokens with 2-kid rotation (see §Waitpoint Security)
 
 Designed for later but not required in v1:
 
@@ -1102,7 +1212,7 @@ No unresolved questions remain.
 
 ## Implementation Notes (v1)
 
-- **`waitpoint_key` uses simple `wpk:<uuid>` format,** not the HMAC-SHA256 cryptographic token described in §Waitpoint key routing. The crypto token (75 bytes raw, MAC secret rotation, dual-key verification) is deferred to v2 when multi-tenant security requires unguessable tokens. Current tokens are guessable but sufficient for single-tenant deployment. The routing problem is solved by storing the partition number on the waitpoint hash and looking it up via the waitpoint_id embedded in the key.
+- **`waitpoint_key` uses simple `wpk:<uuid>` format** and is not itself a crypto token. Multi-tenant signal authentication is provided by the separate **waitpoint HMAC token** (§Waitpoint Security), returned alongside the waitpoint_id at creation and required on all signal-delivery FCALLs. The HMAC uses SHA1 (in-engine via `redis.sha1hex`) rather than SHA-256 (which is not exposed in the Valkey Lua sandbox). The routing problem is solved by storing the partition number on the waitpoint hash and looking it up via the waitpoint_id embedded in the key.
 - **`auto_resume_with_timeout_signal` does not append a synthetic timeout signal.** The timeout scanner triggers resume directly without injecting a signal into the waitpoint buffer. Synthetic signal injection is deferred to v2.
 - **Suspension timeout scanner and pending waitpoint expiry scanner are fully implemented** as Rust-only scanners in `ff-engine::scanner`. They use `ZRANGEBYSCORE` on the respective timeout indexes.
 - **OOM-safe write ordering is enforced.** `ff_suspend_execution` writes `exec_core` HSET first (lifecycle → suspended), then creates sub-objects. `ff_resume_execution` writes `exec_core` first (lifecycle → runnable), then closes sub-objects.

--- a/rfcs/RFC-006-stream.md
+++ b/rfcs/RFC-006-stream.md
@@ -674,6 +674,352 @@ Mitigations:
 
 ---
 
+## Implementation Notes (Batch B — RFC-006 #2, 2026-04-17)
+
+Read-side primitives landed on `feat/batch-b` to unblock cairn checkpoint
+recovery. Two endpoints, two different transports; the split is forced by
+Valkey's rule that blocking commands cannot run inside Functions.
+
+**`ff_read_attempt_stream` (XRANGE, inside a Lua Function)**
+- `XRANGE` is non-blocking and therefore safe in `redis.register_function`.
+- KEYS(2): `stream_data`, `stream_meta` (both share the `{p:N}` hash tag).
+- ARGV(3): `from_id`, `to_id`, `count_limit`.
+- `count_limit` MUST be in `1..=STREAM_READ_HARD_CAP` (10_000); `0`
+  returns `invalid_input` rather than silently reading the entire stream.
+- Returns an empty array when the stream key does not exist — a
+  never-written attempt is a legitimate state, not an error.
+- Also returns `closed_at` and `closed_reason` (read via `HMGET` on
+  `stream_meta`) so consumers get the **terminal signal** alongside the
+  frames in the same FCALL. A never-written attempt yields empty strings
+  for both fields, which the Rust layer maps to `None`/`None`
+  (indistinguishable from "still open" at this layer, which is the
+  intended semantics).
+
+**`xread_block` (XREAD / XREAD BLOCK, direct client command)**
+- Blocking inside a Function is rejected by Valkey, so this lives in
+  `crates/ff-script/src/stream_tail.rs` as a plain async helper that
+  invokes the client directly.
+- `block_ms == 0` → plain `XREAD` (no BLOCK). `XREAD BLOCK 0` blocks
+  *indefinitely*, which is never what a web handler wants.
+- `block_ms > 0` → `XREAD COUNT <limit> BLOCK <ms> STREAMS <key> <last_id>`.
+  Timeout returns `Value::Nil`, which we normalize to `Vec::new()`.
+- The REST layer rejects `block_ms > 30_000ms` with HTTP 400. Ceiling
+  chosen to sit below common LB idle timeouts (ALB 60s, nginx 60s,
+  Cloudflare 100s) so the response can't be cut mid-block.
+- After the XREAD settles we fire one follow-up `HMGET stream_meta
+  closed_at closed_reason` to attach the terminal signal to the return.
+  This is cheap (single RTT, same `{p:N}` slot) and avoids consumers
+  having to poll a separate endpoint to learn whether the stream is
+  closed. The follow-up HMGET is ALWAYS performed, even on timeout —
+  that's the common case where the signal matters most.
+
+**Routing by `(execution_id, attempt_index)` — not `attempt_id`**
+
+The stream key is `ff:stream:{p:N}:<eid>:<idx>`. There is no
+`attempt_id → (eid, idx)` reverse index, and the task consumer (cairn)
+already has both values at checkpoint time. We route by
+`(execution_id, attempt_index)` instead of building a new index.
+`attempt_id` remains an audit field inside each frame's write args, not a
+routing key. REST paths reflect this:
+
+- `GET /v1/executions/{eid}/attempts/{idx}/stream?from=-&to=+&limit=100`
+- `GET /v1/executions/{eid}/attempts/{idx}/stream/tail?after=<id>&block_ms=5000&limit=50`
+
+**REST transport: long-poll in v1**
+
+Tail is exposed as long-poll, not SSE. Rationale:
+- Simpler: no SSE framing, works through any HTTP stack, no client state
+  beyond "remember the last id I saw".
+- Bounded: `block_ms <= 30s` cap means a single request never outlives a
+  typical LB idle timeout.
+- SSE can be added later without changing the server-side shape — the
+  Server method `tail_attempt_stream` already returns `Vec<StreamFrame>`
+  suitable for either transport.
+
+**Transport timeout interaction (ferriskey)**
+
+The ferriskey client's default `request_timeout` (5s on ff-server) does
+NOT apply to blocking XREAD calls. `ferriskey::client::get_request_timeout`
+inspects outgoing commands; for `XREAD`/`XREADGROUP` with a `BLOCK`
+argument it returns `BlockingCommand(block_ms + 500ms)` via the
+`BLOCKING_CMD_TIMEOUT_EXTENSION` constant (0.5s), overriding the client's
+default for that single command.
+
+Practical consequence for **timeouts**: the REST `block_ms` ceiling of
+30s is the only knob that bounds tail latency from a transport
+perspective. The dedicated tail client (§"Dedicated tail connection"
+below) exists for a DIFFERENT reason — head-of-line isolation — not
+for request_timeout tuning. Two different concerns, two different
+fixes; don't conflate. The regression test
+`test_tail_stream_long_block_respects_ferriskey_timeout_extension`
+blocks for 7s (above the 5s default) to pin the timeout-extension
+behavior.
+
+**Input validation: both bounds reject, neither silently clamps**
+
+Both REST handlers reject out-of-range inputs with HTTP 400 rather than
+silently clamping:
+- `block_ms > MAX_TAIL_BLOCK_MS (30_000)` → 400.
+- `limit == 0` → 400 (`"limit must be >= 1"`).
+- `limit > REST_STREAM_LIMIT_CEILING (1_000)` → 400. Lower than the
+  internal `STREAM_READ_HARD_CAP (10_000)` because the REST layer
+  buffers the full JSON body in axum — a max-payload × max-limit
+  response is multi-hundred-MB per call and a clear DoS vector from a
+  single client. Internal callers via FCALL or the SDK directly retain
+  the 10_000 bound; REST clients paginate through `from`/`to`/`after`
+  for larger spans. Chunked-transfer / SSE deferred to v2.
+- Malformed `from` / `to` / `after` (anything outside `"-"`, `"+"`, or
+  `<ms>[-<seq>]`) → 400 at the REST boundary, never forwarded to Valkey.
+
+Explicit 400 responses surface client misconfiguration; silent clamps
+mask it. `STREAM_READ_HARD_CAP` is a single source of truth in
+`ff_core::contracts` and is mirrored in the Lua-side `HARD_CAP` literal
+in `lua/stream.lua`.
+
+**Dedicated stream-op connection (head-of-line isolation)**
+
+`Server::tail_attempt_stream` AND `Server::read_attempt_stream` both run
+on `Server.tail_client` — a dedicated `ferriskey::Client` built alongside
+the main client in `Server::start`. The main `Server.client` and the
+`Engine`'s scanner client are unaffected by stream-op latency.
+
+The split is about **head-of-line isolation**, not request_timeout
+(which ferriskey already handles; see §Transport timeout interaction
+above). Two separate classes of stream-op load would otherwise starve
+the main mux:
+
+- **Blocking**: `XREAD BLOCK 30_000` holds the socket read side for up
+  to 30 seconds.
+- **Large reads**: an XRANGE with `COUNT=STREAM_READ_HARD_CAP (10_000)`
+  returning ~64 KB-per-frame payloads is a multi-MB reply serialized
+  on one TCP socket.
+
+Either load on a shared client would stall every concurrent FCALL
+(claim, create, rotate-waitpoint-secret, budget/quota, admin) AND every
+engine scanner for the duration. Splitting both reads and tails out
+onto the dedicated `tail_client` makes foreground API and
+background-scanner cadence independent of stream-op latency.
+
+**Tail serialization on the dedicated client (v1)**
+
+The dedicated `tail_client` is still one multiplexed TCP connection:
+Valkey processes commands FIFO on it, and ferriskey's per-call
+`request_timeout` starts on the client side at future-poll. Two
+`XREAD BLOCK` calls pipelined down one mux therefore DO NOT run
+concurrently at the server — the second waits for the first to return
+— and the second call's `request_timeout` (auto-extended to
+`block_ms + 500ms`) expires BEFORE it ever reaches the server, producing
+spurious `timed_out` errors under concurrent tail load.
+
+V1 ships an explicit `tokio::sync::Mutex` (`Server.xread_block_lock`)
+that serializes `xread_block` calls against the tail client.
+Acquisition order is **semaphore permit first, Mutex second**. The
+`max_concurrent_stream_ops` ceiling becomes the queue depth; throughput
+on the tail client is 1 BLOCK at a time, but each call gets its full
+`block_ms` budget at Valkey instead of racing client-side timeouts.
+
+XRANGE reads (`read_attempt_stream`) are NOT gated by the Mutex. XRANGE
+is non-blocking at the server — pipelined XRANGEs on one mux complete
+in microseconds each — so they don't trigger the same client-side
+timeout race. Keeping reads unserialized preserves read throughput.
+
+**V2 upgrade path**: replace the single `tail_client` + Mutex pair with
+a pool of N dedicated `ferriskey::Client` connections. Each tail gets
+its own socket; BLOCKs run truly in parallel. Deferred from Batch B
+because it requires Server-state changes (pool lifecycle, shutdown
+draining of all N clients) that are scope-creep relative to the Mutex
+fix. The `xread_block_lock` is labeled with a pointer to this upgrade
+so the v2 removal is mechanical.
+
+**Backpressure on concurrent stream ops (`FF_MAX_CONCURRENT_STREAM_OPS`)**
+
+`Server.stream_semaphore` bounds concurrent stream-op calls — reads AND
+tails combined (default 64). Read and tail share the same pool because
+they share the same `tail_client`; a flood of one can starve the other
+unless fairness accounting is unified.
+
+Both `Server::read_attempt_stream` and `Server::tail_attempt_stream`
+acquire a permit via `try_acquire_owned` before their Valkey command;
+when the pool is exhausted, callers receive
+`ServerError::TailUnavailable` which the REST layer surfaces as
+**HTTP 429 Too Many Requests** (`retryable=true` in the error body).
+Non-blocking acquisition is deliberate: queueing would hold the caller's
+HTTP request open with no upper bound, which is exactly the exhaustion
+pattern the limit exists to prevent.
+
+Env var precedence: `FF_MAX_CONCURRENT_STREAM_OPS` is the preferred
+name; the older `FF_MAX_CONCURRENT_TAIL` is accepted for one release to
+keep existing deployments working while they update their config. If
+both are set, the new name wins.
+
+Operators tune this based on the server's overall request-concurrency
+budget. A single multiplexed tail connection handles arbitrary
+pipelining, so the ceiling is about fairness — how many stream ops can
+be in flight before new ones must back off — not about
+connection-count.
+
+**Permit-hold latency (closed via HSET while tail is blocking)**
+
+`XREAD BLOCK` wakes on `XADD` to the stream, not on `HSET` to
+`stream_meta`. When a producer closes a stream via one of the non-XADD
+terminal paths — `ff_cancel_execution` / `ff_complete_execution` /
+`ff_fail_execution` / `mark_expired` / reclaim, all of which HSET
+`closed_at` without appending a frame — any in-flight `tail_stream`
+will NOT wake early. It continues to hold its `stream_semaphore`
+permit until its configured `block_ms` expires OR a subsequent `XADD`
+happens to land (the close paths typically don't append further).
+
+Worst case: a tail with `block_ms=30_000` holds its permit for the
+full 30s even though the terminal signal is already on `stream_meta`.
+Under load this shrinks effective stream-op capacity for up to
+`block_ms` after a close cascade.
+
+V1 accepts this limitation. Operators who see stream-op 429s during
+cancellation storms can:
+- Tune `FF_MAX_CONCURRENT_STREAM_OPS` up (each permit is cheap — one
+  TCP-pipeline slot).
+- Recommend callers use smaller `block_ms` values (3–5s) and rely on
+  tail loops for responsiveness.
+
+**V2 upgrade path**: have the close paths emit a sentinel
+`XADD stream_key * frame_type stream_closed closed_reason=<reason>`
+entry. XREAD BLOCK wakes on the sentinel, consumers see a terminal
+frame (different from a normal frame via `frame_type`) and exit the
+loop immediately. Releases the permit as soon as the close happens,
+turning worst-case permit hold into ~RTT. Not done in v1 because it
+couples the close paths (execution.lua, signal.lua, reclaim) to the
+stream in a way that requires coordinated edits across 8+ Lua
+functions.
+
+**Terminal signal contract (closed_at / closed_reason)**
+
+Every read/tail call returns a `StreamFrames { frames, closed_at,
+closed_reason }` struct. `closed_at` is `Some` iff the writer has
+finalized the stream via one of the close paths below; `closed_reason`
+names the specific reason.
+
+**`closed_reason` enumeration (stable, public contract)**
+
+The full set of values `stream_meta.closed_reason` may take. New
+entries to this list are a breaking change to consumers and require a
+LIBRARY_VERSION bump:
+
+| value | write path | notes |
+|---|---|---|
+| `attempt_success` | `ff_complete_execution` (lua/execution.lua) | Worker called complete; most common case. |
+| `attempt_failure` | `ff_fail_execution` → terminal branch | Retry budget exhausted or unrecoverable fail. |
+| `attempt_cancelled` | `ff_cancel_execution` | External cancel while attempt active. |
+| `attempt_interrupted` | `ff_fail_execution` → retry-scheduled branch | Will retry; new attempt opens a new stream. |
+| `reclaimed` | reclaim path (lua/execution.lua reclaim branches) | Lease reclaimed by a different worker; stream of the reclaimed attempt is closed. |
+| `lease_expired` | `mark_expired` (lua/helpers.lua) | Worker died / lease expired without reclaim yet; surfaces the terminal signal so consumers don't wait for reclaim. Overwritten by `reclaimed` if reclaim runs later. |
+| `timed_out_auto_resume` | suspension auto-resume timeout path | Attempt's auto-resume suspension timed out. |
+| `timed_out_fail` | suspension fail-on-timeout path | Attempt's fail-on-timeout suspension tripped. |
+| `retention_trim` | retention trimmer scanner | Entire stream trimmed under a hard MAXLEN; very rare — normally XTRIM prunes entries, not closes streams. Reserved. |
+
+A never-written stream and an in-progress stream both present as
+`closed_at=None`; distinguishing them requires reading `exec_core`
+separately (out of scope here).
+
+Consumer polling pattern:
+```rust
+let mut last_id = "0-0".to_string();
+loop {
+    let page = ff_sdk::tail_stream(&client, &cfg, &eid, idx, &last_id, 5_000, 100).await?;
+    for frame in &page.frames {
+        handle(frame)?;
+        last_id = frame.id.clone();
+    }
+    if page.is_closed() {
+        break; // drained + terminal — exit cleanly, no timeout fallback needed
+    }
+}
+```
+
+The equivalent REST shape surfaces `closed_at` (i64 ms) and
+`closed_reason` (string) as optional top-level fields on both the
+`/stream` and `/stream/tail` JSON responses; fields are omitted when the
+stream is still open.
+
+**Terminal-signal drain pattern (XREAD / HMGET race)**
+
+`xread_block` issues the XREAD and the follow-up HMGET of `stream_meta`
+as separate round trips. A close can land between them — `frames`
+reflects the stream as of T1, `closed_at`/`closed_reason` reflect
+`stream_meta` as of T2. Correctness is preserved because
+`ff_append_frame` gates on `closed_at` before every XADD: a stream that
+is closed at T2 cannot have gained frames between T1 and T2, so anything
+XREAD returned was already the tail.
+
+The only consequence is that frames which landed between a previous
+tail's last read and the close may not appear in the tail call that
+*observes* the close. Consumers close the race with a final XRANGE
+drain:
+
+```rust
+let mut last_id = "0-0".to_string();
+loop {
+    let page = ff_sdk::tail_stream(&client, &cfg, &eid, idx, &last_id, 5_000, 100).await?;
+    for frame in &page.frames {
+        handle(frame)?;
+        last_id = frame.id.clone();
+    }
+    if page.is_closed() {
+        // Final drain: XRANGE from the cursor to '+' picks up any frames
+        // that were appended after our last tail read but before the
+        // writer called close. `read_stream` also reports closed_at, so
+        // the loop is self-terminating.
+        let trailing = ff_sdk::read_stream(
+            &client, &cfg, &eid, idx, &last_id, "+", 1_000,
+        ).await?;
+        for frame in trailing.frames.iter().filter(|f| f.id > last_id) {
+            handle(frame)?;
+        }
+        break;
+    }
+}
+```
+
+The SDK `tail_stream` rustdoc carries a short hint; this section is the
+normative reference. Implementations MAY skip the final drain when they
+can tolerate the edge case (e.g. log-shipping where late frames are
+best-effort), but correctness-sensitive consumers (cairn checkpoint
+recovery) MUST drain.
+
+**Authorization**
+
+Inherits the global Bearer middleware that protects every other
+`/v1/executions/…` route. Namespace-scoped ACLs are a cross-cutting
+concern (not stream-specific); when/if we add them, both endpoints pick
+them up for free. No per-stream authz is layered in at this time — it
+would be redundant until the surrounding ACL story exists.
+
+**Tests** (`crates/ff-test/tests/e2e_lifecycle.rs`, RFC-006 #2 section):
+- `test_read_stream_round_trips_append_frame_fields`
+- `test_read_stream_empty_returns_empty`
+- `test_read_stream_slice_and_resume`
+- `test_tail_stream_timeout_returns_empty`
+- `test_tail_stream_unblocks_on_write`
+- `test_tail_stream_no_block_returns_available`
+- `test_tail_stream_long_block_respects_ferriskey_timeout_extension`
+  (regression: 7s block does not spuriously transport-timeout at 5s)
+- `test_stream_closed_signal_propagates_to_read_and_tail`
+  (terminal signal: after complete, both read and tail report
+  `closed_at` + `closed_reason=attempt_success`)
+- `test_read_stream_rejects_zero_count_limit` (R3 BUG2 regression)
+- `test_tail_stream_rejects_zero_count_limit` (R3 BUG2 regression)
+- `test_lease_expired_closes_stream_meta` (R4 regression: tail
+  consumer observes terminal signal even if no reclaim ever runs)
+
+**Library version** bumped to `"4"` — the initial read path landed at
+`"3"`; the R2 change that adds the terminal-signal fields to the return
+shape of `ff_read_attempt_stream` (positions 2 and 3:
+`closed_at`, `closed_reason`) is a return-arity change, so we bump again
+per the library-version policy. Older binaries will hit the version
+mismatch on boot and force a `FUNCTION LOAD REPLACE`, which matches the
+intent.
+
+---
+
 ## References
 
 - Pre-RFC: flowfabric_use_cases_and_primitives (2).md — Primitive 5, Finalization item 5

--- a/rfcs/RFC-006-stream.md
+++ b/rfcs/RFC-006-stream.md
@@ -1009,6 +1009,9 @@ would be redundant until the surrounding ACL story exists.
 - `test_tail_stream_rejects_zero_count_limit` (R3 BUG2 regression)
 - `test_lease_expired_closes_stream_meta` (R4 regression: tail
   consumer observes terminal signal even if no reclaim ever runs)
+- `test_read_stream_rejects_over_hard_cap_at_lua` (PR#7 regression:
+  direct FCALL with count_limit > HARD_CAP must reject, not silently
+  clamp — closes the Lua-side gap that SDK + server already covered)
 
 **Library version** bumped to `"4"` — the initial read path landed at
 `"3"`; the R2 change that adds the terminal-signal fields to the return

--- a/rfcs/RFC-009-scheduling.md
+++ b/rfcs/RFC-009-scheduling.md
@@ -345,6 +345,61 @@ The scheduler prefers the highest-scoring eligible worker. Ties are broken by le
 | C3 | **Capability view is inspectable.** `explain_capability_mismatch` must show why no worker matches. | "Why is this stuck?" for routing. |
 | C4 | **Matching is deterministic enough to debug.** Same inputs → same match result. | Operators can reproduce routing decisions. |
 
+#### 7.5 V1 Implementation (Batch B, 2026-04)
+
+The design above is the target. V1 ships a deliberately simpler subset.
+
+**Model.** `required_capabilities` is a `BTreeSet<String>` of opaque string tokens (e.g. `"gpu"`, `"torch>=2.3"`, `"tools:playwright"`). Match is **exact-string subset**: a worker advertising capability set `W` may claim an execution requiring `R` iff `R ⊆ W`. Empty `R` matches any worker (backwards compatibility). Preferred/forbidden capabilities, isolation levels, locality, and scoring are **not implemented in V1**.
+
+**Token format restriction.** Tokens MUST be non-empty strings containing no comma, no whitespace, and no control characters. UTF-8 printable characters above 0x7F are allowed — i18n cap names like `"东京-gpu"` are valid. The CSV wire form is byte-safe for multibyte UTF-8 because `,` (0x2C) is single-byte and never a UTF-8 continuation (only 0x80-0xBF are). Three independent reasons for the restrictions:
+- `,` is reserved as the CSV delimiter for the wire-level representation between caller and Lua (`ff_issue_claim_grant` ARGV[9] on the worker side and `exec_core.required_capabilities` on the execution side). Embedding a comma would split a single token into two mid-parse: a worker with `{"gpu"}` would appear to satisfy a requirement of `{"gpu,cuda"}` — a silent auth bypass.
+- Empty tokens inflate the CSV with adjacent/leading commas and push the token count past CAPS_MAX_TOKENS for no semantic reason.
+- Whitespace and non-printable / control bytes (`"gpu "`, `"gpu\n"`, zero-width Unicode) produce silent mismatches that are painful to debug — reject at ingress so typos fail loud instead of forever-starving.
+
+Ingress validators reject on all three surfaces:
+- `ff-sdk` `FlowFabricWorker::connect` → `SdkError::Config`
+- `ff-scheduler` `Scheduler::claim_for_worker` → `SchedulerError::Config`
+- Lua `ff_create_execution` (required side) → `err("invalid_capabilities", "required:comma_in_token" | "required:empty_token" | "required:non_string_token")` and `err("invalid_policy_json", ...)` for malformed routing_requirements structure.
+
+Lua validation fails CLOSED: malformed policy_json or any non-string required_capabilities element aborts `ff_create_execution` before exec_core is written. Silent-drop would have let a typed-config typo erase a security-relevant requirement and leave the execution wildcard-claimable.
+
+The same wire form also bounds total size and token count (`CAPS_MAX_BYTES=4096`, `CAPS_MAX_TOKENS=256`), enforced symmetrically on both sides. V2 attestation (see deferred list) would replace CSV with a length-prefixed or JSON encoding, at which point these restrictions lift.
+
+**Starvation timestamp (observability).** On each `capability_mismatch` in `ff_issue_claim_grant` / `ff_issue_reclaim_grant`, the Lua stamps `last_capability_mismatch_at` on exec_core — a single idempotent scalar field. Operators identify permanently-unclaimable executions via `SCAN` + `HGET last_capability_mismatch_at` against a "stuck > 1h" threshold. An earlier design HINCRBY'd a `capability_mismatch_count` field alongside the timestamp; that was removed because under the "stay in eligible ZSET" failure mode (since fixed by block-on-mismatch) the counter grew unboundedly — 100 workers × 1 tick/s × one stuck exec = 8.6M increments/day. A single timestamp field is enough; recency, not rate, is the signal operators want. Full `explain_capability_mismatch` API remains V2.
+
+**Block-on-mismatch (starvation protection).** When `ff_issue_claim_grant` returns `capability_mismatch`, the scheduler MUST move the execution out of the eligible ZSET into a `blocked_route` (reason: `waiting_for_capability`) index on the same partition. Otherwise `ZRANGEBYSCORE eligible -inf +inf LIMIT 0 1` keeps returning the same top-of-zset every scheduling tick, and N workers × 1 tick/s per unmatchable execution = wasted FCALLs/quota-writes/log volume scaling linearly with the backlog. A periodic "blocked_route sweep" (v1: every 30 s) promotes blocked executions back to eligible for re-evaluation; workers that newly connected with matching caps then pick them up. Worker-registration-driven re-evaluation is the V2 target. The reclaim path (`ff_issue_reclaim_grant`) applies the same block-on-mismatch invariant — otherwise the reclaim scanner loops on the same lease-expired execution forever.
+
+**Authority: worker passes caps in ARGV (option a).**
+
+The worker ships its sorted CSV via `ff_issue_claim_grant` ARGV[9]. The Lua loads the execution's `required_capabilities` CSV from the exec_core hash and checks subset containment atomically. This is cluster-safe: both CSVs live in the FCALL scope; no cross-slot read is needed.
+
+The alternative — an authoritative `{c:worker}:{worker_id}:caps` hash that Lua reads — was rejected because (1) it would be cross-slot with `{p:N}` exec_core and require per-partition duplication, and (2) it does not add a real trust boundary. A malicious worker can lie about `worker_id` just as easily as about caps, and the claim/grant path already trusts `worker_id`. Authentication/attestation is the right tool for that threat model and is deferred.
+
+**On mismatch: block to `blocked_route` (scheduler-side).** `ff_issue_claim_grant` returns `err("capability_mismatch", missing_csv)` with a single exec_core HSET (`last_capability_mismatch_at`) and NO eligible-ZSET mutation of its own — Lua stays the authoritative atomic yes/no step. The scheduler caller (`ff-scheduler::Scheduler::claim_for_worker` AND `ff-sdk::FlowFabricWorker::claim_next` for the inline-direct-claim path) then invokes `ff_block_execution_for_admission(reason="waiting_for_capable_worker")` which moves the execution from the lane's eligible ZSET into its `blocked:route` ZSET (eligibility_state=`blocked_by_route`, blocking_reason=`waiting_for_capable_worker`, public_state=`rate_limited`).
+
+Earlier designs kept the execution in eligible. That invariant leaked into a hot-loop bug: 100 workers × 1 tick/s × one unclaimable top-of-zset = 100 wasted FCALLs/s plus quota-admission churn. Block-on-mismatch + periodic sweep is the stable shape.
+
+**Promotion back to eligible.** The engine's unblock scanner (`ff-engine::scanner::unblock`) scans `blocked:route` per lane per execution partition on its usual tick. For each member it reads the execution's `required_capabilities` CSV and checks subset coverage against the UNION of connected workers' `ff:worker:*:caps` STRING advertisements (loaded once per scan cycle, bounded by the number of online workers). If subset holds, `ff_unblock_execution(reason="waiting_for_capable_worker")` moves the execution back to eligible. Fail-open on the caps-union read: a transient Valkey error on SCAN / GET is treated as "match possible" so executions don't starve when the caps hash query transiently fails — the scheduler re-decides on the next tick anyway.
+
+`ff:worker:*:caps` is written non-authoritatively by `ff-sdk::FlowFabricWorker::connect` (atomic SET on connect, DEL on empty-caps restart). Lua never reads it; only the unblock scanner does. V2 target: worker-connect-triggered sweep so promotion latency is O(connect-time), not O(scanner interval).
+
+Starvation still surfaces in logs: the scheduler and SDK emit a single `tracing::info!` per mismatch with a `worker_caps_hash` (8-hex FNV-1a digest of the CSV) and the `missing` tokens — the full 4KB CSV is logged once at worker-connect WARN, so per-mismatch log volume is bounded by execution count, not caps length.
+
+**Bound checks.** The Lua rejects worker-or-required CSVs exceeding 4096 bytes or 256 tokens with `err("invalid_capabilities", detail)`. Defense-in-depth against misconfigured or buggy clients shipping large repeated payloads into the atomic section.
+
+**Non-authoritative visibility SET.** The SDK writes `SADD ff:worker:{instance_id}:caps` (with a TTL matching the alive key) on connect. This is **for operator introspection only**. The scheduler and Lua never read it. If a future version ditches option (a) in favor of option (b), this key becomes the source of truth — today it is not.
+
+**Deferred to V2 (explicitly):**
+- Worker attestation (HMAC signing of worker caps), enabling option (b) where Lua reads an authoritative cap store.
+- Semver predicates (`torch>=2.3` parsed as a range), not opaque strings.
+- Key-value capability attributes (`provider=anthropic`) — V1 is flat string tokens only.
+- Preferred/forbidden capabilities and scoring.
+- Secondary ZSET index per capability to avoid O(N) eligible scans when very few workers have a niche capability.
+- Operator `explain_capability_mismatch` API for C3.
+- Isolation level and locality matching.
+- Worker-connect-triggered `blocked_route` sweep (V1 uses the periodic unblock scanner — promotion latency is bounded by unblock scanner interval, not connect time).
+- Reclaim scanner integration for `ff_issue_reclaim_grant` — deferred to cairn Batch C (no production Rust caller today). When added, MUST apply the same block-on-capability-mismatch pattern as the claim path; the Lua helper already stamps `last_capability_mismatch_at` and documents the invariant inline.
+
 ---
 
 ### 8. Lane / Queue Facade


### PR DESCRIPTION
## Summary
Three cairn-blocking items: capability-based worker routing, stream read primitives for checkpoint recovery, and HMAC-authenticated waitpoint signals for multi-tenant security. 5 adversarial review rounds, 70+ findings fixed inline, 0 deferred, cluster-tested against Valkey 7.x on AWS ElastiCache with TLS.

## What's shipped

### #1 Capability routing (RFC-009)
- `ExecutionPolicy.required_capabilities: BTreeSet<String>`
- Workers advertise capabilities on `connect`; scheduler claim-grant does subset match
- Block-on-mismatch: unclaimable execs move `eligible → lane_blocked_route`
- Unblock scanner promotes back when a capable worker registers (cluster-safe via `ff:idx:workers` index SET — Batch A SCAN→index pattern)
- SDK + scheduler parity via shared `block_candidate` path
- Ingress validation: rejects commas, empty tokens, ASCII control/whitespace (allows UTF-8 printable for i18n cap names)
- Bounds enforced at both SDK and Lua: `CAPS_MAX_BYTES=4096`, `CAPS_MAX_TOKENS=256`
- Observability: `last_capability_mismatch_at` timestamp on exec_core
- 10 new e2e tests covering match, miss, block, unblock, coverage

### #2 Stream read ops (RFC-006)
- `ff_read_attempt_stream`: FCALL-wrapped XRANGE (cluster-safe via `{p:N}` tag)
- `xread_block`: direct-client XREAD BLOCK (Lua sandbox disallows blocking)
- Terminal signal: `closed_at` + `closed_reason` propagated through read + tail
- 9-value `closed_reason` enum documented as STABLE contract
- Dedicated `tail_client` isolates tail from main mux head-of-line
- `stream_semaphore` (`FF_MAX_CONCURRENT_STREAM_OPS=64`) + 429 backpressure
- `tokio::sync::Mutex` serializes `xread_block` (ferriskey pipelined FIFO correctness)
- `lease_expired` writes `closed_reason` so dead-worker tails terminate cleanly
- REST `/stream` and `/stream/tail` endpoints with explicit `limit=0` and malformed-id 400s
- `ServerError::ValkeyContext` preserves `ferriskey::ErrorKind` for proper retry classification
- 11 new stream tests

### #4 Waitpoint HMAC tokens (RFC-004)
- HMAC-SHA1 via `redis.sha1hex`, constant-time compare, pipe-delimited binding
- Per-partition secret replication (`ff:sec:{p:N}:waitpoint_hmac`, cluster-safe)
- Multi-kid validation: per-kid `expires_at`, current + every in-grace kid valid
- Rapid rotation preserves 24h grace contract (A→B→C with A still valid during A's grace window)
- Boot init parallelized (16-concurrency `FuturesUnordered`, ~1s vs sequential 15s)
- Rotate endpoint: `Semaphore(1)` rate-limit, 120s HTTP timeout, aggregated audit log
- Validate-before-state-probe (no state oracle for unauthenticated callers)
- `WaitpointToken` `Debug`/`Display` redacted (`kid:<REDACTED:len=N>`); wire sites use `.as_str()`
- Boot fail-fast if `FF_WAITPOINT_HMAC_SECRET` missing or odd-length hex
- 12 HMAC tests

### Cross-cutting
- `LIBRARY_VERSION` single source of truth: `lua/version.lua` authoritative, `build.rs` extracts to `env!("FLOWFABRIC_LUA_VERSION")`. Drift class eliminated.
- `tail_client` split prevents tail from starving engine scanners

## Metrics
- 38 files changed, +6985/-322
- 122 tests pass standalone, 122 tests pass on Valkey cluster (TLS, `clustercfg.glide-perf-test-cache-2026...`)
- Zero clippy warnings across 7 crates
- 5 review rounds, 70+ findings, 0 deferrals

## RFCs updated
- RFC-004 §Waitpoint Security — ~200 new lines (HMAC algorithm, kid ring, rotation, grace semantics, audit events contract)
- RFC-006 §Terminal signal contract + §Transport timeout + §Tail serialization — ~350 new lines
- RFC-009 §7.5 Capability matching + block-on-mismatch + unblock scanner — ~50 new lines

## Test plan
- [x] `cargo clippy -p ff-core -p ff-script -p ff-sdk -p ff-scheduler -p ff-engine -p ff-server -p ff-test --tests --all-features -- -D warnings`
- [x] `cargo test -p ff-test -- --test-threads=1` standalone (localhost:6379): 122/122
- [x] `FF_HOST=clustercfg.glide-perf-test-cache-2026.nra7gl.use1.cache.amazonaws.com FF_TLS=true FF_CLUSTER=true cargo test -p ff-test` cluster: 122/122 (cluster run caught a final SCAN regression in the unblock scanner — fixed with index-SET pattern before merge)
- [x] `cargo doc --workspace --no-deps` clean on new docs
- [x] LIBRARY_VERSION=4 consistent across `lua/version.lua` and `env!()` extraction
- [x] Smoke tests: capability match + block + unblock, HMAC rotation preserves grace, stream terminal signal, 429 backpressure under concurrent tails, shutdown drain via semaphore close

## Review rounds (for context)
- R1 initial: scopes rotated, found 28 findings (4 BUGs + 4 NITs each scope)
- R2 theme silent-errors: 14 findings incl. state-oracle, WaitpointToken leak, config drift
- R3 theme backpressure: 14 findings incl. hot-loop-on-mismatch, quota churn, rapid-rotation grace violation
- R4 theme deep-sweep: 2 integration BLOCKERS independently confirmed by 2+ reviewers (unblock scanner gap, rapid rotation kid-selector eviction), both fixed
- R5 ship-ready + cluster-run: caught final SCAN cluster-unsafety, fixed inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes scheduling/admission behavior, adds new server endpoints, and introduces new security-critical HMAC token validation/rotation plus new Valkey keys/FCALL signatures that affect compatibility.
> 
> **Overview**
> Enables **capability-based execution routing** by changing `required_capabilities`/`worker_capabilities` to deterministic sets, passing worker capability CSVs into `ff_issue_claim_grant`, blocking mismatches into `lane_blocked_route`, and teaching the engine unblock scanner to re-promote when a matching worker is observed via a new cluster-safe worker capability index.
> 
> Adds **stream consumption primitives**: a new `ff_read_attempt_stream` FCALL contract plus SDK helpers and server REST endpoints (`/stream` + `/stream/tail`) backed by direct `XREAD BLOCK`, including terminal close markers, request validation, response limits, and server-side concurrency/backpressure via a dedicated `tail_client` and semaphore.
> 
> Adds **waitpoint HMAC token security** by introducing `WaitpointToken` (redacted formatting), requiring tokens for signal delivery/buffering and returning them from suspend/pending-waitpoint creation, persisting per-partition HMAC secret material (`ff:sec:{p:N}:waitpoint_hmac`), requiring `FF_WAITPOINT_HMAC_SECRET` at boot, and exposing an admin rotation endpoint (`POST /v1/admin/rotate-waitpoint-secret`). Also makes Lua library `LIBRARY_VERSION` derive from `lua/version.lua` at build time to reduce drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b827f2cfb3bdfc214ab78dd115396fabc4991e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->