### PR TITLE
chore(ff-sdk): rename insecure-direct-claim → direct-valkey-claim

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -165,7 +165,7 @@ jobs:
           cargo clippy \
             -p ff-core -p ff-script -p ff-engine -p ff-scheduler \
             -p ff-sdk -p ff-server -p ff-test \
-            --features ff-sdk/insecure-direct-claim \
+            --features ff-sdk/direct-valkey-claim \
             -- -D warnings
 
       - name: cargo clippy (ferriskey, all targets, no features)
@@ -191,7 +191,7 @@ jobs:
           cargo test \
             -p ff-core -p ff-script -p ff-engine -p ff-scheduler \
             -p ff-sdk -p ff-server \
-            --features ff-sdk/insecure-direct-claim
+            --features ff-sdk/direct-valkey-claim
 
       - name: Integration tests (serial)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           cargo clippy \
             -p ff-core -p ff-script -p ff-engine -p ff-scheduler \
             -p ff-sdk -p ff-server -p ff-test \
-            --features ff-sdk/insecure-direct-claim \
+            --features ff-sdk/direct-valkey-claim \
             -- -D warnings
       - name: cargo clippy (ferriskey all targets, no features)
         run: cargo clippy -p ferriskey --all-targets -- -D warnings
@@ -105,7 +105,7 @@ jobs:
           cargo test \
             -p ff-core -p ff-script -p ff-engine -p ff-scheduler \
             -p ff-sdk -p ff-server \
-            --features ff-sdk/insecure-direct-claim
+            --features ff-sdk/direct-valkey-claim
       - name: e2e tests (serial)
         run: cargo test -p ff-test -- --test-threads=1
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cargo run --bin submit -- --issue "Write a Rust function that checks if a string
 The SDK's `claim_next()` method bypasses budget/quota admission control and is gated behind a feature flag. Enable it explicitly:
 
 ```toml
-ff-sdk = { path = "crates/ff-sdk", features = ["insecure-direct-claim"] }
+ff-sdk = { path = "crates/ff-sdk", features = ["direct-valkey-claim"] }
 ```
 
 For production deployments, use the Scheduler (`ff-scheduler`) which enforces admission control before issuing claim grants. The direct claim path is intended for development, testing, and trusted single-worker setups.

--- a/benches/harness/Cargo.toml
+++ b/benches/harness/Cargo.toml
@@ -47,7 +47,7 @@ path = "src/bin/cap_routed.rs"
 
 [dependencies]
 ff-core = { path = "../../crates/ff-core" }
