### PR TITLE
RFC-011 phase 5A + 5C: Valkey 8.0 version floor + operator runbook

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,18 +1,20 @@
 name: Matrix CI
 
-# Cross-host + cross-Valkey-version + cross-mode verification.
+# Cross-host + cross-mode verification against Valkey latest.
 #
-# Matrix coverage (9 jobs):
+# Matrix coverage (5 jobs):
 #
-#   linux x86_64  × valkey 7.2    × standalone   → ubuntu-latest
-#   linux x86_64  × valkey 7.2    × cluster      → ubuntu-latest
 #   linux x86_64  × valkey latest × standalone   → ubuntu-latest
 #   linux x86_64  × valkey latest × cluster      → ubuntu-latest
-#   linux arm64   × valkey 7.2    × standalone   → ubuntu-24.04-arm
-#   linux arm64   × valkey 7.2    × cluster      → ubuntu-24.04-arm
 #   linux arm64   × valkey latest × standalone   → ubuntu-24.04-arm
 #   linux arm64   × valkey latest × cluster      → ubuntu-24.04-arm
 #   macos arm64   × valkey latest × standalone   → macos-latest
+#
+# **Valkey version:** `latest` only. RFC-011 §13 requires Valkey >= 8.0
+# (enforced at ff-server boot via `verify_valkey_version`). The Valkey
+# 7.2 rows from pre-RFC-011 matrix coverage are retired — the server
+# refuses to start against 7.x, so running tests there only validates
+# "the refusal works," not engine behavior.
 #
 # Mac arm64 validates Apple Silicon Rust correctness on the latest
 # Valkey release; the 7.2 × mac combination is intentionally skipped
@@ -77,17 +79,13 @@ jobs:
           - { os: ubuntu-24.04-arm, kind: linux, arch: arm64 }
           - { os: macos-latest,     kind: mac,   arch: arm64 }
         valkey:
-          - { version: "7.2",    image: "valkey/valkey:7.2" }
           - { version: "latest", image: "valkey/valkey:latest" }
         mode: [standalone, cluster]
         exclude:
-          # Mac: latest Valkey only, standalone only. Homebrew has no
-          # 7.2 formula + docker-on-mac cluster setup is unsupported on
-          # GitHub hosted runners. x86_64 mac coverage is intentionally
+          # Mac: standalone only. docker-on-mac cluster setup is
+          # unsupported on GitHub hosted runners. x86_64 mac coverage is
           # omitted — GitHub's Intel runner (macos-13) is EOL December
           # 2025; x86_64 correctness is validated through ubuntu-latest.
-          - host: { os: macos-latest, kind: mac, arch: arm64 }
-            valkey: { version: "7.2", image: "valkey/valkey:7.2" }
           - host: { os: macos-latest, kind: mac, arch: arm64 }
             mode: cluster
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,20 +1,22 @@
 name: Matrix CI
 
-# Cross-host + cross-mode verification against Valkey latest.
+# Cross-host + cross-mode verification against Valkey 8.
 #
 # Matrix coverage (5 jobs):
 #
-#   linux x86_64  × valkey latest × standalone   → ubuntu-latest
-#   linux x86_64  × valkey latest × cluster      → ubuntu-latest
-#   linux arm64   × valkey latest × standalone   → ubuntu-24.04-arm
-#   linux arm64   × valkey latest × cluster      → ubuntu-24.04-arm
-#   macos arm64   × valkey latest × standalone   → macos-latest
+#   linux x86_64  × valkey 8 × standalone   → ubuntu-latest
+#   linux x86_64  × valkey 8 × cluster      → ubuntu-latest
+#   linux arm64   × valkey 8 × standalone   → ubuntu-24.04-arm
+#   linux arm64   × valkey 8 × cluster      → ubuntu-24.04-arm
+#   macos arm64   × valkey 8 × standalone   → macos-latest
 #
-# **Valkey version:** `latest` only. RFC-011 §13 requires Valkey >= 8.0
-# (enforced at ff-server boot via `verify_valkey_version`). The Valkey
-# 7.2 rows from pre-RFC-011 matrix coverage are retired — the server
-# refuses to start against 7.x, so running tests there only validates
-# "the refusal works," not engine behavior.
+# **Valkey version:** `valkey/valkey:8-alpine` (major-version pin).
+# RFC-011 §13 requires Valkey >= 8.0 (enforced at ff-server boot via
+# `verify_valkey_version`). Pinning to major 8 tracks patch releases
+# automatically without the drift risk of `:latest` rolling to 9.x with
+# breaking behavior changes. Matches cairn-fabric's integration-test pin.
+# The Valkey 7.2 rows from pre-RFC-011 coverage are retired — the server
+# refuses to start against 7.x.
 #
 # Mac arm64 validates Apple Silicon Rust correctness on the latest
 # Valkey release; the 7.2 × mac combination is intentionally skipped
@@ -79,7 +81,12 @@ jobs:
           - { os: ubuntu-24.04-arm, kind: linux, arch: arm64 }
           - { os: macos-latest,     kind: mac,   arch: arm64 }
         valkey:
-          - { version: "latest", image: "valkey/valkey:latest" }
+          # Pin to major 8 (alpine variant) — matches cairn-fabric's
+          # integration-test pin and RFC-011 §13's required floor. Using
+          # a major-version tag tracks patch releases automatically without
+          # the drift risk of `:latest` (which could roll to 9.x with
+          # breaking behavior changes).
+          - { version: "8", image: "valkey/valkey:8-alpine" }
         mode: [standalone, cluster]
         exclude:
           # Mac: standalone only. docker-on-mac cluster setup is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       valkey:
-        image: valkey/valkey:7.2
+        # Valkey >= 8.0 required by RFC-011 §13 (ff-server refuses to
+        # boot against 7.x). `valkey:latest` tracks current stable.
+        image: valkey/valkey:latest
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,10 @@ jobs:
     services:
       valkey:
         # Valkey >= 8.0 required by RFC-011 §13 (ff-server refuses to
