### PR TITLE
chore(release): fix v0.1.0 publish pipeline + runbook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,12 @@
 #     `publish-new` + `publish-update`.
 #   - GITHUB_TOKEN is auto-provided by GHA; `gh release create` uses it.
 #
-# Publish set (8 crates, topologically ordered):
-#   telemetrylib -> ferriskey -> ff-core -> ff-script -> ff-engine
+# Publish set (7 crates, topologically ordered):
+#   ferriskey -> ff-core -> ff-script -> ff-engine
 #     -> ff-scheduler -> ff-sdk -> ff-server
 # ff-test is dev-only (publish = false) and not in the set.
+# The former telemetrylib sub-crate was inlined into ferriskey
+# during the Tier 1 envelope collapse (PR #18).
 #
 # Partial-publish recovery:
 #   If publish succeeds for crate N but fails for crate N+1, the workflow
@@ -119,27 +121,20 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
-      # Ordering respects path->version deps. telemetrylib is the root of
-      # the ferriskey subtree; ferriskey depends on it. ff-script, ff-sdk,
-      # ff-server, ff-engine, ff-scheduler, ff-test all depend on
-      # ferriskey. ff-core is a leaf. ff-server closes the chain.
+      # Ordering respects path->version deps. ferriskey is a leaf after
+      # the Tier 1 envelope collapse (PR #18) inlined the former
+      # telemetrylib sub-crate. ff-script, ff-sdk, ff-server, ff-engine,
+      # ff-scheduler all depend on ferriskey. ff-core is a leaf.
+      # ff-server closes the chain.
       # `--no-verify` is safe because `verify` already built + clippied +
       # tested the same ref. Without it every `cargo publish` re-builds
       # from scratch.
-      - name: publish telemetrylib
-        run: |
-          cargo publish -p telemetrylib --no-verify || {
-            echo "::error::cargo publish telemetrylib failed -- no crates published yet, safe to re-tag"
-            exit 1
-          }
-      - name: wait for index propagation
-        run: sleep 30
       - name: publish ferriskey
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
           cargo publish -p ferriskey --no-verify || {
-            echo "::error::cargo publish ferriskey failed -- yank telemetrylib@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ferriskey failed -- no crates published yet, safe to re-tag"
             exit 1
           }
       - run: sleep 30
@@ -148,7 +143,7 @@ jobs:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
           cargo publish -p ff-core --no-verify || {
-            echo "::error::cargo publish ff-core failed -- yank telemetrylib,ferriskey@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-core failed -- yank ferriskey@${TAG_VERSION#v} before re-tagging"
             exit 1
           }
       - run: sleep 30
@@ -157,7 +152,7 @@ jobs:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
           cargo publish -p ff-script --no-verify || {
-            echo "::error::cargo publish ff-script failed -- yank telemetrylib,ferriskey,ff-core@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-script failed -- yank ferriskey,ff-core@${TAG_VERSION#v} before re-tagging"
             exit 1
           }
       - run: sleep 30
@@ -166,7 +161,7 @@ jobs:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
           cargo publish -p ff-engine --no-verify || {
-            echo "::error::cargo publish ff-engine failed -- yank telemetrylib,ferriskey,ff-core,ff-script@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-engine failed -- yank ferriskey,ff-core,ff-script@${TAG_VERSION#v} before re-tagging"
             exit 1
           }
       - run: sleep 30
@@ -175,7 +170,7 @@ jobs:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
           cargo publish -p ff-scheduler --no-verify || {
-            echo "::error::cargo publish ff-scheduler failed -- yank telemetrylib,ferriskey,ff-core,ff-script,ff-engine@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-scheduler failed -- yank ferriskey,ff-core,ff-script,ff-engine@${TAG_VERSION#v} before re-tagging"
             exit 1
           }
       - run: sleep 30
@@ -184,7 +179,7 @@ jobs:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
           cargo publish -p ff-sdk --no-verify || {
-            echo "::error::cargo publish ff-sdk failed -- yank telemetrylib,ferriskey,ff-core,ff-script,ff-engine,ff-scheduler@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-sdk failed -- yank ferriskey,ff-core,ff-script,ff-engine,ff-scheduler@${TAG_VERSION#v} before re-tagging"
             exit 1
           }
       - run: sleep 30
