### PR TITLE
chore: fix quickstart, env-var table, deny.toml drift, create_execution deadline wrapper

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,31 +1,33 @@
 name: Matrix CI
 
-# Cross-host + cross-mode verification against Valkey 8.
+# Cross-host + cross-mode + cross-version verification.
 #
-# Matrix coverage (5 jobs):
+# Matrix coverage (6 jobs):
 #
-#   linux x86_64  × valkey 8 × standalone   → ubuntu-latest
-#   linux x86_64  × valkey 8 × cluster      → ubuntu-latest
-#   linux arm64   × valkey 8 × standalone   → ubuntu-24.04-arm
-#   linux arm64   × valkey 8 × cluster      → ubuntu-24.04-arm
-#   macos arm64   × valkey 8 × standalone   → macos-latest
+#   linux x86_64  × valkey 8   × standalone   -> ubuntu-latest
+#   linux x86_64  × valkey 8   × cluster      -> ubuntu-latest
+#   linux x86_64  × valkey 7.2 × standalone   -> ubuntu-latest    (floor guard)
+#   linux arm64   × valkey 8   × standalone   -> ubuntu-24.04-arm
+#   linux arm64   × valkey 8   × cluster      -> ubuntu-24.04-arm
+#   macos arm64   × valkey 8   × standalone   -> macos-latest
 #
-# **Valkey version:** `valkey/valkey:8-alpine` (major-version pin).
-# RFC-011 §13 requires Valkey >= 8.0 (enforced at ff-server boot via
-# `verify_valkey_version`). Pinning to major 8 tracks patch releases
-# automatically without the drift risk of `:latest` rolling to 9.x with
-# breaking behavior changes. Matches cairn-fabric's integration-test pin.
-# The Valkey 7.2 rows from pre-RFC-011 coverage are retired — the server
-# refuses to start against 7.x.
+# **Valkey versions:** RFC-011 §13 sets the floor at Valkey >= 7.2
+# (enforced at ff-server boot via `verify_valkey_version`). 7.2 is where
+# Functions + RESP3 stabilized; those are the primitives we actually
+# depend on. We pin major 8 as the primary coverage (cairn-fabric's
+# reference deployment) and carry one 7.2 × standalone entry as a
+# guard against accidental 8-specific primitive adoption. If the 7.2
+# job breaks, that is a signal to either document the new dependency
+# in an RFC-011 §13 amendment or fix the accidental usage.
 #
-# Mac arm64 validates Apple Silicon Rust correctness on the latest
-# Valkey release; the 7.2 × mac combination is intentionally skipped
-# because Homebrew does not package 7.2 and docker-on-mac on GitHub
-# runners is flaky under privileged-mode requirements. x86_64 mac is
-# NOT in the matrix: GitHub's Intel runner (macos-13) is EOL December
-# 2025, and x86_64 Rust correctness is already validated through
-# ubuntu-latest. Linux covers the full Valkey version matrix where we
-# actually deploy.
+# Mac arm64 validates Apple Silicon Rust correctness on Valkey 8;
+# the 7.2 × mac combination is intentionally skipped because
+# Homebrew does not package 7.2 and docker-on-mac on GitHub runners
+# is flaky under privileged-mode requirements. x86_64 mac is NOT in
+# the matrix: GitHub's Intel runner (macos-13) is EOL December 2025,
+# and x86_64 Rust correctness is already validated through
+# ubuntu-latest. Linux covers the full Valkey version matrix where
+# we actually deploy.
 
 on:
   # `paths-ignore` drops doc-only PRs from CI entirely (the matrix
@@ -81,11 +83,11 @@ jobs:
           - { os: ubuntu-24.04-arm, kind: linux, arch: arm64 }
           - { os: macos-latest,     kind: mac,   arch: arm64 }
         valkey:
-          # Pin to major 8 (alpine variant) — matches cairn-fabric's
-          # integration-test pin and RFC-011 §13's required floor. Using
-          # a major-version tag tracks patch releases automatically without
-          # the drift risk of `:latest` (which could roll to 9.x with
-          # breaking behavior changes).
+          # Pin to major 8 (alpine variant) for primary coverage —
+          # matches cairn-fabric's integration-test pin. Using a
+          # major-version tag tracks patch releases automatically
+          # without the drift risk of `:latest` (which could roll to
+          # 9.x with breaking behavior changes).
           - { version: "8", image: "valkey/valkey:8-alpine" }
         mode: [standalone, cluster]
         exclude:
@@ -95,6 +97,16 @@ jobs:
           # 2025; x86_64 correctness is validated through ubuntu-latest.
           - host: { os: macos-latest, kind: mac, arch: arm64 }
             mode: cluster
+        include:
+          # RFC-011 §13 floor-guard entry: one x86_64 linux standalone
+          # job against Valkey 7.2 (the explicit floor). Purpose is to
+          # detect accidental 8-specific primitive adoption — not to
+          # replicate full matrix coverage. If this job starts failing,
+          # either amend RFC-011 §13 to raise the floor with a specific
+          # justification or fix the offending usage.
+          - host: { os: ubuntu-latest, kind: linux, arch: x86_64 }
+            valkey: { version: "7.2", image: "valkey/valkey:7.2" }
+            mode: standalone
 
     steps:
       # Third-party actions pinned to commit SHAs (CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     services:
       valkey:
-        # Valkey >= 8.0 required by RFC-011 §13 (ff-server refuses to
-        # boot against 7.x). Major-version pin — tracks 8.x patches
-        # without drift risk from a moving `:latest`. Matches the
-        # matrix-ci and cairn-fabric pins for reproducibility.
+        # Valkey >= 7.2 required by RFC-011 §13 Amendment F (ff-server
+        # refuses to boot below 7.2). Release-time verification pins
+        # the major-8 alpine image — matches cairn-fabric's reference
+        # deployment. Matrix CI separately exercises the 7.2 floor;
+        # this job just needs a floor-compliant image to run the tests.
         image: valkey/valkey:8-alpine
         ports:
           - 6379:6379

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Two PR-time GitHub Actions workflows gate merges:
 - **`.github/workflows/matrix.yml`** — 5-job host × mode matrix against Valkey 8 (`valkey/valkey:8-alpine`). RFC-011 §13 requires Valkey >= 8.0, enforced at `ff-server` boot; the pre-RFC-011 Valkey 7.2 rows are retired.
   - linux x86_64 (`ubuntu-latest`) × {standalone, cluster}
   - linux arm64 (`ubuntu-24.04-arm`) × {standalone, cluster}
-  - macos arm64 (`macos-latest`) × standalone (Homebrew Valkey 8; docker-on-mac on GitHub hosted runners does not support the privileged-mode cluster setup).
+  - macos arm64 (`macos-latest`) × standalone (Homebrew Valkey, currently tracking the 8.x line unpinned; docker-on-mac on GitHub hosted runners does not support the privileged-mode cluster setup).
   - Cluster mode on linux uses a 3-master 3-replica cluster via `.github/cluster/docker-compose.cluster.yml` + `bootstrap.sh`.
 - **`.github/workflows/security-and-quality.yml`** — 6 independent gates, any one blocks merge:
   - `cargo audit` with `--deny warnings`; ignore list in `.cargo/audit.toml`

--- a/README.md
+++ b/README.md
@@ -45,16 +45,25 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
 
 ## Quick start
 
-### 1. Start Valkey
+### 1. Start Valkey 8
+
+FlowFabric requires Valkey >= 8.0 (RFC-011 §13, enforced at boot). Valkey 7.x
+is rejected by `ff-server`.
 
 ```bash
-docker run -d --name valkey -p 6379:6379 valkey/valkey:7.2
+docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine
 ```
 
 ### 2. Start the FlowFabric server
 
+`FF_WAITPOINT_HMAC_SECRET` is required at boot — the server refuses to start
+without it so waitpoint HMAC authentication can never be silently disabled
+(see RFC-004 §Waitpoint Security). Any even-length hex string works for
+local dev; production should use 64 hex chars (32 bytes) from a secret
+manager.
+
 ```bash
-cargo run -p ff-server
+FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32) cargo run -p ff-server
 ```
 
 ### 3. Try the coding-agent example
@@ -96,7 +105,39 @@ For production deployments, use the Scheduler (`ff-scheduler`) which enforces ad
 
 ## Production considerations
 
