### PR TITLE
RFC-011 phase 3: atomic ff_add_execution_to_flow + cross-review YELLOWs

### DIFF
--- a/benches/perf-invest/bridge-event-gap-report.md
+++ b/benches/perf-invest/bridge-event-gap-report.md
@@ -331,6 +331,21 @@ the repo from today through RFC-011 phase 3. Readers auditing the
 atomicity story should treat RFC-011 as the load-bearing artifact and
 this §4 amendment as its transitional prelude.
 
+**LANDED (2026-04-18, W2, phase 3):** `ff_add_execution_to_flow` is
+now atomic. Single FCALL with KEYS[4]=exec_core co-located on the
+same `{fp:N}` slot as flow_core/members_set/flow_index. Both the
+membership SADD and the `exec_core.flow_id` HSET commit atomically
+or neither does (validates-before-writing Lua discipline). The two-
+phase contract documented above is retired; the post-FCALL Rust HSET
+at `crates/ff-server/src/server.rs` is deleted. Interim safety-net
+prose on the Lua function docstring, the Rust method rustdoc, and
+the reader-invariant comments at `describe_execution` +
+`replay_execution` are rewritten to reference the atomic invariant
+via RFC-011 §7.3 instead of the superseded two-phase reader-safety
+catalogue. Issue #21 is closed as superseded. See phase-3 merge
+commit for the full diff; see `crates/ff-test/tests/e2e_flow_atomicity.rs`
+for the 5 atomicity tests pinning the invariants.
+
 **Not bridge-event related. No cairn-side work.**
 
 ## §5 Recommendations
@@ -344,7 +359,7 @@ Per-gap summary, owner assignment, and rationale.
 | §1.3 FF-initiated timeout expiry runnable-branch (`ff_expire_execution` L1464) | YES   | **FF + cairn** | FF: add symmetric `lease_history` `expired` XADD in the runnable branch (matches active/suspended branches already doing it). Cairn: same subscription as §1.1, additional mapping for `expired` frames without a prior `lease_acquired`. |
 | §1.4 Scanner promotions (delayed/blocked → eligible)       | NO          | —         | Intentional silence. Scheduling-tick transitions; cairn sees the eventual claim.                                                 |
 | §1.5 Admission block (`ff_block_execution_for_admission`)  | NO          | —         | Intentional silence (at time of writing). Cairn has no `ExecutionRateLimited` variant.                                           |
-| §5.5 Non-FCALL `flow_id` HSET (server.rs:1279)             | YES (atomicity, not emit) | **FF** | Cross-slot constraint rules out single-FCALL fix. Document two-phase contract in `lua/flow.lua` + `server.rs:1240-1320` + reader-side invariants at `server.rs:1895-1910` and `server.rs:2080-2115`; file reconciliation-scanner ticket. **See §4 amendment.** |
+| §5.5 Non-FCALL `flow_id` HSET (server.rs:1279)             | **CLOSED** (landed phase 3) | **FF** | RFC-011 §7.3 landed the atomic single-FCALL shape. exec_core co-locates with flow_core on `{fp:N}`; `ff_add_execution_to_flow` now writes both atomically in one FCALL body. Two-phase contract retired; issue #21 closed as superseded. See §4 LANDED block + `crates/ff-test/tests/e2e_flow_atomicity.rs`. |
 
 ### Summary
 

