### PR TITLE
chore(ferriskey): fix clippy drift in tests/benches + gate in CI

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -168,11 +168,19 @@ jobs:
             --features ff-sdk/insecure-direct-claim \
             -- -D warnings
 
-      - name: cargo clippy (ferriskey, all targets)
+      - name: cargo clippy (ferriskey, all targets, no features)
         # Ferriskey is vendored in-tree. Its test suite and benches had
         # drifted against lib changes until a dedicated cleanup pass;
         # gate them here so drift cannot recur unnoticed.
         run: cargo clippy -p ferriskey --all-targets -- -D warnings
+
+      - name: cargo clippy (ferriskey, all targets, +iam)
+        # The iam feature adds the IAMTokenManager arg to
+        # StandaloneClient::create_client and the iam_config field on
+        # AuthenticationInfo. Running clippy in this configuration
+        # catches drift in cfg-gated paths (e.g. #[cfg(feature = "iam")]
+        # init lines or test helpers) that the no-feature run cannot see.
+        run: cargo clippy -p ferriskey --all-targets --features iam -- -D warnings
 
       - name: Unit tests
         env:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -168,6 +168,12 @@ jobs:
             --features ff-sdk/insecure-direct-claim \
             -- -D warnings
 
+      - name: cargo clippy (ferriskey, all targets)
+        # Ferriskey is vendored in-tree. Its test suite and benches had
+        # drifted against lib changes until a dedicated cleanup pass;
+        # gate them here so drift cannot recur unnoticed.
+        run: cargo clippy -p ferriskey --all-targets -- -D warnings
+
       - name: Unit tests
         env:
           FF_HOST: 127.0.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,10 @@ jobs:
             -p ff-sdk -p ff-server -p ff-test \
             --features ff-sdk/insecure-direct-claim \
             -- -D warnings
-      - name: cargo clippy (ferriskey all targets)
+      - name: cargo clippy (ferriskey all targets, no features)
         run: cargo clippy -p ferriskey --all-targets -- -D warnings
+      - name: cargo clippy (ferriskey all targets, +iam)
+        run: cargo clippy -p ferriskey --all-targets --features iam -- -D warnings
       - name: unit tests
         run: |
           cargo test \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
             -p ff-sdk -p ff-server -p ff-test \
             --features ff-sdk/insecure-direct-claim \
             -- -D warnings
+      - name: cargo clippy (ferriskey all targets)
+        run: cargo clippy -p ferriskey --all-targets -- -D warnings
       - name: unit tests
         run: |
           cargo test \

--- a/ferriskey/benches/connections_benchmark.rs
+++ b/ferriskey/benches/connections_benchmark.rs
@@ -232,6 +232,7 @@ fn parse_cpu_count(cpu_str: &str) -> usize {
     num_cpus::get()
 }
 
