### PR TITLE
feat(ff-readiness-tests): e2e harness scaffold + lifecycle + cancel_flow_partial (PR-D1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff-readiness-tests"
+version = "0.3.0"
+dependencies = [
+ "axum",
+ "ferriskey",
+ "ff-core",
+ "ff-engine",
+ "ff-scheduler",
+ "ff-script",
+ "ff-sdk",
+ "ff-server",
+ "ff-test",
+ "hex",
+ "hmac",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha2",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "ff-scheduler"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,21 +862,14 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-engine",
- "ff-scheduler",
- "ff-script",
  "ff-sdk",
  "ff-server",
  "ff-test",
- "hex",
- "hmac",
  "reqwest",
- "serde",
  "serde_json",
  "serial_test",
- "sha2",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/ff-sdk",
     "crates/ff-test",
     "crates/ff-server",
+    "crates/ff-readiness-tests",
 ]
 
 [workspace.package]

--- a/crates/ff-readiness-tests/Cargo.toml
+++ b/crates/ff-readiness-tests/Cargo.toml
@@ -34,5 +34,9 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "
 serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-serial_test = "3"
 axum = { workspace = true }
+
+[dev-dependencies]
+# `serial_test` is only used by `tests/*.rs` (readiness integration
+# tests) — keep it off the library dependency surface per reviewer.
+serial_test = "3"

--- a/crates/ff-readiness-tests/Cargo.toml
+++ b/crates/ff-readiness-tests/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "ff-readiness-tests"
+publish = false
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "FlowFabric readiness tests — release-gate smoke tests (PR-D1)"
+
+# Skip cargo-release version bumps — dev-only, never published.
+[package.metadata.release]
+release = false
+
+[features]
+# Default OFF so `cargo test --workspace` does not attempt to run these.
+# CI enables `readiness` on the dedicated matrix cell (PR-D4).
+readiness = []
+
+[dependencies]
+ff-core = { workspace = true }
+ff-script = { workspace = true }
+ff-engine = { workspace = true }
+ff-scheduler = { workspace = true }
+ff-sdk = { workspace = true, features = ["direct-valkey-claim"] }
+ff-server = { workspace = true }
+ff-test = { workspace = true }
+ferriskey = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "process"] }
+uuid = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+serial_test = "3"
+axum = { workspace = true }

--- a/crates/ff-readiness-tests/Cargo.toml
+++ b/crates/ff-readiness-tests/Cargo.toml
@@ -19,22 +19,20 @@ release = false
 readiness = []
 
 [dependencies]
+# PR-D1 uses the in-process ff-server + in-process SDK worker. Dependencies
+# that later PRs will add (ff-script / ff-scheduler for FCALL-level helpers,
+# hmac/sha2/hex for waitpoint-token signing, uuid for ad-hoc ids, serde for
+# evidence deserialization) live on the branches that introduce them — kept
+# out here so `cargo-machete` stays green on the default workspace lint.
 ff-core = { workspace = true }
-ff-script = { workspace = true }
 ff-engine = { workspace = true }
-ff-scheduler = { workspace = true }
 ff-sdk = { workspace = true, features = ["direct-valkey-claim"] }
 ff-server = { workspace = true }
 ff-test = { workspace = true }
 ferriskey = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "process"] }
-uuid = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-hmac = "0.12"
-sha2 = "0.10"
-hex = "0.4"
 serial_test = "3"
 axum = { workspace = true }

--- a/crates/ff-readiness-tests/src/evidence.rs
+++ b/crates/ff-readiness-tests/src/evidence.rs
@@ -1,0 +1,30 @@
+//! Per-test JSON evidence writer. Each readiness test writes a
+//! single JSON document at `target/readiness-evidence/<test>.json`
+//! summarising what the test observed. PR-D4 wires this into CI
+//! artifact upload.
+
+use std::path::PathBuf;
+
+/// Locate `target/readiness-evidence/` relative to the workspace root,
+/// creating it if needed. Returns the file path for `<test>.json`.
+pub fn path_for(test_name: &str) -> PathBuf {
+    // CARGO_MANIFEST_DIR points at crates/ff-readiness-tests; step up
+    // twice to reach the workspace root.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .unwrap_or_else(|_| ".".to_owned());
+    let mut root = PathBuf::from(manifest);
+    root.pop(); // crates/
+    root.pop(); // workspace root
+    let dir = root.join("target").join("readiness-evidence");
+    let _ = std::fs::create_dir_all(&dir);
+    dir.join(format!("{test_name}.json"))
+}
+
+/// Write a JSON evidence document for `test_name`. Overwrites.
+pub fn write(test_name: &str, value: &serde_json::Value) {
+    let path = path_for(test_name);
+    let body = serde_json::to_string_pretty(value).expect("evidence serialise");
+    if let Err(e) = std::fs::write(&path, body) {
+        tracing::warn!(?path, error = %e, "failed to write readiness evidence");
+    }
+}

--- a/crates/ff-readiness-tests/src/lib.rs
+++ b/crates/ff-readiness-tests/src/lib.rs
@@ -1,0 +1,17 @@
+//! FlowFabric readiness tests — release-gate smoke tests.
+//!
+//! All tests live in `tests/*.rs` behind `#[cfg(feature = "readiness")]`
+//! and `#[ignore]`. They run only in the dedicated CI matrix cell
+//! (PR-D4, not yet landed). No business logic lives in this crate —
+//! the harness modules under `pub mod` are the only library surface.
+//!
+//! Run locally:
+//! ```bash
+//! cargo test -p ff-readiness-tests --features readiness -- --ignored --test-threads=1
+//! ```
+
+pub mod evidence;
+pub mod process;
+pub mod server;
+pub mod valkey;
+pub mod worker;

