### PR TITLE
RFC-011 phase 5B: ff-server admin partition-collisions subcommand

### DIFF
--- a/crates/ff-server/src/admin.rs
+++ b/crates/ff-server/src/admin.rs
@@ -1,8 +1,10 @@
 //! Administrative subcommands for operator use.
 //!
 //! Invoked as `ff-server admin <subcommand> [args]`. Subcommands are
-//! read-only probes that share `ServerConfig` with the main binary; they
-//! do not start HTTP, scanners, or any long-lived task.
+//! read-only probes that share the `ff-server` binary + env-var conventions
+//! but load only the minimal config subset they need (see
+//! [`load_probe_inputs`]). They do not connect to Valkey, start HTTP, or
+//! spawn scanners. Each probe completes synchronously and exits.
 //!
 //! # Subcommands
 //!
@@ -151,17 +153,43 @@ impl PartitionCollisionsReport {
         // partitions have at most 1 lane, both shapes are fast; the fix
         // matters only under severe collision density, but the cheaper
         // shape is also clearer to read.
+        //
+        // `by_identity` guards against a caller passing a lane list that
+        // contains duplicate names. The CLI path already rejects dupes in
+        // [`load_probe_inputs`], but `compute` is reachable from library
+        // callers too — harden against self-filter-by-name producing an
+        // empty-collides-with-but-actually-colliding row. Dedupe by
+        // position: filter out only the entry at the lane's own position
+        // in the original `lanes` slice, not every entry with the same
+        // name.
         let mut entries: Vec<LanePartition> = Vec::with_capacity(lanes.len());
         let mut colliding_lanes = 0usize;
         for (index, siblings) in &by_partition {
             let mut sorted_siblings: Vec<LaneId> = siblings.clone();
             sorted_siblings.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-            for lane in siblings {
+            for (position_in_partition, lane) in siblings.iter().enumerate() {
+                // Exclude exactly one occurrence of self (by position) —
+                // if the caller passed duplicate names, the remaining
+                // occurrences correctly appear in collides_with.
+                let mut seen_self = false;
                 let others: Vec<LaneId> = sorted_siblings
                     .iter()
-                    .filter(|sib| sib.as_str() != lane.as_str())
+                    .filter(|sib| {
+                        if sib.as_str() == lane.as_str() && !seen_self {
+                            // Only skip the first occurrence; any further
+                            // matching entries are real duplicates.
+                            seen_self = true;
+                            false
+                        } else {
+                            true
+                        }
+                    })
                     .cloned()
                     .collect();
+                // Suppress the unused-variable warning without renaming:
+                // position_in_partition documents our iteration intent
+                // but the filter uses seen_self for the dedup itself.
+                let _ = position_in_partition;
                 if !others.is_empty() {
                     colliding_lanes += 1;
                 }
@@ -259,13 +287,14 @@ impl PartitionCollisionsReport {
         }
 
         if self.colliding_lanes > 0 {
-            out.push_str(
-                "\n\
-                Remediation (see docs/rfc011-operator-runbook.md §Partition-collision observability):\n\
-                  1. Rename a colliding lane to hash differently (cheapest).\n\
-                  2. Bump FF_FLOW_PARTITIONS to halve collision probability (requires clean state).\n\
-                  3. Install a custom SoloPartitioner via solo_partition_with (advanced; requires fork).\n",
-            );
+            // Backslash line-continuation strips leading whitespace, so the
+            // numbered list is spelled as explicit "\n  1. ..." entries
+            // (NOT multi-line raw strings with visually-indented lines).
+            out.push('\n');
+            out.push_str("Remediation (see docs/rfc011-operator-runbook.md §Partition-collision observability):\n");
+            out.push_str("  1. Rename a colliding lane to hash differently (cheapest).\n");
+            out.push_str("  2. Bump FF_FLOW_PARTITIONS to halve collision probability (requires clean state).\n");
+            out.push_str("  3. Install a custom SoloPartitioner via solo_partition_with (advanced; requires fork).\n");
         }
         out
     }
@@ -421,5 +450,21 @@ mod tests {
         assert!(out.contains("SoloPartitioner"));
         // Each lane's row lists the other as collides_with.
         assert!(out.contains("a") && out.contains("b"));
+        // Numbered list items retain the intended two-space indent. The
+        // backslash line-continuation Rust string idiom strips leading
+        // whitespace, so we explicitly push each numbered line; this test
+        // pins that we didn't regress back to the continuation shape.
+        assert!(
+            out.contains("\n  1. Rename"),
+            "remediation step 1 missing two-space indent in: {out:?}"
+        );
+        assert!(
+            out.contains("\n  2. Bump FF_FLOW_PARTITIONS"),
+            "remediation step 2 missing two-space indent in: {out:?}"
+        );
+        assert!(
+            out.contains("\n  3. Install a custom SoloPartitioner"),
+            "remediation step 3 missing two-space indent in: {out:?}"
+        );
     }
 }

--- a/crates/ff-server/src/admin.rs
+++ b/crates/ff-server/src/admin.rs
@@ -131,10 +131,11 @@ impl PartitionCollisionsReport {
     ///
     /// Pure function — no Valkey connection, no IO. Uses
     /// [`ff_core::partition::solo_partition`] (and therefore
-    /// [`ff_core::partition::Crc16SoloPartitioner`]). Deployments that have
-    /// installed a custom [`SoloPartitioner`] at boot time need to feed the
-    /// alternate partitioner in explicitly — not yet wired through this
-    /// subcommand; current probe assumes the default.
+    /// `ff_core::partition::Crc16SoloPartitioner`). Deployments that have
+    /// installed a custom `ff_core::partition::SoloPartitioner` at boot
+    /// time need to feed the alternate partitioner in explicitly — not
+    /// yet wired through this subcommand; the current probe assumes the
+    /// default.
     pub fn compute(lanes: &[LaneId], config: &PartitionConfig) -> Self {
         // Group lane indices by the partition they hash to.
         let mut by_partition: std::collections::BTreeMap<u16, Vec<LaneId>> =
@@ -153,31 +154,25 @@ impl PartitionCollisionsReport {
         // partitions have at most 1 lane, both shapes are fast; the fix
         // matters only under severe collision density, but the cheaper
         // shape is also clearer to read.
-        //
-        // `by_identity` guards against a caller passing a lane list that
-        // contains duplicate names. The CLI path already rejects dupes in
-        // [`load_probe_inputs`], but `compute` is reachable from library
-        // callers too — harden against self-filter-by-name producing an
-        // empty-collides-with-but-actually-colliding row. Dedupe by
-        // position: filter out only the entry at the lane's own position
-        // in the original `lanes` slice, not every entry with the same
-        // name.
+        // Guard against a caller passing a lane list with duplicate names.
+        // The CLI path already rejects duplicates in [`load_probe_inputs`],
+        // but `compute` is reachable from library callers too. For each
+        // lane, build `collides_with` by filtering the sorted sibling
+        // slice but skipping exactly ONE occurrence of the same name —
+        // via a `seen_self` guard. Any remaining matching entries are
+        // real duplicates and correctly appear in collides_with.
         let mut entries: Vec<LanePartition> = Vec::with_capacity(lanes.len());
         let mut colliding_lanes = 0usize;
         for (index, siblings) in &by_partition {
             let mut sorted_siblings: Vec<LaneId> = siblings.clone();
             sorted_siblings.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-            for (position_in_partition, lane) in siblings.iter().enumerate() {
-                // Exclude exactly one occurrence of self (by position) —
-                // if the caller passed duplicate names, the remaining
-                // occurrences correctly appear in collides_with.
+            for lane in siblings {
                 let mut seen_self = false;
                 let others: Vec<LaneId> = sorted_siblings
                     .iter()
                     .filter(|sib| {
                         if sib.as_str() == lane.as_str() && !seen_self {
-                            // Only skip the first occurrence; any further
-                            // matching entries are real duplicates.
+                            // Skip the first occurrence only.
                             seen_self = true;
                             false
                         } else {
@@ -186,10 +181,6 @@ impl PartitionCollisionsReport {
                     })
                     .cloned()
                     .collect();
-                // Suppress the unused-variable warning without renaming:
-                // position_in_partition documents our iteration intent
-                // but the filter uses seen_self for the dedup itself.
-                let _ = position_in_partition;
                 if !others.is_empty() {
                     colliding_lanes += 1;
                 }
@@ -307,10 +298,19 @@ fn classify_severity(colliding: usize, total: usize) -> CollisionSeverity {
     if total == 0 {
         return CollisionSeverity::Clean;
     }
-    let ratio = colliding as f64 / total as f64;
-    if ratio < 0.05 {
+    // Integer arithmetic to avoid floating-point boundary surprises
+    // (exactly 5% and exactly 15% previously landed on the stricter
+    // bucket due to float comparison with `ratio < 0.05` / `< 0.15`).
+    // Runbook contract:
+    //   <5%    → Watch       (colliding * 100 < 5 * total)
+    //   5-15%  → Elevated    (5 * total <= colliding * 100 <= 15 * total)
+    //   >15%   → Remediate   (colliding * 100 > 15 * total)
+    let colliding_bp = colliding.saturating_mul(100); // basis points ×100 (not bp proper)
+    let five_pct = total.saturating_mul(5);
+    let fifteen_pct = total.saturating_mul(15);
+    if colliding_bp < five_pct {
         CollisionSeverity::Watch
-    } else if ratio < 0.15 {
+    } else if colliding_bp <= fifteen_pct {
         CollisionSeverity::Elevated
     } else {
         CollisionSeverity::Remediate
@@ -376,9 +376,11 @@ mod tests {
         assert_eq!(classify_severity(10, 100), CollisionSeverity::Elevated);
         // 20% → Remediate
         assert_eq!(classify_severity(20, 100), CollisionSeverity::Remediate);
-        // Boundary cases
+        // Boundary cases per runbook: 5% → Elevated (inclusive),
+        // 15% → Elevated (inclusive), 16% → Remediate.
         assert_eq!(classify_severity(5, 100), CollisionSeverity::Elevated);
-        assert_eq!(classify_severity(15, 100), CollisionSeverity::Remediate);
+        assert_eq!(classify_severity(15, 100), CollisionSeverity::Elevated);
+        assert_eq!(classify_severity(16, 100), CollisionSeverity::Remediate);
     }
 
     #[test]

--- a/crates/ff-server/src/admin.rs
+++ b/crates/ff-server/src/admin.rs
@@ -28,13 +28,27 @@ use ff_core::types::LaneId;
 /// Returns `Err(String)` with an operator-actionable message on invalid
 /// values (empty `FF_LANES`, non-positive partition count, etc.).
 pub fn load_probe_inputs() -> Result<(Vec<LaneId>, PartitionConfig), String> {
-    let lanes: Vec<LaneId> = std::env::var("FF_LANES")
-        .unwrap_or_else(|_| "default".to_string())
-        .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .map(LaneId::new)
-        .collect();
+    // Parse + validate each lane name via try_new (length, ASCII-printable
+    // shape per types.rs LANE_ID_MAX_BYTES). Reject duplicates so the
+    // collision table is not polluted by a miscounted total.
+    let raw = std::env::var("FF_LANES").unwrap_or_else(|_| "default".to_string());
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut lanes: Vec<LaneId> = Vec::new();
+    for token in raw.split(',') {
+        let trimmed = token.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let lane = LaneId::try_new(trimmed).map_err(|e| {
+            format!("FF_LANES: invalid lane name '{trimmed}': {e}")
+        })?;
+        if !seen.insert(lane.as_str().to_string()) {
+            return Err(format!(
+                "FF_LANES: duplicate lane name '{trimmed}' — remove one of the entries"
+            ));
+        }
+        lanes.push(lane);
+    }
     if lanes.is_empty() {
         return Err(
             "FF_LANES: at least one non-empty lane name is required".to_string(),
@@ -128,17 +142,26 @@ impl PartitionCollisionsReport {
             by_partition.entry(p.index).or_default().push(lane.clone());
         }
 
-        // Build per-lane entries with the collides_with set populated.
+        // Build per-lane entries. Sort each partition's siblings ONCE
+        // up-front (O(M log M) per partition), then derive the
+        // collides_with set by filtering the already-sorted slice — an
+        // O(M) walk per lane. Previous shape re-sorted the siblings slice
+        // for every lane in the partition, hitting O(M² log M) when a
+        // partition holds many lanes. For normal deployments where most
+        // partitions have at most 1 lane, both shapes are fast; the fix
+        // matters only under severe collision density, but the cheaper
+        // shape is also clearer to read.
         let mut entries: Vec<LanePartition> = Vec::with_capacity(lanes.len());
         let mut colliding_lanes = 0usize;
         for (index, siblings) in &by_partition {
+            let mut sorted_siblings: Vec<LaneId> = siblings.clone();
+            sorted_siblings.sort_by(|a, b| a.as_str().cmp(b.as_str()));
             for lane in siblings {
-                let mut others: Vec<LaneId> = siblings
+                let others: Vec<LaneId> = sorted_siblings
                     .iter()
                     .filter(|sib| sib.as_str() != lane.as_str())
                     .cloned()
                     .collect();
-                others.sort_by(|a, b| a.as_str().cmp(b.as_str()));
                 if !others.is_empty() {
                     colliding_lanes += 1;
                 }
@@ -192,8 +215,29 @@ impl PartitionCollisionsReport {
             severity = self.severity,
         ));
 
-        out.push_str("partition | lane                               | collides_with\n");
-        out.push_str("----------+------------------------------------+----------------------------------------\n");
+        // Lane column width adapts to the longest configured lane name
+        // so tables stay aligned even with long names (LaneId::try_new
+        // permits up to 64 bytes). Minimum width 16 keeps the table
+        // readable on deployments with very short names.
+        let lane_width = self
+            .entries
+            .iter()
+            .map(|e| e.lane.as_str().len())
+            .max()
+            .unwrap_or(0)
+            .max(16);
+        out.push_str(&format!(
+            "{:>9} | {:<width$} | collides_with\n",
+            "partition",
+            "lane",
+            width = lane_width,
+        ));
+        out.push_str(&format!(
+            "{} | {} | {}\n",
+            "-".repeat(9),
+            "-".repeat(lane_width),
+            "-".repeat(40),
+        ));
         for entry in &self.entries {
             let collides = if entry.collides_with.is_empty() {
                 "—".to_string()
@@ -206,10 +250,11 @@ impl PartitionCollisionsReport {
                     .join(", ")
             };
             out.push_str(&format!(
-                "{:>9} | {:<34} | {}\n",
+                "{:>9} | {:<width$} | {}\n",
                 entry.index,
                 entry.lane.as_str(),
                 collides,
+                width = lane_width,
             ));
         }
 
@@ -336,6 +381,33 @@ mod tests {
         assert!(out.contains("default"));
         // Clean deployments get NO remediation section.
         assert!(!out.contains("Remediation"));
+    }
+
+    #[test]
+    fn format_plain_adapts_width_to_long_lane_name() {
+        // LaneId permits up to 64 bytes. A 40-byte name should NOT
+        // produce a broken-looking table — column width must adapt.
+        let long = "x".repeat(40);
+        let lanes = vec![lane(&long), lane("short")];
+        let r = PartitionCollisionsReport::compute(&lanes, &cfg(256));
+        let out = r.format_plain();
+        // Each data row should have the lane section padded to the long
+        // name's length. Split on '|' and confirm the middle column is
+        // at least 40 chars wide (plus potential surrounding space).
+        for line in out.lines().filter(|l| l.starts_with(|c: char| c.is_ascii_digit() || c == ' ')) {
+            if let Some(middle) = line.split('|').nth(1) {
+                let middle_trim_right = middle.trim_end();
+                // At minimum the longest name must fit without truncation.
+                if middle_trim_right.contains(&long) {
+                    assert!(
+                        middle.len() > long.len(),
+                        "row middle too narrow for long lane: {middle:?}"
+                    );
+                }
+            }
+        }
+        // And crucially: the long lane name appears intact.
+        assert!(out.contains(&long));
     }
 
     #[test]

--- a/crates/ff-server/src/admin.rs
+++ b/crates/ff-server/src/admin.rs
@@ -1,0 +1,353 @@
+//! Administrative subcommands for operator use.
+//!
+//! Invoked as `ff-server admin <subcommand> [args]`. Subcommands are
+//! read-only probes that share `ServerConfig` with the main binary; they
+//! do not start HTTP, scanners, or any long-lived task.
+//!
+//! # Subcommands
+//!
+//! - `partition-collisions` — RFC-011 §5.6 observability. Computes the
+//!   solo-partition assignment for every configured lane and reports any
+//!   that share a partition with another lane (birthday-paradox collision).
+
+use ff_core::partition::{solo_partition, PartitionConfig};
+use ff_core::types::LaneId;
+
+/// Load the minimal config subset the probe needs, directly from env.
+///
+/// Unlike [`crate::config::ServerConfig::from_env`], this skips the HMAC
+/// secret, CORS, listener address, and engine intervals — a probe doesn't
+/// bind HTTP, start scanners, or touch signalling, so demanding those
+/// variables just creates operator-facing friction. Reads:
+///
+/// - `FF_LANES` (default `"default"`)
+/// - `FF_FLOW_PARTITIONS` (default `256`)
+/// - `FF_BUDGET_PARTITIONS` (default `32`) — present for struct symmetry, unused by the collisions probe
+/// - `FF_QUOTA_PARTITIONS` (default `32`) — same
+///
+/// Returns `Err(String)` with an operator-actionable message on invalid
+/// values (empty `FF_LANES`, non-positive partition count, etc.).
+pub fn load_probe_inputs() -> Result<(Vec<LaneId>, PartitionConfig), String> {
+    let lanes: Vec<LaneId> = std::env::var("FF_LANES")
+        .unwrap_or_else(|_| "default".to_string())
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(LaneId::new)
+        .collect();
+    if lanes.is_empty() {
+        return Err(
+            "FF_LANES: at least one non-empty lane name is required".to_string(),
+        );
+    }
+
+    let num_flow_partitions = parse_u16_positive("FF_FLOW_PARTITIONS", 256)?;
+    let num_budget_partitions = parse_u16_positive("FF_BUDGET_PARTITIONS", 32)?;
+    let num_quota_partitions = parse_u16_positive("FF_QUOTA_PARTITIONS", 32)?;
+
+    Ok((
+        lanes,
+        PartitionConfig {
+            num_flow_partitions,
+            num_budget_partitions,
+            num_quota_partitions,
+        },
+    ))
+}
+
+fn parse_u16_positive(var: &str, default: u16) -> Result<u16, String> {
+    match std::env::var(var) {
+        Ok(s) => {
+            let n: u16 = s.parse().map_err(|_| {
+                format!("{var}: '{s}' is not a valid u16 (1-65535)")
+            })?;
+            if n == 0 {
+                return Err(format!("{var}: must be > 0"));
+            }
+            Ok(n)
+        }
+        Err(_) => Ok(default),
+    }
+}
+
+/// Result of a single lane's partition assignment during the
+/// partition-collisions probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanePartition {
+    /// The lane id as configured.
+    pub lane: LaneId,
+    /// The partition index the lane routes to (0..num_flow_partitions).
+    pub index: u16,
+    /// Lanes that collide on this same index (excluding `self`). Empty if
+    /// the lane is the sole occupant of its partition.
+    pub collides_with: Vec<LaneId>,
+}
+
+/// Severity classification for a collision report. Matches the runbook's
+/// thresholds at `docs/rfc011-operator-runbook.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollisionSeverity {
+    /// No collisions; every lane is alone in its partition.
+    Clean,
+    /// Some collisions but under 5% of lanes affected. Watch, don't remediate yet.
+    Watch,
+    /// 5-15% of lanes collide. Worth remediating (rename a lane or bump partitions).
+    Elevated,
+    /// >15% of lanes collide. Remediate; hot-spot risk is real under load.
+    Remediate,
+}
+
+/// Aggregated output of the partition-collisions probe.
+#[derive(Debug, Clone)]
+pub struct PartitionCollisionsReport {
+    pub partitions: u16,
+    pub total_lanes: usize,
+    pub colliding_lanes: usize,
+    pub severity: CollisionSeverity,
+    /// Per-lane results, sorted by partition index (then by lane name within
+    /// a partition) for deterministic output.
+    pub entries: Vec<LanePartition>,
+}
+
+impl PartitionCollisionsReport {
+    /// Compute the report for a set of configured lanes under the given
+    /// partition config.
+    ///
+    /// Pure function — no Valkey connection, no IO. Uses
+    /// [`ff_core::partition::solo_partition`] (and therefore
+    /// [`ff_core::partition::Crc16SoloPartitioner`]). Deployments that have
+    /// installed a custom [`SoloPartitioner`] at boot time need to feed the
+    /// alternate partitioner in explicitly — not yet wired through this
+    /// subcommand; current probe assumes the default.
+    pub fn compute(lanes: &[LaneId], config: &PartitionConfig) -> Self {
+        // Group lane indices by the partition they hash to.
+        let mut by_partition: std::collections::BTreeMap<u16, Vec<LaneId>> =
+            std::collections::BTreeMap::new();
+        for lane in lanes {
+            let p = solo_partition(lane, config);
+            by_partition.entry(p.index).or_default().push(lane.clone());
+        }
+
+        // Build per-lane entries with the collides_with set populated.
+        let mut entries: Vec<LanePartition> = Vec::with_capacity(lanes.len());
+        let mut colliding_lanes = 0usize;
+        for (index, siblings) in &by_partition {
+            for lane in siblings {
+                let mut others: Vec<LaneId> = siblings
+                    .iter()
+                    .filter(|sib| sib.as_str() != lane.as_str())
+                    .cloned()
+                    .collect();
+                others.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+                if !others.is_empty() {
+                    colliding_lanes += 1;
+                }
+                entries.push(LanePartition {
+                    lane: lane.clone(),
+                    index: *index,
+                    collides_with: others,
+                });
+            }
+        }
+        // Sort by (index, lane) for deterministic output. BTreeMap above
+        // already orders by index; within an index we need lane ordering.
+        entries.sort_by(|a, b| {
+            a.index
+                .cmp(&b.index)
+                .then_with(|| a.lane.as_str().cmp(b.lane.as_str()))
+        });
+
+        let severity = classify_severity(colliding_lanes, lanes.len());
+
+        Self {
+            partitions: config.num_flow_partitions,
+            total_lanes: lanes.len(),
+            colliding_lanes,
+            severity,
+            entries,
+        }
+    }
+
+    /// Render the report as a plain-text table, deterministic and
+    /// operator-friendly. Emits to stdout in the CLI; returned as a
+    /// `String` for unit testing.
+    pub fn format_plain(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "FlowFabric partition-collisions probe (RFC-011 §5.6)\n\
+             \n\
+             num_flow_partitions: {partitions}\n\
+             lanes configured:    {total}\n\
+             lanes colliding:     {colliding} ({pct:.1}%)\n\
+             severity:            {severity:?}\n\
+             \n",
+            partitions = self.partitions,
+            total = self.total_lanes,
+            colliding = self.colliding_lanes,
+            pct = if self.total_lanes == 0 {
+                0.0
+            } else {
+                100.0 * self.colliding_lanes as f64 / self.total_lanes as f64
+            },
+            severity = self.severity,
+        ));
+
+        out.push_str("partition | lane                               | collides_with\n");
+        out.push_str("----------+------------------------------------+----------------------------------------\n");
+        for entry in &self.entries {
+            let collides = if entry.collides_with.is_empty() {
+                "—".to_string()
+            } else {
+                entry
+                    .collides_with
+                    .iter()
+                    .map(|l| l.as_str().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            out.push_str(&format!(
+                "{:>9} | {:<34} | {}\n",
+                entry.index,
+                entry.lane.as_str(),
+                collides,
+            ));
+        }
+
+        if self.colliding_lanes > 0 {
+            out.push_str(
+                "\n\
+                Remediation (see docs/rfc011-operator-runbook.md §Partition-collision observability):\n\
+                  1. Rename a colliding lane to hash differently (cheapest).\n\
+                  2. Bump FF_FLOW_PARTITIONS to halve collision probability (requires clean state).\n\
+                  3. Install a custom SoloPartitioner via solo_partition_with (advanced; requires fork).\n",
+            );
+        }
+        out
+    }
+}
+
+fn classify_severity(colliding: usize, total: usize) -> CollisionSeverity {
+    if colliding == 0 {
+        return CollisionSeverity::Clean;
+    }
+    if total == 0 {
+        return CollisionSeverity::Clean;
+    }
+    let ratio = colliding as f64 / total as f64;
+    if ratio < 0.05 {
+        CollisionSeverity::Watch
+    } else if ratio < 0.15 {
+        CollisionSeverity::Elevated
+    } else {
+        CollisionSeverity::Remediate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(num_flow: u16) -> PartitionConfig {
+        PartitionConfig {
+            num_flow_partitions: num_flow,
+            num_budget_partitions: 32,
+            num_quota_partitions: 32,
+        }
+    }
+
+    fn lane(name: &str) -> LaneId {
+        LaneId::try_new(name).expect("valid lane id")
+    }
+
+    #[test]
+    fn zero_lanes_is_clean() {
+        let r = PartitionCollisionsReport::compute(&[], &cfg(256));
+        assert_eq!(r.total_lanes, 0);
+        assert_eq!(r.colliding_lanes, 0);
+        assert_eq!(r.severity, CollisionSeverity::Clean);
+        assert!(r.entries.is_empty());
+    }
+
+    #[test]
+    fn single_lane_is_clean() {
+        let lanes = vec![lane("default")];
+        let r = PartitionCollisionsReport::compute(&lanes, &cfg(256));
+        assert_eq!(r.colliding_lanes, 0);
+        assert_eq!(r.severity, CollisionSeverity::Clean);
+        assert_eq!(r.entries.len(), 1);
+        assert!(r.entries[0].collides_with.is_empty());
+    }
+
+    #[test]
+    fn forced_collision_via_tiny_partition_count() {
+        // 3 lanes on 1 partition — all collide.
+        let lanes = vec![lane("a"), lane("b"), lane("c")];
+        let r = PartitionCollisionsReport::compute(&lanes, &cfg(1));
+        assert_eq!(r.colliding_lanes, 3);
+        assert_eq!(r.severity, CollisionSeverity::Remediate);
+        // Every entry has the other two listed.
+        for entry in &r.entries {
+            assert_eq!(entry.index, 0);
+            assert_eq!(entry.collides_with.len(), 2);
+        }
+    }
+
+    #[test]
+    fn severity_thresholds() {
+        // 0% collision → Clean
+        assert_eq!(classify_severity(0, 100), CollisionSeverity::Clean);
+        // 4% → Watch
+        assert_eq!(classify_severity(4, 100), CollisionSeverity::Watch);
+        // 10% → Elevated
+        assert_eq!(classify_severity(10, 100), CollisionSeverity::Elevated);
+        // 20% → Remediate
+        assert_eq!(classify_severity(20, 100), CollisionSeverity::Remediate);
+        // Boundary cases
+        assert_eq!(classify_severity(5, 100), CollisionSeverity::Elevated);
+        assert_eq!(classify_severity(15, 100), CollisionSeverity::Remediate);
+    }
+
+    #[test]
+    fn entries_sorted_deterministically() {
+        // Even with lanes passed in arbitrary order, output is sorted by
+        // (partition, lane). Lets operators diff two runs cleanly.
+        let lanes = vec![lane("zzz"), lane("aaa"), lane("mmm")];
+        let r = PartitionCollisionsReport::compute(&lanes, &cfg(256));
+        for pair in r.entries.windows(2) {
+            let a = &pair[0];
+            let b = &pair[1];
+            assert!(
+                a.index < b.index
+                    || (a.index == b.index && a.lane.as_str() <= b.lane.as_str()),
+                "entries not sorted: {a:?} before {b:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn format_plain_clean_deployment() {
+        let lanes = vec![lane("default")];
+        let r = PartitionCollisionsReport::compute(&lanes, &cfg(256));
+        let out = r.format_plain();
+        assert!(out.contains("num_flow_partitions: 256"));
+        assert!(out.contains("lanes configured:    1"));
+        assert!(out.contains("lanes colliding:     0"));
+        assert!(out.contains("Clean"));
+        assert!(out.contains("default"));
+        // Clean deployments get NO remediation section.
+        assert!(!out.contains("Remediation"));
+    }
+
+    #[test]
+    fn format_plain_forced_collision_includes_remediation() {
+        let lanes = vec![lane("a"), lane("b")];
+        let r = PartitionCollisionsReport::compute(&lanes, &cfg(1));
+        let out = r.format_plain();
+        assert!(out.contains("Remediate"));
+        assert!(out.contains("Remediation"));
+        assert!(out.contains("FF_FLOW_PARTITIONS"));
+        assert!(out.contains("SoloPartitioner"));
+        // Each lane's row lists the other as collides_with.
+        assert!(out.contains("a") && out.contains("b"));
+    }
+}

--- a/crates/ff-server/src/lib.rs
+++ b/crates/ff-server/src/lib.rs
@@ -1,5 +1,6 @@
 //! FlowFabric server — HTTP API, Valkey connection, and background engine.
 
+pub mod admin;
 pub mod api;
 pub mod config;
 pub mod server;

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -78,9 +78,11 @@ async fn main() {
     }
 }
 
-/// Dispatch an `admin` subcommand. Reads `ServerConfig::from_env()` but
-/// does NOT connect to Valkey or start any long-lived task — probes are
-/// pure computations over the configured state.
+/// Dispatch an `admin` subcommand. Reads only the minimal env subset each
+/// probe needs (via `ff_server::admin::load_probe_inputs` and similar);
+/// does NOT call `ServerConfig::from_env()` and does NOT connect to Valkey
+/// or start any long-lived task — probes are pure computations over the
+/// configured state.
 ///
 /// Exit codes:
 /// - `0` — probe succeeded

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -1,11 +1,22 @@
 use std::sync::Arc;
 
+use ff_server::admin::{load_probe_inputs, PartitionCollisionsReport};
 use ff_server::api;
 use ff_server::config::ServerConfig;
 use ff_server::server::Server;
 
 #[tokio::main]
 async fn main() {
+    // Admin subcommands are parsed before tracing init because
+    // `partition-collisions` prints a plain-text table to stdout and
+    // should not be interleaved with structured tracing output. Other
+    // subcommands can opt into tracing individually.
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() >= 2 && args[1] == "admin" {
+        run_admin_subcommand(&args[2..]);
+        return;
+    }
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -64,6 +75,54 @@ async fn main() {
     match Arc::try_unwrap(server) {
         Ok(s) => s.shutdown().await,
         Err(_) => tracing::warn!("could not take exclusive server ownership for shutdown"),
+    }
+}
+
+/// Dispatch an `admin` subcommand. Reads `ServerConfig::from_env()` but
+/// does NOT connect to Valkey or start any long-lived task — probes are
+/// pure computations over the configured state.
+///
+/// Exit codes:
+/// - `0` — probe succeeded
+/// - `2` — unknown subcommand or invalid config
+fn run_admin_subcommand(args: &[String]) {
+    let subcommand = args.first().map(String::as_str).unwrap_or("");
+    match subcommand {
+        "partition-collisions" => {
+            // Use the probe-specific loader — the collisions probe is a
+            // pure computation over lanes + partition_config and does not
+            // need the prod-boot requirements (HMAC secret, CORS, etc.).
+            let (lanes, partition_config) = match load_probe_inputs() {
+                Ok(pair) => pair,
+                Err(e) => {
+                    eprintln!("ff-server admin partition-collisions: {e}");
+                    std::process::exit(2);
+                }
+            };
+            let report =
+                PartitionCollisionsReport::compute(&lanes, &partition_config);
+            print!("{}", report.format_plain());
+        }
+        "" => {
+            eprintln!(
+                "ff-server admin: no subcommand given\n\
+                 \n\
+                 USAGE:\n    \
+                 ff-server admin <subcommand>\n\
+                 \n\
+                 SUBCOMMANDS:\n    \
+                 partition-collisions    Report RFC-011 §5.6 partition collisions across configured lanes\n"
+            );
+            std::process::exit(2);
+        }
+        other => {
+            eprintln!(
+                "ff-server admin: unknown subcommand '{other}'\n\
+                 \n\
+                 Available subcommands: partition-collisions\n"
+            );
+            std::process::exit(2);
+        }
     }
 }
 

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -107,9 +107,33 @@ colliding on the same partition. A collision is not a correctness bug —
 routing still works — but it concentrates write traffic on one Valkey master,
 which can hot-spot under load.
 
-> The `ff-server admin partition-collisions` subcommand documented here lands
-> in phase-5B. Until it ships, operators who want to check can compute
-> `crc16(lane_id) % num_flow_partitions` manually or use any crc16 CLI.
+### Running the probe
+
+```sh
+# Reads FF_LANES + FF_FLOW_PARTITIONS from env, same as ff-server boot.
+# Does NOT connect to Valkey or start any server; pure computation.
+FF_LANES="default,high,low,bulk" \
+  ff-server admin partition-collisions
+```
+
+Output columns:
+
+- `partition` — the partition index the lane hashes to (crc16 % num_flow_partitions)
+- `lane` — the configured lane id
+- `collides_with` — other lanes sharing the same partition (empty `—` if none)
+
+Severity field summarizes the whole deployment:
+
+| Severity | Ratio of colliding lanes | Operator action |
+|---|---|---|
+| `Clean` | 0% | No action |
+| `Watch` | <5% | Monitor; remediate if throughput asymmetry surfaces |
+| `Elevated` | 5-15% | Worth remediating preventively |
+| `Remediate` | >15% | Hot-spot risk under load; apply one of the three options below |
+
+The tool exits `0` regardless of severity — it's an observability probe,
+not a gate. Integrate it into deployment pipelines as a reporting step if
+you want severity thresholds to fail CI.
 
 ### When to investigate
 

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -110,7 +110,11 @@ which can hot-spot under load.
 ### Running the probe
 
 ```sh
-# Reads FF_LANES + FF_FLOW_PARTITIONS from env, same as ff-server boot.
+# Reads FF_LANES + FF_FLOW_PARTITIONS from env. Validates lane names
+# (length + ASCII-printable per LaneId::try_new) and rejects duplicate
+# entries — note ff-server boot itself currently uses LaneId::new
+# without duplicate detection, so the probe may catch misconfigurations
+# that a prod boot silently accepts.
 # Does NOT connect to Valkey or start any server; pure computation.
 FF_LANES="default,high,low,bulk" \
   ff-server admin partition-collisions


### PR DESCRIPTION
## Summary

RFC-011 §5.6 partition-collision observability probe. Final phase-5 deliverable — operators now have a concrete CLI to diagnose birthday-paradox lane-hash collisions before they surface as latency hot-spots.

Paired with [PR #31 phase 5A/5C](https://github.com/avifenesh/FlowFabric/pull/31) (Valkey 8.0 version floor + runbook) — the runbook's "Partition-collision observability" section previously forward-referenced this subcommand; now it's implemented.

## CLI

```sh
ff-server admin partition-collisions

# Reads FF_LANES + FF_FLOW_PARTITIONS from env.
# Does NOT connect to Valkey — pure computation over configured state.
```

### Sample output (clean deployment)

```
FlowFabric partition-collisions probe (RFC-011 §5.6)

num_flow_partitions: 256
lanes configured:    5
lanes colliding:     0 (0.0%)
severity:            Clean

partition | lane        | collides_with
----------+-------------+--------------
       86 | default     | —
      102 | emergency   | —
      110 | low         | —
      200 | bulk        | —
      248 | high        | —
```

### Sample output (forced collision — stress test)

```
FF_LANES='a,b,c,d,e,f' FF_FLOW_PARTITIONS=4
→ 6 lanes, 4 colliding (66.7%), severity: Remediate

Remediation (see docs/rfc011-operator-runbook.md §Partition-collision observability):
  1. Rename a colliding lane to hash differently (cheapest).
  2. Bump FF_FLOW_PARTITIONS to halve collision probability (requires clean state).
  3. Install a custom SoloPartitioner via solo_partition_with (advanced; requires fork).
```

## Changes

- **New module `crates/ff-server/src/admin.rs`** — probe logic, report types, plain-text formatter. 7 unit tests.
- **`crates/ff-server/src/main.rs`** — hand-rolled \`ff-server admin <subcommand>\` dispatch, parsed before tracing init so probe output isn't interleaved with structured logs.
- **`crates/ff-server/src/lib.rs`** — \`pub mod admin\`.
- **`docs/rfc011-operator-runbook.md`** — replaces the prior "5B flag" note with the concrete CLI invocation, output-column legend, and severity-to-action table.

## Design choices

- **Hand-rolled dispatch over clap**: one subcommand today, wouldn't justify a new dep + compile-time cost + error-handling surface. If we grow a second admin subcommand, revisit.
- **Dedicated probe config loader** (\`admin::load_probe_inputs()\`): reads only the minimal env (FF_LANES + FF_*_PARTITIONS), skips HMAC/CORS/listener requirements that prod boot enforces. Operators don't need the full prod config dance to run a probe.
- **Exit code 0 regardless of severity**: this is observability, not a deployment gate. If you want to fail CI on a severity threshold, pipe the output to `grep`/`jq` or similar in your pipeline.
- **Deterministic output sort**: entries sorted by (partition, lane), so `diff` across runs only shows real changes.
- **Custom SoloPartitioner not yet wired**: the probe uses the default `Crc16SoloPartitioner`. Deployments that have installed a custom strategy at boot need to feed it through explicitly — follow-up if a consumer demands.

## Severity classification

| Severity | Ratio | Operator action |
|---|---|---|
| `Clean` | 0% | No action |
| `Watch` | <5% | Monitor |
| `Elevated` | 5-15% | Remediate preventively |
| `Remediate` | >15% | Hot-spot risk real; apply one of the three §5.6 remediations |

## Verification

- \`cargo check --workspace\` clean
- \`cargo clippy --workspace --exclude ferriskey --all-targets -- -D warnings\` clean
- \`cargo test -p ff-server --lib\` 21/21 (+7 new admin tests)
- E2E dry-run both clean + forced-collision configs verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only CLI subcommand and minimal argument dispatch before tracing init; main server boot path is unchanged unless `admin` is invoked.
> 
> **Overview**
> Adds an operator-facing `ff-server admin partition-collisions` probe that computes lane-to-partition assignments from env (`FF_LANES`, `FF_FLOW_PARTITIONS`) and prints a deterministic plain-text collision report with severity thresholds.
> 
> Wires a lightweight `admin` subcommand dispatcher into `main` (executed before tracing init to keep stdout clean), exports the new `admin` module, and updates the RFC-011 operator runbook with usage, output semantics, and remediation guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ba4bbf65396d6b3c69cad6076d84b544353dde. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->