### PR TITLE
feat(ff-sdk): describe_execution + ExecutionSnapshot (#58.1)

### DIFF
--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -6,11 +6,12 @@
 use crate::policy::ExecutionPolicy;
 use crate::state::{AttemptType, PublicState, StateVector};
 use crate::types::{
-    AttemptId, AttemptIndex, CancelSource, ExecutionId, LaneId, LeaseEpoch, LeaseId, Namespace,
-    SignalId, SuspensionId, TimestampMs, WaitpointId, WaitpointToken, WorkerId, WorkerInstanceId,
+    AttemptId, AttemptIndex, CancelSource, ExecutionId, FlowId, LaneId, LeaseEpoch, LeaseId,
+    Namespace, SignalId, SuspensionId, TimestampMs, WaitpointId, WaitpointToken, WorkerId,
+    WorkerInstanceId,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 // ─── create_execution ───
 
@@ -1382,6 +1383,180 @@ pub struct ExecutionInfo {
     pub current_attempt_index: u32,
     pub flow_id: Option<String>,
     pub blocking_detail: String,
+}
+
+// ─── describe_execution (issue #58.1) ───
+
+/// Engine-decoupled read-model for one execution.
+///
+/// Returned by `ff_sdk::FlowFabricWorker::describe_execution`. Consumers
+/// consult this struct instead of reaching into Valkey's exec_core hash
+/// directly — the engine is free to rename fields or restructure storage
+/// under this surface.
+///
+/// `#[non_exhaustive]` — FF may add fields in minor releases without a
+/// semver break. Match with `..` or use field-by-field construction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ExecutionSnapshot {
+    pub execution_id: ExecutionId,
+    pub flow_id: Option<FlowId>,
+    pub lane_id: LaneId,
+    pub namespace: Namespace,
+    pub public_state: PublicState,
+    /// Blocking reason string (e.g. `"waiting_for_worker"`,
+    /// `"waiting_for_delay"`, `"waiting_for_dependencies"`). `None` when
+    /// the exec_core field is empty.
+    pub blocking_reason: Option<String>,
+    /// Free-form operator-readable detail explaining `blocking_reason`.
+    /// `None` when the exec_core field is empty.
+    pub blocking_detail: Option<String>,
+    /// Summary of the execution's currently-active attempt. `None` when
+    /// no attempt has been started (pre-claim) or when the exec_core
+    /// attempt fields are all empty.
+    pub current_attempt: Option<AttemptSummary>,
+    /// Summary of the execution's currently-held lease. `None` when the
+    /// execution is not held by a worker.
+    pub current_lease: Option<LeaseSummary>,
+    /// The waitpoint this execution is currently suspended on, if any.
+    pub current_waitpoint: Option<WaitpointId>,
+    pub created_at: TimestampMs,
+    /// Timestamp of the last write that mutated exec_core. Engine-maintained.
+    pub last_mutation_at: TimestampMs,
+    pub total_attempt_count: u32,
+    /// Caller-owned labels. The prefix `^[a-z][a-z0-9_]*\.` is reserved for
+    /// consumer metadata (e.g. `cairn.task_id`); FF guarantees it will not
+    /// write keys matching that shape. FF's own fields stay in snake_case
+    /// without dots. Empty when no tags are set.
+    pub tags: BTreeMap<String, String>,
+}
+
+impl ExecutionSnapshot {
+    /// Construct an [`ExecutionSnapshot`]. Present so downstream crates
+    /// (ff-sdk's `describe_execution`) can assemble the struct despite
+    /// the `#[non_exhaustive]` marker. Prefer adding builder-style
+    /// helpers here over loosening `non_exhaustive`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        execution_id: ExecutionId,
+        flow_id: Option<FlowId>,
+        lane_id: LaneId,
+        namespace: Namespace,
+        public_state: PublicState,
+        blocking_reason: Option<String>,
+        blocking_detail: Option<String>,
+        current_attempt: Option<AttemptSummary>,
+        current_lease: Option<LeaseSummary>,
+        current_waitpoint: Option<WaitpointId>,
+        created_at: TimestampMs,
+        last_mutation_at: TimestampMs,
+        total_attempt_count: u32,
+        tags: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            execution_id,
+            flow_id,
+            lane_id,
+            namespace,
+            public_state,
+            blocking_reason,
+            blocking_detail,
+            current_attempt,
+            current_lease,
+            current_waitpoint,
+            created_at,
+            last_mutation_at,
+            total_attempt_count,
+            tags,
+        }
+    }
+}
+
+/// Currently-active attempt summary inside an [`ExecutionSnapshot`].
+///
+/// `#[non_exhaustive]`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AttemptSummary {
+    pub attempt_id: AttemptId,
+    pub attempt_index: AttemptIndex,
+}
+
+impl AttemptSummary {
+    /// Construct an [`AttemptSummary`]. See [`ExecutionSnapshot::new`]
+    /// for the rationale — `#[non_exhaustive]` blocks cross-crate
+    /// struct-literal construction.
+    pub fn new(attempt_id: AttemptId, attempt_index: AttemptIndex) -> Self {
+        Self {
+            attempt_id,
+            attempt_index,
+        }
+    }
+}
+
+/// Currently-held lease summary inside an [`ExecutionSnapshot`].
+///
+/// `#[non_exhaustive]`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct LeaseSummary {
+    pub lease_epoch: LeaseEpoch,
+    pub worker_instance_id: WorkerInstanceId,
+    pub expires_at: TimestampMs,
+}
+
+impl LeaseSummary {
+    /// Construct a [`LeaseSummary`]. See [`ExecutionSnapshot::new`]
+    /// for the rationale.
+    pub fn new(
+        lease_epoch: LeaseEpoch,
+        worker_instance_id: WorkerInstanceId,
+        expires_at: TimestampMs,
+    ) -> Self {
+        Self {
+            lease_epoch,
+            worker_instance_id,
+            expires_at,
+        }
+    }
+}
+
+// ─── set_execution_tags / set_flow_tags (issue #58.4) ───
+
+/// Args for `ff_set_execution_tags`. Tag keys MUST match
+/// `^[a-z][a-z0-9_]*\.` — the caller-namespace rule — or the FCALL
+/// returns `invalid_tag_key`. Values are arbitrary strings. The map is
+/// ordered (`BTreeMap`) so two callers submitting the same logical set
+/// of tags produce identical ARGV, which keeps FCALL tracing +
+/// idempotency reasoning simple.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SetExecutionTagsArgs {
+    pub execution_id: ExecutionId,
+    pub tags: BTreeMap<String, String>,
+}
+
+/// Result of `ff_set_execution_tags`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SetExecutionTagsResult {
+    /// Tags written. `count` is the number of key-value pairs applied.
+    Ok { count: u32 },
+}
+
+/// Args for `ff_set_flow_tags`. Same namespace rule as
+/// [`SetExecutionTagsArgs`]. The Lua function also lazy-migrates any
+/// pre-58.4 reserved-namespace fields stashed inline on `flow_core` into
+/// the new tags key.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SetFlowTagsArgs {
+    pub flow_id: FlowId,
+    pub tags: BTreeMap<String, String>,
+}
+
+/// Result of `ff_set_flow_tags`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SetFlowTagsResult {
+    /// Tags written. `count` is the number of key-value pairs applied.
+    Ok { count: u32 },
 }
 
 // ─── Common sub-types ───

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -1521,44 +1521,6 @@ impl LeaseSummary {
     }
 }
 
