### PR TITLE
fix(ff-server): CORS fail-closed + Authorization preflight (#71 #66)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/ff-server/Cargo.toml
+++ b/crates/ff-server/Cargo.toml
@@ -31,3 +31,10 @@ thiserror = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
 futures = { workspace = true }
+
+[dev-dependencies]
+# Used by CORS preflight tests in `api::cors_tests` (#66, #71) — exercises
+# the layer via `tower::ServiceExt::oneshot`, which is the integration-style
+# harness that mirrors real browser preflights.
+tower = { version = "0.5", features = ["util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -13,7 +13,7 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use axum::http::{HeaderName, Method};
+use axum::http::Method;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 
@@ -301,10 +301,14 @@ fn build_cors_layer(origins: &[String], auth_enabled: bool) -> Result<CorsLayer,
     }
 
     let mut parsed = Vec::with_capacity(origins.len());
+    let mut accepted = Vec::with_capacity(origins.len());
     let mut invalid = Vec::new();
     for o in origins {
         match o.parse() {
-            Ok(v) => parsed.push(v),
+            Ok(v) => {
+                parsed.push(v);
+                accepted.push(o.as_str());
+            }
             Err(_) => invalid.push(o.clone()),
         }
     }
@@ -313,7 +317,7 @@ fn build_cors_layer(origins: &[String], auth_enabled: bool) -> Result<CorsLayer,
         return Err(ConfigError::InvalidValue {
             var: "FF_CORS_ORIGINS".to_owned(),
             message: format!(
-                "all configured origins failed to parse as HTTP header values: {:?}; \
+                "all configured origins failed to parse as valid HTTP header values: {:?}; \
                  refusing to fall back to permissive CORS",
                 origins
             ),
@@ -321,19 +325,20 @@ fn build_cors_layer(origins: &[String], auth_enabled: bool) -> Result<CorsLayer,
     }
 
     if !invalid.is_empty() {
+        // Collected `accepted` list during the single parse loop above to
+        // avoid an O(N*M) filter-contains scan per log event.
         tracing::warn!(
-            invalid = ?invalid,
-            accepted = ?origins
-                .iter()
-                .filter(|o| !invalid.contains(o))
-                .collect::<Vec<_>>(),
+            ?invalid,
+            ?accepted,
             "some FF_CORS_ORIGINS entries failed to parse and were dropped"
         );
     }
 
-    let mut headers = vec![HeaderName::from_static("content-type")];
+    // Prefer typed `header::*` constants over stringly-typed `from_static`
+    // so typos fail to compile rather than fail at runtime.
+    let mut headers = vec![axum::http::header::CONTENT_TYPE];
     if auth_enabled {
-        headers.push(HeaderName::from_static("authorization"));
+        headers.push(axum::http::header::AUTHORIZATION);
     }
 
     Ok(CorsLayer::new()

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -21,6 +21,7 @@ use ff_core::contracts::*;
 use ff_core::state::PublicState;
 use ff_core::types::*;
 
+use crate::config::ConfigError;
 use crate::server::{Server, ServerError};
 
 // ── Custom JSON extractor (uniform JSON error on malformed body) ──
@@ -174,8 +175,13 @@ impl IntoResponse for ApiError {
 
 // ── Router ──
 
-pub fn router(server: Arc<Server>, cors_origins: &[String], api_token: Option<String>) -> Router {
-    let cors = build_cors_layer(cors_origins);
+pub fn router(
+    server: Arc<Server>,
+    cors_origins: &[String],
+    api_token: Option<String>,
+) -> Result<Router, ConfigError> {
+    let auth_enabled = api_token.is_some();
+    let cors = build_cors_layer(cors_origins, auth_enabled)?;
 
     let mut app = Router::new()
         // Executions
@@ -232,9 +238,9 @@ pub fn router(server: Arc<Server>, cors_origins: &[String], api_token: Option<St
         }));
     }
 
-    app.layer(TraceLayer::new_for_http())
+    Ok(app.layer(TraceLayer::new_for_http())
         .layer(cors)
-        .with_state(server)
+        .with_state(server))
 }
 
 async fn auth_middleware(
@@ -279,25 +285,61 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-fn build_cors_layer(origins: &[String]) -> CorsLayer {
+/// Build the CORS layer from the configured `FF_CORS_ORIGINS` list.
+///
+/// Fails closed (#71): if every entry fails to parse as a `HeaderValue`,
+/// return `ConfigError` so startup aborts instead of silently falling back
+/// to `CorsLayer::permissive()` (a typo would otherwise broaden browser
+/// access to "allow any origin").
+///
+/// When `auth_enabled` is true (i.e. `FF_API_TOKEN` is set), `Authorization`
+/// is added to `allow_headers` (#66) so browser preflights for
+/// cross-origin authenticated requests succeed.
+fn build_cors_layer(origins: &[String], auth_enabled: bool) -> Result<CorsLayer, ConfigError> {
     if origins.iter().any(|o| o == "*") {
-        return CorsLayer::permissive();
+        return Ok(CorsLayer::permissive());
     }
-    let parsed: Vec<_> = origins
-        .iter()
-        .filter_map(|o| o.parse().ok())
-        .collect();
+
+    let mut parsed = Vec::with_capacity(origins.len());
+    let mut invalid = Vec::new();
+    for o in origins {
+        match o.parse() {
+            Ok(v) => parsed.push(v),
+            Err(_) => invalid.push(o.clone()),
+        }
+    }
+
     if parsed.is_empty() && !origins.is_empty() {
-        tracing::warn!(
-            configured = ?origins,
-            "all configured CORS origins failed to parse, falling back to permissive"
-        );
-        return CorsLayer::permissive();
+        return Err(ConfigError::InvalidValue {
+            var: "FF_CORS_ORIGINS".to_owned(),
+            message: format!(
+                "all configured origins failed to parse as HTTP header values: {:?}; \
+                 refusing to fall back to permissive CORS",
+                origins
+            ),
+        });
     }
-    CorsLayer::new()
+
+    if !invalid.is_empty() {
+        tracing::warn!(
+            invalid = ?invalid,
+            accepted = ?origins
+                .iter()
+                .filter(|o| !invalid.contains(o))
+                .collect::<Vec<_>>(),
+            "some FF_CORS_ORIGINS entries failed to parse and were dropped"
+        );
+    }
+
+    let mut headers = vec![HeaderName::from_static("content-type")];
+    if auth_enabled {
+        headers.push(HeaderName::from_static("authorization"));
+    }
+
+    Ok(CorsLayer::new()
         .allow_origin(AllowOrigin::list(parsed))
         .allow_methods([Method::GET, Method::POST, Method::PUT])
-        .allow_headers([HeaderName::from_static("content-type")])
+        .allow_headers(headers))
 }
 
 // ── Execution handlers ──
@@ -1034,4 +1076,137 @@ fn parse_flow_id(s: &str) -> Result<FlowId, ApiError> {
 fn parse_budget_id(s: &str) -> Result<BudgetId, ApiError> {
     BudgetId::parse(s)
         .map_err(|e| ApiError(ServerError::InvalidInput(format!("invalid budget_id: {e}"))))
+}
+
+#[cfg(test)]
+mod cors_tests {
+    //! CORS + auth preflight tests (#66, #71).
+    //!
+    //! Exercised via `tower::ServiceExt::oneshot` against a minimal router
+    //! that applies only the CORS layer to a noop `/healthz`-style route.
+    //! This mirrors what browsers actually see (the `CorsLayer` is terminal
+    //! for OPTIONS preflights) without needing a live `Server`.
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    fn app_with_cors(origins: &[String], auth_enabled: bool) -> Router {
+        let cors = build_cors_layer(origins, auth_enabled)
+            .expect("build_cors_layer succeeds for valid inputs");
+        Router::new().route("/noop", get(|| async { "ok" })).layer(cors)
+    }
+
+    #[test]
+    fn all_origins_invalid_returns_config_error_instead_of_permissive() {
+        // #71: invalid HeaderValue (contains a control character) should
+        // fail closed rather than falling back to permissive CORS.
+        //
+        // Note: `HeaderValue` parsing is intentionally lax — it accepts
+        // almost any printable ASCII, so "not a url" parses fine. We use
+        // a string with an embedded NUL byte to exercise the actual parse
+        // failure path.
+        let err = build_cors_layer(&["bad\0origin".to_owned()], false).unwrap_err();
+        let ConfigError::InvalidValue { var, message } = err;
+        assert_eq!(var, "FF_CORS_ORIGINS");
+        assert!(
+            message.contains("all configured origins failed to parse"),
+            "message was: {message}"
+        );
+    }
+
+    #[test]
+    fn wildcard_still_returns_permissive() {
+        // Explicit `*` is still the documented permissive path.
+        let layer = build_cors_layer(&["*".to_owned()], false);
+        assert!(layer.is_ok());
+    }
+
+    #[test]
+    fn empty_origins_returns_empty_allowlist_ok() {
+        // Empty list (no origins configured) produces an empty allowlist;
+        // no browser origin matches. This is NOT the fail-open case — that
+        // only happens when origins are configured but all parse-invalid.
+        let layer = build_cors_layer(&[], false);
+        assert!(layer.is_ok());
+    }
+
+    #[test]
+    fn mixed_valid_and_invalid_keeps_valid_entries() {
+        // A partial typo should not fail the whole boot — we log a warning
+        // and keep the parsable entries.
+        let layer = build_cors_layer(
+            &["https://ok.example.com".to_owned(), "bad\0origin".to_owned()],
+            false,
+        );
+        assert!(layer.is_ok());
+    }
+
+    #[tokio::test]
+    async fn preflight_allows_authorization_when_auth_enabled() {
+        // #66: with token auth on, browsers need `Authorization` in the
+        // preflight's `Access-Control-Allow-Headers` response.
+        let app = app_with_cors(&["https://client.example.com".to_owned()], true);
+
+        let req = Request::builder()
+            .method("OPTIONS")
+            .uri("/noop")
+            .header("origin", "https://client.example.com")
+            .header("access-control-request-method", "GET")
+            .header("access-control-request-headers", "authorization,content-type")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let allow_headers = resp
+            .headers()
+            .get("access-control-allow-headers")
+            .expect("access-control-allow-headers present")
+            .to_str()
+            .unwrap()
+            .to_ascii_lowercase();
+        assert!(
+            allow_headers.contains("authorization"),
+            "expected `authorization` in Access-Control-Allow-Headers, got: {allow_headers}"
+        );
+        assert!(
+            allow_headers.contains("content-type"),
+            "expected `content-type` in Access-Control-Allow-Headers, got: {allow_headers}"
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_omits_authorization_when_auth_disabled() {
+        // Negative case: without auth, Authorization is not needed and
+        // should not be advertised (principle of least privilege).
+        let app = app_with_cors(&["https://client.example.com".to_owned()], false);
+
+        let req = Request::builder()
+            .method("OPTIONS")
+            .uri("/noop")
+            .header("origin", "https://client.example.com")
+            .header("access-control-request-method", "GET")
+            .header("access-control-request-headers", "content-type")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let allow_headers = resp
+            .headers()
+            .get("access-control-allow-headers")
+            .expect("access-control-allow-headers present")
+            .to_str()
+            .unwrap()
+            .to_ascii_lowercase();
+        assert!(
+            !allow_headers.contains("authorization"),
+            "Authorization should not be advertised when auth is off; got: {allow_headers}"
+        );
+        assert!(allow_headers.contains("content-type"));
+    }
 }

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -53,7 +53,13 @@ async fn main() {
     };
 
     let server = Arc::new(server);
-    let app = api::router(server.clone(), &cors_origins, api_token);
+    let app = match api::router(server.clone(), &cors_origins, api_token) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to build HTTP router");
+            std::process::exit(1);
+        }
+    };
 
     let listener = tokio::net::TcpListener::bind(&listen_addr)
         .await

--- a/crates/ff-test/tests/admin_rotate_api.rs
+++ b/crates/ff-test/tests/admin_rotate_api.rs
@@ -88,7 +88,8 @@ impl TestApi {
             .await
             .expect("Server::start failed");
         let server = Arc::new(server);
-        let app = ff_server::api::router(server, &["*".to_owned()], api_token.clone());
+        let app = ff_server::api::router(server, &["*".to_owned()], api_token.clone())
+            .expect("router builds with wildcard CORS");
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -62,7 +62,8 @@ impl TestApi {
             .expect("Server::start failed");
 
         let server = Arc::new(server);
-        let app = ff_server::api::router(server.clone(), &["*".to_owned()], None);
+        let app = ff_server::api::router(server.clone(), &["*".to_owned()], None)
+            .expect("router builds with wildcard CORS");
 
         // 3. Bind to random port
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -678,7 +679,8 @@ async fn test_stream_semaphore_returns_429_on_burst() {
         .await
         .expect("Server::start failed");
     let server = Arc::new(server);
-    let app = ff_server::api::router(server.clone(), &["*".to_owned()], None);
+    let app = ff_server::api::router(server.clone(), &["*".to_owned()], None)
+        .expect("router builds with wildcard CORS");
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await

--- a/crates/ff-test/tests/pending_waitpoints_api.rs
+++ b/crates/ff-test/tests/pending_waitpoints_api.rs
@@ -52,7 +52,8 @@ impl TestApi {
             .await
             .expect("Server::start failed");
         let server = Arc::new(server);
-        let app = ff_server::api::router(server, &["*".to_owned()], None);
+        let app = ff_server::api::router(server, &["*".to_owned()], None)
+            .expect("router builds with wildcard CORS");
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await

--- a/crates/ff-test/tests/result_api.rs
+++ b/crates/ff-test/tests/result_api.rs
@@ -58,7 +58,8 @@ impl TestApi {
             .await
             .expect("Server::start failed");
         let server = Arc::new(server);
-        let app = ff_server::api::router(server, &["*".to_owned()], None);
+        let app = ff_server::api::router(server, &["*".to_owned()], None)
+            .expect("router builds with wildcard CORS");
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await


### PR DESCRIPTION
## Summary

- **#71 (fail-open CORS):** `build_cors_layer` now returns `Result<CorsLayer, ConfigError>`. When `FF_CORS_ORIGINS` is set but every entry fails to parse as a `HeaderValue`, boot aborts via `main.rs` instead of silently installing `CorsLayer::permissive()`. Mixed valid/invalid entries keep the valid ones with a warning log.
- **#66 (Authorization blocked by preflight):** `router` threads `auth_enabled = api_token.is_some()` into `build_cors_layer`. When token auth is on, `Authorization` joins `content-type` in `Access-Control-Allow-Headers`. Wildcard path (`FF_CORS_ORIGINS=*`) is unchanged — permissive already allows any header.

## Design choices (plan-approved)

1. **Error type:** `ConfigError::InvalidValue { var, message }` — matches house style in `crates/ff-server/src/config.rs` (existing empty-`FF_CORS_ORIGINS` and `FF_WAITPOINT_HMAC_SECRET` validations use the same enum). No new error type invented.
2. **Test harness:** Integration-style via `tower::ServiceExt::oneshot` against a minimal router with only `build_cors_layer` applied. This is the exact path a browser OPTIONS preflight takes — `CorsLayer` is terminal for preflights, so a live `Server` isn't required. `tower` added as `dev-dependencies` only.
3. **Option A (bool flag):** Surgical — one extra parameter to `build_cors_layer`, no middleware refactor.

## Red → Green

### RED (original fail-open impl, new test signatures)
```
running 6 tests
test api::cors_tests::wildcard_still_returns_permissive ... ok
test api::cors_tests::mixed_valid_and_invalid_keeps_valid_entries ... ok
test api::cors_tests::empty_origins_returns_empty_allowlist_ok ... ok
test api::cors_tests::all_origins_invalid_returns_config_error_instead_of_permissive ... FAILED
test api::cors_tests::preflight_omits_authorization_when_auth_disabled ... ok
test api::cors_tests::preflight_allows_authorization_when_auth_enabled ... FAILED

test result: FAILED. 4 passed; 2 failed
```

Failure detail for `all_origins_invalid_…`: returned `CorsLayer { allow_origin: Const("*"), … }` (permissive fallback) instead of `Err(ConfigError)`.
Failure detail for `preflight_allows_authorization_when_auth_enabled`: `Access-Control-Allow-Headers` was `content-type` only, missing `authorization`.

### GREEN (this PR)
```
running 6 tests
test api::cors_tests::all_origins_invalid_returns_config_error_instead_of_permissive ... ok
test api::cors_tests::empty_origins_returns_empty_allowlist_ok ... ok
test api::cors_tests::mixed_valid_and_invalid_keeps_valid_entries ... ok
test api::cors_tests::wildcard_still_returns_permissive ... ok
test api::cors_tests::preflight_allows_authorization_when_auth_enabled ... ok
test api::cors_tests::preflight_omits_authorization_when_auth_disabled ... ok

test result: ok. 6 passed; 0 failed
```

Full `cargo test -p ff-server --lib`: 28 passed, 0 failed. `cargo clippy -p ff-server --all-targets -- -D warnings`: clean.

## Semver impact

Breaking for anyone pinning the `ff-server` library target directly: `api::router` now returns `Result<Router, ConfigError>` instead of `Router`. `main.rs` is the only in-tree caller and has been updated. `ff-server` ships primarily as a binary; no known library consumers.

## Test plan

- [x] `cargo test -p ff-server --lib` green (28 tests)
- [x] `cargo clippy -p ff-server --all-targets -- -D warnings` clean
- [x] RED captured against fail-open impl (2/6 tests fail as expected)
- [x] GREEN captured with fix (6/6 tests pass)
- [ ] CI green on push

Closes #71
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CORS behavior and startup validation: misconfigured `FF_CORS_ORIGINS` can now abort boot instead of silently enabling permissive CORS, and CORS headers differ when token auth is enabled.
> 
> **Overview**
> Hardens `ff-server` CORS configuration by making `build_cors_layer` fail closed: if `FF_CORS_ORIGINS` is set but all entries are unparsable, router construction now returns `ConfigError` and `main.rs` exits rather than falling back to permissive CORS; partially invalid lists log a warning and keep valid entries.
> 
> When `FF_API_TOKEN` is set, CORS preflights now advertise `Authorization` in `Access-Control-Allow-Headers` so cross-origin authenticated requests succeed. Adds `tower` as a dev-dependency and new integration-style CORS/preflight tests using `tower::ServiceExt::oneshot`, and changes `api::router` to return `Result<Router, ConfigError>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1ab83e5cdedbf47364d7e65953b10c41cbed5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->