### PR TITLE
chore(deps): bump rustls-webpki 0.103.12 -> 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,9 +2293,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Security patch for transitive dep \`rustls-webpki\`:
- **GHSA-82j2-j2ch-gfr8**: reachable panic in CRL parsing
- URI name-constraint handling fix (excluded subtrees were being processed inverted)

One-line Cargo.lock change; no Cargo.toml touched.

## Why not Dependabot PR #52

The grouped Dependabot PR combined this security fix with a major rand 0.9→0.10 bump that broke ferriskey's \`random_range\` call sites. Closed #52 and scoped this PR to just the security patch. The rand 0.9 patch bump can come in a follow-up after the 0.10 major is explicitly ignored in dependabot config.

## Test plan

- [x] \`cargo build --workspace\` clean
- [ ] CI matrix (Valkey 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency bump; behavior changes are limited to the updated `rustls-webpki` crate, but it affects TLS certificate validation so regressions would surface in connection/verification paths.
> 
> **Overview**
> Updates the transitive TLS certificate verification dependency `rustls-webpki` from `0.103.12` to `0.103.13` in `Cargo.lock` (checksum updated accordingly). No `Cargo.toml` changes; this is a lockfile-only bump intended to pick up the upstream security/bugfix release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80876a15891591ea05df179e6bcf9e8fcf5953a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->