-        # boot against 7.x). `valkey:latest` tracks current stable.
-        image: valkey/valkey:latest
+        # boot against 7.x). Major-version pin — tracks 8.x patches
+        # without drift risk from a moving `:latest`. Matches the
+        # matrix-ci and cairn-fabric pins for reproducibility.
+        image: valkey/valkey:8-alpine
         ports:
           - 6379:6379
         options: >-

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -2489,42 +2489,78 @@ const VERSION_CHECK_RETRY_BUDGET: Duration = Duration::from_secs(60);
 
 /// Verify the connected Valkey reports `redis_version` ≥ 8.0.
 ///
-/// Sends `INFO server`, parses the `redis_version` field, and compares the
-/// major component. Retries on transient errors (connection refused mid-
-/// upgrade, parse-below-threshold) with exponential backoff capped at the
-/// rolling-upgrade budget. On exhaustion of the budget, returns the last
-/// typed error (either `ValkeyVersionTooLow` for a low-version response, or
-/// `ValkeyContext` for a transport error).
+/// Per RFC-011 §9.17, during a rolling upgrade the node we happen to connect
+/// to may temporarily be pre-upgrade while others are post-upgrade. The check
+/// tolerates this by retrying the whole verification (including low-version
+/// responses) with exponential backoff, capped at a 60s budget.
+///
+/// **Retries on:**
+/// - Low-version responses (`detected_major < REQUIRED_VALKEY_MAJOR`) — may
+///   resolve as the rolling upgrade progresses onto the connected node.
+/// - Retryable ferriskey transport errors — connection refused,
+///   `BusyLoadingError`, `ClusterDown`, etc., classified via
+///   `ff_script::retry::is_retryable_kind`.
+/// - Missing/unparsable `redis_version` — treated as transient (fresh-boot
+///   server may not have the field populated yet).
+///
+/// **Does NOT retry on:**
+/// - Non-retryable transport errors (auth failures, permission denied,
+///   invalid client config) — these are operator misconfiguration, not
+///   transient cluster state; fast-fail preserves a clear signal.
+///
+/// On budget exhaustion, returns the last observed error.
 async fn verify_valkey_version(client: &Client) -> Result<(), ServerError> {
     let deadline = tokio::time::Instant::now() + VERSION_CHECK_RETRY_BUDGET;
     let mut backoff = Duration::from_millis(200);
     loop {
-        let transient_err = match query_valkey_version(client).await {
-            Ok(detected_major) if detected_major >= REQUIRED_VALKEY_MAJOR => {
-                tracing::info!(
-                    detected_major,
-                    required = REQUIRED_VALKEY_MAJOR,
-                    "Valkey version accepted"
-                );
-                return Ok(());
-            }
-            Ok(detected_major) => {
-                // Low version — not transient, don't retry. The cluster
-                // can't "grow" past this without operator action. Return
-                // immediately with a typed error.
-                return Err(ServerError::ValkeyVersionTooLow {
-                    detected: detected_major.to_string(),
-                    required: format!("{REQUIRED_VALKEY_MAJOR}.0"),
-                });
-            }
-            Err(e) => e,
-        };
+        let (should_retry, err_for_budget_exhaust, log_detail): (bool, ServerError, String) =
+            match query_valkey_version(client).await {
+                Ok(detected_major) if detected_major >= REQUIRED_VALKEY_MAJOR => {
+                    tracing::info!(
+                        detected_major,
+                        required = REQUIRED_VALKEY_MAJOR,
+                        "Valkey version accepted"
+                    );
+                    return Ok(());
+                }
+                Ok(detected_major) => (
+                    // Low version — may be a rolling-upgrade stale node.
+                    // Retry within budget; after exhaustion, the cluster
+                    // is misconfigured and fast-fail is the correct signal.
+                    true,
+                    ServerError::ValkeyVersionTooLow {
+                        detected: detected_major.to_string(),
+                        required: format!("{REQUIRED_VALKEY_MAJOR}.0"),
+                    },
+                    format!("detected_major={detected_major} < required={REQUIRED_VALKEY_MAJOR}"),
+                ),
+                Err(e) => {
+                    // Only retry if the underlying Valkey error is retryable
+                    // by kind. Auth / permission / invalid-config should fast-
+                    // fail so operators see the true root cause immediately,
+                    // not a 60s hang followed by a generic "transient" error.
+                    let retryable = e
+                        .valkey_kind()
+                        .map(ff_script::retry::is_retryable_kind)
+                        // Non-Valkey errors (parse, missing field, operation
+                        // failures) are treated as transient — a fresh-boot
+                        // Valkey may not have redis_version populated yet.
+                        .unwrap_or(true);
+                    let detail = e.to_string();
+                    (retryable, e, detail)
+                }
+            };
+
+        if !should_retry {
+            return Err(err_for_budget_exhaust);
+        }
         if tokio::time::Instant::now() >= deadline {
-            return Err(transient_err);
+            return Err(err_for_budget_exhaust);
         }
         tracing::warn!(
             backoff_ms = backoff.as_millis() as u64,
-            "valkey version check transient error; retrying"
+            detail = %log_detail,
+            "valkey version check transient failure; retrying"
         );
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(Duration::from_secs(5));
@@ -2557,13 +2593,17 @@ fn parse_valkey_major_version(info: &str) -> Result<u32, ServerError> {
             ServerError::OperationFailed(
                 "valkey version check: INFO missing redis_version".into(),
             )
-        })?;
-    let major_str = version_line.split('.').next().ok_or_else(|| {
-        ServerError::OperationFailed(format!(
-            "valkey version check: unparsable version '{version_line}'"
-        ))
-    })?;
-    major_str.trim().parse::<u32>().map_err(|_| {
+        })?
+        .trim();
+    // `split('.').next()` always returns Some; the real empty-input case
+    // surfaces as an empty major segment rather than None.
+    let major_str = version_line.split('.').next().unwrap_or("").trim();
+    if major_str.is_empty() {
+        return Err(ServerError::OperationFailed(format!(
+            "valkey version check: empty version field in '{version_line}'"
+        )));
+    }
+    major_str.parse::<u32>().map_err(|_| {
         ServerError::OperationFailed(format!(
             "valkey version check: non-numeric major in '{version_line}'"
         ))

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -2500,8 +2500,10 @@ const VERSION_CHECK_RETRY_BUDGET: Duration = Duration::from_secs(60);
 /// - Retryable ferriskey transport errors — connection refused,
 ///   `BusyLoadingError`, `ClusterDown`, etc., classified via
 ///   `ff_script::retry::is_retryable_kind`.
-/// - Missing/unparsable `redis_version` — treated as transient (fresh-boot
-///   server may not have the field populated yet).
+/// - Missing/unparsable version field — treated as transient (fresh-boot
+///   server may not have the INFO fields populated yet). Reads
+///   `valkey_version` when present (authoritative on Valkey 8.0+), falls
+///   back to `redis_version` for Valkey 7.x.
 ///
 /// **Does NOT retry on:**
 /// - Non-retryable transport errors (auth failures, permission denied,

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -2567,10 +2567,19 @@ async fn verify_valkey_version(client: &Client) -> Result<(), ServerError> {
     }
 }
 
-/// Run `INFO server` and extract the major component of `redis_version`.
+/// Run `INFO server` and extract the major component of the Valkey version.
+///
 /// Returns `Err` on transport errors, missing field, or unparsable version.
+/// Handles three response shapes:
+///
+/// - **Standalone:** single string body; parse directly.
+/// - **Cluster (RESP3 map):** `INFO` returns a map keyed by node address;
+///   every node runs the same version in a healthy deployment, so we pick
+///   one entry and parse it. Divergent versions during a rolling upgrade
+///   are handled by the outer retry loop.
+/// - **Empty / unexpected:** surfaces as `OperationFailed` with context.
 async fn query_valkey_version(client: &Client) -> Result<u32, ServerError> {
-    let info: String = client
+    let raw: Value = client
         .cmd("INFO")
         .arg("server")
         .execute()
@@ -2579,35 +2588,79 @@ async fn query_valkey_version(client: &Client) -> Result<u32, ServerError> {
             source: e,
             context: "INFO server".into(),
         })?;
-    parse_valkey_major_version(&info)
+    let info_body = extract_info_body(&raw)?;
+    parse_valkey_major_version(&info_body)
 }
 
-/// Extract the major component of `redis_version` from an `INFO server`
+/// Normalize an `INFO server` response to a single string body.
+///
+/// Standalone returns the body directly. Cluster returns a map of
+/// `node_addr → body`; we pick any entry (they should all report the same
+/// version in a stable cluster; divergent versions during rolling upgrade
+/// are reconciled by the outer retry loop).
+fn extract_info_body(raw: &Value) -> Result<String, ServerError> {
+    match raw {
+        Value::BulkString(bytes) => Ok(String::from_utf8_lossy(bytes).into_owned()),
+        Value::VerbatimString { text, .. } => Ok(text.clone()),
+        Value::SimpleString(s) => Ok(s.clone()),
+        Value::Map(entries) => {
+            // Pick the first entry's value. For cluster-wide INFO the map is
+            // node_addr → body; every body carries the same version. If a
+            // node is mid-upgrade, the outer retry loop handles divergence.
+            let (_, body) = entries.first().ok_or_else(|| {
+                ServerError::OperationFailed(
+                    "valkey version check: cluster INFO returned empty map".into(),
+                )
+            })?;
+            extract_info_body(body)
+        }
+        other => Err(ServerError::OperationFailed(format!(
+            "valkey version check: unexpected INFO shape: {other:?}"
+        ))),
+    }
+}
+
+/// Extract the major component of the Valkey version from an `INFO server`
 /// response body. Pure parser — pulled out of [`query_valkey_version`] so it
 /// is unit-testable without a live Valkey.
+///
+/// Prefers the `valkey_version:` field introduced in Valkey 8.0+. Falls back
+/// to `redis_version:` for Valkey 7.x compat. **Note:** Valkey 8.x/9.x still
+/// emit `redis_version:7.2.4` for Redis-client compatibility; the real
+/// server version is in `valkey_version:`, so always check that field first.
 fn parse_valkey_major_version(info: &str) -> Result<u32, ServerError> {
-    let version_line = info
+    let extract_major = |line: &str| -> Result<u32, ServerError> {
+        let trimmed = line.trim();
+        let major_str = trimmed.split('.').next().unwrap_or("").trim();
+        if major_str.is_empty() {
+            return Err(ServerError::OperationFailed(format!(
+                "valkey version check: empty version field in '{trimmed}'"
+            )));
+        }
+        major_str.parse::<u32>().map_err(|_| {
+            ServerError::OperationFailed(format!(
+                "valkey version check: non-numeric major in '{trimmed}'"
+            ))
+        })
+    };
+    // Prefer valkey_version (authoritative on Valkey 8.0+).
+    if let Some(valkey_line) = info
+        .lines()
+        .find_map(|line| line.strip_prefix("valkey_version:"))
+    {
+        return extract_major(valkey_line);
+    }
+    // Fall back to redis_version (Valkey 7.x only — 8.x+ pins this to 7.2.4
+    // for Redis-client compat, so reading it there would under-report).
+    if let Some(redis_line) = info
         .lines()
         .find_map(|line| line.strip_prefix("redis_version:"))
-        .ok_or_else(|| {
-            ServerError::OperationFailed(
-                "valkey version check: INFO missing redis_version".into(),
-            )
-        })?
-        .trim();
-    // `split('.').next()` always returns Some; the real empty-input case
-    // surfaces as an empty major segment rather than None.
-    let major_str = version_line.split('.').next().unwrap_or("").trim();
-    if major_str.is_empty() {
-        return Err(ServerError::OperationFailed(format!(
-            "valkey version check: empty version field in '{version_line}'"
-        )));
+    {
+        return extract_major(redis_line);
     }
-    major_str.parse::<u32>().map_err(|_| {
-        ServerError::OperationFailed(format!(
-            "valkey version check: non-numeric major in '{version_line}'"
-        ))
-    })
+    Err(ServerError::OperationFailed(
+        "valkey version check: INFO missing valkey_version and redis_version".into(),
+    ))
 }
 
 // ── Partition config validation ──
@@ -4159,40 +4212,88 @@ mod tests {
     // ── Valkey version check (RFC-011 §13) ──
 
     #[test]
-    fn parse_valkey_major_extracts_8_from_real_info_body() {
-        // Sample INFO server output from Valkey 8.0.
+    fn parse_valkey_major_prefers_valkey_version_over_redis_version() {
+        // Valkey 8.x+ pins redis_version to 7.2.4 for Redis-client compat
+        // and exposes the real version in valkey_version. Parser must use
+        // valkey_version when both are present.
         let info = "\
 # Server\r\n\
-redis_version:8.0.1\r\n\
-redis_git_sha1:00000000\r\n\
-redis_git_dirty:0\r\n\
-redis_build_id:abc\r\n\
-redis_mode:standalone\r\n\
-os:Linux\r\n\
-arch_bits:64\r\n";
-        assert_eq!(parse_valkey_major_version(info).unwrap(), 8);
+redis_version:7.2.4\r\n\
+valkey_version:9.0.3\r\n\
+server_mode:cluster\r\n\
+os:Linux\r\n";
+        assert_eq!(parse_valkey_major_version(info).unwrap(), 9);
     }
 
     #[test]
-    fn parse_valkey_major_extracts_7_from_low_version() {
+    fn parse_valkey_major_real_valkey_8_cluster_body() {
+        // Actual INFO server response observed on valkey/valkey:latest in
+        // cluster mode (CI matrix): redis_version compat-pinned to 7.2.4,
+        // valkey_version authoritative at 9.0.3.
+        let info = "\
+# Server\r\n\
+redis_version:7.2.4\r\n\
+server_name:valkey\r\n\
+valkey_version:9.0.3\r\n\
+valkey_release_stage:ga\r\n\
+redis_git_sha1:00000000\r\n\
+server_mode:cluster\r\n";
+        assert_eq!(parse_valkey_major_version(info).unwrap(), 9);
+    }
+
+    #[test]
+    fn parse_valkey_major_falls_back_to_redis_version_on_valkey_7() {
+        // Valkey 7.x doesn't emit valkey_version; parser falls back.
         let info = "# Server\r\nredis_version:7.2.4\r\nfoo:bar\r\n";
         assert_eq!(parse_valkey_major_version(info).unwrap(), 7);
     }
 
     #[test]
-    fn parse_valkey_major_errors_when_field_missing() {
+    fn parse_valkey_major_errors_when_no_version_field() {
         let info = "# Server\r\nfoo:bar\r\n";
         let err = parse_valkey_major_version(info).unwrap_err();
         assert!(matches!(err, ServerError::OperationFailed(_)));
-        assert!(err.to_string().contains("missing redis_version"));
+        assert!(
+            err.to_string().contains("missing"),
+            "expected 'missing' in message, got: {err}"
+        );
     }
 
     #[test]
     fn parse_valkey_major_errors_on_non_numeric() {
-        let info = "redis_version:invalid.x.y\n";
+        let info = "valkey_version:invalid.x.y\n";
         let err = parse_valkey_major_version(info).unwrap_err();
         assert!(matches!(err, ServerError::OperationFailed(_)));
         assert!(err.to_string().contains("non-numeric major"));
+    }
+
+    #[test]
+    fn extract_info_body_unwraps_cluster_map() {
+        // Simulates cluster-mode INFO response: map of node_addr → body.
+        // extract_info_body picks any entry's body.
+        let body_text = "\
+# Server\r\n\
+redis_version:7.2.4\r\n\
+valkey_version:9.0.3\r\n";
+        let node_entry = (
+            Value::SimpleString("127.0.0.1:7000".to_string()),
+            Value::VerbatimString {
+                format: ferriskey::value::VerbatimFormat::Text,
+                text: body_text.to_string(),
+            },
+        );
+        let map = Value::Map(vec![node_entry]);
+        let body = extract_info_body(&map).unwrap();
+        assert_eq!(body, body_text);
+        assert_eq!(parse_valkey_major_version(&body).unwrap(), 9);
+    }
+
+    #[test]
+    fn extract_info_body_handles_simple_string() {
+        let body_text = "redis_version:7.2.4\r\nvalkey_version:9.0.3\r\n";
+        let v = Value::SimpleString(body_text.to_string());
+        let body = extract_info_body(&v).unwrap();
+        assert_eq!(body, body_text);
     }
 
     #[test]

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -159,6 +159,17 @@ pub enum ServerError {
     /// Fields: (source_label, max_permits).
     #[error("too many concurrent {0} calls (max: {1})")]
     ConcurrencyLimitExceeded(&'static str, u32),
+    /// Detected Valkey version is below the RFC-011 §13 minimum. The hash-slot
+    /// co-location design and Valkey Functions API behavior the engine depends
+    /// on were introduced/stabilized in 8.0; older versions silently behave
+    /// differently on some cluster edge cases. Operator action: upgrade Valkey.
+    #[error(
+        "valkey version too low: detected {detected}, required >= {required} (RFC-011 §13)"
+    )]
+    ValkeyVersionTooLow {
+        detected: String,
+        required: String,
+    },
 }
 
 impl ServerError {
@@ -197,6 +208,8 @@ impl ServerError {
             // so the retry will succeed once a permit frees up. Applies
             // equally to stream ops, admin rotate, etc.
             Self::ConcurrencyLimitExceeded(_, _) => true,
+            // Operator must upgrade Valkey; a retry at the caller won't help.
+            Self::ValkeyVersionTooLow { .. } => false,
         }
     }
 }
@@ -243,6 +256,12 @@ impl Server {
             )));
         }
         tracing::info!("Valkey connection established");
+
+        // Step 1b: Verify Valkey version meets the RFC-011 §13 minimum (8.0).
+        // Tolerates a rolling upgrade via a 60s exponential-backoff budget
+        // per RFC-011 §9.17 — transient INFO errors during a node restart
+        // don't trip the check until the whole budget is exhausted.
+        verify_valkey_version(&client).await?;
 
         // Step 2: Validate or create partition config
         validate_or_create_partition_config(&client, &config.partition_config).await?;
@@ -2456,6 +2475,101 @@ impl Server {
     }
 }
 