-// ─── set_execution_tags / set_flow_tags (issue #58.4) ───
-
-/// Args for `ff_set_execution_tags`. Tag keys MUST match
-/// `^[a-z][a-z0-9_]*\.` — the caller-namespace rule — or the FCALL
-/// returns `invalid_tag_key`. Values are arbitrary strings. The map is
-/// ordered (`BTreeMap`) so two callers submitting the same logical set
-/// of tags produce identical ARGV, which keeps FCALL tracing +
-/// idempotency reasoning simple.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SetExecutionTagsArgs {
-    pub execution_id: ExecutionId,
-    pub tags: BTreeMap<String, String>,
-}
-
-/// Result of `ff_set_execution_tags`.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum SetExecutionTagsResult {
-    /// Tags written. `count` is the number of key-value pairs applied.
-    Ok { count: u32 },
-}
-
-/// Args for `ff_set_flow_tags`. Same namespace rule as
-/// [`SetExecutionTagsArgs`]. The Lua function also lazy-migrates any
-/// pre-58.4 reserved-namespace fields stashed inline on `flow_core` into
-/// the new tags key.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SetFlowTagsArgs {
-    pub flow_id: FlowId,
-    pub tags: BTreeMap<String, String>,
-}
-
-/// Result of `ff_set_flow_tags`.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum SetFlowTagsResult {
-    /// Tags written. `count` is the number of key-value pairs applied.
-    Ok { count: u32 },
-}
-
 // ─── Common sub-types ───
 
 /// Summary of state after a mutation, returned by many functions.

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -62,6 +62,7 @@
 
 pub mod admin;
 pub mod config;
