### PR TITLE
feat(ff-sdk): describe_edge + list_*_edges + EdgeSnapshot (#58.3)

### DIFF
--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -6,8 +6,8 @@
 use crate::policy::ExecutionPolicy;
 use crate::state::{AttemptType, PublicState, StateVector};
 use crate::types::{
-    AttemptId, AttemptIndex, CancelSource, ExecutionId, FlowId, LaneId, LeaseEpoch, LeaseId,
-    Namespace, SignalId, SuspensionId, TimestampMs, WaitpointId, WaitpointToken, WorkerId,
+    AttemptId, AttemptIndex, CancelSource, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch,
+    LeaseId, Namespace, SignalId, SuspensionId, TimestampMs, WaitpointId, WaitpointToken, WorkerId,
     WorkerInstanceId,
 };
 use serde::{Deserialize, Serialize};
@@ -1654,6 +1654,87 @@ impl FlowSnapshot {
             cancel_reason,
             cancellation_policy,
             tags,
+        }
+    }
+}
+
+// ─── describe_edge / list_*_edges (issue #58.3) ───
+
+/// Engine-decoupled read-model for one dependency edge.
+///
+/// Returned by `ff_sdk::FlowFabricWorker::describe_edge`,
+/// `list_incoming_edges`, and `list_outgoing_edges`. Consumers consult
+/// this struct instead of reaching into Valkey's per-flow `edge:` hash
+/// directly — the engine is free to rename hash fields or restructure
+/// key layout under this surface.
+///
+/// `#[non_exhaustive]` — FF may add fields in minor releases without a
+/// semver break. Match with `..` or use [`EdgeSnapshot::new`].
+///
+/// # Fields
+///
+/// The struct mirrors the immutable edge record written by
+/// `ff_stage_dependency_edge` (see `lua/flow.lua`). The flow-scoped
+/// edge hash is only ever written once, at staging time; per-execution
+/// resolution state lives on a separate `dep:<edge_id>` hash and is not
+/// surfaced here. The `edge_state` field therefore reflects the
+/// staging-time literal (currently `pending`), not the downstream
+/// execution's dep-edge state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EdgeSnapshot {
+    pub edge_id: EdgeId,
+    pub flow_id: FlowId,
+    pub upstream_execution_id: ExecutionId,
+    pub downstream_execution_id: ExecutionId,
+    /// The `dependency_kind` literal (e.g. `success_only`) from
+    /// `stage_dependency_edge`. Preserved as-is; FF does not interpret
+    /// it on reads.
+    pub dependency_kind: String,
+    /// The satisfaction-condition literal stamped at staging time
+    /// (e.g. `all_required`).
+    pub satisfaction_condition: String,
+    /// Optional opaque handle to a data-passing artifact. `None` when
+    /// the stored field is empty (the most common case).
+    pub data_passing_ref: Option<String>,
+    /// Edge-state literal on the flow-scoped edge hash. Written once
+    /// at staging as `pending`; this hash is immutable on the flow
+    /// side. Per-execution resolution state is tracked separately on
+    /// the child's `dep:<edge_id>` hash.
+    pub edge_state: String,
+    pub created_at: TimestampMs,
+    /// Origin of the edge (e.g. `engine`). Preserved as-is.
+    pub created_by: String,
+}
+
+impl EdgeSnapshot {
+    /// Construct an [`EdgeSnapshot`]. Present so downstream crates
+    /// (ff-sdk's `describe_edge` / `list_*_edges`) can assemble the
+    /// struct despite the `#[non_exhaustive]` marker.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        edge_id: EdgeId,
+        flow_id: FlowId,
+        upstream_execution_id: ExecutionId,
+        downstream_execution_id: ExecutionId,
+        dependency_kind: String,
+        satisfaction_condition: String,
+        data_passing_ref: Option<String>,
+        edge_state: String,
+        created_at: TimestampMs,
+        created_by: String,
+    ) -> Self {
+        Self {
+            edge_id,
+            flow_id,
+            upstream_execution_id,
+            downstream_execution_id,
+            dependency_kind,
+            satisfaction_condition,
+            data_passing_ref,
+            edge_state,
+            created_at,
+            created_by,
         }
     }
 }

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -685,7 +685,13 @@ impl FlowFabricWorker {
         };
         let partition = flow_partition(&flow_id, self.partition_config());
         let ctx = FlowKeyContext::new(&partition, &flow_id);
-        self.list_edges_from_set(&ctx.outgoing(upstream_eid), &flow_id).await
+        self.list_edges_from_set(
+            &ctx.outgoing(upstream_eid),
+            &flow_id,
+            upstream_eid,
+            AdjacencySide::Outgoing,
+        )
+        .await
     }
 
     /// List all incoming dependency edges landing on an execution.
@@ -699,18 +705,30 @@ impl FlowFabricWorker {
         };
         let partition = flow_partition(&flow_id, self.partition_config());
         let ctx = FlowKeyContext::new(&partition, &flow_id);
-        self.list_edges_from_set(&ctx.incoming(downstream_eid), &flow_id).await
+        self.list_edges_from_set(
+            &ctx.incoming(downstream_eid),
+            &flow_id,
+            downstream_eid,
+            AdjacencySide::Incoming,
+        )
+        .await
     }
 
     /// `HGET exec_core.flow_id` and parse to a [`FlowId`]. `None` when
     /// the exec_core hash is absent OR the flow_id field is empty
     /// (standalone execution).