+#[cfg(target_os = "linux")]
 fn set_cpu_affinity(cpu_str: &str) -> Result<(), String> {
     // Use libc sched_setaffinity to pin this process
     if let Some((start, end)) = cpu_str.split_once('-') {
@@ -250,6 +251,15 @@ fn set_cpu_affinity(cpu_str: &str) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+/// CPU pinning stub for non-Linux platforms. macOS and Windows lack
+/// `sched_setaffinity` (macOS had `thread_policy_set` affinity hints
+/// which Apple now silently ignores). Benchmarks on those platforms
+/// skip pinning entirely; the caller logs a warning and continues.
+#[cfg(not(target_os = "linux"))]
+fn set_cpu_affinity(_cpu_str: &str) -> Result<(), String> {
+    Err("CPU affinity is only supported on Linux".to_owned())
 }
 
 // ---------------------------------------------------------------------------

--- a/ferriskey/benches/connections_benchmark.rs
+++ b/ferriskey/benches/connections_benchmark.rs
@@ -225,11 +225,10 @@ fn create_runtime() -> Runtime {
 
 fn parse_cpu_count(cpu_str: &str) -> usize {
     // "4-15" -> 12, "0-7" -> 8, "0-15" -> 16
-    if let Some((start, end)) = cpu_str.split_once('-') {
-        if let (Ok(s), Ok(e)) = (start.parse::<usize>(), end.parse::<usize>()) {
+    if let Some((start, end)) = cpu_str.split_once('-')
+        && let (Ok(s), Ok(e)) = (start.parse::<usize>(), end.parse::<usize>()) {
             return e - s + 1;
         }
-    }
     num_cpus::get()
 }
 
@@ -273,7 +272,7 @@ impl FastRng {
     }
 
     fn is_get(&mut self) -> bool {
-        (self.next_u64() % 5) != 0
+        !self.next_u64().is_multiple_of(5)
     }
 }
 
@@ -403,7 +402,7 @@ async fn run_pipeline_workload<C: ConnectionLike + Clone + Send + 'static>(
 
             // Seed key
             let _ = conn
-                .req_packed_command(&cmd("SET").arg(&key).arg("val"))
+                .req_packed_command(cmd("SET").arg(&key).arg("val"))
                 .await;
 
             // Build pipeline once — same key, same slot
@@ -506,7 +505,7 @@ async fn run_mget_workload<C: ConnectionLike + Clone + Send + 'static>(
             // Seed keys
             for k in &keys {
                 let _ = conn
-                    .req_packed_command(&cmd("SET").arg(k).arg("v"))
+                    .req_packed_command(cmd("SET").arg(k).arg("v"))
                     .await;
             }
 
@@ -608,7 +607,7 @@ async fn run_batch_cross_slot_workload<C: ConnectionLike + Clone + Send + 'stati
             // Seed keys
             for k in &keys {
                 let _ = conn
-                    .req_packed_command(&cmd("SET").arg(k).arg("v"))
+                    .req_packed_command(cmd("SET").arg(k).arg("v"))
                     .await;
             }
 
@@ -699,7 +698,7 @@ fn main() {
     let permutations = cfg.value_sizes.len() * cfg.concurrencies.len();
     let total_runs = permutations * cfg.runs;
     let est_mins =
-        (total_runs as u64 * (cfg.duration.as_secs() + cfg.warmup.as_secs()) + 59) / 60;
+        (total_runs as u64 * (cfg.duration.as_secs() + cfg.warmup.as_secs())).div_ceil(60);
 
     println!("=== Ferriskey Benchmark [{}] ===", cfg.profile);
     println!(

--- a/ferriskey/src/cluster/mod.rs
+++ b/ferriskey/src/cluster/mod.rs
@@ -4911,6 +4911,7 @@ mod direct_dispatch_tests {
         }
 
         /// Returns a copy of the nth received payload, panicking if absent.
+        #[allow(dead_code)]
         fn received_nth(&self, n: usize) -> Vec<u8> {
             self.received.lock().unwrap()[n].clone()
         }

--- a/ferriskey/src/cluster/routing.rs
+++ b/ferriskey/src/cluster/routing.rs
@@ -1628,12 +1628,10 @@ mod tests_routing {
             )))
         );
 
-        for cmd in vec![
-            cmd("SCAN"),
+        for cmd in [cmd("SCAN"),
             cmd("SHUTDOWN"),
             cmd("SLAVEOF"),
-            cmd("REPLICAOF"),
-        ] {
+            cmd("REPLICAOF")] {
             assert_eq!(
                 RoutingInfo::for_routable(&cmd),
                 None,

--- a/ferriskey/src/cluster/topology.rs
+++ b/ferriskey/src/cluster/topology.rs
@@ -460,10 +460,13 @@ mod tests {
         Map,
     }
 
+    // (address, port, optional metadata pairs)
+    type NodeWithMetadata<'a> = (&'a str, u16, Option<Vec<(&'a str, &'a str)>>);
+
     fn slot_value_with_metadata(
         start: u16,
         end: u16,
-        nodes: Vec<(&str, u16, Option<Vec<(&str, &str)>>)>, // (address, port, metadata)
+        nodes: Vec<NodeWithMetadata<'_>>,
         format: MetadataFormat,
     ) -> Value {
         let node_values: Vec<Result<Value>> = nodes

--- a/ferriskey/src/cluster/topology.rs
+++ b/ferriskey/src/cluster/topology.rs
@@ -1063,11 +1063,9 @@ mod tests {
     fn test_topology_calculator_4_nodes_queried_has_a_majority_success() {
         // 4 nodes queried (1 error): Has a majority, single_node_view should be chosen
         let queried_nodes: usize = 4;
-        let topology_results = vec![
+        let topology_results = [get_view(&ViewType::SingleNodeViewFullCoverage),
             get_view(&ViewType::SingleNodeViewFullCoverage),
-            get_view(&ViewType::SingleNodeViewFullCoverage),
-            get_view(&ViewType::TwoNodesViewFullCoverage),
-        ];
+            get_view(&ViewType::TwoNodesViewFullCoverage)];
 
         let (topology_view, _) = calculate_topology(
             topology_results.iter().map(|(addr, value)| (*addr, value)),
@@ -1087,11 +1085,9 @@ mod tests {
     fn test_topology_calculator_3_nodes_queried_no_majority_has_more_retries_raise_error() {
         // 3 nodes queried: No majority, should return an error
         let queried_nodes = 3;
-        let topology_results = vec![
-            get_view(&ViewType::SingleNodeViewFullCoverage),
+        let topology_results = [get_view(&ViewType::SingleNodeViewFullCoverage),
             get_view(&ViewType::TwoNodesViewFullCoverage),
-            get_view(&ViewType::TwoNodesViewMissingSlots),
-        ];
+            get_view(&ViewType::TwoNodesViewMissingSlots)];
         let topology_view = calculate_topology(
             topology_results.iter().map(|(addr, value)| (*addr, value)),
             1,
@@ -1106,11 +1102,9 @@ mod tests {
     fn test_topology_calculator_3_nodes_queried_no_majority_last_retry_success() {
         // 3 nodes queried:: No majority, last retry, should get the view that has a full slot coverage
         let queried_nodes = 3;
-        let topology_results = vec![
-            get_view(&ViewType::SingleNodeViewMissingSlots),
+        let topology_results = [get_view(&ViewType::SingleNodeViewMissingSlots),
             get_view(&ViewType::TwoNodesViewFullCoverage),
-            get_view(&ViewType::TwoNodesViewMissingSlots),
-        ];
+            get_view(&ViewType::TwoNodesViewMissingSlots)];
         let (topology_view, _) = calculate_topology(
             topology_results.iter().map(|(addr, value)| (*addr, value)),
             3,
@@ -1177,11 +1171,9 @@ mod tests {
     fn test_topology_calculator_3_nodes_queried_no_full_coverage_prefer_majority() {
         //  2 nodes queried: No majority, no full slot coverage, should return error
         let queried_nodes = 2;
-        let topology_results = vec![
-            get_view(&ViewType::SingleNodeViewMissingSlots),
+        let topology_results = [get_view(&ViewType::SingleNodeViewMissingSlots),
             get_view(&ViewType::TwoNodesViewMissingSlots),
-            get_view(&ViewType::SingleNodeViewMissingSlots),
-        ];
+            get_view(&ViewType::SingleNodeViewMissingSlots)];
         let (topology_view, _) = calculate_topology(
             topology_results.iter().map(|(addr, value)| (*addr, value)),
             1,

--- a/ferriskey/src/iam/mod.rs
+++ b/ferriskey/src/iam/mod.rs
@@ -501,7 +501,6 @@ fn strip_scheme(full: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
     use serial_test::serial;
     use std::env;
     use std::fs;

--- a/ferriskey/src/protocol/parser.rs
+++ b/ferriskey/src/protocol/parser.rs
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn decode_eof_returns_none_at_eof() {
         use tokio_util::codec::Decoder;
-        let mut codec = ValueCodec::default();
+        let mut codec = ValueCodec;
 
         let mut bytes = bytes::BytesMut::from(&b"+GET 123\r\n"[..]);
         assert_eq!(
@@ -733,7 +733,7 @@ mod tests {
     #[test]
     fn decode_eof_returns_error_inside_array_and_can_parse_more_inputs() {
         use tokio_util::codec::Decoder;
-        let mut codec = ValueCodec::default();
+        let mut codec = ValueCodec;
 
         let mut bytes =
             bytes::BytesMut::from(b"*3\r\n+OK\r\n-LOADING server is loading\r\n+OK\r\n".as_slice());
@@ -927,7 +927,7 @@ mod tests {
     #[test]
     fn test_codec_incomplete_returns_none() {
         use tokio_util::codec::Decoder;
-        let mut codec = ValueCodec::default();
+        let mut codec = ValueCodec;
 
         // Incomplete bulk string — should return None, not error
         let mut bytes = bytes::BytesMut::from(&b"$5\r\nhel"[..]);

--- a/ferriskey/tests/test_client.rs
+++ b/ferriskey/tests/test_client.rs
@@ -77,8 +77,7 @@ pub(crate) mod shared_client_tests {
                         create_connection_request(
                             std::slice::from_ref(&connection_addr),
                             &configuration,
-                        )
-                        .into(),
+                        ),
                         None,
                     )
                     .await

--- a/ferriskey/tests/test_compression.rs
+++ b/ferriskey/tests/test_compression.rs
@@ -244,21 +244,9 @@ mod compression_tests {
 
     #[test]
     fn test_command_compression_behavior() {
-        // Test description()
-        assert_eq!(
-            CommandCompressionBehavior::CompressValues.description(),
-            "Compress values before sending to server"
-        );
-        assert_eq!(
-            CommandCompressionBehavior::DecompressValues.description(),
-            "Decompress values after receiving from server"
-        );
-        assert_eq!(
-            CommandCompressionBehavior::NoCompression.description(),
-            "No compression processing required"
-        );
-
-        // Test Display
+        // CommandCompressionBehavior used to expose a standalone description()
+        // method alongside Display; that method was removed and Display is
+        // the single source of truth for the human-readable form.
         assert_eq!(
             CommandCompressionBehavior::CompressValues.to_string(),
             "CompressValues"

--- a/ferriskey/tests/test_dns.rs
+++ b/ferriskey/tests/test_dns.rs
@@ -81,7 +81,7 @@ mod dns_tests {
             },
         );
         connection_request.tls_mode = Some(TlsMode::SecureTls);
-        connection_request.root_certs = vec![CA_CERT_BYTES.clone().into()];
+        connection_request.root_certs = vec![CA_CERT_BYTES.clone()];
 
         // Wait to ensure server is ready before connecting.
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
@@ -107,7 +107,7 @@ mod dns_tests {
         // Wait to ensure server is ready before connecting.
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
-        let client = StandaloneClient::create_client(connection_request, None, None, None)
+        let client = create_test_standalone_client(connection_request, None)
             .await
             .ok()?;
         Some((client, server))
@@ -135,12 +135,12 @@ mod dns_tests {
             },
         );
         connection_request.tls_mode = Some(TlsMode::SecureTls);
-        connection_request.root_certs = vec![CA_CERT_BYTES.clone().into()];
+        connection_request.root_certs = vec![CA_CERT_BYTES.clone()];
 
         // Wait to ensure server is ready before connecting.
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
-        let client = StandaloneClient::create_client(connection_request, None, None, None)
+        let client = create_test_standalone_client(connection_request, None)
             .await
             .ok()?;
         Some((client, server))

--- a/ferriskey/tests/test_integration_real_workload.rs
+++ b/ferriskey/tests/test_integration_real_workload.rs
@@ -61,10 +61,10 @@ macro_rules! require_cluster {
 #[ignore] // Requires live cluster
 async fn test_basic_get_set() {
     let mut conn = require_cluster!();
-    let _ = conn.req_packed_command(&cmd("SET").arg("itest:basic").arg("hello")).await.unwrap();
-    let val = conn.req_packed_command(&cmd("GET").arg("itest:basic")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("SET").arg("itest:basic").arg("hello")).await.unwrap();
+    let val = conn.req_packed_command(cmd("GET").arg("itest:basic")).await.unwrap();
     assert_eq!(val, Value::BulkString(bytes::Bytes::from_static(b"hello")));
-    let _ = conn.req_packed_command(&cmd("DEL").arg("itest:basic")).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg("itest:basic")).await;
 }
 
 #[tokio::test]
@@ -73,21 +73,21 @@ async fn test_list_operations_rpop_lpush() {
     // Same pattern as rusty-celery's broker
     let mut conn = require_cluster!();
     let key = "itest:queue";
-    let _ = conn.req_packed_command(&cmd("DEL").arg(key)).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg(key)).await;
 
     // LPUSH 3 items
-    let _ = conn.req_packed_command(&cmd("LPUSH").arg(key).arg("task1")).await.unwrap();
-    let _ = conn.req_packed_command(&cmd("LPUSH").arg(key).arg("task2")).await.unwrap();
-    let _ = conn.req_packed_command(&cmd("LPUSH").arg(key).arg("task3")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("LPUSH").arg(key).arg("task1")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("LPUSH").arg(key).arg("task2")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("LPUSH").arg(key).arg("task3")).await.unwrap();
 
     // RPOP should return in FIFO order (task1 first)
-    let val = conn.req_packed_command(&cmd("RPOP").arg(key)).await.unwrap();
+    let val = conn.req_packed_command(cmd("RPOP").arg(key)).await.unwrap();
     assert_eq!(val, Value::BulkString(bytes::Bytes::from_static(b"task1")));
 
-    let val = conn.req_packed_command(&cmd("RPOP").arg(key)).await.unwrap();
+    let val = conn.req_packed_command(cmd("RPOP").arg(key)).await.unwrap();
     assert_eq!(val, Value::BulkString(bytes::Bytes::from_static(b"task2")));
 
-    let _ = conn.req_packed_command(&cmd("DEL").arg(key)).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg(key)).await;
 }
 
 #[tokio::test]
@@ -96,22 +96,22 @@ async fn test_hash_operations_hset_hdel() {
     // Same pattern as rusty-celery's task result tracking
     let mut conn = require_cluster!();
     let key = "itest:results";
-    let _ = conn.req_packed_command(&cmd("DEL").arg(key)).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg(key)).await;
 
     // HSET
-    let _ = conn.req_packed_command(&cmd("HSET").arg(key).arg("task-123").arg("SUCCESS")).await.unwrap();
-    let _ = conn.req_packed_command(&cmd("HSET").arg(key).arg("task-456").arg("FAILURE")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("HSET").arg(key).arg("task-123").arg("SUCCESS")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("HSET").arg(key).arg("task-456").arg("FAILURE")).await.unwrap();
 
     // HGET
-    let val = conn.req_packed_command(&cmd("HGET").arg(key).arg("task-123")).await.unwrap();
+    let val = conn.req_packed_command(cmd("HGET").arg(key).arg("task-123")).await.unwrap();
     assert_eq!(val, Value::BulkString(bytes::Bytes::from_static(b"SUCCESS")));
 
     // HDEL
-    let _ = conn.req_packed_command(&cmd("HDEL").arg(key).arg("task-123")).await.unwrap();
-    let val = conn.req_packed_command(&cmd("HGET").arg(key).arg("task-123")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("HDEL").arg(key).arg("task-123")).await.unwrap();
+    let val = conn.req_packed_command(cmd("HGET").arg(key).arg("task-123")).await.unwrap();
     assert_eq!(val, Value::Nil);
 
-    let _ = conn.req_packed_command(&cmd("DEL").arg(key)).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg(key)).await;
 }
 
 #[tokio::test]
@@ -119,12 +119,12 @@ async fn test_hash_operations_hset_hdel() {
 async fn test_mget_multi_key() {
     let mut conn = require_cluster!();
     // Use hash tags to ensure same slot
-    let _ = conn.req_packed_command(&cmd("SET").arg("{itest}:k1").arg("v1")).await.unwrap();
-    let _ = conn.req_packed_command(&cmd("SET").arg("{itest}:k2").arg("v2")).await.unwrap();
-    let _ = conn.req_packed_command(&cmd("SET").arg("{itest}:k3").arg("v3")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("SET").arg("{itest}:k1").arg("v1")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("SET").arg("{itest}:k2").arg("v2")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("SET").arg("{itest}:k3").arg("v3")).await.unwrap();
 
     let val = conn.req_packed_command(
-        &cmd("MGET").arg("{itest}:k1").arg("{itest}:k2").arg("{itest}:k3")
+        cmd("MGET").arg("{itest}:k1").arg("{itest}:k2").arg("{itest}:k3")
     ).await.unwrap();
 
     if let Value::Array(items) = val {
@@ -136,7 +136,7 @@ async fn test_mget_multi_key() {
         panic!("Expected Array, got {:?}", val);
     }
 
-    let _ = conn.req_packed_command(&cmd("DEL").arg("{itest}:k1").arg("{itest}:k2").arg("{itest}:k3")).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg("{itest}:k1").arg("{itest}:k2").arg("{itest}:k3")).await;
 }
 
 #[tokio::test]
@@ -144,7 +144,7 @@ async fn test_mget_multi_key() {
 async fn test_pipeline_atomic() {
     let mut conn = require_cluster!();
     let key = "{itest:pipe}:counter";
-    let _ = conn.req_packed_command(&cmd("SET").arg(key).arg("0")).await;
+    let _ = conn.req_packed_command(cmd("SET").arg(key).arg("0")).await;
 
     // Pipeline: INCR 3 times atomically
     let mut pipe = Pipeline::new();
@@ -159,7 +159,7 @@ async fn test_pipeline_atomic() {
     assert_eq!(results[1], Value::Int(2));
     assert_eq!(results[2], Value::Int(3));
 
-    let _ = conn.req_packed_command(&cmd("DEL").arg(key)).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg(key)).await;
 }
 
 #[tokio::test]
@@ -182,16 +182,16 @@ async fn test_expiry_and_ttl() {
     let mut conn = require_cluster!();
     let key = "itest:expiry";
 
-    let _ = conn.req_packed_command(&cmd("SET").arg(key).arg("temp").arg("EX").arg("10")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("SET").arg(key).arg("temp").arg("EX").arg("10")).await.unwrap();
 
-    let ttl = conn.req_packed_command(&cmd("TTL").arg(key)).await.unwrap();
+    let ttl = conn.req_packed_command(cmd("TTL").arg(key)).await.unwrap();
     if let Value::Int(t) = ttl {
         assert!(t > 0 && t <= 10, "TTL should be between 1-10, got {t}");
     } else {
         panic!("Expected Int, got {:?}", ttl);
     }
 
-    let _ = conn.req_packed_command(&cmd("DEL").arg(key)).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg(key)).await;
 }
 
 #[tokio::test]
@@ -199,8 +199,8 @@ async fn test_expiry_and_ttl() {
 async fn test_cross_slot_pipeline_non_atomic() {
     let mut conn = require_cluster!();
     // Keys WITHOUT hash tags → likely different slots
-    let _ = conn.req_packed_command(&cmd("SET").arg("itest:xslot:a").arg("1")).await.unwrap();
-    let _ = conn.req_packed_command(&cmd("SET").arg("itest:xslot:b").arg("2")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("SET").arg("itest:xslot:a").arg("1")).await.unwrap();
+    let _ = conn.req_packed_command(cmd("SET").arg("itest:xslot:b").arg("2")).await.unwrap();
 
     // Non-atomic pipeline across slots — exercises our direct dispatch splitting
     let mut pipe = Pipeline::new();
@@ -212,6 +212,6 @@ async fn test_cross_slot_pipeline_non_atomic() {
     assert_eq!(results[0], Value::BulkString(bytes::Bytes::from_static(b"1")));
     assert_eq!(results[1], Value::BulkString(bytes::Bytes::from_static(b"2")));
 
-    let _ = conn.req_packed_command(&cmd("DEL").arg("itest:xslot:a")).await;
-    let _ = conn.req_packed_command(&cmd("DEL").arg("itest:xslot:b")).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg("itest:xslot:a")).await;
+    let _ = conn.req_packed_command(cmd("DEL").arg("itest:xslot:b")).await;
 }

--- a/ferriskey/tests/test_pubsub.rs
+++ b/ferriskey/tests/test_pubsub.rs
@@ -675,10 +675,11 @@ mod standalone_pubsub_tests {
     use ferriskey::client::types::{ConnectionRetryStrategy, NodeAddress};
     use ferriskey::client::Client;
     use ferriskey::value::Value;
-    use ferriskey::{ConnectionAddr, PushInfo};
+    use ferriskey::PushInfo;
     use std::time::Duration;
     use tokio::sync::mpsc;
 
+    #[allow(dead_code)]
     fn standalone_url() -> Option<String> {
         let host = std::env::var("VALKEY_STANDALONE_HOST").ok()?;
         let port = std::env::var("VALKEY_STANDALONE_PORT").unwrap_or_else(|_| "6379".into());

--- a/ferriskey/tests/test_standalone_client.rs
+++ b/ferriskey/tests/test_standalone_client.rs
@@ -9,7 +9,7 @@ mod standalone_client_tests {
     use crate::constants::{IP_ADDRESS_V4, IP_ADDRESS_V6};
     use crate::utilities::mocks::{Mock, ServerMock};
     use ferriskey::{
-        client::{Client as FerrisKeyClient, StandaloneClient},
+        client::StandaloneClient,
         client::types::ReadFrom,
     };
     use ferriskey::{FromValue, Value};
@@ -261,7 +261,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .unwrap();
             tracing::info!(
@@ -404,7 +404,7 @@ mod standalone_client_tests {
             create_connection_request(addresses.as_slice(), &Default::default());
         block_on_all(async {
             let client_res =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(client_res.is_err());
             let error = client_res.unwrap_err();
             let primary_1_addr = addresses.first().unwrap().to_string();
@@ -441,7 +441,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .unwrap();
 
@@ -647,11 +647,11 @@ mod standalone_client_tests {
                 },
             );
             connection_request.tls_mode = Some(ferriskey::client::types::TlsMode::SecureTls);
-            connection_request.root_certs = vec![ca_cert_bytes.into()];
+            connection_request.root_certs = vec![ca_cert_bytes];
 
             // Test that connection works with custom root cert
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .expect("Failed to create client with custom root cert");
 
@@ -688,7 +688,7 @@ mod standalone_client_tests {
                 },
             );
             connection_request.tls_mode = ferriskey::client::types::TlsMode::SecureTls.into();
-            connection_request.root_certs = vec![wrong_ca_cert_bytes.into()];
+            connection_request.root_certs = vec![wrong_ca_cert_bytes];
             // Use minimal retries to fail fast
             connection_request.connection_retry_strategy =
                 Some(ferriskey::client::types::ConnectionRetryStrategy {
@@ -696,12 +696,11 @@ mod standalone_client_tests {
                     factor: 1,
                     exponent_base: 1,
                     ..Default::default()
-                })
-                .into();
+                });
 
             // Connection should fail due to certificate mismatch
             let client_result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 client_result.is_err(),
                 "Expected connection to fail with wrong root certificate"
@@ -734,13 +733,12 @@ mod standalone_client_tests {
             // Using a PEM-like structure but with invalid base64 content
             connection_request.root_certs = vec![
                 b"-----BEGIN CERTIFICATE-----\n!!!invalid base64!!!\n-----END CERTIFICATE-----"
-                    .to_vec()
-                    .into(),
+                    .to_vec(),
             ];
 
             // Client creation should fail during certificate parsing
             let client_result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 client_result.is_err(),
                 "Expected client creation to fail with invalid certificate bytes"
@@ -766,11 +764,11 @@ mod standalone_client_tests {
             );
             connection_request.tls_mode = ferriskey::client::types::TlsMode::NoTls.into();
             // Provide custom root certs but with NoTls mode
-            connection_request.root_certs = vec![b"some certificate".to_vec().into()];
+            connection_request.root_certs = vec![b"some certificate".to_vec()];
 
             // Client creation should fail due to invalid configuration
             let client_result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 client_result.is_err(),
                 "Expected client creation to fail when custom certs provided with NoTls mode"
@@ -816,11 +814,11 @@ mod standalone_client_tests {
             );
             connection_request.tls_mode = ferriskey::client::types::TlsMode::SecureTls.into();
             connection_request.root_certs =
-                vec![invalid_ca_cert_bytes.into(), valid_ca_cert_bytes.into()];
+                vec![invalid_ca_cert_bytes, valid_ca_cert_bytes];
 
             // Connection should succeed using the second (valid) certificate
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .expect("Failed to create client with multiple root certs");
 
@@ -868,13 +866,13 @@ mod standalone_client_tests {
                 },
             );
             connection_request.tls_mode = ferriskey::client::types::TlsMode::SecureTls.into();
-            connection_request.root_certs = vec![ca_cert_bytes.into()];
-            connection_request.client_cert = client_cert_bytes.into();
-            connection_request.client_key = client_key_bytes.into();
+            connection_request.root_certs = vec![ca_cert_bytes];
+            connection_request.client_cert = client_cert_bytes;
+            connection_request.client_key = client_key_bytes;
 
             // Test that connection works with custom root cert and client TLS auth
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .expect("Failed to create client with custom root cert");
 
@@ -920,10 +918,10 @@ mod standalone_client_tests {
                 },
             );
             connection_request.tls_mode = ferriskey::client::types::TlsMode::SecureTls.into();
-            connection_request.root_certs = vec![ca_cert_bytes.into()];
+            connection_request.root_certs = vec![ca_cert_bytes];
 
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .expect("Failed to create client with IP address");
 
@@ -954,7 +952,7 @@ mod standalone_client_tests {
             );
 
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .expect("Failed to create client with IP address");
 
@@ -1004,7 +1002,7 @@ mod standalone_client_tests {
         block_on_all(async {
             // This should succeed because read_only mode doesn't require a primary
             let client_result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 client_result.is_ok(),
                 "read_only mode should connect without requiring a primary node"
@@ -1031,7 +1029,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .unwrap();
 
@@ -1069,7 +1067,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let mut client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .unwrap();
 
@@ -1097,7 +1095,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 result.is_err(),
                 "AZAffinity should be rejected with read_only mode"
@@ -1125,7 +1123,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 result.is_err(),
                 "AZAffinityReplicasAndPrimary should be rejected with read_only mode"
@@ -1153,7 +1151,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 result.is_ok(),
                 "PreferReplica should be accepted with read_only mode"
@@ -1175,7 +1173,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             assert!(
                 result.is_ok(),
                 "Primary ReadFrom should be accepted with read_only mode (reads go to connected nodes)"
@@ -1197,7 +1195,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let _client =
-                StandaloneClient::create_client(connection_request, None, None, None)
+                create_test_standalone_client(connection_request, None)
                     .await
                     .unwrap();
 
@@ -1222,7 +1220,7 @@ mod standalone_client_tests {
 
         block_on_all(async {
             let result =
-                StandaloneClient::create_client(connection_request, None, None, None).await;
+                create_test_standalone_client(connection_request, None).await;
             // Normal mode should fail because no primary is found
             assert!(
                 result.is_err(),
@@ -1258,27 +1256,19 @@ mod standalone_client_tests {
             // Create a normal client connected to the primary for writes
             let primary_connection_request =
                 create_connection_request(primary_address.as_slice(), &Default::default());
-            let mut primary_client = StandaloneClient::create_client(
-                primary_connection_request,
-                None,
-                None,
-                None,
-            )
-            .await
-            .expect("Primary client should connect successfully");
+            let mut primary_client =
+                create_test_standalone_client(primary_connection_request, None)
+                    .await
+                    .expect("Primary client should connect successfully");
 
             // Create a read-only client connected to the replica for reads
             let mut replica_connection_request =
                 create_connection_request(replica_address.as_slice(), &Default::default());
             replica_connection_request.read_only = true;
-            let mut replica_client = StandaloneClient::create_client(
-                replica_connection_request,
-                None,
-                None,
-                None,
-            )
-            .await
-            .expect("Read-only replica client should connect successfully");
+            let mut replica_client =
+                create_test_standalone_client(replica_connection_request, None)
+                    .await
+                    .expect("Read-only replica client should connect successfully");
 
             // Write to primary using normal client
             let write_result = primary_client.send_command(&set_cmd).await;

--- a/ferriskey/tests/test_tracing_spans.rs
+++ b/ferriskey/tests/test_tracing_spans.rs
@@ -22,7 +22,6 @@ use std::sync::{Arc, Mutex};
 
 use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 /// A `MakeWriter` backed by an `Arc<Mutex<Vec<u8>>>` so tests can
 /// install a subscriber, run ferriskey code, then inspect the output.
@@ -50,6 +49,7 @@ impl Write for BufferedWriterGuard {
     }
 }
 
+#[allow(dead_code)]
 fn buffer_contains(buf: &Arc<Mutex<Vec<u8>>>, needle: &str) -> bool {
     let guard = buf.lock().expect("poisoned test buffer");
     std::str::from_utf8(&guard)

--- a/ferriskey/tests/utilities/cluster.rs
+++ b/ferriskey/tests/utilities/cluster.rs
@@ -839,13 +839,12 @@ pub async fn wait_for_node_to_become_primary(
             tokio::time::timeout(per_query_timeout, ClusterTopology::from_connection(connection))
                 .await;
 
-        if let Ok(topology) = query_result {
-            if let Some(node) = topology.nodes.iter().find(|n| n.node_id == node_id)
+        if let Ok(topology) = query_result
+            && let Some(node) = topology.nodes.iter().find(|n| n.node_id == node_id)
                 && node.is_primary
             {
                 return true;
             }
-        }
         // On timeout or wrong state, wait briefly and retry
 
         tokio::time::sleep(Duration::from_millis(200)).await;

--- a/ferriskey/tests/utilities/mod.rs
+++ b/ferriskey/tests/utilities/mod.rs
@@ -29,6 +29,29 @@ use versions::Versioning;
 pub mod cluster;
 pub mod mocks;
 
+/// Feature-aware shim around [`StandaloneClient::create_client`] for tests.
+///
+/// The real function takes an extra `iam_token_manager` argument under
+/// `#[cfg(feature = "iam")]`. Tests don't exercise IAM but still need to
+/// compile in both configurations, so this wrapper absorbs the variance
+/// and presents a 2-arg surface (`request`, `push_sender`). The remaining
+/// `iam_token_manager` / `pubsub_synchronizer` args are always `None` for
+/// test harnesses.
+#[allow(dead_code)]
+pub async fn create_test_standalone_client(
+    connection_request: ConnectionRequest,
+    push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
+) -> std::result::Result<StandaloneClient, ferriskey::value::Error> {
+    #[cfg(feature = "iam")]
+    {
+        StandaloneClient::create_client(connection_request, push_sender, None, None).await
+    }
+    #[cfg(not(feature = "iam"))]
+    {
+        StandaloneClient::create_client(connection_request, push_sender, None).await
+    }
+}
+
 pub(crate) const SHORT_STANDALONE_TEST_TIMEOUT: Duration = Duration::from_millis(20_000);
 pub(crate) const LONG_STANDALONE_TEST_TIMEOUT: Duration = Duration::from_millis(40_000);
 
@@ -134,7 +157,7 @@ pub fn get_listener_on_available_port() -> TcpListener {
     socket.bind(&socket2::SockAddr::from(*addr)).unwrap();
     socket.listen(1).unwrap();
 
-    TcpListener::from(std::net::TcpListener::from(socket))
+    std::net::TcpListener::from(socket)
 }
 
 impl ValkeyServer {
@@ -729,6 +752,9 @@ pub fn create_connection_request(
         Some(AuthenticationInfo {
             password: connection_info.password,
             username: connection_info.username,
+            // iam_config is only present on `feature = "iam"` builds.
+            // Tests don't exercise IAM, so always default when the field exists.
+            #[cfg(feature = "iam")]
             iam_config: None,
         })
     } else {
@@ -827,7 +853,7 @@ pub(crate) async fn setup_test_basics_internal(configuration: &TestConfiguration
     connection_request.cluster_mode_enabled = false;
     connection_request.protocol = Some(configuration.protocol);
     let (push_sender, push_receiver) = tokio::sync::mpsc::unbounded_channel();
-    let client = StandaloneClient::create_client(connection_request, Some(push_sender), None, None)
+    let client = create_test_standalone_client(connection_request, Some(push_sender))
         .await
         .unwrap();
 

--- a/ferriskey/tests/utilities/mod.rs
+++ b/ferriskey/tests/utilities/mod.rs
@@ -749,13 +749,17 @@ pub fn create_connection_request(
     };
     let connection_info = configuration.connection_info.clone().unwrap_or_default();
     let auth = if connection_info.password.is_some() || connection_info.username.is_some() {
+        // Use `..Default::default()` so feature-gated fields (e.g. the
+        // iam-only `iam_config` added under `#[cfg(feature = "iam")]`)
+        // are populated without needing their own cfg-gated init line
+        // here. Tests don't exercise IAM, so the default is always None.
+        // The lint fires on no-feature builds where all fields ARE
+        // specified — allowed since the IAM build needs the rest.
+        #[allow(clippy::needless_update)]
         Some(AuthenticationInfo {
             password: connection_info.password,
             username: connection_info.username,
-            // iam_config is only present on `feature = "iam"` builds.
-            // Tests don't exercise IAM, so always default when the field exists.
-            #[cfg(feature = "iam")]
-            iam_config: None,
+            ..Default::default()
         })
     } else {
         None


### PR DESCRIPTION
## Summary

Ferriskey's integration tests + benches had accumulated **85 clippy errors** that FlowFabric CI never caught — the workflow only ran clippy on \`ff-*\` crates, not on the vendored ferriskey fork. This PR fixes all of them and adds a CI gate so the drift cannot recur.

Motivation: blocker for PR #(forthcoming) that adds \`ClientBuilder::push_sender()\` to ferriskey. We want that PR to land on a clippy-clean base.

## Root causes

| Count | Kind | Fix |
|---|---|---|
| 25 | \`StandaloneClient::create_client(req, None, None, None)\` — signature has an iam-gated \`iam_token_manager\` arg | New test helper \`create_test_standalone_client(req, push_sender)\` in \`tests/utilities/mod.rs\` that absorbs the cfg variance |
| 1 | \`AuthenticationInfo { iam_config: None }\` unconditional | Field init gated with \`#[cfg(feature = \"iam\")]\` |
| 3 | \`.description()\` on \`CommandCompressionBehavior\` — method removed when \`Display\` became the single source of truth | Dropped the stale duplicate assertions; \`Display\` test kept |
| 34 | needless_borrow | \`cargo clippy --fix\` |
| ~14 | useless_conversion | \`cargo clippy --fix\` |
| 3 | default_constructed_unit_structs | \`cargo clippy --fix\` |
| 3 | dead dev-only helpers (\`buffer_contains\`, \`standalone_url\`, \`received_nth\`) | \`#[allow(dead_code)]\` — each is a harness shim deliberately kept alongside its test |
| 1 | complex type signature in cluster/topology tests | \`NodeWithMetadata<'a>\` type alias |

## CI gate

Added to \`matrix.yml\` + \`release.yml\`:

\`\`\`yaml
- name: cargo clippy (ferriskey, all targets)
  run: cargo clippy -p ferriskey --all-targets -- -D warnings
\`\`\`

## Verification

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — 0 errors, 0 warnings (was 85 errors on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily CI gating and clippy-driven refactors in ferriskey tests/benches/utilities, with no functional changes to production crates expected. Main risk is CI becoming stricter and failing on ferriskey lint issues across additional targets.
> 
> **Overview**
> Adds a CI gate to run `cargo clippy -p ferriskey --all-targets -D warnings` in both the matrix and release workflows so the vendored ferriskey crate’s tests/benches can’t drift unnoticed.
> 
> Cleans up ferriskey benches/tests to satisfy clippy (e.g., remove needless borrows/conversions, simplify conditionals, update unit-struct construction, and minor API callsite tweaks like `req_packed_command(cmd(...))`). Introduces a feature-aware test helper `create_test_standalone_client` to hide `iam`-gated `StandaloneClient::create_client` signature differences, and applies small test-only allowances/type aliases to silence dead-code/complex-type warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4452e7f7bed730d48f03c70d6ab92818a6ef03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->