### PR TITLE
feat(ff-core): deterministic ExecutionId mint (cairn unblocker)

### DIFF
--- a/crates/ff-core/src/types.rs
+++ b/crates/ff-core/src/types.rs
@@ -140,6 +140,63 @@ impl ExecutionId {
         Self(format!("{{fp:{partition}}}:{uuid}"))
     }
 
+    fn with_partition_and_uuid(partition: u16, uuid: Uuid) -> Self {
+        Self(format!("{{fp:{partition}}}:{uuid}"))
+    }
+
+    /// Deterministic mint: same `(flow_id, uuid)` inputs always produce the
+    /// same `ExecutionId`. Intended for consumers that derive a stable UUID
+    /// externally (e.g. `Uuid::new_v5` from application-scoped keys) and
+    /// need idempotent execution identity on retry without coordinating
+    /// through FlowFabric.
+    ///
+    /// Any `Uuid` value is accepted — no version or shape strictness. The
+    /// caller owns the derivation scheme; FlowFabric treats the UUID as an
+    /// opaque 128-bit identifier.
+    ///
+    /// # Partition-count stability
+    ///
+    /// The returned id's hash-tag embeds
+    /// `crc16(flow_id.bytes) % num_flow_partitions`. **Determinism holds
+    /// only while `num_flow_partitions` is stable** across the caller's
+    /// usage window. Resizing the deployment's partition count invalidates
+    /// previously-minted ids: the same inputs will produce a different
+    /// hash-tag, and lookups against the old id will miss. Consumers relying
+    /// on cross-run determinism should pin `num_flow_partitions` or embed a
+    /// namespace-version in their UUID derivation so a resize surfaces as a
+    /// namespace rollover rather than silent drift.
+    pub fn deterministic_for_flow(
+        flow_id: &FlowId,
+        config: &crate::partition::PartitionConfig,
+        uuid: Uuid,
+    ) -> Self {
+        let partition = crate::partition::flow_partition(flow_id, config).index;
+        Self::with_partition_and_uuid(partition, uuid)
+    }
+
+    /// Deterministic mint for solo (no-parent-flow) executions. Same
+    /// `(lane_id, uuid)` always yields the same `ExecutionId`. Mirrors
+    /// [`ExecutionId::solo`] but with a caller-supplied UUID.
+    ///
+    /// Partition routing uses the default
+    /// [`crate::partition::Crc16SoloPartitioner`]. Deployments that
+    /// installed a custom [`crate::partition::SoloPartitioner`] must mint
+    /// via their own path — this constructor hard-codes the default and
+    /// will diverge from a custom partitioner's routing.
+    ///
+    /// # Partition-count stability
+    ///
+    /// Same stability contract as [`ExecutionId::deterministic_for_flow`]:
+    /// determinism holds only while `num_flow_partitions` is stable.
+    pub fn deterministic_solo(
+        lane_id: &LaneId,
+        config: &crate::partition::PartitionConfig,
+        uuid: Uuid,
+    ) -> Self {
+        let partition = crate::partition::solo_partition(lane_id, config).index;
+        Self::with_partition_and_uuid(partition, uuid)
+    }
+
     /// Parse a hash-tagged execution-id string.
     ///
     /// Rejects:
@@ -627,6 +684,116 @@ mod tests {
         let json = serde_json::to_string(&lane).unwrap();
         let parsed: LaneId = serde_json::from_str(&json).unwrap();
         assert_eq!(lane, parsed);
+    }
+
+    // ── Deterministic mint (RFC-011 — cairn-fabric idempotency) ──
+
+    #[test]
+    fn deterministic_for_flow_is_stable() {
+        let config = crate::partition::PartitionConfig::default();
+        let fid = FlowId::new();
+        let u = Uuid::new_v4();
+        let a = ExecutionId::deterministic_for_flow(&fid, &config, u);
+        let b = ExecutionId::deterministic_for_flow(&fid, &config, u);
+        assert_eq!(a, b);
+        assert_eq!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn deterministic_for_flow_partition_matches_for_flow() {
+        let config = crate::partition::PartitionConfig::default();
+        let fid = FlowId::new();
+        let u = Uuid::new_v4();
+        let det = ExecutionId::deterministic_for_flow(&fid, &config, u);
+        let rnd = ExecutionId::for_flow(&fid, &config);
+        assert_eq!(det.partition(), rnd.partition());
+    }
+
+    #[test]
+    fn deterministic_for_flow_uuid_embedded_verbatim() {
+        let config = crate::partition::PartitionConfig::default();
+        let fid = FlowId::new();
+        let u = Uuid::new_v4();
+        let eid = ExecutionId::deterministic_for_flow(&fid, &config, u);
+        assert!(eid.as_str().ends_with(&u.to_string()));
+    }
+
+    #[test]
+    fn deterministic_for_flow_accepts_any_uuid_version() {
+        // No strictness — v5 (cairn's case), v4, and nil all accepted.
+        let config = crate::partition::PartitionConfig::default();
+        let fid = FlowId::new();
+        // Include nil, v4, and a synthetic from_bytes (stand-in for v5/v7
+        // which aren't enabled as uuid features in this crate).
+        for u in [
+            Uuid::nil(),
+            Uuid::new_v4(),
+            Uuid::from_bytes([0xab; 16]),
+        ] {
+            let eid = ExecutionId::deterministic_for_flow(&fid, &config, u);
+            assert!(ExecutionId::parse(eid.as_str()).is_ok());
+        }
+    }
+
+    #[test]
+    fn deterministic_for_flow_resize_changes_partition() {
+        // Documents the stability contract: different num_flow_partitions
+        // generally yields a different partition (i.e. a different id).
+        let small = crate::partition::PartitionConfig {
+            num_flow_partitions: 4,
+            num_budget_partitions: 32,
+            num_quota_partitions: 32,
+        };
+        let big = crate::partition::PartitionConfig {
+            num_flow_partitions: 256,
+            num_budget_partitions: 32,
+            num_quota_partitions: 32,
+        };
+        let u = Uuid::new_v4();
+        // Try several flow ids — at least one must differ. Using the same
+        // fid under the two configs could collide (4 divides 256), but
+        // across distinct fids the hash-tags must not be uniformly equal.
+        let mut any_diff = false;
+        for _ in 0..16 {
+            let fid = FlowId::new();
+            let a = ExecutionId::deterministic_for_flow(&fid, &small, u);
+            let b = ExecutionId::deterministic_for_flow(&fid, &big, u);
+            if a.partition() != b.partition() {
+                any_diff = true;
+                break;
+            }
+        }
+        assert!(any_diff, "partition resize should change at least one id");
+    }
+
+    #[test]
+    fn deterministic_solo_is_stable() {
+        let config = crate::partition::PartitionConfig::default();
+        let lane = LaneId::new("default");
+        let u = Uuid::new_v4();
+        let a = ExecutionId::deterministic_solo(&lane, &config, u);
+        let b = ExecutionId::deterministic_solo(&lane, &config, u);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn deterministic_solo_partition_matches_solo() {
+        let config = crate::partition::PartitionConfig::default();
+        let lane = LaneId::new("default");
+        let u = Uuid::new_v4();
+        let det = ExecutionId::deterministic_solo(&lane, &config, u);
+        let rnd = ExecutionId::solo(&lane, &config);
+        assert_eq!(det.partition(), rnd.partition());
+    }
+
+    #[test]
+    fn deterministic_mint_parse_roundtrip() {
+        let config = crate::partition::PartitionConfig::default();
+        let fid = FlowId::new();
+        let u = Uuid::new_v4();
+        let eid = ExecutionId::deterministic_for_flow(&fid, &config, u);
+        let parsed = ExecutionId::parse(eid.as_str()).unwrap();
+        assert_eq!(eid, parsed);
     }
 
     // ── LaneId validation (RFC-011 §9.15) ──

--- a/crates/ff-core/src/types.rs
+++ b/crates/ff-core/src/types.rs
@@ -96,9 +96,12 @@ macro_rules! string_id {
 ///
 /// String-backed shape `{fp:N}:<uuid>` where `fp:N` is the Valkey
 /// hash-tag for the flow partition this execution co-locates with, and
-/// `<uuid>` is a UUIDv4 for intra-partition uniqueness. Construct via
-/// [`ExecutionId::for_flow`] (known parent flow) or [`ExecutionId::solo`]
-/// (no parent flow; per-lane synthetic shard).
+/// `<uuid>` is an opaque 128-bit identifier for intra-partition
+/// uniqueness. [`ExecutionId::for_flow`] / [`ExecutionId::solo`] mint a
+/// UUIDv4; [`ExecutionId::deterministic_for_flow`] /
+/// [`ExecutionId::deterministic_solo`] accept any caller-supplied
+/// `Uuid` without version or shape strictness — the caller owns the
+/// derivation scheme.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct ExecutionId(String);
@@ -749,20 +752,20 @@ mod tests {
             num_budget_partitions: 32,
             num_quota_partitions: 32,
         };
-        let u = Uuid::new_v4();
-        // Try several flow ids — at least one must differ. Using the same
-        // fid under the two configs could collide (4 divides 256), but
-        // across distinct fids the hash-tags must not be uniformly equal.
-        let mut any_diff = false;
-        for _ in 0..16 {
-            let fid = FlowId::new();
+        // Deterministic search across a fixed byte-pattern set of flow ids
+        // so the test outcome does not depend on RNG. 4 divides 256 so the
+        // same fid *could* collide across configs; across 256 varied fids
+        // the hash-tags cannot be uniformly equal.
+        let u = Uuid::from_bytes([0x5a; 16]);
+        let any_diff = (0u8..=u8::MAX).any(|i| {
+            let mut bytes = [0u8; 16];
+            bytes[0] = i;
+            bytes[15] = i.wrapping_mul(31).wrapping_add(17);
+            let fid = FlowId::from_uuid(Uuid::from_bytes(bytes));
             let a = ExecutionId::deterministic_for_flow(&fid, &small, u);
             let b = ExecutionId::deterministic_for_flow(&fid, &big, u);
-            if a.partition() != b.partition() {
-                any_diff = true;
-                break;
-            }
-        }
+            a.partition() != b.partition()
+        });
         assert!(any_diff, "partition resize should change at least one id");
     }
 


### PR DESCRIPTION
## Summary

Public `ExecutionId::deterministic_for_flow(flow_id, config, uuid)` and `ExecutionId::deterministic_solo(lane_id, config, uuid)` constructors. Same `(routing_key, uuid)` inputs always produce the same id — enables external consumers (cairn-fabric) to derive stable execution identity from application-scoped keys for retry idempotency without coordinating through FlowFabric.

## Design decisions

- **No UUID strictness** — any 128-bit value accepted. Caller owns the derivation (cairn computes `Uuid::new_v5(&CAIRN_NAMESPACE, v5_input.as_bytes())`).
- **Partition-count-stability** documented in rustdoc, no runtime check. Resize invalidates previously-minted ids. Consumers embed a namespace-version if they need resize-triggered rollover.
- **No `deterministic_solo_with` variant** — cairn uses default `Crc16SoloPartitioner`. Custom-partitioner deployments need their own mint path; documented explicitly.

## Tests

8 new unit tests in `crates/ff-core/src/types.rs`:
- Stability (same inputs → same id)
- Partition parity with random-uuid siblings (`for_flow`/`solo`)
- Verbatim UUID embedding
- Accept any UUID shape (nil, v4, arbitrary bytes)
- Resize changes partition (documents the contract)
- Parse round-trip

## Test plan

- [x] `cargo test -p ff-core --lib deterministic` — 8 pass
- [x] `cargo clippy -p ff-core --all-targets -- -D warnings` — clean
- [ ] Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API change limited to `ExecutionId` construction plus unit tests; existing minting/parsing behavior is unchanged, with the main risk being consumers misunderstanding the documented partition-count stability caveat.
> 
> **Overview**
> Adds deterministic `ExecutionId` minting via `ExecutionId::deterministic_for_flow` and `ExecutionId::deterministic_solo`, allowing callers to supply a pre-derived UUID for idempotent retries while preserving existing partition routing.
> 
> Introduces an internal `with_partition_and_uuid` helper, expands rustdoc to document the partition-count stability contract and solo-partitioner caveat, and adds unit tests covering stability, partition parity, UUID embedding/acceptance, resize behavior, and parse round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eba0386c604641be3432ccf6bdae14f19f3bc13. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->