-- **Full env var reference** — see the `ServerConfig::from_env` rustdoc in `crates/ff-server/src/config.rs` for the complete table (FF_HOST, FF_PORT, FF_TLS, FF_CLUSTER, FF_LANES, FF_CORS_ORIGINS, FF_API_TOKEN, FF_WAITPOINT_HMAC_SECRET (required), FF_WAITPOINT_HMAC_GRACE_MS, FF_MAX_CONCURRENT_STREAM_OPS, scanner intervals, partition counts).
+- **Env var reference** — `ServerConfig::from_env` in `crates/ff-server/src/config.rs` is the source of truth. Full list below (required ones are marked `required`):
+
+  | Variable | Default | Description |
+  |----------|---------|-------------|
+  | `FF_WAITPOINT_HMAC_SECRET` | *required* | Hex-encoded HMAC signing secret for waitpoint tokens (RFC-004 §Waitpoint Security). Even-length hex; 64 chars (32 bytes) recommended. |
+  | `FF_HOST` | `localhost` | Valkey host |
+  | `FF_PORT` | `6379` | Valkey port |
+  | `FF_TLS` | `false` | Enable TLS (`1` or `true`) |
+  | `FF_CLUSTER` | `false` | Enable cluster mode |
+  | `FF_LISTEN_ADDR` | `0.0.0.0:9090` | API listen address |
+  | `FF_LANES` | `default` | Comma-separated lane names |
+  | `FF_FLOW_PARTITIONS` | `256` | Flow partition count (exec keys co-locate under RFC-011) |
+  | `FF_BUDGET_PARTITIONS` | `32` | Budget partition count |
+  | `FF_QUOTA_PARTITIONS` | `32` | Quota partition count |
+  | `FF_CORS_ORIGINS` | `*` | Comma-separated CORS origins; empty string is rejected |
+  | `FF_API_TOKEN` | *(none)* | Shared-secret Bearer token; if set, all non-`/healthz` requests require it |
+  | `FF_WAITPOINT_HMAC_GRACE_MS` | `86400000` | Grace window for previous-kid token acceptance after rotation |
+  | `FF_MAX_CONCURRENT_STREAM_OPS` | `64` | Shared semaphore for stream reads + tails; legacy `FF_MAX_CONCURRENT_TAIL` still accepted |
+  | `FF_LEASE_EXPIRY_INTERVAL_MS` | `1500` | Lease-expiry scanner interval |
+  | `FF_DELAYED_PROMOTER_INTERVAL_MS` | `750` | Delayed-promoter scanner interval |
+  | `FF_INDEX_RECONCILER_INTERVAL_S` | `45` | Index reconciler interval |
+  | `FF_ATTEMPT_TIMEOUT_INTERVAL_S` | `2` | Attempt-timeout scanner interval |
+  | `FF_SUSPENSION_TIMEOUT_INTERVAL_S` | `2` | Suspension-timeout scanner interval |
+  | `FF_PENDING_WP_EXPIRY_INTERVAL_S` | `5` | Pending-waitpoint expiry interval |
+  | `FF_RETENTION_TRIMMER_INTERVAL_S` | `60` | Retention-trimmer scanner interval |
+  | `FF_BUDGET_RESET_INTERVAL_S` | `15` | Budget-reset scanner interval |
+  | `FF_BUDGET_RECONCILER_INTERVAL_S` | `30` | Budget reconciler interval |
+  | `FF_QUOTA_RECONCILER_INTERVAL_S` | `30` | Quota reconciler interval |
+  | `FF_UNBLOCK_INTERVAL_S` | `5` | Unblock scanner interval |
+  | `FF_DEPENDENCY_RECONCILER_INTERVAL_S` | `15` | DAG dependency reconciler interval |
+  | `FF_FLOW_PROJECTOR_INTERVAL_S` | `15` | Flow projector scanner interval |
+  | `FF_EXECUTION_DEADLINE_INTERVAL_S` | `5` | Execution-deadline scanner interval |
+  | `FF_CANCEL_RECONCILER_INTERVAL_S` | `15` | Cancel-reconciler scanner interval |
 - **Auth is opt-in** — if `FF_API_TOKEN` is unset, every endpoint except `GET /healthz` is reachable without authentication. Always set `FF_API_TOKEN` (and consider CORS via `FF_CORS_ORIGINS`) before exposing the server beyond localhost.
 - **No API rate limiting** — deploy behind a reverse proxy (nginx, Envoy) with rate limiting configured
 - **No HTTP connection limit** — axum accepts unbounded connections; configure limits at the load balancer
@@ -118,10 +159,10 @@ Future: per-FCALL version negotiation. For now: drain old instances before start
 
 Two PR-time GitHub Actions workflows gate merges:
 
-- **`.github/workflows/matrix.yml`** — 10-job host × Valkey × mode matrix:
-  - linux x86_64 (`ubuntu-latest`) and linux arm64 (`ubuntu-24.04-arm`) × Valkey 7.2 + latest × {standalone, cluster}
-  - mac arm64 (`macos-latest`) and mac x86_64 (`macos-13`) × Valkey latest × standalone
-  - Linux covers the full version matrix where we deploy. Mac runners validate cross-arch Rust correctness against the latest Valkey release only (Homebrew does not package 7.2 and docker-on-mac on GitHub hosted runners does not support the privileged-mode cluster setup).
+- **`.github/workflows/matrix.yml`** — 5-job host × mode matrix against Valkey 8 (`valkey/valkey:8-alpine`). RFC-011 §13 requires Valkey >= 8.0, enforced at `ff-server` boot; the pre-RFC-011 Valkey 7.2 rows are retired.
+  - linux x86_64 (`ubuntu-latest`) × {standalone, cluster}
+  - linux arm64 (`ubuntu-24.04-arm`) × {standalone, cluster}
+  - macos arm64 (`macos-latest`) × standalone (Homebrew Valkey 8; docker-on-mac on GitHub hosted runners does not support the privileged-mode cluster setup).
   - Cluster mode on linux uses a 3-master 3-replica cluster via `.github/cluster/docker-compose.cluster.yml` + `bootstrap.sh`.
 - **`.github/workflows/security-and-quality.yml`** — 6 independent gates, any one blocks merge:
   - `cargo audit` with `--deny warnings`; ignore list in `.cargo/audit.toml`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
 
 FlowFabric requires Valkey >= 7.2 (RFC-011 §13, enforced at boot). 7.2 is the
 release where the Valkey Functions API + RESP3 stabilized. Valkey 7.0 and