+// ── Valkey version check (RFC-011 §13) ──
+
+/// Minimum Valkey version the engine requires (see RFC-011 §13). 8.0 ships the
+/// hash-slot and Functions behavior the co-location design relies on.
+const REQUIRED_VALKEY_MAJOR: u32 = 8;
+
+/// Upper bound on the rolling-upgrade retry window (RFC-011 §9.17). A Valkey
+/// node cycling through SIGTERM → restart typically completes in well under
+/// 60s; this budget is generous without letting a truly-stuck cluster hang
+/// boot indefinitely.
+const VERSION_CHECK_RETRY_BUDGET: Duration = Duration::from_secs(60);
+
+/// Verify the connected Valkey reports `redis_version` ≥ 8.0.
+///
+/// Sends `INFO server`, parses the `redis_version` field, and compares the
+/// major component. Retries on transient errors (connection refused mid-
+/// upgrade, parse-below-threshold) with exponential backoff capped at the
+/// rolling-upgrade budget. On exhaustion of the budget, returns the last
+/// typed error (either `ValkeyVersionTooLow` for a low-version response, or
+/// `ValkeyContext` for a transport error).
+async fn verify_valkey_version(client: &Client) -> Result<(), ServerError> {
+    let deadline = tokio::time::Instant::now() + VERSION_CHECK_RETRY_BUDGET;
+    let mut backoff = Duration::from_millis(200);
+    loop {
+        let transient_err = match query_valkey_version(client).await {
+            Ok(detected_major) if detected_major >= REQUIRED_VALKEY_MAJOR => {
+                tracing::info!(
+                    detected_major,
+                    required = REQUIRED_VALKEY_MAJOR,
+                    "Valkey version accepted"
+                );
+                return Ok(());
+            }
+            Ok(detected_major) => {
+                // Low version — not transient, don't retry. The cluster
+                // can't "grow" past this without operator action. Return
+                // immediately with a typed error.
+                return Err(ServerError::ValkeyVersionTooLow {
+                    detected: detected_major.to_string(),
+                    required: format!("{REQUIRED_VALKEY_MAJOR}.0"),
+                });
+            }
+            Err(e) => e,
+        };
+        if tokio::time::Instant::now() >= deadline {
+            return Err(transient_err);
+        }
+        tracing::warn!(
+            backoff_ms = backoff.as_millis() as u64,
+            "valkey version check transient error; retrying"
+        );
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(5));
+    }
+}
+
+/// Run `INFO server` and extract the major component of `redis_version`.
+/// Returns `Err` on transport errors, missing field, or unparsable version.
+async fn query_valkey_version(client: &Client) -> Result<u32, ServerError> {
+    let info: String = client
+        .cmd("INFO")
+        .arg("server")
+        .execute()
+        .await
+        .map_err(|e| ServerError::ValkeyContext {
+            source: e,
+            context: "INFO server".into(),
+        })?;
+    parse_valkey_major_version(&info)
+}
+
+/// Extract the major component of `redis_version` from an `INFO server`
+/// response body. Pure parser — pulled out of [`query_valkey_version`] so it
+/// is unit-testable without a live Valkey.
+fn parse_valkey_major_version(info: &str) -> Result<u32, ServerError> {
+    let version_line = info
+        .lines()
+        .find_map(|line| line.strip_prefix("redis_version:"))
+        .ok_or_else(|| {
+            ServerError::OperationFailed(
+                "valkey version check: INFO missing redis_version".into(),
+            )
+        })?;
+    let major_str = version_line.split('.').next().ok_or_else(|| {
+        ServerError::OperationFailed(format!(
+            "valkey version check: unparsable version '{version_line}'"
+        ))
+    })?;
+    major_str.trim().parse::<u32>().map_err(|_| {
+        ServerError::OperationFailed(format!(
+            "valkey version check: non-numeric major in '{version_line}'"
+        ))
+    })
+}
+
 // ── Partition config validation ──
 
 /// Validate or create the `ff:config:partitions` key on first boot.
