### PR TITLE
fix(ff-server): multi-node cluster version check + README Redis wording (#83 #84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
 ### 1. Start Valkey
 
 FlowFabric is Valkey-native and is not tested or supported against Redis.
-The version check uses Valkey's `INFO` shape; pointing `ff-server` at a Redis
-server is outside the supported configuration matrix — behavior is undefined.
-The `redis_version:` fallback exists for pre-8.0 Valkey (which emits only
-`redis_version:`, not `valkey_version:`), not to legitimize Redis.
+The version check expects Valkey's `INFO` shape; pointing `ff-server` at a
+Redis server is unsupported and is rejected at boot by the version gate
+(`parse_valkey_version` requires `server_name:valkey` in INFO). The
+`redis_version:` fallback exists for pre-8.0 Valkey (which emits only
+`redis_version:`, not `valkey_version:`), not to legitimize or allow Redis.
 
 FlowFabric requires Valkey >= 7.2 (RFC-011 §13, enforced at boot). 7.2 is the
 release where the Valkey Functions API + RESP3 stabilized. Valkey 7.0 and

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
 
 ### 1. Start Valkey
 
+FlowFabric is Valkey-native and is not tested or supported against Redis.
+The version check uses Valkey's `INFO` shape; pointing `ff-server` at a Redis
+server is outside the supported configuration matrix — behavior is undefined.
+The `redis_version:` fallback exists for pre-8.0 Valkey (which emits only
+`redis_version:`, not `valkey_version:`), not to legitimize Redis.
+
 FlowFabric requires Valkey >= 7.2 (RFC-011 §13, enforced at boot). 7.2 is the
 release where the Valkey Functions API + RESP3 stabilized. Valkey 7.0 and
-earlier are rejected by `ff-server`; Redis is also rejected (the boot check
-requires an affirmative `server_name:valkey` INFO marker before accepting a
-`redis_version:` fallback, and Redis does not emit that marker).
+earlier are rejected by `ff-server`.
 
 ```bash
 docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -4409,6 +4409,103 @@ os:Linux\r\n";
         assert!(err.to_string().contains("empty map"));
     }
 
+    /// End-to-end composition test for the cluster-min fix (issue #84):
+    /// `extract_info_bodies` → `parse_valkey_version` per node → min-reduce →
+    /// floor comparison. A mixed-version cluster where one node is 7.1.0 must
+    /// fail the gate, even if another node is already on 8.0.0 and that
+    /// node's entry appears first in the map.
+    #[test]
+    fn parse_valkey_version_min_across_cluster_map_picks_lowest() {
+        // node1 appears first and is above the floor. Pre-fix behavior
+        // (first-entry only) would accept. The min across all three nodes is
+        // (7, 1), below the (7, 2) floor, so the gate must reject.
+        let body_node1 = "# Server\r\nredis_version:7.2.4\r\nserver_name:valkey\r\nvalkey_version:8.0.0\r\n";
+        let body_node2 = "# Server\r\nredis_version:7.1.0\r\nserver_name:valkey\r\n";
+        let body_node3 = "# Server\r\nredis_version:7.2.4\r\nserver_name:valkey\r\nvalkey_version:7.2.0\r\n";
+        let map = Value::Map(vec![
+            (
+                Value::SimpleString("node1:6379".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_node1.to_string(),
+                },
+            ),
+            (
+                Value::SimpleString("node2:6379".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_node2.to_string(),
+                },
+            ),
+            (
+                Value::SimpleString("node3:6379".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_node3.to_string(),
+                },
+            ),
+        ]);
+
+        let bodies = extract_info_bodies(&map).unwrap();
+        let min = bodies
+            .iter()
+            .map(|b| parse_valkey_version(b).unwrap())
+            .min()
+            .unwrap();
+
+        assert_eq!(min, (7, 1), "min across cluster must be the lowest node");
+        assert!(
+            min < (REQUIRED_VALKEY_MAJOR, REQUIRED_VALKEY_MINOR),
+            "mixed-version cluster with 7.1.0 node must fail the (7,2) gate"
+        );
+    }
+
+    /// Companion to `parse_valkey_version_min_across_cluster_map_picks_lowest`:
+    /// when every node is at or above the floor, the min-reduce + gate
+    /// composition accepts.
+    #[test]
+    fn parse_valkey_version_all_nodes_at_or_above_floor_accepts() {
+        let body_node1 = "# Server\r\nredis_version:7.2.4\r\nserver_name:valkey\r\nvalkey_version:8.0.0\r\n";
+        let body_node2 = "# Server\r\nredis_version:7.2.4\r\nserver_name:valkey\r\nvalkey_version:7.2.0\r\n";
+        let body_node3 = "# Server\r\nredis_version:7.2.4\r\nserver_name:valkey\r\nvalkey_version:9.0.3\r\n";
+        let map = Value::Map(vec![
+            (
+                Value::SimpleString("node1:6379".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_node1.to_string(),
+                },
+            ),
+            (
+                Value::SimpleString("node2:6379".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_node2.to_string(),
+                },
+            ),
+            (
+                Value::SimpleString("node3:6379".to_string()),
+                Value::VerbatimString {
+                    format: ferriskey::value::VerbatimFormat::Text,
+                    text: body_node3.to_string(),
+                },
+            ),
+        ]);
+
+        let bodies = extract_info_bodies(&map).unwrap();
+        let min = bodies
+            .iter()
+            .map(|b| parse_valkey_version(b).unwrap())
+            .min()
+            .unwrap();
+
+        assert_eq!(min, (7, 2), "min across cluster is the lowest node (7.2)");
+        assert!(
+            min >= (REQUIRED_VALKEY_MAJOR, REQUIRED_VALKEY_MINOR),
+            "all-above-floor cluster must pass the gate"
+        );
+    }
+
     #[test]
     fn valkey_version_too_low_is_not_retryable() {
         let err = ServerError::ValkeyVersionTooLow {


### PR DESCRIPTION
Closes #83, closes #84. Addresses two Copilot comments on PR #79.

## Summary

- **#83 (README-only per owner clarification):** Soften README compatibility wording. Redis is not rejected — it's not supported. The `redis_version:` fallback exists for pre-8.0 Valkey (which emits only `redis_version:`, not `valkey_version:`), not to legitimize Redis. Parser is left untouched.
- **#84 (cluster-min tests):** Add two end-to-end unit tests for the multi-node cluster version-check flow (`extract_info_bodies` → `parse_valkey_version` per node → min-reduce → floor compare). The underlying parser fix (returning every node's body and min-reducing across them) landed in #79; this PR provides the two tests Copilot asked for by name and captures the RED proof.

## Scope notes

- Parser behavior is unchanged in this PR.
- README wording is owner-authored per the #83 clarification.
- No version bumps, no RFC edits (§13 and Amendment F untouched).
- Standalone mode unchanged (single body → single version); cluster mode already fans out to every map entry and reduces by `min`.

## RED-proof for #84

Temporarily replaced `extract_info_bodies`'s cluster-map branch with first-entry-only behavior and ran the new test:

```
running 1 test
test server::tests::parse_valkey_version_min_across_cluster_map_picks_lowest ... FAILED

---- server::tests::parse_valkey_version_min_across_cluster_map_picks_lowest stdout ----

thread '...' panicked at crates/ff-server/src/server.rs:4454:9:
assertion `left == right` failed: min across cluster must be the lowest node
  left: (8, 0)
 right: (7, 1)
```

The probe returned `(8, 0)` — only the first map entry, the high-version node — and never saw the 7.1 node that should have failed the gate. Restored the multi-entry fan-out; test passes.

## Test plan

- [x] `cargo test -p ff-server --lib` — 35 passed.
- [x] `cargo clippy -p ff-server --all-targets -- -D warnings` — clean.
- [x] `cargo check -p ff-server` after README edit — clean (no code depends on the README text).
- [x] New tests exercise: mixed-version rejection (min=(7,1) < (7,2)), uniform acceptance (min=(7,2) ≥ (7,2)).
- [x] RED proof captured above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation wording and new unit tests covering the existing Valkey cluster version-floor enforcement logic.
> 
> **Overview**
> Clarifies `README.md` quickstart wording to state FlowFabric is **Valkey-only** (Redis is *unsupported*), and explains that the `redis_version:` fallback exists solely for pre-8.0 Valkey.
> 
> Adds two end-to-end unit tests in `ff-server` to ensure cluster-mode boot version gating computes the **minimum** Valkey version across all `INFO` map entries, rejecting mixed-version clusters below the `(7,2)` floor and accepting clusters where every node meets the floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809f16323a259f28f03801affe6d46ad8beada2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->