### PR TITLE
perf-invest: cairn P3.6 bridge-event audit (reports)

### DIFF
--- a/benches/perf-invest/bridge-event-audit.md
+++ b/benches/perf-invest/bridge-event-audit.md
@@ -1,0 +1,415 @@
+# P3.6 — Bridge-event completeness audit
+
+**Author:** Worker-2
+**Branch:** `bench/p36-bridge-audit` (off `main @ cbe35f1`)
+**Scope:** Inventory every FCALL and every `ff-server` pub method
+that writes terminal/lifecycle/public_state fields, cross-referenced
+against every emit site (XADD). Flag candidate gaps for W3's
+comparison pass against cairn's consumer list.
+
+Read-only. No code changes.
+
+## §1 Emit-site inventory — "what the engine fires"
+
+**Load-bearing finding: there is no dedicated 'bridge event' stream
+in-repo.** A grep across `crates/` and `lua/` for `PUBLISH`,
+`ff_event`, `ff:events`, `bridge`, `observer`, `consumer_group` finds
+zero hits. All observable emits are `XADD`s to one of three
+purpose-specific Valkey streams, each with its own semantics:
+
+| Stream key (Lua binding)           | Scope              | Event shape                           | Intended consumer                                    |
+| ---------------------------------- | ------------------ | ------------------------------------- | ---------------------------------------------------- |
+| `K.lease_history_key`              | per-execution      | `kind=<transition>` + snapshot fields | audit / replay / cairn lifecycle observer            |
+| `K.wp_signals_stream`              | per-waitpoint      | `signal_id, name, payload, token`     | cairn waitpoint-signal observer + suspension resumer |
+| `K.attempt_stream` (`ff_append_frame`) | per-attempt    | caller-supplied frame bytes           | cairn attempt-output tail / task progress            |
+
+Cairn presumably ingests bridge-events by:
+  (a) tailing `lease_history_key` per exec for lifecycle transitions;
+  (b) tailing `wp_signals_stream` per waitpoint for signal arrivals;
+  (c) tailing `attempt_stream` per attempt for task output;
+  (d) polling `exec_core` / `flow_core` via `get_execution_state` for
+      fields that never stream.
+
+**Consequence for gap analysis:** an FCALL that mutates state
+WITHOUT appending to any of those three streams requires cairn to
+either poll `exec_core` (via the server's public getters) or miss
+the change entirely. PR#26's `SessionCreated` gap is exactly that
+pattern — an entity-creation write with no XADD.
+
+### §1.1 `lease_history_key` XADD sites (audit/lifecycle)
+
+Extracted from `grep -n 'XADD.*lease_history' lua/*.lua`:
+
+| File                     | Line   | FCALL (enclosing)                 | Frame kind (ARGV) |
+| ------------------------ | -----: | --------------------------------- | ----------------- |
+| `lua/execution.lua`      |    533 | `ff_claim_execution`              | `lease_acquired`  |
+| `lua/execution.lua`      |    643 | `ff_complete_execution`           | `attempt_success` |
+| `lua/execution.lua`      |    763 | `ff_cancel_execution`             | `attempt_cancelled` |
+| `lua/execution.lua`      |    924 | `ff_delay_execution`              | `delayed` |
+| `lua/execution.lua`      |   1013 | `ff_move_to_waiting_children`     | `waiting_children` |
+| `lua/execution.lua`      |   1165 | `ff_fail_execution` (retry path)  | `retry_scheduled` |
+| `lua/execution.lua`      |   1205 | `ff_fail_execution` (terminal)    | `attempt_failed` |
+| `lua/execution.lua`      |   1437 | `ff_reclaim_execution`            | `reclaimed` |
+| `lua/execution.lua`      |   1534 | `ff_expire_execution`             | `expired` |
+| `lua/suspension.lua`     |    238 | `ff_suspend_execution`            | `suspended` |
+| `lua/signal.lua`         |    627 | `ff_claim_resumed_execution`      | `resumed` |
+| `lua/lease.lua`          |    290 | `ff_revoke_lease`                 | `revoked` |
+| `lua/flow.lua`           |    828 | `ff_replay_execution` (replaying) | `replay_*` |
+| `lua/flow.lua`           |    861 | `ff_replay_execution` (rebuilding)| `replay_*` |
+| `lua/helpers.lua`        |    443 | `append_lease_event` helper       | (caller-specified kind) |
+| `lua/helpers.lua`        |    553 | `release_lease` helper            | `released` |
+
+### §1.2 `wp_signals_stream` XADD sites (waitpoint signals)
+
+| File                | Line | FCALL                                      | Purpose |
+| ------------------- | ---: | ------------------------------------------ | ------- |
+| `lua/signal.lua`    |  181 | `ff_deliver_signal`                        | active waitpoint receives a signal |
+| `lua/signal.lua`    |  456 | `ff_buffer_signal_for_pending_waitpoint`   | signal buffered pre-suspend |
+
+### §1.3 Attempt-output stream (`ff_append_frame` → attempt_stream)
+
+| File             | Line | FCALL              | Purpose |
+| ---------------- | ---: | ------------------ | ------- |
+| `lua/stream.lua` |  122 | `ff_append_frame`  | worker writes a frame to the current attempt's output stream |
+
+### §1.4 What is NOT emitted (documented absences)
+
+No stream covers (confirmed by greps over all Lua):
+
+- Execution creation (`ff_create_execution` writes exec_core but
+  does not XADD anywhere).
+- Waitpoint creation (`ff_create_pending_waitpoint` writes
+  `waitpoint_key` but does not XADD — no `wp_signals_stream` entry
+  on creation).
+- Flow creation (`ff_create_flow` writes flow_core; no XADD).
+- Budget/quota policy creation (`ff_create_budget`,
+  `ff_create_quota_policy` — policy documents only, no XADD).
+- Attempt start (the `attempt_state=started` write inside
+  `ff_claim_execution`). Lease-history XADD is called `lease_acquired`
+  — it carries the attempt transition implicitly but the event is
+  framed around the lease, not the attempt.
+- All scheduling-side mutations that do NOT change lifecycle (e.g.
+  `ff_issue_claim_grant` writes the grant hash + stamps
+  `last_capability_mismatch_at` on reject; no stream).
+- Dependency resolution / flow-graph mutations
+  (`ff_stage_dependency_edge`, `ff_apply_dependency_to_child`,
+  `ff_resolve_dependency`, `ff_evaluate_flow_eligibility`,
+  `ff_promote_blocked_to_eligible`).
+
+This is the pool §5 draws candidate gaps from.
+
+## §2 Lua FCALLs writing terminal/lifecycle/public_state
+
+One row per `register_function`. "State writes" is the fields from
+the set `{public_state, lifecycle_phase, ownership_state,
+eligibility_state, attempt_state, blocking_reason, closed_at,
+closed_reason, terminal_reason, public_flow_state}` actually
+HSET'd inside that function body. Not every dimension is relevant
+to every FCALL — the 7-dim state vector is in
+`ff_core::state::StateVector` (see RFC-001 §2).
+
+### `lua/execution.lua`
+
+| FCALL                             | State writes (HSET K.core_key)                                                                                         | Lifecycle emit                  | Conditions |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ---------- |
+| `ff_create_execution` (L22)       | lifecycle_phase, ownership_state, eligibility_state, attempt_state, public_state (new row)                             | **none** (no XADD)              | always on Ok |
+| `ff_claim_execution` (L326)       | lifecycle_phase, ownership_state, eligibility_state, attempt_state, public_state                                       | `lease_history` `lease_acquired` | on Ok path |
+| `ff_complete_execution` (L557)    | lifecycle_phase=terminal, attempt_state=attempt_terminal, public_state=completed, closed_at, closed_reason=attempt_success | `lease_history` `attempt_success` | on Ok path |
+| `ff_cancel_execution` (L673)      | lifecycle_phase=terminal, attempt_state=ended_cancelled / attempt_terminal, public_state=cancelled, closed_at, closed_reason | `lease_history` (active branch) | branches on source lifecycle_phase |
+| `ff_delay_execution` (L853)       | lifecycle_phase=runnable, eligibility_state=not_eligible_until_time, attempt_state=attempt_interrupted, public_state=delayed | `lease_history` delay entry | on Ok path |
+| `ff_move_to_waiting_children` (L947) | lifecycle_phase=runnable, eligibility_state=blocked_by_dependencies, attempt_state=attempt_interrupted, public_state=waiting_children | `lease_history` waiting entry | on Ok path |
+| `ff_fail_execution` (L1043)       | (retry) lifecycle_phase=runnable, attempt_state=pending_retry_attempt, public_state=delayed // (terminal) lifecycle_phase=terminal, attempt_state=attempt_terminal, public_state=failed, closed_at, closed_reason=attempt_failure | `lease_history` either branch | branches on retry policy |
+| `ff_reclaim_execution` (L1231)    | (cap-exceeded) lifecycle_phase=terminal, public_state=failed, closed_reason=reclaim_limit // (success) lifecycle_phase=active, ownership_state=leased, attempt_state=started, reclaim_reason | `lease_history` `reclaimed`/`attempt_failed` | branches on reclaim_count vs max |
+| `ff_expire_execution` (L1464)     | lifecycle_phase=terminal, attempt_state=ended_failure/attempt_terminal, public_state=expired, closed_at, closed_reason=expired | `lease_history` (active/suspended branches) | branches on source lifecycle_phase |
+
+### `lua/suspension.lua`
+
+| FCALL                               | State writes                                                                                         | Lifecycle emit          | Conditions |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------- | ---------- |
+| `ff_suspend_execution` (L31)        | lifecycle_phase=suspended, ownership_state=unowned, eligibility_state=not_applicable, attempt_state=attempt_interrupted/suspended, public_state=suspended | `lease_history` `suspended` | on Ok path |
+| `ff_resume_execution` (L292)        | lifecycle_phase=runnable, eligibility_state=eligible_now/not_eligible_until_time, attempt_state=attempt_interrupted, public_state=waiting/delayed | **none** (no XADD)      | on Ok path |
+| `ff_create_pending_waitpoint` (L403)| waitpoint_key.closed_at="" (new waitpoint doc)                                                       | **none** (no XADD)      | on Ok path — **entity creation, no emit** |
+| `ff_expire_suspension` (L498)       | branches: auto_resume → runnable/waiting // terminal → lifecycle_phase=terminal, attempt_state=attempt_terminal, public_state=cancelled/expired/failed, closed_at/closed_reason | **lease_history (terminal branch only)** | behavior arg controls branch |
+| `ff_close_waitpoint` (L710)         | waitpoint_key.closed_at, close_reason                                                                | **none** (no XADD)      | on Ok path |
+
+### `lua/signal.lua`
+
+| FCALL                                         | State writes                                                                                                                                       | Lifecycle emit                           | Conditions |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------- |
+| `ff_deliver_signal` (L27)                     | waitpoint closed_at/closed_reason=satisfied; execution (on resume) lifecycle_phase=runnable, attempt_state=attempt_interrupted, public_state=waiting | `wp_signals_stream` (always); no `lease_history` emit on the runnable-transition branch | multi-branch on waitpoint match |
+| `ff_buffer_signal_for_pending_waitpoint` (L342) | waitpoint signal buffer; no core state change                                                                                                      | `wp_signals_stream`                      | on Ok path |
+| `ff_claim_resumed_execution` (L486)           | lifecycle_phase=active, ownership_state=leased, attempt_state=started/running_attempt, public_state=active                                         | `lease_history` `resumed`                | on Ok path |
+
+### `lua/scheduling.lua`
+
+| FCALL                              | State writes                                                             | Lifecycle emit | Conditions |
+| ---------------------------------- | ------------------------------------------------------------------------ | -------------- | ---------- |
+| `ff_issue_claim_grant` (L79)       | claim_grant hash (ephemeral, TTL-auto); on mismatch: `last_capability_mismatch_at` scalar on core | **none**       | advisory only |
+| `ff_change_priority` (L185)        | ZADD on eligible ZSET only (score change)                                | **none**       | scheduling-op |
+| `ff_update_progress` (L244)        | last_progress_ts + progress_tag + progress_percent on core               | **none**       | heartbeat-ish |
+| `ff_promote_delayed` (L308)        | lifecycle_phase=runnable (preserve), eligibility_state=eligible_now, blocking_reason=waiting_for_worker, public_state=waiting | **none**       | timer-scanner callback |
+| `ff_issue_reclaim_grant` (L419)    | claim_grant hash (ephemeral); on mismatch: `last_capability_mismatch_at` | **none**       | advisory only |
+
+### `lua/lease.lua`
+
+| FCALL                               | State writes                                                                                              | Lifecycle emit                   | Conditions |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------- |
+| `ff_renew_lease` (L16)              | lease_expires_at, renewed_count                                                                           | **none**                         | liveness-op |
+| `ff_mark_lease_expired_if_due` (L125) | via `append_lease_event` helper: ownership_state=lease_expired_reclaimable, blocking_reason, lease_expired_at | `lease_history` `expired` (via helper at 443) | on Ok path |
+| `ff_revoke_lease` (L206)            | lifecycle_phase=active (preserve), ownership_state=lease_revoked, blocking_reason=waiting_for_worker, attempt_state=attempt_interrupted, public_state=active | `lease_history` (at 290) `revoked` | on Ok path |
+
+### `lua/flow.lua`
+
+| FCALL                                  | State writes                                                                                         | Lifecycle emit                          | Conditions |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------- |
+| `ff_create_flow` (L69)                 | flow_core.public_flow_state=open (new row)                                                           | **none** (no XADD)                      | on Ok path — **entity creation, no emit** |
+| `ff_add_execution_to_flow` (L122)      | flow_core member count; exec_core.flow_id is NOT written here — see §3 ff-server non-FCALL write     | **none** (no XADD)                      | on Ok path |
+| `ff_cancel_flow` (L190)                | flow_core.public_flow_state=cancelled                                                                | **none** (no XADD)                      | on Ok path |
+| `ff_stage_dependency_edge` (L271)      | edges hash; edge attrs (status=waiting), no core_key HSET                                            | **none**                                | on Ok path |
+| `ff_apply_dependency_to_child` (L369)  | lifecycle_phase=runnable (preserve), eligibility_state=blocked_by_dependencies, attempt_state=pending_first_attempt (preserve), public_state=waiting_children | **none**                                | on Ok path |
+| `ff_resolve_dependency` (L460)         | lifecycle_phase=runnable (preserve), attempt_state=various (preserve or set to ended_cancelled on skip), public_state=waiting; closed_at/reason on skip-cancel path | **none**                                | branches on satisfied/skip/cancel |
+| `ff_evaluate_flow_eligibility` (L612)  | no core HSET (read-only flow evaluation)                                                             | **none**                                | read path |
+| `ff_promote_blocked_to_eligible` (L655)| lifecycle_phase=runnable (preserve), eligibility_state=eligible_now, attempt_state (preserve), public_state=waiting | **none**                                | scanner callback |
+| `ff_replay_execution` (L731)           | lifecycle_phase=runnable, attempt_state=pending_replay_attempt, public_state=waiting/waiting_children | `lease_history` (at 828 + 861) `replay_*` | on Ok path |
+
+### `lua/budget.lua` + `lua/quota.lua` + `lua/stream.lua`
+
+| FCALL                              | State writes                                                                                                                                | Lifecycle emit | Conditions |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- |
+| `ff_create_budget` (L18)           | budget policy hash + definition (no exec_core touch)                                                                                        | **none**       | **entity creation** |
+| `ff_report_usage_and_check` (L99)  | budget usage counters (no exec_core touch)                                                                                                  | **none**       | usage-op |
+| `ff_reset_budget` (L188)           | budget usage (no exec_core touch)                                                                                                           | **none**       | admin-op |
+| `ff_unblock_execution` (L243)      | lifecycle_phase=runnable, eligibility_state=eligible_now, blocking_reason=waiting_for_worker, attempt_state (preserve), public_state=waiting | **none**       | scanner callback |
+| `ff_block_execution_for_admission` (L313) | lifecycle_phase=runnable, eligibility_state=(mapped from blocking_reason), blocking_reason, public_state=rate_limited                       | **none**       | admission-reject |
+| `ff_create_quota_policy` (L17)     | quota policy hash (no exec_core touch)                                                                                                      | **none**       | **entity creation** |
+| `ff_check_admission_and_record` (L70)| admission record + usage sliding window (no exec_core touch)                                                                                | **none**       | admission-op |
+| `ff_release_admission` (L163)      | usage window rollback (no exec_core touch)                                                                                                  | **none**       | admission-op |
+| `ff_append_frame` (L18)            | no core_key HSET; XADD'd                                                                                                                    | `attempt_stream` (L122) | on Ok path — this IS a bridge-event emit path for task output |
+| `ff_read_attempt_stream` (L180)    | read-only                                                                                                                                   | —              | read path |
+| `ff_version`                       | read-only                                                                                                                                   | —              | read path |
+
+## §3 ff-server pub methods writing same
+
+Each server method maps to one or more FCALLs. Inventory shape:
+`pub fn` → delegated FCALL(s) → any extra direct Valkey writes
+outside the FCALL.
+
+Read `crates/ff-server/src/server.rs`. Methods that wrap FCALLs
+without any extra direct write are GREEN on the non-FCALL-write
+dimension; those are omitted from the table to cut noise. Only
+methods with notable facts listed:
+
+| Method (line)                      | Delegates to FCALL                     | Direct HSET(s) outside FCALL? | Note |
+| ---------------------------------- | -------------------------------------- | ----------------------------- | ---- |
+| `create_execution` (L444)          | `ff_create_execution`                  | no                            | Ok |
+| `cancel_execution` (L528)          | `ff_cancel_execution`                  | no                            | Ok |
+| `get_execution_state` / `get_execution_result` / `get_execution` (L560, 614, 1858) | read-only                              | no                            | getters |
+| `list_pending_waitpoints` (L688)   | read-only (SCAN + HGET)                | no                            | getter |
+| `create_budget` (L974)             | `ff_create_budget`                     | no                            | Ok |
+| `create_quota_policy` (L1028)      | `ff_create_quota_policy`               | no                            | Ok |
+| `get_budget_status` (L1066)        | read-only                              | no                            | getter |
+| `report_usage` (L1142)             | `ff_report_usage_and_check`            | no                            | Ok |
+| `reset_budget` (L1183)             | `ff_reset_budget`                      | no                            | Ok |
+| `create_flow` (L1211)              | `ff_create_flow`                       | no                            | Ok |
+| `add_execution_to_flow` (L1245)    | `ff_add_execution_to_flow`             | **YES — HSET flow_id on exec_core at L1279** | see §5 `non-FCALL` bucket |
+| `cancel_flow` / `cancel_flow_wait` (L1327, 1337) | `ff_cancel_flow` + cross-partition dispatch | no (dispatched cancels go via `cancel_execution` on each member) | Ok |
+| `stage_dependency_edge` (L1567)    | `ff_stage_dependency_edge`             | no                            | Ok |
+| `apply_dependency_to_child` (L1611)| `ff_apply_dependency_to_child`         | no                            | Ok |
+| `deliver_signal` (L1670)           | `ff_deliver_signal`                    | no                            | Ok |
+| `change_priority` (L1771)          | `ff_change_priority`                   | no                            | Ok |
+| `revoke_lease` (L1808)             | `ff_revoke_lease`                      | no                            | Ok |
+| `list_executions` (L1948)          | read-only (SCAN + HGET)                | no                            | getter |
+| `replay_execution` (L2078)         | `ff_replay_execution`                  | no                            | Ok |
+| `read_attempt_stream` (L2179) / `tail_attempt_stream` (L2259) | read-only (`ff_read_attempt_stream` + XREAD) | stream_meta HSET is mentioned in comment L2282 but NOT called here | the HSET mentioned is a deferred v2 plan, not current |
+| `rotate_waitpoint_secret` (L2673)  | no FCALL                               | **YES — multiple HSETs on HMAC secrets hash** | secret rotation, NOT exec state; out of scope for bridge events but flagged |
+| `start` (L212)                     | library load + partition-config HSETs  | **YES — HSET ff:config:partitions at L2413-2427, HSET HMAC secrets at L2525-2555** | boot-time config, not exec state; out of scope |
+
+All non-read-only methods are accounted for. The 3 non-FCALL HSET
+sites are:
+
+1. **`add_execution_to_flow` → HSET `flow_id` on `exec_core`** (L1279).
+   A relational link added to exec_core AFTER the FCALL returns. Not
+   a state-vector field; the 7-dim state is untouched. Flagged in §5
+   because it violates the "all state writes go through Lua" rule,
+   even though the field itself isn't bridge-event-relevant.
+2. **`start` → HSET `ff:config:partitions`** (L2413-2427). Boot-time
+   partition config, never mutated at runtime.
+3. **HMAC secrets init + rotation** (L2525-2555, L2673). Crypto
+   material, not exec state.
+
+## §4 Cross-reference: writer → state fields → bridge-event emitted?
+
+Columns:
+
+- **FCALL** — Lua function name.
+- **core state mutation** — does it HSET any of {public_state,
+  lifecycle_phase, ownership_state, eligibility_state,
+  attempt_state, blocking_reason, closed_at/closed_reason,
+  terminal_reason, public_flow_state}? Y/N.
+- **emits to lease_history?** — Y/N.
+- **emits to wp_signals?** — Y/N.
+- **emits to attempt_stream?** — Y/N.
+- **gap?** — Y/candidate/N (see §5 for rationale on each candidate).
+
+| FCALL                                        | core state | lease_history | wp_signals | attempt_stream | gap?         |
+| -------------------------------------------- | :--------: | :-----------: | :--------: | :------------: | ------------ |
+| `ff_create_execution`                        |     Y      |       N       |     N      |       N        | **candidate (entity creation)** |
+| `ff_claim_execution`                         |     Y      |       Y       |     N      |       N        | N |
+| `ff_complete_execution`                      |     Y      |       Y       |     N      |       N        | N |
+| `ff_cancel_execution`                        |     Y      |       Y (active branch) / conditional on suspended branch | N | N | **candidate (suspended-branch closed_at on waitpoint without lease_history emit in some sub-paths)** |
+| `ff_delay_execution`                         |     Y      |       Y       |     N      |       N        | N |
+| `ff_move_to_waiting_children`                |     Y      |       Y       |     N      |       N        | N |
+| `ff_fail_execution`                          |     Y      |       Y       |     N      |       N        | N |
+| `ff_reclaim_execution`                       |     Y      |       Y       |     N      |       N        | N |
+| `ff_expire_execution`                        |     Y      |   Y (active / suspended branches) / **N on runnable branch (L1464 → L1615)** | N | N | **candidate (runnable-expire branch emits no lease_history)** |
+| `ff_suspend_execution`                       |     Y      |       Y       |     N      |       N        | N |
+| `ff_resume_execution`                        |     Y      |       N       |     N      |       N        | **candidate (lifecycle_phase suspended→runnable without emit)** |
+| `ff_create_pending_waitpoint`                |     N (waitpoint doc only) | N | N | N | **candidate (entity creation — waitpoint born silent)** |
+| `ff_expire_suspension`                       |     Y      |   Y (terminal branch) / N (auto_resume branch) | N | N | **candidate (auto_resume branch mutates state, no emit)** |
+| `ff_close_waitpoint`                         |     Y (waitpoint closed fields) | N | N | N | **candidate (waitpoint close without emit)** |
+| `ff_deliver_signal`                          |     Y (on resume branch) | N (on resume branch) | Y | N | **candidate (resume-on-signal transitions exec state but lifecycle emit is wp_signals only, not lease_history)** |
+| `ff_buffer_signal_for_pending_waitpoint`     |     N      |       N       |     Y      |       N        | N |
+| `ff_claim_resumed_execution`                 |     Y      |       Y       |     N      |       N        | N |
+| `ff_issue_claim_grant`                       |     N (grant hash only; advisory `last_capability_mismatch_at`) | N | N | N | N (advisory — grant is transient) |
+| `ff_change_priority`                         |     N      |       N       |     N      |       N        | N (ZADD only) |
+| `ff_update_progress`                         |     N (progress fields, not core state) | N | N | N | N (heartbeat-ish) |
+| `ff_promote_delayed`                         |     Y      |       N       |     N      |       N        | **candidate (eligibility_state transition not_eligible_until_time→eligible_now silent)** |
+| `ff_issue_reclaim_grant`                     |     N (grant hash only) | N | N | N | N |
+| `ff_renew_lease`                             |     N (lease_expires_at only) | N | N | N | N (liveness-op) |
+| `ff_mark_lease_expired_if_due`               |     Y (ownership_state transition) | Y (via helper) | N | N | N |
+| `ff_revoke_lease`                            |     Y      |       Y       |     N      |       N        | N |
+| `ff_create_flow`                             |     Y (flow_core only) | N | N | N | **candidate (entity creation — flow born silent)** |
+| `ff_add_execution_to_flow`                   |     Y (flow member count + exec_core.flow_id via ff-server non-FCALL HSET) | N | N | N | **candidate (flow-membership event silent)** |
+| `ff_cancel_flow`                             |     Y (flow_core.public_flow_state) | N | N | N | **candidate (flow terminal transition silent)** |
+| `ff_stage_dependency_edge`                   |     N (edge attrs only) | N | N | N | N |
+| `ff_apply_dependency_to_child`               |     Y (public_state→waiting_children, eligibility_state→blocked_by_dependencies) | N | N | N | **candidate (dependency-block transition silent)** |
+| `ff_resolve_dependency`                      |     Y (on satisfied + skip-cancel branches) | N | N | N | **candidate (dependency-resolve transition silent; cancel-on-skip path especially)** |
+| `ff_evaluate_flow_eligibility`               |     N (read-only) | N | N | N | N |
+| `ff_promote_blocked_to_eligible`             |     Y (eligibility_state→eligible_now) | N | N | N | **candidate (block→eligible silent)** |
+| `ff_replay_execution`                        |     Y      |       Y       |     N      |       N        | N |
+| `ff_create_budget`                           |     N (policy only) | N | N | N | **candidate (entity creation — budget born silent)** |
+| `ff_report_usage_and_check`                  |     N (counters only) | N | N | N | N (usage-op; breach reporting flows via return value) |
+| `ff_reset_budget`                            |     N (counter clear) | N | N | N | **candidate (admin-mutation silent — is budget-reset observable to cairn?)** |
+| `ff_unblock_execution`                       |     Y (eligibility_state→eligible_now, blocking_reason→waiting_for_worker) | N | N | N | **candidate (blocked→eligible silent)** |
+| `ff_block_execution_for_admission`           |     Y (eligibility_state transition, public_state→rate_limited) | N | N | N | **candidate (admission-block → rate_limited silent)** |
+| `ff_create_quota_policy`                     |     N (policy only) | N | N | N | **candidate (entity creation — quota policy born silent)** |
+| `ff_check_admission_and_record`              |     N (counters only) | N | N | N | N (usage-op) |
+| `ff_release_admission`                       |     N (counter rollback) | N | N | N | N (usage-op) |
+| `ff_append_frame`                            |     N (stream_meta frame_count only) | N | N | Y | N |
+| `ff_read_attempt_stream`                     |     N (read-only) | N | N | N | N |
+| `ff_version`                                 |     N (read-only) | N | N | N | N |
+
+## §5 Candidate gaps
+
+Grouped by flag-class. Each row cites the §4 line and a short
+rationale. W3 cross-references these against cairn's actual
+consumer list to confirm/dismiss.
+
+### §5.1 Entity-creation writes with no XADD (class flagged by manager)
+
+New entities are born in Valkey but no stream announces them.
+Cairn must discover them by polling — pathological per the manager's
+note.
+
+| FCALL                         | Entity created                  | Rationale                               |
+| ----------------------------- | ------------------------------- | --------------------------------------- |
+| `ff_create_execution`         | exec_core (new execution)       | **strong gap candidate** — direct analog to PR#26 `SessionCreated`. An execution is born runnable + eligible with zero stream emit; cairn must poll `list_executions` or tail the lane's `eligible` ZSET indirectly to discover new work. |
+| `ff_create_flow`              | flow_core (new flow container)  | **strong gap candidate** — flow membership events downstream depend on cairn knowing the flow exists. Same polling-discovery problem. |
+| `ff_create_pending_waitpoint` | waitpoint_key (suspension point)| **strong gap candidate** — a waitpoint comes into being able to receive signals, but `wp_signals_stream` starts empty. Cairn can only know the waitpoint exists via `list_pending_waitpoints`. |
+| `ff_create_budget`            | budget policy document          | Medium-strength candidate. Budgets are admin-managed and typically created out-of-band; cairn may not need to observe creations. W3 confirm. |
+| `ff_create_quota_policy`      | quota policy document           | Same rationale as budget — admin-managed. W3 confirm. |
+
+### §5.2 Lifecycle transitions without lease_history emit
+
+The state vector mutates but no entry appears in the
+per-execution `lease_history` stream. Cairn's lifecycle-tracking
+tail may miss these.
+
+| FCALL                                | Transition (partial / branch)                                                                    | Rationale |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------ | --------- |
+| `ff_expire_execution` (runnable branch, L1464→L1615) | lifecycle_phase=runnable → terminal + public_state=expired                                         | **strong gap candidate** — the `active` and `suspended` branches DO emit, but the `runnable` branch (never-claimed execution expired on deadline) writes the terminal row without XADD. Non-trivial: an execution can silently transition `runnable→terminal/expired` and the lease_history tail shows nothing because no lease was ever taken. |
+| `ff_resume_execution`                | lifecycle_phase=suspended → runnable                                                             | **strong gap candidate** — a resume is a first-class lifecycle event (the execution becomes claimable again) but there is no XADD here. The paired `ff_claim_resumed_execution` emits `resumed`, but only IF and when the worker actually claims. Between resume and claim, lease_history shows nothing. |
+| `ff_deliver_signal` (resume branch)  | exec_core transitions on resume-on-signal (suspended → runnable)                                 | **candidate** — `wp_signals_stream` records the SIGNAL, but the exec-state transition that resumes the execution does not emit to `lease_history`. Cairn's lifecycle view sees signal-in but must correlate with a later `ff_claim_resumed_execution` to know the exec resumed. |
+| `ff_expire_suspension` (auto_resume) | suspended → runnable (auto-resume timeout behaviour)                                             | **candidate** — terminal branch emits; auto_resume branch mutates state silently. Same shape as the `ff_resume_execution` gap. |
+| `ff_cancel_execution` (suspended source, sub-paths L712-L773) | suspension closed_at writes without an accompanying lease_history on some paths                  | YELLOW candidate — the `active`-lifecycle branch always emits; the suspended-lifecycle branch emits on most paths but a reader tracing `closed_at` transitions on the waitpoint may see updates that have no execution-level event. W3 verify. |
+
+### §5.3 Scheduling / admission transitions with no emit at all
+
+These transitions are functionally visible to cairn (an execution
+becomes eligible, or becomes blocked) but the only way to observe
+them is by polling `exec_core`.
+
+| FCALL                                | Transition                                                                | Rationale |
+| ------------------------------------ | ------------------------------------------------------------------------- | --------- |
+| `ff_promote_delayed`                 | eligibility_state=not_eligible_until_time → eligible_now                  | Scanner-driven; no emit. Cairn only sees an execution "become claimable" by its next poll. |
+| `ff_promote_blocked_to_eligible`     | eligibility_state=blocked_by_dependencies → eligible_now                  | Same shape. Critical for DAG-observer use cases: a dependency-satisfied promotion is invisible to streams. |
+| `ff_unblock_execution`               | budget/quota unblock → eligible_now                                       | Same shape. Admission-scanner unblocks silently. |
+| `ff_block_execution_for_admission`   | runnable/eligible → blocked (public_state=rate_limited)                   | Same shape. Admission-reject is a public_state transition that's only visible via polling. |
+| `ff_apply_dependency_to_child`       | eligibility_state=blocked_by_dependencies + public_state=waiting_children | Same shape. Dependency-graph edge applied silently. |
+| `ff_resolve_dependency`              | dependency-satisfied path: preserves phase; cancel-on-skip path: writes ended_cancelled + closed_at/reason | Two sub-paths, both silent. The cancel-on-skip path is higher-severity — it writes terminal-ish attempt state without a lease_history emit. |
+
+### §5.4 Flow-level transitions with no emit
+
+| FCALL                        | Transition                                     | Rationale |
+| ---------------------------- | ---------------------------------------------- | --------- |
+| `ff_add_execution_to_flow`   | flow membership added                          | A new member joins a flow; cairn must poll flow_core to discover. |
+| `ff_cancel_flow`             | public_flow_state → cancelled                  | **strong gap candidate** — flow-terminal transition parallel to exec-terminal, but exec-terminal emits lease_history while flow-terminal emits nothing. Member cancellations propagate per-execution via `cancel_execution` (which does emit), so individual members are observable — but the FLOW-level transition is not. |
+| `ff_reset_budget`            | budget usage counters cleared                  | Admin-mutation. Cairn-side may not care. W3 confirm. |
+
+### §5.5 Non-FCALL direct state writes (manager's separate bucket)
+
+Per manager: "atomic state should go through Lua; bypassing that is
+a separate class of defect."
+
+| File:line                                | Field(s)                                                     | Rationale |
+| ---------------------------------------- | ------------------------------------------------------------ | --------- |
+| `crates/ff-server/src/server.rs:1279`    | `exec_core.flow_id` (non-FCALL HSET in `add_execution_to_flow`) | **YELLOW** — the field is a relational link, not a state-vector member; the comment at L1274 acknowledges the two-phase write is "idempotent, safe to retry if phase 1 succeeded but phase 2 failed". But it sits outside the atomic FCALL boundary, meaning a crash between phases leaves the flow_core thinking the exec is a member while exec_core has no flow_id. Not a bridge-event gap per se; flagged for the non-FCALL-state-writes bucket. |
+| `crates/ff-server/src/server.rs:2413-2427` | `ff:config:partitions` HSETs at server boot                   | Config, not exec state. GREEN — intentionally outside Lua because it's boot-time config a server writes once. No bridge-event concern. |
+| `crates/ff-server/src/server.rs:2525-2555`, 2673, 2955, 3021-3046 | HMAC-secret init + rotation HSETs                     | Crypto material, not exec state. GREEN — intentionally outside Lua for crypto-rotation atomicity. No bridge-event concern. |
+
+Only one non-FCALL exec-state write in the entire codebase: the
+`flow_id` field in `add_execution_to_flow`. Worth noting because
+it's the ONLY violation of the "all exec_core writes go through
+Lua" invariant.
+
+## §6 Summary
+
+**Total FCALLs audited:** 45 (across 9 Lua files).
+**Total ff-server pub methods audited:** ~30 (server.rs).
+**Emit streams identified:** 3 (lease_history_key, wp_signals_stream,
+attempt_stream via `ff_append_frame`). **No dedicated bridge-event
+stream exists.**
+
+**Candidate gap count by class:**
+
+| Class                                        | Count |
+| -------------------------------------------- | ----: |
+| §5.1 Entity-creation writes with no XADD     |     5 |
+| §5.2 Lifecycle transitions without emit      |     5 |
+| §5.3 Scheduling/admission transitions silent |     6 |
+| §5.4 Flow-level transitions silent           |     3 |
+| §5.5 Non-FCALL direct state writes (not an emit-gap, but a separate defect bucket) | 1 |
+
+**Strongest candidates (W3 should prioritise):**
+
+1. `ff_create_execution` — PR#26 analog; executions born without
+   emit.
+2. `ff_create_flow` + `ff_create_pending_waitpoint` — entities born
+   without emit.
+3. `ff_expire_execution` runnable branch — terminal transition with
+   no lease_history.
+4. `ff_resume_execution` — suspended→runnable silent.
+5. `ff_cancel_flow` — flow terminal transition silent.
+6. `ff_promote_blocked_to_eligible` + `ff_unblock_execution` —
+   dependency/admission unblocks that only surface via polling.
+
+W3's comparison pass against cairn's known bridge-event consumer
+list will confirm which of these are actual gaps vs intentional
+polling points.
+
+## §7 Deliverable boundary
+
+This report ends at "candidate gaps." No fixes, no cairn touches,
+no code changes. The three-way distinction (bridge-event / stream
+tail / poll) from the manager's approval is the lens throughout.
+W3 produces the confirmed-gap-plus-fix-recommendation report next.

--- a/benches/perf-invest/bridge-event-gap-report.md
+++ b/benches/perf-invest/bridge-event-gap-report.md
@@ -1,0 +1,349 @@
+# P3.6 — Bridge-event gap report (comparison pass)
+
+**Author:** Worker-3.
+**Branch:** `bench/p36-bridge-audit` (stacked on W2's `aab0c83`).
+**Input:** `benches/perf-invest/bridge-event-audit.md` (W2's inventory,
+415 lines) + cairn-rs at `/tmp/cairn-rs` (read-only).
+**Scope:** cross-reference W2's 19 candidate gaps (§5.1–§5.4) + 1
+non-FCALL defect (§5.5) against cairn-fabric's actual consumer /
+emit sites.
+
+Read-only. No code changes.
+
+## §0 Load-bearing finding
+
+**Cairn does not subscribe to any FF stream for lifecycle
+observation.** It emits its own `BridgeEvent` variants synchronously
+after calling FF — the bridge is cairn-internal, driven entirely by
+cairn's service-method call graph, not by FF-side XADDs.
+
+Evidence:
+- `grep -rn "BridgeEvent::" /tmp/cairn-rs/crates/` — every emit is
+  from cairn's own wrapper methods (`run_service.rs`,
+  `task_service.rs`, `session_service.rs`, `worker_sdk.rs`). Pattern
+  is always `FCALL-to-FF → emit(BridgeEvent::…)` in the same
+  request function.
+- `grep -rn "xread\|XREAD\|XRANGE\|xrange" /tmp/cairn-rs/crates/`
+  returns only `ff_sdk::task::read_stream` call sites in
+  `cairn-fabric/src/stream.rs`, all for attempt-output frame replay
+  — not lifecycle observation.
+- `grep -rn "tail\|subscribe\|poll.*execution" /tmp/cairn-rs/…` —
+  only `is_lease_healthy()` SDK-side self-checks and many
+  `hgetall(&ctx.core())` call sites inside cairn's own service
+  methods (read-back-after-write, not polling).
+- There is NO background task in cairn that periodically reads
+  exec_core state.
+
+Cairn's authoritative emit list (cairn-fabric/src/event_bridge.rs:17-87):
+
+```
+BridgeEvent::ExecutionCreated { run_id, session_id, project, correlation_id }
+BridgeEvent::ExecutionCompleted { run_id, project, prev_state }
+BridgeEvent::ExecutionFailed { run_id, project, failure_class, prev_state }
+BridgeEvent::ExecutionCancelled { run_id, project, prev_state }
+BridgeEvent::ExecutionSuspended { run_id, project, prev_state }
+BridgeEvent::ExecutionResumed { run_id, project, prev_state }
+BridgeEvent::ExecutionRetryScheduled { run_id, project, attempt }
+BridgeEvent::TaskCreated { task_id, project, parent_run_id, parent_task_id }
+BridgeEvent::TaskLeaseClaimed { task_id, project, lease_owner, lease_epoch, lease_expires_at_ms }
+BridgeEvent::TaskStateChanged { task_id, project, to, failure_class }
+BridgeEvent::SessionCreated { session_id, project }
+BridgeEvent::SessionArchived { session_id, project }
+```
+
+**Implication for W2's candidate gaps:** the FF-side gap analysis
+(XADD or no XADD?) is orthogonal to cairn's consumption. Most of
+W2's candidates are not gaps FROM CAIRN'S PERSPECTIVE because cairn
+doesn't observe FF streams at all. But some ARE gaps in a different
+sense: FF-initiated state transitions (scanner-driven promotions,
+lease expiries, timeout-triggered retries) that cairn's
+call-then-emit pattern cannot reach by construction.
+
+This report reclassifies W2's candidates under that lens.
+
+## §1 Confirmed gaps (cairn expects, FF doesn't emit)
+
+These are transitions where cairn's read-model will diverge from
+FF's exec_core truth because cairn has no way to observe the
+transition.
+
+### §1.1 FF-initiated lease expiry / reclaim
+
+**W2 inventory §4 row:** `ff_mark_lease_expired_if_due` — emits
+`lease_history` `expired`, core state writes
+`ownership_state=lease_expired_reclaimable`.
+
+**Cairn expectation:** When a lease expires and FF transitions the
+execution off the worker, cairn's `TaskReadModel` should see a
+`TaskStateChanged` → `Failed` (failure_class = `LeaseExpired`) or
+equivalent. The test at
+`/tmp/cairn-rs/crates/cairn-fabric/tests/integration/test_event_emission.rs:1-20`
+explicitly documents this historical bug: "tasks claimed via any
+path that did not populate the registry … silently skipped emission
+— and the cairn-store TaskReadModel projection drifted from FF's
+exec_core truth."
+
+**Current cairn handling:** cairn emits `TaskStateChanged` only
+from its own `FabricTaskService::complete` / `fail` / `cancel` paths
+(task_service.rs:562, 663, 741). If the worker dies mid-task and FF
+scanner-reclaims the lease, none of those methods fires. Cairn's
+read model stays stuck at `Running`.
+
+**Fix site recommendation — FF side.** Add emission in
+`ff_mark_lease_expired_if_due` via an already-present
+`lease_history` XADD. Cairn then needs a tail consumer on
+`lease_history_key` for the lease-expiry kind. Alternative: FF emits
+a dedicated `BridgeEvent`-shape message on a new stream. The
+already-existing `lease_history` XADD is the obvious path; the
+missing piece is cairn-side consumer that reads it.
+
+Two fix-owner options, pick one:
+- **Option A (FF-side):** keep the `lease_history` `expired` XADD,
+  add a FF-server-owned tail daemon that forwards lease-expiry
+  events to cairn over the existing event-bridge mpsc. Lower cairn
+  churn.
+- **Option B (cairn-side):** add a cairn-fabric background task
+  that tails `lease_history_key` for each active execution and
+  emits `BridgeEvent::ExecutionFailed { failure_class: LeaseExpired }`
+  on an `expired` frame. Per-execution tail cost; may need
+  cross-partition aggregation.
+
+**Recommendation: Option B — cairn owns it.** The observation is
+cairn-specific (cairn is the only current consumer), and FF-server
+should not grow a bridge-specific forwarder. Cairn can subscribe to
+`lease_history_key` per-execution at claim time (the ClaimedTask
+shape already knows the exec_id) and unsubscribe on terminal.
+
+### §1.2 FF-initiated retry schedule (scanner-triggered)
+
+**W2 inventory §4 row:** `ff_fail_execution` retry path — emits
+`lease_history` `retry_scheduled`, core writes
+`attempt_state=pending_retry_attempt`, `public_state=delayed`.
+
+**Cairn expectation:** When a task fails via cairn's `fail_with_retry`
+(worker_sdk.rs:293-333), cairn emits
+`BridgeEvent::ExecutionRetryScheduled`. BUT: when FF re-eligibles
+a delayed retry via `ff_promote_delayed`
+(scheduling.lua:308, W2 §5.3), cairn isn't told that the task is
+now eligible to be re-claimed. The retry scheduler's transition
+from `delayed` → `eligible` is scanner-driven, cairn never called
+anything.
+
+**Current cairn handling:** cairn's read model projects retry via
+the initial `ExecutionRetryScheduled` event. It does NOT track the
+delayed→eligible transition.
+
+**Is this a gap?** Arguable. The external observer of a retry is
+usually interested in "retry was scheduled" and "retry outcome"
+(next claim + terminal), not the scheduler tick. Cairn's current
+model seems fine for external SSE audit.
+
+**Recommendation: NO FIX NEEDED.** Mark as intentional silence —
+cairn tracks retry via the initial scheduling event and the
+eventual next-attempt claim; the scanner tick between them is not
+observable and doesn't need to be.
+
+### §1.3 FF-initiated timeout expiry
+
+**W2 inventory §4 row:** `ff_expire_execution` has three branches:
+`active`, `suspended`, `runnable`. Only `active` and `suspended`
+emit `lease_history`; the `runnable` branch (L1464→L1615, execution
+expired on deadline WITHOUT ever being claimed) writes terminal
+state with no XADD.
+
+**Cairn expectation:** Cairn's emission for execution-level terminal
+transitions comes from
+`run_service.rs:628` (`ExecutionCancelled`) and `worker_sdk.rs`
+complete/fail/cancel paths. None of those fires when FF's scanner
+expires an unclaimed execution. Cairn's read model stays at
+`Created` / `Waiting` indefinitely.
+
+**Severity: HIGH.** An execution that never got claimed and hit
+its deadline is a real operator-visible event — the user submitted
+work, the worker never picked it up in time, and the execution
+died silently. Cairn's projection showing the run as still
+`Waiting` is pathological for UX.
+
+**Fix site recommendation — FF side + cairn side.**
+- **FF side:** add the missing `lease_history` `expired` XADD in
+  the `runnable` branch of `ff_expire_execution` (L1464→L1615). The
+  inventory flag from W2 §5.2 is correct. This is a
+  lease-history-emit-gap in isolation from bridge events.
+- **Cairn side:** subscribe to `lease_history_key` (per §1.1
+  recommendation) and map `expired` frames to
+  `BridgeEvent::ExecutionFailed { failure_class: Timeout }` or a
+  new `ExecutionExpired` variant.
+
+**Recommendation: BOTH, FF fix first.** The FF-side emit is a
+straightforward symmetric fix — the other two branches already
+emit. Cairn-side subscription can land once FF is consistent.
+
+### §1.4 FF-initiated scheduler promotions (delayed → eligible, blocked → eligible)
+
+**W2 inventory §5.3:** `ff_promote_delayed`,
+`ff_promote_blocked_to_eligible`, `ff_unblock_execution` — all
+transition `eligibility_state` → `eligible_now` with no stream emit.
+
+**Cairn expectation:** None. These are intra-lifecycle transitions
+(an execution becomes ready for claim). Cairn observes claim via
+`TaskLeaseClaimed` (task_service.rs:420), so the "promoted to
+eligible" step is redundant — the next claim makes the transition
+cairn-visible. If no claim ever happens, the timeout path in §1.3
+catches it.
+
+**Recommendation: NO FIX NEEDED.** Mark as intentional silence —
+these are scheduling tick transitions, not lifecycle events cairn
+cares about.
+
+### §1.5 FF-initiated admission block
+
+**W2 inventory §4 row:** `ff_block_execution_for_admission` —
+transitions `public_state=rate_limited` via scanner. No emit.
+
+**Cairn expectation:** Unclear. If cairn wants to surface
+"rate-limited" status to users (via SSE audit), the
+`rate_limited` public_state transition must be visible. Cairn's
+current `BridgeEvent` enum has no `ExecutionRateLimited` variant,
+so the answer is probably "no, cairn does not surface this."
+
+**Recommendation: NO FIX NEEDED.** Cairn's consumer shape doesn't
+include rate-limited as a public-facing state. Document as
+intentional silence. If cairn ever adds a rate-limited UI, this
+moves to confirmed-gap and needs FF-side emission.
+
+## §2 Intentional silences (cairn doesn't subscribe, documented rationale)
+
+These are the W2 candidates that are NOT gaps from cairn's
+perspective. Listed so future readers know the silence is
+deliberate.
+
+| FCALL (W2 §5 class)                       | Cairn-side rationale                                                                                                     |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `ff_create_execution` (§5.1)              | Cairn emits `ExecutionCreated` itself at run_service.rs:399 after the call. No subscription needed.                      |
+| `ff_create_flow` (§5.1)                   | Cairn's `BridgeEvent` has no `FlowCreated` variant. Flows are FF-internal coordination; cairn uses them as opaque IDs.   |
+| `ff_create_pending_waitpoint` (§5.1)      | Cairn observes suspensions via `ExecutionSuspended` (worker_sdk.rs:376, 409, 441). Waitpoint lifecycle is a FF implementation detail it calls transparently. |
+| `ff_create_budget` / `ff_create_quota_policy` (§5.1) | Admin-managed; cairn `BridgeEvent` has no budget/quota variants. No subscription intended.                          |
+| `ff_resume_execution` (§5.2)              | Cairn calls `ff_resume_execution` itself (run_service.rs:888) and emits `ExecutionResumed` at :894 / :1134.              |
+| `ff_deliver_signal` resume-branch (§5.2)  | Cairn calls `deliver_signal` via its SignalBridge (signal_bridge.rs) and emits via its own wrappers. Bridge covers it.    |
+| `ff_expire_suspension` auto_resume (§5.2) | Out of cairn's current consumption model — cairn invokes `ExecutionSuspended` but does not track auto-resume transitions. If this is a defect, cairn-side fix (not in PR#19 scope). |
+| `ff_close_waitpoint` (§5.2)               | Waitpoint close is FF-internal; cairn observes the paired `ExecutionCancelled` / `ExecutionCompleted` at the exec level. |
+| `ff_promote_delayed` / `ff_promote_blocked_to_eligible` / `ff_unblock_execution` (§5.3) | Covered in §1.4 above — scheduling ticks, cairn doesn't need them.                                               |
+| `ff_block_execution_for_admission` (§5.3) | Covered in §1.5 above — cairn has no rate-limited variant.                                                              |
+| `ff_apply_dependency_to_child` / `ff_resolve_dependency` (§5.3) | Cairn does not currently track FF flow-edge dependencies (task_service.rs:350-356 explicitly defers to FF's native coordination). No subscription intended. |
+| `ff_add_execution_to_flow` (§5.4)         | Membership is opaque to cairn — cairn uses flows as grouping handles, not as observed entities.                           |
+| `ff_cancel_flow` (§5.4)                   | Cairn calls `cancel_flow` itself via `run_service.cancel_execution` for each member — per-execution cancels emit `ExecutionCancelled`. The flow-level transition is redundant. |
+| `ff_reset_budget` (§5.4)                  | Admin-managed, no cairn consumer.                                                                                        |
+| `ff_cancel_execution` suspended-branch sub-paths (§5.2) | Cairn emits `ExecutionCancelled` synchronously (run_service.rs:628 + worker_sdk.rs:344). The FF-side lease_history branch is covered by the FCALL — no cairn subscription needed. |
+
+## §3 Poll-dependent consumers
+
+**Finding: cairn does not poll FF state on any schedule.**
+
+Every `hgetall(&ctx.core())` in cairn-fabric/src is a
+read-back-after-write or a read-once-per-request (inside a service
+method). There is no background task / interval / tick that reads
+exec_core periodically.
+
+Consequence: if FF transitions state server-side (scanner, lease
+expiry, timeout) without cairn initiating it, cairn will NEVER
+observe the transition until the next cairn-initiated call on that
+execution. For most entity-creation events this is fine because
+cairn initiated the creation. But for §1.1 (lease expiry) and
+§1.3 (timeout expiry), this is the source of the drift.
+
+**No pathological creation-event polling exists** — cairn emits
+creation events itself from its own wrappers. This is the
+healthiest pattern for creation; the gaps are on
+FF-initiated-terminal transitions.
+
+## §4 Non-FCALL atomicity defect (§5.5 only)
+
+**Per-manager dispatch:** separate defect class from bridge events.
+
+**Site:** `crates/ff-server/src/server.rs:1279` — `flow_id` HSET on
+exec_core inside `add_execution_to_flow`, outside the FCALL
+boundary.
+
+**Risk:** phase-1 (ff_add_execution_to_flow FCALL) succeeds +
+phase-2 (HSET flow_id) fails → flow_core thinks exec is a member
+but exec_core has no flow_id back-pointer. The W2 inventory notes
+the comment at L1274 calling it "idempotent, safe to retry if phase
+1 succeeded but phase 2 failed" — but a retry requires the caller
+to notice the failure and retry. If the process crashes between
+phases, no retry fires and the inconsistency sticks.
+
+**Fix site — FF side.** Move the `flow_id` HSET into the FCALL.
+Two options:
+
+- **Option A:** extend `ff_add_execution_to_flow` to accept an
+  optional `back_pointer_field` arg and HSET inside the FCALL. The
+  Lua already has KEYS[1]=exec_core; pass the exec_core key +
+  field name, and do the HSET under the same Lua atomicity.
+- **Option B:** add a new FCALL `ff_link_execution_to_flow` that
+  does both writes atomically. Called in place of the
+  two-phase ff-server code.
+
+**Recommendation: Option A.** Lower churn; extends an existing
+FCALL rather than introducing a new one. The ff-server caller
+becomes a single FCALL invocation with no follow-up HSET. Any
+cairn-fabric / ff-sdk callers of the FF API are unaffected because
+`add_execution_to_flow` is a ff-server REST method, not an FCALL
+cairn calls directly.
+
+**Not bridge-event related. No cairn-side work.**
+
+## §5 Recommendations
+
+Per-gap summary, owner assignment, and rationale.
+
+| Gap                                                        | Confirmed? | Fix owner | Recommended emit/consumer site                                                                                                   |
+| ---------------------------------------------------------- | :--------: | :-------: | -------------------------------------------------------------------------------------------------------------------------------- |
+| §1.1 FF-initiated lease expiry (`ff_mark_lease_expired_if_due`) | YES   | **cairn** | Cairn-fabric subscribes to `lease_history_key` per-execution at claim time, maps `expired` → `BridgeEvent::ExecutionFailed { failure_class: LeaseExpired }`. FF already emits the XADD. |
+| §1.2 FF-initiated retry schedule (`ff_promote_delayed`)    | NO          | —         | Intentional silence. Cairn tracks retry via the initial `ExecutionRetryScheduled` event.                                         |
+| §1.3 FF-initiated timeout expiry runnable-branch (`ff_expire_execution` L1464) | YES   | **FF + cairn** | FF: add symmetric `lease_history` `expired` XADD in the runnable branch (matches active/suspended branches already doing it). Cairn: same subscription as §1.1, additional mapping for `expired` frames without a prior `lease_acquired`. |
+| §1.4 Scanner promotions (delayed/blocked → eligible)       | NO          | —         | Intentional silence. Scheduling-tick transitions; cairn sees the eventual claim.                                                 |
+| §1.5 Admission block (`ff_block_execution_for_admission`)  | NO          | —         | Intentional silence (at time of writing). Cairn has no `ExecutionRateLimited` variant.                                           |
+| §5.5 Non-FCALL `flow_id` HSET (server.rs:1279)             | YES (atomicity, not emit) | **FF** | Extend `ff_add_execution_to_flow` to write the `exec_core.flow_id` back-pointer inside the FCALL (Option A). Remove the follow-up HSET in `add_execution_to_flow` method. |
+
+### Summary
+
+- **2 confirmed bridge-event gaps** (§1.1 lease-expiry, §1.3
+  timeout-expiry runnable-branch). Both centred on FF-initiated
+  terminal transitions that cairn's call-then-emit pattern cannot
+  reach.
+- **1 confirmed atomicity defect** (§5.5) — orthogonal to
+  bridge-events; FF-side fix.
+- **15 of W2's 19 candidates are intentional silences** from
+  cairn's perspective. Cairn emits its own events for every
+  transition it initiates; the "no XADD" observation at the FF
+  layer is noise for cairn's consumption model.
+
+### Priority ordering for follow-up PRs
+
+1. **§1.3 FF runnable-branch `ff_expire_execution`** — FF fix
+   first, small + symmetric with existing emits. Closes a real
+   read-model drift where unclaimed-expired executions hang in
+   "Waiting" forever in cairn's projection.
+2. **§5.5 non-FCALL `flow_id` HSET** — FF fix, atomicity-class
+   defect. Not a bridge-event issue but manager explicitly
+   scoped it; small change to extend existing FCALL.
+3. **§1.1 lease-expiry subscription** — cairn-side work. Larger
+   change (new per-execution tail subscription pattern) but
+   captures the biggest class of drift. Should come after FF-side
+   fixes so the subscriber has consistent producer behaviour.
+
+## §6 Deliverable boundary
+
+This report ends at confirmed-gaps + fix-site-recommendations. No
+code changes. Numbers to track in follow-up PRs:
+
+- `lua/execution.lua:1464-1615` — `ff_expire_execution` runnable
+  branch missing XADD.
+- `crates/ff-server/src/server.rs:1279` — two-phase flow_id HSET.
+- `crates/cairn-fabric/src/event_bridge.rs:17-87` — canonical
+  BridgeEvent enum (add `LeaseExpired` failure class if §1.1 fix
+  lands).
+- `lua/execution.lua:1437` — `ff_reclaim_execution` already emits
+  `lease_history` `reclaimed`; cairn's §1.1 subscriber should also
+  consume this frame shape so reclaim drives the same
+  `ExecutionFailed { failure_class: LeaseExpired }` emission.


### PR DESCRIPTION
## Scope

Two reports documenting the FF ↔ cairn bridge-event surface. **No code changes.** Reports-only PR.

- [`benches/perf-invest/bridge-event-audit.md`](benches/perf-invest/bridge-event-audit.md) (W2, 415 LOC) — inventory of every FCALL and `ff-server` pub method that writes terminal / lifecycle / public_state fields, cross-referenced against every emit site (XADD). Flags 19 candidate gaps across 5 buckets (§5.1–§5.4 emit gaps, §5.5 non-FCALL direct write).
- [`benches/perf-invest/bridge-event-gap-report.md`](benches/perf-invest/bridge-event-gap-report.md) (W3, 349 LOC) — comparison pass against `cairn-rs` consumer + emit sites. Classifies each candidate as confirmed-gap / intentional-silence / atomicity-defect.

## Load-bearing finding

**Cairn does not subscribe to any FF stream** for lifecycle observation. Its bridge is cairn-internal — service methods call FF FCALLs and emit `BridgeEvent` synchronously on the return path. Every `BridgeEvent::*` emit grepped in `/tmp/cairn-rs` is from a cairn wrapper method (`run_service.rs`, `task_service.rs`, `session_service.rs`, `worker_sdk.rs`). No `xread` / `XREAD` of `lease_history_key` or `wp_signals_stream`; no background poll on `exec_core`. The "no XADD" observation at the FF layer is noise for cairn's consumption model — cairn emits its own event for every transition it initiates.

## Classified outcome

Starting from W2's 19 candidates (§5.1–§5.4 emit gaps + §5.5 non-FCALL write):

- **§1 Confirmed bridge-event gaps: 2.**
  - §1.1 FF-initiated lease expiry (`ff_mark_lease_expired_if_due`) — cairn's read model drifts when a worker dies and FF scanner-reclaims the lease; cairn never sees it.
  - §1.3 FF-initiated timeout on a never-claimed execution (`ff_expire_execution` runnable branch, `lua/execution.lua:1464-1615`) — state transitions to terminal with **no** `lease_history` XADD (active/suspended branches DO emit). Cairn's projection stays stuck in "Waiting" forever.
- **§2 Intentional silences: 15.** cairn's call-then-emit pattern covers these; the "no XADD" observation at the FF layer is not a cairn-visible defect.
- **§4 Non-FCALL atomicity defect: 1 (§5.5).** Orthogonal to bridge events: `flow_id` HSET at `crates/ff-server/src/server.rs:1279` sits outside the FCALL boundary, so a crash between phases leaves `flow_core` and `exec_core` inconsistent.

## Follow-up ownership

- **§1.3 FF-side XADD**: W1 on `feat/p36-fix-expire-xadd` (fix in flight).
- **§5.5 FF-side atomicity**: W2 on `feat/p36-fix-flow-id-atomicity` (fix in flight).
- **§1.1 cairn-side lease-history subscription**: handed off to the cairn team (cairn-side work; touches `/tmp/cairn-rs/crates/cairn-fabric/src/event_bridge.rs` + `services/*`).

## Verification

Reports-only; no code. `cargo build` / `cargo test` are unaffected.

---

Stacked context: PR rebased onto `main @ 87810fa` so the diff contains only the two new report files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR adding investigative reports; no runtime behavior, APIs, or data paths are modified.
> 
> **Overview**
> Adds two new perf-investigation reports documenting the FF↔cairn bridge-event surface.
> 
> The audit report inventories Lua FCALL/state mutations vs Valkey stream `XADD` emit sites and flags candidate “silent” transitions, while the comparison report cross-references cairn’s actual `BridgeEvent` emission model and reclassifies candidates into *confirmed gaps* (FF-initiated lease expiry and unclaimed timeout expiry), *intentional silences*, and one *non-FCALL atomicity concern* (`exec_core.flow_id` written outside Lua).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fadf0f2c9224c5ce4016f75c26ef585d60c613e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->