### PR TITLE
fix(ff-sdk): suppress false-positive ClaimedTask Drop warning

### DIFF
--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -181,12 +181,21 @@ pub struct ClaimedTask {
     /// task. Reset to 0 on each successful renewal. Workers should check
     /// `is_lease_healthy()` before committing expensive side effects.
     renewal_failures: Arc<AtomicU32>,
-    /// Set to `true` by `stop_renewal()` before a terminal op's FCALL
-    /// completes. `Drop` reads this instead of `renewal_handle.is_finished()`
-    /// to suppress the false-positive "dropped without terminal operation"
+    /// Set to `true` by `stop_renewal()` after a terminal op's FCALL
+    /// response is received, just before `self` is consumed into `Drop`.
+    /// `Drop` reads this instead of `renewal_handle.is_finished()` to
+    /// suppress the false-positive "dropped without terminal operation"
     /// warning: after `notify_one`, the renewal task has not yet been
     /// polled by the runtime, so `is_finished()` is still `false` on the
     /// happy path when self is being consumed.
+    ///
+    /// Note: the flag is set for any terminal-op path that reaches
+    /// `stop_renewal()`, which includes Lua-level script errors (the
+    /// FCALL returned a `{0, "error", ...}` payload). That is intentional:
+    /// the caller already receives the `Err` via the op's return value,
+    /// so an additional `Drop` warning would be noise. The warning is
+    /// reserved for genuine drop-without-terminal-op cases (panic, early
+    /// return, transport failure before stop_renewal ran).
     terminal_op_called: AtomicBool,
     /// Concurrency permit from the worker's semaphore. Held for the lifetime
     /// of the task; released on complete/fail/cancel/drop.
@@ -1058,7 +1067,10 @@ impl Drop for ClaimedTask {
         // has not yet been polled by the runtime, so `is_finished()` is still
         // `false` here — which previously fired the warning on every
         // complete/fail/cancel/suspend call. `terminal_op_called` is the
-        // authoritative signal: if stop_renewal ran, this was a clean exit.
+        // authoritative signal that a terminal-op path ran to the point of
+        // stopping renewal; it does not by itself certify the Lua side
+        // succeeded (see the field doc). The caller surfaces any error via
+        // the op's return value, so a `Drop` warning is unneeded there.
         if !self.terminal_op_called.load(Ordering::Acquire) {
             tracing::warn!(
                 execution_id = %self.execution_id,

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -181,6 +181,13 @@ pub struct ClaimedTask {
     /// task. Reset to 0 on each successful renewal. Workers should check
     /// `is_lease_healthy()` before committing expensive side effects.
     renewal_failures: Arc<AtomicU32>,
+    /// Set to `true` by `stop_renewal()` before a terminal op's FCALL
+    /// completes. `Drop` reads this instead of `renewal_handle.is_finished()`
+    /// to suppress the false-positive "dropped without terminal operation"
+    /// warning: after `notify_one`, the renewal task has not yet been
+    /// polled by the runtime, so `is_finished()` is still `false` on the
+    /// happy path when self is being consumed.
+    terminal_op_called: AtomicBool,
     /// Concurrency permit from the worker's semaphore. Held for the lifetime
     /// of the task; released on complete/fail/cancel/drop.
     _concurrency_permit: Option<OwnedSemaphorePermit>,
@@ -288,6 +295,7 @@ impl ClaimedTask {
             renewal_handle,
             renewal_stop,
             renewal_failures,
+            terminal_op_called: AtomicBool::new(false),
             _concurrency_permit: None,
         }
     }
@@ -995,8 +1003,13 @@ impl ClaimedTask {
         parse_suspend_result(&raw, suspension_id, waitpoint_id, waitpoint_key)
     }
 
-    /// Signal the renewal task to stop.
+    /// Signal the renewal task to stop. Called by every terminal op
+    /// (`complete`/`fail`/`cancel`/`suspend`/`delay_execution`/
+    /// `move_to_waiting_children`) after the FCALL returns. Also marks
+    /// `terminal_op_called` so the `Drop` impl can distinguish happy-path
+    /// consumption from a genuine drop-without-terminal-op.
     fn stop_renewal(&self) {
+        self.terminal_op_called.store(true, Ordering::Release);
         self.renewal_stop.notify_one();
     }
 
@@ -1038,7 +1051,15 @@ impl Drop for ClaimedTask {
         // This is a safety net — complete/fail/cancel already stop renewal
         // via notify before consuming self. But if the task is dropped
         // without being consumed (e.g., panic), abort prevents leaked renewals.
-        if !self.renewal_handle.is_finished() {
+        //
+        // Why check `terminal_op_called` instead of `renewal_handle.is_finished()`:
+        // on the happy path, `stop_renewal()` fires `notify_one` synchronously
+        // and then self is consumed into Drop immediately. The renewal task
+        // has not yet been polled by the runtime, so `is_finished()` is still
+        // `false` here — which previously fired the warning on every
+        // complete/fail/cancel/suspend call. `terminal_op_called` is the
+        // authoritative signal: if stop_renewal ran, this was a clean exit.
+        if !self.terminal_op_called.load(Ordering::Acquire) {
             tracing::warn!(
                 execution_id = %self.execution_id,
                 "ClaimedTask dropped without terminal operation — lease will expire"


### PR DESCRIPTION
## Summary

Batch C item 1 (issue #9). The warning \"ClaimedTask dropped without terminal operation — lease will expire\" fires on every happy-path `complete`/`fail`/`cancel`/`suspend`/`delay_execution`/`move_to_waiting_children` call — not just on a genuine leak.

**Root cause**: `Drop` runs synchronously immediately after `stop_renewal()` issues `notify_one` on the shutdown `Notify`. The renewal task hasn't been polled yet, so `renewal_handle.is_finished()` is still `false` when `Drop` inspects it.

**Fix**: add a `terminal_op_called: AtomicBool` flag. `stop_renewal()` sets it `true` (Release); `Drop` reads it (Acquire) and suppresses the warning when set. Every terminal op already calls `stop_renewal()` after the FCALL, so the flag is set on every clean exit path.

Panic / mid-op-drop paths keep the warning (stop_renewal never ran → flag stays false). The `abort()` safety net on the renewal handle is unchanged.

## Test plan

- [x] `cargo check -p ff-sdk` — clean
- [x] `cargo clippy -p ff-sdk --all-targets -- -D warnings` — clean
- [x] `cargo test -p ff-sdk --lib` — 23 pass
- [ ] Verify no warnings emitted in examples/coding-agent + examples/media-pipeline happy path (manual smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small internal lifecycle/observability change that only affects when a warning is emitted and does not alter FCALL behavior or lease renewal mechanics.
> 
> **Overview**
> Fixes a false-positive warning when a `ClaimedTask` is consumed via a terminal operation by tracking terminal completion explicitly.
> 
> Adds a `terminal_op_called: AtomicBool` set in `stop_renewal()` and updates `Drop` to use this flag (Acquire/Release) instead of `renewal_handle.is_finished()`, so the "dropped without terminal operation" warning only fires on genuine drop-without-terminal-op paths while still aborting the renewal task on drop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3969301399f71bb904378bcfb6865cf8df59cba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->