+    ///
+    /// Also pins the RFC-011 co-location invariant
+    /// (`execution_partition(eid) == flow_partition(flow_id)`) — a
+    /// parsed-but-wrong flow_id would otherwise silently route the
+    /// follow-up adjacency reads to the wrong partition and return
+    /// bogus empty results. A mismatch surfaces as `SdkError::Config`.
     async fn resolve_flow_id(
         &self,
         eid: &ExecutionId,
     ) -> Result<Option<FlowId>, SdkError> {
-        let partition = execution_partition(eid, self.partition_config());
-        let ctx = ExecKeyContext::new(&partition, eid);
+        let exec_partition = execution_partition(eid, self.partition_config());
+        let ctx = ExecKeyContext::new(&exec_partition, eid);
         let raw: Option<String> = self
             .client()
             .cmd("HGET")
@@ -725,22 +743,39 @@ impl FlowFabricWorker {
         let Some(raw) = raw.filter(|s| !s.is_empty()) else {
             return Ok(None);
         };
-        FlowId::parse(&raw)
-            .map(Some)
-            .map_err(|e| {
-                SdkError::Config(format!(
-                    "list_edges: exec_core.flow_id '{raw}' is not a valid UUID \
-                     (key corruption?): {e}"
-                ))
-            })
+        let flow_id = FlowId::parse(&raw).map_err(|e| {
+            SdkError::Config(format!(
+                "list_edges: exec_core.flow_id '{raw}' is not a valid UUID \
+                 (key corruption?): {e}"
+            ))
+        })?;
+        let flow_partition_index = flow_partition(&flow_id, self.partition_config()).index;
+        if exec_partition.index != flow_partition_index {
+            return Err(SdkError::Config(format!(
+                "list_edges: exec_core.flow_id '{flow_id}' partition \
+                 {flow_partition_index} does not match execution partition \
+                 {} (RFC-011 co-location violation; key corruption?)",
+                exec_partition.index
+            )));
+        }
+        Ok(Some(flow_id))
     }
 
     /// Shared body for `list_incoming_edges` / `list_outgoing_edges`:
     /// SMEMBERS + pipelined HGETALL.
+    ///
+    /// `subject_eid` + `side` pin the expected endpoint on each
+    /// returned `EdgeSnapshot`: an adjacency SET entry whose edge
+    /// hash points at a different upstream (for `Outgoing` listings)
+    /// or downstream (for `Incoming`) is treated as corruption and
+    /// surfaced as `SdkError::Config`, matching the strict-parse
+    /// posture elsewhere in this module.
     async fn list_edges_from_set(
         &self,
         adj_key: &str,
         flow_id: &FlowId,
+        subject_eid: &ExecutionId,
+        side: AdjacencySide,
     ) -> Result<Vec<EdgeSnapshot>, SdkError> {
         let edge_id_strs: Vec<String> = self
             .client()
@@ -801,10 +836,38 @@ impl FlowFabricWorker {
                      but its edge_hash is absent (key corruption?)"
                 )));
             }
-            out.push(build_edge_snapshot(flow_id, edge_id, &raw)?);
+            let snap = build_edge_snapshot(flow_id, edge_id, &raw)?;
+            // Cross-check: the edge hash's endpoint on the listed side
+            // must match the execution we're listing for. A mismatch
+            // means the adjacency SET and edge hash disagree (e.g. a
+            // stale or corrupted SET entry) — refuse to silently
+            // return an edge the caller did not ask about.
+            let endpoint = match side {
+                AdjacencySide::Outgoing => &snap.upstream_execution_id,
+                AdjacencySide::Incoming => &snap.downstream_execution_id,
+            };
+            if endpoint != subject_eid {
+                return Err(SdkError::Config(format!(
+                    "list_edges: adjacency SET for execution '{subject_eid}' \
+                     (side={side:?}) contains edge '{edge_id}' whose stored \
+                     endpoint is '{endpoint}' (adjacency/edge-hash drift?)"
+                )));
+            }
+            out.push(snap);
         }
         Ok(out)
     }
+}
+
+/// Which side of an adjacency SET the subject execution lives on.
+/// Used by [`list_edges_from_set`] to cross-check the returned edge's
+/// stored endpoint against the listing's subject.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AdjacencySide {
+    /// Outgoing: subject is the `upstream_execution_id` on each edge.
+    Outgoing,
+    /// Incoming: subject is the `downstream_execution_id` on each edge.
+    Incoming,
 }
 
 /// Assemble an [`EdgeSnapshot`] from the raw HGETALL field map. Kept

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -887,7 +887,7 @@ fn build_edge_snapshot(
     for k in raw.keys() {
         if !EDGE_KNOWN_FIELDS.contains(&k.as_str()) {
             return Err(SdkError::Config(format!(
-                "describe_edge: edge_hash has unexpected field '{k}' \
+                "edge_snapshot: edge_hash has unexpected field '{k}' \
                  (protocol drift or corruption?)"
             )));
         }
@@ -897,12 +897,12 @@ fn build_edge_snapshot(
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             SdkError::Config(
-                "describe_edge: edge_hash.edge_id is missing or empty (key corruption?)".to_owned(),
+                "edge_snapshot: edge_hash.edge_id is missing or empty (key corruption?)".to_owned(),
             )
         })?;
     if stored_edge_id_str != edge_id.to_string() {
         return Err(SdkError::Config(format!(
-            "describe_edge: edge_hash.edge_id '{stored_edge_id_str}' does not match \
+            "edge_snapshot: edge_hash.edge_id '{stored_edge_id_str}' does not match \
              requested edge_id '{edge_id}' (key corruption or wrong-key read?)"
         )));
     }
@@ -911,12 +911,12 @@ fn build_edge_snapshot(
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             SdkError::Config(
-                "describe_edge: edge_hash.flow_id is missing or empty (key corruption?)".to_owned(),
+                "edge_snapshot: edge_hash.flow_id is missing or empty (key corruption?)".to_owned(),
             )
         })?;
     if stored_flow_id_str != flow_id.to_string() {
         return Err(SdkError::Config(format!(
-            "describe_edge: edge_hash.flow_id '{stored_flow_id_str}' does not match \
+            "edge_snapshot: edge_hash.flow_id '{stored_flow_id_str}' does not match \
              requested flow_id '{flow_id}' (key corruption or wrong-key read?)"
         )));
     }
