### PR TITLE
feat(ff-sdk): pipeline resume_signals + integration tests (#36 items 1+3)

### DIFF
--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -1225,16 +1225,44 @@ impl ClaimedTask {
             }
         }
 
+        if signal_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Pipeline HGETALL signal_hash + GET signal_payload for all matched
+        // signals into one round-trip (closes #36 item 1). Previous
+        // implementation did 2N sequential round-trips; the single-matcher
+        // happy path is unaffected (1 pipelined round-trip ≈ 2 sequential
+        // for N=1), and "all" conditions with N>1 matchers see ~N× latency
+        // reduction on a loaded cluster.
+        let mut pipe = self.client.pipeline();
+        let mut slots = Vec::with_capacity(signal_ids.len());
+        for signal_id in &signal_ids {
+            let hash_slot = pipe
+                .cmd::<HashMap<String, String>>("HGETALL")
+                .arg(ctx.signal(signal_id))
+                .finish();
+            let payload_slot = pipe
+                .cmd::<Option<Value>>("GET")
+                .arg(ctx.signal_payload(signal_id))
+                .finish();
+            slots.push((hash_slot, payload_slot));
+        }
+        pipe.execute()
+            .await
+            .map_err(|e| SdkError::ValkeyContext {
+                source: e,
+                context: "pipeline HGETALL signal + GET payload".into(),
+            })?;
+
         let mut out: Vec<ResumeSignal> = Vec::with_capacity(signal_ids.len());