-earlier — and Redis of any version — are rejected by `ff-server`.
+earlier are rejected by `ff-server`; Redis is also rejected (the boot check
+requires an affirmative `server_name:valkey` INFO marker before accepting a
+`redis_version:` fallback, and Redis does not emit that marker).
 
 ```bash
 docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine

--- a/README.md
+++ b/README.md
@@ -45,14 +45,18 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
 
 ## Quick start
 
-### 1. Start Valkey 8
+### 1. Start Valkey
 
-FlowFabric requires Valkey >= 8.0 (RFC-011 §13, enforced at boot). Valkey 7.x
-is rejected by `ff-server`.
+FlowFabric requires Valkey >= 7.2 (RFC-011 §13, enforced at boot). 7.2 is the
+release where the Valkey Functions API + RESP3 stabilized. Valkey 7.0 and
+earlier — and Redis of any version — are rejected by `ff-server`.
 
 ```bash
 docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine
 ```
+
+The quickstart image pins major 8 for reproducibility, but any `valkey/valkey`
+tag whose version is ≥ 7.2 will boot. CI exercises both 7.2 and 8.
 
 ### 2. Start the FlowFabric server
 
@@ -159,10 +163,11 @@ Future: per-FCALL version negotiation. For now: drain old instances before start
 
 Two PR-time GitHub Actions workflows gate merges:
 
-- **`.github/workflows/matrix.yml`** — 5-job host × mode matrix against Valkey 8 (`valkey/valkey:8-alpine`). RFC-011 §13 requires Valkey >= 8.0, enforced at `ff-server` boot; the pre-RFC-011 Valkey 7.2 rows are retired.
-  - linux x86_64 (`ubuntu-latest`) × {standalone, cluster}
-  - linux arm64 (`ubuntu-24.04-arm`) × {standalone, cluster}
-  - macos arm64 (`macos-latest`) × standalone (Homebrew Valkey, currently tracking the 8.x line unpinned; docker-on-mac on GitHub hosted runners does not support the privileged-mode cluster setup).
+- **`.github/workflows/matrix.yml`** — 6-job host × valkey × mode matrix. RFC-011 §13 requires Valkey >= 7.2, enforced at `ff-server` boot.
+  - linux x86_64 (`ubuntu-latest`) × valkey 8 (`valkey/valkey:8-alpine`) × {standalone, cluster}
+  - linux x86_64 (`ubuntu-latest`) × valkey 7.2 (`valkey/valkey:7.2`) × standalone — guards against accidental 8-specific primitive adoption
+  - linux arm64 (`ubuntu-24.04-arm`) × valkey 8 × {standalone, cluster}
+  - macos arm64 (`macos-latest`) × valkey 8 × standalone (Homebrew Valkey, currently tracking the 8.x line unpinned; docker-on-mac on GitHub hosted runners does not support the privileged-mode cluster setup).
   - Cluster mode on linux uses a 3-master 3-replica cluster via `.github/cluster/docker-compose.cluster.yml` + `bootstrap.sh`.
 - **`.github/workflows/security-and-quality.yml`** — 6 independent gates, any one blocks merge:
   - `cargo audit` with `--deny warnings`; ignore list in `.cargo/audit.toml`

--- a/crates/ff-script/src/functions/execution.rs
+++ b/crates/ff-script/src/functions/execution.rs
@@ -198,7 +198,7 @@ ff_function! {
             args.delay_until.map(|t| t.to_string()).unwrap_or_default(),
             args.idempotency_key.as_ref().map(|_| "86400000".to_string()).unwrap_or_default(),
             serde_json::to_string(&args.tags).unwrap_or_else(|_| "{}".into()),
-            String::new(),
+            args.execution_deadline_at.map(|t| t.to_string()).unwrap_or_default(),
             args.partition_id.to_string(),
         }
     }

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -2750,31 +2750,48 @@ async fn query_valkey_version(client: &Client) -> Result<(u32, u32), ServerError
             source: e,
             context: "INFO server".into(),
         })?;
-    let info_body = extract_info_body(&raw)?;
-    parse_valkey_version(&info_body)
+    let bodies = extract_info_bodies(&raw)?;
+    // Cluster: return the minimum (major, minor) across all nodes so a stale
+    // pre-upgrade replica cannot hide behind an already-upgraded primary.
+    // Standalone: exactly one body. The outer retry loop tolerates rolling
+    // upgrades — a briefly-low minimum gets retried; a persistently-low one
+    // exits with the structured floor error.
+    let mut min_version: Option<(u32, u32)> = None;
+    for body in &bodies {
+        let version = parse_valkey_version(body)?;
+        min_version = Some(match min_version {
+            None => version,
+            Some(existing) => existing.min(version),
+        });
+    }
+    min_version.ok_or_else(|| {
+        ServerError::OperationFailed(
+            "valkey version check: cluster INFO returned no node bodies".into(),
+        )
+    })
 }
 
-/// Normalize an `INFO server` response to a single string body.
+/// Normalize an `INFO server` response to one string body per node.
 ///
-/// Standalone returns the body directly. Cluster returns a map of
-/// `node_addr → body`; we pick any entry (they should all report the same
-/// version in a stable cluster; divergent versions during rolling upgrade
-/// are reconciled by the outer retry loop).
-fn extract_info_body(raw: &Value) -> Result<String, ServerError> {
+/// Standalone returns a single body. Cluster (RESP3 map keyed by node address)
+/// returns every node's body — the caller must consider all of them to reject
+/// a mixed-version cluster where one stale node is below the floor.
+fn extract_info_bodies(raw: &Value) -> Result<Vec<String>, ServerError> {
     match raw {
-        Value::BulkString(bytes) => Ok(String::from_utf8_lossy(bytes).into_owned()),
-        Value::VerbatimString { text, .. } => Ok(text.clone()),
-        Value::SimpleString(s) => Ok(s.clone()),
+        Value::BulkString(bytes) => Ok(vec![String::from_utf8_lossy(bytes).into_owned()]),
+        Value::VerbatimString { text, .. } => Ok(vec![text.clone()]),
+        Value::SimpleString(s) => Ok(vec![s.clone()]),
         Value::Map(entries) => {
-            // Pick the first entry's value. For cluster-wide INFO the map is
-            // node_addr → body; every body carries the same version. If a
-            // node is mid-upgrade, the outer retry loop handles divergence.
-            let (_, body) = entries.first().ok_or_else(|| {
-                ServerError::OperationFailed(
+            if entries.is_empty() {
+                return Err(ServerError::OperationFailed(
                     "valkey version check: cluster INFO returned empty map".into(),
-                )
-            })?;
-            extract_info_body(body)
+                ));
+            }
+            let mut out = Vec::with_capacity(entries.len());
+            for (_, body) in entries {
+                out.extend(extract_info_bodies(body)?);
+            }
+            Ok(out)
         }
         other => Err(ServerError::OperationFailed(format!(
             "valkey version check: unexpected INFO shape: {other:?}"
@@ -2786,10 +2803,16 @@ fn extract_info_body(raw: &Value) -> Result<String, ServerError> {
 /// `INFO server` response body. Pure parser — pulled out of
 /// [`query_valkey_version`] so it is unit-testable without a live Valkey.
 ///
-/// Prefers the `valkey_version:` field introduced in Valkey 8.0+. Falls back
-/// to `redis_version:` for Valkey 7.x compat. **Note:** Valkey 8.x/9.x still
-/// emit `redis_version:7.2.4` for Redis-client compatibility; the real
-/// server version is in `valkey_version:`, so always check that field first.
+/// **Prefers `valkey_version:`** (introduced in Valkey 8.0+; this is the real
+/// server version on 8.x/9.x, which pin `redis_version:7.2.4` for
+/// Redis-client compatibility).
+///
+/// **Falls back to `redis_version:` only when the body carries an affirmative
+/// `server_name:valkey` field.** `server_name:` was introduced in Valkey 7.2,
+/// which is our floor — so every floor-compliant Valkey deployment carries
+/// the marker. Redis does not emit `server_name:valkey`, which is how we
+/// reject a Redis backend that would otherwise look identical to Valkey 7.x
+/// at the `redis_version:` level.
 fn parse_valkey_version(info: &str) -> Result<(u32, u32), ServerError> {
     let extract_major_minor = |line: &str| -> Result<(u32, u32), ServerError> {
         let trimmed = line.trim();
@@ -2828,8 +2851,24 @@ fn parse_valkey_version(info: &str) -> Result<(u32, u32), ServerError> {
     {
         return extract_major_minor(valkey_line);
     }
-    // Fall back to redis_version (Valkey 7.x only — 8.x+ pins this to 7.2.4
-    // for Redis-client compat, so reading it there would under-report).
+    // No valkey_version — could be Valkey 7.2 (which doesn't emit the field)
+    // or could be Redis. Require an affirmative server_name:valkey marker
+    // before falling back to redis_version. This rejects Redis backends,
+    // which don't emit server_name:valkey.
+    let server_is_valkey = info
+        .lines()
+        .map(str::trim)
+        .any(|line| line.eq_ignore_ascii_case("server_name:valkey"));
+    if !server_is_valkey {
+        return Err(ServerError::OperationFailed(
+            "valkey version check: INFO missing valkey_version and server_name:valkey marker \
+             (unsupported backend — FlowFabric requires Valkey >= 7.2; Redis is not supported)"
+                .into(),
+        ));
+    }
+    // Valkey 7.x fallback. 8.x+ pins redis_version:7.2.4 for Redis-client
+    // compat, so reading it there would under-report — but 8.x+ is handled
+    // by the valkey_version branch above, so we only reach here on 7.x.
     if let Some(redis_line) = info
         .lines()
         .find_map(|line| line.strip_prefix("redis_version:"))
@@ -2837,7 +2876,8 @@ fn parse_valkey_version(info: &str) -> Result<(u32, u32), ServerError> {
         return extract_major_minor(redis_line);
     }
     Err(ServerError::OperationFailed(
-        "valkey version check: INFO missing valkey_version and redis_version".into(),
+        "valkey version check: INFO has server_name:valkey but no redis_version or valkey_version field"
+            .into(),
     ))
 }
 
@@ -4254,8 +4294,36 @@ server_mode:cluster\r\n";
 
     #[test]
     fn parse_valkey_version_falls_back_to_redis_version_on_valkey_7() {
-        // Valkey 7.x doesn't emit valkey_version; parser falls back.
-        let info = "# Server\r\nredis_version:7.2.4\r\nfoo:bar\r\n";
+        // Valkey 7.x doesn't emit valkey_version, but does emit
+        // server_name:valkey; parser falls back to redis_version.
+        let info = "# Server\r\nredis_version:7.2.4\r\nserver_name:valkey\r\nfoo:bar\r\n";
+        assert_eq!(parse_valkey_version(info).unwrap(), (7, 2));
+    }
+
+    #[test]
+    fn parse_valkey_version_rejects_redis_backend() {
+        // Real Redis emits redis_version: but not server_name:valkey and
+        // not valkey_version:. Parser must reject this affirmatively so an
+        // operator pointing ff-server at a Redis instance fails loud instead
+        // of silently running against an unsupported backend.
+        let info = "\
+# Server\r\n\
+redis_version:7.4.0\r\n\
+redis_mode:standalone\r\n\
+os:Linux\r\n";
+        let err = parse_valkey_version(info).unwrap_err();
+        assert!(matches!(err, ServerError::OperationFailed(_)));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Redis is not supported") && msg.contains("server_name:valkey"),
+            "expected Redis-rejection message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_valkey_version_accepts_valkey_7_marker_case_insensitively() {
+        // INFO values are conventionally lowercase but be defensive.
+        let info = "redis_version:7.2.0\r\nSERVER_NAME:Valkey\r\n";
         assert_eq!(parse_valkey_version(info).unwrap(), (7, 2));
     }
 
@@ -4297,32 +4365,48 @@ server_mode:cluster\r\n";
     }
 
     #[test]
-    fn extract_info_body_unwraps_cluster_map() {
+    fn extract_info_bodies_unwraps_cluster_map_all_entries() {
         // Simulates cluster-mode INFO response: map of node_addr → body.
-        // extract_info_body picks any entry's body.
-        let body_text = "\
-# Server\r\n\
-redis_version:7.2.4\r\n\
-valkey_version:9.0.3\r\n";
-        let node_entry = (
-            Value::SimpleString("127.0.0.1:7000".to_string()),
-            Value::VerbatimString {
-                format: ferriskey::value::VerbatimFormat::Text,
-                text: body_text.to_string(),
-            },
-        );
-        let map = Value::Map(vec![node_entry]);
-        let body = extract_info_body(&map).unwrap();
-        assert_eq!(body, body_text);
-        assert_eq!(parse_valkey_version(&body).unwrap(), (9, 0));
+        // extract_info_bodies must return EVERY node's body so a stale
+        // pre-upgrade replica cannot hide behind an upgraded primary.
+        let body_a = "# Server\r\nredis_version:7.2.4\r\nvalkey_version:9.0.3\r\n";
+        let body_b = "# Server\r\nredis_version:7.2.4\r\nvalkey_version:8.0.0\r\n";
+        let map = Value::Map(vec![
+            (
+                Value::SimpleString("127.0.0.1:7000".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_a.to_string(),
+                },
+            ),
+            (
+                Value::SimpleString("127.0.0.1:7001".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_b.to_string(),
+                },
+            ),
+        ]);
+        let bodies = extract_info_bodies(&map).unwrap();
+        assert_eq!(bodies.len(), 2);
+        assert_eq!(bodies[0], body_a);
+        assert_eq!(bodies[1], body_b);
     }
 
     #[test]
-    fn extract_info_body_handles_simple_string() {
+    fn extract_info_bodies_handles_simple_string() {
         let body_text = "redis_version:7.2.4\r\nvalkey_version:9.0.3\r\n";
         let v = Value::SimpleString(body_text.to_string());
-        let body = extract_info_body(&v).unwrap();
-        assert_eq!(body, body_text);
+        let bodies = extract_info_bodies(&v).unwrap();
+        assert_eq!(bodies, vec![body_text.to_string()]);
+    }
+
+    #[test]
+    fn extract_info_bodies_rejects_empty_cluster_map() {
+        let map = Value::Map(vec![]);
+        let err = extract_info_bodies(&map).unwrap_err();
+        assert!(matches!(err, ServerError::OperationFailed(_)));
+        assert!(err.to_string().contains("empty map"));
     }
 
     #[test]

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -160,10 +160,10 @@ pub enum ServerError {
     /// Fields: (source_label, max_permits).
     #[error("too many concurrent {0} calls (max: {1})")]
     ConcurrencyLimitExceeded(&'static str, u32),
-    /// Detected Valkey version is below the RFC-011 §13 minimum. The hash-slot
-    /// co-location design and Valkey Functions API behavior the engine depends
-    /// on were introduced/stabilized in 8.0; older versions silently behave
-    /// differently on some cluster edge cases. Operator action: upgrade Valkey.
+    /// Detected Valkey version is below the RFC-011 §13 minimum. The engine
+    /// depends on Valkey Functions (stabilized in 7.2), RESP3 (7.2+), and
+    /// hash-tag routing; older versions do not implement the required
+    /// primitives. Operator action: upgrade Valkey.
     #[error(
         "valkey version too low: detected {detected}, required >= {required} (RFC-011 §13)"
     )]
@@ -2627,9 +2627,11 @@ impl Server {
 
 // ── Valkey version check (RFC-011 §13) ──
 
-/// Minimum Valkey version the engine requires (see RFC-011 §13). 8.0 ships the
-/// hash-slot and Functions behavior the co-location design relies on.
-const REQUIRED_VALKEY_MAJOR: u32 = 8;
+/// Minimum Valkey version the engine requires (see RFC-011 §13). 7.2 is the
+/// release where Valkey Functions and RESP3 stabilized — the primitives the
+/// co-location design and typed FCALL wrappers actually depend on.
+const REQUIRED_VALKEY_MAJOR: u32 = 7;
+const REQUIRED_VALKEY_MINOR: u32 = 2;
 
 /// Upper bound on the rolling-upgrade retry window (RFC-011 §9.17). A Valkey
 /// node cycling through SIGTERM → restart typically completes in well under
@@ -2637,7 +2639,7 @@ const REQUIRED_VALKEY_MAJOR: u32 = 8;
 /// boot indefinitely.
 const VERSION_CHECK_RETRY_BUDGET: Duration = Duration::from_secs(60);
 
-/// Verify the connected Valkey reports `redis_version` ≥ 8.0.
+/// Verify the connected Valkey reports a version ≥ 7.2.
 ///
 /// Per RFC-011 §9.17, during a rolling upgrade the node we happen to connect
 /// to may temporarily be pre-upgrade while others are post-upgrade. The check
@@ -2645,8 +2647,8 @@ const VERSION_CHECK_RETRY_BUDGET: Duration = Duration::from_secs(60);
 /// responses) with exponential backoff, capped at a 60s budget.
 ///
 /// **Retries on:**
-/// - Low-version responses (`detected_major < REQUIRED_VALKEY_MAJOR`) — may
-///   resolve as the rolling upgrade progresses onto the connected node.
+/// - Low-version responses (below `(REQUIRED_VALKEY_MAJOR, REQUIRED_VALKEY_MINOR)`)
+///   — may resolve as the rolling upgrade progresses onto the connected node.
 /// - Retryable ferriskey transport errors — connection refused,
 ///   `BusyLoadingError`, `ClusterDown`, etc., classified via
 ///   `ff_script::retry::is_retryable_kind`.
@@ -2667,24 +2669,31 @@ async fn verify_valkey_version(client: &Client) -> Result<(), ServerError> {
     loop {
         let (should_retry, err_for_budget_exhaust, log_detail): (bool, ServerError, String) =
             match query_valkey_version(client).await {
-                Ok(detected_major) if detected_major >= REQUIRED_VALKEY_MAJOR => {
+                Ok((detected_major, detected_minor))
+                    if (detected_major, detected_minor)
+                        >= (REQUIRED_VALKEY_MAJOR, REQUIRED_VALKEY_MINOR) =>
+                {
                     tracing::info!(
                         detected_major,
-                        required = REQUIRED_VALKEY_MAJOR,
+                        detected_minor,
+                        required_major = REQUIRED_VALKEY_MAJOR,
+                        required_minor = REQUIRED_VALKEY_MINOR,
                         "Valkey version accepted"
                     );
                     return Ok(());
                 }
-                Ok(detected_major) => (
+                Ok((detected_major, detected_minor)) => (
                     // Low version — may be a rolling-upgrade stale node.
                     // Retry within budget; after exhaustion, the cluster
                     // is misconfigured and fast-fail is the correct signal.
                     true,
                     ServerError::ValkeyVersionTooLow {
-                        detected: detected_major.to_string(),
-                        required: format!("{REQUIRED_VALKEY_MAJOR}.0"),
+                        detected: format!("{detected_major}.{detected_minor}"),
+                        required: format!("{REQUIRED_VALKEY_MAJOR}.{REQUIRED_VALKEY_MINOR}"),
                     },
-                    format!("detected_major={detected_major} < required={REQUIRED_VALKEY_MAJOR}"),
+                    format!(
+                        "detected={detected_major}.{detected_minor} < required={REQUIRED_VALKEY_MAJOR}.{REQUIRED_VALKEY_MINOR}"
+                    ),
                 ),
                 Err(e) => {
                     // Only retry if the underlying Valkey error is retryable
@@ -2719,7 +2728,8 @@ async fn verify_valkey_version(client: &Client) -> Result<(), ServerError> {
     }
 }
 
-/// Run `INFO server` and extract the major component of the Valkey version.
+/// Run `INFO server` and extract the `(major, minor)` components of the
+/// Valkey version.
 ///
 /// Returns `Err` on transport errors, missing field, or unparsable version.
 /// Handles three response shapes:
@@ -2730,7 +2740,7 @@ async fn verify_valkey_version(client: &Client) -> Result<(), ServerError> {
 ///   one entry and parse it. Divergent versions during a rolling upgrade
 ///   are handled by the outer retry loop.
 /// - **Empty / unexpected:** surfaces as `OperationFailed` with context.
-async fn query_valkey_version(client: &Client) -> Result<u32, ServerError> {
+async fn query_valkey_version(client: &Client) -> Result<(u32, u32), ServerError> {
     let raw: Value = client
         .cmd("INFO")
         .arg("server")
@@ -2741,7 +2751,7 @@ async fn query_valkey_version(client: &Client) -> Result<u32, ServerError> {
             context: "INFO server".into(),
         })?;
     let info_body = extract_info_body(&raw)?;
-    parse_valkey_major_version(&info_body)
+    parse_valkey_version(&info_body)
 }
 
 /// Normalize an `INFO server` response to a single string body.
@@ -2772,35 +2782,51 @@ fn extract_info_body(raw: &Value) -> Result<String, ServerError> {
     }
 }
 
-/// Extract the major component of the Valkey version from an `INFO server`
-/// response body. Pure parser — pulled out of [`query_valkey_version`] so it
-/// is unit-testable without a live Valkey.
+/// Extract the `(major, minor)` components of the Valkey version from an
+/// `INFO server` response body. Pure parser — pulled out of
+/// [`query_valkey_version`] so it is unit-testable without a live Valkey.
 ///
 /// Prefers the `valkey_version:` field introduced in Valkey 8.0+. Falls back
 /// to `redis_version:` for Valkey 7.x compat. **Note:** Valkey 8.x/9.x still
 /// emit `redis_version:7.2.4` for Redis-client compatibility; the real
 /// server version is in `valkey_version:`, so always check that field first.
-fn parse_valkey_major_version(info: &str) -> Result<u32, ServerError> {
-    let extract_major = |line: &str| -> Result<u32, ServerError> {
+fn parse_valkey_version(info: &str) -> Result<(u32, u32), ServerError> {
+    let extract_major_minor = |line: &str| -> Result<(u32, u32), ServerError> {
         let trimmed = line.trim();
-        let major_str = trimmed.split('.').next().unwrap_or("").trim();
+        let mut parts = trimmed.split('.');
+        let major_str = parts.next().unwrap_or("").trim();
         if major_str.is_empty() {
             return Err(ServerError::OperationFailed(format!(
                 "valkey version check: empty version field in '{trimmed}'"
             )));
         }
-        major_str.parse::<u32>().map_err(|_| {
+        let major = major_str.parse::<u32>().map_err(|_| {
             ServerError::OperationFailed(format!(
                 "valkey version check: non-numeric major in '{trimmed}'"
             ))
-        })
+        })?;
+        // Minor is required — a bare major ("7") cannot be compared against
+        // the (major, minor) floor reliably. Valkey always reports
+        // major.minor.patch for INFO, so missing minor is a real parse error.
+        let minor_str = parts.next().unwrap_or("").trim();
+        if minor_str.is_empty() {
+            return Err(ServerError::OperationFailed(format!(
+                "valkey version check: missing minor component in '{trimmed}'"
+            )));
+        }
+        let minor = minor_str.parse::<u32>().map_err(|_| {
+            ServerError::OperationFailed(format!(
+                "valkey version check: non-numeric minor in '{trimmed}'"
+            ))
+        })?;
+        Ok((major, minor))
     };
     // Prefer valkey_version (authoritative on Valkey 8.0+).
     if let Some(valkey_line) = info
         .lines()
         .find_map(|line| line.strip_prefix("valkey_version:"))
     {
-        return extract_major(valkey_line);
+        return extract_major_minor(valkey_line);
     }
     // Fall back to redis_version (Valkey 7.x only — 8.x+ pins this to 7.2.4
     // for Redis-client compat, so reading it there would under-report).
@@ -2808,7 +2834,7 @@ fn parse_valkey_major_version(info: &str) -> Result<u32, ServerError> {
         .lines()
         .find_map(|line| line.strip_prefix("redis_version:"))
     {
-        return extract_major(redis_line);
+        return extract_major_minor(redis_line);
     }
     Err(ServerError::OperationFailed(
         "valkey version check: INFO missing valkey_version and redis_version".into(),
@@ -4197,7 +4223,7 @@ mod tests {
     // ── Valkey version check (RFC-011 §13) ──
 
     #[test]
-    fn parse_valkey_major_prefers_valkey_version_over_redis_version() {
+    fn parse_valkey_version_prefers_valkey_version_over_redis_version() {
         // Valkey 8.x+ pins redis_version to 7.2.4 for Redis-client compat
         // and exposes the real version in valkey_version. Parser must use
         // valkey_version when both are present.
@@ -4207,11 +4233,11 @@ redis_version:7.2.4\r\n\
 valkey_version:9.0.3\r\n\
 server_mode:cluster\r\n\
 os:Linux\r\n";
-        assert_eq!(parse_valkey_major_version(info).unwrap(), 9);
+        assert_eq!(parse_valkey_version(info).unwrap(), (9, 0));
     }
 
     #[test]
-    fn parse_valkey_major_real_valkey_8_cluster_body() {
+    fn parse_valkey_version_real_valkey_8_cluster_body() {
         // Actual INFO server response observed on valkey/valkey:latest in
         // cluster mode (CI matrix): redis_version compat-pinned to 7.2.4,
         // valkey_version authoritative at 9.0.3.
@@ -4223,20 +4249,20 @@ valkey_version:9.0.3\r\n\
 valkey_release_stage:ga\r\n\
 redis_git_sha1:00000000\r\n\
 server_mode:cluster\r\n";
-        assert_eq!(parse_valkey_major_version(info).unwrap(), 9);
+        assert_eq!(parse_valkey_version(info).unwrap(), (9, 0));
     }
 
     #[test]
-    fn parse_valkey_major_falls_back_to_redis_version_on_valkey_7() {
+    fn parse_valkey_version_falls_back_to_redis_version_on_valkey_7() {
         // Valkey 7.x doesn't emit valkey_version; parser falls back.
         let info = "# Server\r\nredis_version:7.2.4\r\nfoo:bar\r\n";
-        assert_eq!(parse_valkey_major_version(info).unwrap(), 7);
+        assert_eq!(parse_valkey_version(info).unwrap(), (7, 2));
     }
 
     #[test]
-    fn parse_valkey_major_errors_when_no_version_field() {
+    fn parse_valkey_version_errors_when_no_version_field() {
         let info = "# Server\r\nfoo:bar\r\n";
-        let err = parse_valkey_major_version(info).unwrap_err();
+        let err = parse_valkey_version(info).unwrap_err();
         assert!(matches!(err, ServerError::OperationFailed(_)));
         assert!(
             err.to_string().contains("missing"),
@@ -4245,11 +4271,29 @@ server_mode:cluster\r\n";
     }
 
     #[test]
-    fn parse_valkey_major_errors_on_non_numeric() {
+    fn parse_valkey_version_errors_on_non_numeric_major() {
         let info = "valkey_version:invalid.x.y\n";
-        let err = parse_valkey_major_version(info).unwrap_err();
+        let err = parse_valkey_version(info).unwrap_err();
         assert!(matches!(err, ServerError::OperationFailed(_)));
         assert!(err.to_string().contains("non-numeric major"));
+    }
+
+    #[test]
+    fn parse_valkey_version_errors_on_non_numeric_minor() {
+        let info = "valkey_version:7.x.0\n";
+        let err = parse_valkey_version(info).unwrap_err();
+        assert!(matches!(err, ServerError::OperationFailed(_)));
+        assert!(err.to_string().contains("non-numeric minor"));
+    }
+
+    #[test]
+    fn parse_valkey_version_errors_on_missing_minor() {
+        // Bare major (no dot) — cannot be compared against a (major, minor)
+        // floor. Flag as a real parse error.
+        let info = "valkey_version:7\n";
+        let err = parse_valkey_version(info).unwrap_err();
+        assert!(matches!(err, ServerError::OperationFailed(_)));
+        assert!(err.to_string().contains("missing minor"));
     }
 
     #[test]
@@ -4270,7 +4314,7 @@ valkey_version:9.0.3\r\n";
         let map = Value::Map(vec![node_entry]);
         let body = extract_info_body(&map).unwrap();
         assert_eq!(body, body_text);
-        assert_eq!(parse_valkey_major_version(&body).unwrap(), 9);
+        assert_eq!(parse_valkey_version(&body).unwrap(), (9, 0));
     }
 
     #[test]
@@ -4284,8 +4328,8 @@ valkey_version:9.0.3\r\n";
     #[test]
     fn valkey_version_too_low_is_not_retryable() {
         let err = ServerError::ValkeyVersionTooLow {
-            detected: "7".into(),
-            required: "8.0".into(),
+            detected: "7.0".into(),
+            required: "7.2".into(),
         };
         assert!(!err.is_retryable());
         assert_eq!(err.valkey_kind(), None);
@@ -4294,12 +4338,12 @@ valkey_version:9.0.3\r\n";
     #[test]
     fn valkey_version_too_low_error_message_includes_both_versions() {
         let err = ServerError::ValkeyVersionTooLow {
-            detected: "7".into(),
-            required: "8.0".into(),
+            detected: "7.0".into(),
+            required: "7.2".into(),
         };
         let msg = err.to_string();
-        assert!(msg.contains("7"), "detected version in message: {msg}");
-        assert!(msg.contains("8.0"), "required version in message: {msg}");
+        assert!(msg.contains("7.0"), "detected version in message: {msg}");
+        assert!(msg.contains("7.2"), "required version in message: {msg}");
         assert!(msg.contains("RFC-011"), "RFC pointer in message: {msg}");
     }
 }

--- a/crates/ff-test/tests/pr_c3_create_execution_deadline.rs
+++ b/crates/ff-test/tests/pr_c3_create_execution_deadline.rs
@@ -1,0 +1,98 @@
+//! PR-C3 regression (#68): the typed `ff_create_execution` wrapper in
+//! `ff-script` must forward `CreateExecutionArgs::execution_deadline_at`
+//! into ARGV slot 12 so direct consumers of the published crate can set
+//! an execution deadline. The server-side code path in `ff-server`
+//! already did this; only the public typed wrapper dropped it.
+//!
+//! Failure mode before the fix:
+//!   Line `execution.rs:201` emitted `String::new()` regardless of
+//!   `args.execution_deadline_at`, so the Lua contract observed an
+//!   empty string and skipped the `ZADD` into `execution_deadline_zset`.
+//!
+//! Proof of fix:
+//!   1. Create an execution through the typed wrapper with
+//!      `execution_deadline_at = Some(t)`.
+//!   2. `ZSCORE execution_deadline_zset eid == t`.
+//!
+//! Run with: `cargo test -p ff-test --test pr_c3_create_execution_deadline \
+//!            -- --test-threads=1`
+
+use ff_core::contracts::{CreateExecutionArgs, CreateExecutionResult};
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::execution_partition;
+use ff_core::types::*;
+use ff_script::functions::execution::{ff_create_execution, ExecOpKeys};
+use ff_test::fixtures::TestCluster;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn typed_wrapper_threads_execution_deadline_at_into_argv12() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    let partition = execution_partition(&eid, tc.partition_config());
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane = tc.test_lane();
+    let worker_instance = WorkerInstanceId::new("pr-c3-test-worker");
+
+    // Deadline 10 minutes out — arbitrary, just needs to be a valid
+    // ms timestamp we can read back from the deadline zset.
+    let now = TimestampMs::now();
+    let deadline = TimestampMs(now.0 + 600_000);
+
+    let args = CreateExecutionArgs {
+        execution_id: eid.clone(),
+        namespace: tc.test_namespace(),
+        lane_id: lane.clone(),
+        execution_kind: "pr-c3-deadline".into(),
+        input_payload: b"{}".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "pr-c3-test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: Some(deadline),
+        partition_id: partition.index,
+        now,
+    };
+
+    let op_keys = ExecOpKeys {
+        ctx: &ctx,
+        idx: &idx,
+        lane_id: &lane,
+        worker_instance_id: &worker_instance,
+    };
+
+    let res = ff_create_execution(tc.client(), &op_keys, &args)
+        .await
+        .expect("ff_create_execution wrapper call must succeed");
+    match res {
+        CreateExecutionResult::Created { .. } => {}
+        other => panic!("expected Created, got {other:?}"),
+    }
+
+    // Proof: the execution_deadline_zset carries this eid at the score
+    // we passed in. If ARGV[12] were empty (the pre-fix bug) the Lua
+    // contract would skip the ZADD entirely.
+    let deadline_key = idx.execution_deadline();
+    let score: Option<String> = tc
+        .client()
+        .cmd("ZSCORE")
+        .arg(&deadline_key)
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .expect("ZSCORE must not error");
+    let score = score.expect(
+        "execution must be in execution_deadline zset — ARGV[12] was dropped",
+    );
+    let parsed: i64 = score.parse().expect("deadline score must parse as i64");
+    assert_eq!(
+        parsed, deadline.0,
+        "deadline zset score must equal the value passed to the wrapper"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,10 @@ feature-depth = 1
 [licenses]
 version = 2
 confidence-threshold = 0.8
+# Keep this list tight. An entry is justified only when a currently
+# resolved crate in Cargo.lock actually carries that SPDX identifier
+# (cargo deny warns on unmatched allowances). Add with a commit
+# message pointer when a new transitive introduces a novel license.
 allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
@@ -37,12 +41,8 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
     "CC0-1.0",
-    "Zlib",
-    "MPL-2.0",
-    "0BSD",
     # Permissive; covers webpki-root-certs and its peers.
     "CDLA-Permissive-2.0",
 ]
