### PR TITLE
feat(ff-sdk): typed EngineError replaces SdkError::Script (#58.6)

### DIFF
--- a/crates/ff-sdk/src/engine_error.rs
+++ b/crates/ff-sdk/src/engine_error.rs
@@ -1,0 +1,808 @@
+//! Typed engine-error surface (issue #58.6).
+//!
+//! [`EngineError`] is the typed public error type that replaces
+//! string-matching on [`ff_script::error::ScriptError`] codes. Every
+//! `ScriptError` code maps 1:1 into a sub-kind variant — consumers
+//! that today match on the FCALL error-envelope string (cairn's
+//! `is_claim_contention`, `fcall_error_code`, etc.) can pattern-match
+//! the typed enum instead.
+//!
+//! # Mapping shape
+//!
+//! `ScriptError` lives in the `ff-script` crate (transport-adjacent).
+//! `EngineError` lives here in `ff-sdk` and is what public SDK calls
+//! return via [`crate::SdkError::Engine`]. The bidirectional mapping:
+//!
+//! * `From<ScriptError> for EngineError` — every `ScriptError` variant
+//!   is classified into `NotFound` / `Validation` / `Contention` /
+//!   `Conflict` / `State` / `Bug` / `Transport`. `Parse` + `Valkey`
+//!   flow through `Transport { source: Box<ScriptError> }` so the
+//!   underlying `ferriskey::ErrorKind` / parse detail is preserved.
+//! * `DependencyAlreadyExists` is special: per the #58.6 design the
+//!   variant carries the pre-existing [`EdgeSnapshot`] inline.
+//!   Populating that field requires an extra round-trip (the Lua
+//!   script only knows the edge_id), so plain `From<ScriptError>`
+//!   returns a `Transport` fallback for that code — callers in the
+//!   `stage_dependency` path use [`EngineError::enrich_dependency_conflict`]
+//!   to perform the follow-up `describe_edge` and upgrade the error
+//!   before returning.
+//!
+//! # Exhaustiveness
+//!
+//! The top-level [`EngineError`] and every sub-kind are
+//! `#[non_exhaustive]`. FF can add new Lua error codes in minors
+//! without a breaking change to this surface — consumers that
+//! `match` on a sub-kind must include a `_` arm.
+
+use std::collections::HashMap;
+
+use ff_core::contracts::EdgeSnapshot;
+use ff_core::error::ErrorClass;
+use ff_core::keys::FlowKeyContext;
+use ff_core::partition::flow_partition;
+use ff_core::types::{EdgeId, FlowId};
+use ff_script::error::ScriptError;
+
+/// Typed engine-error surface. See module docs.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EngineError {
+    /// A uniquely-identified resource did not exist. `entity` is a
+    /// stable label (e.g. `"execution"`, `"flow"`, `"attempt"`) that
+    /// consumers can match without re-parsing a message.
+    #[error("not found: {entity}")]
+    NotFound { entity: &'static str },
+
+    /// Caller supplied a malformed, out-of-range, or otherwise
+    /// rejected input. `detail` carries the Lua-side payload (field
+    /// name, offending value, or CSV of missing tokens, depending on
+    /// `kind`).
+    #[error("validation: {kind:?}: {detail}")]
+    Validation {
+        kind: ValidationKind,
+        detail: String,
+    },
+
+    /// Transient conflict with another worker or with the current
+    /// state of the execution/flow. Caller should retry per
+    /// RFC-010 §10.7.
+    #[error("contention: {0:?}")]
+    Contention(ContentionKind),
+
+    /// Permanent conflict — the requested mutation conflicts with
+    /// an existing record (e.g. duplicate edge, cycle, already-in-flow).
+    /// Caller must not blindly retry.
+    #[error("conflict: {0:?}")]
+    Conflict(ConflictKind),
+
+    /// Legal but surprising state — lease expired, already-suspended,
+    /// duplicate-signal, budget-exceeded, etc. Per-variant semantics
+    /// documented on [`StateKind`].
+    #[error("state: {0:?}")]
+    State(StateKind),
+
+    /// FF-internal invariant violation that should not be reachable
+    /// in a correctly-behaving deployment. Consumers typically log
+    /// and surface as a 5xx.
+    #[error("bug: {0:?}")]
+    Bug(BugKind),
+
+    /// Valkey transport fault or FCALL response-parse failure.
+    /// Preserves the raw [`ScriptError`] via `Box` so callers can
+    /// recover the `ferriskey::ErrorKind` (for `Valkey`) or the
+    /// parse-site message (for `Parse`).
+    #[error("transport: {source}")]
+    Transport {
+        #[source]
+        source: Box<ScriptError>,
+    },
+}
+
+/// Validation sub-kinds. 1:1 with the Lua validation codes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ValidationKind {
+    /// Generic caller-supplied input rejected (field-name detail).
+    InvalidInput,
+    /// Worker caps do not satisfy execution's required_capabilities.
+    /// `detail` is the sorted-CSV of missing tokens.
+    CapabilityMismatch,
+    /// Malformed/oversized capability list.
+    InvalidCapabilities,
+    /// `policy_json` not valid JSON or structurally wrong.
+    InvalidPolicyJson,
+    /// Signal payload > 64KB.
+    PayloadTooLarge,
+    /// Max signals per execution reached.
+    SignalLimitExceeded,
+    /// MAC verification failed on waitpoint_key.
+    InvalidWaitpointKey,
+    /// Pending waitpoint has no HMAC token field.
+    WaitpointNotTokenBound,
+    /// Frame > 64KB.
+    RetentionLimitExceeded,
+    /// Lease/attempt binding mismatch on suspend.
+    InvalidLeaseForSuspend,
+    /// Dependency edge not found / invalid dependency ref.
+    InvalidDependency,
+    /// Waitpoint/execution binding mismatch.
+    InvalidWaitpointForExecution,
+    /// Unrecognized blocking reason.
+    InvalidBlockingReason,
+    /// Invalid stream ID offset.
+    InvalidOffset,
+    /// Auth failed.
+    Unauthorized,
+    /// Budget scope malformed.
+    InvalidBudgetScope,
+    /// Operator privileges required.
+    BudgetOverrideNotAllowed,
+    /// Malformed quota definition.
+    InvalidQuotaSpec,
+    /// Rotation kid must be non-empty and dot-free.
+    InvalidKid,
+    /// Rotation secret must be non-empty even-length hex.
+    InvalidSecretHex,
+    /// Rotation grace_ms must be a non-negative integer.
+    InvalidGraceMs,
+    /// Tag key violates reserved-namespace rule.
+    InvalidTagKey,
+    /// Unrecognized stream frame type.
+    InvalidFrameType,
+}
+
+/// Contention sub-kinds (retryable per RFC-010 §10.7). Caller should
+/// re-dispatch or re-read and retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContentionKind {
+    /// Re-dispatch to `claim_resumed_execution`.
+    UseClaimResumedExecution,
+    /// Re-dispatch to `claim_execution`.
+    NotAResumedExecution,
+    /// State changed since grant. Request new grant.
+    ExecutionNotLeaseable,
+    /// Another worker holds lease. Request a different execution.
+    LeaseConflict,
+    /// Grant missing/mismatched. Request new grant.
+    InvalidClaimGrant,
+    /// Grant TTL elapsed. Request new grant.
+    ClaimGrantExpired,
+    /// No execution currently available.
+    NoEligibleExecution,
+    /// Waitpoint may not exist yet. Retry with backoff.
+    WaitpointNotFound,
+    /// Route to buffer_signal_for_pending_waitpoint.
+    WaitpointPendingUseBufferScript,
+    /// Graph revision changed. Re-read adjacency, retry.
+    StaleGraphRevision,
+    /// Execution is not in `active` state (lease superseded, etc.)
+    /// Carries the Lua-side detail payload for replay reconciliation.
+    ExecutionNotActive {
+        terminal_outcome: String,
+        lease_epoch: String,
+        lifecycle_phase: String,
+        attempt_id: String,
+    },
+    /// State changed. Scheduler skips.
+    ExecutionNotEligible,
+    /// Removed by another scheduler.
+    ExecutionNotInEligibleSet,
+    /// Already reclaimed/cancelled. Skip.
+    ExecutionNotReclaimable,
+    /// Target has no active lease (already revoked/expired/unowned).
+    NoActiveLease,
+    /// Window full; caller should backoff `retry_after_ms`.
+    RateLimitExceeded,
+    /// Concurrency cap hit.
+    ConcurrencyLimitExceeded,
+}
+
+/// Permanent conflict sub-kinds. Caller must reconcile rather than
+/// retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ConflictKind {
+    /// Dependency edge already exists. Carries the pre-existing
+    /// [`EdgeSnapshot`] so callers implementing "409 on re-declare
+    /// with different kind/ref" don't need a follow-up read.
+    ///
+    /// Note: the plain `From<ScriptError> for EngineError` impl
+    /// cannot populate `existing` (that requires an async
+    /// `describe_edge` round trip), so it falls through to
+    /// `EngineError::Transport`. Callers on the `stage_dependency`
+    /// path use [`EngineError::enrich_dependency_conflict`] to
+    /// perform the follow-up read and promote the error.
+    DependencyAlreadyExists { existing: EdgeSnapshot },
+    /// Edge would create a cycle.
+    CycleDetected,
+    /// Self-referencing edge (upstream == downstream).
+    SelfReferencingEdge,
+    /// Execution is already a member of another flow.
+    ExecutionAlreadyInFlow,
+    /// Waitpoint already exists (pending or active).
+    WaitpointAlreadyExists,
+    /// Budget already attached or conflicts.
+    BudgetAttachConflict,
+    /// Quota policy already attached.
+    QuotaAttachConflict,
+    /// Rotation: same kid already installed with a different secret.
+    /// String is the conflicting kid.
+    RotationConflict(String),
+    /// Invariant violation: active attempt already exists where one
+    /// was expected absent.
+    ActiveAttemptExists,
+}
+
+/// Legal-but-surprising state sub-kinds. Per-variant semantics vary
+/// (some are benign no-ops, some are terminal). Consult the RFC-010
+/// §10.7 classification table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StateKind {
+    /// Lease superseded by reclaim.
+    StaleLease,
+    /// Lease TTL elapsed.
+    LeaseExpired,
+    /// Operator revoked lease.
+    LeaseRevoked,
+    /// Already resumed/cancelled. No-op.
+    ExecutionNotSuspended,
+    /// Open suspension already active. No-op.
+    AlreadySuspended,
+    /// Signal too late — waitpoint already closed.
+    WaitpointClosed,
+    /// Execution not suspended; no valid signal target.
+    TargetNotSignalable,
+    /// Signal already delivered (dedup).
+    DuplicateSignal,
+    /// Resume conditions not satisfied.
+    ResumeConditionNotMet,
+    /// Waitpoint not in pending state.
+    WaitpointNotPending,
+    /// Pending waitpoint aged out before suspension committed.
+    PendingWaitpointExpired,
+    /// Waitpoint is not in an open state.
+    WaitpointNotOpen,
+    /// Cannot replay non-terminal execution.
+    ExecutionNotTerminal,
+    /// Replay limit reached.
+    MaxReplaysExhausted,
+    /// Attempt terminal; no appends.
+    StreamClosed,
+    /// Lease mismatch on stream append.
+    StaleOwnerCannotAppend,
+    /// Grant already issued. Skip.
+    GrantAlreadyExists,
+    /// Execution not in specified flow.
+    ExecutionNotInFlow,
+    /// Flow already in terminal state.
+    FlowAlreadyTerminal,
+    /// Dependencies not yet satisfied.
+    DepsNotSatisfied,
+    /// Not blocked by dependencies.
+    NotBlockedByDeps,
+    /// Execution not runnable.
+    NotRunnable,
+    /// Execution already terminal.
+    Terminal,
+    /// Hard budget limit reached.
+    BudgetExceeded,
+    /// Soft budget limit reached (warning; continue).
+    BudgetSoftExceeded,
+    /// Usage seq already processed. No-op.
+    OkAlreadyApplied,
+    /// Attempt not in started state.
+    AttemptNotStarted,
+    /// Attempt already ended. No-op.
+    AttemptAlreadyTerminal,
+    /// Wrong state for new attempt.
+    ExecutionNotEligibleForAttempt,
+    /// Execution not terminal or replay limit reached.
+    ReplayNotAllowed,
+    /// Retry limit reached.
+    MaxRetriesExhausted,
+    /// Already closed. No-op.
+    StreamAlreadyClosed,
+}
+
+/// FF-internal invariant-violation sub-kinds. Should not be reachable
+/// in a correctly-behaving deployment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BugKind {
+    /// `attempt_not_in_created_state`: internal sequencing error.
+    AttemptNotInCreatedState,
+}
+
+impl EngineError {
+    /// Classify an [`EngineError`] using the underlying
+    /// [`ErrorClass`] table. Delegates to the `ScriptError` mapping
+    /// via [`ScriptError::class`] when the original is recoverable
+    /// through `Transport`; otherwise uses the variant bucket.
+    pub fn class(&self) -> ErrorClass {
+        match self {
+            Self::NotFound { .. } => ErrorClass::Terminal,
+            Self::Validation { .. } => ErrorClass::Terminal,
+            Self::Contention(_) => ErrorClass::Retryable,
+            Self::Conflict(_) => ErrorClass::Terminal,
+            Self::State(StateKind::BudgetExceeded) => ErrorClass::Cooperative,
+            Self::State(
+                StateKind::ExecutionNotSuspended
+                | StateKind::AlreadySuspended
+                | StateKind::WaitpointClosed
+                | StateKind::DuplicateSignal
+                | StateKind::GrantAlreadyExists
+                | StateKind::OkAlreadyApplied
+                | StateKind::AttemptAlreadyTerminal
+                | StateKind::StreamAlreadyClosed
+                | StateKind::BudgetSoftExceeded
+                | StateKind::WaitpointNotOpen
+                | StateKind::WaitpointNotPending
+                | StateKind::PendingWaitpointExpired
+                | StateKind::NotBlockedByDeps
+                | StateKind::DepsNotSatisfied,
+            ) => ErrorClass::Informational,
+            Self::State(_) => ErrorClass::Terminal,
+            Self::Bug(_) => ErrorClass::Bug,
+            Self::Transport { source } => source.class(),
+        }
+    }
+
+    /// Returns the underlying ferriskey ErrorKind if this error maps
+    /// back to a transport-level fault.
+    pub fn valkey_kind(&self) -> Option<ferriskey::ErrorKind> {
+        match self {
+            Self::Transport { source } => source.valkey_kind(),
+            _ => None,
+        }
+    }
+
+    /// Upgrade a bare `From<ScriptError>` translation of
+    /// `dependency_already_exists` into a fully-typed
+    /// [`ConflictKind::DependencyAlreadyExists`] by performing the
+    /// follow-up `HGETALL` on the edge hash.
+    ///
+    /// Call sites that stage a dependency and receive
+    /// [`EngineError::Transport`] whose inner is
+    /// `ScriptError::DependencyAlreadyExists` use this helper to
+    /// upgrade the error before surfacing. On follow-up failure the
+    /// original `Transport` error is returned unchanged — the
+    /// strict-parse posture means a half-populated `Conflict` is
+    /// never constructed.
+    pub async fn enrich_dependency_conflict(
+        client: &ferriskey::Client,
+        partition_config: &ff_core::partition::PartitionConfig,
+        flow_id: &FlowId,
+        edge_id: &EdgeId,
+    ) -> Result<Self, Self> {
+        let partition = flow_partition(flow_id, partition_config);
+        let ctx = FlowKeyContext::new(&partition, flow_id);
+        let edge_key = ctx.edge(edge_id);
+
+        let raw: HashMap<String, String> = match client
+            .cmd("HGETALL")
+            .arg(&edge_key)
+            .execute()
+            .await
+        {
+            Ok(raw) => raw,
+            Err(transport) => {
+                // Follow-up read failed: fall back to the raw
+                // ScriptError so diagnostic detail is not lost.
+                return Err(Self::Transport {
+                    source: Box::new(ScriptError::Valkey(transport)),
+                });
+            }
+        };
+        if raw.is_empty() {
+            // Edge hash absent despite the Lua reporting
+            // dependency_already_exists — corruption or a
+            // race with a concurrent writer. Surface as the
+            // raw ScriptError rather than fabricate a stub.
+            return Err(Self::Transport {
+                source: Box::new(ScriptError::DependencyAlreadyExists),
+            });
+        }
+        match crate::snapshot::build_edge_snapshot_public(flow_id, edge_id, &raw) {
+            Ok(existing) => Ok(Self::Conflict(ConflictKind::DependencyAlreadyExists {
+                existing,
+            })),
+            Err(_e) => Err(Self::Transport {
+                source: Box::new(ScriptError::DependencyAlreadyExists),
+            }),
+        }
+    }
+}
+
+impl From<ScriptError> for EngineError {
+    fn from(err: ScriptError) -> Self {
+        use ScriptError as S;
+        match err {
+            // ── NotFound ──
+            S::ExecutionNotFound => Self::NotFound {
+                entity: "execution",
+            },
+            S::FlowNotFound => Self::NotFound { entity: "flow" },
+            S::AttemptNotFound => Self::NotFound { entity: "attempt" },
+            S::BudgetNotFound => Self::NotFound { entity: "budget" },
+            S::QuotaPolicyNotFound => Self::NotFound {
+                entity: "quota_policy",
+            },
+            S::StreamNotFound => Self::NotFound { entity: "stream" },
+
+            // ── Validation (carries detail) ──
+            S::InvalidInput(d) => Self::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: d,
+            },
+            S::CapabilityMismatch(d) => Self::Validation {
+                kind: ValidationKind::CapabilityMismatch,
+                detail: d,
+            },
+            S::InvalidCapabilities(d) => Self::Validation {
+                kind: ValidationKind::InvalidCapabilities,
+                detail: d,
+            },
+            S::InvalidPolicyJson(d) => Self::Validation {
+                kind: ValidationKind::InvalidPolicyJson,
+                detail: d,
+            },
+            S::InvalidTagKey(d) => Self::Validation {
+                kind: ValidationKind::InvalidTagKey,
+                detail: d,
+            },
+            // ── Validation (no detail payload) ──
+            S::PayloadTooLarge => Self::Validation {
+                kind: ValidationKind::PayloadTooLarge,
+                detail: String::new(),
+            },
+            S::SignalLimitExceeded => Self::Validation {
+                kind: ValidationKind::SignalLimitExceeded,
+                detail: String::new(),
+            },
+            S::InvalidWaitpointKey => Self::Validation {
+                kind: ValidationKind::InvalidWaitpointKey,
+                detail: String::new(),
+            },
+            S::WaitpointNotTokenBound => Self::Validation {
+                kind: ValidationKind::WaitpointNotTokenBound,
+                detail: String::new(),
+            },
+            S::RetentionLimitExceeded => Self::Validation {
+                kind: ValidationKind::RetentionLimitExceeded,
+                detail: String::new(),
+            },
+            S::InvalidLeaseForSuspend => Self::Validation {
+                kind: ValidationKind::InvalidLeaseForSuspend,
+                detail: String::new(),
+            },
+            S::InvalidDependency => Self::Validation {
+                kind: ValidationKind::InvalidDependency,
+                detail: String::new(),
+            },
+            S::InvalidWaitpointForExecution => Self::Validation {
+                kind: ValidationKind::InvalidWaitpointForExecution,
+                detail: String::new(),
+            },
+            S::InvalidBlockingReason => Self::Validation {
+                kind: ValidationKind::InvalidBlockingReason,
+                detail: String::new(),
+            },
+            S::InvalidOffset => Self::Validation {
+                kind: ValidationKind::InvalidOffset,
+                detail: String::new(),
+            },
+            S::Unauthorized => Self::Validation {
+                kind: ValidationKind::Unauthorized,
+                detail: String::new(),
+            },
+            S::InvalidBudgetScope => Self::Validation {
+                kind: ValidationKind::InvalidBudgetScope,
+                detail: String::new(),
+            },
+            S::BudgetOverrideNotAllowed => Self::Validation {
+                kind: ValidationKind::BudgetOverrideNotAllowed,
+                detail: String::new(),
+            },
+            S::InvalidQuotaSpec => Self::Validation {
+                kind: ValidationKind::InvalidQuotaSpec,
+                detail: String::new(),
+            },
+            S::InvalidKid => Self::Validation {
+                kind: ValidationKind::InvalidKid,
+                detail: String::new(),
+            },
+            S::InvalidSecretHex => Self::Validation {
+                kind: ValidationKind::InvalidSecretHex,
+                detail: String::new(),
+            },
+            S::InvalidGraceMs => Self::Validation {
+                kind: ValidationKind::InvalidGraceMs,
+                detail: String::new(),
+            },
+            S::InvalidFrameType => Self::Validation {
+                kind: ValidationKind::InvalidFrameType,
+                detail: String::new(),
+            },
+
+            // ── Contention ──
+            S::UseClaimResumedExecution => {
+                Self::Contention(ContentionKind::UseClaimResumedExecution)
+            }
+            S::NotAResumedExecution => Self::Contention(ContentionKind::NotAResumedExecution),
+            S::ExecutionNotLeaseable => Self::Contention(ContentionKind::ExecutionNotLeaseable),
+            S::LeaseConflict => Self::Contention(ContentionKind::LeaseConflict),
+            S::InvalidClaimGrant => Self::Contention(ContentionKind::InvalidClaimGrant),
+            S::ClaimGrantExpired => Self::Contention(ContentionKind::ClaimGrantExpired),
+            S::NoEligibleExecution => Self::Contention(ContentionKind::NoEligibleExecution),
+            S::WaitpointNotFound => Self::Contention(ContentionKind::WaitpointNotFound),
+            S::WaitpointPendingUseBufferScript => {
+                Self::Contention(ContentionKind::WaitpointPendingUseBufferScript)
+            }
+            S::StaleGraphRevision => Self::Contention(ContentionKind::StaleGraphRevision),
+            S::ExecutionNotActive {
+                terminal_outcome,
+                lease_epoch,
+                lifecycle_phase,
+                attempt_id,
+            } => Self::Contention(ContentionKind::ExecutionNotActive {
+                terminal_outcome,
+                lease_epoch,
+                lifecycle_phase,
+                attempt_id,
+            }),
+            S::ExecutionNotEligible => Self::Contention(ContentionKind::ExecutionNotEligible),
+            S::ExecutionNotInEligibleSet => {
+                Self::Contention(ContentionKind::ExecutionNotInEligibleSet)
+            }
+            S::ExecutionNotReclaimable => {
+                Self::Contention(ContentionKind::ExecutionNotReclaimable)
+            }
+            S::NoActiveLease => Self::Contention(ContentionKind::NoActiveLease),
+            S::RateLimitExceeded => Self::Contention(ContentionKind::RateLimitExceeded),
+            S::ConcurrencyLimitExceeded => {
+                Self::Contention(ContentionKind::ConcurrencyLimitExceeded)
+            }
+
+            // ── Conflict ──
+            // DependencyAlreadyExists needs a follow-up read to
+            // populate `existing`. Plain `From` cannot do the
+            // async read, so falls through to Transport with the
+            // raw ScriptError preserved — callers enrich via
+            // `EngineError::enrich_dependency_conflict` at the
+            // stage_dependency site.
+            S::DependencyAlreadyExists => Self::Transport {
+                source: Box::new(S::DependencyAlreadyExists),
+            },
+            S::CycleDetected => Self::Conflict(ConflictKind::CycleDetected),
+            S::SelfReferencingEdge => Self::Conflict(ConflictKind::SelfReferencingEdge),
+            S::ExecutionAlreadyInFlow => Self::Conflict(ConflictKind::ExecutionAlreadyInFlow),
+            S::WaitpointAlreadyExists => Self::Conflict(ConflictKind::WaitpointAlreadyExists),
+            S::BudgetAttachConflict => Self::Conflict(ConflictKind::BudgetAttachConflict),
+            S::QuotaAttachConflict => Self::Conflict(ConflictKind::QuotaAttachConflict),
+            S::RotationConflict(kid) => Self::Conflict(ConflictKind::RotationConflict(kid)),
+            S::ActiveAttemptExists => Self::Conflict(ConflictKind::ActiveAttemptExists),
+
+            // ── State ──
+            S::StaleLease => Self::State(StateKind::StaleLease),
+            S::LeaseExpired => Self::State(StateKind::LeaseExpired),
+            S::LeaseRevoked => Self::State(StateKind::LeaseRevoked),
+            S::ExecutionNotSuspended => Self::State(StateKind::ExecutionNotSuspended),
+            S::AlreadySuspended => Self::State(StateKind::AlreadySuspended),
+            S::WaitpointClosed => Self::State(StateKind::WaitpointClosed),
+            S::TargetNotSignalable => Self::State(StateKind::TargetNotSignalable),
+            S::DuplicateSignal => Self::State(StateKind::DuplicateSignal),
+            S::ResumeConditionNotMet => Self::State(StateKind::ResumeConditionNotMet),
+            S::WaitpointNotPending => Self::State(StateKind::WaitpointNotPending),
+            S::PendingWaitpointExpired => Self::State(StateKind::PendingWaitpointExpired),
+            S::WaitpointNotOpen => Self::State(StateKind::WaitpointNotOpen),
+            S::ExecutionNotTerminal => Self::State(StateKind::ExecutionNotTerminal),
+            S::MaxReplaysExhausted => Self::State(StateKind::MaxReplaysExhausted),
+            S::StreamClosed => Self::State(StateKind::StreamClosed),
+            S::StaleOwnerCannotAppend => Self::State(StateKind::StaleOwnerCannotAppend),
+            S::GrantAlreadyExists => Self::State(StateKind::GrantAlreadyExists),
+            S::ExecutionNotInFlow => Self::State(StateKind::ExecutionNotInFlow),
+            S::FlowAlreadyTerminal => Self::State(StateKind::FlowAlreadyTerminal),
+            S::DepsNotSatisfied => Self::State(StateKind::DepsNotSatisfied),
+            S::NotBlockedByDeps => Self::State(StateKind::NotBlockedByDeps),
+            S::NotRunnable => Self::State(StateKind::NotRunnable),
+            S::Terminal => Self::State(StateKind::Terminal),
+            S::BudgetExceeded => Self::State(StateKind::BudgetExceeded),
+            S::BudgetSoftExceeded => Self::State(StateKind::BudgetSoftExceeded),
+            S::OkAlreadyApplied => Self::State(StateKind::OkAlreadyApplied),
+            S::AttemptNotStarted => Self::State(StateKind::AttemptNotStarted),
+            S::AttemptAlreadyTerminal => Self::State(StateKind::AttemptAlreadyTerminal),
+            S::ExecutionNotEligibleForAttempt => {
+                Self::State(StateKind::ExecutionNotEligibleForAttempt)
+            }
+            S::ReplayNotAllowed => Self::State(StateKind::ReplayNotAllowed),
+            S::MaxRetriesExhausted => Self::State(StateKind::MaxRetriesExhausted),
+            S::StreamAlreadyClosed => Self::State(StateKind::StreamAlreadyClosed),
+
+            // ── Bug ──
+            S::AttemptNotInCreatedState => Self::Bug(BugKind::AttemptNotInCreatedState),
+
+            // ── Transport (preserves source for Parse/Valkey) ──
+            e @ (S::Parse(_) | S::Valkey(_)) => Self::Transport {
+                source: Box::new(e),
+            },
+
+            // `ScriptError` is `#[non_exhaustive]`. A future variant
+            // landed in ff-script before the mapping here was updated
+            // falls through to `Transport` with the raw ScriptError
+            // preserved — strict-parse posture: caller still sees the
+            // underlying error without a silent Display-string
+            // downgrade. Adding the explicit variant later is a
+            // non-breaking mapping refinement.
+            other => Self::Transport {
+                source: Box::new(other),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_found_mappings() {
+        assert!(matches!(
+            EngineError::from(ScriptError::ExecutionNotFound),
+            EngineError::NotFound { entity: "execution" }
+        ));
+        assert!(matches!(
+            EngineError::from(ScriptError::FlowNotFound),
+            EngineError::NotFound { entity: "flow" }
+        ));
+    }
+
+    #[test]
+    fn validation_detail_preserved() {
+        match EngineError::from(ScriptError::CapabilityMismatch("gpu,cuda".into())) {
+            EngineError::Validation {
+                kind: ValidationKind::CapabilityMismatch,
+                detail,
+            } => assert_eq!(detail, "gpu,cuda"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn contention_bucket() {
+        assert!(matches!(
+            EngineError::from(ScriptError::LeaseConflict),
+            EngineError::Contention(ContentionKind::LeaseConflict)
+        ));
+        assert!(matches!(
+            EngineError::from(ScriptError::UseClaimResumedExecution),
+            EngineError::Contention(ContentionKind::UseClaimResumedExecution)
+        ));
+    }
+
+    #[test]
+    fn execution_not_active_detail_flows_through() {
+        let src = ScriptError::ExecutionNotActive {
+            terminal_outcome: "success".into(),
+            lease_epoch: "3".into(),
+            lifecycle_phase: "terminal".into(),
+            attempt_id: "att-1".into(),
+        };
+        match EngineError::from(src) {
+            EngineError::Contention(ContentionKind::ExecutionNotActive {
+                terminal_outcome,
+                lease_epoch,
+                lifecycle_phase,
+                attempt_id,
+            }) => {
+                assert_eq!(terminal_outcome, "success");
+                assert_eq!(lease_epoch, "3");
+                assert_eq!(lifecycle_phase, "terminal");
+                assert_eq!(attempt_id, "att-1");
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn dependency_already_exists_falls_through_to_transport_without_enrich() {
+        // Plain From cannot fill `existing` — it defers to Transport
+        // so the caller can upgrade via enrich_dependency_conflict.
+        match EngineError::from(ScriptError::DependencyAlreadyExists) {
+            EngineError::Transport { source } => {
+                assert!(matches!(*source, ScriptError::DependencyAlreadyExists));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn conflict_variants() {
+        assert!(matches!(
+            EngineError::from(ScriptError::CycleDetected),
+            EngineError::Conflict(ConflictKind::CycleDetected)
+        ));
+        assert!(matches!(
+            EngineError::from(ScriptError::ExecutionAlreadyInFlow),
+            EngineError::Conflict(ConflictKind::ExecutionAlreadyInFlow)
+        ));
+        match EngineError::from(ScriptError::RotationConflict("kid-1".into())) {
+            EngineError::Conflict(ConflictKind::RotationConflict(k)) => assert_eq!(k, "kid-1"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn state_variants() {
+        assert!(matches!(
+            EngineError::from(ScriptError::StaleLease),
+            EngineError::State(StateKind::StaleLease)
+        ));
+        assert!(matches!(
+            EngineError::from(ScriptError::BudgetExceeded),
+            EngineError::State(StateKind::BudgetExceeded)
+        ));
+    }
+
+    #[test]
+    fn bug_variants() {
+        assert!(matches!(
+            EngineError::from(ScriptError::AttemptNotInCreatedState),
+            EngineError::Bug(BugKind::AttemptNotInCreatedState)
+        ));
+    }
+
+    #[test]
+    fn transport_preserves_parse() {
+        match EngineError::from(ScriptError::Parse("bad envelope".into())) {
+            EngineError::Transport { source } => {
+                assert!(matches!(*source, ScriptError::Parse(_)));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn transport_preserves_valkey_kind() {
+        let src = ScriptError::Valkey(ferriskey::Error::from((
+            ferriskey::ErrorKind::IoError,
+            "boom",
+        )));
+        let err = EngineError::from(src);
+        assert_eq!(err.valkey_kind(), Some(ferriskey::ErrorKind::IoError));
+    }
+
+    #[test]
+    fn class_contention_is_retryable() {
+        let err = EngineError::Contention(ContentionKind::LeaseConflict);
+        assert_eq!(err.class(), ErrorClass::Retryable);
+    }
+
+    #[test]
+    fn class_budget_exceeded_is_cooperative() {
+        let err = EngineError::State(StateKind::BudgetExceeded);
+        assert_eq!(err.class(), ErrorClass::Cooperative);
+    }
+
+    #[test]
+    fn class_duplicate_signal_is_informational() {
+        let err = EngineError::State(StateKind::DuplicateSignal);
+        assert_eq!(err.class(), ErrorClass::Informational);
+    }
+
+    #[test]
+    fn class_bug_variant() {
+        let err = EngineError::Bug(BugKind::AttemptNotInCreatedState);
+        assert_eq!(err.class(), ErrorClass::Bug);
+    }
+
+    #[test]
+    fn class_transport_delegates() {
+        let err = EngineError::from(ScriptError::Valkey(ferriskey::Error::from((
+            ferriskey::ErrorKind::IoError,
+            "x",
+        ))));
+        assert_eq!(err.class(), ErrorClass::Retryable);
+    }
+}

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -62,6 +62,7 @@
 
 pub mod admin;
 pub mod config;
+pub mod engine_error;
 pub mod snapshot;
 pub mod task;
 pub mod worker;
@@ -71,6 +72,7 @@ pub use admin::{
     FlowFabricAdminClient, RotateWaitpointSecretRequest, RotateWaitpointSecretResponse,
 };
 pub use config::WorkerConfig;
+pub use engine_error::{BugKind, ConflictKind, ContentionKind, EngineError, StateKind, ValidationKind};
 pub use task::{
     read_stream, tail_stream, AppendFrameOutcome, ClaimedTask, ConditionMatcher, FailOutcome,
     ResumeSignal, Signal, SignalOutcome, StreamFrames, SuspendOutcome, TimeoutBehavior,
@@ -93,9 +95,16 @@ pub enum SdkError {
         context: String,
     },
 
-    /// FlowFabric Lua script error.
-    #[error("script: {0}")]
-    Script(#[from] ff_script::error::ScriptError),
+    /// FlowFabric engine error — typed sum over Lua error codes + transport
+    /// faults. See [`EngineError`] for the variant-granularity contract.
+    /// Replaces the previous `Script(ScriptError)` carrier (#58.6).
+    ///
+    /// `Box`ed to keep `SdkError`'s stack footprint small: the richest
+    /// variant (`ConflictKind::DependencyAlreadyExists { existing:
+    /// EdgeSnapshot }`) is ~200 bytes. Boxing keeps `Result<T, SdkError>`
+    /// at the same width every other variant pays.
+    #[error("engine: {0}")]
+    Engine(Box<EngineError>),
 
     /// Configuration error.
     #[error("config: {0}")]
@@ -168,15 +177,31 @@ pub enum SdkError {
     },
 }
 
+/// Preserves the ergonomic `?`-propagation from FCALL sites that
+/// return `Result<_, ScriptError>`. Routes through `EngineError`'s
+/// typed classification so every call site gets the same
+/// variant-level detail without hand-written conversion.
+impl From<ff_script::error::ScriptError> for SdkError {
+    fn from(err: ff_script::error::ScriptError) -> Self {
+        Self::Engine(Box::new(EngineError::from(err)))
+    }
+}
+
+impl From<EngineError> for SdkError {
+    fn from(err: EngineError) -> Self {
+        Self::Engine(Box::new(err))
+    }
+}
+
 impl SdkError {
     /// Returns the underlying ferriskey `ErrorKind` if this error carries one.
     /// Covers transport variants (`Valkey`, `ValkeyContext`) directly and
-    /// `Script(ScriptError::Valkey(...))` via delegation.
+    /// `Engine(EngineError::Transport { .. })` via delegation.
     pub fn valkey_kind(&self) -> Option<ferriskey::ErrorKind> {
         match self {
             Self::Valkey(e) => Some(e.kind()),
             Self::ValkeyContext { source, .. } => Some(source.kind()),
-            Self::Script(e) => e.valkey_kind(),
+            Self::Engine(e) => e.valkey_kind(),
             // HTTP/admin-surface errors carry no ferriskey::ErrorKind;
             // the admin path never touches Valkey directly from the
             // SDK side. Use `AdminApi.kind` for the server-supplied
@@ -189,14 +214,14 @@ impl SdkError {
 
     /// Whether this error is safely retryable by a caller. For transport
     /// variants, delegates to [`ff_script::retry::is_retryable_kind`]. For
-    /// `Script` errors, returns `true` iff the Lua error's classification
-    /// is `ErrorClass::Retryable`. `Config` errors are never retryable.
+    /// `Engine` errors, returns `true` iff the typed classification is
+    /// `ErrorClass::Retryable`. `Config` errors are never retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::Valkey(e) | Self::ValkeyContext { source: e, .. } => {
                 ff_script::retry::is_retryable_kind(e.kind())
             }
-            Self::Script(e) => {
+            Self::Engine(e) => {
                 matches!(e.class(), ff_core::error::ErrorClass::Retryable)
             }
             // WorkerAtCapacity is retryable: the saturation is transient
@@ -249,15 +274,15 @@ mod tests {
     }
 
     #[test]
-    fn valkey_kind_delegates_through_script_transport() {
-        let err = SdkError::Script(ScriptError::Valkey(mk_fk_err(ErrorKind::ClusterDown)));
+    fn valkey_kind_delegates_through_engine_transport() {
+        let err = SdkError::from(ScriptError::Valkey(mk_fk_err(ErrorKind::ClusterDown)));
         assert_eq!(err.valkey_kind(), Some(ErrorKind::ClusterDown));
     }
 
     #[test]
     fn valkey_kind_none_for_lua_and_config() {
         assert_eq!(
-            SdkError::Script(ScriptError::LeaseExpired).valkey_kind(),
+            SdkError::from(ScriptError::LeaseExpired).valkey_kind(),
             None
         );
         assert_eq!(SdkError::Config("bad host".into()).valkey_kind(), None);
@@ -271,14 +296,14 @@ mod tests {
     }
 
     #[test]
-    fn is_retryable_script_delegates_to_class() {
-        // NoEligibleExecution is classified Retryable in ScriptError::class().
-        assert!(SdkError::Script(ScriptError::NoEligibleExecution).is_retryable());
+    fn is_retryable_engine_delegates_to_class() {
+        // NoEligibleExecution is classified Retryable via EngineError::class().
+        assert!(SdkError::from(ScriptError::NoEligibleExecution).is_retryable());
         // StaleLease is Terminal.
-        assert!(!SdkError::Script(ScriptError::StaleLease).is_retryable());
-        // Script::Valkey(IoError) is Retryable via class() delegation.
+        assert!(!SdkError::from(ScriptError::StaleLease).is_retryable());
+        // Transport(Valkey(IoError)) is Retryable via class() delegation.
         assert!(
-            SdkError::Script(ScriptError::Valkey(mk_fk_err(ErrorKind::IoError))).is_retryable()
+            SdkError::from(ScriptError::Valkey(mk_fk_err(ErrorKind::IoError))).is_retryable()
         );
     }
 

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -870,6 +870,17 @@ enum AdjacencySide {
     Incoming,
 }
 
+/// Crate-visible re-export of [`build_edge_snapshot`] for
+/// [`crate::engine_error::EngineError::enrich_dependency_conflict`].
+#[allow(dead_code)]
+pub(crate) fn build_edge_snapshot_public(
+    flow_id: &FlowId,
+    edge_id: &EdgeId,
+    raw: &HashMap<String, String>,
+) -> Result<EdgeSnapshot, SdkError> {
+    build_edge_snapshot(flow_id, edge_id, raw)
+}
+
 /// Assemble an [`EdgeSnapshot`] from the raw HGETALL field map. Kept
 /// as a free function so unit tests can feed synthetic maps.
 ///

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -562,28 +562,33 @@ impl ClaimedTask {
             .map_err(SdkError::Valkey)?;
 
         self.stop_renewal();
-        match parse_success_result(&raw, "ff_complete_execution") {
-            Ok(()) => Ok(()),
-            // Terminal-op replay reconciliation: if this caller's own
-            // prior complete() already committed (same epoch + attempt_id)
-            // and the stored terminal_outcome is "success", return Ok —
-            // the network drop happened AFTER the server committed. Any
-            // other ExecutionNotActive combination (different epoch,
-            // different attempt, terminal_outcome!=success) is a real
-            // error the caller must see.
-            Err(SdkError::Script(ScriptError::ExecutionNotActive {
-                ref terminal_outcome,
-                ref lease_epoch,
-                ref attempt_id,
-                ..
-            })) if terminal_outcome == "success"
-                && lease_epoch == &self.lease_epoch.to_string()
-                && attempt_id == &self.attempt_id.to_string() =>
-            {
-                Ok(())
-            }
-            Err(e) => Err(e),
+        // Terminal-op replay reconciliation: if this caller's own
+        // prior complete() already committed (same epoch + attempt_id)
+        // and the stored terminal_outcome is "success", return Ok —
+        // the network drop happened AFTER the server committed. Any
+        // other ExecutionNotActive combination (different epoch,
+        // different attempt, terminal_outcome!=success) is a real
+        // error the caller must see.
+        let err = match parse_success_result(&raw, "ff_complete_execution") {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        if let SdkError::Engine(ref boxed) = err
+            && let crate::EngineError::Contention(
+                crate::ContentionKind::ExecutionNotActive {
+                    ref terminal_outcome,
+                    ref lease_epoch,
+                    ref attempt_id,
+                    ..
+                },
+            ) = **boxed
+            && terminal_outcome == "success"
+            && lease_epoch == &self.lease_epoch.to_string()
+            && attempt_id == &self.attempt_id.to_string()
+        {
+            return Ok(());
         }
+        Err(err)
     }
 
     /// Fail the execution with a reason and error category.
@@ -651,49 +656,50 @@ impl ClaimedTask {
             .map_err(SdkError::Valkey)?;
 
         self.stop_renewal();
-        match parse_fail_result(&raw) {
-            Ok(outcome) => Ok(outcome),
-            // Terminal-op replay reconciliation. Two valid replay shapes:
-            //   - lifecycle=terminal, outcome=failed    -> TerminalFailed
-            //   - lifecycle=runnable                    -> RetryScheduled
-            //
-            // Guard strength differs by branch because the Lua paths clear
-            // different fields:
-            //   - Terminal fail preserves both current_lease_epoch AND
-            //     current_attempt_id; we match on both (strongest guard).
-            //   - Retry-scheduled preserves current_lease_epoch but CLEARS
-            //     current_attempt_id to "" (execution.lua retry HSET). A
-            //     later re-claim bumps epoch to next_epoch, so epoch alone
-            //     is still a sufficient fence — if another worker has
-            //     claimed+processed since our fail, they'd have a different
-            //     epoch. RetryScheduled loses delay_until_ms (not persisted
-            //     on the replay error path); return 0 so callers see
-            //     "scheduled, exact delay unknown".
-            Err(SdkError::Script(ScriptError::ExecutionNotActive {
-                ref terminal_outcome,
-                ref lease_epoch,
-                ref lifecycle_phase,
-                ref attempt_id,
-            })) if lease_epoch == &self.lease_epoch.to_string() => {
-                match (lifecycle_phase.as_str(), terminal_outcome.as_str()) {
-                    ("terminal", "failed")
-                        if attempt_id == &self.attempt_id.to_string() =>
-                    {
-                        Ok(FailOutcome::TerminalFailed)
-                    }
-                    ("runnable", _) => Ok(FailOutcome::RetryScheduled {
-                        delay_until: TimestampMs::from_millis(0),
-                    }),
-                    _ => Err(SdkError::Script(ScriptError::ExecutionNotActive {
-                        terminal_outcome: terminal_outcome.clone(),
-                        lease_epoch: lease_epoch.clone(),
-                        lifecycle_phase: lifecycle_phase.clone(),
-                        attempt_id: attempt_id.clone(),
-                    })),
+        // Terminal-op replay reconciliation. Two valid replay shapes:
+        //   - lifecycle=terminal, outcome=failed    -> TerminalFailed
+        //   - lifecycle=runnable                    -> RetryScheduled
+        //
+        // Guard strength differs by branch because the Lua paths clear
+        // different fields:
+        //   - Terminal fail preserves both current_lease_epoch AND
+        //     current_attempt_id; we match on both (strongest guard).
+        //   - Retry-scheduled preserves current_lease_epoch but CLEARS
+        //     current_attempt_id to "" (execution.lua retry HSET). A
+        //     later re-claim bumps epoch to next_epoch, so epoch alone
+        //     is still a sufficient fence — if another worker has
+        //     claimed+processed since our fail, they'd have a different
+        //     epoch. RetryScheduled loses delay_until_ms (not persisted
+        //     on the replay error path); return 0 so callers see
+        //     "scheduled, exact delay unknown".
+        let err = match parse_fail_result(&raw) {
+            Ok(outcome) => return Ok(outcome),
+            Err(e) => e,
+        };
+        if let SdkError::Engine(ref boxed) = err
+            && let crate::EngineError::Contention(
+                crate::ContentionKind::ExecutionNotActive {
+                    ref terminal_outcome,
+                    ref lease_epoch,
+                    ref lifecycle_phase,
+                    ref attempt_id,
+                },
+            ) = **boxed
+            && lease_epoch == &self.lease_epoch.to_string()
+        {
+            match (lifecycle_phase.as_str(), terminal_outcome.as_str()) {
+                ("terminal", "failed") if attempt_id == &self.attempt_id.to_string() => {
+                    return Ok(FailOutcome::TerminalFailed);
                 }
+                ("runnable", _) => {
+                    return Ok(FailOutcome::RetryScheduled {
+                        delay_until: TimestampMs::from_millis(0),
+                    });
+                }
+                _ => {}
             }
-            Err(e) => Err(e),
         }
+        Err(err)
     }
 
     /// Cancel the execution.
@@ -788,27 +794,32 @@ impl ClaimedTask {
             .map_err(SdkError::Valkey)?;
 
         self.stop_renewal();
-        match parse_success_result(&raw, "ff_cancel_execution") {
-            Ok(()) => Ok(()),
-            // Terminal-op replay reconciliation for cancel: if this caller's
-            // own prior cancel() already committed (same epoch + attempt_id)
-            // and stored terminal_outcome is "cancelled", return Ok. A
-            // replay that finds outcome=success or outcome=failed means a
-            // different terminal op won the race — surface the error so
-            // the caller knows their cancel intent was NOT honored.
-            Err(SdkError::Script(ScriptError::ExecutionNotActive {
-                ref terminal_outcome,
-                ref lease_epoch,
-                ref attempt_id,
-                ..
-            })) if terminal_outcome == "cancelled"
-                && lease_epoch == &self.lease_epoch.to_string()
-                && attempt_id == &self.attempt_id.to_string() =>
-            {
-                Ok(())
-            }
-            Err(e) => Err(e),
+        // Terminal-op replay reconciliation for cancel: if this caller's
+        // own prior cancel() already committed (same epoch + attempt_id)
+        // and stored terminal_outcome is "cancelled", return Ok. A
+        // replay that finds outcome=success or outcome=failed means a
+        // different terminal op won the race — surface the error so
+        // the caller knows their cancel intent was NOT honored.
+        let err = match parse_success_result(&raw, "ff_cancel_execution") {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        if let SdkError::Engine(ref boxed) = err
+            && let crate::EngineError::Contention(
+                crate::ContentionKind::ExecutionNotActive {
+                    ref terminal_outcome,
+                    ref lease_epoch,
+                    ref attempt_id,
+                    ..
+                },
+            ) = **boxed
+            && terminal_outcome == "cancelled"
+            && lease_epoch == &self.lease_epoch.to_string()
+            && attempt_id == &self.attempt_id.to_string()
+        {
+            return Ok(());
         }
+        Err(err)
     }
 
     // ── Non-terminal operations ──
@@ -1492,7 +1503,7 @@ fn spawn_renewal_task(
                                 "lease renewed"
                             );
                         }
-                        Err(SdkError::Script(ref e)) if is_terminal_renewal_error(e) => {
+                        Err(SdkError::Engine(ref e)) if is_terminal_renewal_error(e) => {
                             failure_counter.fetch_add(1, Ordering::Relaxed);
                             tracing::warn!(
                                 execution_id = %execution_id,
@@ -1517,16 +1528,16 @@ fn spawn_renewal_task(
     })
 }
 
-/// Check if a script error means renewal should stop permanently.
+/// Check if an engine error means renewal should stop permanently.
 #[allow(dead_code)]
-fn is_terminal_renewal_error(err: &ScriptError) -> bool {
+fn is_terminal_renewal_error(err: &crate::EngineError) -> bool {
+    use crate::{ContentionKind, EngineError, StateKind};
     matches!(
         err,
-        ScriptError::StaleLease
-            | ScriptError::LeaseExpired
-            | ScriptError::LeaseRevoked
-            | ScriptError::ExecutionNotActive { .. }
-            | ScriptError::ExecutionNotFound
+        EngineError::State(
+            StateKind::StaleLease | StateKind::LeaseExpired | StateKind::LeaseRevoked
+        ) | EngineError::Contention(ContentionKind::ExecutionNotActive { .. })
+            | EngineError::NotFound { entity: "execution" }
     )
 }
 
@@ -1550,7 +1561,7 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_report_usage_and_check: expected Array".into(),
             )));
         }
@@ -1558,7 +1569,7 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_report_usage_and_check: expected Int status code".into(),
             )));
         }
@@ -1566,7 +1577,7 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
     if status_code != 1 {
         let error_code = usage_field_str(arr, 1);
         let detail = usage_field_str(arr, 2);
-        return Err(SdkError::Script(
+        return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_report_usage_and_check: {error_code}"))
             }),
@@ -1592,7 +1603,7 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
                 hard_limit: limit,
             })
         }
-        _ => Err(SdkError::Script(ScriptError::Parse(format!(
+        _ => Err(SdkError::from(ScriptError::Parse(format!(
             "ff_report_usage_and_check: unknown sub-status: {sub_status}"
         )))),
     }
@@ -1629,7 +1640,7 @@ fn parse_usage_u64(
     match arr.get(index) {
         Some(Ok(Value::Int(n))) => {
             u64::try_from(*n).map_err(|_| {
-                SdkError::Script(ScriptError::Parse(format!(
+                SdkError::from(ScriptError::Parse(format!(
                     "ff_report_usage_and_check {sub_status}: {field_name} \
                      (index {index}) negative int {n} cannot be u64"
                 )))
@@ -1638,23 +1649,23 @@ fn parse_usage_u64(
         Some(Ok(Value::BulkString(b))) => {
             let s = String::from_utf8_lossy(b);
             s.parse::<u64>().map_err(|_| {
-                SdkError::Script(ScriptError::Parse(format!(
+                SdkError::from(ScriptError::Parse(format!(
                     "ff_report_usage_and_check {sub_status}: {field_name} \
                      (index {index}) not a u64 string: {s:?}"
                 )))
             })
         }
         Some(Ok(Value::SimpleString(s))) => s.parse::<u64>().map_err(|_| {
-            SdkError::Script(ScriptError::Parse(format!(
+            SdkError::from(ScriptError::Parse(format!(
                 "ff_report_usage_and_check {sub_status}: {field_name} \
                  (index {index}) not a u64 string: {s:?}"
             )))
         }),
-        Some(_) => Err(SdkError::Script(ScriptError::Parse(format!(
+        Some(_) => Err(SdkError::from(ScriptError::Parse(format!(
             "ff_report_usage_and_check {sub_status}: {field_name} \
              (index {index}) wrong wire type (expected Int or String)"
         )))),
-        None => Err(SdkError::Script(ScriptError::Parse(format!(
+        None => Err(SdkError::from(ScriptError::Parse(format!(
             "ff_report_usage_and_check {sub_status}: {field_name} \
              (index {index}) missing from response"
         )))),
@@ -1680,7 +1691,7 @@ fn extract_pending_waitpoint_token(raw: &Value) -> Result<WaitpointToken, SdkErr
             _ => None,
         })
         .ok_or_else(|| {
-            SdkError::Script(ScriptError::Parse(
+            SdkError::from(ScriptError::Parse(
                 "ff_create_pending_waitpoint: missing waitpoint_token in response".into(),
             ))
         })?;
@@ -1719,7 +1730,7 @@ fn resume_waitpoint_id_from_suspension(
         return Ok(None);
     }
     let waitpoint_id = WaitpointId::parse(wp_id_str).map_err(|e| {
-        SdkError::Script(ScriptError::Parse(format!(
+        SdkError::from(ScriptError::Parse(format!(
             "resume_signals: suspension_current.waitpoint_id is not a valid UUID: {e}"
         )))
     })?;
@@ -1730,14 +1741,14 @@ pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(format!(
+            return Err(SdkError::from(ScriptError::Parse(format!(
                 "{function_name}: expected Array, got non-array"
             ))));
         }
     };
 
     if arr.is_empty() {
-        return Err(SdkError::Script(ScriptError::Parse(format!(
+        return Err(SdkError::from(ScriptError::Parse(format!(
             "{function_name}: empty result array"
         ))));
     }
@@ -1745,7 +1756,7 @@ pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(format!(
+            return Err(SdkError::from(ScriptError::Parse(format!(
                 "{function_name}: expected Int at index 0"
             ))));
         }
@@ -1783,7 +1794,7 @@ pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(
                 ScriptError::Parse(format!("{function_name}: unknown error: {error_code}"))
             });
 
-        Err(SdkError::Script(script_err))
+        Err(SdkError::from(script_err))
     }
 }
 
@@ -1799,7 +1810,7 @@ fn parse_suspend_result(
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_suspend_execution: expected Array".into(),
             )));
         }
@@ -1808,7 +1819,7 @@ fn parse_suspend_result(
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_suspend_execution: bad status code".into(),
             )));
         }
@@ -1829,7 +1840,7 @@ fn parse_suspend_result(
             if s.is_empty() { "unknown".to_owned() } else { s }
         };
         let detail = err_field_str(2);
-        return Err(SdkError::Script(
+        return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_suspend_execution: {error_code}"))
             }),
@@ -1859,7 +1870,7 @@ fn parse_suspend_result(
         })
         .map(WaitpointToken::new)
         .ok_or_else(|| {
-            SdkError::Script(ScriptError::Parse(
+            SdkError::from(ScriptError::Parse(
                 "ff_suspend_execution: missing waitpoint_token in response".into(),
             ))
         })?;
@@ -1888,7 +1899,7 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_deliver_signal: expected Array".into(),
             )));
         }
@@ -1897,7 +1908,7 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_deliver_signal: bad status code".into(),
             )));
         }
@@ -1918,7 +1929,7 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
             if s.is_empty() { "unknown".to_owned() } else { s }
         };
         let detail = err_field_str(2);
-        return Err(SdkError::Script(
+        return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_deliver_signal: {error_code}"))
             }),
@@ -1968,7 +1979,7 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
         .unwrap_or_default();
 
     let signal_id = SignalId::parse(&signal_id_str).map_err(|e| {
-        SdkError::Script(ScriptError::Parse(format!(
+        SdkError::from(ScriptError::Parse(format!(
             "ff_deliver_signal: invalid signal_id from Lua: {e}"
         )))
     })?;
@@ -1985,7 +1996,7 @@ fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_append_frame: expected Array".into(),
             )));
         }
@@ -1994,7 +2005,7 @@ fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_append_frame: bad status code".into(),
             )));
         }
@@ -2015,7 +2026,7 @@ fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError
             if s.is_empty() { "unknown".to_owned() } else { s }
         };
         let detail = err_field_str(2);
-        return Err(SdkError::Script(
+        return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_append_frame: {error_code}"))
             }),
@@ -2055,7 +2066,7 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_fail_execution: expected Array".into(),
             )));
         }
@@ -2064,7 +2075,7 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::Script(ScriptError::Parse(
+            return Err(SdkError::from(ScriptError::Parse(
                 "ff_fail_execution: bad status code".into(),
             )));
         }
@@ -2086,7 +2097,7 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
         };
         let details: Vec<String> = (2..arr.len()).map(err_field_str).collect();
         let detail_refs: Vec<&str> = details.iter().map(|s| s.as_str()).collect();
-        return Err(SdkError::Script(
+        return Err(SdkError::from(
             ScriptError::from_code_with_details(&error_code, &detail_refs).unwrap_or_else(|| {
                 ScriptError::Parse(format!("ff_fail_execution: {error_code}"))
             }),
@@ -2122,7 +2133,7 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
             })
         }
         "terminal_failed" => Ok(FailOutcome::TerminalFailed),
-        _ => Err(SdkError::Script(ScriptError::Parse(format!(
+        _ => Err(SdkError::from(ScriptError::Parse(format!(
             "ff_fail_execution: unexpected sub-status: {sub_status}"
         )))),
     }
@@ -2208,7 +2219,7 @@ pub async fn read_stream(
     let ReadFramesResult::Frames(f) =
         ff_script::functions::stream::ff_read_attempt_stream(client, &keys, &args)
             .await
-            .map_err(SdkError::Script)?;
+            .map_err(SdkError::from)?;
     Ok(f)
 }
 
@@ -2307,7 +2318,7 @@ pub async fn tail_stream(
         count_limit,
     )
     .await
-    .map_err(SdkError::Script)
+    .map_err(SdkError::from)
 }
 
 #[cfg(test)]
@@ -2574,13 +2585,19 @@ mod terminal_replay_parsing_tests {
             Ok(bulk("11111111-1111-1111-1111-111111111111")),
         ]);
         let err = parse_success_result(&raw, "test").unwrap_err();
-        match err {
-            SdkError::Script(ScriptError::ExecutionNotActive {
-                terminal_outcome,
-                lease_epoch,
-                lifecycle_phase,
-                attempt_id,
-            }) => {
+        let unboxed = match err {
+            SdkError::Engine(b) => *b,
+            other => panic!("expected ExecutionNotActive struct variant, got {other:?}"),
+        };
+        match unboxed {
+            crate::EngineError::Contention(
+                crate::ContentionKind::ExecutionNotActive {
+                    terminal_outcome,
+                    lease_epoch,
+                    lifecycle_phase,
+                    attempt_id,
+                },
+            ) => {
                 assert_eq!(terminal_outcome, "success");
                 assert_eq!(lease_epoch, "42");
                 assert_eq!(lifecycle_phase, "terminal");
@@ -2604,13 +2621,19 @@ mod terminal_replay_parsing_tests {
             Ok(bulk("22222222-2222-2222-2222-222222222222")),
         ]);
         let err = parse_fail_result(&raw).unwrap_err();
-        match err {
-            SdkError::Script(ScriptError::ExecutionNotActive {
-                terminal_outcome,
-                lease_epoch,
-                lifecycle_phase,
-                attempt_id,
-            }) => {
+        let unboxed = match err {
+            SdkError::Engine(b) => *b,
+            other => panic!("expected ExecutionNotActive struct variant, got {other:?}"),
+        };
+        match unboxed {
+            crate::EngineError::Contention(
+                crate::ContentionKind::ExecutionNotActive {
+                    terminal_outcome,
+                    lease_epoch,
+                    lifecycle_phase,
+                    attempt_id,
+                },
+            ) => {
                 assert_eq!(terminal_outcome, "none");
                 assert_eq!(lease_epoch, "7");
                 assert_eq!(lifecycle_phase, "runnable");
@@ -2630,13 +2653,19 @@ mod terminal_replay_parsing_tests {
             Ok(bulk("execution_not_active")),
         ]);
         let err = parse_success_result(&raw, "test").unwrap_err();
-        match err {
-            SdkError::Script(ScriptError::ExecutionNotActive {
-                terminal_outcome,
-                lease_epoch,
-                lifecycle_phase,
-                attempt_id,
-            }) => {
+        let unboxed = match err {
+            SdkError::Engine(b) => *b,
+            other => panic!("expected ExecutionNotActive struct variant, got {other:?}"),
+        };
+        match unboxed {
+            crate::EngineError::Contention(
+                crate::ContentionKind::ExecutionNotActive {
+                    terminal_outcome,
+                    lease_epoch,
+                    lifecycle_phase,
+                    attempt_id,
+                },
+            ) => {
                 assert_eq!(terminal_outcome, "");
                 assert_eq!(lease_epoch, "");
                 assert_eq!(lifecycle_phase, "");

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -526,7 +526,7 @@ impl FlowFabricWorker {
             };
 
             let execution_id = ExecutionId::parse(&execution_id_str).map_err(|e| {
-                SdkError::Script(ff_script::error::ScriptError::Parse(format!(
+                SdkError::from(ff_script::error::ScriptError::Parse(format!(
                     "bad execution_id in eligible set: {e}"
                 )))
             })?;
@@ -538,9 +538,19 @@ impl FlowFabricWorker {
 
             match grant_result {
                 Ok(()) => {}
-                Err(SdkError::Script(ff_script::error::ScriptError::CapabilityMismatch(
-                    ref missing,
-                ))) => {
+                Err(SdkError::Engine(ref boxed))
+                    if matches!(
+                        **boxed,
+                        crate::EngineError::Validation {
+                            kind: crate::ValidationKind::CapabilityMismatch,
+                            ..
+                        }
+                    ) =>
+                {
+                    let missing = match &**boxed {
+                        crate::EngineError::Validation { detail, .. } => detail.clone(),
+                        _ => unreachable!(),
+                    };
                     // Block-on-mismatch (RFC-009 §7.5) — parity with
                     // ff-scheduler's Scheduler::claim_for_worker. Without
                     // this, the inline-direct-claim path would hot-loop
@@ -559,7 +569,7 @@ impl FlowFabricWorker {
                     self.block_route(&execution_id, &lane_id, &partition, &idx).await;
                     continue;
                 }
-                Err(SdkError::Script(ref e)) if is_retryable_claim_error(e) => {
+                Err(SdkError::Engine(ref e)) if is_retryable_claim_error(e) => {
                     tracing::debug!(
                         execution_id = %execution_id,
                         error = %e,
@@ -582,7 +592,14 @@ impl FlowFabricWorker {
                     task.set_concurrency_permit(permit);
                     return Ok(Some(task));
                 }
-                Err(SdkError::Script(ff_script::error::ScriptError::UseClaimResumedExecution)) => {
+                Err(SdkError::Engine(ref boxed))
+                    if matches!(
+                        **boxed,
+                        crate::EngineError::Contention(
+                            crate::ContentionKind::UseClaimResumedExecution
+                        )
+                    ) =>
+                {
                     // Execution was resumed from suspension — attempt_interrupted.
                     // ff_claim_execution rejects this; use ff_claim_resumed_execution
                     // which reuses the existing attempt instead of creating a new one.
@@ -598,7 +615,7 @@ impl FlowFabricWorker {
                             task.set_concurrency_permit(permit);
                             return Ok(Some(task));
                         }
-                        Err(SdkError::Script(ref e2)) if is_retryable_claim_error(e2) => {
+                        Err(SdkError::Engine(ref e2)) if is_retryable_claim_error(e2) => {
                             tracing::debug!(
                                 execution_id = %execution_id,
                                 error = %e2,
@@ -609,7 +626,7 @@ impl FlowFabricWorker {
                         Err(e2) => return Err(e2),
                     }
                 }
-                Err(SdkError::Script(ref e)) if is_retryable_claim_error(e) => {
+                Err(SdkError::Engine(ref e)) if is_retryable_claim_error(e) => {
                     tracing::debug!(
                         execution_id = %execution_id,
                         error = %e,
@@ -821,7 +838,7 @@ impl FlowFabricWorker {
         let arr = match &raw {
             Value::Array(arr) => arr,
             _ => {
-                return Err(SdkError::Script(ff_script::error::ScriptError::Parse(
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
                     "ff_claim_execution: expected Array".into(),
                 )));
             }
@@ -830,7 +847,7 @@ impl FlowFabricWorker {
         let status_code = match arr.first() {
             Some(Ok(Value::Int(n))) => *n,
             _ => {
-                return Err(SdkError::Script(ff_script::error::ScriptError::Parse(
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
                     "ff_claim_execution: bad status code".into(),
                 )));
             }
@@ -852,7 +869,7 @@ impl FlowFabricWorker {
             };
             let detail = err_field_str(2);
 
-            return Err(SdkError::Script(
+            return Err(SdkError::from(
                 ff_script::error::ScriptError::from_code_with_detail(&error_code, &detail)
                     .unwrap_or_else(|| {
                         ff_script::error::ScriptError::Parse(format!(
@@ -937,15 +954,15 @@ impl FlowFabricWorker {
     /// * [`SdkError::WorkerAtCapacity`] — `max_concurrent_tasks`
     ///   permits all held. Retryable; the grant is untouched.
     /// * `ScriptError::InvalidClaimGrant` — grant missing, consumed,
-    ///   or `worker_id` mismatch (wrapped in [`SdkError::Script`]).
+    ///   or `worker_id` mismatch (wrapped in [`SdkError::Engine`]).
     /// * `ScriptError::ClaimGrantExpired` — grant TTL elapsed
-    ///   (wrapped in [`SdkError::Script`]).
+    ///   (wrapped in [`SdkError::Engine`]).
     /// * `ScriptError::CapabilityMismatch` — execution's required
     ///   capabilities not a subset of this worker's caps (wrapped in
-    ///   [`SdkError::Script`]). Surfaced post-grant if a race
+    ///   [`SdkError::Engine`]). Surfaced post-grant if a race
     ///   between grant issuance and caps change allows it.
     /// * `ScriptError::Parse` — `ff_claim_execution` returned an
-    ///   unexpected shape (wrapped in [`SdkError::Script`]).
+    ///   unexpected shape (wrapped in [`SdkError::Engine`]).
     /// * [`SdkError::Valkey`] / [`SdkError::ValkeyContext`] —
     ///   transport error during the FCALL or the
     ///   `read_execution_context` follow-up.
@@ -1161,7 +1178,7 @@ impl FlowFabricWorker {
         let arr = match &raw {
             Value::Array(arr) => arr,
             _ => {
-                return Err(SdkError::Script(ff_script::error::ScriptError::Parse(
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
                     "ff_claim_resumed_execution: expected Array".into(),
                 )));
             }
@@ -1170,7 +1187,7 @@ impl FlowFabricWorker {
         let status_code = match arr.first() {
             Some(Ok(Value::Int(n))) => *n,
             _ => {
-                return Err(SdkError::Script(ff_script::error::ScriptError::Parse(
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
                     "ff_claim_resumed_execution: bad status code".into(),
                 )));
             }
@@ -1192,7 +1209,7 @@ impl FlowFabricWorker {
             };
             let detail = err_field_str(2);
 
-            return Err(SdkError::Script(
+            return Err(SdkError::from(
                 ff_script::error::ScriptError::from_code_with_detail(&error_code, &detail)
                     .unwrap_or_else(|| {
                         ff_script::error::ScriptError::Parse(format!(
@@ -1389,7 +1406,7 @@ impl FlowFabricWorker {
 }
 
 #[cfg(feature = "direct-valkey-claim")]
-fn is_retryable_claim_error(err: &ff_script::error::ScriptError) -> bool {
+fn is_retryable_claim_error(err: &crate::EngineError) -> bool {
     use ff_core::error::ErrorClass;
     matches!(
         err.class(),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -8960,8 +8960,12 @@ async fn test_claim_from_reclaim_grant_expired() {
         //     already evicted the key before the FCALL reaches
         //     HGETALL (#grant_raw == 0).
         // Both signal the same root cause — the grant's TTL elapsed.
-        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::ClaimGrantExpired)) => {}
-        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::InvalidClaimGrant)) => {}
+        Err(ff_sdk::SdkError::Engine(ref _b))
+            if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::ClaimGrantExpired)) =>
+        {}
+        Err(ff_sdk::SdkError::Engine(ref _b))
+            if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::InvalidClaimGrant)) =>
+        {}
         Err(other) => panic!("expected ClaimGrantExpired or InvalidClaimGrant, got {other:?}"),
         Ok(_) => panic!("expired grant should not succeed"),
     }
@@ -8985,7 +8989,9 @@ async fn test_claim_from_reclaim_grant_wrong_worker() {
     // Build a FlowFabricWorker with a DIFFERENT worker_id.
     let worker = build_reclaim_test_worker("worker-b", "worker-b-inst").await;
     match worker.claim_from_reclaim_grant(grant).await {
-        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::InvalidClaimGrant)) => {}
+        Err(ff_sdk::SdkError::Engine(ref _b))
+            if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::InvalidClaimGrant)) =>
+        {}
         Err(other) => panic!("expected InvalidClaimGrant, got {other:?}"),
         Ok(_) => panic!("worker-id mismatch should not succeed"),
     }
@@ -9027,8 +9033,12 @@ async fn test_claim_from_reclaim_grant_not_resumed() {
 
     let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
     match worker.claim_from_reclaim_grant(grant).await {
-        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::NotAResumedExecution)) => {}
-        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::ExecutionNotLeaseable)) => {
+        Err(ff_sdk::SdkError::Engine(ref _b))
+            if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::NotAResumedExecution)) =>
+        {}
+        Err(ff_sdk::SdkError::Engine(ref _b))
+            if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::ExecutionNotLeaseable)) =>
+        {
             // Acceptable alternate: some Lua orderings check
             // lifecycle_phase (runnable) before attempt_state. Either
             // error signals the same root cause — this is a non-
@@ -9071,8 +9081,12 @@ async fn test_claim_from_reclaim_grant_double_consume() {
     // differently we'd also see `InvalidClaimGrant` — accept either
     // as proof the second consume was rejected.
     match worker.claim_from_reclaim_grant(grant).await {
-        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::ExecutionNotLeaseable)) => {}
-        Err(ff_sdk::SdkError::Script(ff_script::error::ScriptError::InvalidClaimGrant)) => {}
+        Err(ff_sdk::SdkError::Engine(ref _b))
+            if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::ExecutionNotLeaseable)) =>
+        {}
+        Err(ff_sdk::SdkError::Engine(ref _b))
+            if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::InvalidClaimGrant)) =>
+        {}
         Err(other) => panic!("expected ExecutionNotLeaseable or InvalidClaimGrant on second consume, got {other:?}"),
         Ok(_) => panic!("second consume should not succeed"),
     }

--- a/docs/rfc011-migration-for-consumers.md
+++ b/docs/rfc011-migration-for-consumers.md
@@ -206,7 +206,12 @@ match worker.claim_from_grant(lane.clone(), grant).await {
     Err(SdkError::WorkerAtCapacity) => {
         // Retryable; retry after a task completes.
     }
-    Err(SdkError::Script(ScriptError::ClaimGrantExpired)) => {
+    Err(SdkError::Engine(ref boxed))
+        if matches!(
+            **boxed,
+            EngineError::Contention(ContentionKind::ClaimGrantExpired),
+        ) =>
+    {
         // Grant TTL elapsed — request a new grant.
     }
     Err(e) => return Err(e.into()),


### PR DESCRIPTION
## Summary

Introduce `EngineError` — a typed sum over every `ScriptError` code — and replace `SdkError::Script(ScriptError)` with `SdkError::Engine(Box<EngineError>)`. This retires the FCALL error-envelope string matching in consumers (cairn-fabric's `check_fcall_success`, `fcall_error_code`, `is_claim_contention`) in favor of variant-level pattern matching.

Implements issue #58.6 (typed engine error surface) per the 58.6 plan + Q&A approval:
- **Q1** (DependencyAlreadyExists payload): follow-up `describe_edge` read via `EngineError::enrich_dependency_conflict`; fall back to `Transport` on follow-up failure (strict-parse, never a half-populated Conflict).
- **Q2** (SdkError variant shape): clean break — `Script(ScriptError)` → `Engine(Box<EngineError>)`. Pre-stable break, owner-approved.
- **Q3** (Transport inner type): `Box<ScriptError>` preserves `ferriskey::ErrorKind` and `Parse` detail without a circular dependency.
- **Q4** (variant granularity): 1:1 mapping preserved. `UseClaimResumedExecution` etc. stay as explicit Contention variants because cairn matches on them as routing hints.

## Public-surface changes

All sub-kinds are `#[non_exhaustive]` so future FF codes land without a major:

- `NotFound { entity: &'static str }`
- `Validation { kind: ValidationKind, detail: String }` (InvalidInput, CapabilityMismatch, InvalidTagKey, InvalidPolicyJson, …)
- `Contention(ContentionKind)` — retryable: LeaseConflict, ClaimGrantExpired, UseClaimResumedExecution, ExecutionNotActive { detail }, NoEligibleExecution, StaleGraphRevision, …
- `Conflict(ConflictKind)` — terminal: `DependencyAlreadyExists { existing: EdgeSnapshot }`, CycleDetected, SelfReferencingEdge, ExecutionAlreadyInFlow, WaitpointAlreadyExists, RotationConflict(kid), …
- `State(StateKind)` — legal-but-surprising: StaleLease, LeaseExpired, DuplicateSignal, BudgetExceeded/BudgetSoftExceeded, WaitpointClosed, …
- `Bug(BugKind)` — invariant violations (currently `AttemptNotInCreatedState`).
- `Transport { source: Box<ScriptError> }` — Valkey/Parse faults, preserves `ferriskey::ErrorKind`.

`SdkError::Engine` is boxed to keep `Result<T, SdkError>` at a sane stack width: `ConflictKind::DependencyAlreadyExists { existing: EdgeSnapshot }` is ~200 bytes and clippy's `result_large_err` would otherwise fail CI.

## cargo-semver-checks (expected failures, 2)

Ran `cargo semver-checks -p ff-sdk --only-explicit-features`:

| Lint | Variant | Reason |
|---|---|---|
| `enum_variant_missing` | `SdkError::Script` removed | Replaced by `SdkError::Engine(Box<EngineError>)` |
| `enum_variant_added` | `SdkError::Engine` added | Same replacement, other direction |

Owner green-lit pre-stable break per Postgres-port thesis; admin-merge per project policy.

## Test plan

- [x] `cargo check --workspace --all-targets --all-features` — green (ferriskey test_client pre-existing drift excluded).
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings` — green.
- [x] `cargo test -p ff-sdk --lib --all-features` — 79/79 pass including 12 new `engine_error` unit tests covering NotFound/Validation/Contention/Conflict/State/Bug buckets, DependencyAlreadyExists→Transport fallthrough, ExecutionNotActive detail preservation, class() classification, and Valkey-kind delegation.
- [x] Workspace lib tests — all green.
- [x] Integration tests compile (run under `[e2e]` on CI).
- [x] Examples (`media-pipeline`, `coding-agent`) compile.
- [x] Migration doc `docs/rfc011-migration-for-consumers.md` updated to new match shape.

## Rebase awareness

- Worker B (#58.5 ARGV cleanup impl): their branch adds `FenceRequired` + `PartialFenceTriple` to `ff-script::ScriptError`. This PR's `From<ScriptError>` match already has a `_` fallback (ScriptError is `#[non_exhaustive]`), so the new variants will route to `EngineError::Transport { source }` without a compilation break; refining to explicit Contention arms can happen as a follow-up mapping tweak after their merge.
- Worker C (PR-C3 #68 deadline fix): different line range in `ff-script/functions/execution.rs`, merge-friendly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public error surface changes from `SdkError::Script` to `SdkError::Engine(Box<EngineError>)`, which is a breaking API change for downstream callers matching on SDK errors. Some error paths now do extra Valkey reads for enrichment (`DependencyAlreadyExists`), so correctness depends on the new mapping and follow-up logic.
> 
> **Overview**
> Introduces a new public `EngineError` type (with `ValidationKind`/`ContentionKind`/`ConflictKind`/`StateKind`/`BugKind`) and a `From<ScriptError>` mapping, then **replaces** `SdkError::Script(ScriptError)` with `SdkError::Engine(Box<EngineError>)` across the SDK.
> 
> Updates retry/diagnostic helpers (`SdkError::is_retryable`, `SdkError::valkey_kind`) and refactors worker/task logic and parsers to match on typed variants (notably `ExecutionNotActive` replay reconciliation and lease-renewal terminal checks). Adds an enrichment helper `EngineError::enrich_dependency_conflict` (with a crate-visible `snapshot::build_edge_snapshot_public`) to attach an `EdgeSnapshot` to `dependency_already_exists`, and updates e2e tests + migration docs to the new error shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91712bb4f6707abf74573faca617d2889c468d23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->