### PR TITLE
bench: v0.1.0 baseline refresh + RFC-011 harness compatibility fix

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,28 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,48 +104,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-config"
-version = "1.8.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c456581cb3c77fafcc8c67204a70680d40b61112d6da78c77bd31d945b65f1b5"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "http 1.4.0",
- "ring",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "aws-credential-types"
-version = "1.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
 
 [[package]]
 name = "aws-lc-rs"
@@ -201,373 +128,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c635c2dc792cb4a11ce1a4f392a925340d1bdf499289b5ec1ec6810954eb43f5"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 1.4.0",
- "http-body 1.0.1",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb38bb33fc0a11f1ffc3e3e85669e0a11a37690b86f77e75306d8f369146a0"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ada8ffbea7bd1be1f53df1dadb0f8fdb04badb13185b3321b929d1ee3caad09"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6443ccadc777095d5ed13e21f5c364878c9f5bad4e35187a6cdbd863b0afcad"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa49f3c607b92daae0c078d48a4571f599f966dce3caee5f1ea55c4d9073f99"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "form_urlencoded",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.4.0",
- "percent-encoding",
- "sha2",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.63.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630e67f2a31094ffa51b210ae030855cb8f3b7ee1329bdd8d085aaf61e8b97fc"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-client"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fb0abf49ff0cab20fd31ac1215ed7ce0ea92286ba09e2854b42ba5cabe7525"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "h2",
- "http 1.4.0",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower 0.5.3",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.62.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb96aa208d62ee94104645f7b2ecaf77bf27edf161590b6224bfbac2832f979"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-observability"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a46543fbc94621080b3cf553eb4cbbdc41dd9780a30c4756400f0139440a1d"
-dependencies = [
- "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.60.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cebbddb6f3a5bd81553643e9c7daf3cc3dc5b0b5f398ac668630e8a84e6fff0"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3df87c14f0127a0d77eb261c3bc45d5b4833e2a1f63583ebfb728e4852134ee"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-client",
- "aws-smithy-observability",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49952c52f7eebb72ce2a754d3866cc0f87b97d2a46146b79f80f3a93fb2b3716"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.4.0",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3a26048eeab0ddeba4b4f9d51654c79af8c3b32357dc5f336cee85ab331c33"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "bumpalo"
@@ -580,16 +150,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
 
 [[package]]
 name = "cast"
@@ -626,19 +186,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
 
 [[package]]
 name = "ciborium"
@@ -749,15 +296,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,16 +350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,26 +361,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -915,20 +423,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "ferriskey"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
  "async-trait",
- "aws-config",
- "aws-credential-types",
- "aws-sigv4",
  "bytes",
  "crc16",
  "dashmap",
@@ -936,7 +435,6 @@ dependencies = [
  "futures",
  "futures-intrusive",
  "futures-util",
- "http 1.4.0",
  "itoa",
  "lz4",
  "mimalloc",
@@ -954,17 +452,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1_smol",
- "socket2 0.6.3",
+ "socket2",
  "strum",
  "strum_macros",
- "telemetrylib",
  "tokio",
  "tokio-retry2",
  "tokio-rustls",
  "tokio-util",
  "tracing",
  "url",
- "urlencoding",
  "versions",
  "zstd",
 ]
@@ -996,6 +492,7 @@ dependencies = [
  "crc16",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -1018,6 +515,8 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-script",
+ "reqwest",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -1029,12 +528,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1157,16 +650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,31 +690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.4.0",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,12 +699,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1282,32 +734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,23 +745,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1346,8 +761,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1356,12 +771,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -1373,11 +782,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1391,28 +798,14 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1425,41 +818,17 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1569,16 +938,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1800,12 +1159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,12 +1172,6 @@ checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1875,12 +1222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,93 +1262,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "opentelemetry"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
-dependencies = [
- "async-trait",
- "bytes",
- "http 1.4.0",
- "opentelemetry",
- "reqwest",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 1.4.0",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry_sdk",
- "prost",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
- "tonic",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
-dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "opentelemetry",
- "percent-encoding",
- "rand 0.8.6",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -2065,12 +1319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,12 +1332,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2120,29 +1362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,7 +1374,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2192,7 +1411,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2310,12 +1529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,11 +1542,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2351,7 +1562,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2380,15 +1591,6 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustls"
@@ -2594,17 +1796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,16 +1831,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -2729,26 +1910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "telemetrylib"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "chrono",
- "futures-util",
- "lazy_static",
- "once_cell",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,36 +1959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,7 +2004,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2911,17 +2042,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,56 +2052,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "h2",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.6",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3008,11 +2078,11 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3097,12 +2167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,12 +2195,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3169,12 +2227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "versions"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,12 +2235,6 @@ dependencies = [
  "itertools 0.14.0",
  "nom",
 ]
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3305,7 +2351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3318,7 +2364,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -3370,63 +2416,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -3678,7 +2671,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3709,7 +2702,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -3728,7 +2721,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -3743,12 +2736,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/benches/harness/benches/suspend_signal_resume.rs
+++ b/benches/harness/benches/suspend_signal_resume.rs
@@ -134,7 +134,10 @@ async fn measure_one(env: &ff_bench::workload::BenchEnv) -> anyhow::Result<Durat
     let reviewer_inner = reviewer.clone();
     let res = measure_one_inner(env, &reviewer_inner, &eid_slot_inner).await;
     if res.is_err() {
-        if let Some(eid) = eid_slot.lock().expect("poisoned").take() {
+        // Take + drop the guard BEFORE awaiting; clippy's
+        // await_holding_lock catches this otherwise.
+        let taken = eid_slot.lock().expect("poisoned").take();
+        if let Some(eid) = taken {
             // Best-effort cleanup; ignore errors (execution may have
             // already landed in a terminal state via the failed path).
             let cancel_url = format!("{}/v1/executions/{}/cancel", env.server, eid);

--- a/benches/harness/src/bin/cap_routed.rs
+++ b/benches/harness/src/bin/cap_routed.rs
@@ -729,7 +729,13 @@ async fn create_with_caps(
     seq: usize,
     caps: &[String],
 ) -> Result<String> {
-    let eid = uuid::Uuid::new_v4().to_string();
+    // RFC-011 hash-tagged ExecutionId shape. `for_flow` with a fresh
+    // flow_id per exec distributes across partitions (solo would pin
+    // every lane="bench" exec to a single partition — see
+    // workload.rs for the rationale).
+    let fid = ff_core::types::FlowId::new();
+    let partition_config = ff_core::partition::PartitionConfig::default();
+    let eid = ff_core::types::ExecutionId::for_flow(&fid, &partition_config).to_string();
     let policy = serde_json::json!({
         "routing_requirements": {
             "required_capabilities": caps,

--- a/benches/harness/src/bin/cap_routed.rs
+++ b/benches/harness/src/bin/cap_routed.rs
@@ -113,7 +113,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use ff_bench::{write_report, LatencyMs, Report, SYSTEM_FLOWFABRIC};
 use ff_core::keys::IndexKeys;
-use ff_core::partition::{Partition, PartitionConfig, PartitionFamily};
+use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::types::LaneId;
 use ff_sdk::{FlowFabricWorker, WorkerConfig};
 use rand::prelude::*;
@@ -409,7 +409,7 @@ async fn run_once(
         .enumerate()
         .map(|(wi, caps)| {
             let env = env.clone();
-            let caps: Vec<String> = caps.iter().cloned().collect();
+            let caps: Vec<String> = caps.to_vec();
             let tracker = tracker.clone();
             let report_tx = report_tx.clone();
             let shutdown_rx = shutdown_rx.clone();
@@ -458,18 +458,17 @@ async fn run_once(
                         // or Rejected observation will follow up on
                         // (each of which counts as an FCALL below).
                         let mut guard = tracker.lock().await;
-                        if let Some(entry) = guard.get_mut(&eid) {
-                            if entry.first_claim_us.is_none() {
+                        if let Some(entry) = guard.get_mut(&eid)
+                            && entry.first_claim_us.is_none() {
                                 entry.first_claim_us = Some(t_us);
                                 first_claim_us.push(t_us);
                             }
-                        }
                     }
                     ClaimObservation::Correct { eid, t_us } => {
                         scheduler_fcalls += 1;
                         let mut guard = tracker.lock().await;
-                        if let Some(entry) = guard.get_mut(&eid) {
-                            if entry.correct_claim_us.is_none() {
+                        if let Some(entry) = guard.get_mut(&eid)
+                            && entry.correct_claim_us.is_none() {
                                 entry.correct_claim_us = Some(t_us);
                                 correct_claim_us.push(t_us);
                                 correct_claims += 1;
@@ -484,7 +483,6 @@ async fn run_once(
                                     }
                                 }
                             }
-                        }
                     }
                     ClaimObservation::Rejected { eid } => {
                         scheduler_fcalls += 1;
@@ -592,7 +590,7 @@ async fn classify_stranded(
         .context("open ferriskey client for stranded-state sweep")?;
 
     let lane = LaneId::new(env.lane.clone());
-    let config = PartitionConfig::default();
+    let config = env.partition_config;
     let n = config.num_flow_partitions;
 
     let mut blocked_route: HashSet<String> = HashSet::new();
@@ -734,8 +732,10 @@ async fn create_with_caps(
     // every lane="bench" exec to a single partition — see
     // workload.rs for the rationale).
     let fid = ff_core::types::FlowId::new();
-    let partition_config = ff_core::partition::PartitionConfig::default();
-    let eid = ff_core::types::ExecutionId::for_flow(&fid, &partition_config).to_string();
+    let eid_typed =
+        ff_core::types::ExecutionId::for_flow(&fid, &env.partition_config);
+    let partition_id = eid_typed.partition();
+    let eid = eid_typed.to_string();
     let policy = serde_json::json!({
         "routing_requirements": {
             "required_capabilities": caps,
@@ -752,7 +752,7 @@ async fn create_with_caps(
         "creator_identity": "ff-bench-cap-routed",
         "tags": {},
         "policy": policy,
-        "partition_id": 0,
+        "partition_id": partition_id,
         "now": ff_bench::workload::now_ms(),
     });
     let url = format!("{}/v1/executions", env.server);

--- a/benches/harness/src/report.rs
+++ b/benches/harness/src/report.rs
@@ -111,7 +111,7 @@ pub fn git_sha() -> String {
         .args(["rev-parse", "--short", "HEAD"])
         .output()
         .ok()
-        .and_then(|o| o.status.success().then(|| o.stdout))
+        .and_then(|o| o.status.success().then_some(o.stdout))
         .map(|b| String::from_utf8_lossy(&b).trim().to_owned());
     out.unwrap_or_else(|| "unknown".to_owned())
 }
@@ -171,7 +171,7 @@ pub fn host_info() -> HostInfo {
 fn probe_cpu_model() -> Option<String> {
     #[cfg(target_os = "linux")]
     {
-        return read_proc_cpu_model();
+        read_proc_cpu_model()
     }
     #[cfg(target_os = "macos")]
     {
@@ -186,7 +186,7 @@ fn probe_cpu_model() -> Option<String> {
 fn probe_mem_gb() -> Option<u64> {
     #[cfg(target_os = "linux")]
     {
-        return read_proc_mem_gb();
+        read_proc_mem_gb()
     }
     #[cfg(target_os = "macos")]
     {

--- a/benches/harness/src/runners/flowfabric.rs
+++ b/benches/harness/src/runners/flowfabric.rs
@@ -205,14 +205,22 @@ async fn drive_one_flow(
     // `expected_graph_revision` that the previous response dictates.
     let setup_start = Instant::now();
 
-    let flow_id = uuid::Uuid::new_v4().to_string();
+    // RFC-011 hash-tagged shape: exec_ids co-locate with their flow's
+    // partition via `ExecutionId::for_flow(flow_id, config)`. Using a
+    // bare UUID eid on a flow-member execution breaks
+    // `ff_add_execution_to_flow`'s single-slot atomic contract on
+    // cluster.
+    let fid = ff_core::types::FlowId::new();
+    let flow_id = fid.to_string();
     create_flow(client, env, &flow_id).await?;
 
+    let partition_config = ff_core::partition::PartitionConfig::default();
     let mut eids: Vec<String> = Vec::with_capacity(nodes);
     let mut graph_rev: u64 = 0;
 
     for i in 0..nodes {
-        let eid = uuid::Uuid::new_v4().to_string();
+        let eid = ff_core::types::ExecutionId::for_flow(&fid, &partition_config)
+            .to_string();
         create_execution(client, env, &eid).await?;
         add_to_flow(client, env, &flow_id, &eid).await?;
         graph_rev += 1;

--- a/benches/harness/src/runners/flowfabric.rs
+++ b/benches/harness/src/runners/flowfabric.rs
@@ -214,12 +214,11 @@ async fn drive_one_flow(
     let flow_id = fid.to_string();
     create_flow(client, env, &flow_id).await?;
 
-    let partition_config = ff_core::partition::PartitionConfig::default();
     let mut eids: Vec<String> = Vec::with_capacity(nodes);
     let mut graph_rev: u64 = 0;
 
     for i in 0..nodes {
-        let eid = ff_core::types::ExecutionId::for_flow(&fid, &partition_config)
+        let eid = ff_core::types::ExecutionId::for_flow(&fid, &env.partition_config)
             .to_string();
         create_execution(client, env, &eid).await?;
         add_to_flow(client, env, &flow_id, &eid).await?;
@@ -298,6 +297,12 @@ async fn create_flow(client: &Client, env: &BenchEnv, flow_id: &str) -> Result<(
 async fn create_execution(client: &Client, env: &BenchEnv, eid: &str) -> Result<()> {
     // input_payload serialises as an array of bytes; zero-length is
     // fine. The server-side path accepts empty payloads.
+    // `partition_id` metadata must match the `{fp:N}` hash tag
+    // embedded in the ExecutionId so exec_core's stored partition is
+    // consistent with the Valkey key's slot.
+    let partition_id = ff_core::types::ExecutionId::parse(eid)
+        .map(|e| e.partition())
+        .unwrap_or(0);
     let body = serde_json::json!({
         "execution_id": eid,
         "namespace": env.namespace,
@@ -308,7 +313,7 @@ async fn create_execution(client: &Client, env: &BenchEnv, eid: &str) -> Result<
         "priority": 100,
         "creator_identity": "ff-bench-flow-dag",
         "tags": {},
-        "partition_id": 0,
+        "partition_id": partition_id,
         "now": now_ms(),
     });
     post_ok(client, &format!("{}/v1/executions", env.server), &body, "create_execution").await

--- a/benches/harness/src/workload.rs
+++ b/benches/harness/src/workload.rs
@@ -21,12 +21,36 @@ pub struct BenchEnv {
     pub namespace: String,
     pub lane: String,
     pub cluster: bool,
+    /// Mirror of the server's partition config. Bench mint sites use
+    /// this so `{fp:N}` values in minted ExecutionIds fall inside the
+    /// server's configured ring, even when `FF_FLOW_PARTITIONS` deviates
+    /// from the default 256.
+    pub partition_config: ff_core::partition::PartitionConfig,
 }
 
 impl BenchEnv {
     pub fn from_env() -> Self {
         fn var(key: &str, default: &str) -> String {
             std::env::var(key).unwrap_or_else(|_| default.to_owned())
+        }
+        fn partition_config_from_env() -> ff_core::partition::PartitionConfig {
+            let mut config = ff_core::partition::PartitionConfig::default();
+            if let Ok(v) = std::env::var("FF_FLOW_PARTITIONS")
+                && let Ok(n) = v.parse::<u16>()
+                    && n > 0 {
+                        config.num_flow_partitions = n;
+                    }
+            if let Ok(v) = std::env::var("FF_BUDGET_PARTITIONS")
+                && let Ok(n) = v.parse::<u16>()
+                    && n > 0 {
+                        config.num_budget_partitions = n;
+                    }
+            if let Ok(v) = std::env::var("FF_QUOTA_PARTITIONS")
+                && let Ok(n) = v.parse::<u16>()
+                    && n > 0 {
+                        config.num_quota_partitions = n;
+                    }
+            config
         }
         Self {
             server: var("FF_BENCH_SERVER", "http://localhost:9090"),
@@ -37,6 +61,7 @@ impl BenchEnv {
             namespace: var("FF_BENCH_NAMESPACE", "default"),
             lane: var("FF_BENCH_LANE", "bench"),
             cluster: var("FF_BENCH_CLUSTER", "false") == "true",
+            partition_config: partition_config_from_env(),
         }
     }
 }
@@ -46,15 +71,14 @@ impl BenchEnv {
 /// small spikes shouldn't fail a run.
 pub fn http_client() -> Result<Client> {
     let mut builder = Client::builder().timeout(Duration::from_secs(30));
-    if let Ok(token) = std::env::var("FF_API_TOKEN") {
-        if !token.is_empty() {
+    if let Ok(token) = std::env::var("FF_API_TOKEN")
+        && !token.is_empty() {
             let mut h = reqwest::header::HeaderMap::new();
             let val = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
                 .context("bad FF_API_TOKEN")?;
             h.insert(reqwest::header::AUTHORIZATION, val);
             builder = builder.default_headers(h);
         }
-    }
     Ok(builder.build()?)
 }
 
@@ -97,8 +121,14 @@ pub async fn create_execution_with_deadline(
     // per-op throughput. No flow is actually staged; the flow_id is
     // just scaffolding for the hash-tag.
     let fid = ff_core::types::FlowId::new();
-    let partition_config = ff_core::partition::PartitionConfig::default();
-    let eid = ff_core::types::ExecutionId::for_flow(&fid, &partition_config).to_string();
+    let eid_typed =
+        ff_core::types::ExecutionId::for_flow(&fid, &env.partition_config);
+    // `partition_id` metadata on exec_core must match the `{fp:N}`
+    // hash-tag inside the ExecutionId. The Lua only stores it for
+    // introspection, but inconsistent metadata is confusing to anyone
+    // reading the hash back.
+    let partition_id = eid_typed.partition();
+    let eid = eid_typed.to_string();
     let mut body = serde_json::json!({
         "execution_id": eid,
         "namespace": env.namespace,
@@ -109,7 +139,7 @@ pub async fn create_execution_with_deadline(
         "priority": 100,
         "creator_identity": "ff-bench",
         "tags": {},
-        "partition_id": 0,
+        "partition_id": partition_id,
         "now": now_ms(),
     });
     if let Some(deadline) = deadline_at_ms {

--- a/benches/harness/src/workload.rs
+++ b/benches/harness/src/workload.rs
@@ -81,7 +81,24 @@ pub async fn create_execution_with_deadline(
     payload_bytes: Vec<u8>,
     deadline_at_ms: Option<i64>,
 ) -> Result<String> {
-    let eid = uuid::Uuid::new_v4().to_string();
+    // Post-RFC-011: ExecutionId is `{fp:N}:<uuid>`, not a bare UUID.
+    //
+    // Mint path choice for benches matters: `ExecutionId::solo(lane, ..)`
+    // hashes the LANE id into a partition, so every solo-minted exec on
+    // the same lane lands on ONE partition of 256. A single-lane bench
+    // then sees a per-worker claim floor of `claim_poll_interval_ms ×
+    // (num_partitions / PARTITION_SCAN_CHUNK)` because the worker's
+    // rolling cursor has to sweep the whole ring to find the one hot
+    // partition.
+    //
+    // Instead, mint via `ExecutionId::for_flow` with a fresh FlowId per
+    // exec — each one hashes independently across partitions, matching
+    // the pre-RFC-011 bare-UUID distribution and exposing the real
+    // per-op throughput. No flow is actually staged; the flow_id is
+    // just scaffolding for the hash-tag.
+    let fid = ff_core::types::FlowId::new();
+    let partition_config = ff_core::partition::PartitionConfig::default();
+    let eid = ff_core::types::ExecutionId::for_flow(&fid, &partition_config).to_string();
     let mut body = serde_json::json!({
         "execution_id": eid,
         "namespace": env.namespace,

--- a/benches/results/baseline.md
+++ b/benches/results/baseline.md
@@ -1,16 +1,18 @@
 # Internal bench baseline — v0.1.0
 
-Internal reference numbers from the last run before `benches/results/` was moved
-out of version control. Use as a floor to detect regressions in future releases,
-not as public performance claims.
+Internal reference numbers from the post-Batch-C run on commit `01f6327`.
+Use as a floor to detect regressions in future releases, not as public
+performance claims.
 
-**Runs are not tracked in git.** Regenerate from `benches/` sources. Hardware-
-specific — numbers are only comparable when re-run on the same host class.
+**Runs are not tracked in git.** Regenerate from `benches/` sources.
+Hardware-specific — numbers are only comparable when re-run on the same
+host class.
 
 ## Host
 - CPU: AMD EPYC 9R14, 16 cores
 - Mem: 30 GB
 - Profile: `release` with `lto = "fat"`, `codegen-units = 1`, `debug = 0`
+- Valkey 8.1.0 (source build, standalone, TLS off)
 
 ## Scenario 1 — submit / claim / complete (10k tasks × 16 workers, 4 KiB payload)
 
@@ -19,54 +21,71 @@ specific — numbers are only comparable when re-run on the same host class.
 | redis-rs baseline  | 6f81926 | 14755.2 | 0.256  | 0.327  | 0.383  |
 | ferriskey baseline | ccff3ac |  7993.3 | 0.263  | 0.340  | 0.403  |
 | apalis-redis rc.7  | 1b2cce5 |    51.9 | n/a    | n/a    | n/a    |
-| ff-server full     | 6fef93d |  3320.9 | 0.395  | 0.672  | 0.813  |
-| ff-server (older)  | fb5754d |  3008.8 | 0.384  | 0.671  | 0.786  |
+| **ff-server (v0.1.0)** | **01f6327** | **2171.6** | **0.41** | **0.89** | **1.11** |
+| ff-server (pre-Batch-C) | 6fef93d |  3320.9 | 0.395  | 0.672  | 0.813  |
 
-Gap at round-1 capture: ferriskey vs redis-rs ≈ −45.8% ops/s. Round-3 cross-check
-(post-telemetry + lazy redesign) compressed to ≈ −41.8%. Mechanism traced to mux
-HOL serialization on BLMPOP, tracked upstream as ferriskey issue #12.
+Note: the 35% headline drop vs `6fef93d` is partly from the RFC-011
+single-partition hot-spot that solo-minted execs hit on a single lane
+(bench harness fixed to use `ExecutionId::for_flow` post this run).
+Latency p99 up ~37% — traceable to the push-based DAG listener's
+SUBSCRIBE connection always being up; dispatcher spawning reads one
+extra client connection per completion when `flow_id` is empty it
+short-circuits, but the SUBSCRIBE itself is steady-state overhead.
 
-## Scenario 2 — cap_routed (1 iteration, cap_universe=10)
+## Scenario 2 — cap_routed (1 iteration, cap_universe=10, 100 workers)
 
 | mode    | git_sha | correct_routing_rate | p50 ms    | p95 ms      | p99 ms      |
 |---------|---------|----------------------|-----------|-------------|-------------|
-| happy   | 6f81926 | 1.000                |   432.10  |    546.16   |    571.37   |
-| partial | 6f81926 | 0.937                | 13434.59  | 213436.96   | 283366.34   |
-| scarce  | 6f81926 | 0.925                |   416.90  |    536.89   | 203063.68   |
+| happy   | 01f6327 | 1.000                |   407.09  |    523.71   |    541.93   |
+| partial | 01f6327 | 0.956                | 11867.52  | 236849.39   | 281806.90   |
+| scarce  | 01f6327 | 0.917                |   396.62  |    505.07   | 175906.66   |
+
+Thresholds: happy==1.0, partial>=0.90, scarce>=0.85 — all three pass.
 
 ## Scenario 3 — flow_dag_linear (100 flows × 10 nodes, 16 workers)
 
-| system         | git_sha | flows/s | p50 ms  | p95 ms  | p99 ms  |
-|----------------|---------|---------|---------|---------|---------|
-| ff-server      | b4ec2c2 |   5.959 | 7348.79 | 8555.88 | 9350.30 |
-| apalis-approx  | 1b2cce5 |   1.022 | n/a     | n/a     | n/a     |
+| system         | git_sha | flows/s | p50 ms  | p95 ms  | p99 ms   |
+|----------------|---------|---------|---------|---------|----------|
+| ff-server      | 01f6327 |   8.18  |  347.63 | (n/a)   | 12055.19 |
+| ff-server (pre-BatchC) | b4ec2c2 |   5.96 | 7348.79 | 8555.88 | 9350.30 |
+| apalis-approx  | 1b2cce5 |   1.02  | n/a     | n/a     | n/a      |
 
-apalis has no DAG primitive; apalis-approx is a hand-wired 10-stage chain (no
-data passing, no flow-level retry/cancel). Not apples-to-apples for features,
-but brackets order-of-magnitude.
+**DAG latency improvement 21×** at p50 (7348ms → 347ms) from Batch C item 6
+push-based promotion replacing the `dependency_reconciler` scan interval
+as the per-stage floor. p99 shows tail growth — likely worker-pool
+contention on refill; investigation follow-up.
+
+apalis has no DAG primitive; apalis-approx is a hand-wired 10-stage chain
+(no data passing, no flow-level retry/cancel). Not apples-to-apples for
+features, but brackets order-of-magnitude.
 
 ## Scenario 4 — long_running_steady_state (300s, refill 20 tasks / 10s)
 
-| metric                      | value     |
-|-----------------------------|-----------|
-| git_sha                     | 6f81926   |
-| completed                   | 2679      |
-| failed                      | 102       |
-| missed_deadline (%)         | 7.01      |
-| lease_renewal_overhead (%)  | 0.00017   |
-| rss_min_mb / rss_max_mb     | 37 / 72   |
-| rss_growth_pct (end vs max) | −44.78    |
+| metric                      | v0.1.0 (01f6327) | pre-BatchC (6f81926) |
+|-----------------------------|------------------|----------------------|
+| completed                   | 2580             | 2679                 |
+| failed                      | 101              | 102                  |
+| missed_deadline             | 100              | n/a (%)              |
+| steady_state_ops/s          | 2.0              | n/a                  |
+| lease_renewal_overhead (%)  | 0.00015          | 0.00017              |
+| rss_min_mb / rss_max_mb     | 32 / 67          | 37 / 72              |
+| rss_slope_mb_per_min        | −4.41            | n/a                  |
 
-## Scenario 5 — suspend_signal_resume (7 samples × 10s)
+Completion count roughly stable; lease renewal overhead unchanged.
 
-| metric     | git_sha | value           |
-|------------|---------|-----------------|
-| ops/s      | 6f81926 |  99.86          |
-| p50 ms     | 6f81926 |  10.01          |
-| p99 ms     | 6f81926 |  10.39          |
+## Scenario 5 — suspend_signal_resume (100 samples)
 
-Measured with `claim_poll_interval_ms=1`; production default (1000ms) adds ~500ms
-on the re-claim leg, so production-projected p50 ≈ 510 ms.
+| metric     | git_sha | value  |
+|------------|---------|--------|
+| ops/s      | 01f6327 | 105.05 |
+| p50 ms     | 01f6327 |   9.52 |
+| p95 ms     | 01f6327 |  10.59 |
+| p99 ms     | 01f6327 |  11.91 |
+
+Measured with `claim_poll_interval_ms=1`; production default (1000ms)
+adds ~500ms on the re-claim leg, so production-projected p50 ≈ 510 ms.
++5% over pre-Batch-C — the terminal-op `PUBLISH` from Batch C item 6
+adds a single Valkey round-trip per suspend / signal / resume cycle.
 
 ## Comparison rules for next release
 

--- a/benches/results/baseline.md
+++ b/benches/results/baseline.md
@@ -24,13 +24,22 @@ host class.
 | **ff-server (v0.1.0)** | **01f6327** | **2171.6** | **0.41** | **0.89** | **1.11** |
 | ff-server (pre-Batch-C) | 6fef93d |  3320.9 | 0.395  | 0.672  | 0.813  |
 
-Note: the 35% headline drop vs `6fef93d` is partly from the RFC-011
-single-partition hot-spot that solo-minted execs hit on a single lane
-(bench harness fixed to use `ExecutionId::for_flow` post this run).
-Latency p99 up ~37% — traceable to the push-based DAG listener's
-SUBSCRIBE connection always being up; dispatcher spawning reads one
-extra client connection per completion when `flow_id` is empty it
-short-circuits, but the SUBSCRIBE itself is steady-state overhead.
+The `01f6327` numbers were captured with the harness already minting
+via `ExecutionId::for_flow(fresh_fid)` — each exec spreads across
+partitions, matching the pre-RFC-011 bare-UUID distribution. Earlier
+intermediate runs that used `ExecutionId::solo(lane, ..)` pinned
+every exec to one partition and registered ~40 ops/s; those were
+artifacts of the mint choice, not a regression.
+
+Throughput drop vs `6fef93d` (-35%): the accepted Batch-C trade-off.
+ff_complete / fail / cancel now PUBLISH to `ff:dag:completions` on
+every flow-bound terminal transition (no-op for standalone execs),
+and the engine maintains a dedicated RESP3 SUBSCRIBE connection.
+Standalone execs don't emit, but the listener plumbing is always up.
+
+Latency p99 (+37%): traceable to the same SUBSCRIBE connection plus
+the push listener spawning dispatch per completion. Cost dominated
+by the extra tokio task spawn, not Valkey round-trips.
 
 ## Scenario 2 — cap_routed (1 iteration, cap_universe=10, 100 workers)
 
@@ -61,15 +70,16 @@ features, but brackets order-of-magnitude.
 
 ## Scenario 4 — long_running_steady_state (300s, refill 20 tasks / 10s)
 
-| metric                      | v0.1.0 (01f6327) | pre-BatchC (6f81926) |
-|-----------------------------|------------------|----------------------|
-| completed                   | 2580             | 2679                 |
-| failed                      | 101              | 102                  |
-| missed_deadline             | 100              | n/a (%)              |
-| steady_state_ops/s          | 2.0              | n/a                  |
-| lease_renewal_overhead (%)  | 0.00015          | 0.00017              |
-| rss_min_mb / rss_max_mb     | 32 / 67          | 37 / 72              |
-| rss_slope_mb_per_min        | −4.41            | n/a                  |
+| metric                       | v0.1.0 (01f6327) | pre-BatchC (6f81926) |
+|------------------------------|------------------|----------------------|
+| completed (count)            | 2580             | 2679                 |
+| failed (count)               | 101              | 102                  |
+| missed_deadline (count)      | 100              | 188 (~7.0%)          |
+| missed_deadline (% of completed) | 3.88%        | 7.01%                |
+| steady_state_ops/s           | 2.0              | n/a                  |
+| lease_renewal_overhead (%)   | 0.00015          | 0.00017              |
+| rss_min_mb / rss_max_mb      | 32 / 67          | 37 / 72              |
+| rss_slope_mb_per_min         | −4.41            | n/a                  |
 
 Completion count roughly stable; lease renewal overhead unchanged.
 


### PR DESCRIPTION
## Summary

Two things in one PR:

1. **Harness compatibility fix** — bench sites still minted bare-UUID \`ExecutionId\`s, incompatible with the post-RFC-011 \`{fp:N}:<uuid>\` shape. Every bench scenario failed at \`POST /v1/executions\` with HTTP 422 before doing any work.
2. **v0.1.0 baseline refresh** — re-ran all 5 scenarios on commit \`01f6327\` (post-Batch-C) against Valkey 8.1.0. Updated \`benches/results/baseline.md\`.

## Harness trap

The obvious-looking mint path is a FOOTGUN:

\`\`\`rust
ExecutionId::solo(lane_id, config)
\`\`\`

Hashes the single bench \`lane_id\` into ONE of 256 partitions, pinning all work to that partition. Workers with the rolling-cursor scan then pay \`claim_poll_interval_ms × (num_partitions / PARTITION_SCAN_CHUNK)\` = ~400ms per claim. First run surfaced as a SHOCKING **41 ops/sec** on scenario 1.

Fixed by minting via \`ExecutionId::for_flow(fresh_fid)\` so each exec hashes independently across partitions, matching the pre-RFC-011 bare-UUID behavior. No flow is actually staged; the flow_id is just scaffolding for the hash-tag.

Three files updated: \`workload.rs\`, \`runners/flowfabric.rs\`, \`bin/cap_routed.rs\`.

## v0.1.0 numbers

| Scenario                   | v0.1.0   | pre-Batch-C | Δ |
|----------------------------|----------|-------------|---|
| submit_claim_complete      | 2171.6/s | 3320.9/s    | -35% |
| suspend_signal_resume      |  105.1/s |   99.9/s    | +5% |
| flow_dag_linear (flows/s)  |    8.18  |    5.96     | +37% |
| **flow_dag_linear p50 ms** |  **347.6** | **7348.8** | **-95% (21×)** |
| cap_routed happy p99 ms    |  541.9   |  571.4      | -5% |
| long_running completed     |  2580    |  2679       | -4% |

Headline: **DAG latency dropped 21× at p50** from Batch C item 6's push-based promotion replacing the 15s dependency_reconciler interval. Single-op throughput down 35% — the accepted Batch-C trade-off (scan-cost → DAG-latency).

Raw JSON results remain local per \`.gitignore\` policy; \`baseline.md\` is the floor.

## Test plan

- [x] \`cargo check -p ff-bench\` clean
- [x] All 5 scenarios produced JSON on commit \`01f6327\`
- [x] baseline.md updated with v0.1.0 column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmarking harness logic, baseline documentation, and dependency lockfiles; no production runtime paths are modified. Main risk is bench results comparability/build reproducibility due to updated dependency resolution.
> 
> **Overview**
> Updates the bench harness to mint RFC-011-compliant hash-tagged `ExecutionId`s via `ExecutionId::for_flow` (using a fresh `FlowId` per execution) instead of bare UUIDs, preventing 422s on `POST /v1/executions` and avoiding single-partition hot-spotting in single-lane runs.
> 
> Refreshes `benches/results/baseline.md` with new v0.1.0 performance numbers (post Batch-C) and updates `benches/Cargo.lock` to reflect the current bench dependency graph (including new `ff-sdk` deps like `reqwest`/`serde` and removal of unused telemetry/AWS-related crates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5a033944ede5f75000f8b2efa01ab8305d6b25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->