@@ -108,14 +108,7 @@ allow-git = []
 version = 2
 # Each entry MUST carry a justification comment. Review on every
 # release; if the fix has shipped upstream, remove the entry.
-ignore = [
-    # rand 0.8.5 unsoundness when a custom logger calls `rand::rng()`.
-    # We reach rand 0.8 only transitively via
-    # tower 0.4.13 → tonic 0.12.3 → opentelemetry-proto 0.27.0 →
-    # opentelemetry-otlp 0.27.0 → telemetrylib 0.1.0 → ferriskey.
-    # FlowFabric does not install a custom tracing logger (we use the
-    # default EnvFilter subscriber), so the trigger condition does not
-    # apply. Remove when opentelemetry-otlp upgrades to tonic >=0.13
-    # which pulls a patched tower.
-    "RUSTSEC-2026-0097",
-]
+# `cargo deny check` warns on unmatched advisories — an entry whose
+# affected-version range no longer intersects the resolved graph is
+# noise, not policy, and must be removed here (not left in place).
+ignore = []

--- a/docs/rfc011-migration-for-consumers.md
+++ b/docs/rfc011-migration-for-consumers.md
@@ -292,19 +292,22 @@ let key = usage_dedup_key(hash_tag, dedup_id);
 **Action:** replace every hardcoded `format!("ff:usagededup:...")` in your
 codebase. Eliminates drift if the keyspace convention ever changes.
 
