### PR TITLE
feat: push-based DAG promotion (Batch C item 6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "futures",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -14,6 +14,7 @@ description = "FlowFabric cross-partition dispatch and background scanners"
 ff-core = { workspace = true }
 ferriskey = { workspace = true }
 futures = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ff-engine/src/completion_listener.rs
+++ b/crates/ff-engine/src/completion_listener.rs
@@ -44,10 +44,13 @@ pub const COMPLETION_CHANNEL: &str = "ff:dag:completions";
 
 /// Wire format of a completion message. JSON-encoded by the Lua
 /// producers; parsed with serde here so field drift surfaces as a
-/// typed error rather than silent skip.
+/// typed error rather than silent skip. `execution_id` uses
+/// `ExecutionId`'s Deserialize impl, which validates the
+/// `{fp:N}:<uuid>` shape at parse time — a malformed id fails loudly
+/// here instead of routing to the wrong partition downstream.
 #[derive(Debug, Deserialize)]
 struct CompletionPayload {
-    execution_id: String,
+    execution_id: ExecutionId,
     flow_id: String,
     #[serde(default)]
     #[allow(dead_code)]
@@ -70,7 +73,12 @@ async fn build_listener_client(
         builder = builder.cluster();
     }
     if tls {
-        builder = builder.tls_insecure();
+        // Match the main client's TLS stance (`ClientBuilder::tls()` —
+        // certificate verification enabled). Downgrading to
+        // `tls_insecure` on the listener alone would silently weaken
+        // transport guarantees even though completion payloads are
+        // metadata, not user data — consistency matters.
+        builder = builder.tls();
     }
     for (host, port) in addresses {
         builder = builder.host(host, *port);
@@ -115,7 +123,15 @@ pub fn spawn_completion_listener(
                     );
                     tokio::select! {
                         _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
-                        _ = shutdown.changed() => return,
+                        changed = shutdown.changed() => {
+                            // `changed()` errors only when every sender
+                            // has been dropped — treat that as a hard
+                            // shutdown signal (the engine owner is
+                            // gone). Otherwise check the latest value.
+                            if changed.is_err() || *shutdown.borrow() {
+                                return;
+                            }
+                        }
                     }
                     continue;
                 }
@@ -138,7 +154,11 @@ pub fn spawn_completion_listener(
                 );
                 tokio::select! {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
-                    _ = shutdown.changed() => return,
+                    changed = shutdown.changed() => {
+                        if changed.is_err() || *shutdown.borrow() {
+                            return;
+                        }
+                    }
                 }
                 continue;
             }
@@ -152,8 +172,8 @@ pub fn spawn_completion_listener(
             // (push_rx closes) or shutdown fires.
             loop {
                 tokio::select! {
-                    _ = shutdown.changed() => {
-                        if *shutdown.borrow() {
+                    changed = shutdown.changed() => {
+                        if changed.is_err() || *shutdown.borrow() {
                             return;
                         }
                     }
@@ -164,7 +184,16 @@ pub fn spawn_completion_listener(
                             );
                             break;
                         };
-                        handle_push(&router, &dispatch_client, push).await;
+                        // Spawn per-dispatch so slow ff_resolve_dependency
+                        // calls (multi-partition FCALLs, cascade recursion)
+                        // don't head-of-line-block subsequent completions.
+                        // dispatch is idempotent; redundant re-entry on the
+                        // same eid is harmless.
+                        let router = router.clone();
+                        let client = dispatch_client.clone();
+                        tokio::spawn(async move {
+                            handle_push(&router, &client, push).await;
+                        });
                     }
                 }
             }
@@ -187,6 +216,24 @@ async fn handle_push(
 
     // RESP3 Message frame layout (per Valkey docs):
     //   data = [ channel, message_payload ]
+    // Verify the channel name so an unexpected fan-in (e.g. a future
+    // second SUBSCRIBE on the same client) can't feed unrelated
+    // payloads into the dispatcher.
+    let channel_match = matches!(
+        push.data.first(),
+        Some(Value::BulkString(b)) if b.as_ref() == COMPLETION_CHANNEL.as_bytes()
+    ) || matches!(
+        push.data.first(),
+        Some(Value::SimpleString(s)) if s == COMPLETION_CHANNEL
+    );
+    if !channel_match {
+        tracing::debug!(
+            data = ?push.data.first(),
+            "completion_listener: Message on unexpected channel, ignoring"
+        );
+        return;
+    }
+
     let payload_str = match push.data.get(1) {
         Some(Value::BulkString(b)) => String::from_utf8_lossy(b).into_owned(),
         Some(Value::SimpleString(s)) => s.clone(),
@@ -199,32 +246,23 @@ async fn handle_push(
         }
     };
 
+    // ExecutionId is validated by its Deserialize impl; a malformed
+    // id fails here and we drop the message with a log. Reconciler
+    // picks up the completion on its next scan.
     let parsed: CompletionPayload = match serde_json::from_str(&payload_str) {
         Ok(p) => p,
         Err(e) => {
             tracing::warn!(
                 error = %e,
                 payload = %payload_str,
-                "completion_listener: cjson decode failed, skipping"
-            );
-            return;
-        }
-    };
-
-    let eid = match ExecutionId::parse(&parsed.execution_id) {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                raw = %parsed.execution_id,
-                "completion_listener: invalid execution_id in payload"
+                "completion_listener: json decode failed, skipping"
             );
             return;
         }
     };
 
     tracing::debug!(
-        execution_id = %eid,
+        execution_id = %parsed.execution_id,
         flow_id = %parsed.flow_id,
         outcome = %parsed.outcome,
         "completion_listener: dispatching dependency resolution"
@@ -233,7 +271,7 @@ async fn handle_push(
     dispatch_dependency_resolution(
         dispatch_client,
         router,
-        &eid,
+        &parsed.execution_id,
         Some(parsed.flow_id.as_str()),
     )
     .await;
@@ -247,6 +285,7 @@ mod tests {
     fn parses_canonical_payload() {
         let raw = r#"{"execution_id":"{fp:5}:11111111-1111-1111-1111-111111111111","flow_id":"22222222-2222-2222-2222-222222222222","outcome":"success"}"#;
         let p: CompletionPayload = serde_json::from_str(raw).unwrap();
+        assert_eq!(p.execution_id.partition(), 5);
         assert_eq!(p.flow_id, "22222222-2222-2222-2222-222222222222");
         assert_eq!(p.outcome, "success");
     }
@@ -263,5 +302,19 @@ mod tests {
     fn malformed_payload_is_error() {
         let raw = r#"{"not":"valid"}"#;
         assert!(serde_json::from_str::<CompletionPayload>(raw).is_err());
+    }
+
+    /// Malformed execution_id (missing hash-tag) must fail parse —
+    /// ExecutionId's Deserialize impl validates the shape, so a
+    /// bare-UUID producer (legacy, wire-format drift) surfaces as
+    /// a parse error rather than silently routing to partition 0.
+    #[test]
+    fn malformed_execution_id_rejected_at_parse() {
+        let raw = r#"{"execution_id":"11111111-1111-1111-1111-111111111111","flow_id":"22222222-2222-2222-2222-222222222222"}"#;
+        let err = serde_json::from_str::<CompletionPayload>(raw).unwrap_err();
+        assert!(
+            err.to_string().contains("hash-tag") || err.to_string().contains("{fp:"),
+            "error should mention hash-tag shape: {err}"
+        );
     }
 }

--- a/crates/ff-engine/src/completion_listener.rs
+++ b/crates/ff-engine/src/completion_listener.rs
@@ -1,0 +1,267 @@
+//! Push-based DAG promotion listener (Batch C item 6, issue #9).
+//!
+//! SUBSCRIBEs to the `ff:dag:completions` channel on a dedicated RESP3
+//! client and dispatches `resolve_dependency` for each received
+//! completion. This turns the `dependency_reconciler` scanner into a
+//! pure safety net — user-perceived DAG latency drops from
+//! `interval × levels` to `RTT × levels` under normal operation.
+//!
+//! # Design notes
+//!
+//! - **Dedicated client.** `SUBSCRIBE` puts a connection into pubsub
+//!   mode; the client that serves `FCALL ff_resolve_dependency` must
+//!   be a different handle. Built via `ClientBuilder::push_sender` +
+//!   `ProtocolVersion::RESP3` (the RESP3 gate is enforced at build
+//!   time — see ferriskey PR #38).
+//!
+//! - **Broadcast semantics in cluster mode.** Plain `PUBLISH` in
+//!   Valkey cluster fans out to every node. Every ff-server instance
+//!   that runs an engine will receive every completion. Duplicate
+//!   dispatches are harmless — `ff_resolve_dependency` is idempotent
+//!   — but redundant. If contention surfaces, a follow-up can move
+//!   to sharded pubsub (`SPUBLISH`/`SSUBSCRIBE`) keyed by flow
+//!   partition.
+//!
+//! - **Safety net.** Messages missed during listener restart, server
+//!   disconnect, or the (rare) outage window are picked up by the
+//!   `dependency_reconciler` scanner at its configured interval. The
+//!   listener is an optimization, not a correctness dependency.
+
+use std::sync::Arc;
+
+use ferriskey::{Client, ClientBuilder, PushInfo, PushKind, Value};
+use ferriskey::value::ProtocolVersion;
+use ff_core::types::ExecutionId;
+use serde::Deserialize;
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+
+use crate::partition_router::{dispatch_dependency_resolution, PartitionRouter};
+
+/// Channel name used by `ff_complete_execution` / `ff_fail_execution` /
+/// `ff_cancel_execution` to notify the engine of terminal transitions.
+pub const COMPLETION_CHANNEL: &str = "ff:dag:completions";
+
+/// Wire format of a completion message. JSON-encoded by the Lua
+/// producers; parsed with serde here so field drift surfaces as a
+/// typed error rather than silent skip.
+#[derive(Debug, Deserialize)]
+struct CompletionPayload {
+    execution_id: String,
+    flow_id: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    outcome: String,
+}
+
+/// Build the dedicated RESP3 client the listener uses to receive push
+/// frames. Takes the same address/auth config the dispatcher client was
+/// built with; just adds the push_sender wiring and pins RESP3.
+async fn build_listener_client(
+    addresses: &[(String, u16)],
+    tls: bool,
+    cluster: bool,
+    push_tx: mpsc::UnboundedSender<PushInfo>,
+) -> Result<Client, ferriskey::value::Error> {
+    let mut builder = ClientBuilder::new()
+        .protocol(ProtocolVersion::RESP3)
+        .push_sender(push_tx);
+    if cluster {
+        builder = builder.cluster();
+    }
+    if tls {
+        builder = builder.tls_insecure();
+    }
+    for (host, port) in addresses {
+        builder = builder.host(host, *port);
+    }
+    builder.build().await
+}
+
+/// Spawn the completion listener. Returns a `JoinHandle` that resolves
+/// when the shutdown watch fires. On transient errors (connect failure,
+/// broken pubsub channel) the listener sleeps 1s and retries.
+///
+/// `addresses` / `tls` / `cluster` mirror the dispatcher client's
+/// connection config so the listener reaches the same deployment.
+pub fn spawn_completion_listener(
+    router: Arc<PartitionRouter>,
+    dispatch_client: Client,
+    addresses: Vec<(String, u16)>,
+    tls: bool,
+    cluster: bool,
+    mut shutdown: watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            if *shutdown.borrow() {
+                return;
+            }
+
+            let (push_tx, mut push_rx) = mpsc::unbounded_channel();
+            let listener = match build_listener_client(
+                &addresses,
+                tls,
+                cluster,
+                push_tx,
+            )
+            .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "completion_listener: failed to build listener client, retrying in 1s"
+                    );
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+                        _ = shutdown.changed() => return,
+                    }
+                    continue;
+                }
+            };
+
+            // Issue SUBSCRIBE via the facade's command path. The pubsub
+            // synchronizer intercepts, records the desired state, and
+            // the reconciler issues the actual SUBSCRIBE in the
+            // background. Push frames start arriving on `push_rx` once
+            // the server confirms.
+            let sub_result: Result<(), _> = listener
+                .cmd("SUBSCRIBE")
+                .arg(COMPLETION_CHANNEL)
+                .execute()
+                .await;
+            if let Err(e) = sub_result {
+                tracing::warn!(
+                    error = %e,
+                    "completion_listener: SUBSCRIBE failed, retrying in 1s"
+                );
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+                    _ = shutdown.changed() => return,
+                }
+                continue;
+            }
+
+            tracing::info!(
+                channel = COMPLETION_CHANNEL,
+                "completion_listener: subscribed, awaiting push frames"
+            );
+
+            // Drain the push channel until either the connection drops
+            // (push_rx closes) or shutdown fires.
+            loop {
+                tokio::select! {
+                    _ = shutdown.changed() => {
+                        if *shutdown.borrow() {
+                            return;
+                        }
+                    }
+                    msg = push_rx.recv() => {
+                        let Some(push) = msg else {
+                            tracing::warn!(
+                                "completion_listener: push channel closed, reconnecting"
+                            );
+                            break;
+                        };
+                        handle_push(&router, &dispatch_client, push).await;
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Handle one push frame. Ignores non-Message kinds (Subscribe /
+/// Unsubscribe confirmations, keyspace notifications we didn't ask for).
+/// Malformed payloads are logged and dropped — safety-net reconciler
+/// will still pick the completion up.
+async fn handle_push(
+    router: &PartitionRouter,
+    dispatch_client: &Client,
+    push: PushInfo,
+) {
+    if push.kind != PushKind::Message {
+        return;
+    }
+
+    // RESP3 Message frame layout (per Valkey docs):
+    //   data = [ channel, message_payload ]
+    let payload_str = match push.data.get(1) {
+        Some(Value::BulkString(b)) => String::from_utf8_lossy(b).into_owned(),
+        Some(Value::SimpleString(s)) => s.clone(),
+        _ => {
+            tracing::warn!(
+                data = ?push.data,
+                "completion_listener: malformed Message frame, skipping"
+            );
+            return;
+        }
+    };
+
+    let parsed: CompletionPayload = match serde_json::from_str(&payload_str) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                payload = %payload_str,
+                "completion_listener: cjson decode failed, skipping"
+            );
+            return;
+        }
+    };
+
+    let eid = match ExecutionId::parse(&parsed.execution_id) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                raw = %parsed.execution_id,
+                "completion_listener: invalid execution_id in payload"
+            );
+            return;
+        }
+    };
+
+    tracing::debug!(
+        execution_id = %eid,
+        flow_id = %parsed.flow_id,
+        outcome = %parsed.outcome,
+        "completion_listener: dispatching dependency resolution"
+    );
+
+    dispatch_dependency_resolution(
+        dispatch_client,
+        router,
+        &eid,
+        Some(parsed.flow_id.as_str()),
+    )
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_payload() {
+        let raw = r#"{"execution_id":"{fp:5}:11111111-1111-1111-1111-111111111111","flow_id":"22222222-2222-2222-2222-222222222222","outcome":"success"}"#;
+        let p: CompletionPayload = serde_json::from_str(raw).unwrap();
+        assert_eq!(p.flow_id, "22222222-2222-2222-2222-222222222222");
+        assert_eq!(p.outcome, "success");
+    }
+
+    #[test]
+    fn missing_outcome_defaults_empty() {
+        // defense against older-Lua producers that don't emit outcome yet
+        let raw = r#"{"execution_id":"{fp:0}:11111111-1111-1111-1111-111111111111","flow_id":"22222222-2222-2222-2222-222222222222"}"#;
+        let p: CompletionPayload = serde_json::from_str(raw).unwrap();
+        assert_eq!(p.outcome, "");
+    }
+
+    #[test]
+    fn malformed_payload_is_error() {
+        let raw = r#"{"not":"valid"}"#;
+        assert!(serde_json::from_str::<CompletionPayload>(raw).is_err());
+    }
+}