--- a/crates/ff-readiness-tests/src/process.rs
+++ b/crates/ff-readiness-tests/src/process.rs
@@ -1,0 +1,73 @@
+//! SIGTERM-on-drop guard for child processes spawned by readiness tests.
+//!
+//! Wraps a `tokio::process::Child` and, on `Drop`, sends SIGTERM then
+//! waits up to `GRACE_MS` before forcing SIGKILL. Tests that panic
+//! mid-flight still leave the system clean.
+
+use std::time::Duration;
+use tokio::process::Child;
+
+const GRACE_MS: u64 = 3_000;
+
+/// Guard around a `tokio::process::Child`. On drop, sends SIGTERM then
+/// SIGKILL after a short grace.
+pub struct ChildGuard {
+    child: Option<Child>,
+    label: String,
+}
+
+impl ChildGuard {
+    pub fn new(child: Child, label: impl Into<String>) -> Self {
+        Self {
+            child: Some(child),
+            label: label.into(),
+        }
+    }
+
+    /// Access the underlying child for things like stdout capture.
+    pub fn child_mut(&mut self) -> Option<&mut Child> {
+        self.child.as_mut()
+    }
+
+    /// Graceful shutdown — returns once the child exits or grace
+    /// elapses. Safe to call multiple times; subsequent calls no-op.
+    pub async fn shutdown(&mut self) {
+        let Some(mut child) = self.child.take() else { return };
+        // Best-effort SIGTERM via nix-like path (platform: unix only).
+        #[cfg(unix)]
+        {
+            if let Some(pid) = child.id() {
+                unsafe {
+                    libc_kill(pid as i32, 15 /* SIGTERM */);
+                }
+            }
+        }
+        let grace = Duration::from_millis(GRACE_MS);
+        match tokio::time::timeout(grace, child.wait()).await {
+            Ok(_) => {
+                tracing::debug!(label = %self.label, "child exited cleanly on SIGTERM");
+            }
+            Err(_) => {
+                tracing::warn!(label = %self.label, "child did not exit within grace; SIGKILL");
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+            }
+        }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            // Best-effort: if dropped outside a tokio context (e.g.
+            // test panic teardown), a blocking kill is fine.
+            let _ = child.start_kill();
+        }
+    }
+}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    #[link_name = "kill"]
+    fn libc_kill(pid: i32, sig: i32) -> i32;
+}

--- a/crates/ff-readiness-tests/src/process.rs
+++ b/crates/ff-readiness-tests/src/process.rs
@@ -44,13 +44,34 @@ impl ChildGuard {
         }
         let grace = Duration::from_millis(GRACE_MS);
         match tokio::time::timeout(grace, child.wait()).await {
-            Ok(_) => {
-                tracing::debug!(label = %self.label, "child exited cleanly on SIGTERM");
+            Ok(Ok(status)) => {
+                tracing::debug!(
+                    label = %self.label,
+                    ?status,
+                    "child exited cleanly on SIGTERM"
+                );
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    label = %self.label,
+                    error = %e,
+                    "child wait() failed after SIGTERM; attempting SIGKILL"
+                );
+                if let Err(e) = child.kill().await {
+                    tracing::warn!(label = %self.label, error = %e, "SIGKILL failed");
+                }
+                if let Err(e) = child.wait().await {
+                    tracing::warn!(label = %self.label, error = %e, "final wait failed");
+                }
             }
             Err(_) => {
                 tracing::warn!(label = %self.label, "child did not exit within grace; SIGKILL");
-                let _ = child.kill().await;
-                let _ = child.wait().await;
+                if let Err(e) = child.kill().await {
+                    tracing::warn!(label = %self.label, error = %e, "SIGKILL failed");
+                }
+                if let Err(e) = child.wait().await {
+                    tracing::warn!(label = %self.label, error = %e, "final wait failed");
+                }
             }
         }
     }
@@ -59,9 +80,29 @@ impl ChildGuard {
 impl Drop for ChildGuard {
     fn drop(&mut self) {
         if let Some(mut child) = self.child.take() {
-            // Best-effort: if dropped outside a tokio context (e.g.
-            // test panic teardown), a blocking kill is fine.
+            // Best-effort reap. `start_kill` signals the child; if a
+            // tokio runtime is still live we also schedule a blocking
+            // wait so the child doesn't linger as a zombie. Outside a
+            // tokio context we fall back to synchronous reap via the
+            // raw libc call — `tokio::process::Child::wait` itself
+            // requires an active runtime.
             let _ = child.start_kill();
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = child.wait().await;
+                });
+            } else {
+                // No runtime (e.g. test panic teardown outside tokio).
+                // Reap synchronously via the raw pid so /proc isn't
+                // cluttered for the rest of the test run.
+                #[cfg(unix)]
+                if let Some(pid) = child.id() {
+                    let mut status: i32 = 0;
+                    unsafe {
+                        libc_waitpid(pid as i32, &mut status as *mut i32, 0);
+                    }
+                }
+            }
         }
     }
 }