@@ -928,7 +928,7 @@ fn build_edge_snapshot(
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             SdkError::Config(
-                "describe_edge: edge_hash.dependency_kind is missing or empty \
+                "edge_snapshot: edge_hash.dependency_kind is missing or empty \
                  (key corruption?)"
                     .to_owned(),
             )
@@ -939,7 +939,7 @@ fn build_edge_snapshot(
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             SdkError::Config(
-                "describe_edge: edge_hash.satisfaction_condition is missing or empty \
+                "edge_snapshot: edge_hash.satisfaction_condition is missing or empty \
                  (key corruption?)"
                     .to_owned(),
             )
@@ -956,16 +956,16 @@ fn build_edge_snapshot(
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             SdkError::Config(
-                "describe_edge: edge_hash.edge_state is missing or empty (key corruption?)"
+                "edge_snapshot: edge_hash.edge_state is missing or empty (key corruption?)"
                     .to_owned(),
             )
         })?
         .to_owned();
 
     let created_at =
-        parse_ts(raw, "describe_edge: edge_hash", "created_at")?.ok_or_else(|| {
+        parse_ts(raw, "edge_snapshot: edge_hash", "created_at")?.ok_or_else(|| {
             SdkError::Config(
-                "describe_edge: edge_hash.created_at is missing or empty (key corruption?)"
+                "edge_snapshot: edge_hash.created_at is missing or empty (key corruption?)"
                     .to_owned(),
             )
         })?;
@@ -974,7 +974,7 @@ fn build_edge_snapshot(
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             SdkError::Config(
-                "describe_edge: edge_hash.created_by is missing or empty (key corruption?)"
+                "edge_snapshot: edge_hash.created_by is missing or empty (key corruption?)"
                     .to_owned(),
             )
         })?
@@ -999,12 +999,12 @@ fn parse_eid(raw: &HashMap<String, String>, field: &str) -> Result<ExecutionId, 
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             SdkError::Config(format!(
-                "describe_edge: edge_hash.{field} is missing or empty (key corruption?)"
+                "edge_snapshot: edge_hash.{field} is missing or empty (key corruption?)"
             ))
         })?;
     ExecutionId::parse(s).map_err(|e| {
         SdkError::Config(format!(
-            "describe_edge: edge_hash.{field} '{s}' is not a valid ExecutionId \
+            "edge_snapshot: edge_hash.{field} '{s}' is not a valid ExecutionId \
              (key corruption?): {e}"
         ))
     })

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -787,7 +787,7 @@ impl FlowFabricWorker {
         })?;
 
         let mut out: Vec<EdgeSnapshot> = Vec::with_capacity(edge_ids.len());
