### PR TITLE
feat: scheduler-routed claim endpoint + SDK + example migrations (Batch C item 2 PR-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-engine",
+ "ff-scheduler",
  "ff-script",
  "futures",
  "serde",

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -144,6 +144,71 @@ impl FlowFabricAdminClient {
     /// Rotation is idempotent on the same `(new_kid,
     /// new_secret_hex)` so retries are SAFE even on 504s or
     /// partial failures.
+    /// POST `/v1/workers/{worker_id}/claim` — scheduler-routed claim.
+    ///
+    /// Batch C item 2 PR-B. Swaps the SDK's direct-Valkey claim for a
+    /// server-side one: the request carries lane + identity +
+    /// capabilities + grant TTL; the server runs budget, quota, and
+    /// capability admission via `ff_scheduler::Scheduler::claim_for_worker`
+    /// and returns a `ClaimGrant` on success.
+    ///
+    /// Returns `Ok(None)` when the server responds 204 No Content
+    /// (no eligible execution on the lane). Callers that want to keep
+    /// polling should back off per their claim cadence.
+    pub async fn claim_for_worker(
+        &self,
+        req: ClaimForWorkerRequest,
+    ) -> Result<Option<ClaimForWorkerResponse>, SdkError> {
+        let url = format!(
+            "{}/v1/workers/{}/claim",
+            self.base_url,
+            req.worker_id
+        );
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .map_err(|e| SdkError::Http {
+                source: e,
+                context: "POST /v1/workers/{worker_id}/claim".into(),
+            })?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::NO_CONTENT {
+            return Ok(None);
+        }
+        if status.is_success() {
+            return resp
+                .json::<ClaimForWorkerResponse>()
+                .await
+                .map(Some)
+                .map_err(|e| SdkError::Http {
+                    source: e,
+                    context: "decode claim_for_worker response body".into(),
+                });
+        }
+
+        // Error path — mirror rotate_waitpoint_secret's ErrorBody decode.
+        let status_u16 = status.as_u16();
+        let raw = resp.text().await.map_err(|e| SdkError::Http {
+            source: e,
+            context: format!("read claim_for_worker error body (status {status_u16})"),
+        })?;
+        let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
+        Err(SdkError::AdminApi {
+            status: status_u16,
+            message: parsed
+                .as_ref()
+                .map(|b| b.error.clone())
+                .unwrap_or_else(|| raw.clone()),
+            kind: parsed.as_ref().and_then(|b| b.kind.clone()),
+            retryable: parsed.as_ref().and_then(|b| b.retryable),
+            raw_body: raw,
+        })
+    }
+
     pub async fn rotate_waitpoint_secret(
         &self,
         req: RotateWaitpointSecretRequest,
@@ -245,6 +310,87 @@ struct AdminErrorBody {
     kind: Option<String>,
     #[serde(default)]
     retryable: Option<bool>,
+}
+
+/// Request body for `POST /v1/workers/{worker_id}/claim`.
+///
+/// Mirrors `ff_server::api::ClaimForWorkerBody` 1:1. `worker_id`
+/// goes in the URL path (not the body) but is kept on the struct
+/// for ergonomics — callers don't juggle a separate arg.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimForWorkerRequest {
+    #[serde(skip)]
+    pub worker_id: String,
+    pub lane_id: String,
+    pub worker_instance_id: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Grant TTL in milliseconds. Server rejects 0 or anything over
+    /// 60s (its `CLAIM_GRANT_TTL_MS_MAX`).
+    pub grant_ttl_ms: u64,
+}
+
+/// Response body for `POST /v1/workers/{worker_id}/claim`.
+///
+/// Wire shape of `ff_core::contracts::ClaimGrant`. The core type is
+/// not serde-derived (carries a `Partition` with a non-scalar family
+/// enum) so the SDK decodes into this DTO and reconstructs the core
+/// type via [`Self::into_grant`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClaimForWorkerResponse {
+    pub execution_id: String,
+    pub partition_family: String,
+    pub partition_index: u16,
+    pub grant_key: String,
+    pub expires_at_ms: u64,
+}
+
+impl ClaimForWorkerResponse {
+    /// Convert the wire DTO into a typed
+    /// [`ff_core::contracts::ClaimGrant`] for handoff to
+    /// [`crate::FlowFabricWorker::claim_from_grant`]. Returns
+    /// [`SdkError::AdminApi`] on malformed execution_id / unknown
+    /// partition_family (server and SDK have drifted; fail loud so
+    /// callers don't route to a ghost partition).
+    pub fn into_grant(self) -> Result<ff_core::contracts::ClaimGrant, SdkError> {
+        let execution_id = ff_core::types::ExecutionId::parse(&self.execution_id)
+            .map_err(|e| SdkError::AdminApi {
+                status: 200,
+                message: format!(
+                    "claim_for_worker: server returned malformed execution_id '{}': {e}",
+                    self.execution_id
+                ),
+                kind: Some("malformed_response".to_owned()),
+                retryable: Some(false),
+                raw_body: String::new(),
+            })?;
+        let family = match self.partition_family.as_str() {
+            "flow" => ff_core::partition::PartitionFamily::Flow,
+            "execution" => ff_core::partition::PartitionFamily::Execution,
+            "budget" => ff_core::partition::PartitionFamily::Budget,
+            "quota" => ff_core::partition::PartitionFamily::Quota,
+            other => {
+                return Err(SdkError::AdminApi {
+                    status: 200,
+                    message: format!(
+                        "claim_for_worker: unknown partition_family '{other}'"
+                    ),
+                    kind: Some("malformed_response".to_owned()),
+                    retryable: Some(false),
+                    raw_body: String::new(),
+                });
+            }
+        };
+        Ok(ff_core::contracts::ClaimGrant {
+            execution_id,
+            partition: ff_core::partition::Partition {
+                family,
+                index: self.partition_index,
+            },
+            grant_key: self.grant_key,
+            expires_at_ms: self.expires_at_ms,
+        })
+    }
 }
 
 /// Trim trailing slashes from a base URL so `format!("{base}/v1/...")`

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -117,33 +117,6 @@ impl FlowFabricAdminClient {
         })
     }
 