-        for signal_id in signal_ids {
-            let sig: HashMap<String, String> = self
-                .client
-                .hgetall(&ctx.signal(&signal_id))
-                .await
-                .map_err(|e| SdkError::ValkeyContext {
+        for (signal_id, (hash_slot, payload_slot)) in signal_ids.into_iter().zip(slots) {
+            let sig: HashMap<String, String> = hash_slot.value().map_err(|e| {
+                SdkError::ValkeyContext {
                     source: e,
-                    context: "HGETALL signal_hash".into(),
-                })?;
+                    context: "pipeline HGETALL signal_hash slot".into(),
+                }
+            })?;
             if sig.is_empty() {
                 // Signal hash was GC'd (not currently a code path, but
                 // defensive against future cleanup scanners). Skip.
@@ -1246,15 +1274,10 @@ impl ClaimedTask {
             // which would panic/error on any non-UTF-8 payload (reachable
             // via direct-FCALL callers that bypass the SDK's lossy
             // UTF-8 encode path in deliver_signal).
-            let payload_raw: Option<Value> = self
-                .client
-                .cmd("GET")
-                .arg(ctx.signal_payload(&signal_id))
-                .execute()
-                .await
-                .map_err(|e| SdkError::ValkeyContext {
+            let payload_raw: Option<Value> =
+                payload_slot.value().map_err(|e| SdkError::ValkeyContext {
                     source: e,
-                    context: "GET signal_payload".into(),
+                    context: "pipeline GET signal_payload slot".into(),
                 })?;
             let payload: Option<Vec<u8>> = match payload_raw {
                 Some(Value::BulkString(b)) => Some(b.to_vec()),

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -1260,7 +1260,7 @@ impl ClaimedTask {
             let sig: HashMap<String, String> = hash_slot.value().map_err(|e| {
                 SdkError::ValkeyContext {
                     source: e,
-                    context: "pipeline HGETALL signal_hash slot".into(),
+                    context: format!("pipeline HGETALL signal_hash slot (signal_id={signal_id})"),
                 }
             })?;
             if sig.is_empty() {
@@ -1277,7 +1277,7 @@ impl ClaimedTask {
             let payload_raw: Option<Value> =
                 payload_slot.value().map_err(|e| SdkError::ValkeyContext {
                     source: e,
-                    context: "pipeline GET signal_payload slot".into(),
+                    context: format!("pipeline GET signal_payload slot (signal_id={signal_id})"),
                 })?;
             let payload: Option<Vec<u8>> = match payload_raw {
                 Some(Value::BulkString(b)) => Some(b.to_vec()),

--- a/crates/ff-test/tests/resume_signals_integration.rs
+++ b/crates/ff-test/tests/resume_signals_integration.rs
@@ -1,0 +1,335 @@
+//! Integration tests for `ClaimedTask::resume_signals()` (closes #36 item 3).
+//!
+//! PR #35 landed the API with 3 unit tests for one helper function. The
+//! per-matcher HMGET loop + pipelined HGETALL/GET fetch are exercised
+//! end-to-end here: suspend → deliver_signal → reclaim → resume_signals
+//! and assert the matched-signal list + payload survive the round-trip.
+//!
+//! Covers:
+//!   - single matcher + payload → 1 ResumeSignal with payload bytes
+//!   - "all" mode with 2 matchers → 2 ResumeSignals (both required to resume)
+//!   - payload-less signal → payload field is None
+//!   - resume_signals() returns Vec::new() when the ClaimedTask is NOT
+//!     a resumed attempt (e.g. the worker's first claim of a never-
+//!     suspended execution).
+//!
+//! Run with: cargo test -p ff-test --test resume_signals_integration -- --test-threads=1
+
+use ff_sdk::task::{ConditionMatcher, Signal, SignalOutcome, SuspendOutcome, TimeoutBehavior};
+use ff_test::fixtures::TestCluster;
+
+const LANE: &str = "resume-sig-lane";
+const NS: &str = "resume-sig-ns";
+
+async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        worker_id: ff_core::types::WorkerId::new(format!("resume-sig-worker-{name_suffix}")),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
+            "resume-sig-inst-{name_suffix}"
+        )),
+        namespace: ff_core::types::Namespace::new(NS),
+        lanes: vec![ff_core::types::LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 10,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+/// Write the partition config the SDK reads on claim. Mirrors the
+/// setup used by test_sdk_suspend_signal_resume_reclaim.
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = ff_test::fixtures::TEST_PARTITION_CONFIG;
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn create_and_claim(
+    tc: &TestCluster,
+    worker: &ff_sdk::FlowFabricWorker,
+    payload_hint: &str,
+) -> (ff_core::types::ExecutionId, ff_sdk::task::ClaimedTask) {
+    let eid = tc.new_execution_id();
+
+    // Minimal direct-FCALL ff_create_execution call so the test
+    // file doesn't need to import e2e_lifecycle's fcall_create_execution
+    // (it's file-private).
+    let config = ff_test::fixtures::TEST_PARTITION_CONFIG;
+    let partition = ff_core::partition::execution_partition(&eid, &config);
+    let ctx = ff_core::keys::ExecKeyContext::new(&partition, &eid);
+    let idx = ff_core::keys::IndexKeys::new(&partition);
+    let lane_id = ff_core::types::LaneId::new(LANE);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        payload_hint.to_owned(),
+        "0".to_owned(),
+        "resume-sig-test".to_owned(),
+        "{}".to_owned(),
+        r#"{"test":"resume_signals"}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: ferriskey::Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution");
+
+    let task = worker
+        .claim_next()
+        .await
+        .unwrap()
+        .expect("should claim freshly-created execution");
+    (eid, task)
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_signals_returns_single_matched_signal_with_payload() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("single").await;
+
+    let (eid, task) = create_and_claim(&tc, &worker, "single_sig").await;
+
+    // Suspend with one matcher.
+    let outcome = task
+        .suspend(
+            "waiting_for_approve",
+            &[ConditionMatcher {
+                signal_name: "approve".into(),
+            }],
+            Some(60_000),
+            TimeoutBehavior::Fail,
+        )
+        .await
+        .unwrap();
+    let (waitpoint_id, _wp_key, token) = match outcome {
+        SuspendOutcome::Suspended { waitpoint_id, waitpoint_key, waitpoint_token, .. } => {
+            (waitpoint_id, waitpoint_key, waitpoint_token)
+        }
+        other => panic!("expected Suspended, got {other:?}"),
+    };
+
+    // Deliver signal with a distinctive payload.
+    let payload_bytes = b"approved by jane".to_vec();
+    let sig = Signal {
+        signal_name: "approve".into(),
+        signal_category: "decision".into(),
+        payload: Some(payload_bytes.clone()),
+        source_type: "test".into(),
+        source_identity: "jane".into(),
+        idempotency_key: None,
+        waitpoint_token: token,
+    };
+    match worker.deliver_signal(&eid, &waitpoint_id, sig).await.unwrap() {
+        SignalOutcome::TriggeredResume { .. } => {}
+        other => panic!("expected TriggeredResume, got {other:?}"),
+    }
+
+    // Re-claim and inspect resume_signals.
+    let task2 = worker
+        .claim_next()
+        .await
+        .unwrap()
+        .expect("should re-claim resumed execution");
+    let signals = task2.resume_signals().await.unwrap();
+    assert_eq!(signals.len(), 1, "single matcher → exactly 1 signal");
+    let s = &signals[0];
+    assert_eq!(s.signal_name, "approve");
+    assert_eq!(s.signal_category, "decision");
+    assert_eq!(s.source_identity, "jane");
+    assert_eq!(
+        s.payload.as_deref(),
+        Some(payload_bytes.as_slice()),
+        "payload bytes must round-trip"
+    );
+    assert!(
+        s.accepted_at.0 > 0,
+        "accepted_at must be a real server timestamp"
+    );
+
+    task2.complete(None).await.unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_signals_all_mode_returns_both_matchers() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("all").await;
+
+    let (eid, task) = create_and_claim(&tc, &worker, "all_mode").await;
+
+    let outcome = task
+        .suspend(
+            "waiting_for_both",
+            &[
+                ConditionMatcher { signal_name: "reviewer_a".into() },
+                ConditionMatcher { signal_name: "reviewer_b".into() },
+            ],
+            Some(60_000),
+            TimeoutBehavior::Fail,
+        )
+        .await
+        .unwrap();
+    let (waitpoint_id, _wp_key, token) = match outcome {
+        SuspendOutcome::Suspended { waitpoint_id, waitpoint_key, waitpoint_token, .. } => {
+            (waitpoint_id, waitpoint_key, waitpoint_token)
+        }
+        other => panic!("expected Suspended, got {other:?}"),
+    };
+
+    // Deliver reviewer_a first — suspension must stay open ("all" mode
+    // requires both matchers satisfied).
+    let sig_a = Signal {
+        signal_name: "reviewer_a".into(),
+        signal_category: "decision".into(),
+        payload: Some(b"a-approved".to_vec()),
+        source_type: "test".into(),
+        source_identity: "a".into(),
+        idempotency_key: None,
+        waitpoint_token: token.clone(),
+    };
+    match worker.deliver_signal(&eid, &waitpoint_id, sig_a).await.unwrap() {
+        SignalOutcome::Accepted { .. } => {}
+        other => panic!("expected Accepted after first of two matchers, got {other:?}"),
+    }
+
+    // Deliver reviewer_b → resume.
+    let sig_b = Signal {
+        signal_name: "reviewer_b".into(),
+        signal_category: "decision".into(),
+        payload: Some(b"b-approved".to_vec()),
+        source_type: "test".into(),
+        source_identity: "b".into(),
+        idempotency_key: None,
+        waitpoint_token: token,
+    };
+    match worker.deliver_signal(&eid, &waitpoint_id, sig_b).await.unwrap() {
+        SignalOutcome::TriggeredResume { .. } => {}
+        other => panic!("expected TriggeredResume, got {other:?}"),
+    }
+
+    let task2 = worker
+        .claim_next()
+        .await
+        .unwrap()
+        .expect("should re-claim");
+    let mut signals = task2.resume_signals().await.unwrap();
+    signals.sort_by(|l, r| l.signal_name.cmp(&r.signal_name));
+    assert_eq!(signals.len(), 2, "all mode → both matched signals returned");
+    assert_eq!(signals[0].signal_name, "reviewer_a");
+    assert_eq!(signals[0].payload.as_deref(), Some(b"a-approved".as_slice()));
+    assert_eq!(signals[1].signal_name, "reviewer_b");
+    assert_eq!(signals[1].payload.as_deref(), Some(b"b-approved".as_slice()));
+
+    task2.complete(None).await.unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_signals_payload_none_when_signal_payload_omitted() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("nopayload").await;
+
+    let (eid, task) = create_and_claim(&tc, &worker, "no_payload").await;
+
+    let outcome = task
+        .suspend(
+            "waiting_no_payload",
+            &[ConditionMatcher { signal_name: "ping".into() }],
+            Some(60_000),
+            TimeoutBehavior::Fail,
+        )
+        .await
+        .unwrap();
+    let (waitpoint_id, _wp_key, token) = match outcome {
+        SuspendOutcome::Suspended { waitpoint_id, waitpoint_key, waitpoint_token, .. } => {
+            (waitpoint_id, waitpoint_key, waitpoint_token)
+        }
+        other => panic!("expected Suspended, got {other:?}"),
+    };
+
+    let sig = Signal {
+        signal_name: "ping".into(),
+        signal_category: "event".into(),
+        payload: None,
+        source_type: "test".into(),
+        source_identity: "pinger".into(),
+        idempotency_key: None,
+        waitpoint_token: token,
+    };
+    worker.deliver_signal(&eid, &waitpoint_id, sig).await.unwrap();
+
+    let task2 = worker.claim_next().await.unwrap().unwrap();
+    let signals = task2.resume_signals().await.unwrap();
+    assert_eq!(signals.len(), 1);
+    assert!(
+        signals[0].payload.is_none(),
+        "signal delivered without payload → ResumeSignal.payload is None, got {:?}",
+        signals[0].payload
+    );
+
+    task2.complete(None).await.unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_signals_empty_for_non_resumed_claim() {
+    // First-ever claim of a never-suspended execution must return an
+    // empty Vec, not an error. This is the discriminator workers use
+    // to branch between "fresh execution" and "resumed from signal."
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("fresh").await;
+
+    let (_eid, task) = create_and_claim(&tc, &worker, "fresh").await;
+
+    let signals = task.resume_signals().await.unwrap();
+    assert!(
+        signals.is_empty(),
+        "fresh claim (no prior suspension) → empty Vec, got {signals:?}"
+    );
+
+    task.complete(None).await.unwrap();
+}


### PR DESCRIPTION
## Summary

Two items of #36 in one PR:

### Item 1 — pipeline per-signal HGETALL + GET

\`ClaimedTask::resume_signals\` now issues a single pipelined round-trip for all matched signals' hash + payload fetches. Previous code did 2N sequential round-trips. Single-matcher (common) case: unchanged count, still one round-trip. Multi-matcher "all" conditions: ~N× latency reduction on loaded clusters.

### Item 3 — integration tests

New \`crates/ff-test/tests/resume_signals_integration.rs\` with 4 end-to-end tests: single matcher + payload round-trip, "all" mode with 2 matchers (first Accepted, second TriggeredResume), payload-less signal, and fresh-claim empty-Vec guard.

## What's not in this PR

Item 2 (example migrations — coding-agent + media-pipeline to demonstrate \`resume_signals()\` instead of the ad-hoc HashMap / cancel-path workarounds). Larger surface, separate PR.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] All 4 new integration tests pass locally
- [x] Existing \`test_sdk_suspend_signal_resume_reclaim\` still passes
- [ ] CI matrix (Valkey 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `ClaimedTask::resume_signals()` Valkey I/O behavior by batching per-signal `HGETALL`/`GET` into a pipeline, which could affect ordering/error handling and has cluster/connection-level implications. Added integration tests reduce functional regression risk but the runtime path is still exercised only under Valkey-backed environments.
> 
> **Overview**
> `ClaimedTask::resume_signals()` now batches matched-signal metadata and payload reads into a single Valkey pipeline execution, replacing the previous per-signal sequential `HGETALL` + `GET` round-trips and returning early when no matcher signal IDs are satisfied.
> 
> Adds a new end-to-end test suite (`ff-test` `resume_signals_integration.rs`) that exercises suspend→deliver_signal→reclaim→`resume_signals()` for single-signal resumes, multi-matcher *all* mode, payload-less signals, and the fresh-claim empty result guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5384b995c95e7e50756a138bc1772db1f90db7e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->