--- a/crates/ff-engine/src/lib.rs
+++ b/crates/ff-engine/src/lib.rs
@@ -1,6 +1,7 @@
 //! ff-engine: cross-partition dispatch and background scanners.
 
 pub mod budget;
+pub mod completion_listener;
 pub mod partition_router;
 pub mod scanner;
 pub mod supervisor;
@@ -30,6 +31,22 @@ use scanner::suspension_timeout::SuspensionTimeoutScanner;
 use scanner::flow_projector::FlowProjector;
 use scanner::unblock::UnblockScanner;
 
+/// Connection parameters for the completion listener's dedicated RESP3
+/// client. Must match the deployment the dispatcher client connects to.
+#[derive(Clone, Debug)]
+pub struct CompletionListenerConfig {
+    /// Seed addresses — `(host, port)` pairs. For standalone, one entry.
+    /// For cluster, pass all configured seed nodes.
+    pub addresses: Vec<(String, u16)>,
+    /// Enable TLS (matches `ClientBuilder::tls_insecure` — the listener
+    /// uses insecure TLS because it only handles completion metadata,
+    /// never user payloads; if strict TLS is required, plumb a
+    /// custom flag).
+    pub tls: bool,
+    /// Enable cluster mode.
+    pub cluster: bool,
+}
+
 /// Engine configuration.
 pub struct EngineConfig {
     pub partition_config: PartitionConfig,
@@ -57,23 +74,38 @@ pub struct EngineConfig {
     pub quota_reconciler_interval: Duration,
     /// Unblock scanner interval. Default: 5s.
     pub unblock_interval: Duration,
-    /// Dependency reconciler interval. Default: 1s.
+    /// Dependency reconciler interval. Default: 15s.
     ///
-    /// This scanner is the only promotion path for downstream
-    /// executions blocked on a dependency edge — `dispatch_dependency_
-    /// resolution` in partition_router.rs exists as a push-based
-    /// alternative but has no completion-time call site today (see
-    /// Batch C issue for the push-based wiring). Until that lands,
-    /// this interval is the per-stage floor for DAG latency: a
-    /// 10-node linear chain runs in ~interval × nodes + work.
+    /// Post-Batch-C this scanner is a **safety net**, not the primary
+    /// promotion path. The [`completion_listener`] SUBSCRIBEs to
+    /// `ff:dag:completions` and dispatches dependency resolution
+    /// synchronously with each completion — under normal operation,
+    /// DAG latency is `~RTT × levels`, not `interval × levels`.
     ///
-    /// 1s is the right default for most deployments; the cost is ~256–
-    /// 512 empty-ZRANGEBYSCORE ops per second (one per partition per
-    /// lane), well under 1% of Valkey capacity. Operators running
-    /// huge numbers of partitions or lanes where the idle-scan cost
-    /// matters can raise this knob — it's a public field for that
-    /// purpose.
+    /// The reconciler still runs as a catch-all for:
+    ///   - messages missed during listener restart or reconnect;
+    ///   - pre-Batch-C executions without `core.flow_id` stamped;
+    ///   - operator-driven edge mutation that doesn't pass through
+    ///     the terminal-transition publish path.
+    ///
+    /// 15s idle-scan cost is minimal. If the listener is disabled
+    /// (`completion_listener` = None), drop this to 1s to preserve
+    /// pre-Batch-C DAG latency behavior.
+    ///
+    /// [`completion_listener`]: Self::completion_listener
     pub dependency_reconciler_interval: Duration,
+
+    /// Optional push-based DAG promotion listener (Batch C item 6).
+    /// When `Some`, the engine spawns a [`completion_listener`] task
+    /// that SUBSCRIBEs to `ff:dag:completions` on a dedicated RESP3
+    /// client and dispatches dependency resolution per completion.
+    ///
+    /// `None` disables the listener entirely — the reconciler alone
+    /// promotes. Useful for lightweight single-node deployments or
+    /// test harnesses that don't care about DAG latency.
+    ///
+    /// [`completion_listener`]: crate::completion_listener
+    pub completion_listener: Option<CompletionListenerConfig>,
     /// Flow summary projector interval. Default: 15s.
     ///
     /// Separate observability projection path — maintains the flow
@@ -101,7 +133,8 @@ impl Default for EngineConfig {
             budget_reconciler_interval: Duration::from_secs(30),
             quota_reconciler_interval: Duration::from_secs(30),
             unblock_interval: Duration::from_secs(5),
-            dependency_reconciler_interval: Duration::from_secs(1),
+            dependency_reconciler_interval: Duration::from_secs(15),
+            completion_listener: None,
             flow_projector_interval: Duration::from_secs(15),
             execution_deadline_interval: Duration::from_secs(5),
         }
@@ -283,17 +316,35 @@ impl Engine {
         ));
         handles.push(supervised_spawn(
             deadline_scanner,
-            client,
+            client.clone(),
             num_partitions,
-            shutdown_rx,
+            shutdown_rx.clone(),
         ));
 
+        // Completion listener (Batch C item 6 — push-based DAG promotion).
+        // Optional: when Some, spawns a dedicated RESP3 client that
+        // SUBSCRIBEs to ff:dag:completions and dispatches dependency
+        // resolution per completion. See `completion_listener` module
+        // docs for the design rationale.
+        let listener_enabled = config.completion_listener.is_some();
+        if let Some(listener_cfg) = config.completion_listener {
+            handles.push(completion_listener::spawn_completion_listener(
+                router.clone(),
+                client,
+                listener_cfg.addresses,
+                listener_cfg.tls,
+                listener_cfg.cluster,
+                shutdown_rx,
+            ));
+        }
+
+        let scanner_count = if listener_enabled { "14 scanners + completion listener" } else { "14 scanners" };
         tracing::info!(
             num_partitions,
             budget_partitions = config.partition_config.num_budget_partitions,
             quota_partitions = config.partition_config.num_quota_partitions,
             flow_partitions = config.partition_config.num_flow_partitions,
-            "engine started with 14 scanners"
+            "engine started with {scanner_count}"
         );
 
         Self {

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -189,8 +189,12 @@ impl ServerConfig {
             Duration::from_secs(env_u64("FF_QUOTA_RECONCILER_INTERVAL_S", 30)?);
         let unblock_interval =
             Duration::from_secs(env_u64("FF_UNBLOCK_INTERVAL_S", 5)?);
+        // Raised from 1s (pre-Batch-C) to 15s now that push-based DAG
+        // promotion is primary. The reconciler is a safety net post-
+        // completion-listener; see ff-engine docs on
+        // `dependency_reconciler_interval`.
         let dependency_reconciler_interval =
-            Duration::from_secs(env_u64("FF_DEPENDENCY_RECONCILER_INTERVAL_S", 1)?);
+            Duration::from_secs(env_u64("FF_DEPENDENCY_RECONCILER_INTERVAL_S", 15)?);
 
         let engine_config = EngineConfig {
             partition_config,
@@ -207,6 +211,10 @@ impl ServerConfig {
             quota_reconciler_interval,
             unblock_interval,
             dependency_reconciler_interval,
+            // Listener is owned by `Server::start`, which has the
+            // Valkey endpoint info. Left None here; populated when
+            // the ServerConfig gets consumed by the server.
+            completion_listener: None,
             flow_projector_interval: Duration::from_secs(
                 env_u64("FF_FLOW_PROJECTOR_INTERVAL_S", 15)?
             ),

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -304,6 +304,14 @@ impl Server {
             quota_reconciler_interval: config.engine_config.quota_reconciler_interval,
             unblock_interval: config.engine_config.unblock_interval,
             dependency_reconciler_interval: config.engine_config.dependency_reconciler_interval,
+            // Push-based DAG promotion (Batch C item 6). Enabled by
+            // default with the server's Valkey endpoint; the engine
+            // spawns a dedicated RESP3 client for SUBSCRIBE.
+            completion_listener: Some(ff_engine::CompletionListenerConfig {
+                addresses: vec![(config.host.clone(), config.port)],
+                tls: config.tls,
+                cluster: config.cluster,
+            }),
             flow_projector_interval: config.engine_config.flow_projector_interval,
             execution_deadline_interval: config.engine_config.execution_deadline_interval,
         };

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -166,6 +166,55 @@ In increasing order of operator cost:
    config, &custom_impl)` is the public escape hatch. Defer to a follow-up
    RFC if this becomes common demand.
 
+## DAG promotion: push listener + safety-net reconciler
+
+Post-Batch-C item 6, FlowFabric uses two paths to promote downstream
+executions when an upstream reaches a terminal state:
+
+1. **Push (primary).** `ff_complete_execution` /
+   `ff_fail_execution` / `ff_cancel_execution` `PUBLISH` a JSON
+   completion payload to the `ff:dag:completions` channel. The engine
+   runs a `CompletionListener` on a dedicated RESP3 client that
+   `SUBSCRIBE`s to that channel and dispatches
+   `ff_resolve_dependency` for each downstream edge.
+2. **Reconciler (safety net).** The `dependency_reconciler` scanner
+   still runs — default interval raised from 1s to 15s now that
+   push is primary — and picks up any completion the listener
+   missed (restart window, unstamped legacy `core.flow_id`,
+   cross-node sharded-pubsub gaps).
+
+Under normal operation DAG latency is `~RTT × levels`, not
+`interval × levels`.
+
+### When to tune `FF_DEPENDENCY_RECONCILER_INTERVAL_S`
+
+- **Default (15s)**: listener is primary; the scanner is belt-and-
+  suspenders. Correct for every deployment the server runs in by
+  itself.
+- **Listener disabled** (custom deployments only, via the
+  `ff_engine::EngineConfig::completion_listener = None` escape hatch):
+  drop this back to `1` so DAG latency doesn't regress to the
+  pre-Batch-C floor.
+
+### Cluster mode
+
+Plain `PUBLISH` broadcasts across cluster nodes. Every ff-server
+instance that runs an engine will receive every completion;
+duplicate dispatches are harmless (idempotent) but redundant. If
+contention surfaces under very wide fan-out, a follow-up can shard
+the channel via `SPUBLISH` keyed by flow partition — not required
+at current scale.
+
+### Observability
+
+- `tracing::info!` at subscribe time:
+  `completion_listener: subscribed, awaiting push frames`.
+- `tracing::debug!` per dispatched completion:
+  `completion_listener: dispatching dependency resolution`.
+- `tracing::warn!` on reconnect, malformed payload, or invalid
+  `execution_id` — rare; a non-zero sustained rate means the Lua
+  producers and engine parser have drifted.
+
 ## Superseded artifacts
 
 ### Issue #21 (crash-recovery scanner)

--- a/lua/execution.lua
+++ b/lua/execution.lua
@@ -648,6 +648,23 @@ redis.register_function('ff_complete_execution', function(keys, args)
     "reason", "completed",
     "ts", tostring(now_ms))
 
+  -- Push-based DAG promotion (Batch C item 6). Only publish when the
+  -- execution actually belongs to a flow — standalone executions never
+  -- have downstream edges for the engine to resolve. The engine's
+  -- CompletionListener scanner SUBSCRIBEs to ff:dag:completions and
+  -- calls dispatch_dependency_resolution per message. The
+  -- dependency_reconciler interval scan is retained as a safety net
+  -- for: missed messages during listener restart, ungated state
+  -- (flow_id empty on older executions), and cluster broadcast gaps.
+  if is_set(core.flow_id) then
+    local payload = cjson.encode({
+      execution_id = A.execution_id,
+      flow_id = core.flow_id,
+      outcome = "success",
+    })
+    redis.call("PUBLISH", "ff:dag:completions", payload)
+  end
+
   return ok("completed")
 end)
 
@@ -835,6 +852,21 @@ redis.register_function('ff_cancel_execution', function(keys, args)
 
   -- ZADD terminal (unconditional)
   redis.call("ZADD", K.terminal_key, now_ms, A.execution_id)
+
+  -- Push-based DAG promotion (Batch C item 6). Skip the publish when
+  -- the cancel came from `flow_cascade` — that source means a parent
+  -- already propagated and the engine is walking the edge graph; an
+  -- additional publish here would trigger redundant dispatch work.
+  -- (Not a correctness issue since dispatch is idempotent, but it
+  -- avoids unnecessary load under wide fan-out cancellations.)
+  if is_set(core.flow_id) and A.source ~= "flow_cascade" then
+    local payload = cjson.encode({
+      execution_id = A.execution_id,
+      flow_id = core.flow_id,
+      outcome = "cancelled",
+    })
+    redis.call("PUBLISH", "ff:dag:completions", payload)
+  end
 
   return ok("cancelled", cancelled_from)
 end)
@@ -1209,6 +1241,18 @@ redis.register_function('ff_fail_execution', function(keys, args)
       "attempt_index", core.current_attempt_index or "",
       "reason", "failed_terminal",
       "ts", tostring(now_ms))
+
+    -- Push-based DAG promotion (Batch C item 6). See ff_complete_execution
+    -- for rationale. A terminal-failed upstream triggers
+    -- child-skip cascades via ff_resolve_dependency on the receiver side.
+    if is_set(core.flow_id) then
+      local payload = cjson.encode({
+        execution_id = A.execution_id,
+        flow_id = core.flow_id,
+        outcome = "failed",
+      })
+      redis.call("PUBLISH", "ff:dag:completions", payload)
+    end
 
     return ok("terminal_failed")
   end


### PR DESCRIPTION
## Summary

Wire the previously-orphaned \`dispatch_dependency_resolution\` as a completion-time hook. DAG latency drops from \`interval × levels\` (reconciler-based) to \`~RTT × levels\` (push-based).

Closes Batch C item 6 in issue #9. Depends on ferriskey PR #38 (\`ClientBuilder::push_sender\`).

## Flow

1. Lua terminal transitions (\`ff_complete_execution\` / \`ff_fail_execution\` (terminal_failed) / \`ff_cancel_execution\`) PUBLISH a JSON payload to \`ff:dag:completions\`.
2. Engine \`CompletionListener\` SUBSCRIBEs on a dedicated RESP3 client, parses payloads, calls \`dispatch_dependency_resolution\` for each.
3. \`dependency_reconciler\` scanner becomes safety net — default interval raised 1s → 15s.

## Design notes

- **Cluster broadcast.** Plain \`PUBLISH\` fans out across nodes. Every engine instance receives every completion; duplicates are idempotent. If contention surfaces, sharded pubsub (\`SPUBLISH\`/\`SSUBSCRIBE\`) keyed by flow partition is a follow-up.
- **flow_cascade exemption.** \`ff_cancel_execution\` skips publish when \`source == \"flow_cascade\"\` — prevents redundant dispatch when a parent is already walking the edge graph.
- **Opt-in.** \`EngineConfig::completion_listener = None\` disables the listener; reconciler alone promotes (lightweight test harnesses).

## Tests

- 3 unit tests in \`completion_listener\` for JSON payload parsing.
- Live pub/sub delivery already exercised by ferriskey's \`test_pubsub.rs\` (PR #38).
- Engine-level end-to-end dispatch flow: pending separate ff-test integration (follow-up).

## Docs

\`docs/rfc011-operator-runbook.md\`: new \"DAG promotion\" section covering push-primary + safety-net-reconciler, cluster broadcast, tuning, observability.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p ff-engine --lib\` — 7 pass incl. 3 new
- [x] \`cargo test -p ff-core --lib\` — 78 pass
- [ ] ff-test integration (follow-up issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DAG promotion behavior by adding a pub/sub-driven dependency resolution path and adjusting default reconciliation cadence; issues could manifest as delayed/unresolved downstream executions if publish/subscribe or payload parsing drifts. Correctness still relies on the reconciler safety net, but the new listener adds operational complexity (RESP3 pubsub, reconnect loops, cluster fanout).
> 
> **Overview**
> Introduces a push-based DAG promotion path: Lua terminal transitions now `PUBLISH` completion payloads to `ff:dag:completions`, and `ff-engine` adds a dedicated RESP3 `CompletionListener` that `SUBSCRIBE`s and calls `dispatch_dependency_resolution` per message.
> 
> Updates engine/server configuration to enable the listener by default in `ff-server`, adds an opt-out (`EngineConfig::completion_listener = None`), and raises the default `dependency_reconciler_interval` from 1s to 15s to reflect its new safety-net role. Documentation is updated with operator guidance and observability notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ae05c0a5890bd828b7bd24580b0a3704edf45e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->