@@ -4000,5 +4114,66 @@ mod tests {
             got: "2".into(),
         });
         assert_eq!(err.valkey_kind(), None);
+    }
+
+    // ── Valkey version check (RFC-011 §13) ──
+
+    #[test]
+    fn parse_valkey_major_extracts_8_from_real_info_body() {
+        // Sample INFO server output from Valkey 8.0.
+        let info = "\
+# Server\r\n\
+redis_version:8.0.1\r\n\
+redis_git_sha1:00000000\r\n\
+redis_git_dirty:0\r\n\
+redis_build_id:abc\r\n\
+redis_mode:standalone\r\n\
+os:Linux\r\n\
+arch_bits:64\r\n";
+        assert_eq!(parse_valkey_major_version(info).unwrap(), 8);
+    }
+
+    #[test]
+    fn parse_valkey_major_extracts_7_from_low_version() {
+        let info = "# Server\r\nredis_version:7.2.4\r\nfoo:bar\r\n";
+        assert_eq!(parse_valkey_major_version(info).unwrap(), 7);
+    }
+
+    #[test]
+    fn parse_valkey_major_errors_when_field_missing() {
+        let info = "# Server\r\nfoo:bar\r\n";
+        let err = parse_valkey_major_version(info).unwrap_err();
+        assert!(matches!(err, ServerError::OperationFailed(_)));
+        assert!(err.to_string().contains("missing redis_version"));
+    }
+
+    #[test]
+    fn parse_valkey_major_errors_on_non_numeric() {
+        let info = "redis_version:invalid.x.y\n";
+        let err = parse_valkey_major_version(info).unwrap_err();
+        assert!(matches!(err, ServerError::OperationFailed(_)));
+        assert!(err.to_string().contains("non-numeric major"));
+    }
+
+    #[test]
+    fn valkey_version_too_low_is_not_retryable() {
+        let err = ServerError::ValkeyVersionTooLow {
+            detected: "7".into(),
+            required: "8.0".into(),
+        };
+        assert!(!err.is_retryable());
+        assert_eq!(err.valkey_kind(), None);
+    }
+
+    #[test]
+    fn valkey_version_too_low_error_message_includes_both_versions() {
+        let err = ServerError::ValkeyVersionTooLow {
+            detected: "7".into(),
+            required: "8.0".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("7"), "detected version in message: {msg}");
+        assert!(msg.contains("8.0"), "required version in message: {msg}");
+        assert!(msg.contains("RFC-011"), "RFC pointer in message: {msg}");
     }
 }

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -16,7 +16,7 @@ operator responsible for the Valkey backend + FlowFabric server deployment.
 | `FF_PORT` | `6379` | Valkey port |
 | `FF_TLS` | unset | Set any value to enable TLS |
 | `FF_CLUSTER` | unset | Set any value to enable cluster mode |
