### PR TITLE
ff-sdk: cairn-fabric API gaps P1A + P1B + P2 + P3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "ff-core",
  "ff-engine",
  "ff-scheduler",
+ "ff-script",
  "ff-sdk",
  "ff-server",
  "reqwest",

--- a/benches/perf-invest/review-r1-w1.md
+++ b/benches/perf-invest/review-r1-w1.md
@@ -1,0 +1,233 @@
+# Cross-review round 1 — Worker-1 reviewing 863f2f0 (W2) + 0b86024 (W3)
+
+**Reviewer:** Worker-1
+**Branch:** `feat/cairn-sdk-gaps` @ `c545664`
+**Scope:** Per manager, W1 reviews W2's P1B (`863f2f0`) and W3's
+P2+P3.4 (`0b86024`). W1 does NOT review own commits (`3cee229`,
+`c545664`).
+
+## Verdict table
+
+| SHA     | Subject                                                          | Verdict |
+| ------- | ---------------------------------------------------------------- | ------- |
+| 863f2f0 | ff-sdk: ReclaimGrant + claim_from_reclaim_grant (cairn P1B)      | **RED** (1 RED + 3 YELLOW) |
+| 0b86024 | ff-core + ff-sdk: pub parse_report_usage_result + dedup helper   | **GREEN** (3 YELLOW) |
+
+Overall: round-1 has ONE RED blocker (the missing
+semaphore check in `claim_from_reclaim_grant` already reported via
+team-send). Everything else is YELLOW — docstring + polish.
+
+## 863f2f0 — `ReclaimGrant + claim_from_reclaim_grant`
+
+### Dim 1 — Public API surface
+- GREEN — `ReclaimGrant` in `ff_core::contracts` alongside `ClaimGrant`,
+  both re-exported from `ff-scheduler`. Clean dep-graph: neither
+  ff-sdk nor ff-scheduler pulls the other.
+- GREEN — `pub async fn claim_from_reclaim_grant(&self, grant)` has
+  the right shape (grant carries partition + lane_id, so no extra
+  parameter bloat).
+- **YELLOW** (`crates/ff-core/src/contracts.rs:98` vs `:144`) —
+  **asymmetric derives**. `ClaimGrant` has `#[derive(Clone, Debug)]`;
+  `ReclaimGrant` has `#[derive(Clone, Debug, PartialEq, Eq)]`. The
+  pair is framed as symmetric ("shared wire-level type between
+  ff-scheduler issuer and ff-sdk consumer" in both docstrings), so
+  the derives should match. Also neither has
+  `Serialize`/`Deserialize` while the surrounding contracts types
+  do — consumers like cairn that bus these over JSON/serde will
+  need to re-implement.
+- **YELLOW** (`crates/ff-core/src/contracts.rs:111-143`) —
+  **`ReclaimGrant` docstring claims scheduler-issued but no
+  producer in-tree.** The doc says "Produced when a suspended or
+  signalled execution is ready to resume on a named worker", but
+  `grep -rn 'ReclaimGrant {'` only finds test fixtures and the
+  struct def. No `ff-scheduler` or `ff-server` code constructs a
+  `ReclaimGrant`. In practice callers (cairn) build one manually
+  from the existing `ff_issue_claim_grant` Lua + an `HGET`
+  round-trip (see test helper
+  `suspend_resume_setup_with_grant` at
+  `crates/ff-test/tests/e2e_lifecycle.rs:8176`). Docstring should
+  either drop the "scheduler issues" framing until a producer
+  exists, or the producer should land in the same PR.
+
+### Dim 2 — Error variant coverage
+- GREEN for the documented surface — the
+  `claim_from_reclaim_grant` docstring lists 5 specific
+  `ScriptError` variants plus transport. All reachable error codes
+  from `ff_claim_resumed_execution` are handled via
+  `ScriptError::from_code_with_detail` inside the underlying
+  `claim_resumed_execution` (`worker.rs:1092+`).
+- **GREEN — no swallowed errors.** The 13-arg path returns
+  `SdkError::Script(Parse(...))` on any shape mismatch, never
+  `unwrap_or_default`'s through a malformed FCALL reply.
+
+### Dim 3 — Test coverage
+- GREEN — 6 tests cover happy / control / expired / wrong_worker /
+  not_resumed / double_consume at
+  `crates/ff-test/tests/e2e_lifecycle.rs:8068+`. Each test has
+  meaningful assertions (attempt_index preservation, state vector
+  transitions, grant_key consumption) rather than path-matching. The
+  `test_claim_from_reclaim_grant_expired` pattern (short TTL +
+  control companion with no sleep) specifically guards against the
+  expiry test passing due to a stuck-clock bug.
+- **YELLOW — no test for concurrency semantics.** This is the same
+  gap that underlies the RED below. There's no test that saturates
+  the worker and then calls `claim_from_reclaim_grant` — which
+  means the missing semaphore acquire is not only not fixed, it's
+  not detectable via the existing test suite.
+
+### Dim 4 — Wire-format / Lua contract alignment
+- GREEN — `ff_claim_resumed_execution` KEYS[11] + ARGV[8] match
+  `lua/signal.lua` per the code comments at
+  `crates/ff-sdk/src/worker.rs:1042`. Structure of the success reply
+  (`{1, "OK", lease_id, lease_epoch, expires_at, attempt_id,
+  attempt_index, attempt_type}`) is the same as
+  `ff_claim_execution`, so the existing parser is correct.
+- GREEN — `ReclaimGrant.partition` + `lane_id` line up with Lua's
+  `KEYS[3]` (eligible_zset) and `KEYS[9]` (active_index), as the
+  struct docstring states.
+
+### Dim 5 — Concurrency semantics
+- **🔴 RED — NO semaphore acquire before the FCALL.**
+  `crates/ff-sdk/src/worker.rs:995-1007`:
+  ```rust
+  pub async fn claim_from_reclaim_grant(
+      &self, grant: ff_core::contracts::ReclaimGrant,
+  ) -> Result<ClaimedTask, SdkError> {
+      self.claim_resumed_execution(
+          &grant.execution_id, &grant.lane_id, &grant.partition,
+      ).await
+  }
+  ```
+  No `self.concurrency_semaphore.clone().try_acquire_owned()` call.
+  Compare with:
+  - `claim_next` (`worker.rs:465`): acquires permit, `Ok(None)` on
+    saturation.
+  - `claim_from_grant` (`worker.rs:959`, P1A per manager's explicit
+    ADDITION): acquires permit, `Err(WorkerAtCapacity)` on
+    saturation.
+  `ff_claim_resumed_execution` atomically consumes the reclaim
+  grant — same failure mode as `ff_claim_execution`. If the worker
+  is at `max_concurrent_tasks` capacity when
+  `claim_from_reclaim_grant` runs, the FCALL consumes the grant
+  and returns a `ClaimedTask` with NO concurrency permit
+  transferred — so the worker silently exceeds the configured cap
+  every time this path succeeds past saturation, and the "permit
+  bank" is never debited for the in-flight resume.
+  Docstring does not document this. No rationale for skipping the
+  check (the reclaim is often on a FRESH worker instance — after
+  a crash or restart — so "already has capacity" can't be
+  assumed).
+
+  **Flagged to manager via team-send at round-1 start; W2 is
+  fixing.** Cited here so the review doc captures the finding
+  durably. Fix pattern must mirror P1A:
+  ```rust
+  let permit = self.concurrency_semaphore.clone()
+      .try_acquire_owned()
+      .map_err(|_| SdkError::WorkerAtCapacity)?;
+  let mut task = self.claim_resumed_execution(...).await?;
+  task.set_concurrency_permit(permit);
+  Ok(task)
+  ```
+  Plus an e2e saturation test mirroring
+  `test_claim_from_grant_rejects_at_capacity`.
+
+### Minor observation (not scored, captured for W3's round)
+- `crates/ff-scheduler/src/claim.rs:525` —
+  `expires_at_ms: now_ms + grant_ttl_ms` is computed Rust-side but
+  the Lua FCALL uses `redis.call("TIME")` for the real grant
+  expiry. Drift of a few ms between Rust host clock and Valkey
+  server clock is invisible to the Lua-side enforcement but shows
+  up if consumers use this field for client-side retry deadlines.
+  Not new in 863f2f0 (the `ClaimGrant` producer code is a
+  pre-existing `return Ok(Some(ClaimGrant { ... }))`), but
+  863f2f0 documents the field as "When the grant expires if not
+  consumed" without the "advisory only" caveat.
+
+## 0b86024 — `pub parse_report_usage_result + usage_dedup_key helper`
+
+### Dim 1 — Public API surface
+- GREEN — `parse_report_usage_result` promoted `fn` → `pub fn` with
+  unchanged signature. `usage_dedup_key` + `USAGE_DEDUP_KEY_PREFIX`
+  added to `ff_core::keys`. Both are narrowly scoped — no internal
+  helper leaks.
+- **YELLOW** (`crates/ff-sdk/src/task.rs:1168` and
+  `crates/ff-core/src/keys.rs:598`) — **Lua filename in doc
+  comments is wrong.** Both docstrings reference
+  `lua/ff_report_usage_and_check.lua`; the function actually lives
+  in `lua/budget.lua` at line 99
+  (`redis.register_function('ff_report_usage_and_check', ...)`).
+  Fix: update the doc comments to `lua/budget.lua` (optionally
+  `lua/budget.lua:99`) so grep-seekers land on a real file.
+
+### Dim 2 — Error variant coverage
+- GREEN for happy paths and the main failure modes — non-Array,
+  non-Int first element, unknown sub-status all emit
+  `SdkError::Script(ScriptError::Parse)`.
+- **YELLOW** (`crates/ff-sdk/src/task.rs:1202-1203, 1208-1209`) —
+  **`.unwrap_or(0)` silently coerces malformed numerics to zero.**
+  Lines 1202/1203 (SoftBreach) and 1208/1209 (HardBreach) parse
+  `current` and `limit` via `.parse().unwrap_or(0)`. If Lua ever
+  emits a non-numeric string (`"inf"`, `"NaN"`, blank on an HGET
+  miss), consumers receive `SoftBreach{current_usage: 0,
+  soft_limit: 0}` — which reads as "success with zero usage" and
+  silently defeats the breach-detection contract the public API
+  is meant to enforce. Should return
+  `SdkError::Script(ScriptError::Parse)` like the rest of the
+  function does for shape violations. Not user-triggerable
+  under current Lua, but the whole point of moving the parser to
+  a shared location is to catch producer-side drift — this one
+  can drift without surfacing.
+
+### Dim 3 — Test coverage
+- GREEN — 6 new tests:
+  - `ff-sdk::parse_report_usage_result_tests`: `ok_status`,
+    `already_applied_status`, `soft_breach_status`,
+    `hard_breach_status`, `non_array_input_is_parse_error`,
+    `first_element_non_int_is_parse_error`
+    (`crates/ff-sdk/src/task.rs:1835-1925`).
+  - `ff-core::tests::usage_dedup_key_format`
+    (`crates/ff-core/src/keys.rs:707`) asserts the exact string
+    shape AND count of `{`/`}` to guard against future accidental
+    double-wrapping.
+- Meaningful assertions throughout — no path-matching.
+- **YELLOW** — no test for the
+  `.parse().unwrap_or(0)` silent-coercion path noted in Dim 2. If
+  that arm is fixed to return `Parse`, add a test with
+  `s("not_a_number")` for the current field to cover it.
+
+### Dim 4 — Wire-format / Lua contract alignment
+- GREEN — verified `lua/budget.lua:99-177`:
+  - Line 115: `return {1, "ALREADY_APPLIED"}`
+  - Line 137: `return {1, "HARD_BREACH", dim, tostring(current),
+    tostring(hard_limit)}`
+  - Line 173: `return {1, "SOFT_BREACH", breached_soft,
+    tostring(cur_val), tostring(soft_val)}`
+  - Line 176: `return {1, "OK"}`
+  Matches the docstring wire-format claim at `task.rs:1159`.
+  `tostring(...)` on the numeric fields means they reach Rust as
+  BulkString or SimpleString — `usage_field_str` handles both.
+- GREEN — `usage_dedup_key(hash_tag, dedup_id)` format
+  (`ff:usagededup:{tag}:{dedup_id}`) matches the Lua consumer's
+  expectations in `lua/budget.lua` (the Lua side reads the full
+  key via `KEYS[...]` so there's no implicit prefix assumption on
+  the script side; the matching side is the two Rust callers now
+  using the helper).
+
+### Dim 5 — Concurrency semantics
+- N/A — the parser is pure, the key-builder is pure. No
+  concurrency-relevant code introduced.
+
+## Summary
+
+- **863f2f0: RED.** The saturation check gap on
+  `claim_from_reclaim_grant` violates the configured
+  `max_concurrent_tasks` contract the SDK advertises and matches
+  the exact scenario manager called out as mandatory for
+  `claim_from_grant`. W2 is fixing per manager's routing.
+- **0b86024: GREEN** with three docstring / defensive-parse
+  polish items. Publishable as-is; YELLOWs should be swept before
+  merge.
+
+Round 2 should validate the W2 fix lands with a saturation test
+and the YELLOWs clear.

--- a/benches/perf-invest/review-r2-w2.md
+++ b/benches/perf-invest/review-r2-w2.md
@@ -1,0 +1,301 @@
+# Cross-review round 2 — Worker-2 reviewing 3cee229 (W1) + c545664 (W1) + 0b86024 (W3)
+
+**Reviewer:** Worker-2
+**Branch:** `feat/cairn-sdk-gaps` @ `4a7a149`
+**Scope:** per manager, W2 reviews W1's `3cee229` + `c545664` and
+W3's `0b86024`. W2 does NOT review own commits (`863f2f0`, the
+downstream `3f140dd` permit-acquire fix, or the downstream
+`4a7a149` ClaimedTask::new revert).
+
+## §1 Verdict table
+
+| SHA     | Subject                                                   | Verdict |
+| ------- | --------------------------------------------------------- | ------- |
+| 3cee229 | ff-sdk: pub ClaimedTask::new                              | **RED → FIXED** in `4a7a149` (revert to `pub(crate)`) |
+| c545664 | ff-sdk: pub claim_from_grant                              | **GREEN** (2 YELLOW) |
+| 0b86024 | ff-core + ff-sdk: pub parse_report_usage_result + usage_dedup_key | **GREEN** (1 YELLOW) |
+
+One blocker surfaced (3cee229 unnecessary API widening), reported
+immediately via team-send, fix approved + landed as `4a7a149`. No
+other RED items. Remaining YELLOWs are documentation / test-coverage
+polish, none block merge.
+
+## §2 3cee229 — `pub ClaimedTask::new`
+
+### RED (now fixed in 4a7a149) — `pub` promotion is unnecessary + footgun
+
+**File:line:** `crates/ff-sdk/src/task.rs:191` (pre-revert).
+
+Commit message claims: "Two new entry points (worker-1:
+claim_from_grant wrapping ff-scheduler's ClaimGrant; worker-2:
+claim_from_reclaim_grant wrapping ReclaimGrant) both need to build
+a ClaimedTask from outside the crate-local helpers."
+
+The factual check:
+
+```
+$ grep -rn 'ClaimedTask::new' --include='*.rs'
+crates/ff-sdk/src/worker.rs:884     (in claim_execution)
+crates/ff-sdk/src/worker.rs:1181    (in claim_resumed_execution)
+```
+
+Both callers are in `ff-sdk/src/worker.rs` — **same crate** as
+`task.rs`. `pub(crate)` was sufficient. The commit's stated
+rationale (cross-crate access) does not apply.
+
+Two concrete harms from the unnecessary promotion:
+
+1. **SemVer lock-in on a 13-arg positional constructor** (`task.rs:191-205`).
+   A future refactor that renames/combines/adds a mandatory field
+   breaks every external caller — even though there are no external
+   callers today. `pub(crate)` keeps the same refactors as non-
+   breaking internal changes.
+
+2. **Silent-footgun via asymmetric visibility.** `set_concurrency_permit`
+   is `pub(crate)` (`task.rs:246`). If an external caller constructs
+   `ClaimedTask::new`, they get a task without a concurrency permit
+   AND cannot attach one. That task then bypasses the semaphore by
+   construction — the exact invariant W1's R1 RED on 863f2f0
+   (missing-permit-acquire in `claim_from_reclaim_grant`) was
+   catching. Keeping `new` at `pub(crate)` eliminates the footgun.
+
+**Status:** fixed at `4a7a149`. `pub(crate) fn new` restored; `dead_code`
+allow dropped (call sites are live). Clippy + ff-sdk + ff-test green
+across `--no-default-features`, default, and `--features
+insecure-direct-claim`.
+
+## §3 c545664 — `pub claim_from_grant`
+
+### GREEN — public API + saturation semantics
+
+**File:line:** `crates/ff-sdk/src/worker.rs:900-968`.
+
+The shape is correct:
+
+- `pub async fn claim_from_grant(&self, lane: LaneId, grant: ff_core::contracts::ClaimGrant) -> Result<ClaimedTask, SdkError>`
+- Explicit `lane` parameter matches the scheduler's `claim_for_worker` signature; no implicit lane-lookup that could drift.
+- `ClaimGrant` consumed by value → compile-time prevents accidental reuse.
+
+The concurrency ordering at `worker.rs:950-963` is the load-bearing
+bit:
+
+```rust
+let permit = self.concurrency_semaphore
+    .clone()
+    .try_acquire_owned()
+    .map_err(|_| SdkError::WorkerAtCapacity)?;
+let now = TimestampMs::now();
+let mut task = self.claim_execution(&grant.execution_id, &lane, &grant.partition, now).await?;
+task.set_concurrency_permit(permit);
+Ok(task)
+```
+
+Permit acquired BEFORE `claim_execution` fires the FCALL. If
+`try_acquire_owned` fails, FCALL never runs → grant untouched. If
+`claim_execution` errors after permit acquisition, the permit drops
+(its owning stack variable goes out of scope), semaphore recycles.
+If `set_concurrency_permit` runs, permit ownership transfers into
+the task and releases on task drop/complete/fail/cancel. The
+ordering is provably correct.
+
+Test coverage at `crates/ff-test/tests/e2e_lifecycle.rs:4218-4418`:
+
+- `test_claim_from_grant_via_scheduler` — happy path, verifies
+  scheduler→SDK shape agreement, attempt_index=0 on fresh claim,
+  execution_kind roundtrip, drop-clean contract.
+- `test_claim_from_grant_rejects_at_capacity` —
+  `max_concurrent_tasks=1`, two same-partition executions to
+  guarantee priority order, first claim holds permit, second grant
+  → `WorkerAtCapacity`, grant_key EXISTS=1 after the refusal,
+  `is_retryable() == true`.
+
+The EXISTS=1 post-refusal check is the critical assertion — it
+proves `ff_claim_execution` was not invoked (because the FCALL
+atomically DELs the grant key on success). Without this check the
+test could pass while silently consuming the grant.
+
+### YELLOW (test) — no "second worker can consume the rejected grant" positive path
+
+`test_claim_from_grant_rejects_at_capacity` asserts the grant key
+is preserved in Valkey after `WorkerAtCapacity`, but does not
+demonstrate that a non-saturated worker can actually consume it.
+A future Lua change that DELs the grant on the capacity-check path
+(hypothetically) would still pass the EXISTS=1 assertion if the
+check fired AFTER the DEL. Adding a second-worker consumption step
+— or asserting the grant's `HGETALL` payload is still populated —
+would close the last gap.
+
+Not a blocker; the current assertion catches the realistic
+regression (forgetting to pre-check the semaphore, which fires the
+FCALL and DELs the key). Flagging for a future tightening.
+
+### YELLOW (error surface) — `WorkerAtCapacity.valkey_kind()` returning `None`
+
+**File:line:** `crates/ff-sdk/src/lib.rs:102`.
+
+Manager's review dimension 3 asked whether `kind=None` risks
+silent classification in a caller's retry loop. Reading cairn's
+retry shape is out of scope here (cairn lives in a separate repo)
+but the contract is reasonable:
+
+- `Self::Config(_) | Self::WorkerAtCapacity => None` matches the
+  intent "this error has no transport kind." A retry loop that
+  dispatches on `valkey_kind` for transport classification won't
+  find WorkerAtCapacity classifiable — correct, because it's not a
+  transport issue.
+- `is_retryable()` returns `true` for WorkerAtCapacity — a caller
+  that routes on the boolean flag sees the retry-eligibility
+  directly.
+
+The cairn-side concern would be a caller that does
+`err.valkey_kind().map(classify_transport).unwrap_or(DropSilently)`.
+That idiom would swallow WorkerAtCapacity. It's also swallowing
+`Config(...)`, which would be worse (a misconfiguration drop would
+never surface), so the pattern is already suspect. Not a problem
+introduced by this commit.
+
+Flagging YELLOW only because the docstring could spell out that
+`WorkerAtCapacity` is classified via `is_retryable()` rather than
+`valkey_kind()`. One-sentence fix; not a blocker.
+
+## §4 0b86024 — `pub parse_report_usage_result + usage_dedup_key`
+
+### GREEN — both promotions sound
+
+**Files:line:**
+- `crates/ff-sdk/src/task.rs:1170` — `parse_report_usage_result` now `pub`.
+- `crates/ff-core/src/keys.rs:600` — `USAGE_DEDUP_KEY_PREFIX` const.
+- `crates/ff-core/src/keys.rs:607` — `usage_dedup_key(hash_tag, dedup_id)`.
+
+All producer sites are migrated (verified by greps on
+`ff:usagededup` and `usagededup`):
+
+- `crates/ff-sdk/src/task.rs:701` — uses helper.
+- `crates/ff-server/src/server.rs:1168` — uses helper.
+- No remaining raw `format!("ff:usagededup:...")` in the tree.
+
+Signature match at both call sites: `hash_tag` comes from
+`bctx.hash_tag()` (returns `&str` with braces already in place,
+e.g. `"{bp:7}"`), and the helper concatenates without double-wrapping.
+The `usage_dedup_key_format` test at `keys.rs:707-713` asserts the
+exactly-one-hash-tag-region invariant, which guards future accidental
+double-wrap.
+
+Lua consumer (`lua/budget.lua:109-167`) takes the dedup_key as an
+opaque ARGV string — no format assumption on the Lua side. Rust
+owns the key format; Lua just passes it to `GET` / `SET`. Wire
+contract is safe.
+
+### YELLOW — negative tests don't catch numeric-parse drift
+
+**File:line:** `crates/ff-sdk/src/task.rs:1200-1215`.
+
+The parser has two `.parse().unwrap_or(0)` fallbacks on the
+SOFT_BREACH and HARD_BREACH numeric fields:
+
+```rust
+let current: u64 = usage_field_str(arr, 3).parse().unwrap_or(0);
+let limit: u64 = usage_field_str(arr, 4).parse().unwrap_or(0);
+```
+
+If the Lua function ever shifts those fields (e.g. swapping in a
+non-numeric string, or reordering so the numeric is in a different
+slot), the parser silently returns `SoftBreach { current: 0, limit: 0 }`
+instead of failing loudly.
+
+The committed negative tests (`non_array_input_is_parse_error`,
+`first_element_non_int_is_parse_error`) guard the outer shape
+(must be Array, first element Int). They don't guard the inner
+numeric slots.
+
+A test like:
+```rust
+let raw = arr(vec![int(1), s("SOFT_BREACH"), s("tokens"), s("not_a_number"), s("100")]);
+// expect either Parse error OR current_usage == 0 with a warning
+```
+— would make the `.unwrap_or(0)` fallback decision explicit
+(surface it or tighten it). Not a regression introduced by
+`0b86024` (the `unwrap_or(0)` predates this commit) but worth
+noting since the commit adds the negative-tests infrastructure.
+
+Not a blocker; flagging for parser hardening follow-up.
+
+### YELLOW — `valkey_kind()` / `is_retryable()` path through `parse_report_usage_result`
+
+The parser returns `SdkError::Script(ScriptError::Parse(...))` on
+shape errors. `ScriptError::Parse` is classified as
+`ErrorClass::NonRetryable` (verified earlier reading
+`ff-script/src/error.rs`). So the negative tests' errors flow
+through `is_retryable() == false` — correct, because a wire-format
+break cannot be fixed by retry. Consistent with existing behavior.
+
+The public promotion does not change the error-routing behavior.
+Noting it GREEN explicitly so the cairn-side caller doesn't have
+to re-derive: `parse_report_usage_result` errors are
+NonRetryable-on-Parse, retryable on transport (since
+`SdkError::is_retryable` delegates to the underlying transport
+kind for `Valkey` variants).
+
+## §5 Cross-cutting concerns
+
+### Manager review dimension 1 (Public API surface)
+
+3cee229 was the only one with a surface issue, now reverted. c545664
+adds `SdkError::WorkerAtCapacity` (new pub variant) + a pub
+`claim_from_grant` method — both minimal and well-scoped. 0b86024
+adds 1 const + 1 fn + 1 fn-promotion, all trivially-scoped.
+
+No accidental cross-crate re-exports. `ClaimGrant`/`ReclaimGrant`
+live in `ff-core::contracts` and are re-exported from
+`ff-scheduler`; the `pub use` re-export pattern is correct for a
+shared wire type.
+
+### Manager review dimension 2 (permit-before-FCALL)
+
+c545664's pattern is sound. My own 863f2f0 had the bug (no permit
+acquire) that W1 caught in R1 — fixed in `3f140dd` mirroring
+c545664. R2 verified both pub entry points now acquire permits
+before firing FCALLs.
+
+### Manager review dimension 3 (WorkerAtCapacity classification)
+
+Done above in §3 YELLOW. Short answer: `is_retryable=true,
+valkey_kind=None` is the right combination. Docstring could note
+the classification path explicitly.
+
+### Manager review dimension 4 (negative tests)
+
+Done above in §4. The committed negative tests guard the outer
+shape but not the inner numeric slots (`unwrap_or(0)` silently
+masks numeric-field drift). Not a regression; flagged for follow-up.
+
+### Manager review dimension 5 (shared-keys helper signature parity)
+
+Done above in §4. All producer sites migrated; no stale
+`format!("ff:usagededup:...")` remaining. Signature matches both
+call sites' `hash_tag` vs `dedup_id` pairing.
+
+## §6 Final state
+
+| commit   | original verdict     | status post-fix |
+| -------- | -------------------- | --------------- |
+| 3cee229  | RED (pub surface)    | FIXED in 4a7a149 |
+| c545664  | GREEN (2 YELLOW)     | ships as-is |
+| 0b86024  | GREEN (1 YELLOW)     | ships as-is |
+| 863f2f0  | (W2's own, reviewed by W1 → RED → fixed in 3f140dd) | fixed |
+
+Branch state at review close:
+```
+4a7a149 fix: revert ClaimedTask::new to pub(crate) (R2 YELLOW-leaning-RED from W2)
+3f140dd fix: claim_from_reclaim_grant must acquire permit (R1 RED from W1)
+e079d8a bench/perf-invest: W1 cross-review R1 of 863f2f0 + 0b86024
+c545664 ff-sdk: pub claim_from_grant
+863f2f0 ff-sdk: ReclaimGrant + claim_from_reclaim_grant
+0b86024 ff-core + ff-sdk: pub parse_report_usage_result + usage_dedup_key helper
+3cee229 ff-sdk: pub ClaimedTask::new  ← effect reverted by 4a7a149
+```
+
+Recommendation: **cleared for merge** from R2 cross-review. All
+RED items have been caught and fixed. Remaining YELLOWs are
+non-blocking (documentation + test-coverage polish items flagged
+for post-merge follow-up).

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -95,7 +95,15 @@ pub enum IssueClaimGrantResult {
 /// Shared wire-level type between `ff-scheduler` (issuer) and
 /// `ff-sdk` (consumer, via `FlowFabricWorker::claim_from_grant`).
 /// Lives in `ff-core` so neither crate needs a dep on the other.
-#[derive(Clone, Debug)]
+///
+/// **Lane asymmetry with [`ReclaimGrant`]:** `ClaimGrant` does NOT
+/// carry `lane_id`. The issuing scheduler's caller already picked
+/// a lane (that's how admission reached this grant) and passes it
+/// through to `claim_from_grant` as a separate argument. The grant
+/// handle stays narrow to what uniquely identifies the admission
+/// decision. The matching field on [`ReclaimGrant`] is an
+/// intentional divergence — see the note on that type.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClaimGrant {
     /// The execution that was granted.
     pub execution_id: ExecutionId,
@@ -110,11 +118,12 @@ pub struct ClaimGrant {
 
 /// A reclaim grant issued for a resumed (attempt_interrupted) execution.
 ///
-/// Produced when a suspended or signalled execution is ready to
-/// resume on a named worker. The worker consumes the grant via
-/// `FlowFabricWorker::claim_from_reclaim_grant`, which calls
-/// `ff_claim_resumed_execution` atomically: that FCALL validates
-/// the grant, consumes it, and transitions `attempt_interrupted` →
+/// Issued by a producer (typically `ff-scheduler` once a Batch-C
+/// reclaim scanner is in place; test fixtures in the interim — no
+/// production Rust caller exists in-tree today). Consumed by
+/// [`FlowFabricWorker::claim_from_reclaim_grant`], which calls
+/// `ff_claim_resumed_execution` atomically: that FCALL validates the
+/// grant, consumes it, and transitions `attempt_interrupted` →
 /// `started` while preserving the existing `attempt_index` +
 /// `attempt_id` (a resumed execution re-uses its attempt; it does
 /// not start a new one).
@@ -132,15 +141,19 @@ pub struct ClaimGrant {
 /// consumes it (`ff_claim_execution` for new attempts,
 /// `ff_claim_resumed_execution` for resumes).
 ///
-/// `lane_id` is carried explicitly (unlike [`ClaimGrant`], where
-/// lane is implicit from the admission side) so the consumer
-/// doesn't pay a `HGET exec_core lane_id` round trip on the hot
-/// claim path — the producer already knows the lane at grant issue
-/// time.
+/// **Lane asymmetry with [`ClaimGrant`]:** `ReclaimGrant` CARRIES
+/// `lane_id` as a field. The issuing path already knows the lane
+/// (it's read from `exec_core` at grant time); carrying it here
+/// spares the consumer a `HGET exec_core lane_id` round trip on
+/// the hot claim path. The asymmetry is intentional — prefer
+/// one-fewer-HGET on a type that already lives with the resumer's
+/// lifecycle over strict handle symmetry with `ClaimGrant`.
 ///
 /// Shared wire-level type between `ff-scheduler` (issuer) and
 /// `ff-sdk` (consumer, via `FlowFabricWorker::claim_from_reclaim_grant`).
 /// Lives in `ff-core` so neither crate needs a dep on the other.
+///
+/// [`FlowFabricWorker::claim_from_reclaim_grant`]: https://docs.rs/ff-sdk
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReclaimGrant {
     /// The execution granted for resumption.

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -86,6 +86,79 @@ pub enum IssueClaimGrantResult {
     Granted { execution_id: ExecutionId },
 }
 
+/// A claim grant issued by the scheduler for a specific execution.
+///
+/// The worker uses this to call `ff_claim_execution` (or
+/// `ff_acquire_lease`), which atomically consumes the grant and
+/// creates the lease.
+///
+/// Shared wire-level type between `ff-scheduler` (issuer) and
+/// `ff-sdk` (consumer, via `FlowFabricWorker::claim_from_grant`).
+/// Lives in `ff-core` so neither crate needs a dep on the other.
+#[derive(Clone, Debug)]
+pub struct ClaimGrant {
+    /// The execution that was granted.
+    pub execution_id: ExecutionId,
+    /// The partition where this execution lives.
+    pub partition: crate::partition::Partition,
+    /// The Valkey key holding the grant hash (for the worker to
+    /// reference).
+    pub grant_key: String,
+    /// When the grant expires if not consumed.
+    pub expires_at_ms: u64,
+}
+
+/// A reclaim grant issued for a resumed (attempt_interrupted) execution.
+///
+/// Produced when a suspended or signalled execution is ready to
+/// resume on a named worker. The worker consumes the grant via
+/// `FlowFabricWorker::claim_from_reclaim_grant`, which calls
+/// `ff_claim_resumed_execution` atomically: that FCALL validates
+/// the grant, consumes it, and transitions `attempt_interrupted` →
+/// `started` while preserving the existing `attempt_index` +
+/// `attempt_id` (a resumed execution re-uses its attempt; it does
+/// not start a new one).
+///
+/// Mirrors [`ClaimGrant`] for the resume path. Differences:
+///
+///   * [`ClaimGrant`] is issued against a freshly-eligible
+///     execution and `ff_claim_execution` creates a new attempt.
+///   * [`ReclaimGrant`] is issued against an `attempt_interrupted`
+///     execution; `ff_claim_resumed_execution` re-uses the existing
+///     attempt and bumps the lease epoch.
+///
+/// The grant itself is written to the same `claim_grant` Valkey key
+/// that [`ClaimGrant`] uses; the distinction is which Lua FCALL
+/// consumes it (`ff_claim_execution` for new attempts,
+/// `ff_claim_resumed_execution` for resumes).
+///
+/// `lane_id` is carried explicitly (unlike [`ClaimGrant`], where
+/// lane is implicit from the admission side) so the consumer
+/// doesn't pay a `HGET exec_core lane_id` round trip on the hot
+/// claim path — the producer already knows the lane at grant issue
+/// time.
+///
+/// Shared wire-level type between `ff-scheduler` (issuer) and
+/// `ff-sdk` (consumer, via `FlowFabricWorker::claim_from_reclaim_grant`).
+/// Lives in `ff-core` so neither crate needs a dep on the other.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReclaimGrant {
+    /// The execution granted for resumption.
+    pub execution_id: ExecutionId,
+    /// The partition the execution lives on.
+    pub partition: crate::partition::Partition,
+    /// Valkey key of the grant hash — same key shape as
+    /// [`ClaimGrant`].
+    pub grant_key: String,
+    /// Monotonic ms when the grant expires; unconsumed grants
+    /// vanish.
+    pub expires_at_ms: u64,
+    /// Lane the execution belongs to. Needed by
+    /// `ff_claim_resumed_execution` for `KEYS[3]` (eligible_zset)
+    /// and `KEYS[9]` (active_index).
+    pub lane_id: LaneId,
+}
+
 // ─── claim_execution ───
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -149,9 +149,11 @@ pub struct ClaimGrant {
 /// one-fewer-HGET on a type that already lives with the resumer's
 /// lifecycle over strict handle symmetry with `ClaimGrant`.
 ///
-/// Shared wire-level type between `ff-scheduler` (issuer) and
-/// `ff-sdk` (consumer, via `FlowFabricWorker::claim_from_reclaim_grant`).
-/// Lives in `ff-core` so neither crate needs a dep on the other.
+/// Shared wire-level type between the eventual `ff-scheduler`
+/// producer (Batch-C reclaim scanner — not yet in-tree; test
+/// fixtures construct this type today) and `ff-sdk` (consumer, via
+/// `FlowFabricWorker::claim_from_reclaim_grant`). Lives in
+/// `ff-core` so neither crate needs a dep on the other.
 ///
 /// [`FlowFabricWorker::claim_from_reclaim_grant`]: https://docs.rs/ff-sdk
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ff-core/src/keys.rs
+++ b/crates/ff-core/src/keys.rs
@@ -595,8 +595,9 @@ pub fn waitpoint_key_resolution(tag: &str, wp_key: &WaitpointKey) -> String {
 
 /// Shared prefix for the usage-dedup keyspace. Must match the
 /// `ff:usagededup:` literal referenced in `lua/**.lua` (notably
-/// `lua/ff_report_usage_and_check.lua`). Grep `ff:usagededup:` to
-/// find all producers, consumers, and test fixtures in one search.
+/// `lua/budget.lua:99`, the `ff_report_usage_and_check` function).
+/// Grep `ff:usagededup:` to find all producers, consumers, and test
+/// fixtures in one search.
 pub const USAGE_DEDUP_KEY_PREFIX: &str = "ff:usagededup:";
 
 /// Build a usage-dedup key: `ff:usagededup:<hash_tag>:<dedup_id>`.

--- a/crates/ff-core/src/keys.rs
+++ b/crates/ff-core/src/keys.rs
@@ -593,6 +593,21 @@ pub fn waitpoint_key_resolution(tag: &str, wp_key: &WaitpointKey) -> String {
     format!("ff:wpkey:{}:{}", tag, wp_key)
 }
 
+/// Shared prefix for the usage-dedup keyspace. Must match the
+/// `ff:usagededup:` literal referenced in `lua/**.lua` (notably
+/// `lua/ff_report_usage_and_check.lua`). Grep `ff:usagededup:` to
+/// find all producers, consumers, and test fixtures in one search.
+pub const USAGE_DEDUP_KEY_PREFIX: &str = "ff:usagededup:";
+
+/// Build a usage-dedup key: `ff:usagededup:<hash_tag>:<dedup_id>`.
+///
+/// `hash_tag` must ALREADY include the Valkey hash-tag braces
+/// (e.g. `"{bp:7}"`) — typically obtained from
+/// [`BudgetKeyContext::hash_tag`]. Do not double-wrap.
+pub fn usage_dedup_key(hash_tag: &str, dedup_id: &str) -> String {
+    format!("{USAGE_DEDUP_KEY_PREFIX}{hash_tag}:{dedup_id}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -686,5 +701,16 @@ mod tests {
         let key = lane_config_key(&lane);
         assert_eq!(key, "ff:lane:default:config");
         assert!(!key.contains('{'));
+    }
+
+    #[test]
+    fn usage_dedup_key_format() {
+        // hash_tag already includes braces — helper must not double-wrap.
+        let key = usage_dedup_key("{bp:7}", "dedup-123");
+        assert_eq!(key, "ff:usagededup:{bp:7}:dedup-123");
+        assert!(key.starts_with(USAGE_DEDUP_KEY_PREFIX));
+        // Exactly one `{…}` hash-tag region.
+        assert_eq!(key.matches('{').count(), 1);
+        assert_eq!(key.matches('}').count(), 1);
     }
 }

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -49,10 +49,12 @@ fn worker_caps_digest(csv: &str) -> String {
 /// share one wire-level type without a cross-dep between them.
 pub use ff_core::contracts::ClaimGrant;
 
-/// A reclaim grant issued for a resumed (attempt_interrupted) execution.
+/// A reclaim grant for a resumed (attempt_interrupted) execution.
 ///
-/// Re-exported from [`ff_core::contracts::ReclaimGrant`] for
-/// symmetry with [`ClaimGrant`]. Consumed by
+/// Re-export of [`ff_core::contracts::ReclaimGrant`] for symmetry
+/// with [`ClaimGrant`]. `ff-scheduler` will be the canonical
+/// producer once the Batch-C reclaim scanner lands; today only
+/// test fixtures construct this type. Consumed by
 /// `FlowFabricWorker::claim_from_reclaim_grant`.
 pub use ff_core::contracts::ReclaimGrant;
 

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -44,19 +44,17 @@ fn worker_caps_digest(csv: &str) -> String {
 
 /// A claim grant issued by the scheduler for a specific execution.
 ///
-/// The worker uses this to call `ff_claim_execution` (or `ff_acquire_lease`)
-/// which atomically consumes the grant and creates the lease.
-#[derive(Debug)]
-pub struct ClaimGrant {
-    /// The execution that was granted.
-    pub execution_id: ExecutionId,
-    /// The partition where this execution lives.
-    pub partition: Partition,
-    /// The Valkey key holding the grant hash (for the worker to reference).
-    pub grant_key: String,
-    /// When the grant expires if not consumed.
-    pub expires_at_ms: u64,
-}
+/// Re-exported from [`ff_core::contracts::ClaimGrant`]. Lives in
+/// `ff-core` so `ff-scheduler` (issuer) and `ff-sdk` (consumer)
+/// share one wire-level type without a cross-dep between them.
+pub use ff_core::contracts::ClaimGrant;
+
+/// A reclaim grant issued for a resumed (attempt_interrupted) execution.
+///
+/// Re-exported from [`ff_core::contracts::ReclaimGrant`] for
+/// symmetry with [`ClaimGrant`]. Consumed by
+/// `FlowFabricWorker::claim_from_reclaim_grant`.
+pub use ff_core::contracts::ReclaimGrant;
 
 /// Budget check result from a cross-partition budget read.
 #[derive(Debug)]

--- a/crates/ff-scheduler/src/lib.rs
+++ b/crates/ff-scheduler/src/lib.rs
@@ -2,4 +2,4 @@
 
 pub mod claim;
 
-pub use claim::{ClaimGrant, Scheduler, SchedulerError};
+pub use claim::{ClaimGrant, ReclaimGrant, Scheduler, SchedulerError};

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -75,6 +75,19 @@ pub enum SdkError {
     /// Configuration error.
     #[error("config: {0}")]
     Config(String),
+
+    /// Worker is at its configured `max_concurrent_tasks` capacity —
+    /// the caller should retry later. Returned by
+    /// [`FlowFabricWorker::claim_from_grant`] when the concurrency
+    /// semaphore is saturated. Distinct from `Ok(None)`: a
+    /// `ClaimGrant` represents real work already selected by the
+    /// scheduler, so silently dropping it would waste the grant and
+    /// let the grant TTL elapse. Surfacing the saturation lets the
+    /// caller release the grant (or wait + retry).
+    ///
+    /// [`FlowFabricWorker::claim_from_grant`]: crate::FlowFabricWorker::claim_from_grant
+    #[error("worker at capacity: max_concurrent_tasks reached")]
+    WorkerAtCapacity,
 }
 
 impl SdkError {
@@ -86,7 +99,7 @@ impl SdkError {
             Self::Valkey(e) => Some(e.kind()),
             Self::ValkeyContext { source, .. } => Some(source.kind()),
             Self::Script(e) => e.valkey_kind(),
-            Self::Config(_) => None,
+            Self::Config(_) | Self::WorkerAtCapacity => None,
         }
     }
 
@@ -102,6 +115,9 @@ impl SdkError {
             Self::Script(e) => {
                 matches!(e.class(), ff_core::error::ErrorClass::Retryable)
             }
+            // WorkerAtCapacity is retryable: the saturation is transient
+            // and clears as soon as a concurrent task completes.
+            Self::WorkerAtCapacity => true,
             Self::Config(_) => false,
         }
     }

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -39,6 +39,26 @@
 //!     }
 //! }
 //! ```
+//!
+//! # Migration: `insecure-direct-claim` → scheduler-issued grants
+//!
+//! The `insecure-direct-claim` cargo feature — which gates
+//! [`FlowFabricWorker::claim_next`] — is **deprecated** in favour of
+//! the pair of scheduler-issued grant entry points:
+//!
+//! * [`FlowFabricWorker::claim_from_grant`] — fresh claims. Use
+//!   `ff_scheduler::Scheduler::claim_for_worker` to obtain the
+//!   [`ClaimGrant`], then hand it to the SDK.
+//! * [`FlowFabricWorker::claim_from_reclaim_grant`] — resumed claims
+//!   for an `attempt_interrupted` execution. Wraps a
+//!   [`ReclaimGrant`].
+//!
+//! `claim_next` bypasses budget and quota admission control; the
+//! grant-based path does not. See each method's rustdoc for the
+//! exact migration recipe.
+//!
+//! [`ClaimGrant`]: ff_core::contracts::ClaimGrant
+//! [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
 
 pub mod config;
 pub mod task;
@@ -78,14 +98,30 @@ pub enum SdkError {
 
     /// Worker is at its configured `max_concurrent_tasks` capacity —
     /// the caller should retry later. Returned by
-    /// [`FlowFabricWorker::claim_from_grant`] when the concurrency
-    /// semaphore is saturated. Distinct from `Ok(None)`: a
-    /// `ClaimGrant` represents real work already selected by the
-    /// scheduler, so silently dropping it would waste the grant and
-    /// let the grant TTL elapse. Surfacing the saturation lets the
-    /// caller release the grant (or wait + retry).
+    /// [`FlowFabricWorker::claim_from_grant`] and
+    /// [`FlowFabricWorker::claim_from_reclaim_grant`] when the
+    /// concurrency semaphore is saturated. Distinct from `Ok(None)`:
+    /// a `ClaimGrant`/`ReclaimGrant` represents real work already
+    /// selected by the scheduler, so silently dropping it would waste
+    /// the grant and let the grant TTL elapse. Surfacing the
+    /// saturation lets the caller release the grant (or wait +
+    /// retry).
+    ///
+    /// # Classification
+    ///
+    /// * [`SdkError::is_retryable`] returns `true` — saturation is
+    ///   transient: any in-flight task's
+    ///   complete/fail/cancel/drop releases a permit. Retry after
+    ///   milliseconds, not a retry loop with backoff for a Valkey
+    ///   transport failure.
+    /// * [`SdkError::valkey_kind`] returns `None` — this is not a
+    ///   Valkey transport or Lua error, so there is no
+    ///   `ferriskey::ErrorKind` to inspect. Callers that fan out
+    ///   on `valkey_kind()` should match `WorkerAtCapacity`
+    ///   explicitly (or use `is_retryable()`).
     ///
     /// [`FlowFabricWorker::claim_from_grant`]: crate::FlowFabricWorker::claim_from_grant
+    /// [`FlowFabricWorker::claim_from_reclaim_grant`]: crate::FlowFabricWorker::claim_from_reclaim_grant
     #[error("worker at capacity: max_concurrent_tasks reached")]
     WorkerAtCapacity,
 }

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -187,8 +187,8 @@ pub struct ClaimedTask {
 }
 
 impl ClaimedTask {
-    #[allow(clippy::too_many_arguments, dead_code)]
-    pub fn new(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
         client: Client,
         partition_config: PartitionConfig,
         execution_id: ExecutionId,

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -188,7 +188,7 @@ pub struct ClaimedTask {
 
 impl ClaimedTask {
     #[allow(clippy::too_many_arguments, dead_code)]
-    pub(crate) fn new(
+    pub fn new(
         client: Client,
         partition_config: PartitionConfig,
         execution_id: ExecutionId,

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -187,6 +187,58 @@ pub struct ClaimedTask {
 }
 
 impl ClaimedTask {
+    /// Construct a `ClaimedTask` from the results of a successful
+    /// `ff_claim_execution` or `ff_claim_resumed_execution` FCALL.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` — shared Valkey client used for subsequent lease
+    ///   renewals, signal delivery, and the final
+    ///   complete/fail/cancel FCALL.
+    /// * `partition_config` — partition topology snapshot read at
+    ///   `FlowFabricWorker::connect`. Used for key construction on
+    ///   the lifetime of this task.
+    /// * `execution_id` — the claimed execution's UUID.
+    /// * `attempt_index` / `attempt_id` — current attempt identity.
+    ///   `attempt_index` is 0 on a fresh claim, preserved on a
+    ///   resumed claim.
+    /// * `lease_id` / `lease_epoch` — lease identity. `lease_epoch`
+    ///   is returned by the Lua FCALL and bumped on each resumed
+    ///   claim.
+    /// * `lease_ttl_ms` — lease TTL used to schedule the background
+    ///   renewal task (renews at `lease_ttl_ms / 3`).
+    /// * `lane_id` — the lane the task was claimed on. Used for
+    ///   index key construction (`lane_active`, `lease_expiry`,
+    ///   etc.).
+    /// * `worker_instance_id` — this worker's identity. Used to
+    ///   resolve `worker_leases` index entries during renewal and
+    ///   completion.
+    /// * `input_payload` / `execution_kind` / `tags` — pre-read
+    ///   execution metadata, exposed via getters so the worker
+    ///   doesn't round-trip to Valkey to inspect what it just
+    ///   claimed.
+    ///
+    /// # Invariant: constructor is `pub(crate)` on purpose
+    ///
+    /// **External callers cannot construct a `ClaimedTask`** — only
+    /// the in-crate claim entry points (`claim_next`,
+    /// `claim_from_grant`, `claim_from_reclaim_grant`) may. This is
+    /// load-bearing: those entry points are the ONLY sites that
+    /// acquire a permit from the worker's concurrency semaphore
+    /// (via `FlowFabricWorker::concurrency_semaphore`) and attach
+    /// it through `ClaimedTask::set_concurrency_permit` before
+    /// returning the task. Promoting `new` to `pub` would let
+    /// consumers build tasks that bypass the concurrency contract
+    /// the worker's `max_concurrent_tasks` config advertises — the
+    /// returned task would run alongside other in-flight work
+    /// without debiting the permit bank, and the
+    /// complete/fail/cancel/drop path would have nothing to
+    /// release.
+    ///
+    /// If an external callsite genuinely needs to rehydrate a
+    /// task from saved FCALL results, the right answer is a new
+    /// `FlowFabricWorker` entry point that wraps `new` + acquires a
+    /// permit — not promoting this constructor.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         client: Client,
@@ -1164,9 +1216,9 @@ fn is_terminal_renewal_error(err: &ScriptError) -> bool {
 /// Exposed as `pub` so downstream SDKs that speak the same wire format
 /// — notably cairn-fabric's `budget_service::parse_spend_result` — can
 /// call this directly instead of re-implementing the parse. Keeping one
-/// parser paired with the producer (the Lua function in
-/// `lua/ff_report_usage_and_check.lua`) is the defence against silent
-/// format drift between producer and consumer.
+/// parser paired with the producer (the Lua function registered at
+/// `lua/budget.lua:99`, `ff_report_usage_and_check`) is the defence
+/// against silent format drift between producer and consumer.
 pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,
@@ -1199,14 +1251,14 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
         "ALREADY_APPLIED" => Ok(ReportUsageResult::AlreadyApplied),
         "SOFT_BREACH" => {
             let dim = usage_field_str(arr, 2);
-            let current: u64 = usage_field_str(arr, 3).parse().unwrap_or(0);
-            let limit: u64 = usage_field_str(arr, 4).parse().unwrap_or(0);
+            let current = parse_usage_u64(arr, 3, "SOFT_BREACH", "current_usage")?;
+            let limit = parse_usage_u64(arr, 4, "SOFT_BREACH", "soft_limit")?;
             Ok(ReportUsageResult::SoftBreach { dimension: dim, current_usage: current, soft_limit: limit })
         }
         "HARD_BREACH" => {
             let dim = usage_field_str(arr, 2);
-            let current: u64 = usage_field_str(arr, 3).parse().unwrap_or(0);
-            let limit: u64 = usage_field_str(arr, 4).parse().unwrap_or(0);
+            let current = parse_usage_u64(arr, 3, "HARD_BREACH", "current_usage")?;
+            let limit = parse_usage_u64(arr, 4, "HARD_BREACH", "hard_limit")?;
             Ok(ReportUsageResult::HardBreach {
                 dimension: dim,
                 current_usage: current,
@@ -1225,6 +1277,60 @@ fn usage_field_str(arr: &[Result<Value, ferriskey::Error>], index: usize) -> Str
         Some(Ok(Value::SimpleString(s))) => s.clone(),
         Some(Ok(Value::Int(n))) => n.to_string(),
         _ => String::new(),
+    }
+}
+
+/// Parse a required numeric usage field (u64) from the wire array at
+/// `index`. Returns `Err(ScriptError::Parse)` if the slot is missing,
+/// holds a non-string/non-int value, or contains a string that does
+/// not parse as u64.
+///
+/// Rationale: the Lua producer (`lua/budget.lua:99`,
+/// `ff_report_usage_and_check`) always emits
+/// `tostring(current_usage)` / `tostring(soft_or_hard_limit)` for
+/// SOFT_BREACH/HARD_BREACH, never an empty slot. A missing or
+/// non-numeric value here means the Lua and Rust sides drifted;
+/// silently coercing to `0` would surface drift as "zero-usage breach"
+/// — arithmetically correct but semantically nonsense. Fail loudly
+/// instead so drift shows up as a parse error at the first call site.
+fn parse_usage_u64(
+    arr: &[Result<Value, ferriskey::Error>],
+    index: usize,
+    sub_status: &str,
+    field_name: &str,
+) -> Result<u64, SdkError> {
+    match arr.get(index) {
+        Some(Ok(Value::Int(n))) => {
+            u64::try_from(*n).map_err(|_| {
+                SdkError::Script(ScriptError::Parse(format!(
+                    "ff_report_usage_and_check {sub_status}: {field_name} \
+                     (index {index}) negative int {n} cannot be u64"
+                )))
+            })
+        }
+        Some(Ok(Value::BulkString(b))) => {
+            let s = String::from_utf8_lossy(b);
+            s.parse::<u64>().map_err(|_| {
+                SdkError::Script(ScriptError::Parse(format!(
+                    "ff_report_usage_and_check {sub_status}: {field_name} \
+                     (index {index}) not a u64 string: {s:?}"
+                )))
+            })
+        }
+        Some(Ok(Value::SimpleString(s))) => s.parse::<u64>().map_err(|_| {
+            SdkError::Script(ScriptError::Parse(format!(
+                "ff_report_usage_and_check {sub_status}: {field_name} \
+                 (index {index}) not a u64 string: {s:?}"
+            )))
+        }),
+        Some(_) => Err(SdkError::Script(ScriptError::Parse(format!(
+            "ff_report_usage_and_check {sub_status}: {field_name} \
+             (index {index}) wrong wire type (expected Int or String)"
+        )))),
+        None => Err(SdkError::Script(ScriptError::Parse(format!(
+            "ff_report_usage_and_check {sub_status}: {field_name} \
+             (index {index}) missing from response"
+        )))),
     }
 }
 
@@ -1920,6 +2026,58 @@ mod parse_report_usage_result_tests {
         assert!(
             msg.to_lowercase().contains("int"),
             "error should mention Int status code, got: {msg}"
+        );
+    }
+
+    /// Negative case: SOFT_BREACH with a non-numeric `current_usage`
+    /// field. Guards against the silent-coercion defect cross-review
+    /// caught: the old parser used `.unwrap_or(0)` on numeric fields,
+    /// which would have surfaced Lua-side wire-format drift as a
+    /// `SoftBreach { current_usage: 0, ... }` — arithmetically valid
+    /// but semantically wrong (a "breach with zero usage" is nonsense
+    /// and masks the real error).
+    #[test]
+    fn soft_breach_non_numeric_current_is_parse_error() {
+        let raw = arr(vec![
+            int(1),
+            s("SOFT_BREACH"),
+            s("tokens"),
+            s("not_a_number"), // current_usage — must fail, not coerce to 0
+            s("100"),
+        ]);
+        let err = parse_report_usage_result(&raw).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("SOFT_BREACH") && msg.contains("current_usage"),
+            "error should identify sub-status + field, got: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("u64"),
+            "error should mention the expected type (u64), got: {msg}"
+        );
+    }
+
+    /// Negative case: HARD_BREACH with the limit slot missing
+    /// entirely. Same defence as the non-numeric test above: a
+    /// truncated response must fail loudly rather than coerce to 0.
+    #[test]
+    fn hard_breach_missing_limit_is_parse_error() {
+        let raw = arr(vec![
+            int(1),
+            s("HARD_BREACH"),
+            s("requests"),
+            s("10001"),
+            // no index 4 — hard_limit missing
+        ]);
+        let err = parse_report_usage_result(&raw).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("HARD_BREACH") && msg.contains("hard_limit"),
+            "error should identify sub-status + field, got: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("missing"),
+            "error should say 'missing', got: {msg}"
         );
     }
 }

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use ferriskey::{Client, Value};
 use ff_core::contracts::ReportUsageResult;
 use ff_script::error::ScriptError;
-use ff_core::keys::{BudgetKeyContext, ExecKeyContext, IndexKeys};
+use ff_core::keys::{usage_dedup_key, BudgetKeyContext, ExecKeyContext, IndexKeys};
 use ff_core::partition::{budget_partition, execution_partition, PartitionConfig};
 use ff_core::types::*;
 use tokio::sync::{Notify, OwnedSemaphorePermit};
@@ -698,7 +698,7 @@ impl ClaimedTask {
         argv.push(now.to_string());
         let dedup_key_val = dedup_key
             .filter(|k| !k.is_empty())
-            .map(|k| format!("ff:usagededup:{}:{}", bctx.hash_tag(), k))
+            .map(|k| usage_dedup_key(bctx.hash_tag(), k))
             .unwrap_or_default();
         argv.push(dedup_key_val);
 
@@ -1153,10 +1153,21 @@ fn is_terminal_renewal_error(err: &ScriptError) -> bool {
 
 // ── FCALL result parsing ──
 
-/// Parse ff_report_usage_and_check result.
-/// Standard format: {1, "OK"}, {1, "SOFT_BREACH", dim, current, limit},
-///                  {1, "HARD_BREACH", dim, current, limit}, {1, "ALREADY_APPLIED"}
-fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkError> {
+/// Parse the wire-format result of the `ff_report_usage_and_check` Lua
+/// function into a typed [`ReportUsageResult`].
+///
+/// Standard format: `{1, "OK"}`, `{1, "SOFT_BREACH", dim, current, limit}`,
+///                  `{1, "HARD_BREACH", dim, current, limit}`, `{1, "ALREADY_APPLIED"}`.
+/// Status code `!= 1` is parsed as a [`ScriptError`] via
+/// [`ScriptError::from_code_with_detail`].
+///
+/// Exposed as `pub` so downstream SDKs that speak the same wire format
+/// — notably cairn-fabric's `budget_service::parse_spend_result` — can
+/// call this directly instead of re-implementing the parse. Keeping one
+/// parser paired with the producer (the Lua function in
+/// `lua/ff_report_usage_and_check.lua`) is the defence against silent
+/// format drift between producer and consumer.
+pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
@@ -1819,4 +1830,96 @@ pub async fn tail_stream(
     )
     .await
     .map_err(SdkError::Script)
+}
+
+#[cfg(test)]
+mod parse_report_usage_result_tests {
+    use super::*;
+
+    /// `Value::SimpleString` from a `&str`. `usage_field_str` handles
+    /// BulkString and SimpleString uniformly (see
+    /// `usage_field_str` — `Value::BulkString(b)` → `String::from_utf8_lossy`,
+    /// `Value::SimpleString(s)` → clone). SimpleString avoids a
+    /// dev-dependency on `bytes` just for test construction.
+    fn s(v: &str) -> Result<Value, ferriskey::Error> {
+        Ok(Value::SimpleString(v.to_owned()))
+    }
+
+    fn int(n: i64) -> Result<Value, ferriskey::Error> {
+        Ok(Value::Int(n))
+    }
+
+    fn arr(items: Vec<Result<Value, ferriskey::Error>>) -> Value {
+        Value::Array(items)
+    }
+
+    #[test]
+    fn ok_status() {
+        let raw = arr(vec![int(1), s("OK")]);
+        assert_eq!(parse_report_usage_result(&raw).unwrap(), ReportUsageResult::Ok);
+    }
+
+    #[test]
+    fn already_applied_status() {
+        let raw = arr(vec![int(1), s("ALREADY_APPLIED")]);
+        assert_eq!(
+            parse_report_usage_result(&raw).unwrap(),
+            ReportUsageResult::AlreadyApplied
+        );
+    }
+
+    #[test]
+    fn soft_breach_status() {
+        let raw = arr(vec![int(1), s("SOFT_BREACH"), s("tokens"), s("150"), s("100")]);
+        match parse_report_usage_result(&raw).unwrap() {
+            ReportUsageResult::SoftBreach { dimension, current_usage, soft_limit } => {
+                assert_eq!(dimension, "tokens");
+                assert_eq!(current_usage, 150);
+                assert_eq!(soft_limit, 100);
+            }
+            other => panic!("expected SoftBreach, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hard_breach_status() {
+        let raw = arr(vec![int(1), s("HARD_BREACH"), s("requests"), s("10001"), s("10000")]);
+        match parse_report_usage_result(&raw).unwrap() {
+            ReportUsageResult::HardBreach { dimension, current_usage, hard_limit } => {
+                assert_eq!(dimension, "requests");
+                assert_eq!(current_usage, 10001);
+                assert_eq!(hard_limit, 10000);
+            }
+            other => panic!("expected HardBreach, got {other:?}"),
+        }
+    }
+
+    /// Negative case: non-Array input. Guards against a future Lua refactor
+    /// that accidentally returns a bare string/int — the parser must fail
+    /// loudly rather than silently succeed or panic.
+    #[test]
+    fn non_array_input_is_parse_error() {
+        let raw = Value::SimpleString("OK".to_owned());
+        let err = parse_report_usage_result(&raw).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("expected array"),
+            "error should mention expected shape, got: {msg}"
+        );
+    }
+
+    /// Negative case: Array whose first element isn't an Int status code.
+    /// The Lua function's first return slot is always `status_code` (1 on
+    /// success, an error code otherwise); a non-Int there is a wire-format
+    /// break that must surface as a parse error.
+    #[test]
+    fn first_element_non_int_is_parse_error() {
+        let raw = arr(vec![s("not_an_int"), s("OK")]);
+        let err = parse_report_usage_result(&raw).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("int"),
+            "error should mention Int status code, got: {msg}"
+        );
+    }
 }

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -13,7 +13,6 @@ use ff_core::types::*;
 use tokio::sync::Semaphore;
 
 use crate::config::WorkerConfig;
-#[cfg(feature = "insecure-direct-claim")]
 use crate::task::ClaimedTask;
 use crate::SdkError;
 
@@ -887,7 +886,53 @@ impl FlowFabricWorker {
         ))
     }
 
-    #[cfg(feature = "insecure-direct-claim")]
+    /// Consume a [`ReclaimGrant`] and transition the granted
+    /// `attempt_interrupted` execution into a `started` state on this
+    /// worker. Symmetric partner to `claim_from_grant` for the resume
+    /// path.
+    ///
+    /// The grant must have been issued to THIS worker (matching
+    /// `worker_id` at grant time). A mismatch returns
+    /// `Err(Script(InvalidClaimGrant))`. The grant is consumed
+    /// atomically by `ff_claim_resumed_execution`; a second call with
+    /// the same grant also returns `InvalidClaimGrant`.
+    ///
+    /// # Errors
+    ///
+    /// * `ScriptError::InvalidClaimGrant` — grant missing, consumed,
+    ///   or `worker_id` mismatch.
+    /// * `ScriptError::ClaimGrantExpired` — grant TTL elapsed.
+    /// * `ScriptError::NotAResumedExecution` — `attempt_state` is not
+    ///   `attempt_interrupted`.
+    /// * `ScriptError::ExecutionNotLeaseable` — `lifecycle_phase` is
+    ///   not `runnable`.
+    /// * `ScriptError::ExecutionNotFound` — core key missing.
+    /// * `SdkError::Valkey` / `SdkError::ValkeyContext` — transport.
+    ///
+    /// [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
+    pub async fn claim_from_reclaim_grant(
+        &self,
+        grant: ff_core::contracts::ReclaimGrant,
+    ) -> Result<ClaimedTask, SdkError> {
+        // Grant carries partition + lane_id so no round-trip is needed
+        // to resolve them before the FCALL.
+        self.claim_resumed_execution(
+            &grant.execution_id,
+            &grant.lane_id,
+            &grant.partition,
+        )
+        .await
+    }
+
+    /// Low-level resume claim. Invokes `ff_claim_resumed_execution`
+    /// and returns a `ClaimedTask` bound to the resumed attempt.
+    ///
+    /// Previously gated behind `insecure-direct-claim`; ungated so the
+    /// public [`claim_from_reclaim_grant`] entry point can reuse it.
+    /// The method stays private — external callers use
+    /// `claim_from_reclaim_grant`.
+    ///
+    /// [`claim_from_reclaim_grant`]: FlowFabricWorker::claim_from_reclaim_grant
     async fn claim_resumed_execution(
         &self,
         execution_id: &ExecutionId,
@@ -1033,7 +1078,10 @@ impl FlowFabricWorker {
         ))
     }
 
-    #[cfg(feature = "insecure-direct-claim")]
+    /// Read payload + execution_kind + tags from exec_core. Previously
+    /// gated behind `insecure-direct-claim`; now shared by the
+    /// feature-gated inline claim path and the public
+    /// `claim_from_reclaim_grant` entry point.
     async fn read_execution_context(
         &self,
         execution_id: &ExecutionId,

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 #[cfg(feature = "insecure-direct-claim")]
 use std::sync::atomic::{AtomicUsize, Ordering};
-#[cfg(feature = "insecure-direct-claim")]
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,7 +8,6 @@ use ferriskey::{Client, ClientBuilder, Value};
 use ff_core::keys::{ExecKeyContext, IndexKeys};
 use ff_core::partition::PartitionConfig;
 use ff_core::types::*;
-#[cfg(feature = "insecure-direct-claim")]
 use tokio::sync::Semaphore;
 
 use crate::config::WorkerConfig;
@@ -65,7 +63,15 @@ pub struct FlowFabricWorker {
     worker_capabilities_hash: String,
     #[cfg(feature = "insecure-direct-claim")]
     lane_index: AtomicUsize,
-    #[cfg(feature = "insecure-direct-claim")]
+    /// Concurrency cap for in-flight tasks. Permits are acquired by
+    /// [`claim_next`] (feature-gated) and
+    /// [`claim_from_grant`] (always available), transferred to the
+    /// returned [`ClaimedTask`], and released on task
+    /// complete/fail/cancel/drop. Holds `max_concurrent_tasks` permits
+    /// total.
+    ///
+    /// [`claim_next`]: FlowFabricWorker::claim_next
+    /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
     concurrency_semaphore: Arc<Semaphore>,
     /// Rolling offset for chunked partition scans. Each poll advances the
     /// cursor by `PARTITION_SCAN_CHUNK`, so over `ceil(num_partitions /
@@ -196,9 +202,7 @@ impl FlowFabricWorker {
                 PartitionConfig::default()
             });
 
-        #[cfg(feature = "insecure-direct-claim")]
         let max_tasks = config.max_concurrent_tasks.max(1);
-        #[cfg(feature = "insecure-direct-claim")]
         let concurrency_semaphore = Arc::new(Semaphore::new(max_tasks));
 
         tracing::info!(
@@ -399,7 +403,6 @@ impl FlowFabricWorker {
             worker_capabilities_hash,
             #[cfg(feature = "insecure-direct-claim")]
             lane_index: AtomicUsize::new(0),
-            #[cfg(feature = "insecure-direct-claim")]
             concurrency_semaphore,
             #[cfg(feature = "insecure-direct-claim")]
             scan_cursor: AtomicUsize::new(scan_cursor_init),
@@ -721,7 +724,16 @@ impl FlowFabricWorker {
         }
     }
 
-    #[cfg(feature = "insecure-direct-claim")]
+    /// Low-level claim of a granted execution. Invokes
+    /// `ff_claim_execution` and returns a `ClaimedTask` with auto
+    /// lease renewal.
+    ///
+    /// Previously gated behind `insecure-direct-claim`; ungated so
+    /// the public [`claim_from_grant`] entry point can reuse the
+    /// same FCALL plumbing. The method stays private — external
+    /// callers use `claim_from_grant`.
+    ///
+    /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
     async fn claim_execution(
         &self,
         execution_id: &ExecutionId,
@@ -884,6 +896,76 @@ impl FlowFabricWorker {
             execution_kind,
             tags,
         ))
+    }
+
+    /// Consume a [`ClaimGrant`] and claim the granted execution on
+    /// this worker. The intended production entry point: pair with
+    /// [`ff_scheduler::Scheduler::claim_for_worker`] to flow
+    /// scheduler-issued grants into the SDK without enabling the
+    /// `insecure-direct-claim` feature (which bypasses budget/quota
+    /// admission control).
+    ///
+    /// The worker's concurrency semaphore is checked BEFORE the FCALL
+    /// so a saturated worker does not consume the grant: the grant
+    /// stays valid for its remaining TTL and the caller can either
+    /// release it back to the scheduler or retry after some other
+    /// in-flight task completes.
+    ///
+    /// On success the returned [`ClaimedTask`] holds a concurrency
+    /// permit that releases automatically on
+    /// `complete`/`fail`/`cancel`/drop — same contract as
+    /// `claim_next`.
+    ///
+    /// # Arguments
+    ///
+    /// * `lane` — the lane the grant was issued for. Must match what
+    ///   was passed to `Scheduler::claim_for_worker`; the Lua FCALL
+    ///   uses it to look up `lane_eligible`, `lane_active`, and the
+    ///   `worker_leases` index slot.
+    /// * `grant` — the [`ClaimGrant`] returned by the scheduler.
+    ///
+    /// # Errors
+    ///
+    /// * [`SdkError::WorkerAtCapacity`] — `max_concurrent_tasks`
+    ///   permits all held. Retryable; the grant is untouched.
+    /// * `ScriptError::InvalidClaimGrant` — grant missing, consumed,
+    ///   or `worker_id` mismatch (wrapped in [`SdkError::Script`]).
+    /// * `ScriptError::ClaimGrantExpired` — grant TTL elapsed
+    ///   (wrapped in [`SdkError::Script`]).
+    /// * `ScriptError::CapabilityMismatch` — execution's required
+    ///   capabilities not a subset of this worker's caps (wrapped in
+    ///   [`SdkError::Script`]). Surfaced post-grant if a race
+    ///   between grant issuance and caps change allows it.
+    /// * `ScriptError::Parse` — `ff_claim_execution` returned an
+    ///   unexpected shape (wrapped in [`SdkError::Script`]).
+    /// * [`SdkError::Valkey`] / [`SdkError::ValkeyContext`] —
+    ///   transport error during the FCALL or the
+    ///   `read_execution_context` follow-up.
+    ///
+    /// [`ClaimGrant`]: ff_core::contracts::ClaimGrant
+    /// [`ff_scheduler::Scheduler::claim_for_worker`]: https://docs.rs/ff-scheduler
+    pub async fn claim_from_grant(
+        &self,
+        lane: LaneId,
+        grant: ff_core::contracts::ClaimGrant,
+    ) -> Result<ClaimedTask, SdkError> {
+        // Semaphore check FIRST. If the worker is saturated we must
+        // surface the condition to the caller without touching the
+        // grant — silently returning Ok(None) (as claim_next does)
+        // would drop a grant the scheduler has already committed work
+        // to issuing, wasting the slot until its TTL elapses.
+        let permit = self
+            .concurrency_semaphore
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| SdkError::WorkerAtCapacity)?;
+
+        let now = TimestampMs::now();
+        let mut task = self
+            .claim_execution(&grant.execution_id, &lane, &grant.partition, now)
+            .await?;
+        task.set_concurrency_permit(permit);
+        Ok(task)
     }
 
     /// Consume a [`ReclaimGrant`] and transition the granted

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -970,8 +970,8 @@ impl FlowFabricWorker {
 
     /// Consume a [`ReclaimGrant`] and transition the granted
     /// `attempt_interrupted` execution into a `started` state on this
-    /// worker. Symmetric partner to `claim_from_grant` for the resume
-    /// path.
+    /// worker. Symmetric partner to [`claim_from_grant`] for the
+    /// resume path.
     ///
     /// The grant must have been issued to THIS worker (matching
     /// `worker_id` at grant time). A mismatch returns
@@ -979,8 +979,26 @@ impl FlowFabricWorker {
     /// atomically by `ff_claim_resumed_execution`; a second call with
     /// the same grant also returns `InvalidClaimGrant`.
     ///
+    /// # Concurrency
+    ///
+    /// The worker's concurrency semaphore is checked BEFORE the FCALL
+    /// (same contract as [`claim_from_grant`]). Reclaim does NOT
+    /// assume pre-existing capacity on this worker — a reclaim can
+    /// land on a fresh worker instance that just came up after a
+    /// crash/restart and is picking up a previously-interrupted
+    /// execution. If the worker is saturated, the grant stays valid
+    /// for its remaining TTL and the caller can release it or retry.
+    ///
+    /// On success the returned [`ClaimedTask`] holds a concurrency
+    /// permit that releases automatically on
+    /// `complete`/`fail`/`cancel`/drop.
+    ///
     /// # Errors
     ///
+    /// * [`SdkError::WorkerAtCapacity`] — `max_concurrent_tasks`
+    ///   permits all held. Retryable; the grant is untouched (no
+    ///   FCALL was issued, so `ff_claim_resumed_execution` did not
+    ///   atomically consume the grant key).
     /// * `ScriptError::InvalidClaimGrant` — grant missing, consumed,
     ///   or `worker_id` mismatch.
     /// * `ScriptError::ClaimGrantExpired` — grant TTL elapsed.
@@ -989,21 +1007,38 @@ impl FlowFabricWorker {
     /// * `ScriptError::ExecutionNotLeaseable` — `lifecycle_phase` is
     ///   not `runnable`.
     /// * `ScriptError::ExecutionNotFound` — core key missing.
-    /// * `SdkError::Valkey` / `SdkError::ValkeyContext` — transport.
+    /// * [`SdkError::Valkey`] / [`SdkError::ValkeyContext`] —
+    ///   transport.
     ///
     /// [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
+    /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
     pub async fn claim_from_reclaim_grant(
         &self,
         grant: ff_core::contracts::ReclaimGrant,
     ) -> Result<ClaimedTask, SdkError> {
+        // Semaphore check FIRST — same load-bearing ordering as
+        // `claim_from_grant`. If the worker is saturated, surface
+        // WorkerAtCapacity without firing the FCALL; the FCALL is an
+        // atomic consume on the grant key, so calling it past-
+        // saturation would destroy the grant while leaving no
+        // permit to attach to the returned `ClaimedTask`.
+        let permit = self
+            .concurrency_semaphore
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| SdkError::WorkerAtCapacity)?;
+
         // Grant carries partition + lane_id so no round-trip is needed
         // to resolve them before the FCALL.
-        self.claim_resumed_execution(
-            &grant.execution_id,
-            &grant.lane_id,
-            &grant.partition,
-        )
-        .await
+        let mut task = self
+            .claim_resumed_execution(
+                &grant.execution_id,
+                &grant.lane_id,
+                &grant.partition,
+            )
+            .await?;
+        task.set_concurrency_permit(permit);
+        Ok(task)
     }
 
     /// Low-level resume claim. Invokes `ff_claim_resumed_execution`

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -63,15 +63,16 @@ pub struct FlowFabricWorker {
     worker_capabilities_hash: String,
     #[cfg(feature = "insecure-direct-claim")]
     lane_index: AtomicUsize,
-    /// Concurrency cap for in-flight tasks. Permits are acquired by
-    /// [`claim_next`] (feature-gated) and
-    /// [`claim_from_grant`] (always available), transferred to the
-    /// returned [`ClaimedTask`], and released on task
-    /// complete/fail/cancel/drop. Holds `max_concurrent_tasks` permits
-    /// total.
+    /// Concurrency cap for in-flight tasks. Permits are acquired or
+    /// transferred by [`claim_next`] (feature-gated),
+    /// [`claim_from_grant`] (always available), and
+    /// [`claim_from_reclaim_grant`], transferred to the returned
+    /// [`ClaimedTask`], and released on task complete/fail/cancel/drop.
+    /// Holds `max_concurrent_tasks` permits total.
     ///
     /// [`claim_next`]: FlowFabricWorker::claim_next
     /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
+    /// [`claim_from_reclaim_grant`]: FlowFabricWorker::claim_from_reclaim_grant
     concurrency_semaphore: Arc<Semaphore>,
     /// Rolling offset for chunked partition scans. Each poll advances the
     /// cursor by `PARTITION_SCAN_CHUNK`, so over `ceil(num_partitions /

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -18,8 +18,8 @@ use ff_core::contracts::{
     StageDependencyEdgeArgs, StageDependencyEdgeResult,
 };
 use ff_core::keys::{
-    self, BudgetKeyContext, ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys,
-    QuotaKeyContext,
+    self, usage_dedup_key, BudgetKeyContext, ExecKeyContext, FlowIndexKeys, FlowKeyContext,
+    IndexKeys, QuotaKeyContext,
 };
 use ff_core::partition::{
     budget_partition, execution_partition, flow_partition, quota_partition, Partition,
@@ -1165,7 +1165,7 @@ impl Server {
             .dedup_key
             .as_ref()
             .filter(|k| !k.is_empty())
-            .map(|k| format!("ff:usagededup:{}:{}", bctx.hash_tag(), k))
+            .map(|k| usage_dedup_key(bctx.hash_tag(), k))
             .unwrap_or_default();
         fcall_args.push(dedup_key_val);
 

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -19,6 +19,7 @@ release = false
 ff-core = { workspace = true }
 ff-engine = { workspace = true }
 ff-scheduler = { workspace = true }
+ff-script = { workspace = true }
 ff-sdk = { workspace = true, features = ["insecure-direct-claim"] }
 ferriskey = { workspace = true }
 tokio = { workspace = true }

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4407,10 +4407,62 @@ async fn test_claim_from_grant_rejects_at_capacity() {
         .expect("EXISTS on grant_key");
     assert_eq!(exists, 1, "grant_key must still exist after capacity reject");
 
-    // Release the first task — normally the scheduler or a different
-    // worker would now be able to consume g2. Here we just want the
-    // test to leave the cluster clean.
+    // Stronger proof that the grant is not just present but still
+    // live: spin up a second FlowFabricWorker with available
+    // capacity and have it consume the same grant. If
+    // claim_from_grant had leaked the FCALL through on the first
+    // worker, ff_claim_execution would have atomically consumed
+    // the grant key and this second claim would return
+    // `InvalidClaimGrant`. Ok here is proof of liveness.
+    //
+    // Same worker_id / worker_instance_id so Lua's worker match
+    // on the grant passes — we're modelling a retry from a fresh
+    // worker process with free capacity, not a different identity.
+    let second_worker_config = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        worker_id: ff_core::types::WorkerId::new(WORKER),
+        // Distinct instance id so the alive-key SET NX guard in
+        // `FlowFabricWorker::connect` doesn't reject us as a
+        // duplicate — same worker_id, new process identity.
+        worker_instance_id: ff_core::types::WorkerInstanceId::new("cap-second-inst"),
+        namespace: ff_core::types::Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 16,
+    };
+    let second_worker = ff_sdk::FlowFabricWorker::connect(second_worker_config)
+        .await
+        .expect("second worker should connect");
+
+    // Reconstruct the grant struct by hand — the original `g2` was
+    // moved into the saturated call. The grant values are
+    // unchanged; we just rebuild the Rust wrapper around the same
+    // Valkey key.
+    let rebuilt_g2 = ff_core::contracts::ClaimGrant {
+        execution_id: eid_b.clone(),
+        partition: ff_core::partition::execution_partition(&eid_b, &test_config()),
+        grant_key: g2_key.clone(),
+        // expires_at_ms is advisory on the consumer side; Lua
+        // enforces the real expiry via its own TIME read, so
+        // copying any value from the pre-rejection grant is fine.
+        expires_at_ms: u64::MAX,
+    };
+
+    let task2 = second_worker
+        .claim_from_grant(lane_id.clone(), rebuilt_g2)
+        .await
+        .expect("second worker with free capacity must consume the still-live grant");
+    assert_eq!(*task2.execution_id(), eid_b);
+
+    // Cleanup both tasks so the test leaves the cluster in a
+    // serial-safe state.
     task1.complete(None).await.unwrap();
+    task2.complete(None).await.unwrap();
 }
 
 // ─── Phase 7: Integration tests ───

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4215,6 +4215,204 @@ async fn test_scheduler_claim_priority_ordering() {
     assert!(grant4.is_none(), "no more eligible executions");
 }
 
+/// End-to-end: `Scheduler::claim_for_worker` → `FlowFabricWorker::
+/// claim_from_grant` → live `ClaimedTask`. This is the production
+/// entry path for consumers that cannot enable the
+/// `insecure-direct-claim` feature (cairn, in particular) — the
+/// scheduler does admission control and hands off a grant; the SDK
+/// consumes the grant without touching the eligible ZSET directly.
+///
+/// Asserts:
+///  1. the grant issued by the scheduler is consumable by
+///     `claim_from_grant` (no shape mismatch between the two layers).
+///  2. the returned `ClaimedTask` carries the correct attempt_index
+///     (0 for a fresh claim), execution_id, and kind/tags.
+///  3. `complete()` drops the lease cleanly — proving the concurrency
+///     permit was acquired + transferred properly (otherwise the task
+///     drop would panic on a non-transferred renewal handle).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_grant_via_scheduler() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    let eid = ExecutionId::new();
+    fcall_create_execution(&tc, &eid, NS, LANE, "claim_from_grant_test", 500).await;
+
+    // Issue grant via the Scheduler — not via raw FCALL — so the
+    // test exercises the scheduler-to-SDK handoff shape.
+    let scheduler = ff_scheduler::claim::Scheduler::new(
+        tc.client().clone(),
+        test_config(),
+    );
+    let lane_id = LaneId::new(LANE);
+    let worker_id = ff_core::types::WorkerId::new(WORKER);
+    let wiid = ff_core::types::WorkerInstanceId::new(WORKER_INST);
+    let no_caps = std::collections::BTreeSet::<String>::new();
+
+    let grant = scheduler
+        .claim_for_worker(&lane_id, &worker_id, &wiid, &no_caps, 30_000)
+        .await
+        .expect("scheduler should not error")
+        .expect("the created execution should be eligible");
+    assert_eq!(grant.execution_id, eid, "grant should point at our execution");
+
+    // Hand the grant to the SDK worker. `build_reclaim_test_worker`
+    // configures lanes=[LANE] and max_concurrent_tasks=16 — enough
+    // headroom that the semaphore is never the gating factor here.
+    let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
+    let claimed = worker
+        .claim_from_grant(lane_id.clone(), grant)
+        .await
+        .expect("claim_from_grant should succeed on a fresh grant");
+
+    assert_eq!(*claimed.execution_id(), eid, "claimed task should carry our eid");
+    assert_eq!(
+        claimed.attempt_index().0, 0,
+        "fresh claim should have attempt_index 0"
+    );
+    assert_eq!(claimed.execution_kind(), "claim_from_grant_test");
+
+    // Drop-clean contract: complete() releases the lease, renewal
+    // task, and concurrency permit.
+    claimed.complete(Some(b"ok".to_vec())).await
+        .expect("complete should succeed");
+
+    // State sanity: execution terminal + no active lease.
+    assert_execution_state(&tc, &eid, &ExpectedState {
+        public_state: Some(ff_core::state::PublicState::Completed),
+        ..Default::default()
+    }).await;
+}
+
+/// Saturation guard: when the worker's `max_concurrent_tasks` is
+/// fully committed, `claim_from_grant` must return
+/// `SdkError::WorkerAtCapacity` WITHOUT calling
+/// `ff_claim_execution` — otherwise the grant would be atomically
+/// consumed by the Lua FCALL even though the SDK can't run the
+/// work, and the next scheduler tick would see a stuck execution.
+///
+/// Asserts:
+///   1. A worker with `max_concurrent_tasks=1` plus one permit in
+///      flight refuses the second grant with
+///      `SdkError::WorkerAtCapacity`.
+///   2. The grant stays valid — a different worker can consume it.
+///   3. `SdkError::WorkerAtCapacity.is_retryable()` is `true`
+///      (sanity).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_grant_rejects_at_capacity() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    // Two separate executions so that if the first claim somehow
+    // releases, we still catch the saturation on the second one.
+    // Generate UUIDs until both hash to the SAME execution partition —
+    // otherwise the scheduler's jittered partition scan may pick them
+    // up in a different order than priority dictates (the scheduler
+    // visits partitions linearly, priority-ordering is only guaranteed
+    // within a single partition).
+    let (eid_a, eid_b) = {
+        let config = test_config();
+        loop {
+            let a = ExecutionId::new();
+            let b = ExecutionId::new();
+            let pa = ff_core::partition::execution_partition(&a, &config);
+            let pb = ff_core::partition::execution_partition(&b, &config);
+            if pa.index == pb.index {
+                break (a, b);
+            }
+        }
+    };
+    fcall_create_execution(&tc, &eid_a, NS, LANE, "cap_test", 100).await;
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    fcall_create_execution(&tc, &eid_b, NS, LANE, "cap_test", 50).await;
+
+    // Build a worker with max_concurrent_tasks=1 so the second claim
+    // is guaranteed to saturate. Use the standard worker identity
+    // so both grants are issued to this worker_id.
+    let worker_config = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        worker_id: ff_core::types::WorkerId::new(WORKER),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(WORKER_INST),
+        namespace: ff_core::types::Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    let worker = ff_sdk::FlowFabricWorker::connect(worker_config).await.unwrap();
+
+    let scheduler = ff_scheduler::claim::Scheduler::new(
+        tc.client().clone(),
+        test_config(),
+    );
+    let lane_id = LaneId::new(LANE);
+    let worker_id_t = ff_core::types::WorkerId::new(WORKER);
+    let wiid_t = ff_core::types::WorkerInstanceId::new(WORKER_INST);
+    let no_caps = std::collections::BTreeSet::<String>::new();
+
+    // 1st grant (highest priority on the shared partition = eid_a).
+    // Succeeds and holds the sole permit.
+    let g1 = scheduler
+        .claim_for_worker(&lane_id, &worker_id_t, &wiid_t, &no_caps, 30_000)
+        .await
+        .unwrap()
+        .expect("eligible execution present");
+    assert_eq!(
+        g1.execution_id, eid_a,
+        "same-partition priority: eid_a (100) comes before eid_b (50)"
+    );
+
+    let task1 = worker
+        .claim_from_grant(lane_id.clone(), g1)
+        .await
+        .expect("first claim should take the permit");
+
+    // 2nd grant (eid_b). Semaphore is drained — claim_from_grant
+    // must refuse without consuming the grant.
+    let g2 = scheduler
+        .claim_for_worker(&lane_id, &worker_id_t, &wiid_t, &no_caps, 30_000)
+        .await
+        .unwrap()
+        .expect("second eligible execution present");
+    assert_eq!(g2.execution_id, eid_b);
+    let g2_key = g2.grant_key.clone();
+
+    match worker.claim_from_grant(lane_id.clone(), g2).await {
+        Err(ff_sdk::SdkError::WorkerAtCapacity) => {}
+        Err(other) => panic!("expected WorkerAtCapacity, got {other:?}"),
+        Ok(_) => panic!("saturated worker should not claim"),
+    }
+
+    // Retryability sanity check.
+    assert!(
+        ff_sdk::SdkError::WorkerAtCapacity.is_retryable(),
+        "capacity saturation is transient"
+    );
+
+    // Grant unharmed: the grant key still exists in Valkey (FCALL
+    // was not called, so the grant hash was not atomically deleted).
+    let exists: i64 = tc.client()
+        .cmd("EXISTS")
+        .arg(&g2_key)
+        .execute()
+        .await
+        .expect("EXISTS on grant_key");
+    assert_eq!(exists, 1, "grant_key must still exist after capacity reject");
+
+    // Release the first task — normally the scheduler or a different
+    // worker would now be able to consume g2. Here we just want the
+    // test to leave the cluster clean.
+    task1.complete(None).await.unwrap();
+}
+
 // ─── Phase 7: Integration tests ───
 
 /// Budget enforcement e2e: report 5 tokens (OK), report 6 more (HARD_BREACH),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -8477,3 +8477,95 @@ async fn test_claim_from_reclaim_grant_double_consume() {
     // linger into other serial tests.
     claimed.complete(None).await.unwrap();
 }
+
+/// Saturation guard for `claim_from_reclaim_grant` — mirrors
+/// `test_claim_from_grant_rejects_at_capacity`. A worker at
+/// `max_concurrent_tasks=1` with its single permit in flight must
+/// refuse a second reclaim grant with `SdkError::WorkerAtCapacity`
+/// WITHOUT invoking `ff_claim_resumed_execution` (so the grant key
+/// is not atomically consumed).
+///
+/// Caught during cross-review round 2: the original
+/// `claim_from_reclaim_grant` did NOT acquire a concurrency permit,
+/// which on a saturated worker silently exceeded
+/// `max_concurrent_tasks` and handed back a `ClaimedTask` without a
+/// permit to release — violating the concurrency contract the user
+/// configured. Fix mirrors W1's `claim_from_grant` saturation
+/// pattern exactly.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_reclaim_grant_rejects_at_capacity() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    // Set up two independently-suspended executions so we have two
+    // reclaim grants to try against the same worker. Both use the
+    // standard e2e worker identity so both grants are targeted at
+    // the same worker_id.
+    let eid_a = ExecutionId::new();
+    let grant_a = suspend_resume_setup_with_grant(
+        &tc, &eid_a, 30_000, WORKER, WORKER_INST,
+    ).await;
+    let eid_b = ExecutionId::new();
+    let grant_b = suspend_resume_setup_with_grant(
+        &tc, &eid_b, 30_000, WORKER, WORKER_INST,
+    ).await;
+    let grant_b_key = grant_b.grant_key.clone();
+
+    // Build a worker with max_concurrent_tasks=1 so the second
+    // reclaim is guaranteed to saturate.
+    let worker_config = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        worker_id: ff_core::types::WorkerId::new(WORKER),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(WORKER_INST),
+        namespace: ff_core::types::Namespace::new(NS),
+        lanes: vec![ff_core::types::LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    let worker = ff_sdk::FlowFabricWorker::connect(worker_config).await.unwrap();
+
+    // 1st reclaim takes the sole permit.
+    let task_a = worker
+        .claim_from_reclaim_grant(grant_a)
+        .await
+        .expect("first reclaim should take the permit");
+
+    // 2nd reclaim must refuse at capacity, BEFORE invoking the Lua
+    // FCALL that would atomically consume the grant key.
+    match worker.claim_from_reclaim_grant(grant_b).await {
+        Err(ff_sdk::SdkError::WorkerAtCapacity) => {}
+        Err(other) => panic!("expected WorkerAtCapacity, got {other:?}"),
+        Ok(_) => panic!("saturated worker should not claim"),
+    }
+
+    // Retryability sanity check — same contract as claim_from_grant.
+    assert!(
+        ff_sdk::SdkError::WorkerAtCapacity.is_retryable(),
+        "capacity saturation is transient"
+    );
+
+    // Grant unharmed: grant_b's claim_grant key is still present in
+    // Valkey. If the FCALL had fired on a saturated worker we'd see
+    // EXISTS=0 here (the Lua DELs the key on consume).
+    let exists: i64 = tc.client()
+        .cmd("EXISTS")
+        .arg(&grant_b_key)
+        .execute()
+        .await
+        .expect("EXISTS on grant_key");
+    assert_eq!(exists, 1,
+        "reclaim grant_key must still exist after capacity reject — \
+         claim_from_reclaim_grant must not fire ff_claim_resumed_execution \
+         when the semaphore is drained");
+
+    // Cleanup so the lease from task_a doesn't linger into the next
+    // serial test.
+    task_a.complete(None).await.unwrap();
+}

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -7917,3 +7917,365 @@ async fn test_capable_worker_unblocks_on_get_error_failopen() {
          (fail-open on transient errors preserves liveness)"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// FlowFabricWorker::claim_from_reclaim_grant (cairn-fabric P1B)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Write the test partition config into Valkey so the SDK's worker
+/// reads the same 4-partition layout as `fcall_create_execution`.
+/// Without this, `FlowFabricWorker` picks up whatever config was
+/// already there (often the 256-partition default from a prior
+/// server run), and the `ReclaimGrant.partition` computed from
+/// `test_config()` points at a core-key that doesn't exist.
+async fn write_test_partition_config(tc: &TestCluster) {
+    let config = test_config();
+    let _: () = tc.client().cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_execution_partitions")
+        .arg(config.num_execution_partitions.to_string().as_str())
+        .arg("num_flow_partitions")
+        .arg(config.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(config.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(config.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+/// Build a `FlowFabricWorker` configured for the suspend→signal→resume
+/// flow using the standard e2e worker identity.
+async fn build_reclaim_test_worker(
+    worker_id: &str,
+    worker_instance_id: &str,
+) -> ff_sdk::FlowFabricWorker {
+    let config = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        worker_id: ff_core::types::WorkerId::new(worker_id),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(worker_instance_id),
+        namespace: ff_core::types::Namespace::new(NS),
+        lanes: vec![ff_core::types::LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 16,
+    };
+    ff_sdk::FlowFabricWorker::connect(config).await.unwrap()
+}
+
+/// Drive an execution through create → claim → suspend → deliver-signal,
+/// leaving it in `attempt_interrupted` with the suspended/runnable
+/// transition already completed. Returns the eid plus the `ReclaimGrant`
+/// a caller can pass to `claim_from_reclaim_grant`.
+///
+/// `grant_ttl_ms` is the TTL for the claim-grant the resumed-path
+/// consumer reads. Short TTL = fast expiry test; long TTL = happy path.
+async fn suspend_resume_setup_with_grant(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    grant_ttl_ms: u64,
+    grant_worker_id: &str,
+    grant_worker_instance_id: &str,
+) -> ff_core::contracts::ReclaimGrant {
+    // 1. create + claim the initial attempt
+    fcall_create_execution(tc, eid, NS, LANE, "reclaim_grant_test", 0).await;
+    fcall_issue_claim_grant(tc, eid, LANE, WORKER, WORKER_INST).await;
+    let (lease_id, epoch, att_idx, attempt_id) =
+        fcall_claim_execution(tc, eid, LANE, WORKER, WORKER_INST, 30_000).await;
+
+    // 2. suspend (fail-on-timeout path to avoid timer noise)
+    let resume_cond = build_resume_condition_json(&["approval_result"], "fail");
+    let (_susp_id, waitpoint_id, _wp_key, _sub_status, wp_token) =
+        fcall_suspend_execution(
+            tc, eid, LANE, WORKER_INST,
+            &lease_id, &epoch, &att_idx, &attempt_id,
+            "waiting_for_approval", &resume_cond, None, "fail",
+        ).await;
+
+    // 3. deliver signal so the execution transitions to runnable +
+    //    attempt_interrupted
+    let (_sig_id, effect) = fcall_deliver_signal(
+        tc, eid, LANE, &waitpoint_id,
+        "approval_result", "approval", "", &wp_token,
+    ).await;
+    assert_eq!(effect, "resume_condition_satisfied");
+
+    // 4. issue the reclaim grant — for the resumed flow, the grant is
+    //    written by ff_issue_claim_grant (same key). We want a
+    //    configurable TTL so expiry tests can dial it down; the existing
+    //    fcall_issue_claim_grant helper uses a hardcoded 5 s TTL, so
+    //    inline the FCALL here to parameterise grant_ttl_ms.
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.claim_grant(),
+        idx.lane_eligible(&lane_id),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        grant_worker_id.to_owned(),
+        grant_worker_instance_id.to_owned(),
+        LANE.to_owned(),
+        String::new(),               // capability_hash
+        grant_ttl_ms.to_string(),    // grant_ttl_ms (parameterised)
+        String::new(),               // route_snapshot_json
+        String::new(),               // admission_summary
+        String::new(),               // worker_capabilities_csv
+    ];
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_issue_claim_grant", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_issue_claim_grant failed");
+    assert_ok(&raw, "ff_issue_claim_grant");
+
+    // 5. read grant_expires_at from the claim_grant hash
+    let grant_key = ctx.claim_grant();
+    let expires_at_str: Option<String> = tc.hget(&grant_key, "grant_expires_at").await;
+    let expires_at_ms: u64 = expires_at_str
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .expect("grant_expires_at should be numeric");
+
+    ff_core::contracts::ReclaimGrant {
+        execution_id: eid.clone(),
+        partition,
+        grant_key,
+        expires_at_ms,
+        lane_id,
+    }
+}
+
+/// Happy path + control: `claim_from_reclaim_grant` resumes the
+/// suspended execution cleanly. Paired with the expiry test — both use
+/// the same setup; this one consumes the grant immediately to prove
+/// the flow works, the other waits out the TTL to prove the expiry
+/// check fires.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_reclaim_grant_happy_path() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    let eid = ExecutionId::new();
+    // Long TTL so there's no race with the HGET / FlowFabricWorker
+    // construction below.
+    let grant = suspend_resume_setup_with_grant(
+        &tc, &eid, 30_000, WORKER, WORKER_INST,
+    ).await;
+
+    let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
+    let claimed = worker
+        .claim_from_reclaim_grant(grant)
+        .await
+        .expect("happy path should succeed");
+
+    // Resumed execution preserves attempt_index 0 — a resume re-uses
+    // the existing attempt.
+    assert_eq!(claimed.attempt_index().0, 0,
+        "resumed execution should keep attempt_index 0");
+
+    // Verify active state after consumption.
+    assert_execution_state(&tc, &eid, &ExpectedState {
+        lifecycle_phase: Some(ff_core::state::LifecyclePhase::Active),
+        ownership_state: Some(ff_core::state::OwnershipState::Leased),
+        attempt_state: Some(ff_core::state::AttemptState::RunningAttempt),
+        public_state: Some(ff_core::state::PublicState::Active),
+        ..Default::default()
+    }).await;
+
+    // Complete to release the lease.
+    claimed.complete(Some(b"reclaim-done".to_vec())).await.unwrap();
+}
+
+/// Control companion to the expired-grant test: at the SAME setup
+/// (short TTL) with NO sleep, the claim should succeed. Guards against
+/// the expiry test passing due to a stuck-clock Lua bug rather than a
+/// real TTL check.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_reclaim_grant_immediate_control() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    let eid = ExecutionId::new();
+    // Short TTL — same knob the expiry test uses. No sleep here, so
+    // the grant is still fresh when claimed.
+    let grant = suspend_resume_setup_with_grant(
+        &tc, &eid, 500, WORKER, WORKER_INST,
+    ).await;
+
+    let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
+    let claimed = worker
+        .claim_from_reclaim_grant(grant)
+        .await
+        .expect("control: short-TTL grant claimed immediately should still succeed");
+
+    claimed.complete(None).await.unwrap();
+}
+
+/// Expired grant → `ScriptError::ClaimGrantExpired`. Run AFTER the
+/// control test above so the exit condition isn't confused with
+/// "short TTL always fails" flakiness.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_reclaim_grant_expired() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    let eid = ExecutionId::new();
+    // 200 ms TTL — small enough to wait out cheaply, large enough that
+    // the setup FCALLs finish well inside it.
+    let grant = suspend_resume_setup_with_grant(
+        &tc, &eid, 200, WORKER, WORKER_INST,
+    ).await;
+
+    // Let the grant expire.
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+
+    let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
+    match worker.claim_from_reclaim_grant(grant).await {
+        // Either error is acceptable:
+        //   * `ClaimGrantExpired` fires when the FCALL observes the
+        //     grant key still present but `grant_expires_at < now_ms`
+        //     (Lua deletes the key and returns this code).
+        //   * `InvalidClaimGrant` fires when Valkey's PEXPIREAT has
+        //     already evicted the key before the FCALL reaches
+        //     HGETALL (#grant_raw == 0).
+        // Both signal the same root cause — the grant's TTL elapsed.
+        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::ClaimGrantExpired)) => {}
+        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::InvalidClaimGrant)) => {}
+        Err(other) => panic!("expected ClaimGrantExpired or InvalidClaimGrant, got {other:?}"),
+        Ok(_) => panic!("expired grant should not succeed"),
+    }
+}
+
+/// Grant issued to worker A → worker B calls `claim_from_reclaim_grant`
+/// → `ScriptError::InvalidClaimGrant`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_reclaim_grant_wrong_worker() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    let eid = ExecutionId::new();
+    // Grant issued for "worker-a".
+    let grant = suspend_resume_setup_with_grant(
+        &tc, &eid, 30_000, "worker-a", "worker-a-inst",
+    ).await;
+
+    // Build a FlowFabricWorker with a DIFFERENT worker_id.
+    let worker = build_reclaim_test_worker("worker-b", "worker-b-inst").await;
+    match worker.claim_from_reclaim_grant(grant).await {
+        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::InvalidClaimGrant)) => {}
+        Err(other) => panic!("expected InvalidClaimGrant, got {other:?}"),
+        Ok(_) => panic!("worker-id mismatch should not succeed"),
+    }
+}
+
+/// Execution that was never suspended (attempt_state != attempt_interrupted)
+/// → `ScriptError::NotAResumedExecution`. Builds a plain create+claim
+/// execution, issues a grant, then tries to consume it via the RESUME
+/// path instead of the normal claim path.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_reclaim_grant_not_resumed() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    let eid = ExecutionId::new();
+    fcall_create_execution(&tc, &eid, NS, LANE, "not_resumed_test", 0).await;
+    fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
+    // DO NOT suspend + deliver_signal. Execution is in ClaimGrant state
+    // but attempt_state = NotAttempted (the initial claim hasn't fired
+    // yet) — not attempt_interrupted.
+
+    // Build the ReclaimGrant manually from the just-issued grant key.
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let grant_key = ctx.claim_grant();
+    let expires_at_str: Option<String> = tc.hget(&grant_key, "grant_expires_at").await;
+    let expires_at_ms: u64 = expires_at_str.as_deref().and_then(|s| s.parse().ok()).unwrap();
+
+    let grant = ff_core::contracts::ReclaimGrant {
+        execution_id: eid.clone(),
+        partition,
+        grant_key,
+        expires_at_ms,
+        lane_id: LaneId::new(LANE),
+    };
+
+    let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
+    match worker.claim_from_reclaim_grant(grant).await {
+        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::NotAResumedExecution)) => {}
+        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::ExecutionNotLeaseable)) => {
+            // Acceptable alternate: some Lua orderings check
+            // lifecycle_phase (runnable) before attempt_state. Either
+            // error signals the same root cause — this is a non-
+            // resumed execution, reject.
+        }
+        Err(other) => panic!("expected NotAResumedExecution or ExecutionNotLeaseable, got {other:?}"),
+        Ok(_) => panic!("non-resumed execution should not succeed"),
+    }
+}
+
+/// Grant is consumed atomically — a second call with the same grant
+/// fails with `InvalidClaimGrant`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_claim_from_reclaim_grant_double_consume() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    write_test_partition_config(&tc).await;
+
+    let eid = ExecutionId::new();
+    let grant = suspend_resume_setup_with_grant(
+        &tc, &eid, 30_000, WORKER, WORKER_INST,
+    ).await;
+
+    let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
+
+    // First consumption succeeds.
+    let claimed = worker
+        .claim_from_reclaim_grant(grant.clone())
+        .await
+        .expect("first consume should succeed");
+
+    // Second consume with the same grant handle must fail. The
+    // underlying Valkey `claim_grant` key was DEL'd by the first
+    // consume, AND the execution's `lifecycle_phase` transitioned
+    // from `runnable` to `active`. The Lua FCALL checks
+    // `lifecycle_phase == runnable` (line 524 of signal.lua) BEFORE
+    // grant validation, so the error surfaced first is
+    // `ExecutionNotLeaseable`. If an attacker/race ordered calls
+    // differently we'd also see `InvalidClaimGrant` — accept either
+    // as proof the second consume was rejected.
+    match worker.claim_from_reclaim_grant(grant).await {
+        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::ExecutionNotLeaseable)) => {}
+        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::InvalidClaimGrant)) => {}
+        Err(other) => panic!("expected ExecutionNotLeaseable or InvalidClaimGrant on second consume, got {other:?}"),
+        Ok(_) => panic!("second consume should not succeed"),
+    }
+
+    // Cleanup: complete the still-live claim so the lease doesn't
+    // linger into other serial tests.
+    claimed.complete(None).await.unwrap();
+}


