### PR TITLE
feat(engine): server-side data_passing_ref resolution (Batch C item 3)

### DIFF
--- a/crates/ff-engine/src/partition_router.rs
+++ b/crates/ff-engine/src/partition_router.rs
@@ -233,9 +233,15 @@ async fn dispatch_dependency_resolution_inner(
             &ff_core::types::EdgeId::parse(edge_id).unwrap_or_default(),
         );
 
-        // KEYS (9): exec_core, deps_meta, unresolved_set, dep_hash,
-        //           eligible_zset, terminal_zset, blocked_deps_zset,
-        //           attempt_hash, stream_meta
+        // KEYS (11): exec_core, deps_meta, unresolved_set, dep_hash,
+        //            eligible_zset, terminal_zset, blocked_deps_zset,
+        //            attempt_hash, stream_meta, downstream_payload,
+        //            upstream_result
+        // KEYS[10]/[11] added for Batch C item 3: server-side
+        // data_passing_ref resolution. Upstream and downstream are
+        // co-located via flow membership (RFC-011 §7.3), so we build
+        // the upstream key on the child's partition using the same
+        // ExecKeyContext shape.
         let deps_meta = child_ctx.deps_meta();
         let unresolved = child_ctx.deps_unresolved();
         let eligible = child_idx.lane_eligible(&lane_id);
