### PR TITLE
feat(examples): migrate coding-agent + media-pipeline to resume_signals (#36 item 2)

### DIFF
--- a/examples/coding-agent/Cargo.lock
+++ b/examples/coding-agent/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "crc16",
  "serde",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ferriskey",
  "ff-core",

--- a/examples/coding-agent/src/approve.rs
+++ b/examples/coding-agent/src/approve.rs
@@ -59,100 +59,71 @@ async fn main() {
         .expect("clock")
         .as_millis() as i64;
 
-    if args.approve {
-        // Approval requires the HMAC waitpoint token. An empty / missing
-        // token gets `invalid_token` from ff_deliver_signal — fail fast
-        // at the CLI instead of sending a doomed POST.
-        let waitpoint_token = match args.waitpoint_token {
-            Some(t) if !t.is_empty() => t,
-            _ => {
-                eprintln!(
-                    "--waitpoint-token is required for --approve. The worker prints it as \
-                     `WAITPOINT_TOKEN=...` on suspend, and `GET /v1/executions/{{id}}/pending-waitpoints` \
-                     returns it on the matching waitpoint."
-                );
-                std::process::exit(1);
-            }
-        };
-
-        // Deliver approval signal — resumes the suspended execution
-        let review = ReviewPayload {
-            approved: true,
-            feedback: args.feedback,
-        };
-        let payload_bytes: Vec<u8> = serde_json::to_vec(&review).expect("serialize review");
-
-        let signal_id = uuid::Uuid::new_v4().to_string();
-        let body = serde_json::json!({
-            "execution_id": args.execution_id,
-            "waitpoint_id": args.waitpoint_id,
-            "signal_id": signal_id,
-            "signal_name": "review_response",
-            "signal_category": "human_review",
-            "source_type": "human",
-            "source_identity": "operator",
-            "payload": payload_bytes,
-            "payload_encoding": "json",
-            "target_scope": "execution",
-            "waitpoint_token": waitpoint_token,
-            "now": now_ms
-        });
-
-        let url = format!(
-            "{}/v1/executions/{}/signal",
-            args.server, args.execution_id
-        );
-        let resp = client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await
-            .expect("signal request failed");
-
-        let status = resp.status();
-        let text = resp.text().await.expect("read body");
-
-        if !status.is_success() {
-            eprintln!("Signal error ({}): {}", status, text);
+    // Both approve and reject deliver the same `review_response` signal;
+    // the `approved` field inside the ReviewPayload tells the worker which
+    // branch to take. Previously, reject went through POST /cancel while
+    // only approve delivered a signal — that split meant the worker could
+    // not inspect rejection reason on re-claim (the cancel path never
+    // re-claims). Post-#36 `resume_signals()` surfaces the payload to the
+    // worker, which now does the fail-with-reason for rejections.
+    let waitpoint_token = match args.waitpoint_token {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            eprintln!(
+                "--waitpoint-token is required. The worker prints it as \
+                 `WAITPOINT_TOKEN=...` on suspend, and \
+                 `GET /v1/executions/{{id}}/pending-waitpoints` returns it on \
+                 the matching waitpoint."
+            );
             std::process::exit(1);
         }
+    };
 
-        println!("Approved. Signal delivered: {signal_id}");
-        println!("Response: {text}");
-    } else {
-        // Reject — cancel directly. ff_cancel_execution handles suspended
-        // executions (closes waitpoint, transitions to terminal cancelled).
-        // No signal needed — avoids race where signal resumes before cancel arrives.
-        let reason = args
-            .feedback
-            .unwrap_or_else(|| "rejected by reviewer".to_owned());
+    let review = ReviewPayload {
+        approved: args.approve,
+        feedback: args.feedback,
+    };
+    let payload_bytes: Vec<u8> = serde_json::to_vec(&review).expect("serialize review");
 
-        let cancel_body = serde_json::json!({
-            "execution_id": args.execution_id,
-            "reason": reason,
-            "source": "operator_override",
-            "now": now_ms
-        });
+    let signal_id = uuid::Uuid::new_v4().to_string();
+    let body = serde_json::json!({
+        "execution_id": args.execution_id,
+        "waitpoint_id": args.waitpoint_id,
+        "signal_id": signal_id,
+        "signal_name": "review_response",
+        "signal_category": "human_review",
+        "source_type": "human",
+        "source_identity": "operator",
+        "payload": payload_bytes,
+        "payload_encoding": "json",
+        "target_scope": "execution",
+        "waitpoint_token": waitpoint_token,
+        "now": now_ms
+    });
 
-        let cancel_url = format!(
-            "{}/v1/executions/{}/cancel",
-            args.server, args.execution_id
-        );
-        let resp = client
-            .post(&cancel_url)
-            .json(&cancel_body)
-            .send()
-            .await
-            .expect("cancel request failed");
+    let url = format!(
+        "{}/v1/executions/{}/signal",
+        args.server, args.execution_id
+    );
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .expect("signal request failed");
 
-        let status = resp.status();
-        let text = resp.text().await.expect("read body");
+    let status = resp.status();
+    let text = resp.text().await.expect("read body");
 
-        if status.is_success() {
-            println!("Rejected. Execution cancelled.");
-        } else {
-            eprintln!("Cancel error ({}): {}", status, text);
-            std::process::exit(1);
-        }
+    if !status.is_success() {
+        eprintln!("Signal error ({}): {}", status, text);
+        std::process::exit(1);
     }
+
+    if args.approve {
+        println!("Approved. Signal delivered: {signal_id}");
+    } else {
+        println!("Rejected. Signal delivered: {signal_id}");
+    }
+    println!("Response: {text}");
 }

--- a/examples/coding-agent/src/worker.rs
+++ b/examples/coding-agent/src/worker.rs
@@ -155,14 +155,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .as_deref()
                                 .and_then(|b| serde_json::from_slice(b).ok());
                             let patch_result = pending.lock().await.remove(&eid);
-                            match (decision, patch_result) {
-                                (Some(d), Some(patch)) if d.approved => {
-                                    tracing::info!(execution_id = %eid, "review approved — completing");
-                                    if let Err(e) = task.complete(Some(serde_json::to_vec(&patch)?)).await {
-                                        tracing::error!(execution_id = %eid, error = %e, "complete failed");
+                            match decision {
+                                Some(d) if d.approved => {
+                                    // Approval: complete with the stashed patch if we
+                                    // still have it. If the stash is gone (worker
+                                    // restarted between suspend and resume), fall
+                                    // through to `process_task` below so the agent
+                                    // re-runs and re-suspends — reviewer will see a
+                                    // fresh prompt. An approval MUST NOT be treated
+                                    // as rejection just because local state was lost
+                                    // (caught by @cursor-bugbot + @gemini-code-assist
+                                    // on PR #59).
+                                    match patch_result {
+                                        Some(patch) => {
+                                            tracing::info!(execution_id = %eid, "review approved — completing");
+                                            if let Err(e) = task.complete(Some(serde_json::to_vec(&patch)?)).await {
+                                                tracing::error!(execution_id = %eid, error = %e, "complete failed");
+                                            }
+                                            continue;
+                                        }
+                                        None => {
+                                            tracing::warn!(
+                                                execution_id = %eid,
+                                                "review approved but patch stash missing (likely worker restart) — re-running agent"
+                                            );
+                                            if let Err(e) = process_task(task, &llm, &args.model, budget_id.as_ref(), &pending).await {
+                                                tracing::error!(execution_id = %eid, error = %e, "task re-run failed");
+                                            }
+                                            continue;
+                                        }
                                     }
                                 }
-                                (Some(d), _) => {
+                                Some(d) => {
                                     let reason = d
                                         .feedback
                                         .unwrap_or_else(|| "rejected by reviewer".to_owned());
@@ -174,8 +198,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     if let Err(e) = task.fail(&reason, "human_rejected").await {
                                         tracing::error!(execution_id = %eid, error = %e, "fail call failed");
                                     }
+                                    continue;
                                 }
-                                (None, _) => {
+                                None => {
                                     // Signal with no/invalid payload — defensive fail
                                     // so a malformed approve CLI doesn't silently
                                     // complete with stale stash.
@@ -189,9 +214,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     {
                                         tracing::error!(execution_id = %eid, error = %e, "fail call failed");
                                     }
+                                    continue;
                                 }
                             }
-                            continue;
                         }
 
                         if let Err(e) = process_task(task, &llm, &args.model, budget_id.as_ref(), &pending).await {

--- a/examples/coding-agent/src/worker.rs
+++ b/examples/coding-agent/src/worker.rs
@@ -131,11 +131,65 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Ok(Some(task)) => {
                         let eid = task.execution_id().to_string();
 
-                        // Re-claim after review approval — complete with stashed patch
-                        if let Some(patch_result) = pending.lock().await.remove(&eid) {
-                            tracing::info!(execution_id = %eid, "resumed after review — completing");
-                            if let Err(e) = task.complete(Some(serde_json::to_vec(&patch_result)?)).await {
-                                tracing::error!(execution_id = %eid, error = %e, "complete failed");
+                        // Re-claim after human review. resume_signals() returns the
+                        // matched signal for this resumed attempt (empty Vec on fresh
+                        // claims). We branch on the ReviewPayload inside the signal
+                        // rather than assuming approval — the approve CLI now
+                        // delivers either approve or reject via the same signal name,
+                        // so the worker MUST inspect payload.approved to decide
+                        // complete-vs-fail. Without this check, a rejection would
+                        // incorrectly complete the execution with the old patch.
+                        let signals = match task.resume_signals().await {
+                            Ok(s) => s,
+                            Err(e) => {
+                                tracing::error!(execution_id = %eid, error = %e, "resume_signals failed");
+                                continue;
+                            }
+                        };
+                        if let Some(sig) = signals
+                            .iter()
+                            .find(|s| s.signal_name == "review_response")
+                        {
+                            let decision: Option<common::ReviewPayload> = sig
+                                .payload
+                                .as_deref()
+                                .and_then(|b| serde_json::from_slice(b).ok());
+                            let patch_result = pending.lock().await.remove(&eid);
+                            match (decision, patch_result) {
+                                (Some(d), Some(patch)) if d.approved => {
+                                    tracing::info!(execution_id = %eid, "review approved — completing");
+                                    if let Err(e) = task.complete(Some(serde_json::to_vec(&patch)?)).await {
+                                        tracing::error!(execution_id = %eid, error = %e, "complete failed");
+                                    }
+                                }
+                                (Some(d), _) => {
+                                    let reason = d
+                                        .feedback
+                                        .unwrap_or_else(|| "rejected by reviewer".to_owned());
+                                    tracing::info!(
+                                        execution_id = %eid,
+                                        reason = %reason,
+                                        "review rejected — failing with reviewer feedback"
+                                    );
+                                    if let Err(e) = task.fail(&reason, "human_rejected").await {
+                                        tracing::error!(execution_id = %eid, error = %e, "fail call failed");
+                                    }
+                                }
+                                (None, _) => {
+                                    // Signal with no/invalid payload — defensive fail
+                                    // so a malformed approve CLI doesn't silently
+                                    // complete with stale stash.
+                                    tracing::error!(
+                                        execution_id = %eid,
+                                        "review_response signal had no parseable ReviewPayload; failing"
+                                    );
+                                    if let Err(e) = task
+                                        .fail("review signal had unparseable payload", "bad_signal")
+                                        .await
+                                    {
+                                        tracing::error!(execution_id = %eid, error = %e, "fail call failed");
+                                    }
+                                }
                             }
                             continue;
                         }
@@ -318,7 +372,11 @@ async fn process_task(
                 // Matches the media-pipeline convention.
                 println!("WAITPOINT_TOKEN={}", waitpoint_token.as_str());
                 println!(
-                    "  cargo run --bin approve -- --execution-id {eid} --waitpoint-id {waitpoint_id} --waitpoint-token {} --approve",
+                    "  # approve:\n  cargo run --bin approve -- --execution-id {eid} --waitpoint-id {waitpoint_id} --waitpoint-token {} --approve",
+                    waitpoint_token.as_str()
+                );
+                println!(
+                    "  # reject (same signal, approved=false inside payload):\n  cargo run --bin approve -- --execution-id {eid} --waitpoint-id {waitpoint_id} --waitpoint-token {} --reject --feedback \"...\"",
                     waitpoint_token.as_str()
                 );
             }

--- a/examples/media-pipeline/Cargo.lock
+++ b/examples/media-pipeline/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "crc16",
  "serde",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ferriskey",
  "ff-core",

--- a/examples/media-pipeline/src/bin/review.rs
+++ b/examples/media-pipeline/src/bin/review.rs
@@ -390,10 +390,30 @@ async fn main() -> Result<()> {
             }
 
             if !status.is_success() {
-                anyhow::bail!("reject signal delivery failed ({status}): {text}");
+                // Symmetric with the approve path: re-check state before
+                // bailing. A peer reviewer or FF_SKIP_APPROVAL could have
+                // moved the execution to a terminal state (completed,
+                // failed, cancelled) between our suspend check and our
+                // /signal call — any of those terminal outcomes means the
+                // review window closed without us, which is the same
+                // "someone else won" success case the approve path
+                // already handles.
+                let recheck = recheck_state(&client, &args).await.unwrap_or_default();
+                if recheck == "failed" || recheck == "cancelled" || recheck == "completed" {
+                    println!(
+                        "[review] /signal returned {status} but state={recheck} — peer won; exiting 0"
+                    );
+                    drain_and_stop(tail).await;
+                    return Ok(());
+                }
+                anyhow::bail!(
+                    "reject signal delivery failed ({status}): {text}. recheck state={recheck}"
+                );
             }
             println!("[review] reject signal delivered: {text}");
-            println!("[review] waiting for summarize to transition to failed");
+            // The summarize worker re-claims, calls resume_signals(), sees
+            // the Reject payload, and calls fail(). Keep the tail up for
+            // a short drain so any final frames flush, then return.
             drain_and_stop(tail).await;
             return Ok(());
         }

--- a/examples/media-pipeline/src/bin/review.rs
+++ b/examples/media-pipeline/src/bin/review.rs
@@ -7,23 +7,27 @@
 //!     `--tamper-token` flag mutates the token before send so the user
 //!     can watch the server reject it with `invalid_token`.
 //!
-//! # v1 decision protocol: approve = signal, reject = cancel
+//! # Decision protocol: both approve AND reject deliver a signed signal
 //!
-//! ff-sdk does not surface the resume signal's payload to the re-claimed
-//! worker, so the summarize worker cannot distinguish approve vs reject
-//! by inspecting the signal on resume. Instead this CLI uses the control
-//! plane to differentiate:
+//! ff-sdk v0.3 added `ClaimedTask::resume_signals()`, which exposes the
+//! resume signal's payload to the re-claimed worker. The summarize
+//! worker now inspects the `ApprovalDecision` inside the signal to
+//! branch between complete (Approve) and fail-with-reason (Reject).
 //!
-//!   * `--approve` (or interactive `y`) → POST /signal (HMAC-authenticated).
-//!     Engine fulfils the waitpoint → summarize worker re-claims → reads
-//!     the persisted `summary_final` frame → `complete()`.
+//! Pre-v0.3 this CLI used POST /cancel for rejects because there was
+//! no way to ship the rejection reason through the resume path. With
+//! the payload-carrying resume we now use one HMAC-authenticated
+//! /signal call for both branches:
 //!
-//!   * `--reject <reason>` (or interactive `n`) → POST /cancel. The
-//!     execution transitions to terminal cancelled; no signal is sent
-//!     and no re-claim occurs.
-//!
-//! Tracked as a Batch C follow-up: "Expose resume signal payload on
-//! ClaimedTask so workers can route approve vs reject in-band".
+//!   * `--approve` (or interactive `y`) → POST /signal with
+//!     `ApprovalDecision::Approve`. Worker re-claims → `resume_signals()`
+//!     returns the signal → `complete()` from the persisted
+//!     `summary_final` frame.
+//!   * `--reject <reason>` (or interactive `n`) → POST /signal with
+//!     `ApprovalDecision::Reject { reason }`. Worker re-claims →
+//!     `resume_signals()` surfaces the reason → `fail(reason, "human_rejected")`.
+//!     The operator-supplied reason flows through exec_core.failure_reason
+//!     and the terminal event, which POST /cancel used to drop on the floor.
 
 use std::io::{BufRead, Write};
 use std::time::Duration;
@@ -308,39 +312,88 @@ async fn main() -> Result<()> {
             println!("[review] waiting for summarize to complete");
         }
         ApprovalDecision::Reject { reason } => {
-            // v1 protocol: reject → /cancel, not /signal. ff-sdk does not
-            // surface the resume signal's payload to the summarize worker
-            // on re-claim, so approve vs reject cannot be disambiguated
-            // via the signal. Cancelling the execution is unambiguous:
-            // the worker never re-claims, the flow sees a terminal
-            // cancelled, and downstream edges skip.
-            if args.tamper_token {
-                eprintln!(
-                    "[review] --tamper-token is approve-only (the reject path uses POST /cancel \
-                     which has no HMAC to tamper); re-run without --tamper-token to reject, or \
-                     keep --tamper-token and pass --auto-approve / answer 'y' to exercise the \
-                     HMAC rejection path."
-                );
-                // Exit 2 distinguishes "invalid-args, run differently" from the
-                // pipeline-level exit 1 ("execution actually failed"). Scripts
-                // that wrap review.rs can treat exit 2 as retriable with
-                // different flags.
-                std::process::exit(2);
-            }
+            // Reject now uses the SAME HMAC-signed /signal path as approve.
+            // The ApprovalDecision payload tells the summarize worker which
+            // branch to take on resume (complete-from-persist vs fail-with-
+            // reason). This is symmetric with --approve, so --tamper-token
+            // exercises HMAC rejection on both outcomes.
+            let token = if args.tamper_token {
+                tamper(&wp.waitpoint_token)
+            } else {
+                wp.waitpoint_token.clone()
+            };
+            let signal_payload = serde_json::to_vec(&ApprovalDecision::Reject {
+                reason: reason.clone(),
+            })?;
+
+            let idempotency_key = format!(
+                "review-reject/{}/{}",
+                args.execution_id, wp.waitpoint_id
+            );
+
             let body = serde_json::json!({
                 "execution_id": args.execution_id,
-                "reason": reason,
-                "source": "reviewer",
+                "waitpoint_id": wp.waitpoint_id,
+                "signal_id": uuid::Uuid::new_v4().to_string(),
+                "signal_name": SIGNAL_NAME_APPROVAL,
+                "signal_category": "human_review",
+                "source_type": "human",
+                "source_identity": "reviewer",
+                "payload": signal_payload,
+                "payload_encoding": "json",
+                "target_scope": "execution",
+                "idempotency_key": idempotency_key,
+                "waitpoint_token": token,
                 "now": now_ms(),
             });
-            let url = format!("{}/v1/executions/{}/cancel", args.server, args.execution_id);
-            let resp = client.post(&url).json(&body).send().await?;
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            if !status.is_success() {
-                anyhow::bail!("cancel failed ({status}): {text}");
+
+            let url = format!("{}/v1/executions/{}/signal", args.server, args.execution_id);
+            let send_result = client
+                .post(&url)
+                .json(&body)
+                .timeout(Duration::from_secs(120))
+                .send()
+                .await;
+
+            let (status, text) = match send_result {
+                Ok(resp) => {
+                    let s = resp.status();
+                    let t = resp.text().await.unwrap_or_default();
+                    (Some(s), t)
+                }
+                Err(e) => {
+                    println!("[review] /signal (reject) request error: {e} — rechecking state");
+                    let recheck = recheck_state(&client, &args).await?;
+                    if recheck == "failed" || recheck == "cancelled" {
+                        println!("[review] state={recheck} after error — reject landed; exiting 0");
+                        drain_and_stop(tail).await;
+                        return Ok(());
+                    }
+                    anyhow::bail!(
+                        "reject signal delivery error: {e}. execution state={recheck}. \
+                         Re-run review with the same args; idempotency_key \
+                         {idempotency_key} guarantees at-most-once."
+                    );
+                }
+            };
+            let status = status.expect("matched Ok arm above");
+
+            if args.tamper_token {
+                if status.is_success() {
+                    eprintln!("[review] FAIL — tampered reject token was accepted: {text}");
+                    std::process::exit(1);
+                }
+                println!("[review] tampered reject token rejected ({status}): {text}");
+                println!("[review] ── tail aborted: tamper-reject path ──");
+                drain_and_stop(tail).await;
+                return Ok(());
             }
-            println!("[review] rejected — execution cancelled: {text}");
+
+            if !status.is_success() {
+                anyhow::bail!("reject signal delivery failed ({status}): {text}");
+            }
+            println!("[review] reject signal delivered: {text}");
+            println!("[review] waiting for summarize to transition to failed");
             drain_and_stop(tail).await;
             return Ok(());
         }

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -40,7 +40,7 @@ use llama_cpp_2::{
     sampling::LlamaSampler,
 };
 use media_pipeline::{
-    find_last_summary_final, FrameView, SummarizeResult, TranscribeResult,
+    find_last_summary_final, ApprovalDecision, FrameView, SummarizeResult, TranscribeResult,
     FRAME_FIELD_PAYLOAD, FRAME_FIELD_TYPE, FRAME_SUMMARY_FINAL, SIGNAL_NAME_APPROVAL,
     SUMMARY_CHAR_CAP,
 };
@@ -172,9 +172,12 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Decide whether this claim is a fresh run or a resume-after-approval,
-/// then drive the appropriate path. A resume is identified by the
-/// presence of a persisted `summary_final` frame in the attempt stream.
+/// Decide whether this claim is a fresh run or a resume-after-review,
+/// then drive the appropriate path. The persisted `summary_final` frame
+/// tells us generation has already happened; `resume_signals()` tells us
+/// what the reviewer decided (approve vs reject with reason). Fresh
+/// claims have no signals, so the reject branch only fires on a real
+/// resume from a signed-rejection signal.
 async fn handle(
     task: ClaimedTask,
     engine: Arc<Engine>,
@@ -183,15 +186,71 @@ async fn handle(
     client: &ferriskey::Client,
     partition_config: &ff_core::partition::PartitionConfig,
 ) -> anyhow::Result<()> {
-    if let Some(result) = load_persisted_result(&task, client, partition_config).await? {
+    let persisted = load_persisted_result(&task, client, partition_config).await?;
+
+    if persisted.is_some() {
+        // Summary already generated in a prior attempt. Inspect the resume
+        // signal to decide complete-vs-fail. Previously the reviewer had
+        // to use POST /cancel to reject (no payload visibility); now the
+        // review CLI delivers a signed ApprovalDecision signal for both
+        // outcomes and we branch here.
+        let signals = task
+            .resume_signals()
+            .await
+            .context("resume_signals after approval")?;
+        if let Some(sig) = signals
+            .iter()
+            .find(|s| s.signal_name == SIGNAL_NAME_APPROVAL)
+        {
+            let decision: Option<ApprovalDecision> = sig
+                .payload
+                .as_deref()
+                .and_then(|b| serde_json::from_slice(b).ok());
+            match decision {
+                Some(ApprovalDecision::Approve) => {
+                    let result = persisted.expect("checked above");
+                    tracing::info!(
+                        execution_id = %task.execution_id(),
+                        tokens = result.token_count,
+                        "review approved — completing from persisted summary_final frame"
+                    );
+                    task.complete(Some(serde_json::to_vec(&result)?)).await?;
+                    return Ok(());
+                }
+                Some(ApprovalDecision::Reject { reason }) => {
+                    tracing::info!(
+                        execution_id = %task.execution_id(),
+                        reason = %reason,
+                        "review rejected — failing with reviewer reason"
+                    );
+                    task.fail(&reason, "human_rejected").await?;
+                    return Ok(());
+                }
+                None => {
+                    tracing::error!(
+                        execution_id = %task.execution_id(),
+                        "review signal had no parseable ApprovalDecision payload"
+                    );
+                    task.fail("review signal had unparseable payload", "bad_signal")
+                        .await?;
+                    return Ok(());
+                }
+            }
+        }
+        // No signal present — legacy path for approve-via-signal-only
+        // deployments (pre-#36 review CLI). Complete as we did before so
+        // existing operator tooling that still only delivers approve
+        // keeps working during a rolling upgrade.
+        let result = persisted.expect("checked above");
         tracing::info!(
             execution_id = %task.execution_id(),
             tokens = result.token_count,
-            "resume after approval — completing from persisted summary_final frame"
+            "resume without payload signal — completing (legacy reviewer)"
         );
         task.complete(Some(serde_json::to_vec(&result)?)).await?;
         return Ok(());
     }
+
     process(task, engine, max_new_tokens, skip_approval).await
 }
 

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -197,7 +197,7 @@ async fn handle(
         let signals = task
             .resume_signals()
             .await
-            .context("resume_signals after approval")?;
+            .context("resume_signals after review (approve or reject)")?;
         if let Some(sig) = signals
             .iter()
             .find(|s| s.signal_name == SIGNAL_NAME_APPROVAL)


### PR DESCRIPTION
## Summary

Closes #36 item 2. Both demos previously split human-review into approve=signal and reject=cancel because ff-sdk couldn't surface the resume signal's payload to the re-claimed worker. \`resume_signals()\` (PR #35 → integration-tested in #57) removes that constraint.

**coding-agent**: approve CLI now delivers \`review_response\` for both approve and reject with \`ReviewPayload { approved, feedback }\`. Worker reads \`resume_signals()\` on re-claim, branches complete-vs-fail on \`approved\`.

**media-pipeline**: review.rs now delivers the same HMAC-signed /signal for both \`ApprovalDecision::{Approve, Reject{reason}}\`. summarize.rs' \`handle\` inspects resume_signals() when the persisted \`summary_final\` frame exists and branches accordingly. \`--tamper-token\` now exercises HMAC enforcement on both outcomes.

## Wire schema

No breaking changes. Payload types (\`ReviewPayload\`, \`ApprovalDecision\`) already carried the fields we need. Signal names unchanged.

## Backward compatibility

summarize.rs keeps a legacy path: when \`resume_signals()\` returns no matching signal but a persisted \`summary_final\` frame is present, it completes as before. Lets a rolling-upgrade deployment with an older review CLI still approve via signal. Old reject-via-cancel still works because it never re-claims.

## Test plan

- [x] \`cargo build\` both examples clean
- [x] Manual code review: reject paths in both CLIs now deliver signals; worker branches on payload; defensive fail for missing/malformed payload
- [ ] End-to-end demo run (local Valkey 8 required — will verify post-merge in the release rehearsal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk as changes are confined to example CLIs/workers, but they alter the approve/reject control flow and could change demo behavior if signal payloads are missing or malformed.
> 
> **Overview**
> Both example demos now treat *approve and reject* as the same `/v1/executions/{id}/signal` path, carrying the decision in the signal payload (`ReviewPayload` / `ApprovalDecision`) instead of using `/cancel` for rejections.
> 
> The coding-agent `approve` CLI now always requires `--waitpoint-token` and always delivers `review_response`; the worker inspects `task.resume_signals()` on re-claim to either `complete()` with the stashed patch (approved) or `fail()` with reviewer feedback (rejected), with a defensive fail on unparseable payloads.
> 
> In media-pipeline, `review.rs` switches the reject path to send a signed signal (including idempotency keys and `--tamper-token` support) and `summarize.rs` uses `resume_signals()` to decide complete-vs-fail when a persisted `summary_final` exists, while keeping a legacy “no signal” completion path for rolling upgrades.
> 
> Lockfiles are updated to `ff-*`/`ferriskey` v0.3.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06158136b2ae8a2d830d0bfab6d66fa113518855. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->