### PR TITLE
fix(rfc011): post-merge review sweep — rename-drift + semantic regression

### DIFF
--- a/crates/ff-core/src/partition.rs
+++ b/crates/ff-core/src/partition.rs
@@ -128,8 +128,12 @@ fn partition_for_uuid(uuid_bytes: &[u8; 16], num_partitions: u16) -> u16 {
 /// is retained for API symmetry with the other partition functions, but is
 /// unused — the exec id carries its partition intrinsically.
 pub fn execution_partition(eid: &ExecutionId, _config: &PartitionConfig) -> Partition {
+    // `Execution` family preserves exec-scoped semantics at the metadata
+    // layer (logs, tracing spans, metric labels) even though routing is
+    // aliased to `Flow`'s hash-tag prefix under RFC-011 co-location.
+    // See PartitionFamily enum rustdoc for the alias contract.
     Partition {
-        family: PartitionFamily::Flow,
+        family: PartitionFamily::Execution,
         index: eid.partition(),
     }
 }
@@ -205,8 +209,12 @@ pub fn solo_partition_with(
     config: &PartitionConfig,
     partitioner: &dyn SoloPartitioner,
 ) -> Partition {
+    // Solo execs are execution-scoped — preserve `Execution` family at
+    // the metadata layer. Routing is aliased to `Flow`'s `{fp:N}` tag
+    // under RFC-011 co-location; see PartitionFamily rustdoc for the
+    // alias contract.
     Partition {
-        family: PartitionFamily::Flow,
+        family: PartitionFamily::Execution,
         index: partitioner.partition_for_lane(lane, config),
     }
 }
@@ -357,8 +365,12 @@ mod tests {
         let fp = flow_partition(&fid, &config);
         assert_eq!(eid.partition(), fp.index);
         let ep = execution_partition(&eid, &config);
+        // Indices match (RFC-011 co-location) but family is Execution —
+        // preserves exec-scoped semantics at the metadata layer.
         assert_eq!(ep.index, fp.index);
-        assert_eq!(ep.family, PartitionFamily::Flow);
+        assert_eq!(ep.family, PartitionFamily::Execution);
+        // Alias contract: Execution and Flow produce identical hash-tags.
+        assert_eq!(ep.hash_tag(), fp.hash_tag());
     }
 
     #[test]
@@ -440,7 +452,9 @@ mod tests {
         let p1 = solo_partition(&lane, &config);
         let p2 = solo_partition(&lane, &config);
         assert_eq!(p1, p2);
-        assert_eq!(p1.family, PartitionFamily::Flow);
+        // Solo execs are execution-scoped — family is Execution, routing
+        // is aliased to Flow's `{fp:N}` via PartitionFamily's prefix map.
+        assert_eq!(p1.family, PartitionFamily::Execution);
         assert!(p1.index < config.num_flow_partitions);
     }
 
@@ -493,7 +507,8 @@ mod tests {
         let lane = LaneId::new("pick-me");
         let p = solo_partition_with(&lane, &config, &AlwaysZero);
         assert_eq!(p.index, 0);
-        assert_eq!(p.family, PartitionFamily::Flow);
+        // Solo execs → Execution family (aliases Flow for routing).
+        assert_eq!(p.family, PartitionFamily::Execution);
     }
 
     #[test]

--- a/crates/ff-engine/src/partition_router.rs
+++ b/crates/ff-engine/src/partition_router.rs
@@ -51,7 +51,11 @@ impl PartitionRouter {
         &self.config
     }
 
-    /// Total number of execution partitions.
+    /// Total number of flow partitions.
+    ///
+    /// Post-RFC-011: exec keys co-locate with their parent flow's partition
+    /// under hash-tag routing, so this count governs exec routing too.
+    /// There is no separate `num_execution_partitions`.
     pub fn num_flow_partitions(&self) -> u16 {
         self.config.num_flow_partitions
     }

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -376,15 +376,17 @@ impl Server {
             );
         }
 