-| `FF_FLOW_PARTITIONS` | `256` | **Was `FF_EXEC_PARTITIONS` pre-RFC-011**. Authoritative partition count for both flow and execution routing (hash-slot co-located). Must be a power of 2 in `[1, 16384]`. |
+| `FF_FLOW_PARTITIONS` | `256` | **Was `FF_EXEC_PARTITIONS` pre-RFC-011**. Authoritative partition count for both flow and execution routing (hash-slot co-located). Any positive `u16` value (1–65535); powers of 2 are not required by the implementation but are recommended for even hash-slot distribution. |
 | `FF_BUDGET_PARTITIONS` | `32` | Budget partition count |
 | `FF_QUOTA_PARTITIONS` | `32` | Quota partition count |
 
@@ -45,14 +45,24 @@ deployment, and it's what FlowFabric's integration tests pin.
 ### Rolling upgrade tolerance
 
 The version check includes a **60-second exponential-backoff retry budget**
-(RFC-011 §9.17). If the Valkey node is restarting mid-upgrade, transient
-connection-refused or network errors during the window are treated as
-retryable, not as a low-version signal. Backoff starts at 200ms and doubles up
-to a 5-second cap per attempt.
+(RFC-011 §9.17). During that window both error classes retry:
 
-**A low version response (7.x on the first successful INFO) is NOT retried** —
-the cluster can't grow past this without operator action, so the boot fails
-fast with the typed error.
+- **Transport transients** — connection refused, `BusyLoadingError`,
+  `ClusterDown`, etc. (Valkey error kinds classified as retryable).
+- **Low-version responses** — if the connected node happens to be a
+  pre-upgrade replica during a rolling upgrade, the 7.x response is treated
+  as a rolling-state transient and retried. After 60s of consistent low
+  responses, the server exits with `ServerError::ValkeyVersionTooLow` —
+  that's the misconfiguration signal, not a transient.
+
+Backoff starts at 200ms and doubles up to a 5-second cap per attempt.
+
+**Exception — fast-fail classes:** auth failures, permission denied, and
+invalid client config are **not** retried. These are operator
+misconfiguration (wrong credentials, wrong ACL, bad TLS config) and
+retrying them just hides the true cause under a 60s hang. Server boot fails
+immediately with the structured error and the underlying Valkey error kind
+preserved.
 
 ## Rolling upgrade procedure (Valkey 7.x → 8.0+)
 