@@ -243,17 +249,22 @@ async fn dispatch_dependency_resolution_inner(
         let blocked_deps = child_idx.lane_blocked_dependencies(&lane_id);
         let attempt_hash = child_ctx.attempt_hash(att_idx);
         let stream_meta = child_ctx.stream_meta(att_idx);
+        let downstream_payload = child_ctx.payload();
+        let upstream_ctx = ExecKeyContext::new(&child_partition, eid);
+        let upstream_result = upstream_ctx.result();
 
-        let keys: [&str; 9] = [
-            &child_core_key,  // 1
-            &deps_meta,       // 2
-            &unresolved,      // 3
-            &dep_hash,        // 4
-            &eligible,        // 5
-            &terminal,        // 6
-            &blocked_deps,    // 7
-            &attempt_hash,    // 8
-            &stream_meta,     // 9
+        let keys: [&str; 11] = [
+            &child_core_key,       // 1
+            &deps_meta,            // 2
+            &unresolved,           // 3
+            &dep_hash,             // 4
+            &eligible,             // 5
+            &terminal,             // 6
+            &blocked_deps,         // 7
+            &attempt_hash,         // 8
+            &stream_meta,          // 9
+            &downstream_payload,   // 10
+            &upstream_result,      // 11
         ];
         let argv: [&str; 3] = [edge_id, upstream_outcome, &now_ms];
 
@@ -312,17 +323,16 @@ async fn dispatch_dependency_resolution_inner(
 }
 
 /// Check if an ff_resolve_dependency result indicates the child was skipped.
-/// Result format: [1, "OK", "impossible", "child_skipped"]
+/// Result shapes after Batch C item 3:
+///   [1, "OK", "already_resolved"]           (2 payload fields)
+///   [1, "OK", "satisfied", ""|"data_injected"]
+///   [1, "OK", "impossible", ""|"child_skipped"]
 fn is_child_skipped_result(value: &ferriskey::Value) -> bool {
     match value {
         ferriskey::Value::Array(arr) => {
             if arr.len() < 4 {
-                if arr.len() != 2 {
-                    tracing::warn!(
-                        arr_len = arr.len(),
-                        "is_child_skipped_result: unexpected array length (expected 2 or 4)"
-                    );
-                }
+                // 2- and 3-element responses are normal paths
+                // (already_resolved, etc.). No warning.
                 return false;
             }
             arr.get(3)

--- a/crates/ff-engine/src/partition_router.rs
+++ b/crates/ff-engine/src/partition_router.rs
@@ -322,17 +322,21 @@ async fn dispatch_dependency_resolution_inner(
     }
 }
 
-/// Check if an ff_resolve_dependency result indicates the child was skipped.
-/// Result shapes after Batch C item 3:
-///   [1, "OK", "already_resolved"]           (2 payload fields)
-///   [1, "OK", "satisfied", ""|"data_injected"]
-///   [1, "OK", "impossible", ""|"child_skipped"]
+/// Check if an ff_resolve_dependency result indicates the child was
+/// skipped. Result shapes after Batch C item 3:
+///   `[1, "OK", "already_resolved"]`            — 3 elements total
+///   `[1, "OK", "satisfied", ""|"data_injected"]` — 4 elements total
+///   `[1, "OK", "impossible", ""|"child_skipped"]` — 4 elements total
+///
+/// "Child skipped" lives in slot 3 (0-indexed) on the impossible path
+/// only; the satisfied path's fourth slot is the unrelated
+/// data_injected marker.
 fn is_child_skipped_result(value: &ferriskey::Value) -> bool {
     match value {
         ferriskey::Value::Array(arr) => {
             if arr.len() < 4 {
-                // 2- and 3-element responses are normal paths
-                // (already_resolved, etc.). No warning.
+                // 3-element responses are normal (already_resolved).
+                // No warning.
                 return false;
             }
             arr.get(3)

--- a/crates/ff-engine/src/scanner/dependency_reconciler.rs
+++ b/crates/ff-engine/src/scanner/dependency_reconciler.rs
@@ -199,8 +199,14 @@ async fn reconcile_one_execution(
         // KEYS must match Lua positional order:
         // [1] exec_core, [2] deps_meta, [3] unresolved_set, [4] dep_hash,
         // [5] eligible_zset, [6] terminal_zset, [7] blocked_deps_zset,
-        // [8] attempt_hash, [9] stream_meta
-        let keys: [&str; 9] = [
+        // [8] attempt_hash, [9] stream_meta, [10] downstream_payload,
+        // [11] upstream_result
+        // [10]/[11] added for Batch C item 3. Upstream + downstream are
+        // co-located on the same {fp:N} slot via flow membership;
+        // build both keys with the same partition tag.
+        let downstream_payload = format!("ff:exec:{}:{}:payload", tag, eid_str);
+        let upstream_result = format!("ff:exec:{}:{}:result", tag, upstream_id);
+        let keys: [&str; 11] = [
             &exec_core,           // 1
             &deps_meta,           // 2
             &deps_unresolved_key, // 3
@@ -210,6 +216,8 @@ async fn reconcile_one_execution(
             &blocked_deps_key,    // 7
             &attempt_hash,        // 8
             &stream_meta,         // 9
+            &downstream_payload,  // 10
+            &upstream_result,     // 11
         ];
         let now_s = now_ms.to_string();
         let argv: [&str; 3] = [edge_id.as_str(), resolution, &now_s];

--- a/crates/ff-script/src/functions/flow.rs
+++ b/crates/ff-script/src/functions/flow.rs
@@ -18,6 +18,12 @@ pub struct DepOpKeys<'a> {
     pub ctx: &'a ExecKeyContext,
     pub idx: &'a IndexKeys,
     pub lane_id: &'a ff_core::types::LaneId,
+    /// Upstream's [`ExecKeyContext`] for building `upstream_result` when
+    /// `ff_resolve_dependency` is called with a `data_passing_ref` edge.
+    /// Upstream and downstream are co-located on the same `{fp:N}` slot
+    /// via flow membership (RFC-011 §7.3), so this shares the ctx's
+    /// partition — only the `<eid>` segment differs.
+    pub upstream_ctx: &'a ExecKeyContext,
 }
 
 // ─── ff_create_flow ──────────────────────────────────────────────────
@@ -213,10 +219,16 @@ impl FromFcallResult for ApplyDependencyToChildResult {
 }
 
 // ─── ff_resolve_dependency ────────────────────────────────────────────
-// KEYS (9): exec_core, deps_meta, unresolved_set, dep_hash,
-//           eligible_zset, terminal_zset, blocked_deps_zset,
-//           attempt_hash, stream_meta
+// KEYS (11): exec_core, deps_meta, unresolved_set, dep_hash,
+//            eligible_zset, terminal_zset, blocked_deps_zset,
+//            attempt_hash, stream_meta, downstream_payload,
+//            upstream_result
 // ARGV (3): edge_id, upstream_outcome, now_ms
+//
+// KEYS[10]/[11] added in Batch C item 3 for server-side
+// data_passing_ref resolution. Upstream and downstream are co-located
+// on the same {fp:N} slot via flow membership — the `upstream_ctx`
+// field on DepOpKeys builds the upstream key on that shared partition.
 
 ff_function! {
     pub ff_resolve_dependency(args: ResolveDependencyArgs) -> ResolveDependencyResult {
@@ -230,6 +242,8 @@ ff_function! {
             k.idx.lane_blocked_dependencies(k.lane_id),
             k.ctx.attempt_hash(ff_core::types::AttemptIndex::new(0)), // placeholder
             k.ctx.stream_meta(ff_core::types::AttemptIndex::new(0)),  // placeholder
+            k.ctx.payload(),
+            k.upstream_ctx.result(),
         }
         argv {
             args.edge_id.to_string(),

--- a/crates/ff-script/src/functions/flow.rs
+++ b/crates/ff-script/src/functions/flow.rs
@@ -18,11 +18,23 @@ pub struct DepOpKeys<'a> {
     pub ctx: &'a ExecKeyContext,
     pub idx: &'a IndexKeys,
     pub lane_id: &'a ff_core::types::LaneId,
-    /// Upstream's [`ExecKeyContext`] for building `upstream_result` when
-    /// `ff_resolve_dependency` is called with a `data_passing_ref` edge.
-    /// Upstream and downstream are co-located on the same `{fp:N}` slot
-    /// via flow membership (RFC-011 §7.3), so this shares the ctx's
-    /// partition — only the `<eid>` segment differs.
+}
+
+/// Extended key context for [`ff_resolve_dependency`], which needs
+/// access to the upstream execution's result key for server-side
+/// `data_passing_ref` resolution (Batch C item 3). Separate from
+/// [`DepOpKeys`] so the other dependency wrappers —
+/// `ff_apply_dependency_to_child`, `ff_evaluate_flow_eligibility`,
+/// `ff_promote_blocked_to_eligible`, `ff_replay_execution` — don't
+/// have to carry an upstream context they never use.
+///
+/// Upstream and downstream are co-located on the same `{fp:N}` slot
+/// via flow membership (RFC-011 §7.3), so `upstream_ctx` builds the
+/// upstream key on the child's partition.
+pub struct ResolveDependencyKeys<'a> {
+    pub ctx: &'a ExecKeyContext,
+    pub idx: &'a IndexKeys,
+    pub lane_id: &'a ff_core::types::LaneId,
     pub upstream_ctx: &'a ExecKeyContext,
 }
 
@@ -232,7 +244,7 @@ impl FromFcallResult for ApplyDependencyToChildResult {
 
 ff_function! {
     pub ff_resolve_dependency(args: ResolveDependencyArgs) -> ResolveDependencyResult {
-        keys(k: &DepOpKeys<'_>) {
+        keys(k: &ResolveDependencyKeys<'_>) {
             k.ctx.core(),
             k.ctx.deps_meta(),
             k.ctx.deps_unresolved(),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -3333,6 +3333,15 @@ async fn fcall_apply_dependency(
     tc: &TestCluster, downstream: &ExecutionId, flow_id: &str,
     edge_id: &str, upstream: &ExecutionId,
 ) {
+    fcall_apply_dependency_with_data_passing(
+        tc, downstream, flow_id, edge_id, upstream, "",
+    ).await;
+}
+
+async fn fcall_apply_dependency_with_data_passing(
+    tc: &TestCluster, downstream: &ExecutionId, flow_id: &str,
+    edge_id: &str, upstream: &ExecutionId, data_passing_ref: &str,
+) {
     let config = test_config();
     let p = execution_partition(downstream, &config);
     let ctx = ExecKeyContext::new(&p, downstream);
@@ -3348,7 +3357,8 @@ async fn fcall_apply_dependency(
     let now = TimestampMs::now();
     let args: Vec<String> = vec![
         flow_id.to_owned(), edge_id.to_owned(), upstream.to_string(),
-        "1".to_owned(), "success_only".to_owned(), String::new(), now.to_string(),
+        "1".to_owned(), "success_only".to_owned(),
+        data_passing_ref.to_owned(), now.to_string(),
     ];
     let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
     let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -3359,12 +3369,13 @@ async fn fcall_apply_dependency(
 }
 
 async fn fcall_resolve_dependency(
-    tc: &TestCluster, downstream: &ExecutionId,
+    tc: &TestCluster, downstream: &ExecutionId, upstream: &ExecutionId,
     edge_id: &str, outcome: &str,
 ) -> String {
     let config = test_config();
     let p = execution_partition(downstream, &config);
     let ctx = ExecKeyContext::new(&p, downstream);
+    let upstream_ctx = ExecKeyContext::new(&p, upstream);
     let idx = IndexKeys::new(&p);
     let lane_id = LaneId::new(LANE);
     let eid_p = ff_core::types::EdgeId::parse(edge_id).unwrap();
@@ -3374,6 +3385,7 @@ async fn fcall_resolve_dependency(
         ctx.dep_edge(&eid_p), idx.lane_eligible(&lane_id),
         idx.lane_terminal(&lane_id), idx.lane_blocked_dependencies(&lane_id),
         ctx.attempt_hash(att), ctx.stream_meta(att),
+        ctx.payload(), upstream_ctx.result(),
     ];
     let now = TimestampMs::now();
     let args: Vec<String> = vec![
@@ -3417,13 +3429,13 @@ async fn test_flow_linear_chain() {
     fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
     let (la, ea, _, aa) = fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
-    assert_eq!(fcall_resolve_dependency(&tc, &b, &e_ab, "success").await, "satisfied");
+    assert_eq!(fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await, "satisfied");
     assert_in_eligible(&tc, &b, &LaneId::new(LANE)).await;
     // Complete B, resolve B->C
     fcall_issue_claim_grant(&tc, &b, LANE, WORKER, WORKER_INST).await;
     let (lb, eb, _, ab) = fcall_claim_execution(&tc, &b, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &b, LANE, WORKER_INST, &lb, &eb, &ab).await;
-    assert_eq!(fcall_resolve_dependency(&tc, &c, &e_bc, "success").await, "satisfied");
+    assert_eq!(fcall_resolve_dependency(&tc, &c, &b, &e_bc, "success").await, "satisfied");
     assert_in_eligible(&tc, &c, &LaneId::new(LANE)).await;
     // Complete C
     fcall_issue_claim_grant(&tc, &c, LANE, WORKER, WORKER_INST).await;
@@ -3436,6 +3448,109 @@ async fn test_flow_linear_chain() {
             ..Default::default()
         }).await;
     }
+}
+
+/// Server-side data_passing_ref resolution (Batch C item 3).
+/// Chain A->B with data_passing_ref on the edge. After A completes,
+/// B's input_payload should equal A's result (the canned
+/// `{"status":"ok"}` string that fcall_complete_execution writes).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_flow_data_passing_ref_injects_on_satisfy() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let fid = "flow-dataref";
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let e_ab = uuid::Uuid::new_v4().to_string();
+    fcall_create_execution(&tc, &a, NS, LANE, "dp_a", 0).await;
+    fcall_create_execution(&tc, &b, NS, LANE, "dp_b", 0).await;
+    setup_flow_via_fcall(&tc, fid, &[&a, &b]).await;
+    // Stage the edge with a non-empty data_passing_ref to enable copy.
+    fcall_apply_dependency_with_data_passing(
+        &tc, &b, fid, &e_ab, &a, "result",
+    ).await;
+
+    // Complete A with the canned {"status":"ok"} result_payload baked
+    // into fcall_complete_execution.
+    fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
+    let (la, ea, _, aa) =
+        fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
+    fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
+    assert_eq!(
+        fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await,
+        "satisfied"
+    );
+
+    // Verify B's payload now holds A's result bytes (not the original
+    // create_execution payload).
+    let config = test_config();
+    let p = execution_partition(&b, &config);
+    let ctx = ExecKeyContext::new(&p, &b);
+    let payload: Option<String> = tc.client()
+        .cmd("GET")
+        .arg(ctx.payload())
+        .execute()
+        .await
+        .expect("GET b.payload");
+    assert_eq!(
+        payload.as_deref(),
+        Some(r#"{"status":"ok"}"#),
+        "data_passing_ref should have copied A's result into B's payload"
+    );
+}
+
+/// Control test for data_passing_ref: when the edge is staged with an
+/// EMPTY data_passing_ref, B's payload must NOT be overwritten by A's
+/// result. Guards against an accidental copy on every satisfy.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_flow_data_passing_ref_empty_no_copy() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let fid = "flow-nodataref";
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let e_ab = uuid::Uuid::new_v4().to_string();
+    fcall_create_execution(&tc, &a, NS, LANE, "np_a", 0).await;
+    fcall_create_execution(&tc, &b, NS, LANE, "np_b", 0).await;
+
+    // Write a known payload on B up-front so we can assert it survives.
+    let config = test_config();
+    let p = execution_partition(&b, &config);
+    let ctx = ExecKeyContext::new(&p, &b);
+    let _: () = tc.client()
+        .cmd("SET")
+        .arg(ctx.payload())
+        .arg("b_original_payload")
+        .execute()
+        .await
+        .expect("SET b.payload");
+
+    setup_flow_via_fcall(&tc, fid, &[&a, &b]).await;
+    // Edge has NO data_passing_ref — injection must be skipped.
+    fcall_apply_dependency(&tc, &b, fid, &e_ab, &a).await;
+
+    fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
+    let (la, ea, _, aa) =
+        fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
+    fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
+    assert_eq!(
+        fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await,
+        "satisfied"
+    );
+
+    let payload: Option<String> = tc.client()
+        .cmd("GET")
+        .arg(ctx.payload())
+        .execute()
+        .await
+        .expect("GET b.payload");
+    assert_eq!(
+        payload.as_deref(),
+        Some("b_original_payload"),
+        "empty data_passing_ref must preserve B's original payload"
+    );
 }
 
 /// Fan-out: A->B, A->C. Complete A, both B and C unblocked.
@@ -3459,8 +3574,8 @@ async fn test_flow_fan_out() {
     fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
     let (la, ea, _, aa) = fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
-    fcall_resolve_dependency(&tc, &b, &e_ab, "success").await;
-    fcall_resolve_dependency(&tc, &c, &e_ac, "success").await;
+    fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await;
+    fcall_resolve_dependency(&tc, &c, &a, &e_ac, "success").await;
     assert_in_eligible(&tc, &b, &LaneId::new(LANE)).await;
     assert_in_eligible(&tc, &c, &LaneId::new(LANE)).await;
 }
@@ -3487,13 +3602,13 @@ async fn test_flow_dependency_failure_propagation() {
     fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
     let (la, ea, _, aa) = fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
-    fcall_resolve_dependency(&tc, &b, &e_ab, "success").await;
+    fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await;
     // Fail B
     fcall_issue_claim_grant(&tc, &b, LANE, WORKER, WORKER_INST).await;
     let (lb, eb, _, ab) = fcall_claim_execution(&tc, &b, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_fail_execution(&tc, &b, LANE, WORKER_INST, &lb, &eb, &ab, "err", "worker_error", "").await;
     // Resolve B->C as "failed" -> C becomes skipped
-    assert_eq!(fcall_resolve_dependency(&tc, &c, &e_bc, "failed").await, "impossible");
+    assert_eq!(fcall_resolve_dependency(&tc, &c, &b, &e_bc, "failed").await, "impossible");
     assert_execution_state(&tc, &c, &ExpectedState {
         lifecycle_phase: Some(ff_core::state::LifecyclePhase::Terminal),
         terminal_outcome: Some(ff_core::state::TerminalOutcome::Skipped),
@@ -3518,9 +3633,9 @@ async fn test_flow_resolve_idempotency() {
     fcall_create_execution(&tc, &b, NS, LANE, "ri_b", 0).await;
     setup_flow_via_fcall(&tc, fid, &[&a, &b]).await;
     fcall_apply_dependency(&tc, &b, fid, &e_ab, &a).await;
-    assert_eq!(fcall_resolve_dependency(&tc, &b, &e_ab, "failed").await, "impossible");
+    assert_eq!(fcall_resolve_dependency(&tc, &b, &a, &e_ab, "failed").await, "impossible");
     // Second resolve -> already_resolved
-    assert_eq!(fcall_resolve_dependency(&tc, &b, &e_ab, "success").await, "already_resolved");
+    assert_eq!(fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await, "already_resolved");
     // B still skipped
     assert_execution_state(&tc, &b, &ExpectedState {
         terminal_outcome: Some(ff_core::state::TerminalOutcome::Skipped),
@@ -3551,7 +3666,7 @@ async fn test_flow_with_execution_lifecycle() {
     fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
     let (la, ea, _, aa) = fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
-    fcall_resolve_dependency(&tc, &b, &e_ab, "success").await;
+    fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await;
     assert_in_eligible(&tc, &b, &LaneId::new(LANE)).await;
     fcall_issue_claim_grant(&tc, &b, LANE, WORKER, WORKER_INST).await;
     let (lb, eb, _, ab) = fcall_claim_execution(&tc, &b, LANE, WORKER, WORKER_INST, 30_000).await;
@@ -3588,7 +3703,7 @@ async fn test_flow_replay_after_skip() {
     fcall_fail_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa, "err", "worker_error", "").await;
 
     // Resolve A->B as "failed" -> B becomes skipped
-    fcall_resolve_dependency(&tc, &b, &e_ab, "failed").await;
+    fcall_resolve_dependency(&tc, &b, &a, &e_ab, "failed").await;
     assert_execution_state(&tc, &b, &ExpectedState {
         lifecycle_phase: Some(ff_core::state::LifecyclePhase::Terminal),
         terminal_outcome: Some(ff_core::state::TerminalOutcome::Skipped),
@@ -4897,7 +5012,7 @@ async fn test_flow_full_lifecycle_with_staging() {
     fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
     let (la, ea, _, aa) = fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
-    assert_eq!(fcall_resolve_dependency(&tc, &b, &e_ab, "success").await, "satisfied");
+    assert_eq!(fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await, "satisfied");
     assert_in_eligible(&tc, &b, &lane_id).await;
     assert_not_in_eligible(&tc, &c, &lane_id).await;
 
@@ -4905,7 +5020,7 @@ async fn test_flow_full_lifecycle_with_staging() {
     fcall_issue_claim_grant(&tc, &b, LANE, WORKER, WORKER_INST).await;
     let (lb, eb, _, ab) = fcall_claim_execution(&tc, &b, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &b, LANE, WORKER_INST, &lb, &eb, &ab).await;
-    assert_eq!(fcall_resolve_dependency(&tc, &c, &e_bc, "success").await, "satisfied");
+    assert_eq!(fcall_resolve_dependency(&tc, &c, &b, &e_bc, "success").await, "satisfied");
     assert_in_eligible(&tc, &c, &lane_id).await;
 
     // 8. Complete C
@@ -6051,7 +6166,7 @@ async fn test_server_flow_lifecycle() {
     fcall_complete_execution(&tc, &upstream, LANE, WORKER_INST, &la, &ea, &aa).await;
 
     // 7. Resolve dependency → downstream becomes eligible
-    let resolve_result = fcall_resolve_dependency(&tc, &downstream, &edge_id, "success").await;
+    let resolve_result = fcall_resolve_dependency(&tc, &downstream, &upstream, &edge_id, "success").await;
     assert_eq!(resolve_result, "satisfied");
 
     assert_in_eligible(&tc, &downstream, &LaneId::new(LANE)).await;
@@ -6641,11 +6756,11 @@ async fn test_server_full_flow_lifecycle() {
     fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
     let (la, ea, _, aa) = fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
-    assert_eq!(fcall_resolve_dependency(&tc, &b, &e_ab, "success").await, "satisfied");
+    assert_eq!(fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await, "satisfied");
     fcall_issue_claim_grant(&tc, &b, LANE, WORKER, WORKER_INST).await;
     let (lb, eb, _, ab) = fcall_claim_execution(&tc, &b, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &b, LANE, WORKER_INST, &lb, &eb, &ab).await;
-    assert_eq!(fcall_resolve_dependency(&tc, &c, &e_bc, "success").await, "satisfied");
+    assert_eq!(fcall_resolve_dependency(&tc, &c, &b, &e_bc, "success").await, "satisfied");
     fcall_issue_claim_grant(&tc, &c, LANE, WORKER, WORKER_INST).await;
     let (lc, ec, _, ac) = fcall_claim_execution(&tc, &c, LANE, WORKER, WORKER_INST, 30_000).await;
     fcall_complete_execution(&tc, &c, LANE, WORKER_INST, &lc, &ec, &ac).await;

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -3553,6 +3553,70 @@ async fn test_flow_data_passing_ref_empty_no_copy() {
     );
 }
 
+/// Data-passing guard: a late satisfy against an ALREADY-terminal
+/// child must not overwrite the child's payload. Simulates a cancel
+/// racing with ff_resolve_dependency.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_flow_data_passing_ref_skips_terminal_child() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let fid = "flow-terminal-child";
+    let a = tc.new_execution_id_on_partition(0);
+    let b = tc.new_execution_id_on_partition(0);
+    let e_ab = uuid::Uuid::new_v4().to_string();
+    fcall_create_execution(&tc, &a, NS, LANE, "t_a", 0).await;
+    fcall_create_execution(&tc, &b, NS, LANE, "t_b", 0).await;
+
+    // Write a sentinel payload on B up front.
+    let config = test_config();
+    let p = execution_partition(&b, &config);
+    let ctx = ExecKeyContext::new(&p, &b);
+    let _: () = tc.client()
+        .cmd("SET")
+        .arg(ctx.payload())
+        .arg("b_sentinel")
+        .execute()
+        .await
+        .expect("SET b.payload");
+
+    setup_flow_via_fcall(&tc, fid, &[&a, &b]).await;
+    fcall_apply_dependency_with_data_passing(
+        &tc, &b, fid, &e_ab, &a, "result",
+    ).await;
+
+    // Force B into a terminal state BEFORE A resolves — direct exec_core
+    // patch is the minimal test hook (skips the cancel flow dispatcher).
+    let _: () = tc.client()
+        .cmd("HSET")
+        .arg(ctx.core())
+        .arg("lifecycle_phase").arg("terminal")
+        .arg("terminal_outcome").arg("cancelled")
+        .execute()
+        .await
+        .expect("HSET b.core terminal");
+
+    // Now complete A and resolve. COPY should be skipped by the
+    // terminal-child guard.
+    fcall_issue_claim_grant(&tc, &a, LANE, WORKER, WORKER_INST).await;
+    let (la, ea, _, aa) =
+        fcall_claim_execution(&tc, &a, LANE, WORKER, WORKER_INST, 30_000).await;
+    fcall_complete_execution(&tc, &a, LANE, WORKER_INST, &la, &ea, &aa).await;
+    fcall_resolve_dependency(&tc, &b, &a, &e_ab, "success").await;
+
+    let payload: Option<String> = tc.client()
+        .cmd("GET")
+        .arg(ctx.payload())
+        .execute()
+        .await
+        .expect("GET b.payload");
+    assert_eq!(
+        payload.as_deref(),
+        Some("b_sentinel"),
+        "terminal child's payload must not be overwritten by late satisfy"
+    );
+}
+
 /// Fan-out: A->B, A->C. Complete A, both B and C unblocked.
 #[tokio::test]
 #[serial_test::serial]

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -166,6 +166,36 @@ In increasing order of operator cost:
    config, &custom_impl)` is the public escape hatch. Defer to a follow-up
    RFC if this becomes common demand.
 
+## Data passing between flow nodes
+
+When a flow edge is staged via `ff_stage_dependency_edge` with a
+non-empty `data_passing_ref`, the engine copies the upstream's
+`result` bytes into the downstream's `input_payload` atomically at
+satisfaction time (inside `ff_resolve_dependency`). No separate
+client-side chain is required — submit posts all nodes up-front,
+the worker's subsequent `claim_next` reads the already-injected
+payload.
+
+Semantics:
+
+- Any non-empty `data_passing_ref` triggers injection. The string
+  content is currently opaque to the engine (reserved for a future
+  field-path or schema-ref extension).
+- Copy runs **before** the downstream's eligibility transition so
+  a crash mid-FCALL can't leave the child eligible with a stale
+  payload (RFC-010 §4.8b write-ordering rule).
+- If the upstream called `complete(None)` (no result written), the
+  copy is a no-op — the downstream's original `input_payload` (set
+  at `create_execution` time) is preserved.
+- Multi-upstream children with `data_passing_ref` on multiple edges
+  experience last-writer-wins semantics. Configure the flow with at
+  most one data-passing edge per child if this matters.
+- Uses Valkey `COPY src dst REPLACE` server-side, not round-trip
+  `GET`/`SET` — large payloads don't inflate the FCALL memory budget.
+- Upstream/downstream co-location is guaranteed by flow membership
+  (RFC-011 §7.3 hash-tag routing), so the copy is a single-slot op
+  even on cluster.
+
 ## DAG promotion: push listener + safety-net reconciler
 
 Post-Batch-C item 6, FlowFabric uses two paths to promote downstream

--- a/examples/media-pipeline/README.md
+++ b/examples/media-pipeline/README.md
@@ -156,12 +156,12 @@ FF_MAX_CONCURRENT_STREAM_OPS=2 cargo run -p ff-server &
 
 ## V1 shortcuts (documented)
 
-- **Client-side data passing.** The submit CLI waits for each upstream execution to complete, reads the raw result bytes from `GET /v1/executions/{id}/result`, and embeds them as the next execution's `input_payload`. The flow graph carries `data_passing_ref` on the dependency edges for inspectability, but the engine does not auto-inject the upstream payload into the downstream `input_payload` today. That's a Batch C task.
+- **Client-side data passing (legacy, to be migrated).** The submit CLI currently waits for each upstream execution to complete, reads the raw result bytes from `GET /v1/executions/{id}/result`, and embeds them as the next execution's `input_payload`. Batch C item 3 has landed server-side auto-injection: when the flow edge is staged with a non-empty `data_passing_ref`, the engine atomically copies the upstream's `result` into the downstream's `input_payload` at satisfaction time inside `ff_resolve_dependency`. The submit CLI has not yet been migrated to the server-side path — tracked as a follow-up. See `docs/rfc011-operator-runbook.md` §"Data passing between flow nodes".
 - **`insecure-direct-claim` feature.** Workers use the direct Valkey claim path gated by the `insecure-direct-claim` feature on `ff-sdk`. Batch C will replace this with a proper scheduler-mediated claim API.
 
 ## Submit crash recovery (v1)
 
-Because submit orchestrates the 3-stage sequence client-side, **a crash or Ctrl-C between stages leaves the flow stuck**: transcribe + summarize may exist as members with edges applied, but embed was never POSTed. The server has no way to drive the pipeline forward on its own until server-side `data_passing_ref` resolution lands.
+Because submit in its current form orchestrates the 3-stage sequence client-side, **a crash or Ctrl-C between stages leaves the flow stuck**: transcribe + summarize may exist as members with edges applied, but embed was never POSTed. Once the submit CLI is migrated to stage all 3 executions up-front with `data_passing_ref` edges (follow-up to Batch C item 3), the server drives the pipeline forward autonomously and a crash becomes cosmetic tail-drop instead of a stuck flow.
 
 Recovery options:
 
@@ -177,7 +177,7 @@ Recovery options:
 
 2. **Finish manually.** Read each staged execution's state and result, and POST the next stage yourself via the same REST calls submit uses. Non-trivial — recommend option 1 unless the transcribe / summarize result is expensive to rerun.
 
-3. **Batch C** will add a server-driven chaining path: submit posts all three executions up-front with `data_passing_ref` edges and the engine auto-injects upstream payloads into downstream `input_payload` as each stage completes. At that point submit becomes a tail multiplexer and a crash is a cosmetic tail-drop, not a stuck flow.
+3. **Migrate submit to the server-driven chain** (Batch C item 3 has landed the engine side). Post all three executions up-front with `data_passing_ref` set on the edges; the engine auto-injects upstream payloads into downstream `input_payload` as each stage completes. Submit becomes a tail multiplexer and a crash is cosmetic tail-drop, not a stuck flow.
 
 ## File layout
 

--- a/lua/flow.lua
+++ b/lua/flow.lua
@@ -563,32 +563,41 @@ redis.register_function('ff_resolve_dependency', function(keys, args)
       "unsatisfied_required_count", -1)
     redis.call("HSET", K.deps_meta, "last_dependency_update_at", A.now_ms)
 
-    -- Server-side data_passing_ref resolution (Batch C item 3). When the
-    -- edge was staged with a non-empty `data_passing_ref`, replace the
-    -- downstream's input_payload with the upstream's result. COPY is a
-    -- single-slot server-internal op (no round-trip to Lua memory) so
-    -- large result payloads don't inflate the FCALL's working set.
+    -- Check if all deps now satisfied
+    local raw = redis.call("HGETALL", K.core_key)
+    if #raw == 0 then return ok("satisfied", "") end
+    local core = hgetall_to_table(raw)
+
+    -- Server-side data_passing_ref resolution (Batch C item 3). When
+    -- the edge was staged with a non-empty `data_passing_ref`, replace
+    -- the downstream's input_payload with the upstream's result. COPY
+    -- is a single-slot server-internal op (no round-trip to Lua
+    -- memory) so large result payloads don't inflate the FCALL's
+    -- working set.
     --
-    -- Write-ordering note (RFC-010 §4.8b): this runs BEFORE the
+    -- Terminal-child guard: a late satisfaction can race with the
+    -- child being cancelled or skipped. Don't overwrite the payload
+    -- of a child that has already reached a terminal state — it's at
+    -- best pointless (the worker will never read it) and at worst
+    -- noisy for post-mortem debugging.
+    --
+    -- Write-ordering note (RFC-010 §4.8b): COPY runs BEFORE the
     -- eligibility transition below so a crash between the two leaves
     -- the child blocked (or late-satisfied on reconciler retry) with
     -- the correct payload rather than eligible with a stale one.
     --
     -- Void-completion path: if the upstream called complete(None), the
-    -- result key does not exist — skip silently and leave the child's
-    -- original input_payload intact.
+    -- result key does not exist — COPY returns 0 and data_injected
+    -- stays empty, leaving the child's original input_payload intact.
     local data_injected = ""
-    if is_set(dep.data_passing_ref) then
-      if redis.call("EXISTS", K.upstream_result) == 1 then
-        redis.call("COPY", K.upstream_result, K.downstream_payload, "REPLACE")
+    if is_set(dep.data_passing_ref)
+       and core.terminal_outcome == "none" then
+      local copied = redis.call(
+        "COPY", K.upstream_result, K.downstream_payload, "REPLACE")
+      if copied == 1 then
         data_injected = "data_injected"
       end
     end
-
-    -- Check if all deps now satisfied
-    local raw = redis.call("HGETALL", K.core_key)
-    if #raw == 0 then return ok("satisfied") end
-    local core = hgetall_to_table(raw)
 
     if remaining == 0
        and core.lifecycle_phase == "runnable"

--- a/lua/flow.lua
+++ b/lua/flow.lua
@@ -511,9 +511,16 @@ end)
 -- Resolve one dependency edge: satisfied (upstream success) or impossible
 -- (upstream failed/cancelled/expired). Updates child eligibility.
 --
--- KEYS (9): exec_core, deps_meta, unresolved_set, dep_hash,
---           eligible_zset, terminal_zset, blocked_deps_zset,
---           attempt_hash, stream_meta
+-- On satisfaction, if the edge was staged with a non-empty
+-- `data_passing_ref`, atomically COPYs the upstream's result key into
+-- the downstream's input_payload key before flipping the child to
+-- eligible. Upstream + downstream are guaranteed co-located on the
+-- same {fp:N} slot by flow membership (RFC-011 §7.3).
+--
+-- KEYS (11): exec_core, deps_meta, unresolved_set, dep_hash,
+--            eligible_zset, terminal_zset, blocked_deps_zset,
+--            attempt_hash, stream_meta, downstream_payload,
+--            upstream_result
 -- ARGV (3): edge_id, upstream_outcome, now_ms
 ---------------------------------------------------------------------------
 redis.register_function('ff_resolve_dependency', function(keys, args)
@@ -527,6 +534,8 @@ redis.register_function('ff_resolve_dependency', function(keys, args)
     blocked_deps_zset = keys[7],
     attempt_hash      = keys[8],
     stream_meta       = keys[9],
+    downstream_payload = keys[10],
+    upstream_result    = keys[11],
   }
 
   local A = {
@@ -553,6 +562,28 @@ redis.register_function('ff_resolve_dependency', function(keys, args)
     local remaining = redis.call("HINCRBY", K.deps_meta,
       "unsatisfied_required_count", -1)
     redis.call("HSET", K.deps_meta, "last_dependency_update_at", A.now_ms)
+
+    -- Server-side data_passing_ref resolution (Batch C item 3). When the
+    -- edge was staged with a non-empty `data_passing_ref`, replace the
+    -- downstream's input_payload with the upstream's result. COPY is a
+    -- single-slot server-internal op (no round-trip to Lua memory) so
+    -- large result payloads don't inflate the FCALL's working set.
+    --
+    -- Write-ordering note (RFC-010 §4.8b): this runs BEFORE the
+    -- eligibility transition below so a crash between the two leaves
+    -- the child blocked (or late-satisfied on reconciler retry) with
+    -- the correct payload rather than eligible with a stale one.
+    --
+    -- Void-completion path: if the upstream called complete(None), the
+    -- result key does not exist — skip silently and leave the child's
+    -- original input_payload intact.
+    local data_injected = ""
+    if is_set(dep.data_passing_ref) then
+      if redis.call("EXISTS", K.upstream_result) == 1 then
+        redis.call("COPY", K.upstream_result, K.downstream_payload, "REPLACE")
+        data_injected = "data_injected"
+      end
+    end
 
     -- Check if all deps now satisfied
     local raw = redis.call("HGETALL", K.core_key)
@@ -588,7 +619,7 @@ redis.register_function('ff_resolve_dependency', function(keys, args)
       redis.call("ZADD", K.eligible_zset, score, core.execution_id or "")
     end
 
-    return ok("satisfied")
+    return ok("satisfied", data_injected)
   end
 
   -- 4. Impossible path (upstream failed/cancelled/expired/skipped)


### PR DESCRIPTION
## Summary

When a dependency edge has a non-empty \`data_passing_ref\`, the engine now atomically copies the upstream's result into the downstream's input_payload at satisfaction time (inside \`ff_resolve_dependency\`). Consumers that opt in no longer need the client-side \"GET result → POST payload\" chain.

Batch C item 3 (issue #9). Engine-side only — submit-CLI migration for media-pipeline is a follow-up.

## Lua

\`ff_resolve_dependency\` KEYS 9 → 11 (+ downstream_payload, + upstream_result). In the satisfied branch, if \`dep.data_passing_ref\` is non-empty AND the upstream result key exists:

\`\`\`lua
redis.call(\"COPY\", upstream_result, downstream_payload, \"REPLACE\")
\`\`\`

- Copy runs BEFORE the eligibility transition (RFC-010 §4.8b ordering).
- Void-completion (upstream \`complete(None)\`) is a no-op — original payload preserved.
- Single-slot safe: upstream/downstream co-locate via flow membership (RFC-011 §7.3).
- Uses server-side COPY, not round-trip GET/SET — large payloads stay out of Lua memory.

Return shape: \`ok(\"satisfied\", \"\" | \"data_injected\")\`.

## Engine wiring

- \`DepOpKeys\` gains an \`upstream_ctx\` field.
- \`partition_router::dispatch_dependency_resolution\` + \`dependency_reconciler\` build keys[10]/[11] on the child's partition.
- \`is_child_skipped_result\` tolerates the new 4-tuple shape without noisy warnings.

## Tests

Two new integration tests (live-Valkey):
- \`test_flow_data_passing_ref_injects_on_satisfy\`: positive path, asserts B's payload equals A's result after satisfy.
- \`test_flow_data_passing_ref_empty_no_copy\`: control, asserts empty \`data_passing_ref\` preserves B's original payload.

All 16 existing \`test_flow_*\` callers updated to thread upstream through the new \`fcall_resolve_dependency\` signature.

## Docs

- \`docs/rfc011-operator-runbook.md\`: new \"Data passing between flow nodes\" section (semantics, void handling, multi-upstream last-writer-wins, COPY design, co-location note).
- \`examples/media-pipeline/README.md\`: engine side landed; submit-CLI migration still pending.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo check --workspace\` clean
- [ ] CI integration tests (e2e_lifecycle) pass with live Valkey

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the core `ff_resolve_dependency` Lua function and its KEYS contract across engine paths, which can impact flow scheduling/eligibility if key ordering or partition assumptions are wrong. Adds e2e coverage, but rollout risk remains due to runtime behavior changes in dependency resolution.
> 
> **Overview**
> Enables **server-side payload passing** between flow nodes: when a dependency edge has a non-empty `data_passing_ref`, `ff_resolve_dependency` now atomically copies the upstream `result` key into the downstream `input_payload` via Valkey `COPY` before unblocking the child.
> 
> This extends the `ff_resolve_dependency` KEYS contract from 9→11 (adding `downstream_payload` and `upstream_result`) and updates all callers (`partition_router` dispatch and `dependency_reconciler`) plus the typed wrapper (`DepOpKeys` now carries an `upstream_ctx`). Tests are updated to pass upstream IDs and new e2e cases assert copy vs no-copy behavior; docs are updated to describe the new semantics and operational expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da828c766445b1878dd2f3d37ee7bcb92b2738a4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->