-## Step 6 — Valkey 8.0 minimum (future, phase 5)
+## Step 6 — Valkey 7.2 minimum (landed, phase 3; amended post-phase-3)
 
-**Status:** not yet landed. RFC-011 §13 requires Valkey 8.0+. Phase 5 adds a
-boot-time version check in ff-server and ff-sdk's admin client that fails
-fast if the detected version is below 8.0.
+**Status:** landed. RFC-011 §13 (as amended in Amendment F, floor-revert)
+requires Valkey 7.2+. `ff-server` performs a boot-time version check and
+fails fast if the detected `(major, minor)` is below `(7, 2)` with a typed
+`ServerError::ValkeyVersionTooLow { detected, required }`.
 
-**Action:** if your production Valkey is on 7.x, schedule an upgrade before
-pulling the phase-5 release. FlowFabric's reference deployment (cairn
-integration tests) already pins `valkey/valkey:8-alpine`.
+**Action:** if your production Valkey is on 7.0 / 7.1 (or pre-7), schedule an
+upgrade before pulling a post-amendment release. If you are already on 7.2+
+(including any 8.x), no action required. FlowFabric's reference deployment
+(cairn integration tests) pins `valkey/valkey:8-alpine`; CI also exercises
+`valkey/valkey:7.2` to guard the floor.
 
 A 60-second exponential-backoff retry budget in the boot-check tolerates