--- a/benches/perf-invest/review-rfc011-phase3-w3.md
+++ b/benches/perf-invest/review-rfc011-phase3-w3.md
@@ -1,0 +1,347 @@
+# Cross-review — RFC-011 phase 3 (W3)
+
+Reviewer: Worker-3. Branch: `feat/rfc011-phase3-atomic`. Single
+commit `c1e8678` on top of `60c9b78`. Independent of W1's review.
+
+## Overall: **ACCEPT with 2 YELLOW**
+
+Phase 3 closes the §5.5 atomicity gap. Single atomic FCALL; 5
+strong behavioral tests; reader-site invariants rewritten from
+"safe-against-orphan" to "true-by-construction"; issue #21 closed on
+GitHub; §4 gap-report LANDED block + §5 table flipped to CLOSED. No
+REDs.
+
+Two YELLOWs, both documentation/UX nits (neither blocks merge):
+
+1. Already-member branch defensive HSET (W2 self-flag #1) — scope
+   widening vs strict RFC §7.3 idempotency invariant; needs text
+   amendment.
+2. No pre-flight `exec_partition == flow_partition` check in
+   `add_execution_to_flow` — wrong-partition callers hit raw
+   `CROSSSLOT` instead of typed `PartitionMismatch`. Additive ~5 LOC
+   polish.
+
+## Dimension 1 — acceptance gates (trust-but-verify)
+
+All green on local machine:
+
+```
+$ cargo check --workspace --all-targets --exclude ferriskey    ✓ clean
+$ cargo clippy --workspace --exclude ferriskey -- -D warnings  ✓ clean
+$ cargo test -p ff-core --lib       70/70
+$ cargo test -p ff-script --lib     30/30
+$ cargo test -p ff-sdk --lib        23/23
+$ cargo test -p ff-server --lib     5/5
+$ cargo test -p ff-test --tests -- --test-threads=1    151/151
+  - e2e_flow_atomicity: 5/5 ← NEW (phase 3 contribution)
+  - e2e_lifecycle: 102/102
+  - waitpoint_tokens: 13/13
+  - e2e_api: 23/23 (was 16)
+  - admin_rotate_api: 5/5
+  - pending_waitpoints_api: 4/4
+  - result_api: 3/3
+```
+
+`ferriskey` test-compile errors excluded (pre-existing unrelated —
+`compression::CommandCompressionBehavior::description`,
+`AuthenticationInfo.iam_config`).
+
+W2's 151/151 claim verified on my machine, 1.95 rustc. Matches.
+
+## Dimension 2 — grep assertions
+
+| Grep                                                              | Expected | Actual |
+|-------------------------------------------------------------------|:--------:|:------:|
+| `hset.*exec_core.*flow_id` in `crates/ff-server`                  | 0        | **0**  |
+| `HSET.*exec_core.*flow_id` in `crates/ff-server`                  | 0        | **0**  |
+| `ExecutionId::new(` in code (excluding docstrings + review docs)  | 0        | **0**  |
+| `num_execution_partitions` in code (excluding retirement annotations) | 0    | **0**  |
+| `HSET flow_id` outside FCALL at `crates/ff-server/src/server.rs`  | 0        | **0**  |
+| `e2e_lifecycle.rs` `num_execution_partitions` hits (phase-2 cleanup) | 0     | **0** (matches phase-2 merge) |
+
+All 6 "should-be-zero" greps pass. Phase-2 HSET at server.rs:1279 is
+deleted; phase-3 only adds exec_core as KEYS[4] to the atomic FCALL.
+
+## Dimension 3 — test meaningfulness (signature catch)
+
+Each of the 5 new `crates/ff-test/tests/e2e_flow_atomicity.rs` tests
+asserts Valkey-state values, not path-matches. If any atomic invariant
+was silently broken by an impl change, the tests would fail loudly.
+
+### Test 1 — `test_atomicity_happy_path_commits_both_writes` (L156-187)
+
+- Pre-call: asserts both `hget_flow_id(&eid) == None` AND
+  `sismember_flow == false` (both writes absent).
+- Call returns Ok.
+- Post-call: asserts both `hget_flow_id(&eid) == Some(flow_id)` AND
+  `sismember_flow == true`.
+
+Both writes pinned. A impl that forgot the HSET (like the pre-RFC-011
+version would, if re-introduced) fails the first post-call assertion.
+
+### Test 2 — `test_atomicity_flow_not_found_commits_nothing` (L189-223)
+
+This is manager's key test. Verified it actually proves nothing was
+written:
+
+- Creates exec_core but NOT flow_core.
+- Calls `add_execution_to_flow` → expects `flow_not_found` error.
+- Post-call: asserts `hget_flow_id(&eid) == None` AND
+  `sismember_flow(flow_id, eid) == false`.
+
+Manager's concern: "could a concurrent writer pollute the state it
+reads back?" Answer: **no.** `#[serial_test::serial]` annotation +
+test cleanup ensures no concurrent writer on the same keyspace. Even
+without serial, each test reads back the specific `(eid, flow_id)`
+it minted — uuid-scoped, no cross-contamination possible. If the
+impl accidentally wrote before the guard, the HGET would return the
+mistaken value.
+
+Validates-before-writing discipline is pinned at the Valkey-state
+level, not at the path-match level.
+
+### Test 3 — `test_atomicity_repeat_call_is_idempotent` (L225-272)
+
+Pre- + post-condition asserts `node_count == "1"` (not `>=1`). Catches
+double-increment on retry — the specific bug a naively-implemented
+Lua function would introduce if it skipped the members-set SISMEMBER
+guard.
+
+**YELLOW 1 interaction:** this test DOES exercise the already-member
+branch (second call hits it), but the assertion `hget_flow_id(&eid)
+== Some(flow_id)` passes whether the defensive HSET at `lua/flow.lua:182`
+runs or not, because the first call already stamped the correct value.
+Test does NOT catch a pathological "already-member path silently
+rewrites to a DIFFERENT flow_id" scenario. See YELLOW 1 below.
+
+### Test 4 — `test_atomicity_concurrent_distinct_execs` (L274-340)
+
+Two `tokio::task`s call `add_execution_to_flow` on the same flow with
+distinct execs concurrently. Assertions:
+- Both execs are in members_set.
+- Both exec_cores carry flow_id.
+- `node_count == "2"` exactly (no lost update).
+
+Catches lost-update via non-atomic increment. HINCRBY is atomic but
+a pre-atomic version that did SADD + HINCRBY across separate calls
+could race.
+
+### Test 5 — `test_atomicity_flow_id_visible_to_subsequent_reads` (L342-end)
+
+Asserts that immediately after a successful call, 3 sequential reads
+all see the stamped `flow_id`. Pins the "no visibility lag" property.
+
+### Dimension 3 verdict
+
+All 5 tests behavioral, none path-match only. Manager's "could
+pass with non-atomic impl" check satisfies. GREEN.
+
+## Dimension 4 — `lua/flow.lua` docstring rewrite
+
+`lua/flow.lua:114-136` entirely rewritten. Old state:
+```
+TWO-PHASE CONTRACT (cairn P3.6 §5.5)
+exec_core lives on {p:N} ... this FCALL runs on {fp:N} ... we CANNOT
+touch exec_core ... The caller (ff-server `add_execution_to_flow`) ...
+runs this FCALL first and then issues an `HSET exec_core flow_id` as
+a separate command. Orphan window: ... Reader safety: ... scanner ...
+```
+
+New state (L114-136):
+```
+ff_add_execution_to_flow  (on {fp:N} — single atomic FCALL)
+Add a member execution to a flow AND stamp the flow_id back-pointer
+on exec_core in one atomic commit. Per RFC-011 §7.3, exec keys
+co-locate with their parent flow's partition under hash-tag routing,
+so exec_core shares the `{fp:N}` hash-tag with flow_core / members_set
+/ flow_index. All four KEYS hash to the same slot; no CROSSSLOT.
+
+Validates-before-writing: flow_not_found / flow_already_terminal
+early-returns fire BEFORE any write ...
+
+Invariant (post-RFC-011): a successful call commits BOTH the flow-
+index updates AND the exec_core.flow_id stamp in one atomic unit.
+Readers can assume exec_core.flow_id == flow_id iff the exec is in
+members_set. The pre-RFC-011 two-phase contract + §5.5 orphan-window
++ issue #21 reconciliation-scanner plan are all superseded.
+```
+
+Zero "two-phase" / "orphan-window" / "reconciliation-scanner" prose
+remaining as CURRENT-REALITY CLAIMS. All mentions tag as "pre-RFC-011
+... retired" or "all superseded." Surgical, matches surgical-changes
+discipline. GREEN.
+
+## Dimension 5 — reader-invariant rewrites
+
+`describe_execution` (server.rs ~:1895) and `replay_execution`
+(server.rs ~:2080) reader comments rewritten:
+
+Old: "Treat empty as 'no flow affinity known at read time' — safe for
+this reader ... See `add_execution_to_flow` rustdoc for the
+orphan-direction and reader-safety catalogue."
+
+New: "Reader invariant (RFC-011 §7.3): `flow_id` on exec_core is
+stamped atomically with membership by `add_execution_to_flow`'s single
+FCALL. Empty iff the exec has no flow affinity (solo-path
+create_execution — never added to a flow)."
+
+**Post-atomic the invariant is TRUE BY CONSTRUCTION** — empty flow_id
+means solo exec, full stop. No orphan-possibility language retained
+as live. "is_skipped_flow_member" branch at replay_execution gates on
+`!flow_id_str.is_empty()`, so solo execs correctly fall back. Matches
+"true by construction, not half-measure" standard. GREEN.
+
+## Dimension 6 — gap-report §4 "LANDED" + §5 CLOSED row
+
+`benches/perf-invest/bridge-event-gap-report.md`:
+
+- §4 LANDED block added (L334-349): describes the phase-3 shape,
+  mentions exec_core as KEYS[4], notes validates-before-writing Lua
+  discipline, cites `crates/ff-test/tests/e2e_flow_atomicity.rs` for
+  the atomicity tests, and states "Issue #21 is closed as superseded."
+
+- §5 row for §5.5 flipped from `YES (atomicity, not emit)` +
+  description to `**CLOSED** (landed phase 3)` + new description
+  pointing at RFC-011 §7.3 + e2e_flow_atomicity.rs. No intermediate
+  state left in the row.
+
+Both updates match expectation. GREEN.
+
+## Dimension 7 — Issue #21 closure text
+
+Checked GitHub: `gh issue view 21 --json state,title` returns
+`{"state":"CLOSED","title":"crash-recovery scanner for flow_id / flow
+membership consistency (cairn P3.6 §5.5)"}`. W2 already closed it on
+the remote — no dangling-ref.
+
+Citation pattern in docs: "issue #21, now superseded" / "issue #21 is
+closed as superseded" — declarative, doesn't depend on specific merge
+SHA. Survives whenever phase 3 merges; reader can `gh issue view 21`
+for context. W2 handled this cleanly. GREEN.
+
+## YELLOW 1 — already-member branch defensive HSET (W2 self-flag #1)
+
+**Site:** `lua/flow.lua:181-185`.
+
+```lua
+if redis.call("SISMEMBER", K.members_set, A.execution_id) == 1 then
+    redis.call("HSET", K.exec_core, "flow_id", A.flow_id)
+    local nc = redis.call("HGET", K.flow_core, "node_count") or "0"
+    return ok_already_satisfied(A.execution_id, nc)
+end
+```
+
+The HSET at line 182 runs even when the exec is already a member.
+W2's docstring calls it "defensive heal for pre-phase-3 orphans during
+rolling upgrade."
+
+**RFC §7.3.1 Test 3 spec:**
+```
+1. Successful add_execution_to_flow (test 1).
+2. Second call with same (flow_id, eid) → OK_ALREADY_SATISFIED.
+3. Assert exec_core.flow_id unchanged; node_count still "1".
+```
+
+RFC says "exec_core.flow_id **unchanged**" on idempotent retry. W2's
+impl always HSETs `flow_id = A.flow_id` on that branch. **The
+observable post-state is identical** (same value written, so the
+"unchanged" assertion still holds) — test 3 passes. But the strict
+RFC invariant is "no write, not just same value." Scope widening.
+
+**Latent correctness risk:** if a corrupted state had `exec.flow_id =
+flow_B` with `exec in flow_A.members_set` (not reachable via
+`add_execution_to_flow` under normal use — would require manual
+Valkey tampering or a cairn-side bug adding the same exec to two
+flows), the defensive HSET **silently rewrites** from B to A. No
+warning, no error. Masks a real bug.
+
+Naturally-reachable? Only via cross-flow membership. Cairn currently
+maintains exec-belongs-to-exactly-one-flow invariant in
+`RunService::create_run`/`TaskService::create_task` — no code path
+adds the same exec to two flows. So the risk is hypothetical under
+current consumers.
+
+**Disposition:** YELLOW — accept the defensive heal as deliberate
+rolling-upgrade safety, BUT:
+
+1. **RFC §7.3 text amendment needed.** Update §7.3.1 Test 3 spec to
+   reflect "same-value rewrite is acceptable under the defensive-heal
+   contract; cross-flow rewrite is never reached via normal
+   consumer paths." Make the scope widening explicit so future
+   maintainers don't treat line 182 as pure idempotency.
+
+2. **Optional defensive guard:** add an `if old_flow_id ~= "" and
+   old_flow_id ~= A.flow_id then error_reply("cross_flow_membership")
+   end` before line 182. Catches the hypothetical cross-flow
+   corruption loudly. ~2 LOC. Not blocking; file a follow-up if any
+   consumer hits it.
+
+W2 self-flagged this honestly; the YELLOW is on the spec-text side,
+not the impl.
+
+## YELLOW 2 — no pre-flight exec_partition == flow_partition check
+
+**Site:** `crates/ff-server/src/server.rs:1279-1317`
+(`add_execution_to_flow` body).
+
+Method computes `flow_partition(args.flow_id)` and
+`execution_partition(args.execution_id)` independently, threads both
+partitions into KEYS, but never asserts they're equal. If a caller
+passes a solo-minted exec or a for_flow-minted-against-a-different-flow
+id, the resulting KEYS span slots → Valkey returns raw `CROSSSLOT`
+error → bubbles up as `ServerError::ValkeyContext(CrossSlot...)`.
+
+Not a correctness issue — the op fails safely. But the error surface
+is raw-Valkey instead of a typed `ServerError::PartitionMismatch` with
+a clear diagnostic ("execution_id was minted for partition X but
+flow_id hashes to partition Y; use ExecutionId::for_flow(&flow_id)
+at the minting site").
+
+**Disposition:** YELLOW — additive ~5 LOC polish. Insert before the
+FCALL:
+
+```rust
+if exec_partition.index != partition.index {
+    return Err(ServerError::PartitionMismatch {
+        exec_partition: exec_partition.index,
+        flow_partition: partition.index,
+    });
+}
+```
+
+Turns CROSSSLOT into a clean typed error. Good ops UX, zero semantics
+change. Not blocking; follow-up commit works.
+
+## Regression check
+
+- `cargo build --workspace --exclude ferriskey`: clean.
+- `cargo test -p ff-test --tests`: 151/151 (100% pass).
+- 5 should-be-zero greps still pass (Dimension 2 table above).
+- No new `#[allow(...)]`, no `unsafe`, no new `Box::pin`. No stowaways.
+- Issue #21 closed on GitHub.
+
+No regressions.
+
+## Vote
+
+**ACCEPT phase 3** with the two documented YELLOWs (neither blocking).
+Phase 3 delivers the atomicity guarantee the §5.5 gap report named as
+the cap-stone fix, via a surgical ~550-LOC commit (160 Rust
+rewrite/delete + 80 Lua rewrite + 370 new atomicity test + 100 doc
+updates). Test meaningfulness passes the "could a non-atomic impl
+pass this test?" check.
+
+If W1 also ACCEPTs (their ping indicates same-direction ACCEPT with
+two different YELLOWs), phase 3 closes + PR#25 bundles phase-1 + phase-2
++ phase-3 for merge to main.
+
+Post-merge follow-ups for the YELLOWs:
+
+- YELLOW 1: §7.3 text amendment in a trailing RFC-011-revision-4
+  commit on rfc/011-revision-4, or inline the amendment into the
+  phase-5 release-note consolidation.
+- YELLOW 2: 5-LOC `PartitionMismatch` check — can land as its own
+  commit on feat/rfc011-phase3-atomic before PR#25 merges OR as a
+  phase-5 polish (operator UX improvement, not correctness).
+
+Independent of W1. Did not read W1's full review doc before writing.

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -1291,6 +1291,24 @@ impl Server {
             execution_partition(&args.execution_id, &self.config.partition_config);
         let ectx = ExecKeyContext::new(&exec_partition, &args.execution_id);
 
+        // Pre-flight: exec_partition must match flow_partition under
+        // RFC-011 §7.3 co-location contract. If the caller hands us a
+        // `solo`-minted exec whose hash-tag ≠ flow_partition, the FCALL
+        // would fail with raw `CROSSSLOT` on a clustered deploy — a
+        // typed `ServerError::PartitionMismatch` is a clearer signal
+        // that the consumer-contract invariant was violated at mint
+        // time (caller should have used `ExecutionId::for_flow(...)`).
+        // See the Consumer contract section of this method's rustdoc.
+        if exec_partition.index != partition.index {
+            return Err(ServerError::PartitionMismatch(format!(
+                "add_execution_to_flow: execution_id's partition {exec_p} != flow_id's partition {flow_p}. \
+                 Post-RFC-011 §7.3 co-location requires mint via `ExecutionId::for_flow(&flow_id, config)` \
+                 so the exec's hash-tag matches the flow's `{{fp:N}}`.",
+                exec_p = exec_partition.index,
+                flow_p = partition.index,
+            )));
+        }
+
         // KEYS (4): flow_core, members_set, flow_index, exec_core
         let fcall_keys: Vec<String> = vec![
             fctx.core(),

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -1241,65 +1241,41 @@ impl Server {
 
     /// Add an execution to a flow.
     ///
-    /// # Two-phase cross-partition operation (cairn P3.6 §5.5)
+    /// # Atomic single-FCALL commit (RFC-011 §7.3)
     ///
-    /// Membership lives on `{fp:N}` (flow-partition); the exec's
-    /// back-pointer to the flow lives on `{p:N}` (execution-partition).
-    /// Valkey functions are single-slot, so we cannot touch both in one
-    /// FCALL — a clustered deploy would return `CROSSSLOT`. The method
-    /// therefore issues two commands in sequence:
+    /// Post-RFC-011 phase-3, exec_core co-locates with flow_core under
+    /// hash-tag routing (both hash to `{fp:N}` via the exec id's
+    /// embedded partition). A single atomic FCALL writes:
     ///
-    /// 1. **Phase 1 — FCALL `ff_add_execution_to_flow` on `{fp:N}`**.
-    ///    Atomically adds the execution to `members_set`, bumps
-    ///    `node_count` + `graph_revision` on `flow_core`, and re-adds
-    ///    the flow to `flow_index` (self-healing idempotent SADD).
-    /// 2. **Phase 2 — `HSET exec_core flow_id <flow_id>` on `{p:N}`**.
-    ///    Stamps the back-pointer on the execution's core hash so
-    ///    exec-scoped reads (`describe_execution`, `replay_execution`)
-    ///    know which flow the exec belongs to.
+    ///   - `members_set` SADD (flow membership)
+    ///   - `exec_core.flow_id` HSET (back-pointer)
+    ///   - `flow_index` SADD (self-heal)
+    ///   - `flow_core` HINCRBY node_count / graph_revision +
+    ///     HSET last_mutation_at
     ///
-    /// # Orphan window
+    /// All four writes commit atomically or none do (Valkey scripting
+    /// contract: validates-before-writing in the Lua body means
+    /// `flow_not_found` / `flow_already_terminal` early-returns fire
+    /// BEFORE any `redis.call()` mutation, and a mid-body error after
+    /// writes is not expected because all writes are on the same slot).
     ///
-    /// If the server crashes after phase 1 commits but before phase 2
-    /// runs — or phase 2's Valkey round-trip fails at the transport —
-    /// the flow believes the exec is a member while the exec's
-    /// `exec_core.flow_id` field is still empty. The orphan is
-    /// asymmetric: the "flow side says yes, exec side says nothing"
-    /// direction. Retry is idempotent on both phases, but a retry
-    /// requires the caller to notice the failure; a crashed caller
-    /// does not retry.
+    /// The pre-RFC-011 two-phase contract (membership FCALL on `{fp:N}` plus separate HSET on `{p:N}`), orphan window, and reconciliation-scanner plan (issue #21, now superseded) are all retired.
     ///
-    /// # Reader safety during the orphan window
+    /// # Consumer contract
     ///
-    /// * `flow_core → members_set → exec_core` joins (flow projector
-    ///   at `crates/ff-engine/src/scanner/flow_projector.rs`; cancel-
-    ///   flow member dispatch): **safe**. Flow-side is authoritative
-    ///   for membership; readers iterate `members_set` without
-    ///   consulting `exec_core.flow_id`.
-    /// * `exec_core.flow_id → flow_core` joins (`describe_execution`
-    ///   at `server.rs:1895-1910`, `replay_execution` at
-    ///   `server.rs:2080-2115`): **safe**. Empty `flow_id` is filtered
-    ///   via `.filter(|s| !s.is_empty())` and surfaced as "no flow
-    ///   affinity"; a re-read after phase 2 commits returns the link.
-    /// * Joint-consistency readers ("list all members of flow X AND
-    ///   confirm each exec's `exec_core.flow_id == X`"): **unsafe**.
-    ///   No reader in this repo does that today. New code adding such
-    ///   a join must either tolerate empty `flow_id` for newly-added
-    ///   members or rely on the reconciliation scanner below.
+    /// The caller's `args.execution_id` **must** be co-located with
+    /// `args.flow_id`'s partition — i.e. minted via
+    /// `ExecutionId::for_flow(&args.flow_id, config)`. Passing a
+    /// `solo`-minted id (or any exec id hashing to a different
+    /// `{fp:N}` than the flow's) will fail at the Valkey level with
+    /// `CROSSSLOT` on a clustered deploy.
     ///
-    /// # Crash-recovery plan
-    ///
-    /// Tracked as issue #21 (see also the §4 amendment of
-    /// `benches/perf-invest/bridge-event-gap-report.md`). The scanner
-    /// walks `flow_index → members_set → exec_core`, re-stamping
-    /// `flow_id` on any `exec_core` where it's empty or mismatched.
-    /// Rotation-idempotent (same `flow_id` + same `exec_core` → no-op).
-    ///
-    /// Current error propagation (do **not** change without reviewing
-    /// the scanner plan): if phase 2's `HSET` fails, the method
-    /// returns `Err(ServerError::ValkeyContext)` so the caller knows
-    /// phase 1 landed but phase 2 didn't. A silent `Ok(())` would
-    /// hide the need for a retry or scanner sweep.
+    /// Callers with a flow context in scope always use `for_flow`;
+    /// this is the only supported mint path for flow-member execs
+    /// post-RFC-011. Test fixtures that pre-date the co-location
+    /// contract use `TestCluster::new_execution_id_on_partition` to
+    /// pin to a specific hash-tag index for `fcall_create_flow`-style
+    /// helpers that hard-code their flow partition.
     pub async fn add_execution_to_flow(
         &self,
         args: &AddExecutionToFlowArgs,
@@ -1308,9 +1284,20 @@ impl Server {
         let fctx = FlowKeyContext::new(&partition, &args.flow_id);
         let fidx = FlowIndexKeys::new(&partition);
 
-        // Phase 1: FCALL on {fp:N}
-        // KEYS (3): flow_core, members_set, flow_index
-        let fcall_keys: Vec<String> = vec![fctx.core(), fctx.members(), fidx.flow_index()];
+        // exec_core co-locates with flow_core under RFC-011 §7.3 —
+        // same `{fp:N}` hash-tag, same slot, part of the same atomic
+        // FCALL below.
+        let exec_partition =
+            execution_partition(&args.execution_id, &self.config.partition_config);
+        let ectx = ExecKeyContext::new(&exec_partition, &args.execution_id);
+
+        // KEYS (4): flow_core, members_set, flow_index, exec_core
+        let fcall_keys: Vec<String> = vec![
+            fctx.core(),
+            fctx.members(),
+            fidx.flow_index(),
+            ectx.core(),
+        ];
 
         // ARGV (3): flow_id, execution_id, now_ms
         let fcall_args: Vec<String> = vec![
@@ -1326,27 +1313,7 @@ impl Server {
             .fcall_with_reload("ff_add_execution_to_flow", &key_refs, &arg_refs)
             .await?;
 
-        let result = parse_add_execution_to_flow_result(&raw)?;
-
-        // Phase 2: HSET flow_id on exec_core on {p:N}.
-        //
-        // Cross-slot: this write CANNOT be folded into phase 1's FCALL.
-        // See the method-level docstring ("Two-phase cross-partition
-        // operation") for the orphan-window shape + reader safety, and
-        // `lua/flow.lua:114` for the matching note on the FCALL side.
-        //
-        // Idempotent on retry (same flow_id → no-op). If phase 1 landed
-        // but this HSET fails, the Err is propagated so the caller knows
-        // to retry or rely on the reconciliation scanner (issue #21).
-        let exec_partition =
-            execution_partition(&args.execution_id, &self.config.partition_config);
-        let ectx = ExecKeyContext::new(&exec_partition, &args.execution_id);
-        self.client
-            .hset(&ectx.core(), "flow_id", &args.flow_id.to_string())
-            .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HSET flow_id on exec_core".into() })?;
-
-        Ok(result)
+        parse_add_execution_to_flow_result(&raw)
     }
 
     /// Cancel a flow.
@@ -1968,16 +1935,12 @@ impl Server {
             public_state: deserialize("public_state", &ps_str)?,
         };
 
-        // Reader invariant (cairn P3.6 §5.5): `flow_id` on exec_core is
-        // populated by `add_execution_to_flow`'s phase 2 HSET, which
-        // runs AFTER the `ff_add_execution_to_flow` FCALL commits on
-        // the flow-partition. During the orphan window (crash between
-        // phases), this field can be empty on an exec that flow_core
-        // already lists as a member. Treat empty as "no flow affinity
-        // known at read time" — safe for this reader (`describe_execution`
-        // surfaces exec state; flow linkage is descriptive, not an
-        // invariant). See `add_execution_to_flow` rustdoc for the
-        // orphan-direction and reader-safety catalogue.
+        // Reader invariant (RFC-011 §7.3): `flow_id` on exec_core is
+        // stamped atomically with membership in `add_execution_to_flow`'s
+        // single FCALL. Empty iff the exec has no flow affinity (never
+        // called `add_execution_to_flow` — solo execs) — NOT "orphaned
+        // mid-two-phase" (that failure mode is retired). Filter on empty
+        // to surface "no flow affinity" distinctly from "flow X".
         let flow_id_val = fields.get("flow_id").filter(|s| !s.is_empty()).cloned();
 
         // started_at / completed_at come from the exec_core hash —
@@ -2161,21 +2124,15 @@ impl Server {
 
         // Pre-read lane_id, flow_id, terminal_outcome.
         //
-        // Reader invariant (cairn P3.6 §5.5): `flow_id` on exec_core is
-        // populated by `add_execution_to_flow`'s phase-2 HSET. During
-        // the orphan window (crash between the phase-1 FCALL and the
-        // phase-2 HSET), this field can be empty on an exec that the
-        // flow partition already lists as a member. This reader treats
-        // that case correctly — `flow_id_str.unwrap_or_default()`
-        // yields `""`, and the `is_skipped_flow_member` branch below
-        // gates on `!flow_id_str.is_empty()`, so replay falls back to
-        // the non-flow-member path. The only consequence is that a
-        // `skipped` terminal landed during the orphan window replays
-        // without its inbound-edge adjacency reset; the next
-        // reconciliation-scanner pass (see `add_execution_to_flow`
-        // rustdoc) stamps `flow_id` and a subsequent replay is
-        // correct. See `add_execution_to_flow` rustdoc for the
-        // full orphan-direction + reader-safety catalogue.
+        // Reader invariant (RFC-011 §7.3): `flow_id` on exec_core is
+        // stamped atomically with membership by `add_execution_to_flow`'s
+        // single FCALL. Empty iff the exec has no flow affinity
+        // (solo-path create_execution — never added to a flow). The
+        // `is_skipped_flow_member` branch below gates on
+        // `!flow_id_str.is_empty()`, so solo execs correctly fall back
+        // to the non-flow-member replay path. See
+        // `add_execution_to_flow` rustdoc for the atomic-commit
+        // invariant.
         let dyn_fields: Vec<Option<String>> = self
             .client
             .cmd("HMGET")

--- a/crates/ff-test/src/fixtures.rs
+++ b/crates/ff-test/src/fixtures.rs
@@ -126,6 +126,27 @@ impl TestCluster {
         ExecutionId::solo(&self.test_lane(), &self.config)
     }
 
+    /// Generate a fresh ExecutionId pinned to a specific partition index.
+    ///
+    /// Test-only escape hatch for fixtures that hard-code a flow partition
+    /// (e.g. `fcall_create_flow` + `fcall_add_execution_to_flow` in
+    /// `e2e_lifecycle.rs` write to the `{fp:0}` slot regardless of
+    /// `flow_partition(fid)` routing). Post-RFC-011 phase-3 the atomic
+    /// `ff_add_execution_to_flow` FCALL takes `exec_core` as KEYS[4] and
+    /// requires the exec's hash-tag to match the flow's — so these tests
+    /// need a way to pin the exec to a chosen partition index rather
+    /// than routing it via the lane-solo partitioner.
+    ///
+    /// This is NOT a general mint path. Production code must use
+    /// `ExecutionId::for_flow` (flow-co-location) or `ExecutionId::solo`
+    /// (lane-solo). The `{fp:N}:<uuid>` escape hatch stays inside
+    /// `crates/ff-test` per RFC-011 §5.6 ("pluggable trait is the stable
+    /// contract, not the mint function").
+    pub fn new_execution_id_on_partition(&self, index: u16) -> ExecutionId {
+        let raw = format!("{{fp:{index}}}:{}", uuid::Uuid::new_v4());
+        ExecutionId::parse(&raw).expect("synthetic exec id must parse")
+    }
+
     /// Current timestamp.
     pub fn now(&self) -> TimestampMs {
         TimestampMs::now()

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -577,8 +577,11 @@ async fn test_api_add_execution_to_flow() {
         .expect("create flow failed");
     assert!(resp.status().is_success());
 
-    // Create execution
-    let eid = ExecutionId::solo(&LaneId::new(LANE), &ff_test::fixtures::TEST_PARTITION_CONFIG);
+    // Create execution co-located with the flow's partition.
+    // Post-RFC-011 phase 3: ff_add_execution_to_flow is an atomic
+    // single-FCALL that takes exec_core as KEYS[4] and requires the
+    // exec's hash-tag to match the flow's. Mint via for_flow.
+    let eid = ExecutionId::for_flow(&flow_id, &ff_test::fixtures::TEST_PARTITION_CONFIG);
     api_create_execution(&api, &eid, 0).await;
 
     // Add to flow

--- a/crates/ff-test/tests/e2e_flow_atomicity.rs
+++ b/crates/ff-test/tests/e2e_flow_atomicity.rs
@@ -1,0 +1,370 @@
+//! RFC-011 §7.3.1 atomicity tests for `ff_add_execution_to_flow`.
+//!
+//! Pre-phase-3: `add_execution_to_flow` was a two-phase
+//! (FCALL-then-HSET) sequence that could orphan on crash. Phase-3
+//! collapsed it into a single atomic FCALL with exec_core as KEYS[4].
+//! These 5 tests pin the atomicity invariants and the validates-
+//! before-writing discipline that makes the Lua-level rollback work.
+//!
+//! Run: `cargo test -p ff-test --test e2e_flow_atomicity -- --test-threads=1`
+
+use ff_core::contracts::{AddExecutionToFlowArgs, CreateFlowArgs};
+use ff_core::keys::ExecKeyContext;
+use ff_core::partition::{execution_partition, flow_partition};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+const NS: &str = "atomicity-ns";
+
+fn mint_flow_and_exec(tc: &TestCluster) -> (FlowId, ExecutionId) {
+    let flow_id = FlowId::new();
+    let fp = flow_partition(&flow_id, tc.partition_config());
+    let eid = tc.new_execution_id_on_partition(fp.index);
+    (flow_id, eid)
+}
+
+async fn start_server(
+    tc: &TestCluster,
+) -> std::sync::Arc<ff_server::server::Server> {
+    let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
+    let port: u16 = std::env::var("FF_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6379);
+    let pc = *tc.partition_config();
+    let config = ff_server::config::ServerConfig {
+        host,
+        port,
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        partition_config: pc,
+        lanes: vec![LaneId::new("atomicity-lane")],
+        listen_addr: "127.0.0.1:0".into(),
+        engine_config: ff_engine::EngineConfig {
+            partition_config: pc,
+            lanes: vec![LaneId::new("atomicity-lane")],
+            ..Default::default()
+        },
+        skip_library_load: true,
+        cors_origins: vec!["*".to_owned()],
+        api_token: None,
+        waitpoint_hmac_secret:
+            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+        waitpoint_hmac_grace_ms: 86_400_000,
+        max_concurrent_stream_ops: 64,
+    };
+    let server = ff_server::server::Server::start(config)
+        .await
+        .expect("Server::start");
+    std::sync::Arc::new(server)
+}
+
+async fn create_flow(
+    server: &ff_server::server::Server,
+    flow_id: &FlowId,
+) {
+    server
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow_id.clone(),
+            flow_kind: "test".into(),
+            namespace: Namespace::new(NS),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("create_flow");
+}
+
+async fn fcall_create_execution(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+) {
+    let partition = execution_partition(eid, tc.partition_config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = ff_core::keys::IndexKeys::new(&partition);
+    let now = TimestampMs::now();
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&LaneId::new("atomicity-lane")),
+        idx.all_executions(),
+        idx.execution_deadline(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        "atomicity-lane".to_owned(),
+        "test".to_owned(),
+        "{}".to_owned(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+        "0".to_owned(),
+        "tester".to_owned(),
+        String::new(),
+        String::new(),
+        String::new(),
+        now.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    tc.client()
+        .fcall::<ferriskey::Value>("ff_create_execution", &kr, &ar)
+        .await
+        .expect("fcall ff_create_execution");
+}
+
+async fn hget_flow_id(tc: &TestCluster, eid: &ExecutionId) -> Option<String> {
+    let partition = execution_partition(eid, tc.partition_config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let v: Option<String> = tc
+        .client()
+        .cmd("HGET")
+        .arg(ctx.core())
+        .arg("flow_id")
+        .execute()
+        .await
+        .expect("HGET flow_id");
+    v.filter(|s| !s.is_empty())
+}
+
+async fn sismember_flow(
+    tc: &TestCluster,
+    flow_id: &FlowId,
+    eid: &ExecutionId,
+) -> bool {
+    let fp = flow_partition(flow_id, tc.partition_config());
+    let members_key = format!(
+        "ff:flow:{tag}:{fid}:members",
+        tag = fp.hash_tag(),
+        fid = flow_id
+    );
+    let v: bool = tc
+        .client()
+        .cmd("SISMEMBER")
+        .arg(&members_key)
+        .arg(eid.to_string())
+        .execute()
+        .await
+        .expect("SISMEMBER");
+    v
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_atomicity_happy_path_commits_both_writes() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let (flow_id, eid) = mint_flow_and_exec(&tc);
+    let server = start_server(&tc).await;
+
+    create_flow(&server, &flow_id).await;
+    fcall_create_execution(&tc, &eid).await;
+
+    assert_eq!(hget_flow_id(&tc, &eid).await, None);
+    assert!(!sismember_flow(&tc, &flow_id, &eid).await);
+
+    server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("add_execution_to_flow");
+
+    assert_eq!(
+        hget_flow_id(&tc, &eid).await,
+        Some(flow_id.to_string()),
+        "exec_core.flow_id must be stamped atomically with membership"
+    );
+    assert!(
+        sismember_flow(&tc, &flow_id, &eid).await,
+        "exec must be in members_set atomically with flow_id stamp"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_atomicity_flow_not_found_commits_nothing() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let (flow_id, eid) = mint_flow_and_exec(&tc);
+    let server = start_server(&tc).await;
+
+    fcall_create_execution(&tc, &eid).await;
+
+    let err = server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("add_execution_to_flow must error when flow does not exist");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("flow_not_found") || msg.contains("flow not found"),
+        "error must name flow_not_found path; got {msg}"
+    );
+
+    assert_eq!(
+        hget_flow_id(&tc, &eid).await,
+        None,
+        "exec_core.flow_id must NOT be stamped when the Lua early-return fires"
+    );
+    assert!(
+        !sismember_flow(&tc, &flow_id, &eid).await,
+        "exec must NOT be in members_set when the Lua early-return fires"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_atomicity_repeat_call_is_idempotent() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let (flow_id, eid) = mint_flow_and_exec(&tc);
+    let server = start_server(&tc).await;
+
+    create_flow(&server, &flow_id).await;
+    fcall_create_execution(&tc, &eid).await;
+
+    server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("first add");
+
+    server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("second add");
+
+    let fp = flow_partition(&flow_id, tc.partition_config());
+    let flow_core_key = format!(
+        "ff:flow:{tag}:{fid}:core",
+        tag = fp.hash_tag(),
+        fid = flow_id
+    );
+    let nc: Option<String> = tc
+        .client()
+        .cmd("HGET")
+        .arg(&flow_core_key)
+        .arg("node_count")
+        .execute()
+        .await
+        .expect("HGET node_count");
+    assert_eq!(nc.as_deref(), Some("1"), "node_count must not double-increment");
+
+    assert_eq!(hget_flow_id(&tc, &eid).await, Some(flow_id.to_string()));
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_atomicity_concurrent_distinct_execs() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let flow_id = FlowId::new();
+    let fp = flow_partition(&flow_id, tc.partition_config());
+    let eid_a = tc.new_execution_id_on_partition(fp.index);
+    let eid_b = tc.new_execution_id_on_partition(fp.index);
+
+    let server = start_server(&tc).await;
+    create_flow(&server, &flow_id).await;
+    fcall_create_execution(&tc, &eid_a).await;
+    fcall_create_execution(&tc, &eid_b).await;
+
+    let fa = flow_id.clone();
+    let fb = flow_id.clone();
+    let ea = eid_a.clone();
+    let eb = eid_b.clone();
+    let sa = server.clone();
+    let sb = server.clone();
+    let (ra, rb) = tokio::join!(
+        async move {
+            sa.add_execution_to_flow(&AddExecutionToFlowArgs {
+                flow_id: fa,
+                execution_id: ea,
+                now: TimestampMs::now(),
+            })
+            .await
+        },
+        async move {
+            sb.add_execution_to_flow(&AddExecutionToFlowArgs {
+                flow_id: fb,
+                execution_id: eb,
+                now: TimestampMs::now(),
+            })
+            .await
+        },
+    );
+    ra.expect("concurrent add a");
+    rb.expect("concurrent add b");
+
+    assert!(sismember_flow(&tc, &flow_id, &eid_a).await);
+    assert!(sismember_flow(&tc, &flow_id, &eid_b).await);
+    assert_eq!(hget_flow_id(&tc, &eid_a).await, Some(flow_id.to_string()));
+    assert_eq!(hget_flow_id(&tc, &eid_b).await, Some(flow_id.to_string()));
+
+    let flow_core_key = format!(
+        "ff:flow:{tag}:{fid}:core",
+        tag = fp.hash_tag(),
+        fid = flow_id
+    );
+    let nc: Option<String> = tc
+        .client()
+        .cmd("HGET")
+        .arg(&flow_core_key)
+        .arg("node_count")
+        .execute()
+        .await
+        .expect("HGET node_count");
+    assert_eq!(
+        nc.as_deref(),
+        Some("2"),
+        "concurrent adds must not lose an update"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_atomicity_flow_id_visible_to_subsequent_reads() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let (flow_id, eid) = mint_flow_and_exec(&tc);
+    let server = start_server(&tc).await;
+
+    create_flow(&server, &flow_id).await;
+    fcall_create_execution(&tc, &eid).await;
+
+    server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("add_execution_to_flow");
+
+    for attempt in 0..3 {
+        assert_eq!(
+            hget_flow_id(&tc, &eid).await,
+            Some(flow_id.to_string()),
+            "HGET attempt {attempt} must see the flow_id stamp immediately"
+        );
+    }
+}

--- a/crates/ff-test/tests/e2e_flow_atomicity.rs
+++ b/crates/ff-test/tests/e2e_flow_atomicity.rs
@@ -368,3 +368,63 @@ async fn test_atomicity_flow_id_visible_to_subsequent_reads() {
         );
     }
 }
+
+/// Cross-review YELLOW 2 (W1 + W3 convergent): pre-flight
+/// partition-mismatch check — a wrong-partition caller must see a
+/// typed `ServerError::PartitionMismatch` instead of a raw Valkey
+/// CROSSSLOT / Lua-lib error.
+///
+/// Deliberately mints exec on a DIFFERENT partition than the flow.
+/// Under the post-RFC-011 §7.3 co-location contract this is a
+/// caller-side mint error; `add_execution_to_flow` catches it at
+/// the API boundary before the FCALL runs.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_atomicity_partition_mismatch_pre_flight_check() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Pick a FlowId whose partition index we can compute, then mint
+    // the exec on a DIFFERENT partition.
+    let flow_id = FlowId::new();
+    let fp = flow_partition(&flow_id, tc.partition_config());
+    let wrong_partition = (fp.index + 1) % tc.partition_config().num_flow_partitions;
+    let eid = tc.new_execution_id_on_partition(wrong_partition);
+
+    let server = start_server(&tc).await;
+    create_flow(&server, &flow_id).await;
+    fcall_create_execution(&tc, &eid).await;
+
+    let err = server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("wrong-partition exec must fail at pre-flight");
+
+    // Typed PartitionMismatch — not CROSSSLOT / Lua-lib / other raw
+    // downstream error.
+    assert!(
+        matches!(err, ff_server::server::ServerError::PartitionMismatch(_)),
+        "expected ServerError::PartitionMismatch, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("partition"),
+        "error message must mention partition: {msg}"
+    );
+
+    // Neither write should have happened (pre-flight guards run
+    // before the FCALL).
+    assert_eq!(
+        hget_flow_id(&tc, &eid).await,
+        None,
+        "pre-flight rejection must not mutate exec_core"
+    );
+    assert!(
+        !sismember_flow(&tc, &flow_id, &eid).await,
+        "pre-flight rejection must not add to members_set"
+    );
+}

--- a/crates/ff-test/tests/e2e_flow_atomicity.rs
+++ b/crates/ff-test/tests/e2e_flow_atomicity.rs
@@ -8,7 +8,7 @@
 //!
 //! Run: `cargo test -p ff-test --test e2e_flow_atomicity -- --test-threads=1`
 
-use ff_core::contracts::{AddExecutionToFlowArgs, CreateFlowArgs};
+use ff_core::contracts::{AddExecutionToFlowArgs, CreateExecutionArgs, CreateFlowArgs};
 use ff_core::keys::ExecKeyContext;
 use ff_core::partition::{execution_partition, flow_partition};
 use ff_core::types::*;
@@ -74,45 +74,35 @@ async fn create_flow(
         .expect("create_flow");
 }
 
-async fn fcall_create_execution(
+/// Create an exec via `Server::create_execution` — production path.
+/// Uses the caller-supplied `eid` so tests can pin exec partition
+/// via `mint_flow_and_exec` for co-location.
+async fn create_execution(
+    server: &ff_server::server::Server,
     tc: &TestCluster,
     eid: &ExecutionId,
 ) {
-    let partition = execution_partition(eid, tc.partition_config());
-    let ctx = ExecKeyContext::new(&partition, eid);
-    let idx = ff_core::keys::IndexKeys::new(&partition);
-    let now = TimestampMs::now();
-    let keys: Vec<String> = vec![
-        ctx.core(),
-        ctx.payload(),
-        ctx.policy(),
-        ctx.tags(),
-        idx.lane_eligible(&LaneId::new("atomicity-lane")),
-        idx.all_executions(),
-        idx.execution_deadline(),
-    ];
-    let args: Vec<String> = vec![
-        eid.to_string(),
-        NS.to_owned(),
-        "atomicity-lane".to_owned(),
-        "test".to_owned(),
-        "{}".to_owned(),
-        "{}".to_owned(),
-        String::new(),
-        String::new(),
-        "0".to_owned(),
-        "tester".to_owned(),
-        String::new(),
-        String::new(),
-        String::new(),
-        now.to_string(),
-    ];
-    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    tc.client()
-        .fcall::<ferriskey::Value>("ff_create_execution", &kr, &ar)
+    let partition_id = execution_partition(eid, tc.partition_config()).index;
+    server
+        .create_execution(&CreateExecutionArgs {
+            execution_id: eid.clone(),
+            namespace: Namespace::new(NS),
+            lane_id: LaneId::new("atomicity-lane"),
+            execution_kind: "test".to_owned(),
+            input_payload: b"{}".to_vec(),
+            payload_encoding: Some("json".to_owned()),
+            priority: 0,
+            creator_identity: "tester".to_owned(),
+            idempotency_key: None,
+            tags: std::collections::HashMap::new(),
+            policy: None,
+            delay_until: None,
+            execution_deadline_at: None,
+            partition_id,
+            now: TimestampMs::now(),
+        })
         .await
-        .expect("fcall ff_create_execution");
+        .expect("create_execution");
 }
 
 async fn hget_flow_id(tc: &TestCluster, eid: &ExecutionId) -> Option<String> {
@@ -161,7 +151,7 @@ async fn test_atomicity_happy_path_commits_both_writes() {
     let server = start_server(&tc).await;
 
     create_flow(&server, &flow_id).await;
-    fcall_create_execution(&tc, &eid).await;
+    create_execution(&server, &tc, &eid).await;
 
     assert_eq!(hget_flow_id(&tc, &eid).await, None);
     assert!(!sismember_flow(&tc, &flow_id, &eid).await);
@@ -195,7 +185,7 @@ async fn test_atomicity_flow_not_found_commits_nothing() {
     let (flow_id, eid) = mint_flow_and_exec(&tc);
     let server = start_server(&tc).await;
 
-    fcall_create_execution(&tc, &eid).await;
+    create_execution(&server, &tc, &eid).await;
 
     let err = server
         .add_execution_to_flow(&AddExecutionToFlowArgs {
@@ -232,7 +222,7 @@ async fn test_atomicity_repeat_call_is_idempotent() {
     let server = start_server(&tc).await;
 
     create_flow(&server, &flow_id).await;
-    fcall_create_execution(&tc, &eid).await;
+    create_execution(&server, &tc, &eid).await;
 
     server
         .add_execution_to_flow(&AddExecutionToFlowArgs {
@@ -284,8 +274,8 @@ async fn test_atomicity_concurrent_distinct_execs() {
 
     let server = start_server(&tc).await;
     create_flow(&server, &flow_id).await;
-    fcall_create_execution(&tc, &eid_a).await;
-    fcall_create_execution(&tc, &eid_b).await;
+    create_execution(&server, &tc, &eid_a).await;
+    create_execution(&server, &tc, &eid_b).await;
 
     let fa = flow_id.clone();
     let fb = flow_id.clone();
@@ -349,7 +339,7 @@ async fn test_atomicity_flow_id_visible_to_subsequent_reads() {
     let server = start_server(&tc).await;
 
     create_flow(&server, &flow_id).await;
-    fcall_create_execution(&tc, &eid).await;
+    create_execution(&server, &tc, &eid).await;
 
     server
         .add_execution_to_flow(&AddExecutionToFlowArgs {
@@ -367,6 +357,51 @@ async fn test_atomicity_flow_id_visible_to_subsequent_reads() {
             "HGET attempt {attempt} must see the flow_id stamp immediately"
         );
     }
+}
+
+/// Post-review YELLOW (Gemini PR #28): complement to test 2's
+/// flow_not_found rollback — assert execution_not_found similarly
+/// commits zero state.
+///
+/// Deliberately skips the `create_execution` step so exec_core
+/// hash does not exist when `add_execution_to_flow` runs. The Lua
+/// step-1 guard (EXISTS K.exec_core) fires before any write.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_atomicity_execution_not_found_commits_nothing() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let (flow_id, eid) = mint_flow_and_exec(&tc);
+    let server = start_server(&tc).await;
+
+    create_flow(&server, &flow_id).await;
+    // DO NOT create the execution — exec_core hash is absent.
+
+    let err = server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("add_execution_to_flow must error when exec does not exist");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("execution_not_found") || msg.contains("execution not found"),
+        "error must name execution_not_found path; got {msg}"
+    );
+
+    // Neither flow_index / members_set / exec_core mutated.
+    assert!(
+        !sismember_flow(&tc, &flow_id, &eid).await,
+        "exec must NOT be in members_set when exec guard fires"
+    );
+    assert_eq!(
+        hget_flow_id(&tc, &eid).await,
+        None,
+        "exec_core.flow_id must be untouched (in fact exec_core should not exist at all)"
+    );
 }
 
 /// Cross-review YELLOW 2 (W1 + W3 convergent): pre-flight
@@ -393,7 +428,7 @@ async fn test_atomicity_partition_mismatch_pre_flight_check() {
 
     let server = start_server(&tc).await;
     create_flow(&server, &flow_id).await;
-    fcall_create_execution(&tc, &eid).await;
+    create_execution(&server, &tc, &eid).await;
 
     let err = server
         .add_execution_to_flow(&AddExecutionToFlowArgs {

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -3222,14 +3222,31 @@ async fn fcall_create_flow(tc: &TestCluster, flow_id: &str) -> String {
 }
 
 /// FCALL ff_add_execution_to_flow — returns (eid_or_status, node_count).
+///
+/// Post-RFC-011 phase-3: FCALL is an atomic single-commit and takes
+/// exec_core as KEYS[4]. `execution_id` MUST be pinned to the same
+/// partition as this helper's hardcoded `{fp:0}` flow partition —
+/// mint via `tc.new_execution_id_on_partition(0)`. Passing a solo-
+/// routed exec whose hash-tag ≠ `{fp:0}` fails (cross-slot on cluster,
+/// Lua-lib error on standalone when the exec_core key lives in a
+/// different logical partition index).
 async fn fcall_add_execution_to_flow(
     tc: &TestCluster, flow_id: &str, execution_id: &ExecutionId,
 ) -> (String, String) {
     let prefix = format!("ff:flow:{{fp:0}}:{flow_id}");
+    // exec_core co-located with {fp:0} per the mint-side contract
+    // above. Construct via ExecKeyContext so the key format matches
+    // production (ff:exec:{fp:N}:<eid>:core).
+    let exec_partition = ff_core::partition::execution_partition(
+        execution_id,
+        tc.partition_config(),
+    );
+    let ectx = ff_core::keys::ExecKeyContext::new(&exec_partition, execution_id);
     let keys: Vec<String> = vec![
         format!("{prefix}:core"),
         format!("{prefix}:members"),
         "ff:idx:{fp:0}:flow_index".to_string(),
+        ectx.core(),
     ];
     let now = TimestampMs::now();
     let args: Vec<String> = vec![
@@ -3355,9 +3372,9 @@ async fn test_flow_linear_chain() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     let fid = "flow-chain";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
-    let c = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let c = tc.new_execution_id_on_partition(0);
     let e_ab = uuid::Uuid::new_v4().to_string();
     let e_bc = uuid::Uuid::new_v4().to_string();
     fcall_create_execution(&tc, &a, NS, LANE, "chain_a", 0).await;
@@ -3405,9 +3422,9 @@ async fn test_flow_fan_out() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     let fid = "flow-fanout";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
-    let c = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let c = tc.new_execution_id_on_partition(0);
     let e_ab = uuid::Uuid::new_v4().to_string();
     let e_ac = uuid::Uuid::new_v4().to_string();
     fcall_create_execution(&tc, &a, NS, LANE, "fo_a", 0).await;
@@ -3432,9 +3449,9 @@ async fn test_flow_dependency_failure_propagation() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     let fid = "flow-fail";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
-    let c = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let c = tc.new_execution_id_on_partition(0);
     let e_ab = uuid::Uuid::new_v4().to_string();
     let e_bc = uuid::Uuid::new_v4().to_string();
     fcall_create_execution(&tc, &a, NS, LANE, "fp_a", 0).await;
@@ -3471,8 +3488,8 @@ async fn test_flow_resolve_idempotency() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     let fid = "flow-idem";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
     let e_ab = uuid::Uuid::new_v4().to_string();
     fcall_create_execution(&tc, &a, NS, LANE, "ri_a", 0).await;
     fcall_create_execution(&tc, &b, NS, LANE, "ri_b", 0).await;
@@ -3495,8 +3512,8 @@ async fn test_flow_with_execution_lifecycle() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     let fid = "flow-full";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
     let e_ab = uuid::Uuid::new_v4().to_string();
     fcall_create_execution(&tc, &a, NS, LANE, "fl_a", 0).await;
     fcall_create_execution(&tc, &b, NS, LANE, "fl_b", 0).await;
@@ -3532,8 +3549,8 @@ async fn test_flow_replay_after_skip() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     let fid = "flow-replay";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
     let e_ab = uuid::Uuid::new_v4().to_string();
     let config = test_config();
 
@@ -4819,9 +4836,9 @@ async fn test_flow_full_lifecycle_with_staging() {
     tc.cleanup().await;
 
     let fid = "flow-r7";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
-    let c = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let c = tc.new_execution_id_on_partition(0);
     let e_ab = uuid::Uuid::new_v4().to_string();
     let e_bc = uuid::Uuid::new_v4().to_string();
     let lane_id = LaneId::new(LANE);
@@ -5427,9 +5444,9 @@ async fn test_flow_create_and_membership() {
     tc.cleanup().await;
 
     let fid = "flow-create-test";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
-    let c = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let c = tc.new_execution_id_on_partition(0);
 
     // Create flow
     let result = fcall_create_flow(&tc, fid).await;
@@ -5520,8 +5537,8 @@ async fn test_flow_index_self_heal_on_add() {
     tc.cleanup().await;
 
     let fid = "flow-heal-test";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
     let flow_index_key = "ff:idx:{fp:0}:flow_index";
 
     // 1. Create flow + add one member
@@ -5578,7 +5595,7 @@ async fn test_flow_index_self_heal_on_add() {
         format!("{prefix}:members"),
         flow_index_key.to_string(),
     ];
-    let c = tc.new_execution_id();
+    let c = tc.new_execution_id_on_partition(0);
     let now = TimestampMs::now();
     let args: Vec<String> = vec![
         fid.to_owned(), c.to_string(), now.to_string(),
@@ -5613,9 +5630,9 @@ async fn test_flow_cancel() {
     tc.cleanup().await;
 
     let fid = "flow-cancel-test";
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
-    let c = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let c = tc.new_execution_id_on_partition(0);
 
     // Create flow and add 3 members
     fcall_create_flow(&tc, fid).await;
@@ -6522,9 +6539,9 @@ async fn test_server_full_flow_lifecycle() {
     let config = test_config();
     let now = TimestampMs::now();
 
-    let a = tc.new_execution_id();
-    let b = tc.new_execution_id();
-    let c = tc.new_execution_id();
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let c = tc.new_execution_id_on_partition(0);
     for (eid, kind) in [(&a, "step_a"), (&b, "step_b"), (&c, "step_c")] {
         server.create_execution(&CreateExecutionArgs {
             execution_id: eid.clone(), namespace: Namespace::new(NS),
@@ -6613,7 +6630,7 @@ async fn test_cancel_empty_flow_then_add_member() {
         cancellation_policy: "cancel_all".to_owned(), now,
     }).await.expect("cancel empty flow");
 
-    let eid = tc.new_execution_id();
+    let eid = tc.new_execution_id_on_partition(0);
     fcall_create_execution(&tc, &eid, NS, LANE, "late_add", 0).await;
     let add_result = server.add_execution_to_flow(&AddExecutionToFlowArgs {
         flow_id: flow_id.clone(), execution_id: eid.clone(), now,
@@ -6639,7 +6656,7 @@ async fn test_server_create_cancel_roundtrip() {
     let now = TimestampMs::now();
 
     // Create execution via Server
-    let eid = tc.new_execution_id();
+    let eid = tc.new_execution_id_on_partition(0);
     server.create_execution(&CreateExecutionArgs {
         execution_id: eid.clone(), namespace: Namespace::new(NS),
         lane_id: LaneId::new(LANE), execution_kind: "roundtrip_task".to_owned(),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -5917,9 +5917,10 @@ async fn test_server_flow_lifecycle() {
         "expected Created, got {create_flow_result:?}"
     );
 
-    // 2. Create 2 executions
-    let upstream = tc.new_execution_id();
-    let downstream = tc.new_execution_id();
+    // 2. Create 2 executions co-located with the flow (RFC-011 §7.3).
+    let config = test_config();
+    let upstream = ExecutionId::for_flow(&flow_id, &config);
+    let downstream = ExecutionId::for_flow(&flow_id, &config);
     fcall_create_execution(&tc, &upstream, NS, LANE, "upstream_task", 0).await;
     fcall_create_execution(&tc, &downstream, NS, LANE, "downstream_task", 0).await;
 
@@ -6539,9 +6540,12 @@ async fn test_server_full_flow_lifecycle() {
     let config = test_config();
     let now = TimestampMs::now();
 
-    let a = tc.new_execution_id_on_partition(0);
-    let b = tc.new_execution_id_on_partition(0);
-    let c = tc.new_execution_id_on_partition(0);
+    // Mint flow FIRST so execs can co-locate with it (RFC-011 §7.3
+    // consumer contract enforced by add_execution_to_flow pre-flight).
+    let flow_id = FlowId::new();
+    let a = ExecutionId::for_flow(&flow_id, &config);
+    let b = ExecutionId::for_flow(&flow_id, &config);
+    let c = ExecutionId::for_flow(&flow_id, &config);
     for (eid, kind) in [(&a, "step_a"), (&b, "step_b"), (&c, "step_c")] {
         server.create_execution(&CreateExecutionArgs {
             execution_id: eid.clone(), namespace: Namespace::new(NS),
@@ -6554,7 +6558,6 @@ async fn test_server_full_flow_lifecycle() {
         }).await.expect("create_execution");
     }
 
-    let flow_id = FlowId::new();
     server.create_flow(&CreateFlowArgs {
         flow_id: flow_id.clone(), flow_kind: "chain".to_owned(),
         namespace: Namespace::new(NS), now,
@@ -6630,7 +6633,8 @@ async fn test_cancel_empty_flow_then_add_member() {
         cancellation_policy: "cancel_all".to_owned(), now,
     }).await.expect("cancel empty flow");
 
-    let eid = tc.new_execution_id_on_partition(0);
+    let config = test_config();
+    let eid = ExecutionId::for_flow(&flow_id, &config);
     fcall_create_execution(&tc, &eid, NS, LANE, "late_add", 0).await;
     let add_result = server.add_execution_to_flow(&AddExecutionToFlowArgs {
         flow_id: flow_id.clone(), execution_id: eid.clone(), now,
@@ -6655,8 +6659,11 @@ async fn test_server_create_cancel_roundtrip() {
     let config = test_config();
     let now = TimestampMs::now();
 
-    // Create execution via Server
-    let eid = tc.new_execution_id_on_partition(0);
+    // Mint the flow FIRST so the exec can co-locate with it —
+    // RFC-011 §7.3 co-location contract, enforced by the pre-flight
+    // partition check in `add_execution_to_flow`.
+    let flow_id = FlowId::new();
+    let eid = ExecutionId::for_flow(&flow_id, &config);
     server.create_execution(&CreateExecutionArgs {
         execution_id: eid.clone(), namespace: Namespace::new(NS),
         lane_id: LaneId::new(LANE), execution_kind: "roundtrip_task".to_owned(),
@@ -6672,7 +6679,6 @@ async fn test_server_create_cancel_roundtrip() {
         ff_core::state::PublicState::Waiting);
 
     // Create flow + add member via Server
-    let flow_id = FlowId::new();
     server.create_flow(&CreateFlowArgs {
         flow_id: flow_id.clone(), flow_kind: "roundtrip".to_owned(),
         namespace: Namespace::new(NS), now,

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -3298,12 +3298,35 @@ async fn fcall_cancel_flow(
 }
 
 /// Higher-level helper: create flow + add members + set flow_id on exec_core.
+///
+/// Post-RFC-011 phase-3: `ff_add_execution_to_flow`'s step-1 guard
+/// requires exec_core to exist (`EXISTS K.exec_core`). Pre-seed a
+/// minimal exec_core hash before calling the FCALL.
 async fn setup_flow_via_fcall(tc: &TestCluster, flow_id: &str, members: &[&ExecutionId]) {
     fcall_create_flow(tc, flow_id).await;
     for eid in members {
+        ensure_exec_core_exists(tc, eid).await;
         fcall_add_execution_to_flow(tc, flow_id, eid).await;
         set_flow_id_on_exec(tc, eid, flow_id).await;
     }
+}
+
+/// Minimal exec_core row creator for tests that skip the full
+/// `ff_create_execution` FCALL surface. HSETs a single field so
+/// `EXISTS` returns true; sufficient for the post-phase-3
+/// `ff_add_execution_to_flow` exec-existence guard. Idempotent.
+async fn ensure_exec_core_exists(tc: &TestCluster, eid: &ExecutionId) {
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    tc.client()
+        .cmd("HSET")
+        .arg(ctx.core())
+        .arg("execution_id")
+        .arg(eid.to_string())
+        .execute::<i64>()
+        .await
+        .expect("HSET minimal exec_core");
 }
 
 async fn fcall_apply_dependency(
@@ -5458,6 +5481,11 @@ async fn test_flow_create_and_membership() {
         .arg("public_flow_state").execute().await.unwrap();
     assert_eq!(pfs.as_deref(), Some("open"));
 
+    // Pre-seed exec_core rows (RFC-011 phase-3 guard requires EXISTS).
+    ensure_exec_core_exists(&tc, &a).await;
+    ensure_exec_core_exists(&tc, &b).await;
+    ensure_exec_core_exists(&tc, &c).await;
+
     // Add 3 members
     let (eid1, nc1) = fcall_add_execution_to_flow(&tc, fid, &a).await;
     assert_eq!(eid1, a.to_string());
@@ -5541,8 +5569,11 @@ async fn test_flow_index_self_heal_on_add() {
     let b = tc.new_execution_id_on_partition(0);
     let flow_index_key = "ff:idx:{fp:0}:flow_index";
 
-    // 1. Create flow + add one member
+    // 1. Create flow + add one member (pre-seed exec_core for the
+    //    RFC-011 phase-3 EXISTS guard).
     fcall_create_flow(&tc, fid).await;
+    ensure_exec_core_exists(&tc, &a).await;
+    ensure_exec_core_exists(&tc, &b).await;
     fcall_add_execution_to_flow(&tc, fid, &a).await;
 
     // Sanity: flow is registered in the index
@@ -5588,14 +5619,23 @@ async fn test_flow_index_self_heal_on_add() {
         .cmd("SREM").arg(flow_index_key).arg(fid)
         .execute().await.unwrap();
 
-    // Direct FCALL so we can inspect the error result without panicking
+    // Direct FCALL so we can inspect the error result without panicking.
+    // Post-RFC-011 phase-3 the FCALL requires KEYS[4]=exec_core on the
+    // same {fp:0} slot — pin the exec via on_partition(0). Test happens
+    // to pass even with only 3 KEYS today because flow_already_terminal
+    // returns before step 4 touches exec_core, but relying on Lua
+    // validation order is brittle; pass all 4 KEYS as the contract
+    // dictates.
     let prefix = format!("ff:flow:{{fp:0}}:{fid}");
+    let c = tc.new_execution_id_on_partition(0);
+    let exec_partition = ff_core::partition::execution_partition(&c, tc.partition_config());
+    let ectx = ff_core::keys::ExecKeyContext::new(&exec_partition, &c);
     let keys: Vec<String> = vec![
         format!("{prefix}:core"),
         format!("{prefix}:members"),
         flow_index_key.to_string(),
+        ectx.core(),
     ];
-    let c = tc.new_execution_id_on_partition(0);
     let now = TimestampMs::now();
     let args: Vec<String> = vec![
         fid.to_owned(), c.to_string(), now.to_string(),
@@ -5634,8 +5674,12 @@ async fn test_flow_cancel() {
     let b = tc.new_execution_id_on_partition(0);
     let c = tc.new_execution_id_on_partition(0);
 
-    // Create flow and add 3 members
+    // Create flow and add 3 members (pre-seed exec_core for the
+    // RFC-011 phase-3 EXISTS guard).
     fcall_create_flow(&tc, fid).await;
+    ensure_exec_core_exists(&tc, &a).await;
+    ensure_exec_core_exists(&tc, &b).await;
+    ensure_exec_core_exists(&tc, &c).await;
     fcall_add_execution_to_flow(&tc, fid, &a).await;
     fcall_add_execution_to_flow(&tc, fid, &b).await;
     fcall_add_execution_to_flow(&tc, fid, &c).await;

--- a/lua/flow.lua
+++ b/lua/flow.lua
@@ -184,15 +184,24 @@ redis.register_function('ff_add_execution_to_flow', function(keys, args)
     return ok_already_satisfied(A.execution_id, nc)
   end
 
-  -- 3. Add to membership set
+  -- 3. Cross-flow guard: if exec_core.flow_id is already set to a
+  --    DIFFERENT flow, refuse — silently re-stamping would orphan
+  --    the other flow's accounting. An exec belongs to at most one
+  --    flow at a time per RFC-007.
+  local existing_flow_id = redis.call("HGET", K.exec_core, "flow_id")
+  if existing_flow_id and existing_flow_id ~= "" and existing_flow_id ~= A.flow_id then
+    return err("already_member_of_different_flow:" .. existing_flow_id)
+  end
+
+  -- 4. Add to membership set
   redis.call("SADD", K.members_set, A.execution_id)
 
-  -- 4. Stamp the flow_id back-pointer on exec_core. Co-located with
+  -- 5. Stamp the flow_id back-pointer on exec_core. Co-located with
   --    the flow's partition under RFC-011 §7.3 hash-tag routing; this
   --    HSET is part of the same atomic FCALL as the SADD above.
   redis.call("HSET", K.exec_core, "flow_id", A.flow_id)
 
-  -- 5. Increment node_count and graph_revision
+  -- 6. Increment node_count and graph_revision
   local new_nc = redis.call("HINCRBY", K.flow_core, "node_count", 1)
   local new_rev = redis.call("HINCRBY", K.flow_core, "graph_revision", 1)
   redis.call("HSET", K.flow_core, "last_mutation_at", now_ms)

--- a/lua/flow.lua
+++ b/lua/flow.lua
@@ -153,14 +153,23 @@ redis.register_function('ff_add_execution_to_flow', function(keys, args)
 
   local now_ms = server_time_ms()
 
-  -- 1. Validate flow exists and is not terminal. Validates-before-
-  --    writing: no redis.call() writes happen before these guards.
+  -- 1. Validate flow exists and is not terminal, and execution exists.
+  --    Validates-before-writing: no redis.call() writes happen before
+  --    these guards, so the error paths commit zero state (symmetric
+  --    with step 2's cross-flow guard on AlreadyMember).
   local raw = redis.call("HGETALL", K.flow_core)
   if #raw == 0 then return err("flow_not_found") end
   local flow = hgetall_to_table(raw)
   local pfs = flow.public_flow_state or ""
   if pfs == "cancelled" or pfs == "completed" or pfs == "failed" then
     return err("flow_already_terminal")
+  end
+  -- Execution must exist — otherwise step 5's HSET exec_core would
+  -- silently create a hash for a non-existent exec, leading to an
+  -- inconsistent members_set ↔ exec_core state. Symmetric with the
+  -- flow_not_found guard above.
+  if redis.call("EXISTS", K.exec_core) == 0 then
+    return err("execution_not_found")
   end
 
   -- Self-heal flow_index for LIVE flows only. The projector may have
@@ -173,12 +182,25 @@ redis.register_function('ff_add_execution_to_flow', function(keys, args)
   -- membership mutation below.
   redis.call("SADD", K.flow_index, A.flow_id)
 
-  -- 2. Idempotency: already a member. Still stamp exec_core.flow_id
-  --    defensively — an earlier call may have committed members_set
-  --    but crashed before exec_core HSET under the legacy two-phase
-  --    shape. Stamping here is a no-op if flow_id already matches;
-  --    heals any pre-RFC-011 orphans encountered on a rolling upgrade.
+  -- 2. Idempotency: already a member of THIS flow's members_set.
+  --    Still stamp exec_core.flow_id defensively — an earlier call
+  --    may have committed members_set but crashed before exec_core
+  --    HSET under the legacy two-phase shape. Stamping here is a
+  --    no-op if flow_id already matches; heals any pre-RFC-011
+  --    orphans encountered on a rolling upgrade.
+  --
+  --    Cross-flow guard on the orphan case: if exec_core.flow_id is
+  --    already set to a DIFFERENT flow (corrupted-state orphan that
+  --    IS in this flow's members_set but stamped wrong), refuse
+  --    instead of silently re-stamping. Symmetric with step 3's
+  --    guard on the not-yet-a-member branch — catches the same
+  --    invariant violation earlier in the path. Empty existing
+  --    flow_id goes through the heal path normally.
   if redis.call("SISMEMBER", K.members_set, A.execution_id) == 1 then
+    local existing = redis.call("HGET", K.exec_core, "flow_id")
+    if existing and existing ~= "" and existing ~= A.flow_id then
+      return err("already_member_of_different_flow:" .. existing)
+    end
     redis.call("HSET", K.exec_core, "flow_id", A.flow_id)
     local nc = redis.call("HGET", K.flow_core, "node_count") or "0"
     return ok_already_satisfied(A.execution_id, nc)

--- a/lua/flow.lua
+++ b/lua/flow.lua
@@ -111,62 +111,36 @@ redis.register_function('ff_create_flow', function(keys, args)
 end)
 
 ---------------------------------------------------------------------------
--- ff_add_execution_to_flow  (on {fp:N} ONLY)
+-- ff_add_execution_to_flow  (on {fp:N} — single atomic FCALL)
 --
--- Add a member execution to a flow. Does NOT set flow_id on exec_core
--- (that's on {p:N}, caller must do it separately).
+-- Add a member execution to a flow AND stamp the flow_id back-pointer
+-- on exec_core in one atomic commit. Per RFC-011 §7.3, exec keys
+-- co-locate with their parent flow's partition under hash-tag routing,
+-- so exec_core shares the `{fp:N}` hash-tag with flow_core / members_set
+-- / flow_index. All four KEYS hash to the same slot; no CROSSSLOT.
 --
--- KEYS (3): flow_core, members_set, flow_index
+-- KEYS (4): flow_core, members_set, flow_index, exec_core
 -- ARGV (3): flow_id, execution_id, now_ms (IGNORED — server time used)
 --
--- ── TWO-PHASE CONTRACT (cairn P3.6 §5.5) ────────────────────────────────
--- exec_core lives on {p:N} (execution-partition), this FCALL runs on
--- {fp:N} (flow-partition). Valkey functions are single-slot; we CANNOT
--- touch exec_core from here without a CROSSSLOT failure on a clustered
--- deploy. The caller (ff-server `add_execution_to_flow`, crates/ff-server
--- /src/server.rs:1240-1320) therefore runs this FCALL first and then
--- issues an `HSET exec_core flow_id = <flow_id>` as a separate command.
+-- Validates-before-writing: flow_not_found / flow_already_terminal
+-- early-returns fire BEFORE any write (step 1 below). On those error
+-- paths, zero state mutates — atomicity by construction at the Lua
+-- level (Valkey scripting contract: no redis.call() before error_reply
+-- means nothing to roll back). See RFC-011 §7.3.1 tests for the
+-- structural pin.
 --
--- Orphan window:
---   Phase 1 (this FCALL) succeeds → flow_core/members_set/flow_index on
---   {fp:N} all reflect the new membership and the exec_core on {p:N}
---   does NOT yet carry flow_id.
---   If the server crashes before phase 2 (HSET), exec_core.flow_id stays
---   empty while the flow lists the exec as a member. The orphan is in
---   the "flow says yes, exec says nothing" direction only.
---
--- Reader safety:
---   * flow_core → members_set → exec_core readers (projector,
---     cancel_flow member dispatch): SAFE. They iterate members_set and
---     operate on each exec regardless of whether exec_core.flow_id is
---     stamped — the flow side is the authoritative direction for
---     membership.
---   * exec_core.flow_id → flow_core readers
---     (`describe_execution` at server.rs:1895-1910, `replay_execution`
---     at server.rs:2080-2115): SAFE against the orphan. An empty
---     flow_id is treated as "no flow affinity known at read time" and
---     filtered via `.filter(|s| !s.is_empty())` — the read returns the
---     exec's intrinsic fields and omits the flow link; a subsequent
---     read after phase 2 completes returns the link.
---   * Joint-consistency readers ("list all members of flow X AND
---     confirm each exec's exec_core.flow_id == X"): UNSAFE during the
---     orphan window. No reader in this repo does that today; if one is
---     added, it must either (a) tolerate empty flow_id on the exec
---     side for newly-added members, or (b) wait on the reconciliation
---     scanner (see below).
---
--- Crash-recovery plan: a reconciliation scanner is tracked as issue
--- #21 (see also the §4 amendment of
--- `benches/perf-invest/bridge-event-gap-report.md`). The scanner walks
--- flow_index → members_set → exec_core, re-stamping flow_id on any
--- exec_core hash where it's empty or mismatched. Rotation-idempotent
--- (same flow_id + same exec_core → no-op).
+-- Invariant (post-RFC-011): a successful call commits BOTH the flow-
+-- index updates AND the exec_core.flow_id stamp in one atomic unit.
+-- Readers can assume exec_core.flow_id == flow_id iff the exec is in
+-- members_set. The pre-RFC-011 two-phase contract + §5.5 orphan-window
+-- + issue #21 reconciliation-scanner plan are all superseded.
 ---------------------------------------------------------------------------
 redis.register_function('ff_add_execution_to_flow', function(keys, args)
   local K = {
     flow_core   = keys[1],
     members_set = keys[2],
     flow_index  = keys[3],
+    exec_core   = keys[4],
   }
 
   local A = {
@@ -179,7 +153,8 @@ redis.register_function('ff_add_execution_to_flow', function(keys, args)
 
   local now_ms = server_time_ms()
 
-  -- 1. Validate flow exists and is not terminal
+  -- 1. Validate flow exists and is not terminal. Validates-before-
+  --    writing: no redis.call() writes happen before these guards.
   local raw = redis.call("HGETALL", K.flow_core)
   if #raw == 0 then return err("flow_not_found") end
   local flow = hgetall_to_table(raw)
@@ -198,8 +173,13 @@ redis.register_function('ff_add_execution_to_flow', function(keys, args)
   -- membership mutation below.
   redis.call("SADD", K.flow_index, A.flow_id)
 
-  -- 2. Idempotency: already a member
+  -- 2. Idempotency: already a member. Still stamp exec_core.flow_id
+  --    defensively — an earlier call may have committed members_set
+  --    but crashed before exec_core HSET under the legacy two-phase
+  --    shape. Stamping here is a no-op if flow_id already matches;
+  --    heals any pre-RFC-011 orphans encountered on a rolling upgrade.
   if redis.call("SISMEMBER", K.members_set, A.execution_id) == 1 then
+    redis.call("HSET", K.exec_core, "flow_id", A.flow_id)
     local nc = redis.call("HGET", K.flow_core, "node_count") or "0"
     return ok_already_satisfied(A.execution_id, nc)
   end
@@ -207,7 +187,12 @@ redis.register_function('ff_add_execution_to_flow', function(keys, args)
   -- 3. Add to membership set
   redis.call("SADD", K.members_set, A.execution_id)
 
-  -- 4. Increment node_count and graph_revision
+  -- 4. Stamp the flow_id back-pointer on exec_core. Co-located with
+  --    the flow's partition under RFC-011 §7.3 hash-tag routing; this
+  --    HSET is part of the same atomic FCALL as the SADD above.
+  redis.call("HSET", K.exec_core, "flow_id", A.flow_id)
+
+  -- 5. Increment node_count and graph_revision
   local new_nc = redis.call("HINCRBY", K.flow_core, "node_count", 1)
   local new_rev = redis.call("HINCRBY", K.flow_core, "graph_revision", 1)
   redis.call("HSET", K.flow_core, "last_mutation_at", now_ms)


### PR DESCRIPTION
## Summary

Phase 3 of RFC-011: collapses \`ff_add_execution_to_flow\` from two-phase (Lua FCALL on \`{fp:N}\` + post-FCALL Rust HSET on \`{p:N}\`) to single atomic FCALL on the co-located \`{fp:N}\` slot. Closes the §5.5 atomicity gap by construction.

Phase-3 was a plan-and-cross-review cycle:
- W2 implementation @ \`c1e8678\` (3.5h vs 6h target)
- W1 + W3 independent cross-reviews @ \`2dd465f\` / \`9fc6502\`, unanimous ACCEPT with 2 YELLOWs
- W2 YELLOW fixes @ \`88693b8\`

Companion PR #29 amends RFC §7.3 prose to document the three YELLOW-driven behaviors (heal on AlreadyMember, cross-flow guard, partition pre-flight).

## Scope per RFC §7.3

### Lua atomicity (\`lua/flow.lua\`)
- \`ff_add_execution_to_flow\` gains \`KEYS[4] = exec_core_key\` (co-located on \`{fp:N}\` post-phase-1)
- Body step 4: atomic \`HSET exec_core flow_id\`
- \`redis.error_reply\` before any write → validates-before-writing pin
- Docstring retires §5.5 two-phase preamble + scanner reference

### Rust caller (\`crates/ff-server/src/server.rs\`)
- \`add_execution_to_flow\` collapses to single FCALL (separate HSET at old L1341-1347 removed)
- **Pre-flight partition check** (YELLOW 2): compares \`exec_partition.index\` vs \`flow_partition.index\`; returns \`ServerError::PartitionMismatch\` with both indices + \`ExecutionId::for_flow\` pointer on mismatch. Callers now get a typed error instead of raw CROSSSLOT.
- Rustdoc retires two-phase / orphan-window / reader-safety / crash-recovery sections; states atomic-commit invariant + co-location consumer contract.

### Defensive heal (YELLOW 1)
- Lua step 2 stamps \`flow_id\` on \`AlreadyMember\` branch — idempotent re-stamp heals rolling-upgrade orphans from pre-phase-3 state.
- Lua step 3 **cross-flow guard**: \`HGET exec_core.flow_id\` before \`SADD\`; returns \`already_member_of_different_flow\` if non-empty and ≠ \`args.flow_id\`.

### Test migration + new atomicity tests
- 32 mint sites across 13 test fns migrated: \`tc.new_execution_id()\` → \`tc.new_execution_id_on_partition(0)\` (co-locates with \`{fp:0}\` helper flow_id convention)
- \`e2e_api.rs\` test uses \`ExecutionId::for_flow\` + real UUID FlowId (real co-location shape)
- New fixture: \`TestCluster::new_execution_id_on_partition(index: u16)\` — test-only escape hatch via \`ExecutionId::parse\`, NOT a public mint path (respects §5.6 "trait is the stable contract")
- 3 pre-existing shape-mistake tests (\`test_server_flow_lifecycle\`, \`test_cancel_empty_flow_then_add_member\`, \`test_server_create_cancel_roundtrip\`) surfaced by the pre-flight check + migrated to \`ExecutionId::for_flow\`
- **6 new atomicity tests** at \`crates/ff-test/tests/e2e_flow_atomicity.rs\`:
  1. happy path commits both writes atomically
  2. \`flow_not_found\` early-return commits nothing (validates-before-writing pin)
  3. idempotent repeat (\`AlreadyMember\`, \`node_count\` unchanged)
  4. concurrent distinct-exec adds (no lost updates)
  5. \`flow_id\` visible to subsequent reads (atomic-commit visibility)
  6. partition-mismatch pre-flight returns typed error (YELLOW 2 coverage)

### Interim safety-net cleanup
- \`describe_execution\` + \`replay_execution\` reader-invariant comments rewritten from §5.5 orphan framing to §7.3 atomic-by-construction
- \`benches/perf-invest/bridge-event-gap-report.md\`: §4 gets LANDED block, §5.5 row flips to CLOSED
- Issue #21 (crash-recovery scanner ticket) closed with supersession citation

## Cross-review
Unanimous ACCEPT from W1 + W3. Both converged independently on the same 2 YELLOWs (partition pre-flight missing, defensive HSET RFC-widening) — convergence = real findings. Both addressed in \`88693b8\`.

Review docs: \`benches/perf-invest/review-rfc011-phase3-w1.md\` (branch \`review/rfc011-phase3-w1\`), \`benches/perf-invest/review-rfc011-phase3-w3.md\` (on this branch).

## Verification
- \`cargo check --workspace\` clean
- \`cargo clippy --workspace --exclude ferriskey --tests -- -D warnings\` clean
- \`cargo test -p ff-core --lib\` 70/70
- \`cargo test -p ff-script --lib\` 30/30
- \`cargo test -p ff-test --tests -- --test-threads=1\` 152/152 (+6 atomicity)
- \`grep 'hset.*exec_core.*flow_id' crates/ff-server\`: 0 matches (non-FCALL direct write gone)
- \`grep 'ExecutionId::new(' crates/ benches/ examples/\`: 1 line (docstring only)

## Phases 4–5 ahead
- Phase 4 (W1, ~5h): cairn-fabric coordination — adopt atomic \`add_execution_to_flow\` from cairn side, retire insecure-direct-claim feature
- Phase 5 (W3, ~6.5h): Valkey version floor + runbook + \`ff-server admin partition-collisions\` subcommand

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flow membership persistence to a new atomic FCALL shape and adds partition-mismatch rejection, which could impact clustered routing and callers that mint execution IDs incorrectly. Risk is mitigated by new end-to-end atomicity tests and broad test updates to use co-located IDs.
> 
> **Overview**
> Implements RFC-011 phase 3 by collapsing `add_execution_to_flow` from an FCALL+separate HSET into a **single atomic `ff_add_execution_to_flow` FCALL** that also stamps `exec_core.flow_id` (adds `exec_core` as `KEYS[4]`) and introduces a Lua cross-flow guard plus defensive restamp on the already-member path.
> 
> Adds a **typed pre-flight partition mismatch check** in `ff-server` to fail fast instead of surfacing raw `CROSSSLOT`, and updates reader-side invariants/comments to assume atomic-by-construction flow linkage.
> 
> Updates tests/fixtures to mint co-located execution IDs (new `TestCluster::new_execution_id_on_partition`, API/lifecycle test migrations) and adds a new `e2e_flow_atomicity` suite to pin the atomicity and error-path invariants; documentation/gap reports are updated to mark the previous two-phase atomicity issue as closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88693b81e748592108d579b773e5d3b560c9e526. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->