-    /// Rotate the waitpoint HMAC secret on the server.
-    ///
-    /// Promotes the currently-installed kid to `previous_kid`
-    /// (accepted for the server's configured
-    /// `FF_WAITPOINT_HMAC_GRACE_MS` window) and installs
-    /// `new_secret_hex` under `new_kid` as the new current. Fans
-    /// out across every execution partition. Idempotent: re-running
-    /// with the same `(new_kid, new_secret_hex)` converges.
-    ///
-    /// The server returns 200 if at least one partition rotated OR
-    /// at least one partition was already rotating under a
-    /// concurrent request. See `RotateWaitpointSecretResponse`
-    /// fields for the breakdown.
-    ///
-    /// # Errors
-    ///
-    /// * [`SdkError::AdminApi`] — non-2xx response (400 invalid
-    ///   input, 401 missing/bad bearer, 429 concurrent rotate,
-    ///   500 all partitions failed, 504 server-side timeout).
-    /// * [`SdkError::Http`] — transport error (connect, body
-    ///   decode, client-side timeout).
-    ///
-    /// # Retry semantics
-    ///
-    /// Rotation is idempotent on the same `(new_kid,
-    /// new_secret_hex)` so retries are SAFE even on 504s or
-    /// partial failures.
     /// POST `/v1/workers/{worker_id}/claim` — scheduler-routed claim.
     ///
     /// Batch C item 2 PR-B. Swaps the SDK's direct-Valkey claim for a
@@ -159,11 +132,24 @@ impl FlowFabricAdminClient {
         &self,
         req: ClaimForWorkerRequest,
     ) -> Result<Option<ClaimForWorkerResponse>, SdkError> {
-        let url = format!(
-            "{}/v1/workers/{}/claim",
-            self.base_url,
-            req.worker_id
-        );
+        // Percent-encode `worker_id` in the URL path — `WorkerId` is a
+        // free-form string (could contain `/`, spaces, `%`, etc.) and
+        // splicing it verbatim would produce malformed URLs or
+        // misrouted paths. `Url::path_segments_mut().push` handles the
+        // encoding natively.
+        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| {
+            SdkError::Config(format!("invalid base_url '{}': {e}", self.base_url))
+        })?;
+        {
+            let mut segs = url.path_segments_mut().map_err(|_| {
+                SdkError::Config(format!(
+                    "base_url cannot be a base URL: '{}'",
+                    self.base_url
+                ))
+            })?;
+            segs.extend(&["v1", "workers", &req.worker_id, "claim"]);
+        }
+        let url = url.to_string();
         let resp = self
             .http
             .post(&url)
@@ -209,6 +195,33 @@ impl FlowFabricAdminClient {
         })
     }
 