-rolling Valkey upgrades — you don't need downtime coordination, but both
-versions must be ≥ 8.0 during the rolling window.
+rolling Valkey upgrades — you don't need downtime coordination, but all
+connected nodes must reach ≥ 7.2 within the 60s window.
 
 ## Verification checklist
 

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -35,17 +35,25 @@ and parsing the authoritative version field:
 
 - Prefers `valkey_version:` (present on Valkey 8.0+; this is the real
   server version).
-- Falls back to `redis_version:` for Valkey 7.x, which doesn't emit
-  `valkey_version:`.
+- Falls back to `redis_version:` **only when the body also carries
+  `server_name:valkey`** (introduced in Valkey 7.2 — i.e. the floor itself).
+  Redis does not emit `server_name:valkey`, so a Redis backend is rejected
+  at parse time.
 
 **Note:** Valkey 8.x/9.x keeps `redis_version:7.2.4` pinned for Redis-client
 compat and exposes the true version in `valkey_version:`. Operators
 inspecting the INFO response manually should read `valkey_version:`, not
 `redis_version:`, to see the real server version.
 
-If the parsed `(major, minor)` is below `(7, 2)`, the server refuses to start
-with a typed `ServerError::ValkeyVersionTooLow { detected, required }` and
-exits.
+**Cluster behavior.** In cluster mode the RESP3 `INFO` response is a map of
+`node_addr → body`. The check parses every node's body and compares the
+**minimum** `(major, minor)` against the floor. That way a stale pre-upgrade
+replica cannot hide behind an already-upgraded primary — the minimum is
+what's actually serving reads to a subset of keys.
+
+If the parsed minimum `(major, minor)` is below `(7, 2)`, the server refuses
+to start with a typed `ServerError::ValkeyVersionTooLow { detected, required }`
+and exits.
 
 ### Why 7.2
 