@@ -63,9 +73,12 @@ fast with the typed error.
 2. **Upgrade Valkey node-by-node:**
    - If single-node standalone: stop ff-server briefly, upgrade Valkey, start
      ff-server. The 60s retry budget tolerates restart windows under that.
-   - If cluster: roll node-by-node. At any point during the roll, if ff-server
-     restarts and hits a 7.x node, it retries until that node upgrades or the
-     budget is exhausted. Keep the rolling window under 60s per node.
+   - If cluster: roll node-by-node. If ff-server restarts and connects to a
+     pre-upgrade (7.x) node while the roll is in progress, the version check
+     retries within the 60s budget; once the connected node completes its
+     upgrade (or a reconnect lands on a post-upgrade node), the check
+     succeeds. Keep the rolling window under 60s per node so the check
+     doesn't exhaust before the node ahead finishes.
 
 3. **Verify:** after the upgrade, ff-server boot log should emit
    `Valkey version accepted detected_major=8 required=8` at INFO level.

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -30,10 +30,21 @@ operator responsible for the Valkey backend + FlowFabric server deployment.
 ## Valkey version requirement
 
 FlowFabric requires **Valkey ≥ 8.0** (see RFC-011 §13). The server verifies
-this at boot by issuing `INFO server`, parsing `redis_version`, and comparing
-the major component to the required floor. If the detected version is below
-8.0, the server refuses to start with a typed `ServerError::ValkeyVersionTooLow
-{ detected, required }` and exits.
+this at boot by issuing `INFO server` and parsing the authoritative version
+field:
+
+- Prefers `valkey_version:` (present on Valkey 8.0+; this is the real
+  server version).
+- Falls back to `redis_version:` for Valkey 7.x, which doesn't emit
+  `valkey_version:`.
+
+**Note:** Valkey 8.x/9.x keeps `redis_version:7.2.4` pinned for Redis-client
+compat and exposes the true version in `valkey_version:`. Operators
+inspecting the INFO response manually should read `valkey_version:`, not
+`redis_version:`, to see the real server version.
+
+If the major component is below 8, the server refuses to start with a typed
+`ServerError::ValkeyVersionTooLow { detected, required }` and exits.
 
 ### Why 8.0
 

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -1,0 +1,151 @@
+# RFC-011 operator runbook
+
+Operational guidance for FlowFabric deployments running post-[RFC-011](../rfcs/RFC-011-exec-flow-colocation.md)
+(phases 1-5). Covers environment variables, rolling upgrade, collision
+observability, and migration artifacts.
+
+Paired with the [consumer migration guide](rfc011-migration-for-consumers.md)
+(which tells SDK consumers what to change in their code). This doc is for the
+operator responsible for the Valkey backend + FlowFabric server deployment.
+
+## Environment variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `FF_HOST` | `localhost` | Valkey host |
+| `FF_PORT` | `6379` | Valkey port |
+| `FF_TLS` | unset | Set any value to enable TLS |
+| `FF_CLUSTER` | unset | Set any value to enable cluster mode |
+| `FF_FLOW_PARTITIONS` | `256` | **Was `FF_EXEC_PARTITIONS` pre-RFC-011**. Authoritative partition count for both flow and execution routing (hash-slot co-located). Must be a power of 2 in `[1, 16384]`. |
+| `FF_BUDGET_PARTITIONS` | `32` | Budget partition count |
+| `FF_QUOTA_PARTITIONS` | `32` | Quota partition count |
+
+### Retired
+
+- `FF_EXEC_PARTITIONS` — retired under RFC-011 §3.2. Operators who previously
+  set `FF_EXEC_PARTITIONS=N` must either rename to `FF_FLOW_PARTITIONS=N` or
+  accept the new default of 256. The server does **not** read the old name;
+  setting it has no effect.
+
+## Valkey version requirement
+
+FlowFabric requires **Valkey ≥ 8.0** (see RFC-011 §13). The server verifies
+this at boot by issuing `INFO server`, parsing `redis_version`, and comparing
+the major component to the required floor. If the detected version is below
+8.0, the server refuses to start with a typed `ServerError::ValkeyVersionTooLow
+{ detected, required }` and exits.
+
+### Why 8.0
+
+The hash-slot co-location design (RFC-011 §2) and the Valkey Functions API
+behavior the engine relies on stabilized in 8.0. Older versions will silently
+behave differently on some cluster edge cases. 8.0 is cairn-fabric's reference
+deployment, and it's what FlowFabric's integration tests pin.
+
+### Rolling upgrade tolerance
+
+The version check includes a **60-second exponential-backoff retry budget**
+(RFC-011 §9.17). If the Valkey node is restarting mid-upgrade, transient
+connection-refused or network errors during the window are treated as
+retryable, not as a low-version signal. Backoff starts at 200ms and doubles up
+to a 5-second cap per attempt.
+
+**A low version response (7.x on the first successful INFO) is NOT retried** —
+the cluster can't grow past this without operator action, so the boot fails
+fast with the typed error.
+
+## Rolling upgrade procedure (Valkey 7.x → 8.0+)
+
+1. **Prepare:** confirm cairn (and any other consumer) is on a FF-SDK release
+   that supports the target Valkey version. Consumer coordination is
+   out-of-scope for this runbook; see the consumer migration guide.
+
+2. **Upgrade Valkey node-by-node:**
+   - If single-node standalone: stop ff-server briefly, upgrade Valkey, start
+     ff-server. The 60s retry budget tolerates restart windows under that.
+   - If cluster: roll node-by-node. At any point during the roll, if ff-server
+     restarts and hits a 7.x node, it retries until that node upgrades or the
+     budget is exhausted. Keep the rolling window under 60s per node.
+
+3. **Verify:** after the upgrade, ff-server boot log should emit
+   `Valkey version accepted detected_major=8 required=8` at INFO level.
+
+4. **Post-upgrade partition collision check** (optional, phase-5 probe):
+   see the [Partition-collision observability](#partition-collision-observability)
+   section below.
+
+## Partition-collision observability
+
+Under RFC-011 §5.6, solo-exec routing derives partition from
+`crc16(lane_id) % num_flow_partitions`. With 256 partitions and ~15+ lanes,
+birthday-paradox math gives a non-negligible chance of two popular lanes
+colliding on the same partition. A collision is not a correctness bug —
+routing still works — but it concentrates write traffic on one Valkey master,
+which can hot-spot under load.
+
+> The `ff-server admin partition-collisions` subcommand documented here lands
+> in phase-5B. Until it ships, operators who want to check can compute
+> `crc16(lane_id) % num_flow_partitions` manually or use any crc16 CLI.
+
+### When to investigate
+
+- Tail-latency on a specific lane spikes without a corresponding load spike
+  on other lanes.
+- Valkey `SLOWLOG` shows one master serving substantially more traffic than
+  its siblings.
+- `RedisCommandsProcessed` per-master metrics diverge by >2x.
+
+### Remediation options
+
+In increasing order of operator cost:
+
+1. **Rename the lane** — cheapest. If the lane name is internal, pick a new
+   name that hashes to a different partition. Use the probe subcommand to
+   find a safe target partition.
+
+2. **Bump `FF_FLOW_PARTITIONS`** — doubles the space, halves the collision
+   probability. Requires re-seeding the partition config key (clean state) or
+   a full FLUSHDB + bootstrap. Not valid for production with live state.
+
+3. **Custom `SoloPartitioner`** (RFC-011 §5.6 pluggable trait, rev-3
+   amendment) — for advanced operators who want to override the default
+   crc16 routing with a custom scheme. Requires forking `ExecutionId::solo`
+   minting logic into deployment-owned code; `solo_partition_with(lane,
+   config, &custom_impl)` is the public escape hatch. Defer to a follow-up
+   RFC if this becomes common demand.
+
+## Superseded artifacts
+
+### Issue #21 (crash-recovery scanner)
+
+**Closed as superseded.** The scanner was designed to reconcile exec→flow
+membership orphans from the pre-phase-3 two-phase contract. Under phase 3's
+atomic FCALL (RFC-011 §7.3), orphans cannot be created — `ff_add_execution_to_flow`
+commits all writes atomically or nothing. No scanner is needed; do not
+resurrect.
+
+### Pre-RFC-011 two-phase prose
+
+Docstrings at `lua/flow.lua`, `crates/ff-server/src/server.rs`
+(`describe_execution` + `replay_execution` reader invariants) previously
+described the two-phase contract + orphan reader-safety catalog. Those were
+rewritten in phase 3 to describe the atomic shape. If any operator
+documentation still references "phase 2 HSET" or "orphan window" in FF
+context, it's stale; replace with an RFC-011 §7.3 pointer.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Server exits with `valkey version too low: detected 7, required >= 8.0` | Valkey 7.x backend | Upgrade Valkey to 8.0+; see [rolling upgrade](#rolling-upgrade-procedure-valkey-7x--80) |
+| Boot hangs for ~60s then exits with `valkey ({context}): ...` | Valkey unreachable during rolling upgrade OR truly down | If the cluster is mid-restart, wait and retry; otherwise check network/DNS |
+| `ServerError::PartitionMismatch` on `add_execution_to_flow` | Consumer minted exec with wrong flow/lane routing | Consumer bug — see [migration guide Step 1](rfc011-migration-for-consumers.md#step-1--executionid-construction) |
+| `partition_config mismatch: num_flow_partitions expected N, got M` on boot | `FF_FLOW_PARTITIONS` changed after first boot | Cannot hot-change partition count — re-seed or accept existing config |
+
+## Reference
+
+- [RFC-011 exec/flow hash-slot co-location](../rfcs/RFC-011-exec-flow-colocation.md) — primary design (revisions 3 + 4)
+- [Consumer migration guide](rfc011-migration-for-consumers.md) — what SDK consumers change
+- [Releasing FlowFabric](RELEASING.md) — release cadence + publish workflow
+
+Merged RFC-011 implementation PRs: #19, #20, #23, #25, #26, #27, #28, #29, #30.


### PR DESCRIPTION
## Summary

RFC-011 phase 5 sub-deliverables:
- **5A** — Valkey 8.0 version floor runtime check (RFC-011 §13) with 60s rolling-upgrade retry budget (§9.17)
- **5C** — operator runbook documenting env vars, version requirement, rolling-upgrade procedure, partition-collision observability, superseded artifacts, troubleshooting

**5B** (ff-server admin partition-collisions subcommand) is separable — ships in a follow-up PR. The runbook section forward-references it with a flag.

## Phase 5A changes

`crates/ff-server/src/server.rs`:

- New `ServerError::ValkeyVersionTooLow { detected, required }` variant — is_retryable=false, valkey_kind=None
- New `verify_valkey_version(&client)` called right after PING in `Server::start`, before partition-config validation
- `query_valkey_version` returns `Value` (not `String`), delegates to `extract_info_body` that handles cluster-mode `Map` + `VerbatimString` + `SimpleString` + `BulkString` shapes
- `parse_valkey_major_version(info_body)` — pure parser, unit-testable; prefers `valkey_version:` (authoritative on Valkey 8.0+), falls back to `redis_version:` for Valkey 7.x
- 60s exponential backoff (200ms → 5s cap) retries on:
  - Low-version responses (§9.17 rolling-upgrade tolerance)
  - Retryable ferriskey transport errors (IoError, ClusterDown, BusyLoadingError)
  - Missing/unparsable INFO (fresh-boot lag)
- **Fast-fails** (no retry) on non-retryable ferriskey kinds: auth failures, permission denied, invalid client config

`.github/workflows/matrix.yml` + `release.yml`:
- Valkey 7.2 rows retired (ff-server refuses to boot against 7.x post-RFC-011 §13)
- Pin to `valkey/valkey:8-alpine` (major-version pin matching cairn-fabric)

### New tests (9)
- Valkey-version precedence (8.x+ pins redis_version to 7.2.4 artificially; parser prefers valkey_version)
- Real cluster-mode INFO body parse
- Fall-back to redis_version when valkey_version absent (Valkey 7.x)
- Empty/missing/non-numeric version errors
- Retryable classification
- Error message content
- Cluster map shape unwrapping
- Standalone SimpleString shape

## Phase 5C runbook

`docs/rfc011-operator-runbook.md` (new, ~180 lines):

- Environment variables table with FF_EXEC_PARTITIONS retirement note
- Valkey 8.0 minimum + valkey_version vs redis_version distinction explained
- Rolling-upgrade tolerance mechanism (retries on low-version + transient; fast-fails on auth/permission/invalid-config)
- Rolling upgrade procedure (step-by-step)
- Partition-collision observability (references 5B probe with flag)
- Superseded artifacts section (issue #21 scanner + stale two-phase docstrings)
- Troubleshooting table (symptom → likely cause → fix)

## Verification

- `cargo check --workspace` clean
- `cargo clippy --workspace --exclude ferriskey --all-targets -- -D warnings` clean
- `cargo test -p ff-server --lib` 14/14 (+9 new)

## Scope discipline

- 5B deferred to its own PR.
- No cross-repo edits. Cairn migrates via PR #30's guide on their own pace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)