-        for (edge_id, slot) in edge_ids.iter().zip(slots.into_iter()) {
+        for (edge_id, slot) in edge_ids.iter().zip(slots) {
             let raw = slot.value().map_err(|e| SdkError::ValkeyContext {
                 source: e,
                 context: "list_edges: decode HGETALL edge_hash".into(),

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -14,13 +14,15 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use ff_core::contracts::{AttemptSummary, ExecutionSnapshot, FlowSnapshot, LeaseSummary};
+use ff_core::contracts::{
+    AttemptSummary, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, LeaseSummary,
+};
 use ff_core::keys::{ExecKeyContext, FlowKeyContext};
 use ff_core::partition::{execution_partition, flow_partition};
 use ff_core::state::PublicState;
 use ff_core::types::{
-    AttemptId, AttemptIndex, ExecutionId, FlowId, LaneId, LeaseEpoch, Namespace, TimestampMs,
-    WaitpointId, WorkerInstanceId,
+    AttemptId, AttemptIndex, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch, Namespace,
+    TimestampMs, WaitpointId, WorkerInstanceId,
 };
 
 use crate::SdkError;
@@ -590,6 +592,361 @@ fn is_namespaced_tag_key(k: &str) -> bool {
     saw_dot
 }
 
+// ═══════════════════════════════════════════════════════════════════════
+// describe_edge / list_*_edges (issue #58.3)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// FF-owned fields on the flow-scoped `edge:<edge_id>` hash. An HGETALL
+/// field outside this set signals on-disk corruption or protocol drift
+/// and surfaces as `SdkError::Config` — matching the strict-parse
+/// posture on `describe_flow`.
+const EDGE_KNOWN_FIELDS: &[&str] = &[
+    "edge_id",
+    "flow_id",
+    "upstream_execution_id",
+    "downstream_execution_id",
+    "dependency_kind",
+    "satisfaction_condition",
+    "data_passing_ref",
+    "edge_state",
+    "created_at",
+    "created_by",
+];
+
+impl FlowFabricWorker {
+    /// Read a typed snapshot of one dependency edge.
+    ///
+    /// Takes both `flow_id` and `edge_id`: the edge hash is stored under
+    /// the flow's partition (`ff:flow:{fp:N}:<flow_id>:edge:<edge_id>`)
+    /// and FF does not maintain a global `edge_id -> flow_id` index.
+    /// The caller already knows the flow from the staging call result
+    /// or the consumer's own metadata.
+    ///
+    /// Returns `Ok(None)` when the edge hash is absent (never staged,
+    /// or staged under a different flow). Returns `Ok(Some(snapshot))`
+    /// on success.
+    ///
+    /// # Consistency
+    ///
+    /// Single `HGETALL` — the flow-scoped edge hash is written once at
+    /// staging time and never mutated (per-execution resolution state
+    /// lives on a separate `dep:<edge_id>` hash), so a single round
+    /// trip is authoritative.
+    pub async fn describe_edge(
+        &self,
+        flow_id: &FlowId,
+        edge_id: &EdgeId,
+    ) -> Result<Option<EdgeSnapshot>, SdkError> {
+        let partition = flow_partition(flow_id, self.partition_config());
+        let ctx = FlowKeyContext::new(&partition, flow_id);
+        let edge_key = ctx.edge(edge_id);
+
+        let raw: HashMap<String, String> = self
+            .client()
+            .cmd("HGETALL")
+            .arg(&edge_key)
+            .execute()
+            .await
+            .map_err(|e| SdkError::ValkeyContext {
+                source: e,
+                context: "describe_edge: HGETALL edge_hash".into(),
+            })?;
+
+        if raw.is_empty() {
+            return Ok(None);
+        }
+
+        build_edge_snapshot(flow_id, edge_id, &raw).map(Some)
+    }
+
+    /// List all outgoing dependency edges originating from an execution.
+    ///
+    /// Returns an empty `Vec` when the execution has no outgoing edges
+    /// (including the case where the execution is standalone, i.e. not
+    /// attached to any flow — such executions cannot participate in
+    /// dependency edges).
+    ///
+    /// # Reads
+    ///
+    /// 1. `HGET exec_core flow_id` — resolve the flow owning the
+    ///    adjacency set. Missing or empty flow_id returns an empty Vec.
+    /// 2. `SMEMBERS` on the flow-scoped `out:<upstream_eid>` set.
+    /// 3. One pipelined round trip issuing one `HGETALL` per edge_id.
+    ///
+    /// Ordering is unspecified — the adjacency set is an unordered SET.
+    /// Callers that need deterministic order should sort by
+    /// [`EdgeSnapshot::edge_id`] (or `created_at`) themselves.
+    pub async fn list_outgoing_edges(
+        &self,
+        upstream_eid: &ExecutionId,
+    ) -> Result<Vec<EdgeSnapshot>, SdkError> {
+        let Some(flow_id) = self.resolve_flow_id(upstream_eid).await? else {
+            return Ok(Vec::new());
+        };
+        let partition = flow_partition(&flow_id, self.partition_config());
+        let ctx = FlowKeyContext::new(&partition, &flow_id);
+        self.list_edges_from_set(&ctx.outgoing(upstream_eid), &flow_id).await
+    }
+
+    /// List all incoming dependency edges landing on an execution.
+    /// See [`list_outgoing_edges`] for the read shape.
+    pub async fn list_incoming_edges(
+        &self,
+        downstream_eid: &ExecutionId,
+    ) -> Result<Vec<EdgeSnapshot>, SdkError> {
+        let Some(flow_id) = self.resolve_flow_id(downstream_eid).await? else {
+            return Ok(Vec::new());
+        };
+        let partition = flow_partition(&flow_id, self.partition_config());
+        let ctx = FlowKeyContext::new(&partition, &flow_id);
+        self.list_edges_from_set(&ctx.incoming(downstream_eid), &flow_id).await
+    }
+
+    /// `HGET exec_core.flow_id` and parse to a [`FlowId`]. `None` when
+    /// the exec_core hash is absent OR the flow_id field is empty
+    /// (standalone execution).
+    async fn resolve_flow_id(
+        &self,
+        eid: &ExecutionId,
+    ) -> Result<Option<FlowId>, SdkError> {
+        let partition = execution_partition(eid, self.partition_config());
+        let ctx = ExecKeyContext::new(&partition, eid);
+        let raw: Option<String> = self
+            .client()
+            .cmd("HGET")
+            .arg(ctx.core())
+            .arg("flow_id")
+            .execute()
+            .await
+            .map_err(|e| SdkError::ValkeyContext {
+                source: e,
+                context: "list_edges: HGET exec_core.flow_id".into(),
+            })?;
+        let Some(raw) = raw.filter(|s| !s.is_empty()) else {
+            return Ok(None);
+        };
+        FlowId::parse(&raw)
+            .map(Some)
+            .map_err(|e| {
+                SdkError::Config(format!(
+                    "list_edges: exec_core.flow_id '{raw}' is not a valid UUID \
+                     (key corruption?): {e}"
+                ))
+            })
+    }
+
+    /// Shared body for `list_incoming_edges` / `list_outgoing_edges`:
+    /// SMEMBERS + pipelined HGETALL.
+    async fn list_edges_from_set(
+        &self,
+        adj_key: &str,
+        flow_id: &FlowId,
+    ) -> Result<Vec<EdgeSnapshot>, SdkError> {
+        let edge_id_strs: Vec<String> = self
+            .client()
+            .cmd("SMEMBERS")
+            .arg(adj_key)
+            .execute()
+            .await
+            .map_err(|e| SdkError::ValkeyContext {
+                source: e,
+                context: "list_edges: SMEMBERS adj_set".into(),
+            })?;
+        if edge_id_strs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Parse edge ids first so a corrupt adjacency entry fails loud
+        // before we spend a round trip on it.
+        let mut edge_ids: Vec<EdgeId> = Vec::with_capacity(edge_id_strs.len());
+        for raw in &edge_id_strs {
+            let parsed = EdgeId::parse(raw).map_err(|e| {
+                SdkError::Config(format!(
+                    "list_edges: adjacency SET has invalid edge_id '{raw}' \
+                     (key corruption?): {e}"
+                ))
+            })?;
+            edge_ids.push(parsed);
+        }
+
+        let partition = flow_partition(flow_id, self.partition_config());
+        let ctx = FlowKeyContext::new(&partition, flow_id);
+
+        let mut pipe = self.client().pipeline();
+        let slots: Vec<_> = edge_ids
+            .iter()
+            .map(|eid| {
+                pipe.cmd::<HashMap<String, String>>("HGETALL")
+                    .arg(ctx.edge(eid))
+                    .finish()
+            })
+            .collect();
+        pipe.execute().await.map_err(|e| SdkError::ValkeyContext {
+            source: e,
+            context: "list_edges: pipeline HGETALL edges".into(),
+        })?;
+
+        let mut out: Vec<EdgeSnapshot> = Vec::with_capacity(edge_ids.len());
+        for (edge_id, slot) in edge_ids.iter().zip(slots.into_iter()) {
+            let raw = slot.value().map_err(|e| SdkError::ValkeyContext {
+                source: e,
+                context: "list_edges: decode HGETALL edge_hash".into(),
+            })?;
+            if raw.is_empty() {
+                // Adjacency SET referenced an edge_hash that no longer
+                // exists. FF does not delete edge hashes today (staging
+                // is write-once), so this is corruption — fail loud.
+                return Err(SdkError::Config(format!(
+                    "list_edges: adjacency SET refers to edge_id '{edge_id}' \
+                     but its edge_hash is absent (key corruption?)"
+                )));
+            }
+            out.push(build_edge_snapshot(flow_id, edge_id, &raw)?);
+        }
+        Ok(out)
+    }
+}
+
+/// Assemble an [`EdgeSnapshot`] from the raw HGETALL field map. Kept
+/// as a free function so unit tests can feed synthetic maps.
+///
+/// `flow_id` / `edge_id` are the caller's expected identities — both
+/// are cross-checked against the stored values to catch wrong-key
+/// reads and on-disk corruption.
+fn build_edge_snapshot(
+    flow_id: &FlowId,
+    edge_id: &EdgeId,
+    raw: &HashMap<String, String>,
+) -> Result<EdgeSnapshot, SdkError> {
+    // Sweep for unknown fields before parsing — a future FF rename
+    // that lands an unrecognised field must fail loud rather than
+    // silently drop data.
+    for k in raw.keys() {
+        if !EDGE_KNOWN_FIELDS.contains(&k.as_str()) {
+            return Err(SdkError::Config(format!(
+                "describe_edge: edge_hash has unexpected field '{k}' \
+                 (protocol drift or corruption?)"
+            )));
+        }
+    }
+
+    let stored_edge_id_str = opt_str(raw, "edge_id")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            SdkError::Config(
+                "describe_edge: edge_hash.edge_id is missing or empty (key corruption?)".to_owned(),
+            )
+        })?;
+    if stored_edge_id_str != edge_id.to_string() {
+        return Err(SdkError::Config(format!(
+            "describe_edge: edge_hash.edge_id '{stored_edge_id_str}' does not match \
+             requested edge_id '{edge_id}' (key corruption or wrong-key read?)"
+        )));
+    }
+
+    let stored_flow_id_str = opt_str(raw, "flow_id")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            SdkError::Config(
+                "describe_edge: edge_hash.flow_id is missing or empty (key corruption?)".to_owned(),
+            )
+        })?;
+    if stored_flow_id_str != flow_id.to_string() {
+        return Err(SdkError::Config(format!(
+            "describe_edge: edge_hash.flow_id '{stored_flow_id_str}' does not match \
+             requested flow_id '{flow_id}' (key corruption or wrong-key read?)"
+        )));
+    }
+
+    let upstream_execution_id = parse_eid(raw, "upstream_execution_id")?;
+    let downstream_execution_id = parse_eid(raw, "downstream_execution_id")?;
+
+    let dependency_kind = opt_str(raw, "dependency_kind")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            SdkError::Config(
+                "describe_edge: edge_hash.dependency_kind is missing or empty \
+                 (key corruption?)"
+                    .to_owned(),
+            )
+        })?
+        .to_owned();
+
+    let satisfaction_condition = opt_str(raw, "satisfaction_condition")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            SdkError::Config(
+                "describe_edge: edge_hash.satisfaction_condition is missing or empty \
+                 (key corruption?)"
+                    .to_owned(),
+            )
+        })?
+        .to_owned();
+
+    // data_passing_ref is stored as "" when the stager passed None.
+    // Treat empty as absent rather than surfacing an empty String.
+    let data_passing_ref = opt_str(raw, "data_passing_ref")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+
+    let edge_state = opt_str(raw, "edge_state")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            SdkError::Config(
+                "describe_edge: edge_hash.edge_state is missing or empty (key corruption?)"
+                    .to_owned(),
+            )
+        })?
+        .to_owned();
+
+    let created_at =
+        parse_ts(raw, "describe_edge: edge_hash", "created_at")?.ok_or_else(|| {
+            SdkError::Config(
+                "describe_edge: edge_hash.created_at is missing or empty (key corruption?)"
+                    .to_owned(),
+            )
+        })?;
+
+    let created_by = opt_str(raw, "created_by")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            SdkError::Config(
+                "describe_edge: edge_hash.created_by is missing or empty (key corruption?)"
+                    .to_owned(),
+            )
+        })?
+        .to_owned();
+
+    Ok(EdgeSnapshot::new(
+        edge_id.clone(),
+        flow_id.clone(),
+        upstream_execution_id,
+        downstream_execution_id,
+        dependency_kind,
+        satisfaction_condition,
+        data_passing_ref,
+        edge_state,
+        created_at,
+        created_by,
+    ))
+}
+
+fn parse_eid(raw: &HashMap<String, String>, field: &str) -> Result<ExecutionId, SdkError> {
+    let s = opt_str(raw, field)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            SdkError::Config(format!(
+                "describe_edge: edge_hash.{field} is missing or empty (key corruption?)"
+            ))
+        })?;
+    ExecutionId::parse(s).map_err(|e| {
+        SdkError::Config(format!(
+            "describe_edge: edge_hash.{field} '{s}' is not a valid ExecutionId \
+             (key corruption?): {e}"
+        ))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -919,6 +1276,169 @@ mod tests {
         match err {
             SdkError::Config(msg) => {
                 assert!(msg.contains("graph_revision"), "msg: {msg}")
+            }
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    // ─── EdgeSnapshot (describe_edge) ───
+
+    fn eids_for_flow(f: &FlowId) -> (ExecutionId, ExecutionId) {
+        let cfg = PartitionConfig::default();
+        (ExecutionId::for_flow(f, &cfg), ExecutionId::for_flow(f, &cfg))
+    }
+
+    fn minimal_edge_hash(
+        flow: &FlowId,
+        edge: &EdgeId,
+        up: &ExecutionId,
+        down: &ExecutionId,
+    ) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("edge_id".into(), edge.to_string());
+        m.insert("flow_id".into(), flow.to_string());
+        m.insert("upstream_execution_id".into(), up.to_string());
+        m.insert("downstream_execution_id".into(), down.to_string());
+        m.insert("dependency_kind".into(), "success_only".into());
+        m.insert("satisfaction_condition".into(), "all_required".into());
+        m.insert("data_passing_ref".into(), String::new());
+        m.insert("edge_state".into(), "pending".into());
+        m.insert("created_at".into(), "1234".into());
+        m.insert("created_by".into(), "engine".into());
+        m
+    }
+
+    #[test]
+    fn edge_round_trips_all_fields() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let raw = minimal_edge_hash(&f, &edge, &up, &down);
+        let snap = build_edge_snapshot(&f, &edge, &raw).unwrap();
+        assert_eq!(snap.edge_id, edge);
+        assert_eq!(snap.flow_id, f);
+        assert_eq!(snap.upstream_execution_id, up);
+        assert_eq!(snap.downstream_execution_id, down);
+        assert_eq!(snap.dependency_kind, "success_only");
+        assert_eq!(snap.satisfaction_condition, "all_required");
+        assert!(snap.data_passing_ref.is_none());
+        assert_eq!(snap.edge_state, "pending");
+        assert_eq!(snap.created_at.0, 1234);
+        assert_eq!(snap.created_by, "engine");
+    }
+
+    #[test]
+    fn edge_data_passing_ref_round_trips_when_set() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("data_passing_ref".into(), "ref://blob-42".into());
+        let snap = build_edge_snapshot(&f, &edge, &raw).unwrap();
+        assert_eq!(snap.data_passing_ref.as_deref(), Some("ref://blob-42"));
+    }
+
+    #[test]
+    fn edge_unknown_field_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("bogus_future_field".into(), "v".into());
+        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
+        match err {
+            SdkError::Config(msg) => assert!(msg.contains("bogus_future_field"), "msg: {msg}"),
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn edge_flow_id_mismatch_fails_loud() {
+        let f = fid();
+        let other = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let raw = minimal_edge_hash(&other, &edge, &up, &down);
+        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
+        match err {
+            SdkError::Config(msg) => {
+                assert!(msg.contains("does not match"), "msg: {msg}");
+                assert!(msg.contains("flow_id"), "msg: {msg}");
+            }
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn edge_edge_id_mismatch_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let other_edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let raw = minimal_edge_hash(&f, &other_edge, &up, &down);
+        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
+        match err {
+            SdkError::Config(msg) => {
+                assert!(msg.contains("does not match"), "msg: {msg}");
+                assert!(msg.contains("edge_id"), "msg: {msg}");
+            }
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn edge_missing_required_fields_fail_loud() {
+        for field in [
+            "edge_id",
+            "flow_id",
+            "upstream_execution_id",
+            "downstream_execution_id",
+            "dependency_kind",
+            "satisfaction_condition",
+            "edge_state",
+            "created_at",
+            "created_by",
+        ] {
+            let f = fid();
+            let edge = EdgeId::new();
+            let (up, down) = eids_for_flow(&f);
+            let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+            raw.remove(field);
+            let err = build_edge_snapshot(&f, &edge, &raw)
+                .err()
+                .unwrap_or_else(|| panic!("missing {field} should fail"));
+            match err {
+                SdkError::Config(msg) => assert!(msg.contains(field), "msg for {field}: {msg}"),
+                other => panic!("expected Config for {field}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn edge_malformed_created_at_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("created_at".into(), "not-a-number".into());
+        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
+        match err {
+            SdkError::Config(msg) => assert!(msg.contains("created_at"), "msg: {msg}"),
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn edge_malformed_upstream_eid_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("upstream_execution_id".into(), "not-an-execution-id".into());
+        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
+        match err {
+            SdkError::Config(msg) => {
+                assert!(msg.contains("upstream_execution_id"), "msg: {msg}")
             }
             other => panic!("expected Config, got {other:?}"),
         }

--- a/crates/ff-test/tests/describe_edge_api.rs
+++ b/crates/ff-test/tests/describe_edge_api.rs
@@ -1,0 +1,428 @@
+//! Integration tests for `FlowFabricWorker::describe_edge`,
+//! `list_incoming_edges`, and `list_outgoing_edges` (issue #58.3).
+//!
+//! Exercises the typed edge snapshot reads against a live Valkey:
+//! stages edges via `ff_stage_dependency_edge` (after scaffolding
+//! flow + members) and asserts the resulting `EdgeSnapshot` matches
+//! the engine's on-disk edge hash + adjacency sets.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test describe_edge_api -- --test-threads=1
+
+use ferriskey::Value;
+use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, flow_partition, PartitionConfig};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+const LANE: &str = "desc-edge-lane";
+const NS: &str = "desc-edge-ns";
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = test_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(6379),
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        worker_id: WorkerId::new(format!("desc-edge-worker-{name_suffix}")),
+        worker_instance_id: WorkerInstanceId::new(format!("desc-edge-inst-{name_suffix}")),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+/// Create a flow via FCALL.
+async fn create_flow(tc: &TestCluster, fid: &FlowId) {
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let ctx = FlowKeyContext::new(&partition, fid);
+    let fidx = FlowIndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![ctx.core(), ctx.members(), fidx.flow_index()];
+    let now_ms = TimestampMs::now().0.to_string();
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        "dag".to_owned(),
+        NS.to_owned(),
+        now_ms,
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_flow", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_create_flow failed");
+}
+
+/// Create a bare execution and attach it to a flow. Returns the fresh
+/// `ExecutionId`, co-located with the flow's partition.
+async fn create_and_add_member(tc: &TestCluster, fid: &FlowId) -> ExecutionId {
+    let config = test_config();
+    let eid = ExecutionId::for_flow(fid, &config);
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    // 1. ff_create_execution (bare-minimum, no flow_id stamp yet).
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "edge_test_kind".to_owned(),
+        "0".to_owned(),
+        "desc-edge-test".to_owned(),
+        "{}".to_owned(),
+        "{}".to_owned(),
+        String::new(), // delay_until
+        String::new(), // dedup_ttl_ms
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution");
+
+    // 2. ff_add_execution_to_flow — stamps flow_id + adds to members_set.
+    let fctx = FlowKeyContext::new(&partition, fid);
+    let fidx = FlowIndexKeys::new(&partition);
+    let keys: Vec<String> = vec![
+        fctx.core(),
+        fctx.members(),
+        fidx.flow_index(),
+        ctx.core(),
+    ];
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        eid.to_string(),
+        TimestampMs::now().0.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_add_execution_to_flow", &kr, &ar)
+        .await
+        .expect("FCALL ff_add_execution_to_flow");
+
+    eid
+}
+
+/// Stage a dependency edge. Returns the fresh `EdgeId`.
+async fn stage_edge(
+    tc: &TestCluster,
+    fid: &FlowId,
+    up: &ExecutionId,
+    down: &ExecutionId,
+    expected_graph_revision: u64,
+    data_passing_ref: &str,
+) -> EdgeId {
+    let edge_id = EdgeId::new();
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let fctx = FlowKeyContext::new(&partition, fid);
+
+    let keys: Vec<String> = vec![
+        fctx.core(),
+        fctx.members(),
+        fctx.edge(&edge_id),
+        fctx.outgoing(up),
+        fctx.incoming(down),
+        fctx.grant(&edge_id.to_string()),
+    ];
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        edge_id.to_string(),
+        up.to_string(),
+        down.to_string(),
+        "success_only".to_owned(),
+        data_passing_ref.to_owned(),
+        expected_graph_revision.to_string(),
+        TimestampMs::now().0.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_stage_dependency_edge", &kr, &ar)
+        .await
+        .expect("FCALL ff_stage_dependency_edge");
+    edge_id
+}
+
+// ─── Tests ───
+
+#[tokio::test]
+async fn describe_missing_edge_returns_none() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("missing").await;
+
+    let fid = FlowId::new();
+    let edge = EdgeId::new();
+    let snap = worker
+        .describe_edge(&fid, &edge)
+        .await
+        .expect("describe_edge should not error on missing");
+    assert!(snap.is_none(), "expected Ok(None) for missing edge");
+}
+
+#[tokio::test]
+async fn describe_freshly_staged_edge_round_trips() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("staged").await;
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let up = create_and_add_member(&tc, &fid).await;
+    let down = create_and_add_member(&tc, &fid).await;
+    // After two add_member calls: graph_revision bumped twice from 0 → 2.
+    let edge = stage_edge(&tc, &fid, &up, &down, 2, "").await;
+
+    let snap = worker
+        .describe_edge(&fid, &edge)
+        .await
+        .expect("describe_edge succeeds")
+        .expect("snapshot present for staged edge");
+
+    assert_eq!(snap.edge_id, edge);
+    assert_eq!(snap.flow_id, fid);
+    assert_eq!(snap.upstream_execution_id, up);
+    assert_eq!(snap.downstream_execution_id, down);
+    assert_eq!(snap.dependency_kind, "success_only");
+    assert_eq!(snap.satisfaction_condition, "all_required");
+    assert!(snap.data_passing_ref.is_none());
+    assert_eq!(snap.edge_state, "pending");
+    assert!(snap.created_at.0 > 0);
+    assert_eq!(snap.created_by, "engine");
+}
+
+#[tokio::test]
+async fn describe_edge_preserves_data_passing_ref() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("dpref").await;
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let up = create_and_add_member(&tc, &fid).await;
+    let down = create_and_add_member(&tc, &fid).await;
+    let edge = stage_edge(&tc, &fid, &up, &down, 2, "artifact://hash-abc").await;
+
+    let snap = worker
+        .describe_edge(&fid, &edge)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(snap.data_passing_ref.as_deref(), Some("artifact://hash-abc"));
+}
+
+#[tokio::test]
+async fn list_edges_empty_for_isolated_execution() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("isolated").await;
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let eid = create_and_add_member(&tc, &fid).await;
+
+    let out = worker.list_outgoing_edges(&eid).await.unwrap();
+    let incoming = worker.list_incoming_edges(&eid).await.unwrap();
+    assert!(out.is_empty(), "isolated exec has no outgoing edges");
+    assert!(incoming.is_empty(), "isolated exec has no incoming edges");
+}
+
+#[tokio::test]
+async fn list_edges_empty_for_standalone_execution() {
+    // An ExecutionId whose exec_core has no flow_id (standalone) must
+    // return an empty Vec — the adjacency set lives under a flow, and
+    // a standalone exec has none.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("standalone").await;
+
+    // Use ::solo to keep it legibly standalone.
+    let config = test_config();
+    let eid = ExecutionId::solo(&LaneId::new(LANE), &config);
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "edge_test_kind".to_owned(),
+        "0".to_owned(),
+        "desc-edge-test".to_owned(),
+        "{}".to_owned(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution");
+
+    let out = worker.list_outgoing_edges(&eid).await.unwrap();
+    let incoming = worker.list_incoming_edges(&eid).await.unwrap();
+    assert!(out.is_empty());
+    assert!(incoming.is_empty());
+}
+
+#[tokio::test]
+async fn list_edges_returns_all_adjacent_edges() {
+    // Fan-out pattern: up → mid, up → other. list_outgoing_edges(up)
+    // should return both. list_incoming_edges(mid) should return one.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("fanout").await;
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let up = create_and_add_member(&tc, &fid).await;
+    let mid = create_and_add_member(&tc, &fid).await;
+    let other = create_and_add_member(&tc, &fid).await;
+    // 3 members → graph_revision == 3.
+    let e1 = stage_edge(&tc, &fid, &up, &mid, 3, "").await;
+    // After first edge, revision → 4.
+    let e2 = stage_edge(&tc, &fid, &up, &other, 4, "").await;
+
+    let out = worker.list_outgoing_edges(&up).await.unwrap();
+    assert_eq!(out.len(), 2, "upstream has 2 outgoing edges");
+    // Sort deterministically for comparison (SMEMBERS order is unspecified;
+    // EdgeId has no Ord derive so compare via string form).
+    let mut got_ids: Vec<String> = out.iter().map(|s| s.edge_id.to_string()).collect();
+    got_ids.sort();
+    let mut expected: Vec<String> = vec![e1.to_string(), e2.to_string()];
+    expected.sort();
+    assert_eq!(got_ids, expected);
+    // Both snapshots must point back to the same upstream.
+    for snap in &out {
+        assert_eq!(snap.upstream_execution_id, up);
+        assert_eq!(snap.flow_id, fid);
+        assert_eq!(snap.edge_state, "pending");
+    }
+
+    let incoming = worker.list_incoming_edges(&mid).await.unwrap();
+    assert_eq!(incoming.len(), 1, "mid has exactly one incoming edge");
+    assert_eq!(incoming[0].edge_id, e1);
+    assert_eq!(incoming[0].upstream_execution_id, up);
+    assert_eq!(incoming[0].downstream_execution_id, mid);
+
+    let other_incoming = worker.list_incoming_edges(&other).await.unwrap();
+    assert_eq!(other_incoming.len(), 1);
+    assert_eq!(other_incoming[0].edge_id, e2);
+}
+
+#[tokio::test]
+async fn describe_edge_corrupt_state_surfaces_error() {
+    // A future FF field rename or on-disk drift lands a non-FF-owned
+    // unknown key. Must fail loud, matching the strict-parse posture.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("corrupt").await;
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let up = create_and_add_member(&tc, &fid).await;
+    let down = create_and_add_member(&tc, &fid).await;
+    let edge = stage_edge(&tc, &fid, &up, &down, 2, "").await;
+
+    let config = test_config();
+    let partition = flow_partition(&fid, &config);
+    let ctx = FlowKeyContext::new(&partition, &fid);
+    let _: Value = tc
+        .client()
+        .cmd("HSET")
+        .arg(ctx.edge(&edge))
+        .arg("bogus_future_field")
+        .arg("v")
+        .execute()
+        .await
+        .unwrap();
+
+    let err = worker
+        .describe_edge(&fid, &edge)
+        .await
+        .expect_err("unknown edge_hash field must surface as error");
+    match err {
+        ff_sdk::SdkError::Config(msg) => {
+            assert!(msg.contains("bogus_future_field"), "msg: {msg}");
+        }
+        other => panic!("expected SdkError::Config, got {other:?}"),
+    }
+}

--- a/crates/ff-test/tests/describe_edge_api.rs
+++ b/crates/ff-test/tests/describe_edge_api.rs
@@ -388,6 +388,54 @@ async fn list_edges_returns_all_adjacent_edges() {
 }
 
 #[tokio::test]
+async fn list_edges_detects_adjacency_endpoint_drift() {
+    // Stamp a stale edge_id into an adjacency SET for an execution
+    // that is NOT actually the edge's endpoint. The fix for the
+    // Copilot review-comment catches this as corruption: the SET
+    // claims the edge is outgoing from `innocent`, but the edge
+    // hash's stored upstream is `up`. Must surface as Config.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("drift").await;
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let up = create_and_add_member(&tc, &fid).await;
+    let down = create_and_add_member(&tc, &fid).await;
+    let innocent = create_and_add_member(&tc, &fid).await;
+    let edge = stage_edge(&tc, &fid, &up, &down, 3, "").await;
+
+    // Directly SADD the edge_id into innocent's outgoing set.
+    let config = test_config();
+    let partition = flow_partition(&fid, &config);
+    let fctx = FlowKeyContext::new(&partition, &fid);
+    let _: i64 = tc
+        .client()
+        .cmd("SADD")
+        .arg(fctx.outgoing(&innocent))
+        .arg(edge.to_string())
+        .execute()
+        .await
+        .unwrap();
+
+    let err = worker
+        .list_outgoing_edges(&innocent)
+        .await
+        .expect_err("endpoint drift must surface");
+    match err {
+        ff_sdk::SdkError::Config(msg) => {
+            assert!(msg.contains("adjacency"), "msg: {msg}");
+            assert!(
+                msg.contains("stored endpoint"),
+                "msg should name drift: {msg}"
+            );
+        }
+        other => panic!("expected Config, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn describe_edge_corrupt_state_surfaces_error() {
     // A future FF field rename or on-disk drift lands a non-FF-owned
     // unknown key. Must fail loud, matching the strict-parse posture.


### PR DESCRIPTION
## Summary

Adds three edge read methods on `FlowFabricWorker`, extending the
#58 storage-decoupling surface toward the Postgres-backend port:

- `describe_edge(&FlowId, &EdgeId) -> Result<Option<EdgeSnapshot>, SdkError>`
- `list_incoming_edges(&ExecutionId) -> Result<Vec<EdgeSnapshot>, SdkError>`
- `list_outgoing_edges(&ExecutionId) -> Result<Vec<EdgeSnapshot>, SdkError>`

`EdgeSnapshot` lives in `ff_core::contracts` (`#[non_exhaustive]` +
`new()` constructor) mirroring the existing `FlowSnapshot` /
`ExecutionSnapshot` pattern. Fields match the immutable record
written by `ff_stage_dependency_edge` in `lua/flow.lua`: edge_id,
flow_id, upstream/downstream execution ids, dependency_kind,
satisfaction_condition, data_passing_ref (Option), edge_state,
created_at, created_by.

## Design notes

### Signature drift from the issue spec

The issue specced `describe_edge(&EdgeId)`, but FF has no global
`edge_id -> flow_id` index and the edge hash is keyed under the
flow's partition (`ff:flow:{fp:N}:<flow_id>:edge:<edge_id>`). Without
an index we cannot resolve the partition from `&EdgeId` alone.
Signature changed to `describe_edge(&FlowId, &EdgeId)` — the caller
already has the flow_id from the staging call result or consumer
metadata. Adding a global index would be a separate, larger change
with its own hot-path write cost; flagging for owner review.

The list methods keep their `&ExecutionId`-only signature by
resolving flow_id through `HGET exec_core.flow_id`. Standalone
executions (no flow) return an empty `Vec`.

### Edge hash is write-once on the flow side

The flow-scoped edge hash is only ever HSET at staging time. The
`edge_state` literal stored there is always `pending`; per-execution
dep-edge resolution (satisfied / unsatisfied / impossible) lives on
a separate per-execution `dep:<edge_id>` hash that `EdgeSnapshot`
intentionally does not surface. This matches the storage contract
and keeps a single round trip per edge read.

### Strict-parse posture

Every required field surfaces `SdkError::Config` on missing / malformed
using the `parse_ts` / `parse_u32_strict` helpers refactored in #58.2
(PR #74). Unknown fields on the edge hash fail loud (same posture as
`describe_flow`). An adjacency SET entry whose edge hash is absent is
treated as corruption rather than silently skipped — FF does not
delete edge hashes today, so this branch pins real drift.

### Preparing for #58.6 `DependencyAlreadyExists { existing }`

The struct carries the upstream/downstream eids, edge_state, and
dependency_kind that the typed error will need so #58.6 can surface
the conflict context without a second read.

## Test plan

- [x] 9 new unit tests on `build_edge_snapshot` (round-trip, mismatches,
      missing required fields, unknown-field drift, malformed eid /
      timestamp).
- [x] 7 integration tests in `crates/ff-test/tests/describe_edge_api.rs`:
      missing→None, staged-edge round-trip, data_passing_ref,
      empty-for-isolated, empty-for-standalone, fan-out listing, and
      corrupt-state HSET.
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Rebased on latest `origin/main` (picked up #73 degraded-state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK surface for reading dependency edges; primary risk is strict parsing returning `SdkError::Config` if stored edge hashes/adjacency sets contain unexpected or malformed fields.
> 
> **Overview**
> Adds an engine-decoupled dependency-edge read model `EdgeSnapshot` to `ff-core` (marked `#[non_exhaustive]`) and wires new `FlowFabricWorker` APIs to fetch it.
> 
> Implements `describe_edge(flow_id, edge_id)` plus `list_outgoing_edges(execution_id)`/`list_incoming_edges(execution_id)`, using `HGETALL` on `edge:<edge_id>` and adjacency `SMEMBERS` with pipelined per-edge reads; standalone executions (no `exec_core.flow_id`) return empty results and unknown/missing/corrupt fields fail loud with `SdkError::Config`.
> 
> Adds unit tests for strict `EdgeSnapshot` parsing and a new Valkey-backed integration test suite covering describe/list behavior, data-passing refs, empty cases, fan-out listing, and corruption detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3e3a9f051b4f70da0847ef079cff075b78c819. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->