--- a/docs/rfc011-operator-runbook.md
+++ b/docs/rfc011-operator-runbook.md
@@ -29,9 +29,9 @@ operator responsible for the Valkey backend + FlowFabric server deployment.
 
 ## Valkey version requirement
 
-FlowFabric requires **Valkey ≥ 8.0** (see RFC-011 §13). The server verifies
-this at boot by issuing `INFO server` and parsing the authoritative version
-field:
+FlowFabric requires **Valkey ≥ 7.2** (see RFC-011 §13 and the §13 Amendment F
+floor-revert note). The server verifies this at boot by issuing `INFO server`
+and parsing the authoritative version field:
 
 - Prefers `valkey_version:` (present on Valkey 8.0+; this is the real
   server version).
@@ -43,15 +43,19 @@ compat and exposes the true version in `valkey_version:`. Operators
 inspecting the INFO response manually should read `valkey_version:`, not
 `redis_version:`, to see the real server version.
 
-If the major component is below 8, the server refuses to start with a typed
-`ServerError::ValkeyVersionTooLow { detected, required }` and exits.
+If the parsed `(major, minor)` is below `(7, 2)`, the server refuses to start
+with a typed `ServerError::ValkeyVersionTooLow { detected, required }` and
+exits.
 
-### Why 8.0
+### Why 7.2
 
-The hash-slot co-location design (RFC-011 §2) and the Valkey Functions API
-behavior the engine relies on stabilized in 8.0. Older versions will silently
-behave differently on some cluster edge cases. 8.0 is cairn-fabric's reference
-deployment, and it's what FlowFabric's integration tests pin.
+Valkey 7.2 is where the Functions API and RESP3 stabilized — the primitives
+the co-location design and typed FCALL wrappers actually depend on. Older
+versions do not implement the required APIs. We previously shipped an 8.0
+floor but reverted to 7.2 (RFC-011 §13 Amendment F) because nothing in the
+design requires 8-only behavior, and the lower floor supports downstream
+operators on slower-moving infra. CI exercises both 7.2 and 8 to guard
+against accidental 8-specific adoption.
 
 ### Rolling upgrade tolerance
 
@@ -61,8 +65,9 @@ The version check includes a **60-second exponential-backoff retry budget**
 - **Transport transients** — connection refused, `BusyLoadingError`,
   `ClusterDown`, etc. (Valkey error kinds classified as retryable).
 - **Low-version responses** — if the connected node happens to be a
-  pre-upgrade replica during a rolling upgrade, the 7.x response is treated
-  as a rolling-state transient and retried. After 60s of consistent low
+  pre-upgrade replica during a rolling upgrade (e.g. a 7.0 node briefly
+  reached while rolling to 7.2+), the response is treated as a
+  rolling-state transient and retried. After 60s of consistent low
   responses, the server exits with `ServerError::ValkeyVersionTooLow` —
   that's the misconfiguration signal, not a transient.
 
@@ -75,7 +80,7 @@ retrying them just hides the true cause under a 60s hang. Server boot fails
 immediately with the structured error and the underlying Valkey error kind
 preserved.
 
-## Rolling upgrade procedure (Valkey 7.x → 8.0+)
+## Rolling upgrade procedure (below-floor → ≥ 7.2)
 
 1. **Prepare:** confirm cairn (and any other consumer) is on a FF-SDK release
    that supports the target Valkey version. Consumer coordination is
@@ -85,14 +90,15 @@ preserved.
    - If single-node standalone: stop ff-server briefly, upgrade Valkey, start
      ff-server. The 60s retry budget tolerates restart windows under that.
    - If cluster: roll node-by-node. If ff-server restarts and connects to a
-     pre-upgrade (7.x) node while the roll is in progress, the version check
+     pre-upgrade node while the roll is in progress, the version check
      retries within the 60s budget; once the connected node completes its
      upgrade (or a reconnect lands on a post-upgrade node), the check
      succeeds. Keep the rolling window under 60s per node so the check
      doesn't exhaust before the node ahead finishes.
 
 3. **Verify:** after the upgrade, ff-server boot log should emit