-ff-sdk = { path = "../../crates/ff-sdk", features = ["insecure-direct-claim"] }
+ff-sdk = { path = "../../crates/ff-sdk", features = ["direct-valkey-claim"] }
 ferriskey = { path = "../../ferriskey" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal", "sync"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/benches/perf-invest/review-r2-w2.md
+++ b/benches/perf-invest/review-r2-w2.md
@@ -61,8 +61,7 @@ Two concrete harms from the unnecessary promotion:
 
 **Status:** fixed at `4a7a149`. `pub(crate) fn new` restored; `dead_code`
 allow dropped (call sites are live). Clippy + ff-sdk + ff-test green
-across `--no-default-features`, default, and `--features
-direct-valkey-claim`.
+across `--no-default-features`, default, and `--features direct-valkey-claim`.
 
 ## §3 c545664 — `pub claim_from_grant`
 

--- a/benches/perf-invest/review-r2-w2.md
+++ b/benches/perf-invest/review-r2-w2.md
@@ -62,7 +62,7 @@ Two concrete harms from the unnecessary promotion:
 **Status:** fixed at `4a7a149`. `pub(crate) fn new` restored; `dead_code`
 allow dropped (call sites are live). Clippy + ff-sdk + ff-test green
 across `--no-default-features`, default, and `--features
-insecure-direct-claim`.
+direct-valkey-claim`.
 
 ## §3 c545664 — `pub claim_from_grant`
 

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "FlowFabric worker SDK — public API for worker authors"
 
 [features]
-insecure-direct-claim = []
+direct-valkey-claim = []
 
 # Re-exports of ferriskey feature flags. Consumers opt in on ff-sdk and
 # the flag propagates to the underlying ferriskey crate. OFF by default

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -40,9 +40,9 @@
 //! }
 //! ```
 //!
-//! # Migration: `insecure-direct-claim` → scheduler-issued grants
+//! # Migration: `direct-valkey-claim` → scheduler-issued grants
 //!
-//! The `insecure-direct-claim` cargo feature — which gates
+//! The `direct-valkey-claim` cargo feature — which gates
 //! [`FlowFabricWorker::claim_next`] — is **deprecated** in favour of
 //! the pair of scheduler-issued grant entry points:
 //!

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-#[cfg(feature = "insecure-direct-claim")]
+#[cfg(feature = "direct-valkey-claim")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,15 +17,20 @@ use crate::SdkError;
 /// FlowFabric worker — connects to Valkey, claims executions, and provides
 /// the worker-facing API.
 ///
-/// # Admission Control
+/// # Admission control
 ///
-/// **`claim_next()` bypasses budget and quota admission checks.** The SDK's
-/// inline claim path reads the eligible ZSET directly and issues claim grants
-/// without consulting budget (`{b:M}`) or quota (`{q:K}`) policies. In
-/// production deployments, use the Scheduler (`ff-scheduler`) which enforces
-/// admission control (budget breach check, quota sliding-window check,
-/// concurrency cap) before issuing claim grants. The SDK's inline claim is
-/// suitable for trusted workers, development, and testing.
+/// `claim_next()` lives behind the `direct-valkey-claim` feature flag and
+/// **bypasses the scheduler's admission controls**: it reads the eligible
+/// ZSET directly and mints its own claim grant without consulting budget
+/// (`{b:M}`) or quota (`{q:K}`) policies. Default-off. Intended for
+/// benchmarks, tests, and single-tenant development where the scheduler
+/// hop is measurement noise, not for production.
+///
+/// For production deployments, go through the scheduler's HTTP claim
+/// endpoint instead (see [`FlowFabricWorker::claim_via_server`] in the
+/// follow-up PR). The scheduler enforces budget breach, quota
+/// sliding-window, concurrency cap, and capability-match checks before
+/// issuing grants.
 ///
 /// # Usage
 ///
@@ -53,15 +58,15 @@ pub struct FlowFabricWorker {
     /// `ff_issue_claim_grant` on every claim. BTreeSet sorting is critical:
     /// Lua's `ff_issue_claim_grant` relies on a stable CSV form for
     /// reproducible logs and tests.
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     worker_capabilities_csv: String,
     /// 8-hex FNV-1a digest of `worker_capabilities_csv`. Used in
     /// per-mismatch logs so the 4KB CSV never echoes on every reject
     /// during an incident. Full CSV logged once at connect-time WARN for
     /// cross-reference. Mirrors `ff-scheduler::claim::worker_caps_digest`.
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     worker_capabilities_hash: String,
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     lane_index: AtomicUsize,
     /// Concurrency cap for in-flight tasks. Permits are acquired or
     /// transferred by [`claim_next`] (feature-gated),
@@ -85,14 +90,14 @@ pub struct FlowFabricWorker {
     /// targets (wasm32, i686) `usize` is `u32` and wraps after ~4 years
     /// at 1 poll/sec — acceptable; on wrap, the modulo preserves
     /// correctness because the sequence simply restarts a new cycle.
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     scan_cursor: AtomicUsize,
 }
 
 /// Number of partitions scanned per `claim_next()` poll. Keeps idle Valkey
 /// load at O(PARTITION_SCAN_CHUNK) per worker-second instead of
 /// O(num_flow_partitions).
-#[cfg(feature = "insecure-direct-claim")]
+#[cfg(feature = "direct-valkey-claim")]
 const PARTITION_SCAN_CHUNK: usize = 32;
 
 impl FlowFabricWorker {
@@ -213,7 +218,7 @@ impl FlowFabricWorker {
             "FlowFabricWorker connected"
         );
 
-        #[cfg(feature = "insecure-direct-claim")]
+        #[cfg(feature = "direct-valkey-claim")]
         let scan_cursor_init = scan_cursor_seed(
             config.worker_instance_id.as_str(),
             partition_config.num_flow_partitions.max(1) as usize,
@@ -235,7 +240,7 @@ impl FlowFabricWorker {
         //     loudly at connect instead of silently mis-routing forever.
         // Reject at boot so operator misconfig is loud, symmetric with the
         // scheduler path.
-        #[cfg(feature = "insecure-direct-claim")]
+        #[cfg(feature = "direct-valkey-claim")]
         for cap in &config.capabilities {
             if cap.is_empty() {
                 return Err(SdkError::Config(
@@ -260,7 +265,7 @@ impl FlowFabricWorker {
                 )));
             }
         }
-        #[cfg(feature = "insecure-direct-claim")]
+        #[cfg(feature = "direct-valkey-claim")]
         let worker_capabilities_csv: String = {
             let set: std::collections::BTreeSet<&str> = config
                 .capabilities
@@ -291,12 +296,12 @@ impl FlowFabricWorker {
         // CSV. Shared helper — ff-scheduler uses the same one for its
         // own per-mismatch logs, so cross-component log lines are
         // diffable against each other.
-        #[cfg(feature = "insecure-direct-claim")]
+        #[cfg(feature = "direct-valkey-claim")]
         let worker_capabilities_hash = ff_core::hash::fnv1a_xor8hex(&worker_capabilities_csv);
 
         // Full CSV logged once at connect so per-mismatch logs (which
         // carry only the 8-hex hash) can be cross-referenced by ops.
-        #[cfg(feature = "insecure-direct-claim")]
+        #[cfg(feature = "direct-valkey-claim")]
         if !worker_capabilities_csv.is_empty() {
             tracing::info!(
                 worker_instance_id = %config.worker_instance_id,
@@ -338,7 +343,7 @@ impl FlowFabricWorker {
         // `budget_policies_index` / `flow_index` / `deps_all_edges`:
         // operations stay atomic per command, the index is the
         // cluster-wide enumeration surface.
-        #[cfg(feature = "insecure-direct-claim")]
+        #[cfg(feature = "direct-valkey-claim")]
         {
             let caps_key = ff_core::keys::worker_caps_key(&config.worker_instance_id);
             let index_key = ff_core::keys::workers_index_key();
@@ -398,14 +403,14 @@ impl FlowFabricWorker {
             client,
             config,
             partition_config,
-            #[cfg(feature = "insecure-direct-claim")]
+            #[cfg(feature = "direct-valkey-claim")]
             worker_capabilities_csv,
-            #[cfg(feature = "insecure-direct-claim")]
+            #[cfg(feature = "direct-valkey-claim")]
             worker_capabilities_hash,
-            #[cfg(feature = "insecure-direct-claim")]
+            #[cfg(feature = "direct-valkey-claim")]
             lane_index: AtomicUsize::new(0),
             concurrency_semaphore,
-            #[cfg(feature = "insecure-direct-claim")]
+            #[cfg(feature = "direct-valkey-claim")]
             scan_cursor: AtomicUsize::new(scan_cursor_init),
         })
     }
@@ -439,9 +444,12 @@ impl FlowFabricWorker {
     /// 4. Read execution payload + tags
     /// 5. Return a [`ClaimedTask`] with auto lease renewal
     ///
-    /// **This bypasses budget/quota admission control.** Use the Scheduler
-    /// (`ff-scheduler`) for production deployments. Enable with:
-    /// `ff-sdk = { ..., features = ["insecure-direct-claim"] }`
+    /// Gated behind the `direct-valkey-claim` feature — bypasses the
+    /// scheduler's budget / quota / capability admission checks. Enable
+    /// with `ff-sdk = { ..., features = ["direct-valkey-claim"] }` when
+    /// the scheduler hop would be measurement noise (benches) or when
+    /// the test harness needs a deterministic worker-local path. Prefer
+    /// the scheduler-routed HTTP claim path in production.
     ///
     /// # `None` semantics
     ///
@@ -458,7 +466,7 @@ impl FlowFabricWorker {
     /// when work lives on partitions outside the current window.
     ///
     /// Returns `Err` on Valkey errors or script failures.
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     pub async fn claim_next(&self) -> Result<Option<ClaimedTask>, SdkError> {
         // Enforce max_concurrent_tasks: try to acquire a semaphore permit.
         // try_acquire returns immediately — if no permits available, the worker
@@ -618,7 +626,7 @@ impl FlowFabricWorker {
         Ok(None)
     }
 
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     async fn issue_claim_grant(
         &self,
         execution_id: &ExecutionId,
@@ -674,7 +682,7 @@ impl FlowFabricWorker {
     /// already went terminal between pick and block) are logged and the
     /// outer loop simply `continue`s to the next partition. Parity with
     /// ff-scheduler::Scheduler::block_candidate.
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     async fn block_route(
         &self,
         execution_id: &ExecutionId,
@@ -729,7 +737,7 @@ impl FlowFabricWorker {
     /// `ff_claim_execution` and returns a `ClaimedTask` with auto
     /// lease renewal.
     ///
-    /// Previously gated behind `insecure-direct-claim`; ungated so
+    /// Previously gated behind `direct-valkey-claim`; ungated so
     /// the public [`claim_from_grant`] entry point can reuse the
     /// same FCALL plumbing. The method stays private — external
     /// callers use `claim_from_grant`.
@@ -903,7 +911,7 @@ impl FlowFabricWorker {
     /// this worker. The intended production entry point: pair with
     /// [`ff_scheduler::Scheduler::claim_for_worker`] to flow
     /// scheduler-issued grants into the SDK without enabling the
-    /// `insecure-direct-claim` feature (which bypasses budget/quota
+    /// `direct-valkey-claim` feature (which bypasses budget/quota
     /// admission control).
     ///
     /// The worker's concurrency semaphore is checked BEFORE the FCALL
@@ -1045,7 +1053,7 @@ impl FlowFabricWorker {
     /// Low-level resume claim. Invokes `ff_claim_resumed_execution`
     /// and returns a `ClaimedTask` bound to the resumed attempt.
     ///
-    /// Previously gated behind `insecure-direct-claim`; ungated so the
+    /// Previously gated behind `direct-valkey-claim`; ungated so the
     /// public [`claim_from_reclaim_grant`] entry point can reuse it.
     /// The method stays private — external callers use
     /// `claim_from_reclaim_grant`.
@@ -1197,7 +1205,7 @@ impl FlowFabricWorker {
     }
 
     /// Read payload + execution_kind + tags from exec_core. Previously
-    /// gated behind `insecure-direct-claim`; now shared by the
+    /// gated behind `direct-valkey-claim`; now shared by the
     /// feature-gated inline claim path and the public
     /// `claim_from_reclaim_grant` entry point.
     async fn read_execution_context(
@@ -1336,14 +1344,14 @@ impl FlowFabricWorker {
         crate::task::parse_signal_result(&raw)
     }
 
-    #[cfg(feature = "insecure-direct-claim")]
+    #[cfg(feature = "direct-valkey-claim")]
     fn next_lane(&self) -> LaneId {
         let idx = self.lane_index.fetch_add(1, Ordering::Relaxed) % self.config.lanes.len();
         self.config.lanes[idx].clone()
     }
 }
 
-#[cfg(feature = "insecure-direct-claim")]
+#[cfg(feature = "direct-valkey-claim")]
 fn is_retryable_claim_error(err: &ff_script::error::ScriptError) -> bool {
     use ff_core::error::ErrorClass;
     matches!(
@@ -1356,7 +1364,7 @@ fn is_retryable_claim_error(err: &ff_script::error::ScriptError) -> bool {
 /// instance id with FNV-1a to place distinct worker processes on different
 /// partition windows from their first poll. Zero is valid for single-worker
 /// clusters but spreads work in multi-worker deployments.
-#[cfg(feature = "insecure-direct-claim")]
+#[cfg(feature = "direct-valkey-claim")]
 fn scan_cursor_seed(worker_instance_id: &str, num_partitions: usize) -> usize {
     if num_partitions == 0 {
         return 0;
@@ -1364,7 +1372,7 @@ fn scan_cursor_seed(worker_instance_id: &str, num_partitions: usize) -> usize {
     (ff_core::hash::fnv1a_u64(worker_instance_id.as_bytes()) as usize) % num_partitions
 }
 
-#[cfg(feature = "insecure-direct-claim")]
+#[cfg(feature = "direct-valkey-claim")]
 fn extract_first_array_string(value: &Value) -> Option<String> {
     match value {
         Value::Array(arr) if !arr.is_empty() => match &arr[0] {
@@ -1406,7 +1414,7 @@ async fn read_partition_config(client: &Client) -> Result<PartitionConfig, SdkEr
     })
 }
 
-#[cfg(all(test, feature = "insecure-direct-claim"))]
+#[cfg(all(test, feature = "direct-valkey-claim"))]
 mod scan_cursor_tests {
     use super::scan_cursor_seed;
 

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -26,11 +26,10 @@ use crate::SdkError;
 /// benchmarks, tests, and single-tenant development where the scheduler
 /// hop is measurement noise, not for production.
 ///
-/// For production deployments, go through the scheduler's HTTP claim
-/// endpoint instead (see [`FlowFabricWorker::claim_via_server`] in the
-/// follow-up PR). The scheduler enforces budget breach, quota
-/// sliding-window, concurrency cap, and capability-match checks before
-/// issuing grants.
+/// For production deployments, consume scheduler-issued grants via
+/// [`FlowFabricWorker::claim_from_grant`] — the scheduler enforces
+/// budget breach, quota sliding-window, concurrency cap, and
+/// capability-match checks before issuing grants.
 ///
 /// # Usage
 ///

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -20,7 +20,7 @@ ff-core = { workspace = true }
 ff-engine = { workspace = true }
 ff-scheduler = { workspace = true }
 ff-script = { workspace = true }
-ff-sdk = { workspace = true, features = ["insecure-direct-claim"] }
+ff-sdk = { workspace = true, features = ["direct-valkey-claim"] }
 ferriskey = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4435,7 +4435,7 @@ async fn test_scheduler_claim_priority_ordering() {
 /// End-to-end: `Scheduler::claim_for_worker` → `FlowFabricWorker::
 /// claim_from_grant` → live `ClaimedTask`. This is the production
 /// entry path for consumers that cannot enable the
-/// `insecure-direct-claim` feature (cairn, in particular) — the
+/// `direct-valkey-claim` feature (cairn, in particular) — the
 /// scheduler does admission control and hands off a grant; the SDK
 /// consumes the grant without touching the eligible ZSET directly.
 ///

--- a/docs/rfc011-migration-for-consumers.md
+++ b/docs/rfc011-migration-for-consumers.md
@@ -17,7 +17,7 @@ version floor, operator runbook, partition-collisions probe) is in flight.
 |---|---|---|
 | 1 | `ExecutionId` construction | 1 line per mint site |
 | 2 | `PartitionConfig` field rename | 1 line per field reference + env var rename |
-| 3 | Worker claim flow (replace `insecure-direct-claim`) | Rewrite `claim_next`-based code to grant-based path |
+| 3 | Worker claim flow (replace `direct-valkey-claim`) | Rewrite `claim_next`-based code to grant-based path |
 | 4 | `parse_report_usage_result` | Delete parallel parser, import FF's |
 | 5 | `usage_dedup_key` helper | Replace hardcoded `format!` sites |
 | 6 | Valkey 8.0 minimum (future, phase 5) | Upgrade Valkey if on 7.x |
@@ -122,10 +122,10 @@ constructs `Partition { family: PartitionFamily::Execution, ... }` continues
 to work; both variants produce the `{fp:N}` hash tag and route via
 `num_flow_partitions`.
 
-## Step 3 — Worker claim flow (replace `insecure-direct-claim`)
+## Step 3 — Worker claim flow (replace `direct-valkey-claim`)
 
 **FF change:** two new public entry points on `FlowFabricWorker` replace the
-`insecure-direct-claim` feature-gated direct-FCALL path. They acquire the
+`direct-valkey-claim` feature-gated direct-FCALL path. They acquire the
 worker's concurrency permit before the FCALL so a saturated worker never
 consumes a grant.
 
@@ -190,14 +190,14 @@ match worker.claim_from_grant(lane.clone(), grant).await {
 `use_claim_resumed_execution`. The reclaim grant flow is symmetric.
 
 **New error variant:** `SdkError::WorkerAtCapacity` is retryable. The old
-`insecure-direct-claim` path returned `Ok(None)` on saturation; the new path
+`direct-valkey-claim` path returned `Ok(None)` on saturation; the new path
 returns `Err(WorkerAtCapacity)` with `is_retryable() == true` so callers can
 opt into structured retry. Both `claim_from_grant` and
 `claim_from_reclaim_grant` return this variant under saturation.
 
 **Retiring the feature flag:** after this step, your crate can drop
-`insecure-direct-claim` from its `ff-sdk` feature list and the associated
-`#[cfg(feature = "insecure-direct-claim")]` branches. The ungated grant path
+`direct-valkey-claim` from its `ff-sdk` feature list and the associated
+`#[cfg(feature = "direct-valkey-claim")]` branches. The ungated grant path
 is always available.
 
 ## Step 4 — `parse_report_usage_result` (drop your parallel parser)
@@ -294,7 +294,7 @@ grep -rn 'num_execution_partitions\|FF_EXEC_PARTITIONS' src/
 grep -rn 'ff:usagededup:' src/
 # expect: zero raw format! sites (helper uses are fine)
 
-grep -rn '"insecure-direct-claim"' Cargo.toml
+grep -rn '"direct-valkey-claim"' Cargo.toml
 # expect: feature flag removed from your ff-sdk dep
 
 # 2. Build + test

--- a/docs/rfc011-migration-for-consumers.md
+++ b/docs/rfc011-migration-for-consumers.md
@@ -124,6 +124,12 @@ to work; both variants produce the `{fp:N}` hash tag and route via
 
 ## Step 3 — Worker claim flow (replace `direct-valkey-claim`)
 
+> **Rename note:** the feature flag previously named
+> `insecure-direct-claim` was hard-renamed to `direct-valkey-claim`
+> (see Batch C PR-A). If your `Cargo.toml` or source still references
+> `insecure-direct-claim`, update to `direct-valkey-claim` before
+> following the rest of this step.
+
 **FF change:** two new public entry points on `FlowFabricWorker` replace the
 `direct-valkey-claim` feature-gated direct-FCALL path. They acquire the
 worker's concurrency permit before the FCALL so a saturated worker never
@@ -294,8 +300,10 @@ grep -rn 'num_execution_partitions\|FF_EXEC_PARTITIONS' src/
 grep -rn 'ff:usagededup:' src/
 # expect: zero raw format! sites (helper uses are fine)
 
-grep -rn '"direct-valkey-claim"' Cargo.toml
-# expect: feature flag removed from your ff-sdk dep
+grep -rnE '"(direct-valkey-claim|insecure-direct-claim)"' Cargo.toml
+# expect: both names removed from your ff-sdk dep
+# (insecure-direct-claim was the pre-Batch-C name; direct-valkey-claim
+#  is its post-rename form — neither should survive this migration.)
 
 # 2. Build + test
 cargo check --workspace

--- a/examples/coding-agent/Cargo.toml
+++ b/examples/coding-agent/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/approve.rs"
 
 [dependencies]
 ff-core = { path = "../../crates/ff-core" }
-ff-sdk = { path = "../../crates/ff-sdk", features = ["insecure-direct-claim"] }
+ff-sdk = { path = "../../crates/ff-sdk", features = ["direct-valkey-claim"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/media-pipeline/Cargo.toml
+++ b/examples/media-pipeline/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/bin/review.rs"
 
 [dependencies]
 ff-core = { path = "../../crates/ff-core" }
-ff-sdk = { path = "../../crates/ff-sdk", features = ["insecure-direct-claim"] }
+ff-sdk = { path = "../../crates/ff-sdk", features = ["direct-valkey-claim"] }
 ferriskey = { path = "../../ferriskey" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util", "io-std", "signal", "fs", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/media-pipeline/README.md
+++ b/examples/media-pipeline/README.md
@@ -157,7 +157,7 @@ FF_MAX_CONCURRENT_STREAM_OPS=2 cargo run -p ff-server &
 ## V1 shortcuts (documented)
 
 - **Client-side data passing (legacy, to be migrated).** The submit CLI currently waits for each upstream execution to complete, reads the raw result bytes from `GET /v1/executions/{id}/result`, and embeds them as the next execution's `input_payload`. Batch C item 3 has landed server-side auto-injection: when the flow edge is staged with a non-empty `data_passing_ref`, the engine atomically copies the upstream's `result` into the downstream's `input_payload` at satisfaction time inside `ff_resolve_dependency`. The submit CLI has not yet been migrated to the server-side path — tracked as a follow-up. See `docs/rfc011-operator-runbook.md` §"Data passing between flow nodes".
-- **`insecure-direct-claim` feature.** Workers use the direct Valkey claim path gated by the `insecure-direct-claim` feature on `ff-sdk`. Batch C will replace this with a proper scheduler-mediated claim API.
+- **`direct-valkey-claim` feature.** Workers use the direct Valkey claim path gated by the `direct-valkey-claim` feature on `ff-sdk`. Batch C will replace this with a proper scheduler-mediated claim API.
 
 ## Submit crash recovery (v1)
 


### PR DESCRIPTION
## Summary

The feature that gates the SDK's in-crate claim path was named \`insecure-direct-claim\`. The word \"insecure\" suggested a security vulnerability; in practice the path is fine for benches, tests, and single-tenant development — it just skips the scheduler's budget/quota/capability admission controls. Rename describes what it actually does: claim issued directly against Valkey, bypassing the scheduler's HTTP claim endpoint.

Batch C item 2, PR-A (of two). PR-B adds the scheduler-routed HTTP claim endpoint + SDK \`claim_via_server\` + example migrations.

## Scope

Mechanical rename — no behavior change. **Hard-rename, no deprecation alias**: cairn-fabric coordinates a sha pin update when they pick up the new name (per peer-team discussion).

Docstring updates on \`claim_next\` + type-level docs: reframe from \"insecure\" → \"bypasses scheduler admission controls\"; point at \`claim_via_server\` (PR-B) as the production entry point.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean (feature off)
- [x] \`cargo clippy -p ff-sdk --all-targets --features direct-valkey-claim -- -D warnings\` clean (feature on)
- [x] \`cargo test -p ff-sdk --lib\` — 29 pass (feature off)
- [x] \`cargo test -p ff-sdk --lib --features direct-valkey-claim\` — 33 pass (feature on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hard-renames a public `ff-sdk` feature flag with no compatibility alias, so downstream crates and CI workflows will fail to build until updated. Code behavior is intended unchanged, but the breadth of mechanical edits across docs/CI/examples raises small risk of missed reference.
> 
> **Overview**
> Renames the `ff-sdk` feature flag that enables the SDK’s direct Valkey `claim_next()` path from `insecure-direct-claim` to `direct-valkey-claim`, updating all `#[cfg(feature = ...)]` gates accordingly.
> 
> Updates CI/release workflows, workspace/test/bench/example `Cargo.toml` feature lists, and documentation to use the new feature name and to reframe the docs around *bypassing scheduler admission controls* rather than “insecure” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6042f393f28933edde10cd9320e73fa99c821d0b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->