+pub mod snapshot;
 pub mod task;
 pub mod worker;
 

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -113,8 +113,17 @@ fn build_execution_snapshot(
 ) -> Result<Option<ExecutionSnapshot>, SdkError> {
     let public_state = parse_public_state(opt_str(core, "public_state").unwrap_or(""))?;
 
-    let lane_id_str = opt_str(core, "lane_id").unwrap_or("").to_owned();
-    let lane_id = LaneId::new(lane_id_str);
+    // `LaneId::try_new` validates non-empty + ASCII-printable + <= 64 bytes.
+    // Exec_core writes a LaneId that already passed these invariants at
+    // ingress; a read that fails validation here signals on-disk
+    // corruption — surface it rather than silently constructing an
+    // invalid LaneId that would mis-partition downstream.
+    let lane_id = LaneId::try_new(opt_str(core, "lane_id").unwrap_or("")).map_err(|e| {
+        SdkError::Config(format!(
+            "describe_execution: exec_core.lane_id fails LaneId validation \
+             (key corruption?): {e}"
+        ))
+    })?;
 
     let namespace_str = opt_str(core, "namespace").unwrap_or("").to_owned();
     let namespace = Namespace::new(namespace_str);
@@ -138,13 +147,26 @@ fn build_execution_snapshot(
         .filter(|s| !s.is_empty())
         .map(str::to_owned);
 
-    let created_at = parse_ts(core, "created_at")?.unwrap_or(TimestampMs::from_millis(0));
-    let last_mutation_at =
-        parse_ts(core, "last_mutation_at")?.unwrap_or(TimestampMs::from_millis(0));
+    // created_at + last_mutation_at are engine-maintained invariants
+    // (lua/execution.lua writes both on create; every mutating FCALL
+    // updates last_mutation_at). Missing values indicate on-disk
+    // corruption, not a valid pre-create state — fail loudly.
+    let created_at = parse_ts(core, "created_at")?.ok_or_else(|| {
+        SdkError::Config(
+            "describe_execution: exec_core.created_at is missing or empty \
+             (key corruption?)"
+                .to_owned(),
+        )
+    })?;
+    let last_mutation_at = parse_ts(core, "last_mutation_at")?.ok_or_else(|| {
+        SdkError::Config(
+            "describe_execution: exec_core.last_mutation_at is missing or empty \
+             (key corruption?)"
+                .to_owned(),
+        )
+    })?;
 
-    let total_attempt_count: u32 = opt_str(core, "total_attempt_count")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    let total_attempt_count: u32 = parse_u32_strict(core, "total_attempt_count")?.unwrap_or(0);
 
     let current_attempt = build_attempt_summary(core)?;
     let current_lease = build_lease_summary(core)?;
@@ -203,6 +225,40 @@ fn parse_ts(
     }
 }
 
+/// Strictly parse a `u32` field. Returns `Ok(None)` when the field is
+/// absent or empty (a valid pre-write state), `Err` when the value is
+/// present but unparseable (on-disk corruption), `Ok(Some(v))` otherwise.
+fn parse_u32_strict(
+    map: &HashMap<String, String>,
+    field: &str,
+) -> Result<Option<u32>, SdkError> {
+    match opt_str(map, field).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some(raw) => Ok(Some(raw.parse().map_err(|e| {
+            SdkError::Config(format!(
+                "describe_execution: exec_core.{field} is not a valid u32 \
+                 ('{raw}'): {e}"
+            ))
+        })?)),
+    }
+}
+
+/// Strictly parse a `u64` field. Semantics mirror [`parse_u32_strict`].
+fn parse_u64_strict(
+    map: &HashMap<String, String>,
+    field: &str,
+) -> Result<Option<u64>, SdkError> {
+    match opt_str(map, field).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some(raw) => Ok(Some(raw.parse().map_err(|e| {
+            SdkError::Config(format!(
+                "describe_execution: exec_core.{field} is not a valid u64 \
+                 ('{raw}'): {e}"
+            ))
+        })?)),
+    }
+}
+
 fn parse_public_state(raw: &str) -> Result<PublicState, SdkError> {
     // exec_core stores the snake_case literal (e.g. "waiting"). PublicState's
     // Deserialize accepts the JSON-quoted form, so wrap + delegate.
@@ -228,10 +284,17 @@ fn build_attempt_summary(
              UUID: {e}"
         ))
     })?;