@@ -70,4 +111,6 @@ impl Drop for ChildGuard {
 unsafe extern "C" {
     #[link_name = "kill"]
     fn libc_kill(pid: i32, sig: i32) -> i32;
+    #[link_name = "waitpid"]
+    fn libc_waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
 }

--- a/crates/ff-readiness-tests/src/server.rs
+++ b/crates/ff-readiness-tests/src/server.rs
@@ -79,8 +79,13 @@ impl InProcessServer {
             axum::serve(listener, app).await.ok();
         });
 
-        // Wait for /healthz to return 200 before handing back.
-        let client = reqwest::Client::new();
+        // Wait for /healthz to return 200 before handing back. The
+        // per-request timeout keeps a stalled connect from outlasting
+        // the outer 5s deadline (each probe is capped at 500ms).
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(500))
+            .build()
+            .expect("build healthz probe client");
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         let url = format!("{base_url}/healthz");
         loop {

--- a/crates/ff-readiness-tests/src/server.rs
+++ b/crates/ff-readiness-tests/src/server.rs
@@ -1,0 +1,104 @@
+//! Spawn an in-process `ff_server::Server` (tests 1–5) or the
+//! `ff-server` binary (test 6) against the test Valkey.
+//!
+//! # Binary spawner
+//!
+//! Uses `CARGO_BIN_EXE_ff-server` so integration tests depend on a
+//! fresh build. Binds `FF_LISTEN_ADDR` to `127.0.0.1:0` is not
+//! supported by the server (it reads the port literally), so tests
+//! pass a concrete port. The process is guarded via `ChildGuard`.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::AbortHandle;
+
+use ff_core::types::LaneId;
+use ff_server::config::ServerConfig;
+use ff_server::server::Server;
+
+use crate::valkey::TEST_PARTITION_CONFIG;
+
+/// In-process server for tests 1–5. Wraps `Server::start` + an axum
+/// listener on a random port, same pattern as `ff-test::e2e_api`.
+pub struct InProcessServer {
+    pub server: Arc<Server>,
+    pub base_url: String,
+    pub abort: AbortHandle,
+}
+
+impl Drop for InProcessServer {
+    fn drop(&mut self) {
+        self.abort.abort();
+    }
+}
+
+impl InProcessServer {
+    pub async fn start(lane: &str) -> Self {
+        let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
+        let port: u16 = std::env::var("FF_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6379);
+        let tls = crate::valkey::env_flag("FF_TLS");
+        let cluster = crate::valkey::env_flag("FF_CLUSTER");
+
+        let config = ServerConfig {
+            host,
+            port,
+            tls,
+            cluster,
+            partition_config: TEST_PARTITION_CONFIG,
+            lanes: vec![LaneId::new(lane)],
+            listen_addr: "127.0.0.1:0".into(),
+            engine_config: ff_engine::EngineConfig {
+                partition_config: TEST_PARTITION_CONFIG,
+                lanes: vec![LaneId::new(lane)],
+                ..Default::default()
+            },
+            skip_library_load: true,
+            cors_origins: vec!["*".to_owned()],
+            api_token: None,
+            waitpoint_hmac_secret:
+                "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+            waitpoint_hmac_grace_ms: 86_400_000,
+            max_concurrent_stream_ops: 64,
+        };
+
+        let server = Arc::new(Server::start(config).await.expect("Server::start"));
+        let app = ff_server::api::router(server.clone(), &["*".to_owned()], None)
+            .expect("router with wildcard CORS");
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr: SocketAddr = listener.local_addr().expect("local_addr");
+        let base_url = format!("http://{addr}");
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        // Wait for /healthz to return 200 before handing back.
+        let client = reqwest::Client::new();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let url = format!("{base_url}/healthz");
+        loop {
+            if let Ok(r) = client.get(&url).send().await
+                && r.status().is_success()
+            {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("ff-server in-process /healthz never returned 200");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        Self {
+            server,
+            base_url,
+            abort: handle.abort_handle(),
+        }
+    }
+}

--- a/crates/ff-readiness-tests/src/server.rs
+++ b/crates/ff-readiness-tests/src/server.rs
@@ -4,9 +4,9 @@
 //! # Binary spawner
 //!
 //! Uses `CARGO_BIN_EXE_ff-server` so integration tests depend on a
-//! fresh build. Binds `FF_LISTEN_ADDR` to `127.0.0.1:0` is not
-//! supported by the server (it reads the port literally), so tests
-//! pass a concrete port. The process is guarded via `ChildGuard`.
+//! fresh build. `FF_LISTEN_ADDR` accepts an ephemeral port such as
+//! `127.0.0.1:0` (the server binds via `TcpListener::bind`, same as
+//! the in-process path here). The process is guarded via `ChildGuard`.
 
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/crates/ff-readiness-tests/src/valkey.rs
+++ b/crates/ff-readiness-tests/src/valkey.rs
@@ -1,0 +1,31 @@
+//! Thin wrapper around `ff_test::fixtures::TestCluster`.
+//!
+//! PR-D1 keeps this a passthrough — future PRs (D2+) may add
+//! version-probe + matrix-cell plumbing here.
+
+pub use ff_test::fixtures::{build_client_from_env, env_flag, TestCluster, TEST_PARTITION_CONFIG};
+
+/// Probe Valkey's server version. Prefers `valkey_version:` from INFO,
+/// falls back to `redis_version:` for older or Redis-OSS deployments.
+/// Mirrors the parser in `ff-server::server`.
+pub async fn probe_server_version(client: &ferriskey::Client) -> Option<String> {
+    let info: ferriskey::Value = client
+        .cmd("INFO")
+        .arg("server")
+        .execute()
+        .await
+        .ok()?;
+    let text = match info {
+        ferriskey::Value::BulkString(b) => String::from_utf8_lossy(&b).to_string(),
+        ferriskey::Value::SimpleString(s) => s,
+        ferriskey::Value::VerbatimString { text, .. } => text,
+        _ => return None,
+    };
+    // Prefer valkey_version; fall back to redis_version.
+    for prefix in ["valkey_version:", "redis_version:"] {
+        if let Some(line) = text.lines().find(|l| l.starts_with(prefix)) {
+            return Some(line.trim_start_matches(prefix).trim().to_owned());
+        }
+    }
+    None
+}

--- a/crates/ff-readiness-tests/src/worker.rs
+++ b/crates/ff-readiness-tests/src/worker.rs
@@ -1,0 +1,5 @@
+//! Test worker scaffolding. PR-D1 uses the in-process ff-sdk
+//! `FlowFabricWorker` (no new worker binary). This module is a
+//! placeholder that PR-D2/D3 will extend for LLM-shaped scenarios.
+//!
+//! See `ff-sdk::FlowFabricWorker` for the actual worker API.

--- a/crates/ff-readiness-tests/tests/cancel_flow_partial.rs
+++ b/crates/ff-readiness-tests/tests/cancel_flow_partial.rs
@@ -1,0 +1,269 @@
+//! PR-D1 / Test 2 — `cancel_flow_partial` regression proof.
+//!
+//! Drives `cancel_flow` through the HTTP surface (`POST
+//! /v1/flows/{id}/cancel?wait=true`) to prove the PR-C1 fix holds at
+//! the API layer — not just at the FCALL / typed-Server layer that
+//! Worker C's `pr_c1_cancel_flow_partial` already covers.
+//!
+//! Failure injection mirrors C1's pattern: two real member executions,
+//! the second flipped to lifecycle_phase=active with its
+//! `attempt_hash` planted as a STRING so the in-Lua `HSET` returns
+//! WRONGTYPE. That bubbles out as a non-terminal-ack error, and the
+//! `?wait=true` branch is obliged to report
+//! `CancelFlowResult::PartiallyCancelled` with the sabotaged id.
+//!
+//! RED-PROOF: pre-PR-C1 (commit cd61f11^) returned
+//! `CancelFlowResult::Cancelled` even when one member's cancel failed.
+//! This test pins the post-fix contract. Verifiable by
+//! `git show cd61f11^:crates/ff-server/src/server.rs` around line
+//! 1598. No local red-proof log — reverting the fix in-tree to capture
+//! a RED run would contaminate the branch (per owner's prior note).
+//! The PR body cites `cd61f11` as the regression anchor.
+//!
+//! Run with:
+//!   cargo test -p ff-readiness-tests --features readiness \
+//!       --test cancel_flow_partial -- --ignored --test-threads=1
+#![cfg(feature = "readiness")]
+
+use std::time::Instant;
+
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, CancelFlowArgs, CancelFlowResult, CreateExecutionArgs, CreateFlowArgs,
+};
+use ff_core::keys::ExecKeyContext;
+use ff_core::partition::execution_partition;
+use ff_core::types::*;
+use ff_readiness_tests::evidence;
+use ff_readiness_tests::server::InProcessServer;
+use ff_readiness_tests::valkey::{probe_server_version, TestCluster, TEST_PARTITION_CONFIG};
+use serde_json::json;
+
+const TEST_NAME: &str = "cancel_flow_partial";
+const LANE: &str = "readiness-cancel";
+const NS: &str = "readiness-cancel-ns";
+
+#[tokio::test]
+#[ignore]
+#[serial_test::serial]
+async fn cancel_flow_partial() {
+    let t_start = Instant::now();
+
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let valkey_version = probe_server_version(tc.client()).await;
+
+    let server = InProcessServer::start(LANE).await;
+
+    // ── Sabotaged path: one clean member + one wrong-type member ──
+    let flow_id = FlowId::new();
+    let (member_ids, broken_eid) = create_flow_with_two_members(&server, &flow_id).await;
+    sabotage_member_attempt_hash(&tc, &broken_eid).await;
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/v1/flows/{}/cancel?wait=true", server.base_url, flow_id);
+    let resp = http
+        .post(&url)
+        .json(&CancelFlowArgs {
+            flow_id: flow_id.clone(),
+            reason: "readiness-cancel".to_owned(),
+            cancellation_policy: "cancel_all".to_owned(),
+            now: TimestampMs::now(),
+        })
+        .send()
+        .await
+        .expect("HTTP POST cancel?wait=true");
+    assert!(
+        resp.status().is_success(),
+        "cancel_flow?wait=true returned {}",
+        resp.status()
+    );
+    let result: CancelFlowResult = resp.json().await.expect("deserialize CancelFlowResult");
+
+    match &result {
+        CancelFlowResult::PartiallyCancelled {
+            cancellation_policy,
+            member_execution_ids,
+            failed_member_execution_ids,
+        } => {
+            assert_eq!(cancellation_policy, "cancel_all");
+            assert_eq!(
+                member_execution_ids.len(),
+                2,
+                "both members should be listed in the full membership"
+            );
+            assert_eq!(
+                failed_member_execution_ids.len(),
+                1,
+                "exactly one member should have failed to cancel"
+            );
+            assert_eq!(
+                failed_member_execution_ids[0],
+                broken_eid.to_string(),
+                "sabotaged member should be the failed one"
+            );
+        }
+        other => panic!(
+            "sabotaged cancel should return PartiallyCancelled, got {other:?}"
+        ),
+    }
+
+    let sabotaged_members: Vec<String> = member_ids.iter().map(|e| e.to_string()).collect();
+
+    // ── Control path: same shape, no sabotage, expect Cancelled ──
+    let control_flow_id = FlowId::new();
+    let (control_members, _) = create_flow_with_two_members(&server, &control_flow_id).await;
+    let control_url = format!(
+        "{}/v1/flows/{}/cancel?wait=true",
+        server.base_url, control_flow_id
+    );
+    let control_resp = http
+        .post(&control_url)
+        .json(&CancelFlowArgs {
+            flow_id: control_flow_id.clone(),
+            reason: "readiness-cancel-control".to_owned(),
+            cancellation_policy: "cancel_all".to_owned(),
+            now: TimestampMs::now(),
+        })
+        .send()
+        .await
+        .expect("HTTP POST cancel (control)");
+    assert!(
+        control_resp.status().is_success(),
+        "control cancel returned {}",
+        control_resp.status()
+    );
+    let control_result: CancelFlowResult = control_resp
+        .json()
+        .await
+        .expect("deserialize control CancelFlowResult");
+
+    match &control_result {
+        CancelFlowResult::Cancelled {
+            cancellation_policy,
+            member_execution_ids,
+        } => {
+            assert_eq!(cancellation_policy, "cancel_all");
+            assert_eq!(
+                member_execution_ids.len(),
+                2,
+                "control flow should report both members cancelled"
+            );
+        }
+        other => panic!(
+            "control cancel should return Cancelled (no sabotage), got {other:?}"
+        ),
+    }
+
+    evidence::write(
+        TEST_NAME,
+        &json!({
+            "test": TEST_NAME,
+            "total_ms": t_start.elapsed().as_millis() as u64,
+            "valkey_version": valkey_version,
+            "sabotaged": {
+                "flow_id": flow_id.to_string(),
+                "member_ids": sabotaged_members,
+                "broken_member_id": broken_eid.to_string(),
+                "result_variant": "PartiallyCancelled",
+            },
+            "control": {
+                "flow_id": control_flow_id.to_string(),
+                "member_ids": control_members.iter().map(|e| e.to_string()).collect::<Vec<_>>(),
+                "result_variant": "Cancelled",
+            },
+            "regression_anchor": {
+                "commit": "cd61f11",
+                "note": "pre-fix returned Cancelled on partial failure",
+            },
+        }),
+    );
+}
+
+/// Create a flow plus two real member executions and return their ids
+/// (second id is the one callers sabotage for the partial-cancel path).
+async fn create_flow_with_two_members(
+    server: &InProcessServer,
+    flow_id: &FlowId,
+) -> (Vec<ExecutionId>, ExecutionId) {
+    let now = TimestampMs::now();
+    server
+        .server
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow_id.clone(),
+            flow_kind: "readiness-cancel".to_owned(),
+            namespace: Namespace::new(NS),
+            now,
+        })
+        .await
+        .expect("create_flow");
+
+    let a = ExecutionId::for_flow(flow_id, &TEST_PARTITION_CONFIG);
+    let b = ExecutionId::for_flow(flow_id, &TEST_PARTITION_CONFIG);
+    assert_ne!(a, b, "member ids must be distinct");
+
+    for eid in [&a, &b] {
+        server
+            .server
+            .create_execution(&CreateExecutionArgs {
+                execution_id: eid.clone(),
+                namespace: Namespace::new(NS),
+                lane_id: LaneId::new(LANE),
+                execution_kind: "readiness-cancel-member".to_owned(),
+                input_payload: b"{}".to_vec(),
+                payload_encoding: Some("json".to_owned()),
+                priority: 0,
+                creator_identity: "readiness".to_owned(),
+                idempotency_key: None,
+                tags: std::collections::HashMap::new(),
+                policy: None,
+                delay_until: None,
+                execution_deadline_at: None,
+                partition_id: execution_partition(eid, &TEST_PARTITION_CONFIG).index,
+                now,
+            })
+            .await
+            .expect("create_execution member");
+        server
+            .server
+            .add_execution_to_flow(&AddExecutionToFlowArgs {
+                flow_id: flow_id.clone(),
+                execution_id: eid.clone(),
+                now,
+            })
+            .await
+            .expect("add_execution_to_flow member");
+    }
+
+    (vec![a.clone(), b.clone()], b)
+}
+
+/// Flip the execution to lifecycle_phase="active" + plant its
+/// attempt_hash as a STRING. The cancel Lua's `HSET K.attempt_hash …`
+/// returns WRONGTYPE, which bubbles out as a non-ack failure.
+async fn sabotage_member_attempt_hash(tc: &TestCluster, eid: &ExecutionId) {
+    let partition = execution_partition(eid, &TEST_PARTITION_CONFIG);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let _: i64 = tc
+        .client()
+        .cmd("HSET")
+        .arg(ctx.core().as_str())
+        .arg("lifecycle_phase")
+        .arg("active")
+        .arg("ownership_state")
+        .arg("leased")
+        .arg("current_attempt_index")
+        .arg("1")
+        .execute()
+        .await
+        .expect("HSET broken core active");
+
+    let attempt_key = ctx.attempt_hash(AttemptIndex::new(1));
+    let _: String = tc
+        .client()
+        .cmd("SET")
+        .arg(attempt_key.as_str())
+        .arg("wrongtype-sentinel")
+        .execute()
+        .await
+        .expect("SET attempt_hash as string");
+}

--- a/crates/ff-readiness-tests/tests/cancel_flow_partial.rs
+++ b/crates/ff-readiness-tests/tests/cancel_flow_partial.rs
@@ -59,7 +59,12 @@ async fn cancel_flow_partial() {
     let (member_ids, broken_eid) = create_flow_with_two_members(&server, &flow_id).await;
     sabotage_member_attempt_hash(&tc, &broken_eid).await;
 
-    let http = reqwest::Client::new();
+    // Per-request timeout bounds stalled connects/reads so the
+    // ignored readiness run fails fast on regression, not hang.
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .expect("build reqwest client");
     let url = format!("{}/v1/flows/{}/cancel?wait=true", server.base_url, flow_id);
     let resp = http
         .post(&url)

--- a/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
+++ b/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
@@ -1,0 +1,243 @@
+//! PR-D1 / Test 1 — Lifecycle happy path.
+//!
+//! Proves the readiness harness can drive a full execution lifecycle
+//! end-to-end through the SDK + ff-server + Valkey path:
+//!
+//!   create_flow → create_execution → add_to_flow → worker.claim_next
+//!   → update_progress → append_frame → complete → poll-to-terminal.
+//!
+//! This is a "the whole plumbing works" test, not a regression. It
+//! runs only under the `readiness` feature + `#[ignore]` so the
+//! default `cargo test --workspace` pass is unaffected.
+//!
+//! Run with:
+//!   cargo test -p ff-readiness-tests --features readiness \
+//!       --test lifecycle_happy_path -- --ignored --test-threads=1
+//!
+//! RED-proof: commenting out `task.complete(...)` makes step 11
+//! (poll-to-terminal) time out — proving the assertion exercises the
+//! lifecycle transition, not just type-checks. Captured transcript:
+//! `tests/red-proofs/lifecycle_happy_path.log`.
+#![cfg(feature = "readiness")]
+
+use std::time::{Duration, Instant};
+
+use ff_core::contracts::{AddExecutionToFlowArgs, CreateExecutionArgs, CreateFlowArgs};
+use ff_core::keys::ExecKeyContext;
+use ff_core::partition::execution_partition;
+use ff_core::state::PublicState;
+use ff_core::types::*;
+use ff_readiness_tests::evidence;
+use ff_readiness_tests::server::InProcessServer;
+use ff_readiness_tests::valkey::{probe_server_version, TestCluster, TEST_PARTITION_CONFIG};
+use serde_json::json;
+
+const TEST_NAME: &str = "lifecycle_happy_path";
+const LANE: &str = "readiness-happy";
+const NS: &str = "readiness-happy-ns";
+
+#[tokio::test]
+#[ignore]
+#[serial_test::serial]
+async fn lifecycle_happy_path() {
+    let t_start = Instant::now();
+
+    // 1. Valkey harness — flushes + loads the FF library.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let valkey_version = probe_server_version(tc.client()).await;
+
+    // 2. In-process ff-server — waits for /healthz 200.
+    let server = InProcessServer::start(LANE).await;
+
+    // 3. Flow + 4. execution + 5. membership.
+    let flow_id = FlowId::new();
+    let now = TimestampMs::now();
+    server
+        .server
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow_id.clone(),
+            flow_kind: "readiness-happy".to_owned(),
+            namespace: Namespace::new(NS),
+            now,
+        })
+        .await
+        .expect("create_flow");
+
+    let eid = ExecutionId::for_flow(&flow_id, &TEST_PARTITION_CONFIG);
+    let deadline_at = TimestampMs::from_millis(now.0 + 60_000);
+    server
+        .server
+        .create_execution(&CreateExecutionArgs {
+            execution_id: eid.clone(),
+            namespace: Namespace::new(NS),
+            lane_id: LaneId::new(LANE),
+            execution_kind: "readiness-happy".to_owned(),
+            input_payload: b"{}".to_vec(),
+            payload_encoding: Some("json".to_owned()),
+            priority: 0,
+            creator_identity: "readiness".to_owned(),
+            idempotency_key: None,
+            tags: std::collections::HashMap::new(),
+            policy: None,
+            delay_until: None,
+            execution_deadline_at: Some(deadline_at),
+            partition_id: execution_partition(&eid, &TEST_PARTITION_CONFIG).index,
+            now,
+        })
+        .await
+        .expect("create_execution");
+
+    server
+        .server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now,
+        })
+        .await
+        .expect("add_execution_to_flow");
+
+    // 6. Spawn in-process SDK worker using direct-valkey-claim.
+    let worker_config = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(6379),
+        tls: ff_readiness_tests::valkey::env_flag("FF_TLS"),
+        cluster: ff_readiness_tests::valkey::env_flag("FF_CLUSTER"),
+        worker_id: WorkerId::new("readiness-happy-worker"),
+        worker_instance_id: WorkerInstanceId::new("readiness-happy-inst"),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 4,
+    };
+    let worker = ff_sdk::FlowFabricWorker::connect(worker_config)
+        .await
+        .expect("FlowFabricWorker::connect");
+
+    // 7. Claim the single eligible execution.
+    let t_claim = Instant::now();
+    let task = worker
+        .claim_next()
+        .await
+        .expect("claim_next Result")
+        .expect("claim_next Some(task)");
+    let claim_ms = t_claim.elapsed().as_millis() as u64;
+    assert_eq!(
+        task.execution_id(),
+        &eid,
+        "claimed execution should match the one we created"
+    );
+
+    // 8. Progress update.
+    task.update_progress(50, "halfway")
+        .await
+        .expect("update_progress");
+
+    // 9. Append a progress frame.
+    let frame_outcome = task
+        .append_frame(
+            "progress",
+            &serde_json::to_vec(&json!({"step": "mid"})).expect("encode frame"),
+            None,
+        )
+        .await
+        .expect("append_frame");
+    assert!(
+        !frame_outcome.stream_id.is_empty(),
+        "append_frame must mint a non-empty stream_id"
+    );
+    assert_eq!(frame_outcome.frame_count, 1);
+
+    // Capture attempt_index before `complete` consumes the task so we
+    // can inspect the attempt's stream after terminal.
+    let attempt_index = task.attempt_index();
+
+    // 10. Complete. (Removing this line is the RED-proof.)
+    task.complete(Some(b"readiness-ok".to_vec()))
+        .await
+        .expect("task.complete");
+
+    // 11. Poll the SDK `describe_execution` snapshot until terminal.
+    //     Uses the same read surface consumers see, not the Server's
+    //     internal `get_execution`, so the test exercises the full
+    //     SDK + Valkey path end-to-end.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let (public_state, total_attempts) = loop {
+        let snapshot = worker
+            .describe_execution(&eid)
+            .await
+            .expect("describe_execution")
+            .expect("snapshot must exist for a just-created execution");
+        if matches!(
+            snapshot.public_state,
+            PublicState::Completed
+                | PublicState::Failed
+                | PublicState::Cancelled
+                | PublicState::Expired
+                | PublicState::Skipped
+        ) {
+            break (snapshot.public_state, snapshot.total_attempt_count);
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for execution {eid} to reach terminal \
+                 (5s); last public_state={:?}",
+                snapshot.public_state
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    // 12. Assert terminal shape. `public_state == Completed` is the
+    //     SDK-surface analogue of `terminal_outcome == Success`.
+    assert_eq!(
+        public_state,
+        PublicState::Completed,
+        "derived public state should be Completed"
+    );
+    assert_eq!(
+        total_attempts, 1,
+        "a single happy-path attempt should have been recorded"
+    );
+
+    // Stream must carry at least one progress frame (the one we
+    // appended, plus whatever the engine emits on complete).
+    let stream_partition = execution_partition(&eid, &TEST_PARTITION_CONFIG);
+    let stream_ctx = ExecKeyContext::new(&stream_partition, &eid);
+    let stream_key = stream_ctx.stream(attempt_index);
+    let stream_len: i64 = tc
+        .client()
+        .cmd("XLEN")
+        .arg(stream_key.as_str())
+        .execute()
+        .await
+        .expect("XLEN stream");
+    assert!(
+        stream_len >= 1,
+        "stream should contain at least the progress frame, got {stream_len}"
+    );
+
+    // 13. Evidence JSON.
+    evidence::write(
+        TEST_NAME,
+        &json!({
+            "test": TEST_NAME,
+            "total_ms": t_start.elapsed().as_millis() as u64,
+            "claim_ms": claim_ms,
+            "valkey_version": valkey_version,
+            "execution_id": eid.to_string(),
+            "flow_id": flow_id.to_string(),
+            "assertions": {
+                "public_state": format!("{:?}", public_state),
+                "total_attempt_count": total_attempts,
+                "stream_len": stream_len,
+            },
+        }),
+    );
+}