@@ -193,7 +188,7 @@ jobs:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
           cargo publish -p ff-server --no-verify || {
-            echo "::error::cargo publish ff-server failed -- yank telemetrylib,ferriskey,ff-core,ff-script,ff-engine,ff-scheduler,ff-sdk@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-server failed -- yank ferriskey,ff-core,ff-script,ff-engine,ff-scheduler,ff-sdk@${TAG_VERSION#v} before re-tagging"
             exit 1
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,10 @@ jobs:
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
+          VER="${TAG_VERSION#v}"
           cargo publish -p ff-core --no-verify || {
-            echo "::error::cargo publish ff-core failed -- yank ferriskey@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-core failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
             exit 1
           }
       - run: sleep 30
@@ -151,8 +153,11 @@ jobs:
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
+          VER="${TAG_VERSION#v}"
           cargo publish -p ff-script --no-verify || {
-            echo "::error::cargo publish ff-script failed -- yank ferriskey,ff-core@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-script failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
             exit 1
           }
       - run: sleep 30
@@ -160,8 +165,12 @@ jobs:
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
+          VER="${TAG_VERSION#v}"
           cargo publish -p ff-engine --no-verify || {
-            echo "::error::cargo publish ff-engine failed -- yank ferriskey,ff-core,ff-script@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-engine failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
             exit 1
           }
       - run: sleep 30
@@ -169,8 +178,13 @@ jobs:
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
+          VER="${TAG_VERSION#v}"
           cargo publish -p ff-scheduler --no-verify || {
-            echo "::error::cargo publish ff-scheduler failed -- yank ferriskey,ff-core,ff-script,ff-engine@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-scheduler failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
+            echo "::error::  cargo yank --version ${VER} ff-engine"
             exit 1
           }
       - run: sleep 30
@@ -178,8 +192,14 @@ jobs:
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
+          VER="${TAG_VERSION#v}"
           cargo publish -p ff-sdk --no-verify || {
-            echo "::error::cargo publish ff-sdk failed -- yank ferriskey,ff-core,ff-script,ff-engine,ff-scheduler@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-sdk failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
+            echo "::error::  cargo yank --version ${VER} ff-engine"
+            echo "::error::  cargo yank --version ${VER} ff-scheduler"
             exit 1
           }
       - run: sleep 30
@@ -187,8 +207,15 @@ jobs:
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
+          VER="${TAG_VERSION#v}"
           cargo publish -p ff-server --no-verify || {
-            echo "::error::cargo publish ff-server failed -- yank ferriskey,ff-core,ff-script,ff-engine,ff-scheduler,ff-sdk@${TAG_VERSION#v} before re-tagging"
+            echo "::error::cargo publish ff-server failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
+            echo "::error::  cargo yank --version ${VER} ff-engine"
+            echo "::error::  cargo yank --version ${VER} ff-scheduler"
+            echo "::error::  cargo yank --version ${VER} ff-sdk"
             exit 1
           }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,32 +6,48 @@ This doc covers the operator workflow for cutting a release. Tooling lives in
 
 ## What gets published
 
-Eight crates, all pinned to the same version, published in topological order:
+Seven crates, all pinned to the same version, published in topological order:
 
-1. `telemetrylib`    — root of the ferriskey subtree
-2. `ferriskey`       — Valkey client (reparented fork of glide-core)
-3. `ff-core`         — types, keys, errors
-4. `ff-script`       — typed FCALL wrappers + Lua library loader
-5. `ff-engine`       — cross-partition dispatch + scanners
-6. `ff-scheduler`    — claim-grant scheduler
-7. `ff-sdk`          — worker SDK
-8. `ff-server`       — HTTP server library + binary
+1. `ferriskey`       — Valkey client (reparented fork of glide-core;
+   the former `telemetrylib` sub-crate was inlined during the Tier 1
+   envelope collapse and is no longer a separate publish target)
+2. `ff-core`         — types, keys, errors
+3. `ff-script`       — typed FCALL wrappers + Lua library loader
+4. `ff-engine`       — cross-partition dispatch + scanners
+   (includes the `completion_listener` module for push-based DAG
+   promotion; see docs/rfc011-operator-runbook.md §"DAG promotion")
+5. `ff-scheduler`    — claim-grant scheduler
+6. `ff-sdk`          — worker SDK. `direct-valkey-claim` feature is
+   off by default; production deployments use the scheduler-routed
+   HTTP path via `FlowFabricWorker::claim_via_server`
+7. `ff-server`       — HTTP server library + binary
 
 Excluded from publish:
 
 - `ff-test` — dev-only integration harness (`publish = false`).
+- `ff-bench` — internal bench harness at `benches/harness/`
+  (`publish = false`).
 
 ## Pre-flight checklist
 
 Before cutting a release, verify:
 
-- [ ] W3's benchmark numbers for the target version exist at
-      `benches/results/<new_version>/`. The release workflow does not
-      enforce this; it is an operator-level gate.
+- [ ] Benchmark numbers for the target version have been refreshed.
+      Raw JSONs are local (`benches/results/*.json` is gitignored);
+      the curated summary at `benches/results/baseline.md` is the
+      tracked artifact and must reflect the HEAD that will be tagged.
+      The release workflow does not enforce this; it is an
+      operator-level gate.
+- [ ] Valkey minimum is 8.0+. The server refuses to start against
+      Valkey < 8.0 (RFC-011 §13). Ensure all production + CI targets
+      are on 8.x before cutting.
+- [ ] RESP3 is required for the engine's completion listener.
+      `FlowFabricWorker::connect` defaults to RESP3; servers fronted
+      by protocol-downgrading proxies must be verified against.
 - [ ] `CARGO_REGISTRY_TOKEN` is configured in repo settings (Settings →
       Secrets and variables → Actions). Generate at
       <https://crates.io/me> → API Tokens with scope `publish-new` +
-      `publish-update`. The token must have upload rights to all eight
+      `publish-update`. The token must have upload rights to all seven
       crate names — claim them on crates.io first if they are new.
 - [ ] Working on a release branch (`main` or `release/*`).
 - [ ] Working tree is clean.
@@ -61,9 +77,11 @@ Replace `patch` with `minor` or `major` as appropriate.
 
 On tag push matching `v*.*.*`:
 
-1. **verify** (CI gate) — `cargo check --workspace`, clippy -D warnings,
-   unit tests + `ff-test` serial e2e against a Valkey service container.
-   Same strictness as `.github/workflows/ci.yml`.
+1. **verify** (CI gate) — `cargo check --workspace`, clippy -D warnings
+   across the workspace AND ferriskey (the vendored fork's test suite
+   + benches are gated post-#37), unit tests + `ff-test` serial e2e
+   against a Valkey 8.x service container. Same strictness as
+   `.github/workflows/matrix.yml`.
 2. **publish** (needs verify) — sequential `cargo publish -p <crate>`
    in path→version-dep order with 30s sleeps between each for crates.io
    index propagation. `--no-verify` flag is passed since Job 1 already

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,7 +15,8 @@ Seven crates, all pinned to the same version, published in topological order:
 3. `ff-script`       — typed FCALL wrappers + Lua library loader
 4. `ff-engine`       — cross-partition dispatch + scanners
    (includes the `completion_listener` module for push-based DAG
-   promotion; see docs/rfc011-operator-runbook.md §"DAG promotion")
+   promotion; see [`rfc011-operator-runbook.md`](rfc011-operator-runbook.md)
+   §"DAG promotion: push listener + safety-net reconciler")
 5. `ff-scheduler`    — claim-grant scheduler
 6. `ff-sdk`          — worker SDK. `direct-valkey-claim` feature is
    off by default; production deployments use the scheduler-routed

--- a/release.toml
+++ b/release.toml
@@ -2,8 +2,10 @@
 #
 # This config drives `cargo release <level>` to perform a consolidated,
 # workspace-wide version bump across the publishable crates:
-#   telemetrylib, ferriskey, ff-core, ff-script, ff-engine, ff-scheduler,
-#   ff-sdk, ff-server
+#   ferriskey, ff-core, ff-script, ff-engine, ff-scheduler, ff-sdk,
+#   ff-server
+# (The former telemetrylib sub-crate was inlined into ferriskey in
+# PR #18; it is no longer a separate publish target.)
 #
 # Intentionally excluded from the bump (via [package.metadata.release]
 # release = false in each crate's Cargo.toml):


### PR DESCRIPTION
## Load-bearing fix

\`release.yml\` + \`release.toml\` both referenced \`telemetrylib\` as the first crate in the topological publish order. The \`telemetrylib\` crate was inlined into ferriskey during the Tier 1 envelope collapse (PR #18) and no longer exists as a separate publish target — **the workflow would fail on the first \`cargo publish -p telemetrylib\` step when cutting v0.1.0**.

Fixed:
- \`.github/workflows/release.yml\`: dropped the telemetrylib publish step; updated every downstream step's yank-instructions error message to reflect the new 7-crate dependency chain.
- \`release.toml\`: corrected the publishable-crates list in the header comment.
- \`docs/RELEASING.md\`: 8 → 7 crates; added a note explaining telemetrylib's absence.

## Runbook updates

- Valkey 8.0+ minimum added to the pre-flight checklist (RFC-011 §13).
- RESP3 requirement note for the completion listener.
- Replaced worker-era \"W3's benchmark numbers\" with the current contract: \`baseline.md\` is tracked, raw JSONs are local.
- Corrected stale \`.github/workflows/ci.yml\` → \`matrix.yml\` reference; added the ferriskey clippy gate from PR #37 to the verify-job description.
- Listed \`ff-bench\` alongside \`ff-test\` as excluded crates.

## Test plan

- [x] YAML lints clean
- [x] \`grep -rn telemetrylib\` leaves only the compat stub + accurate explanatory comments
- [x] 7-crate topology matches the actual \`Cargo.toml\` names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the crates.io publishing workflow and release runbook; a mistake could block or partially publish a release, but changes are mostly ordering/docs updates.
> 
> **Overview**
> Fixes the tag-triggered release pipeline to publish **7 crates instead of 8** by removing the obsolete `telemetrylib` step (now inlined into `ferriskey`) and updating all downstream yank/recovery error messages to match the new dependency chain.
> 
> Updates `docs/RELEASING.md` and `release.toml` to reflect the 7-crate publish set, clarify excluded crates (adds `ff-bench`), and refresh the operator pre-flight/runbook notes (bench artifact expectations, Valkey 8.0+ minimum, RESP3 requirement, and correct CI workflow reference).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ab8e45033f42d51c66887fe211c8a19ccab8a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->