-    let attempt_index: u32 = opt_str(core, "current_attempt_index")
-        .filter(|s| !s.is_empty())
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    // When `current_attempt_id` is set, `current_attempt_index` MUST be
+    // set too — lua/execution.lua writes both atomically in
+    // `ff_claim_execution`. A missing index while the id is populated
+    // is corruption, not a valid intermediate state.
+    let attempt_index = parse_u32_strict(core, "current_attempt_index")?.ok_or_else(|| {
+        SdkError::Config(
+            "describe_execution: exec_core.current_attempt_index is missing \
+             while current_attempt_id is set (key corruption?)"
+                .to_owned(),
+        )
+    })?;
     Ok(Some(AttemptSummary::new(
         attempt_id,
         AttemptIndex::new(attempt_index),
@@ -252,10 +315,16 @@ fn build_lease_summary(
         None => return Ok(None),
         Some(ts) => ts,
     };
-    let epoch: u64 = opt_str(core, "current_lease_epoch")
-        .filter(|s| !s.is_empty())
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    // A lease is only "held" if the epoch is present too — lua/helpers.lua
+    // sets/clears epoch atomically with wid + expires_at. Parse strictly
+    // and require it: a missing epoch alongside a live wid is corruption.
+    let epoch = parse_u64_strict(core, "current_lease_epoch")?.ok_or_else(|| {
+        SdkError::Config(
+            "describe_execution: exec_core.current_lease_epoch is missing \
+             while current_worker_instance_id is set (key corruption?)"
+                .to_owned(),
+        )
+    })?;
     Ok(Some(LeaseSummary::new(
         LeaseEpoch::new(epoch),
         WorkerInstanceId::new(wid_str.to_owned()),
@@ -319,6 +388,83 @@ mod tests {
             .unwrap_err();
         match err {
             SdkError::Config(msg) => assert!(msg.contains("public_state"), "msg: {msg}"),
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_lane_id_fails_loud() {
+        // LaneId::try_new rejects non-printable bytes. Simulate on-disk
+        // corruption by stamping a lane_id with an embedded \n.
+        let mut core = minimal_core("waiting");
+        core.insert("lane_id".to_owned(), "lane\nbroken".to_owned());
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        match err {
+            SdkError::Config(msg) => assert!(msg.contains("lane_id"), "msg: {msg}"),
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_required_timestamps_fail_loud() {
+        for field in ["created_at", "last_mutation_at"] {
+            let mut core = minimal_core("waiting");
+            core.remove(field);
+            let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+            match err {
+                SdkError::Config(msg) => {
+                    assert!(msg.contains(field), "msg for {field}: {msg}")
+                }
+                other => panic!("expected Config for {field}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_total_attempt_count_fails_loud() {
+        let mut core = minimal_core("waiting");
+        core.insert("total_attempt_count".to_owned(), "not-a-number".to_owned());
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        match err {
+            SdkError::Config(msg) => {
+                assert!(msg.contains("total_attempt_count"), "msg: {msg}")
+            }
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn attempt_id_without_index_fails_loud() {
+        // current_attempt_id set but current_attempt_index absent =>
+        // corruption, since lua/execution.lua writes both atomically.
+        let mut core = minimal_core("active");
+        core.insert(
+            "current_attempt_id".to_owned(),
+            AttemptId::new().to_string(),
+        );
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        match err {
+            SdkError::Config(msg) => {
+                assert!(msg.contains("current_attempt_index"), "msg: {msg}")
+            }
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lease_without_epoch_fails_loud() {
+        // wid + expires_at present but epoch missing => corruption.
+        let mut core = minimal_core("active");
+        core.insert(
+            "current_worker_instance_id".to_owned(),
+            "w-inst-1".to_owned(),
+        );
+        core.insert("lease_expires_at".to_owned(), "9000".to_owned());
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        match err {
+            SdkError::Config(msg) => {
+                assert!(msg.contains("current_lease_epoch"), "msg: {msg}")
+            }
             other => panic!("expected Config, got {other:?}"),
         }
     }

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -1,0 +1,350 @@
+//! Typed read-models that decouple consumers from FF's storage engine.
+//!
+//! Today the only call here is [`FlowFabricWorker::describe_execution`],
+//! which replaces the HGETALL-on-exec_core pattern downstream consumers
+//! rely on with a typed snapshot. The engine remains free to rename
+//! hash fields or restructure keys under this surface — see issue #58
+//! for the strategic context (decoupling ahead of a Postgres backend
+//! port).
+//!
+//! Snapshot types (`ExecutionSnapshot`, `AttemptSummary`, `LeaseSummary`)
+//! live in [`ff_core::contracts`] so non-SDK consumers (tests, REST
+//! server, future alternate backends) can share them without depending
+//! on ff-sdk.
+
+use std::collections::{BTreeMap, HashMap};
+
+use ff_core::contracts::{AttemptSummary, ExecutionSnapshot, LeaseSummary};
+use ff_core::keys::ExecKeyContext;
+use ff_core::partition::execution_partition;
+use ff_core::state::PublicState;
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, FlowId, LaneId, LeaseEpoch, Namespace, TimestampMs,
+    WaitpointId, WorkerInstanceId,
+};
+
+use crate::worker::FlowFabricWorker;
+use crate::SdkError;
+
+impl FlowFabricWorker {
+    /// Read a typed snapshot of one execution.
+    ///
+    /// Returns `Ok(None)` when no execution exists at `id` (exec_core
+    /// hash absent). Returns `Ok(Some(snapshot))` on success. Errors
+    /// propagate Valkey transport faults and decode failures.
+    ///
+    /// # Consistency
+    ///
+    /// The snapshot is assembled from two pipelined `HGETALL`s — one
+    /// for `exec_core`, one for the sibling tags hash — issued in a
+    /// single round trip against the partition holding the execution.
+    /// The two reads share a hash-tag so they always land on the same
+    /// Valkey slot in cluster mode. They are NOT MULTI/EXEC-atomic:
+    /// a concurrent FCALL that HSETs both keys can interleave, and a
+    /// caller may observe exec_core fields from epoch `N+1` alongside
+    /// tags from epoch `N` (or vice versa). This matches the
+    /// last-write-wins-per-field semantics every existing HGETALL
+    /// consumer already assumes.
+    ///
+    /// # Field semantics
+    ///
+    /// * `public_state` is the engine-maintained derived label written
+    ///   atomically by every state-mutating FCALL. Parsed from the
+    ///   snake_case string stored on exec_core.
+    /// * `blocking_reason` / `blocking_detail` — `None` when the
+    ///   exec_core field is the empty string (cleared on transition).
+    /// * `current_attempt` — `None` before the first claim (exec_core
+    ///   `current_attempt_id` empty).
+    /// * `current_lease` — `None` when no lease is held (typical for
+    ///   terminal, suspended, or pre-claim executions).
+    /// * `current_waitpoint` — `None` unless an active suspension has
+    ///   pinned a waitpoint id.
+    /// * `tags` — empty map if the tags hash is absent (common for
+    ///   executions created without `tags_json`).
+    pub async fn describe_execution(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<ExecutionSnapshot>, SdkError> {
+        let partition = execution_partition(id, self.partition_config());
+        let ctx = ExecKeyContext::new(&partition, id);
+        let core_key = ctx.core();
+        let tags_key = ctx.tags();
+
+        // Pipeline the two HGETALLs in one round trip. The two keys
+        // share `{fp:N}` so cluster mode routes them to the same slot.
+        let mut pipe = self.client().pipeline();
+        let core_slot = pipe
+            .cmd::<HashMap<String, String>>("HGETALL")
+            .arg(&core_key)
+            .finish();
+        let tags_slot = pipe
+            .cmd::<HashMap<String, String>>("HGETALL")
+            .arg(&tags_key)
+            .finish();
+        pipe.execute().await.map_err(|e| SdkError::ValkeyContext {
+            source: e,
+            context: "describe_execution: pipeline HGETALL exec_core + tags".into(),
+        })?;
+
+        let core = core_slot.value().map_err(|e| SdkError::ValkeyContext {
+            source: e,
+            context: "describe_execution: decode HGETALL exec_core".into(),
+        })?;
+        if core.is_empty() {
+            return Ok(None);
+        }
+        let tags_raw = tags_slot.value().map_err(|e| SdkError::ValkeyContext {
+            source: e,
+            context: "describe_execution: decode HGETALL tags".into(),
+        })?;
+
+        build_execution_snapshot(id.clone(), &core, tags_raw)
+    }
+}
+
+/// Assemble an [`ExecutionSnapshot`] from the raw HGETALL field maps.
+///
+/// Kept as a free function so a future unit test can feed synthetic
+/// maps without a live Valkey.
+fn build_execution_snapshot(
+    execution_id: ExecutionId,
+    core: &HashMap<String, String>,
+    tags_raw: HashMap<String, String>,
+) -> Result<Option<ExecutionSnapshot>, SdkError> {
+    let public_state = parse_public_state(opt_str(core, "public_state").unwrap_or(""))?;
+
+    let lane_id_str = opt_str(core, "lane_id").unwrap_or("").to_owned();
+    let lane_id = LaneId::new(lane_id_str);
+
+    let namespace_str = opt_str(core, "namespace").unwrap_or("").to_owned();
+    let namespace = Namespace::new(namespace_str);
+
+    let flow_id = opt_str(core, "flow_id")
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            FlowId::parse(s).map_err(|e| {
+                SdkError::Config(format!(
+                    "describe_execution: exec_core.flow_id is not a valid UUID \
+                     (key corruption?): {e}"
+                ))
+            })
+        })
+        .transpose()?;
+
+    let blocking_reason = opt_str(core, "blocking_reason")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    let blocking_detail = opt_str(core, "blocking_detail")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+
+    let created_at = parse_ts(core, "created_at")?.unwrap_or(TimestampMs::from_millis(0));
+    let last_mutation_at =
+        parse_ts(core, "last_mutation_at")?.unwrap_or(TimestampMs::from_millis(0));
+
+    let total_attempt_count: u32 = opt_str(core, "total_attempt_count")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    let current_attempt = build_attempt_summary(core)?;
+    let current_lease = build_lease_summary(core)?;
+
+    let current_waitpoint = opt_str(core, "current_waitpoint_id")
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            WaitpointId::parse(s).map_err(|e| {
+                SdkError::Config(format!(
+                    "describe_execution: exec_core.current_waitpoint_id is not a \
+                     valid UUID (key corruption?): {e}"
+                ))
+            })
+        })
+        .transpose()?;
+
+    let tags: BTreeMap<String, String> = tags_raw.into_iter().collect();
+
+    Ok(Some(ExecutionSnapshot::new(
+        execution_id,
+        flow_id,
+        lane_id,
+        namespace,
+        public_state,
+        blocking_reason,
+        blocking_detail,
+        current_attempt,
+        current_lease,
+        current_waitpoint,
+        created_at,
+        last_mutation_at,
+        total_attempt_count,
+        tags,
+    )))
+}
+
+fn opt_str<'a>(map: &'a HashMap<String, String>, field: &str) -> Option<&'a str> {
+    map.get(field).map(String::as_str)
+}
+
+fn parse_ts(
+    map: &HashMap<String, String>,
+    field: &str,
+) -> Result<Option<TimestampMs>, SdkError> {
+    match opt_str(map, field).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some(raw) => {
+            let ms: i64 = raw.parse().map_err(|e| {
+                SdkError::Config(format!(
+                    "describe_execution: exec_core.{field} is not a valid ms \
+                     timestamp ('{raw}'): {e}"
+                ))
+            })?;
+            Ok(Some(TimestampMs::from_millis(ms)))
+        }
+    }
+}
+
+fn parse_public_state(raw: &str) -> Result<PublicState, SdkError> {
+    // exec_core stores the snake_case literal (e.g. "waiting"). PublicState's
+    // Deserialize accepts the JSON-quoted form, so wrap + delegate.
+    let quoted = format!("\"{raw}\"");
+    serde_json::from_str(&quoted).map_err(|e| {
+        SdkError::Config(format!(
+            "describe_execution: exec_core.public_state '{raw}' is not a known \
+             public state: {e}"
+        ))
+    })
+}
+
+fn build_attempt_summary(
+    core: &HashMap<String, String>,
+) -> Result<Option<AttemptSummary>, SdkError> {
+    let attempt_id_str = match opt_str(core, "current_attempt_id").filter(|s| !s.is_empty()) {
+        None => return Ok(None),
+        Some(s) => s,
+    };
+    let attempt_id = AttemptId::parse(attempt_id_str).map_err(|e| {
+        SdkError::Config(format!(
+            "describe_execution: exec_core.current_attempt_id is not a valid \
+             UUID: {e}"
+        ))
+    })?;
+    let attempt_index: u32 = opt_str(core, "current_attempt_index")
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    Ok(Some(AttemptSummary::new(
+        attempt_id,
+        AttemptIndex::new(attempt_index),
+    )))
+}
+
+fn build_lease_summary(
+    core: &HashMap<String, String>,
+) -> Result<Option<LeaseSummary>, SdkError> {
+    // A lease is "held" when the worker_instance_id field is populated
+    // AND lease_expires_at is set. Both clear together on revoke/expire
+    // (see clear_lease_and_indexes in lua/helpers.lua).
+    let wid_str = match opt_str(core, "current_worker_instance_id").filter(|s| !s.is_empty()) {
+        None => return Ok(None),
+        Some(s) => s,
+    };
+    let expires_at = match parse_ts(core, "lease_expires_at")? {
+        None => return Ok(None),
+        Some(ts) => ts,
+    };
+    let epoch: u64 = opt_str(core, "current_lease_epoch")
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    Ok(Some(LeaseSummary::new(
+        LeaseEpoch::new(epoch),
+        WorkerInstanceId::new(wid_str.to_owned()),
+        expires_at,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_core::partition::PartitionConfig;
+    use ff_core::types::FlowId;
+
+    fn eid() -> ExecutionId {
+        let config = PartitionConfig::default();
+        ExecutionId::for_flow(&FlowId::new(), &config)
+    }
+
+    fn minimal_core(public_state: &str) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("public_state".to_owned(), public_state.to_owned());
+        m.insert("lane_id".to_owned(), "default".to_owned());
+        m.insert("namespace".to_owned(), "ns".to_owned());
+        m.insert("created_at".to_owned(), "1000".to_owned());
+        m.insert("last_mutation_at".to_owned(), "2000".to_owned());
+        m.insert("total_attempt_count".to_owned(), "0".to_owned());
+        m
+    }
+
+    #[test]
+    fn waiting_exec_no_attempt_no_lease_no_tags() {
+        let snap = build_execution_snapshot(eid(), &minimal_core("waiting"), HashMap::new())
+            .unwrap()
+            .expect("should build");
+        assert_eq!(snap.public_state, PublicState::Waiting);
+        assert!(snap.current_attempt.is_none());
+        assert!(snap.current_lease.is_none());
+        assert!(snap.current_waitpoint.is_none());
+        assert_eq!(snap.tags.len(), 0);
+        assert_eq!(snap.created_at.0, 1000);
+        assert_eq!(snap.last_mutation_at.0, 2000);
+        assert!(snap.flow_id.is_none());
+        assert!(snap.blocking_reason.is_none());
+    }
+
+    #[test]
+    fn tags_flow_through_sorted() {
+        let mut tags = HashMap::new();
+        tags.insert("cairn.task_id".to_owned(), "t-1".to_owned());
+        tags.insert("cairn.project".to_owned(), "proj".to_owned());
+        let snap = build_execution_snapshot(eid(), &minimal_core("waiting"), tags)
+            .unwrap()
+            .unwrap();
+        let keys: Vec<_> = snap.tags.keys().cloned().collect();
+        assert_eq!(keys, vec!["cairn.project".to_owned(), "cairn.task_id".to_owned()]);
+    }
+
+    #[test]
+    fn invalid_public_state_fails_loud() {
+        let err = build_execution_snapshot(eid(), &minimal_core("bogus"), HashMap::new())
+            .unwrap_err();
+        match err {
+            SdkError::Config(msg) => assert!(msg.contains("public_state"), "msg: {msg}"),
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lease_summary_requires_both_wid_and_expires_at() {
+        // Only wid → no lease (lease expired + cleared lease_expires_at
+        // but wid not yet rewritten is not a real state; defensive).
+        let mut core = minimal_core("active");
+        core.insert(
+            "current_worker_instance_id".to_owned(),
+            "w-inst-1".to_owned(),
+        );
+        let snap = build_execution_snapshot(eid(), &core, HashMap::new())
+            .unwrap()
+            .unwrap();
+        assert!(snap.current_lease.is_none());
+
+        core.insert("lease_expires_at".to_owned(), "9000".to_owned());
+        core.insert("current_lease_epoch".to_owned(), "3".to_owned());
+        let snap = build_execution_snapshot(eid(), &core, HashMap::new())
+            .unwrap()
+            .unwrap();
+        let lease = snap.current_lease.expect("lease present");
+        assert_eq!(lease.lease_epoch, LeaseEpoch::new(3));
+        assert_eq!(lease.expires_at.0, 9000);
+        assert_eq!(lease.worker_instance_id.as_str(), "w-inst-1");
+    }
+}

--- a/crates/ff-test/tests/describe_execution_api.rs
+++ b/crates/ff-test/tests/describe_execution_api.rs
@@ -1,0 +1,343 @@
+//! Integration tests for `FlowFabricWorker::describe_execution` (issue #58.1).
+//!
+//! Exercises the typed snapshot read against a live Valkey: creates
+//! executions via `ff_create_execution`, optionally drives them through
+//! claim/lease, and asserts the resulting `ExecutionSnapshot` matches
+//! the engine's on-disk exec_core + tags state.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test describe_execution_api -- --test-threads=1
+
+use ferriskey::Value;
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, PartitionConfig};
+use ff_core::state::PublicState;
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+const LANE: &str = "desc-exec-lane";
+const NS: &str = "desc-exec-ns";
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = test_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(6379),
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        worker_id: WorkerId::new(format!("desc-exec-worker-{name_suffix}")),
+        worker_instance_id: WorkerInstanceId::new(format!("desc-exec-inst-{name_suffix}")),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+/// Create an execution via FCALL, optionally with tags and/or a delay.
+async fn create_execution(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    tags_json: &str,
+    delay_until: &str,
+) {
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let scheduling_key = if delay_until.is_empty() {
+        idx.lane_eligible(&lane_id)
+    } else {
+        idx.lane_delayed(&lane_id)
+    };
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        scheduling_key,
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "test_kind".to_owned(),
+        "0".to_owned(),
+        "desc-exec-test".to_owned(),
+        "{}".to_owned(),
+        String::new(),
+        delay_until.to_owned(),
+        String::new(),
+        tags_json.to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_create_execution failed");
+}
+
+// ─── Tests ───
+
+#[tokio::test]
+async fn describe_missing_execution_returns_none() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("missing").await;
+
+    // Fresh execution id — never written to Valkey.
+    let eid = ExecutionId::for_flow(&FlowId::new(), &test_config());
+    let snap = worker
+        .describe_execution(&eid)
+        .await
+        .expect("describe_execution should not error on missing");
+    assert!(snap.is_none(), "expected Ok(None) for missing execution");
+}
+
+#[tokio::test]
+async fn describe_freshly_created_execution_is_waiting() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("waiting").await;
+
+    let eid = ExecutionId::for_flow(&FlowId::new(), &test_config());
+    create_execution(&tc, &eid, "{}", "").await;
+
+    let snap = worker
+        .describe_execution(&eid)
+        .await
+        .expect("describe_execution should succeed")
+        .expect("snapshot should be Some for created execution");
+
+    assert_eq!(snap.execution_id, eid);
+    assert_eq!(snap.public_state, PublicState::Waiting);
+    assert_eq!(snap.lane_id.as_str(), LANE);
+    assert_eq!(snap.namespace.as_str(), NS);
+    assert!(snap.current_attempt.is_none(), "no attempt pre-claim");
+    assert!(snap.current_lease.is_none(), "no lease pre-claim");
+    assert!(snap.current_waitpoint.is_none(), "no waitpoint pre-suspension");
+    assert!(snap.flow_id.is_none(), "solo exec has no flow affinity");
+    assert_eq!(snap.total_attempt_count, 0);
+    assert!(snap.tags.is_empty(), "empty tags_json → empty tags map");
+    assert!(snap.created_at.0 > 0, "created_at must be populated");
+    assert_eq!(
+        snap.last_mutation_at, snap.created_at,
+        "on create, last_mutation_at == created_at"
+    );
+    assert_eq!(
+        snap.blocking_reason.as_deref(),
+        Some("waiting_for_worker"),
+        "freshly-eligible exec is blocked on worker availability"
+    );
+    assert!(
+        snap.blocking_detail.is_none(),
+        "blocking_detail is empty for waiting_for_worker"
+    );
+}
+
+#[tokio::test]
+async fn describe_execution_with_tags_round_trips() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("tags").await;
+
+    let eid = ExecutionId::for_flow(&FlowId::new(), &test_config());
+    let tags_json = r#"{"cairn.task_id":"t-42","cairn.project":"proj-a"}"#;
+    create_execution(&tc, &eid, tags_json, "").await;
+
+    let snap = worker
+        .describe_execution(&eid)
+        .await
+        .expect("describe_execution succeeds")
+        .expect("snapshot present");
+
+    assert_eq!(snap.tags.len(), 2);
+    assert_eq!(
+        snap.tags.get("cairn.task_id").map(String::as_str),
+        Some("t-42")
+    );
+    assert_eq!(
+        snap.tags.get("cairn.project").map(String::as_str),
+        Some("proj-a")
+    );
+    // BTreeMap sort order keeps enumeration deterministic.
+    let ordered_keys: Vec<&str> = snap.tags.keys().map(String::as_str).collect();
+    assert_eq!(ordered_keys, vec!["cairn.project", "cairn.task_id"]);
+}
+
+#[tokio::test]
+async fn describe_delayed_execution_is_delayed() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("delayed").await;
+
+    let eid = ExecutionId::for_flow(&FlowId::new(), &test_config());
+    // 5 minutes in the future — well beyond any test's wall-clock.
+    let delay_until_ms = (TimestampMs::now().0 + 5 * 60 * 1000).to_string();
+    create_execution(&tc, &eid, "{}", &delay_until_ms).await;
+
+    let snap = worker
+        .describe_execution(&eid)
+        .await
+        .expect("describe succeeds")
+        .expect("snapshot present");
+
+    assert_eq!(snap.public_state, PublicState::Delayed);
+    assert_eq!(snap.blocking_reason.as_deref(), Some("waiting_for_delay"));
+    // blocking_detail is `"delayed until <ms>"` — don't pin the exact
+    // string; assert the prefix so a future format tweak doesn't break
+    // the test.
+    assert!(
+        snap.blocking_detail
+            .as_deref()
+            .is_some_and(|d| d.starts_with("delayed until ")),
+        "blocking_detail = {:?}",
+        snap.blocking_detail
+    );
+}
+
+#[tokio::test]
+async fn describe_execution_after_claim_has_attempt_and_lease() {
+    // After a worker claim, the snapshot must report the active attempt
+    // (current_attempt_id / current_attempt_index) and the held lease
+    // (current_worker_instance_id / lease_expires_at / lease_epoch).
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("claimed").await;
+
+    let eid = ExecutionId::for_flow(&FlowId::new(), &test_config());
+    create_execution(&tc, &eid, "{}", "").await;
+
+    // Directly HSET claim-state fields on exec_core to simulate a live
+    // claim without the full FCALL dance (mirroring how the other read
+    // tests in this file avoid reimplementing the claim lifecycle).
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let attempt_id = AttemptId::new();
+    let wid = "desc-exec-inst-claimed";
+    let expires_at = TimestampMs::now().0 + 30_000;
+    let _: Value = tc
+        .client()
+        .cmd("HSET")
+        .arg(ctx.core())
+        .arg("current_attempt_id")
+        .arg(attempt_id.to_string().as_str())
+        .arg("current_attempt_index")
+        .arg("0")
+        .arg("current_worker_instance_id")
+        .arg(wid)
+        .arg("lease_expires_at")
+        .arg(expires_at.to_string().as_str())
+        .arg("current_lease_epoch")
+        .arg("1")
+        .arg("total_attempt_count")
+        .arg("1")
+        .execute()
+        .await
+        .unwrap();
+
+    let snap = worker
+        .describe_execution(&eid)
+        .await
+        .expect("describe succeeds")
+        .expect("snapshot present");
+
+    let att = snap.current_attempt.expect("attempt summary present");
+    assert_eq!(att.attempt_id, attempt_id);
+    assert_eq!(att.attempt_index, AttemptIndex::new(0));
+
+    let lease = snap.current_lease.expect("lease summary present");
+    assert_eq!(lease.lease_epoch, LeaseEpoch::new(1));
+    assert_eq!(lease.worker_instance_id.as_str(), wid);
+    assert_eq!(lease.expires_at.0, expires_at);
+
+    assert_eq!(snap.total_attempt_count, 1);
+}
+
+#[tokio::test]
+async fn describe_execution_corrupt_public_state_surfaces_error() {
+    // Defensive: if a future field rename leaves a stray literal on
+    // exec_core, describe_execution must fail loudly rather than
+    // silently coercing to a safe default. This test pins the
+    // parse-error contract so a regression to "unwrap_or(Waiting)" is
+    // caught in CI.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("corrupt").await;
+
+    let eid = ExecutionId::for_flow(&FlowId::new(), &test_config());
+    create_execution(&tc, &eid, "{}", "").await;
+
+    let config = test_config();
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let _: Value = tc
+        .client()
+        .cmd("HSET")
+        .arg(ctx.core())
+        .arg("public_state")
+        .arg("not_a_real_state")
+        .execute()
+        .await
+        .unwrap();
+
+    let err = worker
+        .describe_execution(&eid)
+        .await
+        .expect_err("corrupt public_state must surface as error");
+    match err {
+        ff_sdk::SdkError::Config(msg) => {
+            assert!(
+                msg.contains("public_state"),
+                "error message must name the field: {msg}"
+            );
+        }
+        other => panic!("expected SdkError::Config, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

First item of the #58 Valkey-decoupling plan. Adds `FlowFabricWorker::describe_execution` — a typed read-model that replaces the HGETALL-on-exec_core pattern downstream consumers (cairn-rs, tests) hand-roll today.

- `ff_core::contracts`: new `ExecutionSnapshot`, `AttemptSummary`, `LeaseSummary`. All `#[non_exhaustive]` with `::new()` constructors so FF can add fields in minors without a semver break (per issue #58's migration shape).
- `ff_sdk::snapshot`: `describe_execution` pipelines two `HGETALL`s (`exec_core` + sibling `tags` key) in one round trip. Shared `{fp:N}` hash-tag keeps them on the same Valkey slot in cluster mode.
- Not MULTI/EXEC-atomic — matches existing last-write-wins-per-field semantics every HGETALL consumer already assumes. Documented on the method.
- `Ok(None)` when `exec_core` is absent; `Ok(Some(_))` otherwise.
- Corrupt fields (unknown `public_state`, malformed UUIDs, unparseable timestamps) surface as `SdkError::Config` rather than silently coercing to defaults.

Adds the snapshot conventions 58.2 (`describe_flow`) and 58.3 (edge reads) will mirror.

## Tags-storage note (per owner direction)

Execution tags live in the separate `ff:exec:{fp:N}:<eid>:tags` key (`ExecKeyContext::tags()`). The impl pipelines two HGETALLs and constructs an empty `BTreeMap` when the tags hash is absent. Flow-tags handling (58.2) is a separate design decision owned by Worker B in 58.4.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p ff-sdk --lib snapshot` — 4/4 unit tests pass
- [x] `cargo test -p ff-test --test describe_execution_api -- --test-threads=1` — 6/6 integration tests pass against live Valkey:
  - missing execution → `Ok(None)`
  - freshly created → `PublicState::Waiting`, `blocking_reason = "waiting_for_worker"`, no attempt/lease, empty tags
  - with tags → `BTreeMap` populated and sorted
  - delayed execution → `PublicState::Delayed`, `blocking_reason = "waiting_for_delay"`
  - post-claim (simulated) → `current_attempt` and `current_lease` populated
  - corrupt `public_state` → `SdkError::Config` with field name in message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public SDK read API that parses raw `exec_core`/tags data into typed structs; errors now surface on corrupt storage fields, so behavior changes could affect downstream consumers relying on best-effort reads.
> 
> **Overview**
> Adds an engine-decoupled, typed execution read model via `ExecutionSnapshot` (plus `AttemptSummary`/`LeaseSummary`) in `ff-core`, including constructors to support `#[non_exhaustive]` evolution.
> 
> Introduces `ff-sdk`’s `FlowFabricWorker::describe_execution`, which pipelines `HGETALL` reads of `exec_core` and the sibling tags hash and returns `Ok(None)` when the execution is missing; invalid states/UUIDs/timestamps are surfaced as `SdkError::Config`. Includes new unit tests for snapshot assembly and new live-Valkey integration tests covering missing, waiting/delayed, tags, post-claim fields, and corruption cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5689371b1141252487b0fad2a36fc74b4f4ddd1b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->