+    /// Rotate the waitpoint HMAC secret on the server.
+    ///
+    /// Promotes the currently-installed kid to `previous_kid`
+    /// (accepted for the server's configured
+    /// `FF_WAITPOINT_HMAC_GRACE_MS` window) and installs
+    /// `new_secret_hex` under `new_kid` as the new current. Fans
+    /// out across every execution partition. Idempotent: re-running
+    /// with the same `(new_kid, new_secret_hex)` converges.
+    ///
+    /// The server returns 200 if at least one partition rotated OR
+    /// at least one partition was already rotating under a
+    /// concurrent request. See `RotateWaitpointSecretResponse`
+    /// fields for the breakdown.
+    ///
+    /// # Errors
+    ///
+    /// * [`SdkError::AdminApi`] — non-2xx response (400 invalid
+    ///   input, 401 missing/bad bearer, 429 concurrent rotate,
+    ///   500 all partitions failed, 504 server-side timeout).
+    /// * [`SdkError::Http`] — transport error (connect, body
+    ///   decode, client-side timeout).
+    ///
+    /// # Retry semantics
+    ///
+    /// Rotation is idempotent on the same `(new_kid,
+    /// new_secret_hex)` so retries are SAFE even on 504s or
+    /// partial failures.
     pub async fn rotate_waitpoint_secret(
         &self,
         req: RotateWaitpointSecretRequest,
@@ -478,5 +491,57 @@ mod tests {
         let raw = r#"{"rotated": 1, "failed": [], "new_kid": "k1"}"#;
         let r: RotateWaitpointSecretResponse = serde_json::from_str(raw).unwrap();
         assert_eq!(r.in_progress, Vec::<u16>::new());
+    }
+
+    // ── ClaimForWorkerResponse::into_grant ──
+
+    fn sample_claim_response(family: &str) -> ClaimForWorkerResponse {
+        ClaimForWorkerResponse {
+            execution_id: "{fp:5}:11111111-1111-1111-1111-111111111111".to_owned(),
+            partition_family: family.to_owned(),
+            partition_index: 5,
+            grant_key: "ff:exec:{fp:5}:11111111-1111-1111-1111-111111111111:claim_grant".to_owned(),
+            expires_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn into_grant_accepts_all_known_families() {
+        for family in ["flow", "execution", "budget", "quota"] {
+            let g = sample_claim_response(family).into_grant().unwrap_or_else(|e| {
+                panic!("family {family} should parse: {e:?}")
+            });
+            assert_eq!(g.partition.index, 5);
+            assert_eq!(g.expires_at_ms, 1_700_000_000_000);
+        }
+    }
+
+    #[test]
+    fn into_grant_rejects_unknown_family() {
+        let resp = sample_claim_response("nonsense");
+        let err = resp.into_grant().unwrap_err();
+        match err {
+            SdkError::AdminApi { message, kind, .. } => {
+                assert!(message.contains("unknown partition_family"),
+                    "msg: {message}");
+                assert_eq!(kind.as_deref(), Some("malformed_response"));
+            }
+            other => panic!("expected AdminApi, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn into_grant_rejects_malformed_execution_id() {
+        let mut resp = sample_claim_response("flow");
+        resp.execution_id = "not-a-valid-eid".to_owned();
+        let err = resp.into_grant().unwrap_err();
+        match err {
+            SdkError::AdminApi { message, kind, .. } => {
+                assert!(message.contains("malformed execution_id"),
+                    "msg: {message}");
+                assert_eq!(kind.as_deref(), Some("malformed_response"));
+            }
+            other => panic!("expected AdminApi, got {other:?}"),
+        }
     }
 }

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -952,6 +952,30 @@ impl FlowFabricWorker {
     ///
     /// [`ClaimGrant`]: ff_core::contracts::ClaimGrant
     /// [`ff_scheduler::Scheduler::claim_for_worker`]: https://docs.rs/ff-scheduler
+    pub async fn claim_from_grant(
+        &self,
+        lane: LaneId,
+        grant: ff_core::contracts::ClaimGrant,
+    ) -> Result<ClaimedTask, SdkError> {
+        // Semaphore check FIRST. If the worker is saturated we must
+        // surface the condition to the caller without touching the
+        // grant — silently returning Ok(None) (as claim_next does)
+        // would drop a grant the scheduler has already committed work
+        // to issuing, wasting the slot until its TTL elapses.
+        let permit = self
+            .concurrency_semaphore
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| SdkError::WorkerAtCapacity)?;
+
+        let now = TimestampMs::now();
+        let mut task = self
+            .claim_execution(&grant.execution_id, &lane, &grant.partition, now)
+            .await?;
+        task.set_concurrency_permit(permit);
+        Ok(task)
+    }
+
     /// Scheduler-routed claim: POST the server's
     /// `/v1/workers/{id}/claim`, then chain to
     /// [`Self::claim_from_grant`].
@@ -988,30 +1012,6 @@ impl FlowFabricWorker {
         };
         let grant = resp.into_grant()?;
         self.claim_from_grant(lane.clone(), grant).await.map(Some)
-    }
-
-    pub async fn claim_from_grant(
-        &self,
-        lane: LaneId,
-        grant: ff_core::contracts::ClaimGrant,
-    ) -> Result<ClaimedTask, SdkError> {
-        // Semaphore check FIRST. If the worker is saturated we must
-        // surface the condition to the caller without touching the
-        // grant — silently returning Ok(None) (as claim_next does)
-        // would drop a grant the scheduler has already committed work
-        // to issuing, wasting the slot until its TTL elapses.
-        let permit = self
-            .concurrency_semaphore
-            .clone()
-            .try_acquire_owned()
-            .map_err(|_| SdkError::WorkerAtCapacity)?;
-
-        let now = TimestampMs::now();
-        let mut task = self
-            .claim_execution(&grant.execution_id, &lane, &grant.partition, now)
-            .await?;
-        task.set_concurrency_permit(permit);
-        Ok(task)
     }
 
     /// Consume a [`ReclaimGrant`] and transition the granted

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -952,6 +952,44 @@ impl FlowFabricWorker {
     ///
     /// [`ClaimGrant`]: ff_core::contracts::ClaimGrant
     /// [`ff_scheduler::Scheduler::claim_for_worker`]: https://docs.rs/ff-scheduler
+    /// Scheduler-routed claim: POST the server's
+    /// `/v1/workers/{id}/claim`, then chain to
+    /// [`Self::claim_from_grant`].
+    ///
+    /// Batch C item 2 PR-B. This is the production entry point —
+    /// budget + quota + capability admission run server-side inside
+    /// `ff_scheduler::Scheduler::claim_for_worker`. Callers don't
+    /// enable the `direct-valkey-claim` feature.
+    ///
+    /// Returns `Ok(None)` when the server says no eligible execution
+    /// (HTTP 204). Callers typically back off by
+    /// `config.claim_poll_interval_ms` and try again, same cadence
+    /// as the direct-claim path's `Ok(None)`.
+    ///
+    /// The `admin` client is the established HTTP surface
+    /// (`FlowFabricAdminClient`) reused here so workers don't keep a
+    /// second reqwest client around. Build once at worker boot and
+    /// hand in by reference on every claim.
+    pub async fn claim_via_server(
+        &self,
+        admin: &crate::FlowFabricAdminClient,
+        lane: &LaneId,
+        grant_ttl_ms: u64,
+    ) -> Result<Option<ClaimedTask>, SdkError> {
+        let req = crate::admin::ClaimForWorkerRequest {
+            worker_id: self.config.worker_id.to_string(),
+            lane_id: lane.to_string(),
+            worker_instance_id: self.config.worker_instance_id.to_string(),
+            capabilities: self.config.capabilities.clone(),
+            grant_ttl_ms,
+        };
+        let Some(resp) = admin.claim_for_worker(req).await? else {
+            return Ok(None);
+        };
+        let grant = resp.into_grant()?;
+        self.claim_from_grant(lane.clone(), grant).await.map(Some)
+    }
+
     pub async fn claim_from_grant(
         &self,
         lane: LaneId,

--- a/crates/ff-server/Cargo.toml
+++ b/crates/ff-server/Cargo.toml
@@ -20,6 +20,7 @@ iam = ["ferriskey/iam"]
 ff-core = { workspace = true }
 ff-script = { workspace = true }
 ff-engine = { workspace = true }
+ff-scheduler = { workspace = true }
 ferriskey = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 tracing = { workspace = true }

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -622,11 +622,37 @@ impl From<ff_core::contracts::ClaimGrant> for ClaimGrantDto {
 /// execution on a multi-hour grant.
 const CLAIM_GRANT_TTL_MS_MAX: u64 = 60_000;
 
+/// Reject empty / whitespace / non-printable identifiers the way
+/// [`LaneId::try_new`] does for lanes. WorkerId + WorkerInstanceId
+/// feed into scheduler scan jitter + Valkey key construction; silent
+/// acceptance of "" or "w\nork" would either mis-key or mis-hash.
+fn validate_identifier(field: &str, value: &str) -> Result<(), ApiError> {
+    if value.is_empty() {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "{field}: must not be empty"
+        ))));
+    }
+    if value.len() > 256 {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "{field}: exceeds 256 bytes (got {})",
+            value.len()
+        ))));
+    }
+    if value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "{field}: must not contain whitespace or control characters"
+        ))));
+    }
+    Ok(())
+}
+
 async fn claim_for_worker(
     State(server): State<Arc<Server>>,
     Path(worker_id): Path<String>,
     AppJson(body): AppJson<ClaimForWorkerBody>,
 ) -> Result<Response, ApiError> {
+    validate_identifier("worker_id", &worker_id)?;
+    validate_identifier("worker_instance_id", &body.worker_instance_id)?;
     let worker_id = WorkerId::new(worker_id);
     let worker_instance_id = WorkerInstanceId::new(body.worker_instance_id);
     let lane = LaneId::try_new(body.lane_id).map_err(|e| {

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -192,6 +192,11 @@ pub fn router(server: Arc<Server>, cors_origins: &[String], api_token: Option<St
         .route("/v1/executions/{id}/priority", put(change_priority))
         .route("/v1/executions/{id}/replay", post(replay_execution))
         .route("/v1/executions/{id}/revoke-lease", post(revoke_lease))
+        // Scheduler-routed claim (Batch C item 2). Worker POSTs lane +
+        // identity + capabilities; server runs budget/quota/capability
+        // admission via ff-scheduler and returns a ClaimGrant on
+        // success (204 No Content when no eligible execution).
+        .route("/v1/workers/{worker_id}/claim", post(claim_for_worker))
         // Stream read + tail (RFC-006 #2)
         .route(
             "/v1/executions/{id}/attempts/{idx}/stream",
@@ -556,6 +561,98 @@ async fn revoke_lease(
 ) -> Result<Json<RevokeLeaseResult>, ApiError> {
     let eid = parse_execution_id(&id)?;
     Ok(Json(server.revoke_lease(&eid).await?))
+}
+
+// ── Scheduler-routed claim (Batch C item 2 PR-B) ──
+//
+// The server exposes the scheduler's `claim_for_worker` cycle via
+// HTTP so ff-sdk workers can acquire claim grants without enabling
+// the `direct-valkey-claim` feature. The request body carries lane +
+// identity + capabilities; the server returns a serialized
+// `ClaimGrant` (or 204 No Content when no eligible execution exists).
+
+/// Request body for `POST /v1/workers/{worker_id}/claim`.
+#[derive(Deserialize)]
+struct ClaimForWorkerBody {
+    lane_id: String,
+    worker_instance_id: String,
+    /// Capability tokens this worker advertises. Sorted + validated
+    /// on the scheduler side; any non-printable/CSV-breaking token
+    /// surfaces as 400.
+    #[serde(default)]
+    capabilities: Vec<String>,
+    /// Grant TTL in milliseconds. Bounded so a worker can't request a
+    /// multi-hour grant and squat the execution.
+    grant_ttl_ms: u64,
+}
+
+/// Wire shape for `ff_core::contracts::ClaimGrant`. Core type is not
+/// serde-derived (it carries a `Partition` with a non-scalar family
+/// enum); keep a DTO here so we own the HTTP shape without touching
+/// the core contract.
+#[derive(Serialize)]
+struct ClaimGrantDto {
+    execution_id: String,
+    partition_family: &'static str,
+    partition_index: u16,
+    grant_key: String,
+    expires_at_ms: u64,
+}
+
+impl From<ff_core::contracts::ClaimGrant> for ClaimGrantDto {
+    fn from(g: ff_core::contracts::ClaimGrant) -> Self {
+        let family = match g.partition.family {
+            ff_core::partition::PartitionFamily::Flow => "flow",
+            ff_core::partition::PartitionFamily::Execution => "execution",
+            ff_core::partition::PartitionFamily::Budget => "budget",
+            ff_core::partition::PartitionFamily::Quota => "quota",
+        };
+        Self {
+            execution_id: g.execution_id.to_string(),
+            partition_family: family,
+            partition_index: g.partition.index,
+            grant_key: g.grant_key,
+            expires_at_ms: g.expires_at_ms,
+        }
+    }
+}
+
+/// Maximum grant TTL accepted via HTTP. Mirrors the scheduler's
+/// internal ceiling so a misconfigured worker can't squat an
+/// execution on a multi-hour grant.
+const CLAIM_GRANT_TTL_MS_MAX: u64 = 60_000;
+
+async fn claim_for_worker(
+    State(server): State<Arc<Server>>,
+    Path(worker_id): Path<String>,
+    AppJson(body): AppJson<ClaimForWorkerBody>,
+) -> Result<Response, ApiError> {
+    let worker_id = WorkerId::new(worker_id);
+    let worker_instance_id = WorkerInstanceId::new(body.worker_instance_id);
+    let lane = LaneId::try_new(body.lane_id).map_err(|e| {
+        ApiError(ServerError::InvalidInput(format!("lane_id: {e}")))
+    })?;
+    if body.grant_ttl_ms == 0 || body.grant_ttl_ms > CLAIM_GRANT_TTL_MS_MAX {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "grant_ttl_ms must be in 1..={CLAIM_GRANT_TTL_MS_MAX}"
+        ))));
+    }
+    let caps: std::collections::BTreeSet<String> =
+        body.capabilities.into_iter().collect();
+
+    match server
+        .claim_for_worker(
+            &lane,
+            &worker_id,
+            &worker_instance_id,
+            &caps,
+            body.grant_ttl_ms,
+        )
+        .await?
+    {
+        Some(grant) => Ok((StatusCode::OK, Json(ClaimGrantDto::from(grant))).into_response()),
+        None => Ok(StatusCode::NO_CONTENT.into_response()),
+    }
 }
 
 // ── Stream read + tail ──

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -1882,6 +1882,53 @@ impl Server {
         parse_change_priority_result(&raw, execution_id)
     }
 
+    /// Scheduler-routed claim entry point (Batch C item 2 PR-B).
+    ///
+    /// Delegates to [`ff_scheduler::Scheduler::claim_for_worker`] which
+    /// runs budget + quota + capability admission before issuing the
+    /// grant. Returns `Ok(None)` when no eligible execution exists on
+    /// the lane at this scan cycle. The worker's subsequent
+    /// `claim_from_grant(lane, grant)` mints the lease.
+    ///
+    /// Keeping the claim-grant mint inside the server (rather than the
+    /// worker) means capability CSV validation, budget/quota breach
+    /// checks, and lane routing run in one place for every tenant
+    /// worker — the same invariants as the `direct-valkey-claim` path
+    /// enforces inline, but gated at a single server choke point.
+    pub async fn claim_for_worker(
+        &self,
+        lane: &LaneId,
+        worker_id: &WorkerId,
+        worker_instance_id: &WorkerInstanceId,
+        worker_capabilities: &std::collections::BTreeSet<String>,
+        grant_ttl_ms: u64,
+    ) -> Result<Option<ff_core::contracts::ClaimGrant>, ServerError> {
+        let scheduler = ff_scheduler::Scheduler::new(
+            self.client.clone(),
+            self.config.partition_config,
+        );
+        scheduler
+            .claim_for_worker(
+                lane,
+                worker_id,
+                worker_instance_id,
+                worker_capabilities,
+                grant_ttl_ms,
+            )
+            .await
+            .map_err(|e| match e {
+                ff_scheduler::SchedulerError::Valkey(inner) => {
+                    ServerError::Valkey(inner)
+                }
+                ff_scheduler::SchedulerError::ValkeyContext { source, context } => {
+                    ServerError::ValkeyContext { source, context }
+                }
+                ff_scheduler::SchedulerError::Config(msg) => {
+                    ServerError::InvalidInput(msg)
+                }
+            })
+    }
+
     /// Revoke an active lease (operator-initiated).
     pub async fn revoke_lease(
         &self,

--- a/docs/rfc011-migration-for-consumers.md
+++ b/docs/rfc011-migration-for-consumers.md
@@ -130,14 +130,35 @@ to work; both variants produce the `{fp:N}` hash tag and route via
 > `insecure-direct-claim`, update to `direct-valkey-claim` before
 > following the rest of this step.
 
-**FF change:** two new public entry points on `FlowFabricWorker` replace the
+**FF change:** three public entry points on `FlowFabricWorker` replace the
 `direct-valkey-claim` feature-gated direct-FCALL path. They acquire the
 worker's concurrency permit before the FCALL so a saturated worker never
 consumes a grant.
 
+The new default production path is **`claim_via_server`** — issued via the
+server's `POST /v1/workers/{id}/claim` endpoint. That endpoint runs the
+full `ff_scheduler::Scheduler::claim_for_worker` admission cycle (budget
+breach, quota sliding-window, capability match) before minting the grant.
+The SDK method fetches the grant and chains to `claim_from_grant` so the
+lease is still minted on the worker's own Valkey client. Consumers that
+already have a `FlowFabricAdminClient` for other admin endpoints just
+pass it in — no second HTTP client needed.
+
 ```rust
 impl FlowFabricWorker {
-    /// Consume a scheduler-issued ClaimGrant → ClaimedTask.
+    /// Production entry point — scheduler-routed claim.
+    /// POSTs /v1/workers/{id}/claim, parses the ClaimGrant, chains
+    /// to claim_from_grant. Returns Ok(None) on HTTP 204 (no eligible
+    /// execution this cycle).
+    pub async fn claim_via_server(
+        &self,
+        admin: &FlowFabricAdminClient,
+        lane: &LaneId,
+        grant_ttl_ms: u64,
+    ) -> Result<Option<ClaimedTask>, SdkError>;
+
+    /// Low-level entry — consume a caller-provided ClaimGrant.
+    /// Useful if the caller has its own scheduler invocation path.
     /// Errors: WorkerAtCapacity (retryable), Script(ClaimGrantExpired|...).
     pub async fn claim_from_grant(
         &self,

--- a/examples/coding-agent/Cargo.lock
+++ b/examples/coding-agent/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "crc16",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -429,6 +430,8 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-script",
+ "reqwest",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/examples/coding-agent/Cargo.toml
+++ b/examples/coding-agent/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/approve.rs"
 
 [dependencies]
 ff-core = { path = "../../crates/ff-core" }
-ff-sdk = { path = "../../crates/ff-sdk", features = ["direct-valkey-claim"] }
+ff-sdk = { path = "../../crates/ff-sdk" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/coding-agent/src/worker.rs
+++ b/examples/coding-agent/src/worker.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let llm = LlmClient::new(&args.api_key, &args.model);
 
-    let lane = ff_core::types::LaneId::new(&args.lane);
+    let lane = ff_core::types::LaneId::try_new(&args.lane)?;
 
     // Patches awaiting review. suspend() consumes the task, so we stash the
     // result here. When the execution resumes and the worker re-claims it,

--- a/examples/coding-agent/src/worker.rs
+++ b/examples/coding-agent/src/worker.rs
@@ -7,7 +7,10 @@ use std::time::Duration;
 
 use clap::Parser;
 use ff_core::types::BudgetId;
-use ff_sdk::{ConditionMatcher, FlowFabricWorker, SuspendOutcome, TimeoutBehavior, WorkerConfig};
+use ff_sdk::{
+    ConditionMatcher, FlowFabricAdminClient, FlowFabricWorker, SuspendOutcome,
+    TimeoutBehavior, WorkerConfig,
+};
 use tokio::sync::Mutex;
 
 use common::{AgentStep, PatchResult, TaskPayload, DEFAULT_LANE, DEFAULT_MODEL, DEFAULT_NAMESPACE};
@@ -23,6 +26,17 @@ struct Args {
     /// Valkey port.
     #[arg(long, env = "FF_PORT", default_value_t = 6379)]
     port: u16,
+
+    /// ff-server base URL. The worker claims via
+    /// `POST /v1/workers/{id}/claim` — the scheduler-routed entry
+    /// point that runs admission control server-side.
+    #[arg(long, env = "FF_SERVER_URL", default_value = "http://localhost:9090")]
+    server_url: String,
+
+    /// Optional bearer token for ff-server (matches FF_API_TOKEN on
+    /// the server side). Leave unset for an unauthenticated dev server.
+    #[arg(long, env = "FF_API_TOKEN")]
+    api_token: Option<String>,
 
     /// OpenRouter API key.
     #[arg(long, env = "OPENROUTER_API_KEY")]
@@ -75,7 +89,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let worker = FlowFabricWorker::connect(config).await?;
+    let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+        Some(tok) => FlowFabricAdminClient::with_token(&args.server_url, tok)?,
+        None => FlowFabricAdminClient::new(&args.server_url)?,
+    };
     let llm = LlmClient::new(&args.api_key, &args.model);
+
+    let lane = ff_core::types::LaneId::new(&args.lane);
 
     // Patches awaiting review. suspend() consumes the task, so we stash the
     // result here. When the execution resumes and the worker re-claims it,
@@ -104,7 +124,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 tracing::info!("shutdown signal received");
                 break;
             }
-            result = worker.claim_next() => {
+            // 10s grant TTL gives the worker time to call
+            // claim_from_grant even under moderate network jitter.
+            result = worker.claim_via_server(&admin, &lane, 10_000) => {
                 match result {
                     Ok(Some(task)) => {
                         let eid = task.execution_id().to_string();
@@ -126,7 +148,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                     Err(e) => {
-                        tracing::error!(error = %e, "claim_next failed");
+                        tracing::error!(error = %e, "claim_via_server failed");
                         tokio::time::sleep(Duration::from_secs(5)).await;
                     }
                 }

--- a/examples/media-pipeline/Cargo.lock
+++ b/examples/media-pipeline/Cargo.lock
@@ -890,6 +890,7 @@ dependencies = [
  "crc16",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -912,6 +913,8 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-script",
+ "reqwest",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/examples/media-pipeline/Cargo.toml
+++ b/examples/media-pipeline/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/bin/review.rs"
 
 [dependencies]
 ff-core = { path = "../../crates/ff-core" }
-ff-sdk = { path = "../../crates/ff-sdk", features = ["direct-valkey-claim"] }
+ff-sdk = { path = "../../crates/ff-sdk" }
 ferriskey = { path = "../../ferriskey" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util", "io-std", "signal", "fs", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/media-pipeline/README.md
+++ b/examples/media-pipeline/README.md
@@ -157,7 +157,7 @@ FF_MAX_CONCURRENT_STREAM_OPS=2 cargo run -p ff-server &
 ## V1 shortcuts (documented)
 
 - **Client-side data passing (legacy, to be migrated).** The submit CLI currently waits for each upstream execution to complete, reads the raw result bytes from `GET /v1/executions/{id}/result`, and embeds them as the next execution's `input_payload`. Batch C item 3 has landed server-side auto-injection: when the flow edge is staged with a non-empty `data_passing_ref`, the engine atomically copies the upstream's `result` into the downstream's `input_payload` at satisfaction time inside `ff_resolve_dependency`. The submit CLI has not yet been migrated to the server-side path — tracked as a follow-up. See `docs/rfc011-operator-runbook.md` §"Data passing between flow nodes".
-- **`direct-valkey-claim` feature.** Workers use the direct Valkey claim path gated by the `direct-valkey-claim` feature on `ff-sdk`. Batch C will replace this with a proper scheduler-mediated claim API.
+- **Scheduler-routed claim.** As of Batch C item 2 PR-B, the 3 workers (transcribe, summarize, embed) claim via `FlowFabricWorker::claim_via_server` — an HTTP `POST /v1/workers/{id}/claim` that runs budget / quota / capability admission server-side through `ff-scheduler`. The `direct-valkey-claim` feature flag is gone from the example's `Cargo.toml`. Set `FF_SERVER_URL` (and optionally `FF_API_TOKEN`) to point the workers at the ff-server.
 
 ## Submit crash recovery (v1)
 

--- a/examples/media-pipeline/src/bin/embed.rs
+++ b/examples/media-pipeline/src/bin/embed.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use anyhow::Context;
 use clap::Parser;
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
-use ff_sdk::{ClaimedTask, FlowFabricWorker, WorkerConfig};
+use ff_sdk::{ClaimedTask, FlowFabricAdminClient, FlowFabricWorker, WorkerConfig};
 use media_pipeline::{EmbedResult, SummarizeResult, SUMMARY_CHAR_CAP};
 use tokio::sync::Mutex;
 
@@ -23,6 +23,14 @@ struct Args {
 
     #[arg(long, env = "FF_PORT", default_value_t = 6379)]
     port: u16,
+
+    /// ff-server base URL for the scheduler-routed claim path.
+    #[arg(long, env = "FF_SERVER_URL", default_value = "http://localhost:9090")]
+    server_url: String,
+
+    /// Optional bearer token for ff-server.
+    #[arg(long, env = "FF_API_TOKEN")]
+    api_token: Option<String>,
 
     #[arg(long, default_value = "default")]
     namespace: String,
@@ -83,6 +91,11 @@ async fn main() -> anyhow::Result<()> {
     config.capabilities = vec!["embed".into(), "minilm-l6".into()];
 
     let worker = FlowFabricWorker::connect(config).await?;
+    let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+        Some(tok) => FlowFabricAdminClient::with_token(&args.server_url, tok)?,
+        None => FlowFabricAdminClient::new(&args.server_url)?,
+    };
+    let lane = ff_core::types::LaneId::new(&args.lane);
     tracing::info!(instance = %instance_id, "embed worker connected");
 
     let shutdown = shutdown_signal();
@@ -94,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!("shutdown signal received");
                 break;
             }
-            result = worker.claim_next() => {
+            result = worker.claim_via_server(&admin, &lane, 10_000) => {
                 match result {
                     Ok(Some(task)) => {
                         let eid = task.execution_id().to_string();
@@ -104,7 +117,7 @@ async fn main() -> anyhow::Result<()> {
                     }
                     Ok(None) => idle_sleep().await,
                     Err(e) => {
-                        tracing::error!(error = %e, "claim_next failed");
+                        tracing::error!(error = %e, "claim_via_server failed");
                         tokio::time::sleep(Duration::from_secs(5)).await;
                     }
                 }

--- a/examples/media-pipeline/src/bin/embed.rs
+++ b/examples/media-pipeline/src/bin/embed.rs
@@ -95,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
         Some(tok) => FlowFabricAdminClient::with_token(&args.server_url, tok)?,
         None => FlowFabricAdminClient::new(&args.server_url)?,
     };
-    let lane = ff_core::types::LaneId::new(&args.lane);
+    let lane = ff_core::types::LaneId::try_new(&args.lane)?;
     tracing::info!(instance = %instance_id, "embed worker connected");
 
     let shutdown = shutdown_signal();

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -128,7 +128,7 @@ async fn main() -> anyhow::Result<()> {
         Some(tok) => FlowFabricAdminClient::with_token(&args.server_url, tok)?,
         None => FlowFabricAdminClient::new(&args.server_url)?,
     };
-    let lane = ff_core::types::LaneId::new(&args.lane);
+    let lane = ff_core::types::LaneId::try_new(&args.lane)?;
     tracing::info!(
         instance = %instance_id,
         model = %args.model.display(),

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -29,8 +29,8 @@ use std::time::Duration;
 use anyhow::Context;
 use clap::Parser;
 use ff_sdk::{
-    read_stream, ClaimedTask, ConditionMatcher, FlowFabricWorker, SuspendOutcome,
-    TimeoutBehavior, WorkerConfig, STREAM_READ_HARD_CAP,
+    read_stream, ClaimedTask, ConditionMatcher, FlowFabricAdminClient, FlowFabricWorker,
+    SuspendOutcome, TimeoutBehavior, WorkerConfig, STREAM_READ_HARD_CAP,
 };
 use llama_cpp_2::{
     context::params::LlamaContextParams,
@@ -53,6 +53,14 @@ struct Args {
 
     #[arg(long, env = "FF_PORT", default_value_t = 6379)]
     port: u16,
+
+    /// ff-server base URL for the scheduler-routed claim path.
+    #[arg(long, env = "FF_SERVER_URL", default_value = "http://localhost:9090")]
+    server_url: String,
+
+    /// Optional bearer token for ff-server.
+    #[arg(long, env = "FF_API_TOKEN")]
+    api_token: Option<String>,
 
     #[arg(long, default_value = "default")]
     namespace: String,
@@ -116,6 +124,11 @@ async fn main() -> anyhow::Result<()> {
     config.capabilities = vec!["llm".into(), "qwen-500m-q4".into()];
 
     let worker = FlowFabricWorker::connect(config).await?;
+    let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+        Some(tok) => FlowFabricAdminClient::with_token(&args.server_url, tok)?,
+        None => FlowFabricAdminClient::new(&args.server_url)?,
+    };
+    let lane = ff_core::types::LaneId::new(&args.lane);
     tracing::info!(
         instance = %instance_id,
         model = %args.model.display(),
@@ -131,7 +144,7 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!("shutdown signal received");
                 break;
             }
-            result = worker.claim_next() => {
+            result = worker.claim_via_server(&admin, &lane, 10_000) => {
                 match result {
                     Ok(Some(task)) => {
                         let eid = task.execution_id().to_string();
@@ -148,7 +161,7 @@ async fn main() -> anyhow::Result<()> {
                     }
                     Ok(None) => idle_sleep().await,
                     Err(e) => {
-                        tracing::error!(error = %e, "claim_next failed");
+                        tracing::error!(error = %e, "claim_via_server failed");
                         tokio::time::sleep(Duration::from_secs(5)).await;
                     }
                 }

--- a/examples/media-pipeline/src/bin/transcribe.rs
+++ b/examples/media-pipeline/src/bin/transcribe.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use clap::Parser;
-use ff_sdk::{ClaimedTask, FlowFabricWorker, WorkerConfig};
+use ff_sdk::{ClaimedTask, FlowFabricAdminClient, FlowFabricWorker, WorkerConfig};
 use media_pipeline::{PipelineInput, TranscribeResult};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
@@ -33,6 +33,14 @@ struct Args {
 
     #[arg(long, env = "FF_PORT", default_value_t = 6379)]
     port: u16,
+
+    /// ff-server base URL for the scheduler-routed claim path.
+    #[arg(long, env = "FF_SERVER_URL", default_value = "http://localhost:9090")]
+    server_url: String,
+
+    /// Optional bearer token for ff-server.
+    #[arg(long, env = "FF_API_TOKEN")]
+    api_token: Option<String>,
 
     #[arg(long, default_value = "default")]
     namespace: String,
@@ -85,6 +93,11 @@ async fn main() -> anyhow::Result<()> {
     config.capabilities = vec!["asr".into(), "whisper-tiny-en".into()];
 
     let worker = FlowFabricWorker::connect(config).await?;
+    let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+        Some(tok) => FlowFabricAdminClient::with_token(&args.server_url, tok)?,
+        None => FlowFabricAdminClient::new(&args.server_url)?,
+    };
+    let lane = ff_core::types::LaneId::new(&args.lane);
     tracing::info!(instance = %instance_id, "transcribe worker connected");
 
     let shutdown = shutdown_signal();
@@ -96,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!("shutdown signal received");
                 break;
             }
-            result = worker.claim_next() => {
+            result = worker.claim_via_server(&admin, &lane, 10_000) => {
                 match result {
                     Ok(Some(task)) => {
                         let eid = task.execution_id().to_string();
@@ -106,7 +119,7 @@ async fn main() -> anyhow::Result<()> {
                     }
                     Ok(None) => tokio::time::sleep(Duration::from_secs(1)).await,
                     Err(e) => {
-                        tracing::error!(error = %e, "claim_next failed");
+                        tracing::error!(error = %e, "claim_via_server failed");
                         tokio::time::sleep(Duration::from_secs(5)).await;
                     }
                 }

--- a/examples/media-pipeline/src/bin/transcribe.rs
+++ b/examples/media-pipeline/src/bin/transcribe.rs
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
         Some(tok) => FlowFabricAdminClient::with_token(&args.server_url, tok)?,
         None => FlowFabricAdminClient::new(&args.server_url)?,
     };
-    let lane = ff_core::types::LaneId::new(&args.lane);
+    let lane = ff_core::types::LaneId::try_new(&args.lane)?;
     tracing::info!(instance = %instance_id, "transcribe worker connected");
 
     let shutdown = shutdown_signal();
@@ -117,6 +117,11 @@ async fn main() -> anyhow::Result<()> {
                             tracing::error!(execution_id = %eid, error = %e, "task failed");
                         }
                     }
+                    // Fixed 1s sleep; summarize/embed use a jittered
+                    // `idle_sleep` to avoid N workers waking on the
+                    // same second. Pre-existing inconsistency — left
+                    // for a follow-up that extracts one shared
+                    // idle_sleep helper across all three binaries.
                     Ok(None) => tokio::time::sleep(Duration::from_secs(1)).await,
                     Err(e) => {
                         tracing::error!(error = %e, "claim_via_server failed");


### PR DESCRIPTION
## Summary

Follows #41 (rename). Wires a production claim path that runs budget / quota / capability admission server-side through \`ff-scheduler\`, so workers don't need the \`direct-valkey-claim\` feature flag.

## Server

- \`POST /v1/workers/{worker_id}/claim\` — accepts lane + identity + capabilities + \`grant_ttl_ms\`, delegates to \`ff_scheduler::Scheduler::claim_for_worker\`, returns a \`ClaimGrant\` on success or HTTP 204 when no eligible execution.
- \`Server::claim_for_worker\` — Server method wrapping the scheduler; maps \`SchedulerError\` → \`ServerError\`.
- Grant TTL ceiling: 60,000 ms. 0 or over is rejected at the REST boundary to prevent squatting.
- Partition family serialized as a static \`&str\` DTO so the core \`ClaimGrant\` type doesn't need a serde derive it otherwise wouldn't.

## SDK

- \`FlowFabricAdminClient::claim_for_worker(req) -> Option<Response>\` — mirrors the admin-surface pattern (\`rotate_waitpoint_secret\`). Returns \`None\` on 204, \`AdminApi\` error on non-2xx.
- \`ClaimForWorkerResponse::into_grant\` reconstructs the typed \`ff_core::contracts::ClaimGrant\` and fails loud on malformed \`execution_id\` / unknown \`partition_family\` so SDK↔server drift can't silently route to a ghost partition.
- \`FlowFabricWorker::claim_via_server(&admin, &lane, grant_ttl_ms)\` — top-level entry. POSTs, parses, chains to \`claim_from_grant\`.

## Example migrations

- \`examples/coding-agent/src/worker.rs\` → \`claim_via_server\`
- \`examples/media-pipeline/src/bin/{transcribe,summarize,embed}.rs\` → \`claim_via_server\`
- Both drop \`direct-valkey-claim\` from their \`Cargo.toml\` ff-sdk dep
- New \`--server-url\` / \`FF_SERVER_URL\` + \`--api-token\` / \`FF_API_TOKEN\` args

## Docs

- \`docs/rfc011-migration-for-consumers.md\` Step 3 expanded with the new \`claim_via_server\` surface as the production entry point.
- \`examples/media-pipeline/README.md\` V1-shortcut note flipped from \"Batch C will replace\" to \"landed in Batch C item 2 PR-B\".

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo check --manifest-path examples/coding-agent/Cargo.toml\` clean
- [x] \`cargo check --manifest-path examples/media-pipeline/Cargo.toml\` clean
- [ ] Live-server integration test (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new worker-claim HTTP path and changes how workers acquire work, which can impact scheduling/admission behavior and error handling at a critical execution boundary. Risk is mitigated by tight input validation (TTL bounds) and explicit DTO conversion/validation, but rollout should be validated end-to-end.
> 
> **Overview**
> Adds a **scheduler-routed worker claim flow** by introducing `POST /v1/workers/{worker_id}/claim` in `ff-server`, delegating to `ff_scheduler::Scheduler::claim_for_worker` and returning **204** when no eligible execution exists; the REST boundary validates lane/TTL and serializes a `ClaimGrant` via a DTO.
> 
> Extends `ff-sdk` with `FlowFabricAdminClient::claim_for_worker` plus DTO-to-core conversion (`ClaimForWorkerResponse::into_grant`), and adds `FlowFabricWorker::claim_via_server` to fetch a grant over HTTP then claim it via `claim_from_grant`.
> 
> Updates docs and migrates examples (coding-agent and media-pipeline workers) off the `direct-valkey-claim` feature to the new server-claim path, adding `FF_SERVER_URL`/`FF_API_TOKEN` configuration and wiring the new claim loop. Also wires in the new `ff-scheduler` dependency for `ff-server` (lockfile updates included).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02764dd5d27a89c450cca83437b5bb733d90870. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->