+        // Partition counts — post-RFC-011 there are three physical families.
+        // Execution keys co-locate with their parent flow's partition (§2 of
+        // the RFC), so `num_flow_partitions` governs both exec and flow
+        // routing; no separate `num_execution_partitions` count exists.
         tracing::info!(
-            exec_partitions = config.partition_config.num_flow_partitions,
             flow_partitions = config.partition_config.num_flow_partitions,
             budget_partitions = config.partition_config.num_budget_partitions,
             quota_partitions = config.partition_config.num_quota_partitions,
             lanes = ?config.lanes.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
             listen_addr = %config.listen_addr,
-            "FlowFabric server started. Partitions: {}/{}/{}/{}. Scanners: 14 active.",
-            config.partition_config.num_flow_partitions,
+            "FlowFabric server started. Partitions (flow/budget/quota): {}/{}/{}. Scanners: 14 active.",
             config.partition_config.num_flow_partitions,
             config.partition_config.num_budget_partitions,
             config.partition_config.num_quota_partitions,
@@ -2504,10 +2506,6 @@ async fn validate_or_create_partition_config(
             .await
             .map_err(|e| ServerError::ValkeyContext { source: e, context: "HSET num_flow_partitions".into() })?;
         client
-            .hset(&key, "num_flow_partitions", &config.num_flow_partitions.to_string())
-            .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HSET num_flow_partitions".into() })?;
-        client
             .hset(&key, "num_budget_partitions", &config.num_budget_partitions.to_string())
             .await
             .map_err(|e| ServerError::ValkeyContext { source: e, context: "HSET num_budget_partitions".into() })?;
@@ -2534,7 +2532,6 @@ async fn validate_or_create_partition_config(
         Ok(())
     };
 
-    check("num_flow_partitions", config.num_flow_partitions)?;
     check("num_flow_partitions", config.num_flow_partitions)?;
     check("num_budget_partitions", config.num_budget_partitions)?;
     check("num_quota_partitions", config.num_quota_partitions)?;

--- a/crates/ff-test/src/fixtures.rs
+++ b/crates/ff-test/src/fixtures.rs
@@ -117,8 +117,13 @@ impl TestCluster {
     /// scheduler's natural co-location. Callers exercising flow
     /// membership should construct ids directly via
     /// `ExecutionId::for_flow(&fid, &config)` instead.
+    ///
+    /// Uses `self.config` (the cluster's active config, honouring any
+    /// `FF_TEST_PARTITION_CONFIG` env override) rather than the compile-
+    /// time `TEST_PARTITION_CONFIG` constant — matches the partition
+    /// count every other `&self.config` consumer on `TestCluster` sees.
     pub fn new_execution_id(&self) -> ExecutionId {
-        ExecutionId::solo(&self.test_lane(), &TEST_PARTITION_CONFIG)
+        ExecutionId::solo(&self.test_lane(), &self.config)
     }
 
     /// Current timestamp.


### PR DESCRIPTION
## Summary

Post-merge cleanup for PR #25 (RFC-011 phase 1+2) addressing 6 real findings from bot reviews that I failed to sweep before admin-merging. Fix-forward since PR #25 is already on main.

## Fixes

**Rename-drift bugs** (sed-style phase-1.C commit 0f5d180 left duplicates):

1. \`crates/ff-server/src/server.rs:2505-2506\` — duplicate \`HSET\` writing \`num_flow_partitions\` twice on first boot. Remove one. (Copilot + gemini + cursor all flagged)
2. \`crates/ff-server/src/server.rs:2537-2539\` — duplicate \`check(\"num_flow_partitions\", ...)\` validation call. Remove one. (Copilot + gemini)
3. \`crates/ff-server/src/server.rs:389\` — startup logging reported 4 partition counts (exec/flow/budget/quota) with \`num_flow_partitions\` emitted twice under different field names. Collapsed to 3-tuple (flow/budget/quota) with an inline RFC-011 §2 pointer explaining that exec partitions alias flow. (Copilot)

**Latent-path bug**:

4. \`crates/ff-test/src/fixtures.rs:121\` — \`new_execution_id()\` was minting via \`TEST_PARTITION_CONFIG\` instead of \`self.config\`, which broke the \`FF_TEST_PARTITION_CONFIG\` override path. No current test exercises that path (which is why 146/146 still passed), but latent for any future test wanting a non-default config. (Copilot)

**Doc drift**:

5. \`crates/ff-engine/src/partition_router.rs:54\` — doc comment \"Total number of execution partitions\" post-RFC-011 is factually wrong; these are flow partitions (with execution as a routing alias). Updated to reflect reality with RFC-011 pointer. (Copilot ×2)

**Semantic regression** (phase-1 RED-fix miss that snuck through):

6. \`crates/ff-core/src/partition.rs:132 + 212\` — \`execution_partition()\` and \`solo_partition_with()\` returned \`Partition { family: PartitionFamily::Flow, ... }\` instead of \`::Execution\`. W3's original §11 RED fix restored the \`Execution\` variant specifically so callers preserve semantic meaning (scanners iterating executions, logs/metrics using \`family\` for categorization). Routing is identical (aliased), but metadata observability was wrong. (Copilot + gemini ×2)

Test impact: 3 in-module tests asserted \`.family == Flow\` pre-fix; flipped to \`::Execution\`. One added \`hash_tag()\` equivalence assertion so the alias contract is pinned. Fourth site (\`flow_partition_determinism\`) stays \`Flow\` — genuinely flow-scoped API, untouched. No downstream-crate code branches on family.

## Not in scope

- Bug 1 (test contradiction at \`fixtures.rs:489\`) — bot flagged against an intermediate state; W1's commit \`745aa51\` already fixed it before PR #25 merged. Already-resolved stale comment. Thread will be resolved via the sweep workflow, no code change needed.
- \`api.rs:325\` micro-opt on \`params.lane\` clone — not a bug, style preference, won't-fix with rationale.

## Verification

- \`cargo check --workspace\` clean
- \`cargo clippy --workspace --exclude ferriskey -- -D warnings\` clean
- \`cargo test -p ff-core --lib\` 70/70
- \`cargo test -p ff-script --lib\` 30/30
- \`cargo test -p ff-test --tests -- --test-threads=1\` 146/146

## Thread resolution

After this merges, I'll explicitly resolve the addressed threads on PR #25 via \`gh api graphql\` — 13 of the 16 get resolved (the 2 already-fixed ones + the 1 won't-fix), mapped per-file in \`2ab784f\` commit body.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `PartitionFamily` returned for execution/solo partitions (affecting metadata/observability and any downstream branching), and touches server boot-time partition-config persistence/validation paths, though routing indices remain unchanged.
> 
> **Overview**
> Fixes an RFC-011 semantic regression by making `execution_partition()` and `solo_partition_with()` return `PartitionFamily::Execution` again (while still aliasing `Flow` for routing), and updates core tests to assert both family semantics and `hash_tag()` equivalence.
> 
> Cleans up RFC-011 rename drift in `ff-server` by removing duplicate partition-config `HSET`/validation calls and simplifying startup logging to report only the physical partition families (flow/budget/quota). Also fixes `ff-test` fixtures to mint solo `ExecutionId`s using the active cluster `PartitionConfig` so the `FF_TEST_PARTITION_CONFIG` override is honored, and updates `ff-engine` router docs to reflect the unified flow/exec partition count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab784f58b0a2a03066870c9e65d8ab289881b5c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->