### PR DESCRIPTION
## Summary
Closes 4 of 6 cairn-fabric ff-sdk gaps that block retiring the \`insecure-direct-claim\` feature in cairn production.

- **P1A (W1)**: \`pub async fn FlowFabricWorker::claim_from_grant(lane, grant)\` — wrap \`ClaimGrant\` → \`ClaimedTask\` without the insecure feature gate. Saturation checked before FCALL so a saturated worker never consumes the grant.
- **P1B (W2)**: \`pub async fn FlowFabricWorker::claim_from_reclaim_grant(grant)\` + new \`ReclaimGrant\` type for the resume path.
- **P2 (W3)**: \`pub fn parse_report_usage_result\` — drop private gate so cairn's parallel parser can delete its copy, eliminating wire-format drift risk.
- **P3.4 (W3)**: \`ff_core::keys::usage_dedup_key\` — shared helper replaces 2 hardcoded \`format!(\"ff:usagededup:...\")\` call sites.
- **Shared prerequisite**: \`pub ClaimedTask::new\` (W1 landed first, both P1A and P1B depend on it).

Both \`ClaimGrant\` and \`ReclaimGrant\` live in \`ff-core::contracts\`, re-exported by \`ff-scheduler\` for backward compatibility. No cross-dep added between ff-scheduler and ff-sdk.

## Commit stack
- \`3cee229\` ff-sdk: pub ClaimedTask::new (shared prereq)
- \`0b86024\` ff-core + ff-sdk: pub parse_report_usage_result + shared usage-dedup-key helper (W3)
- \`863f2f0\` ff-sdk: ReclaimGrant + claim_from_reclaim_grant (W2, P1B)
- \`c545664\` ff-sdk: pub claim_from_grant (W1, P1A)

## Deferred
- **P3.5** — productionize \`rotate_waitpoint_hmac_secret\` from ff-test fixtures. Not required for P1A/P1B retirement; separate PR.
- **P3.6** — FF-side bridge-event completeness audit. Separate scope, requires Lua-side inventory.

## Test plan
- [ ] CI: cargo check --workspace clean
- [ ] CI: cargo clippy --workspace -- -D warnings clean (default, insecure-direct-claim feature, iam feature)
- [ ] CI: cargo test -p ff-sdk --lib (12+ tests including 6 new parse_report_usage_result cases)
- [ ] CI: cargo test -p ff-test -- --test-threads=1 (141 tests, +8 new: 6 claim_from_reclaim_grant + 2 claim_from_grant including saturation-doesn't-consume-grant)
- [ ] CI: 6 quality gates including unsafe ratchet

## Error surfaces
P1A errors (via \`SdkError\`):
- \`WorkerAtCapacity\` (new) — retryable, grant NOT consumed
- \`Script(ClaimGrantExpired | InvalidClaimGrant | CapabilityMismatch | ...)\` — existing variants

P1B errors (via \`SdkError\`):
- \`Script(InvalidClaimGrant | ClaimGrantExpired | NotAResumedExecution | ExecutionNotLeaseable | ExecutionNotFound)\` — all existing variants

## Cairn migration path
With this PR merged:
1. Cairn's \`task_service::claim\` replaces its direct Lua FCALL with \`Scheduler::claim_for_worker\` → \`FlowFabricWorker::claim_from_grant(lane, grant)\`.
2. Cairn's resume-path replaces its direct Lua FCALL for \`ff_claim_resumed_execution\` with \`FlowFabricWorker::claim_from_reclaim_grant(grant)\`.
3. Cairn's \`budget_service::parse_spend_result\` deletes itself in favor of \`ff_sdk::task::parse_report_usage_result\`.
4. Cairn drops its hardcoded \`ff:usagededup:\` prefix in favor of \`ff_core::keys::usage_dedup_key\`.

After that, cairn can set \`ff-sdk = { ..., default-features = true }\` (no more \`insecure-direct-claim\` feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public SDK claim entry points (`claim_from_grant`/`claim_from_reclaim_grant`) and new shared grant types, which affect execution leasing/claim semantics and could surface new edge cases around concurrency saturation and resume flows.
> 
> **Overview**
> Enables a production-safe scheduler→worker handoff by moving `ClaimGrant` into `ff-core` and adding `FlowFabricWorker::claim_from_grant`, which consumes scheduler-issued grants while enforcing `max_concurrent_tasks` via a new retryable `SdkError::WorkerAtCapacity` (checked before any FCALL so grants aren’t accidentally consumed).
> 
> Adds a resume-path counterpart with a new shared `ReclaimGrant` type plus `FlowFabricWorker::claim_from_reclaim_grant`, and re-exports both grant types from `ff-scheduler` for compatibility.
> 
> Extracts shared primitives: `ff_core::keys::usage_dedup_key` (used by both `ff-sdk` and `ff-server`) and makes `ff_sdk::task::parse_report_usage_result` public with unit tests; updates integration tests to cover grant-claim happy paths, capacity saturation behavior, and reclaim-grant edge cases (expiry, wrong worker, double-consume, non-resumed execution).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c545664eed15b47633539191cf3c20120950b376. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->