-   `Valkey version accepted detected_major=8 required=8` at INFO level.
+   `Valkey version accepted detected_major=<M> detected_minor=<m> required_major=7 required_minor=2`
+   at INFO level.
 
 4. **Post-upgrade partition collision check** (optional, phase-5 probe):
    see the [Partition-collision observability](#partition-collision-observability)
@@ -268,7 +274,7 @@ context, it's stale; replace with an RFC-011 §7.3 pointer.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Server exits with `valkey version too low: detected 7, required >= 8.0` | Valkey 7.x backend | Upgrade Valkey to 8.0+; see [rolling upgrade](#rolling-upgrade-procedure-valkey-7x--80) |
+| Server exits with `valkey version too low: detected <M.m>, required >= 7.2` | Valkey below 7.2 backend | Upgrade Valkey to 7.2+; see [rolling upgrade](#rolling-upgrade-procedure-below-floor--72) |
 | Boot hangs for ~60s then exits with `valkey ({context}): ...` | Valkey unreachable during rolling upgrade OR truly down | If the cluster is mid-restart, wait and retry; otherwise check network/DNS |
 | `ServerError::PartitionMismatch` on `add_execution_to_flow` | Consumer minted exec with wrong flow/lane routing | Consumer bug — see [migration guide Step 1](rfc011-migration-for-consumers.md#step-1--executionid-construction) |
 | `partition_config mismatch: num_flow_partitions expected N, got M` on boot | `FF_FLOW_PARTITIONS` changed after first boot | Cannot hot-change partition count — re-seed or accept existing config |

--- a/rfcs/RFC-011-exec-flow-colocation.md
+++ b/rfcs/RFC-011-exec-flow-colocation.md
@@ -1008,16 +1008,18 @@ Kept to the minimum. Each has a decision protocol for when data arrives; nothing
 
 ## §13 Valkey version compatibility
 
-**Floor: Valkey 8.0.**
+**Floor: Valkey 7.2.** (See Amendment F below for the floor-revert rationale; supersedes the originally-proposed 8.0 floor.)
 
 Rationale:
-* FlowFabric already depends on Valkey Functions (stabilised in Valkey 7.2 / Redis 7.0), RESP3 (Valkey 7.2+), and hash-tag routing (stable since Redis 3.0). We were effectively at the Valkey 7.2 floor before this RFC.
-* cairn-fabric (our only production-adjacent consumer) pins `valkey/valkey:8-alpine` in its test harness. Sources: `/tmp/cairn-rs/scripts/run-fabric-integration-tests.sh` (`VALKEY_IMAGE="${VALKEY_IMAGE:-valkey/valkey:8-alpine}"`), `/tmp/cairn-rs/crates/cairn-fabric/README.md` (same default), `/tmp/cairn-rs/.github/workflows/ci.yml` ("disposable Valkey 8 container via testcontainers-rs").
-* Moving our floor to 8.0 aligns with cairn's pin and unblocks future work (e.g. the Module API explorations in RFC-012, which target Valkey 8's `ValkeyModule_*` naming convention).
+* FlowFabric depends on Valkey Functions (stabilised in Valkey 7.2 / Redis 7.0), RESP3 (Valkey 7.2+), and hash-tag routing (stable since Redis 3.0). These are the primitives actually used by the co-location design — nothing the RFC adds requires an 8.0-only behavior.
+* cairn-fabric (our only production-adjacent consumer) pins `valkey/valkey:8-alpine` in its test harness, but cairn can run against any Valkey ≥ 7.2 — the 8 pin is its reproducibility choice, not a FlowFabric requirement. Sources: `/tmp/cairn-rs/scripts/run-fabric-integration-tests.sh`, `/tmp/cairn-rs/crates/cairn-fabric/README.md`.
+* Holding the floor at 7.2 keeps cairn's current deployment supported while leaving room for downstream operators who cannot move to 8 yet (slower-moving infra, managed-Valkey 7.2 instances, etc.).
 
-**Explicit compatibility commitment:** `ff-server` post-RFC-011 targets Valkey 8.0+. Valkey 7.x is not supported. Redis (any version) is not supported and never was — FlowFabric is a Valkey-native engine.
+**Explicit compatibility commitment:** `ff-server` targets Valkey 7.2+. Valkey 7.0 / 7.1 and earlier are not supported. Redis (any version) is not supported and never was — FlowFabric is a Valkey-native engine.
 
-**Version assertion:** `ff-server` boot-time version check (added in phase 3) reads `INFO server` and refuses to start against Valkey < 8.0 with a structured error message. **Retry budget: 60s with exponential backoff** to tolerate rolling-upgrade transients where a replica is temporarily stale (see §9.17). After 60s the server exits; that's a misconfiguration signal, not a transient. Single CI matrix entry: `VALKEY_IMAGE=valkey/valkey:8-alpine`.
+**Version assertion:** `ff-server` boot-time version check (added in phase 3) reads `INFO server` and refuses to start against Valkey < 7.2 with a structured `ServerError::ValkeyVersionTooLow { detected, required }` error. **Retry budget: 60s with exponential backoff** to tolerate rolling-upgrade transients where a replica is temporarily stale (see §9.17). After 60s the server exits; that's a misconfiguration signal, not a transient. CI matrix includes both `valkey/valkey:8-alpine` (primary) and `valkey/valkey:7.2` (floor guard) to prevent accidental 8-specific primitive adoption.
+
+**Amendment F — Floor revert from 8.0 to 7.2 (post-phase-3).** The originally-shipped phase-3 floor was Valkey 8.0. Post-ship review found the 8.0 floor was not load-bearing: every primitive this RFC actually uses (Functions, RESP3, hash-tags, co-located FCALL, `COPY … REPLACE`) was already available and stable in Valkey 7.2. The 8.0 rationale rested on "cairn pins 8" — but cairn's pin is a reproducibility choice and cairn can run against 7.2. Lowering the floor to 7.2 supports downstream operators on slower-moving infra without costing FlowFabric any capability. The 8.0 floor was implemented in `ff-server`'s `verify_valkey_version` as a major-only (`detected_major >= 8`) comparison; the revert changes it to a `(major, minor) >= (7, 2)` comparison and adds a parse step for the minor component (Valkey always reports `major.minor.patch` in INFO so no response-shape change is needed). CI gains a `valkey/valkey:7.2` × linux-x86_64 × standalone entry to guard against future accidental 8-specific adoption.
 
 ## §14 References
 


### PR DESCRIPTION
Closes #68 #69 #70 #72.

Worker C audit backlog — docs-and-policy batch. Four independent lints against the same slice of the repo (README + deny.toml + one wrapper bug), bundled for review convenience.

> **Note on Valkey version**: during review, owner commit `ed57533` lowered the Valkey floor from 8.0 back to 7.2 (RFC-011 §13 Amendment F) after concluding that 7.2 has every primitive the co-location design needs. Earlier commits on this branch (and sections of this description) pre-date that revert and read as "Valkey 8+"; the canonical source of truth on this branch is now "Valkey >= 7.2".

## Summary

| Issue | File | Fix |
|-------|------|-----|
| #68 | `crates/ff-script/src/functions/execution.rs:201` | Forward `CreateExecutionArgs::execution_deadline_at` into ARGV[12] instead of `String::new()`. |
| #69 | `README.md` quickstart | Require Valkey that ff-server accepts (floor was 8 at commit time, revised to 7.2 by owner commit `ed57533`); add `FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32)` to the `cargo run -p ff-server` line. |
| #70 | `README.md` env-var table + CI matrix text | Inline the full `ServerConfig::from_env` table; correct the CI matrix description to match the current workflow shape. |
| #72 | `deny.toml` | Remove 4 unmatched license allowances (Unicode-DFS-2016, Zlib, MPL-2.0, 0BSD) + 1 unmatched advisory ignore (RUSTSEC-2026-0097). |

## #68: typed wrapper regression test

Pre-fix `execution.rs:201` hardcoded an empty string in ARGV[12], so `ff_create_execution` could never ZADD into `execution_deadline_zset`. The server-side path (`ff-server/src/server.rs:521`) had always done this correctly; only the public typed wrapper in `ff-script` dropped the value — so direct consumers of the published crate had a silent correctness hole.

New regression: `crates/ff-test/tests/pr_c3_create_execution_deadline.rs` creates an execution via the typed wrapper with `execution_deadline_at = Some(t)` and asserts ZSCORE on `execution_deadline_zset` equals t. Test fails on the pre-fix `String::new()` (verified by stashing the fix), passes on HEAD.

## #69: quickstart healthz proof

Local verification against a fresh Valkey 8.1.0 instance (FLUSHALL + FUNCTION FLUSH before boot to simulate a first-time user):

```
$ FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32) cargo run -p ff-server
INFO ff_server::server: Valkey version accepted detected_major=8 required=8
INFO ff_server::server: waitpoint HMAC secret install complete partitions=256
INFO ff_server::server: FlowFabric server started. Partitions (flow/budget/quota): 256/32/32. Scanners: 14 active.

$ curl -si http://127.0.0.1:9090/healthz
HTTP/1.1 200 OK
content-type: application/json
content-length: 15

{"status":"ok"}
```

## #72: cargo deny check before/after

Before: 4 license-not-encountered warnings (Unicode-DFS-2016, Zlib, MPL-2.0, 0BSD) + 1 advisory-not-detected warning (RUSTSEC-2026-0097).
After: `advisories ok, bans ok, licenses ok, sources ok`. Intentional `multiple-versions = "warn"` duplicates remain — policy intent is warn per deny.toml line 65.

RUSTSEC-2026-0097 in particular: affects rand >=0.8.6 / >=0.9.0. Our resolved graph pins rand 0.8.5 (below the affected range), so the ignore was misaimed at a hazard we don't face.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace --lib` all green
- [x] `cargo test -p ff-test --test pr_c3_create_execution_deadline` pass; discriminates against pre-fix code
- [x] `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo clippy -p ff-script -p ff-test -p ff-server --all-targets -- -D warnings` clean
- [x] Local quickstart — `/healthz` returns 200 `{"status":"ok"}` against a fresh Valkey 8
- [x] CI green on HEAD (matrix + security-and-quality + CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