--- a/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
+++ b/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
@@ -120,13 +120,20 @@ async fn lifecycle_happy_path() {
         .await
         .expect("FlowFabricWorker::connect");
 
-    // 7. Claim the single eligible execution.
+    // 7. Claim the single eligible execution. Bounded so an
+    //    eligibility regression fails fast instead of hanging the
+    //    ignored run.
     let t_claim = Instant::now();
-    let task = worker
-        .claim_next()
-        .await
-        .expect("claim_next Result")
-        .expect("claim_next Some(task)");
+    let task = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(t) = worker.claim_next().await.expect("claim_next Result") {
+                break t;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("claim_next timed out after 10s — execution never became eligible");
     let claim_ms = t_claim.elapsed().as_millis() as u64;
     assert_eq!(
         task.execution_id(),

--- a/crates/ff-readiness-tests/tests/red-proofs/lifecycle_happy_path.log
+++ b/crates/ff-readiness-tests/tests/red-proofs/lifecycle_happy_path.log
@@ -1,0 +1,19 @@
+   Compiling ff-readiness-tests v0.3.0 (/home/ubuntu/ff-worker-d-readiness/crates/ff-readiness-tests)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.23s
+     Running tests/lifecycle_happy_path.rs (target/debug/deps/lifecycle_happy_path-7b2847340fe83d0b)
+
+running 1 test
+test lifecycle_happy_path ... 
+thread 'lifecycle_happy_path' panicked at crates/ff-readiness-tests/tests/lifecycle_happy_path.rs:191:13:
+timed out waiting for execution {fp:3}:48833442-f086-45c6-8472-8c190dd931f0 to reach terminal (5s); last public_state=Active
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+FAILED
+
+failures:
+
+failures:
+    lifecycle_happy_path
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.07s
+
+error: test failed, to rerun pass `-p ff-readiness-tests --test lifecycle_happy_path`


### PR DESCRIPTION
## Summary

First PR in the 5-PR readiness-tests sequence. Lands the harness
crate scaffold plus two release-gate smoke tests behind a
`readiness` cargo feature (default OFF) + `#[ignore]` so default CI
is unaffected. PR-D4 will wire the dedicated matrix cell.

- **Scaffold crate `ff-readiness-tests`** (dev-only, `publish = false`).
  Harness modules: `valkey` (TestCluster re-export + version probe),
  `server::InProcessServer::start`, `process::ChildGuard` (for the
  binary spawner path in later PRs), `evidence` (JSON dump under
  `target/readiness-evidence/<test>.json`).
- **`lifecycle_happy_path`** — drives a full execution lifecycle
  end-to-end (create_flow → create_execution → add_to_flow →
  `FlowFabricWorker::claim_next` → `update_progress` →
  `append_frame` → `complete`) and polls the SDK's
  `describe_execution` snapshot until terminal. Asserts
  `public_state == Completed`, `total_attempt_count == 1`, XLEN >= 1
  on the attempt's stream.
- **`cancel_flow_partial`** — PR-C1 regression proof at the HTTP
  surface. POSTs `/v1/flows/{id}/cancel?wait=true`; sabotages one
  member's `attempt_hash` as a STRING (same technique as
  `ff-test::pr_c1_cancel_flow_partial`); asserts the body
  deserialises to `CancelFlowResult::PartiallyCancelled` with the
  broken id listed. Clean-control path asserts `Cancelled`.

## RED / GREEN

### Test 1 (lifecycle_happy_path)

RED-proof captured at `tests/red-proofs/lifecycle_happy_path.log`
by commenting out `task.complete(...)`:

```
thread 'lifecycle_happy_path' panicked at ...lifecycle_happy_path.rs:191:13:
timed out waiting for execution {fp:3}:48833442-... to reach terminal (5s); last public_state=Active
test result: FAILED. 0 passed; 1 failed
```

Restored `task.complete(...)` → GREEN:
```
test lifecycle_happy_path ... ok
test result: ok. 1 passed; 0 failed
```

### Test 2 (cancel_flow_partial)

Regression anchor is `cd61f11` — pre-fix `cancel_flow_wait` returned
`Cancelled` even when a member's cancel FCALL failed. Per owner's
prior guidance ("you can't locally revert the fix just to red-prove"),
no RED log file is captured; the commit reference stands in as the
anchor. Verifiable by
`git show cd61f11^:crates/ff-server/src/server.rs` around line 1598.

GREEN:
```
test cancel_flow_partial ... ok
test result: ok. 1 passed; 0 failed
```

## Local validation

Local environment exposes **Valkey 8.1.0** (matches CI's `valkey/valkey:8`
image) via the pre-provisioned build at
`/tmp/valkey-build/valkey-8.1.0/src/valkey-server` listening on `:6389`.
Docker is not available on this host, so the 7.2 transcript in the
original brief could not be captured locally — and `ff-server`'s boot
gate (`verify_valkey_version`, `REQUIRED_VALKEY_MAJOR = 8`) would
refuse a 7.2 backend regardless, so the readiness-tests matrix cell
is expected to pin `valkey/valkey:8-alpine` (per
`.github/workflows/matrix.yml` line 89). PR-D4 wires the concrete
matrix cell.

Transcript on Valkey 8.1.0 (`FF_PORT=6389`):

```
$ FF_PORT=6389 cargo test -p ff-readiness-tests --features readiness -- --ignored --test-threads=1
test cancel_flow_partial ... ok
test lifecycle_happy_path ... ok
test result: ok. 1 passed; 0 failed  (each)
```

Default-feature workspace compile stays green:

```
$ cargo test -p ff-readiness-tests
running 0 tests
test result: ok. 0 passed; 0 failed

$ cargo check --workspace
    Finished `dev` profile
$ cargo clippy -p ff-readiness-tests --features readiness --all-targets -- -D warnings
    Finished (no warnings)
```

## Test plan
- [ ] CI compiles with default features (crate is a no-op in the
      default workspace test run)
- [ ] CI compiles with `--features readiness`
- [ ] After PR-D4 lands the matrix cell, both tests run green against
      `valkey/valkey:8-alpine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to a new, non-published test crate gated behind a non-default `readiness` feature and `#[ignore]`, with no production runtime behavior changes.
> 
> **Overview**
> Introduces a new dev-only workspace crate, `ff-readiness-tests`, to host release-gate readiness smoke tests that are **disabled by default** via a `readiness` feature and `#[ignore]`.
> 
> Adds a small harness for spawning an in-process `ff-server`, probing Valkey version/fixtures, guarding child processes, and writing per-test JSON evidence to `target/readiness-evidence/`.
> 
> Adds two ignored E2E tests: `lifecycle_happy_path` (drives a full execution lifecycle through SDK/server/Valkey) and `cancel_flow_partial` (regression proof that `POST /v1/flows/{id}/cancel?wait=true` returns `PartiallyCancelled` when one member cancel fails, plus a clean control case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e6f532ab849fe732f6fdee824ee511000c3eae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->