### PR TITLE
feat(ff-server): per-route body size limits (#97)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,6 +2860,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,5 +49,5 @@ tracing = "0.1"
 thiserror = "2"
 crc16 = "0.4"
 axum = "0.8"
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
 futures = "0.3"

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -79,15 +79,64 @@ struct BodyLimit {
 
 /// Apply per-route body-size cap + attach [`BodyLimit`] extension so the
 /// JSON rejection handler can report `limit_bytes` in the 413 response.
+///
+/// Three layers, each guarding a different failure mode:
+///
+///   1. `from_fn(enforce_body_limit)` — inspects `Content-Length` up front
+///      and rejects with our structured 413 body BEFORE the handler runs.
+///      This is the primary enforcement path and works regardless of
+///      whether the handler consumes the body. Also attaches the
+///      [`BodyLimit`] extension so `AppJson`'s 413 branch (below, case 2)
+///      can report `limit_bytes` even when rejection happens during
+///      streaming.
+///   2. `DefaultBodyLimit::max(bytes)` — hint consumed by `AppJson`
+///      (`Bytes::from_request` internally) for the case where a client
+///      lies in `Content-Length` or uses `Transfer-Encoding: chunked`:
+///      the body extractor trips on a streaming-length check and we
+///      rewrite the rejection into the structured 413 shape in
+///      `AppJson::from_request`.
+///   3. `tower_http::limit::RequestBodyLimitLayer::new(bytes)` —
+///      transport-level body cap that also fires on chunked transfers
+///      even when the handler never consumes the body. Returns a plain
+///      413 (no JSON body) in that edge case; the structured path in
+///      (1) covers the overwhelmingly common case (clients sending
+///      Content-Length).
 fn with_body_limit(route: MethodRouter<Arc<Server>>, bytes: usize) -> MethodRouter<Arc<Server>> {
-    let attach_ext =
-        middleware::from_fn(move |mut req: Request, next: middleware::Next| async move {
-            req.extensions_mut().insert(BodyLimit { bytes });
-            let resp: Response = next.run(req).await;
-            resp
-        });
-    let r: MethodRouter<Arc<Server>> = route.layer(attach_ext);
-    r.layer(DefaultBodyLimit::max(bytes))
+    let r: MethodRouter<Arc<Server>> =
+        route.layer(tower_http::limit::RequestBodyLimitLayer::new(bytes));
+    let r: MethodRouter<Arc<Server>> = r.layer(DefaultBodyLimit::max(bytes));
+    r.layer(middleware::from_fn(
+        move |req: Request, next: middleware::Next| enforce_body_limit(bytes, req, next),
+    ))
+}
+
+/// Content-Length-based body-size enforcement + [`BodyLimit`] extension.
+///
+/// Runs before the handler so routes whose handlers never consume the
+/// request body (`replay_execution`, `revoke_lease`, `reset_budget` — see
+/// Copilot review on PR#100) are still protected against large uploads.
+async fn enforce_body_limit(bytes: usize, mut req: Request, next: middleware::Next) -> Response {
+    if let Some(content_length) = req
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<usize>().ok())
+        && content_length > bytes
+    {
+        let route = req
+            .extensions()
+            .get::<MatchedPath>()
+            .map(|m| m.as_str().to_owned())
+            .unwrap_or_default();
+        let body = PayloadTooLargeBody {
+            error: "payload_too_large",
+            limit_bytes: bytes,
+            route,
+        };
+        return (StatusCode::PAYLOAD_TOO_LARGE, Json(body)).into_response();
+    }
+    req.extensions_mut().insert(BodyLimit { bytes });
+    next.run(req).await
 }
 
 /// Shape for the 413 response body.
@@ -113,14 +162,12 @@ where
         req: axum::extract::Request,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        // Snapshot route + limit before `Json::from_request` consumes the request
-        // so we can populate a structured 413 body if axum's body-length guard trips.
+        // Snapshot metadata for a potential 413 before `Json::from_request`
+        // consumes the request. `BodyLimit` is `Copy` and `MatchedPath` is
+        // cheap to clone (its payload is an `Arc<str>`), so the non-413
+        // path pays at most two extension lookups plus a ref-count bump.
         let limit = req.extensions().get::<BodyLimit>().copied();
-        let route = req
-            .extensions()
-            .get::<MatchedPath>()
-            .map(|m| m.as_str().to_owned())
-            .unwrap_or_default();
+        let matched = req.extensions().get::<MatchedPath>().cloned();
 
         match Json::<T>::from_request(req, state).await {
             Ok(Json(value)) => Ok(AppJson(value)),
@@ -129,6 +176,10 @@ where
                 tracing::debug!(detail = %rejection.body_text(), "JSON rejection");
                 if status == StatusCode::PAYLOAD_TOO_LARGE {
                     let limit_bytes = limit.map(|l| l.bytes).unwrap_or(0);
+                    let route = matched
+                        .as_ref()
+                        .map(|m| m.as_str().to_owned())
+                        .unwrap_or_default();
                     let body = PayloadTooLargeBody {
                         error: "payload_too_large",
                         limit_bytes,

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -5,11 +5,11 @@ use std::fmt;
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, Query, Request, State},
+    extract::{DefaultBodyLimit, MatchedPath, Path, Query, Request, State},
     http::StatusCode,
     middleware,
     response::{IntoResponse, Response},
-    routing::{get, post, put},
+    routing::{get, post, put, MethodRouter},
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,80 @@ use ff_core::types::*;
 
 use crate::config::ConfigError;
 use crate::server::{Server, ServerError};
+
+// ── Per-route body-size limits (#97) ──
+//
+// Axum's out-of-the-box `DefaultBodyLimit` is 2 MiB and was applied silently
+// with no per-route override, meaning a misrouted multi-GB JSON would still
+// be buffered up to 2 MiB before rejection and mega-byte payloads on
+// control-plane endpoints (cancel, priority, claim, …) were accepted with
+// no protection beyond that global cap.
+//
+// We apply three categories, ordered by generosity:
+//
+//   * `BODY_LIMIT_LARGE_PAYLOAD` (1 MiB) — carries an application
+//     `input_payload` (`POST /v1/executions`). FlowFabric has no Lua-side
+//     cap on `input_payload` (`execution.lua` SETs whatever is passed);
+//     1 MiB matches common workflow-engine conventions (e.g. AWS Step
+//     Functions input size limit is 256 KB, Temporal's default is 2 MiB)
+//     and is an order of magnitude above typical JSON control envelopes.
+//
+//   * `BODY_LIMIT_MEDIUM_PAYLOAD` (256 KiB) — signal delivery
+//     (`POST /v1/executions/{id}/signal`) carries a `DeliverSignalArgs`
+//     with an optional `Vec<u8> payload`. Signals are notification-shaped
+//     events (webhooks, human approvals), not bulk-data transfers; 256 KiB
+//     is the same ceiling Step Functions imposes on task inputs and is
+//     comfortably above any real correlation-id / approval-blob.
+//
+//   * `BODY_LIMIT_CONTROL` (64 KiB) — everything else. Control-plane JSON
+//     bodies (cancel args, priority changes, claim requests, flow
+//     members, budget/quota definitions, rotate-secret keys) are all tiny
+//     fixed-shape records; 64 KiB leaves plenty of headroom for
+//     metadata-heavy bodies while capping DoS amplification by ~32× vs
+//     the previous axum default.
+//
+// Cross-checked against `lua/*.lua` — the only payload-size caps in the
+// Lua layer are `CAPS_MAX_BYTES=4096` / `CAPS_MAX_TOKENS=256` for
+// capability lists (`lua/helpers.lua`). No other Lua path enforces a
+// byte-length limit on incoming payloads, so HTTP is the right layer to
+// draw the line.
+//
+// Future admin routes that need larger bodies (e.g. bulk import) should
+// introduce a new `BODY_LIMIT_ADMIN_BULK` const and opt in per-route
+// rather than bumping `BODY_LIMIT_CONTROL`.
+
+const BODY_LIMIT_LARGE_PAYLOAD: usize = 1024 * 1024;     // 1 MiB
+const BODY_LIMIT_MEDIUM_PAYLOAD: usize = 256 * 1024;     // 256 KiB
+const BODY_LIMIT_CONTROL: usize = 64 * 1024;             // 64 KiB
+
+/// Limit metadata attached to a request via extension so the 413 error body
+/// can report the route's configured cap. The `DefaultBodyLimit::max(bytes)`
+/// layer enforces; this struct only exists for response shape.
+#[derive(Clone, Copy)]
+struct BodyLimit {
+    bytes: usize,
+}
+
+/// Apply per-route body-size cap + attach [`BodyLimit`] extension so the
+/// JSON rejection handler can report `limit_bytes` in the 413 response.
+fn with_body_limit(route: MethodRouter<Arc<Server>>, bytes: usize) -> MethodRouter<Arc<Server>> {
+    let attach_ext =
+        middleware::from_fn(move |mut req: Request, next: middleware::Next| async move {
+            req.extensions_mut().insert(BodyLimit { bytes });
+            let resp: Response = next.run(req).await;
+            resp
+        });
+    let r: MethodRouter<Arc<Server>> = route.layer(attach_ext);
+    r.layer(DefaultBodyLimit::max(bytes))
+}
+
+/// Shape for the 413 response body.
+#[derive(Serialize)]
+struct PayloadTooLargeBody {
+    error: &'static str,
+    limit_bytes: usize,
+    route: String,
+}
 
 // ── Custom JSON extractor (uniform JSON error on malformed body) ──
 
@@ -39,11 +113,29 @@ where
         req: axum::extract::Request,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
+        // Snapshot route + limit before `Json::from_request` consumes the request
+        // so we can populate a structured 413 body if axum's body-length guard trips.
+        let limit = req.extensions().get::<BodyLimit>().copied();
+        let route = req
+            .extensions()
+            .get::<MatchedPath>()
+            .map(|m| m.as_str().to_owned())
+            .unwrap_or_default();
+
         match Json::<T>::from_request(req, state).await {
             Ok(Json(value)) => Ok(AppJson(value)),
             Err(rejection) => {
                 let status = rejection.status();
                 tracing::debug!(detail = %rejection.body_text(), "JSON rejection");
+                if status == StatusCode::PAYLOAD_TOO_LARGE {
+                    let limit_bytes = limit.map(|l| l.bytes).unwrap_or(0);
+                    let body = PayloadTooLargeBody {
+                        error: "payload_too_large",
+                        limit_bytes,
+                        route,
+                    };
+                    return Err((status, Json(body)).into_response());
+                }
                 let body = ErrorBody::plain(format!(
                     "invalid JSON: {}",
                     status.canonical_reason().unwrap_or("bad request"),
@@ -183,9 +275,18 @@ pub fn router(
     let auth_enabled = api_token.is_some();
     let cors = build_cors_layer(cors_origins, auth_enabled)?;
 
+    // Per-route body-size caps (#97). See module-level `BODY_LIMIT_*` consts
+    // for the category rationale; each route picks the tightest cap that
+    // still accommodates expected real traffic.
     let mut app = Router::new()
         // Executions
-        .route("/v1/executions", get(list_executions).post(create_execution))
+        .route(
+            "/v1/executions",
+            with_body_limit(
+                get(list_executions).post(create_execution),
+                BODY_LIMIT_LARGE_PAYLOAD,
+            ),
+        )
         .route("/v1/executions/{id}", get(get_execution))
         .route("/v1/executions/{id}/state", get(get_execution_state))
         .route(
@@ -193,16 +294,34 @@ pub fn router(
             get(list_pending_waitpoints),
         )
         .route("/v1/executions/{id}/result", get(get_execution_result))
-        .route("/v1/executions/{id}/cancel", post(cancel_execution))
-        .route("/v1/executions/{id}/signal", post(deliver_signal))
-        .route("/v1/executions/{id}/priority", put(change_priority))
-        .route("/v1/executions/{id}/replay", post(replay_execution))
-        .route("/v1/executions/{id}/revoke-lease", post(revoke_lease))
+        .route(
+            "/v1/executions/{id}/cancel",
+            with_body_limit(post(cancel_execution), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/executions/{id}/signal",
+            with_body_limit(post(deliver_signal), BODY_LIMIT_MEDIUM_PAYLOAD),
+        )
+        .route(
+            "/v1/executions/{id}/priority",
+            with_body_limit(put(change_priority), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/executions/{id}/replay",
+            with_body_limit(post(replay_execution), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/executions/{id}/revoke-lease",
+            with_body_limit(post(revoke_lease), BODY_LIMIT_CONTROL),
+        )
         // Scheduler-routed claim (Batch C item 2). Worker POSTs lane +
         // identity + capabilities; server runs budget/quota/capability
         // admission via ff-scheduler and returns a ClaimGrant on
         // success (204 No Content when no eligible execution).
-        .route("/v1/workers/{worker_id}/claim", post(claim_for_worker))
+        .route(
+            "/v1/workers/{worker_id}/claim",
+            with_body_limit(post(claim_for_worker), BODY_LIMIT_CONTROL),
+        )
         // Stream read + tail (RFC-006 #2)
         .route(
             "/v1/executions/{id}/attempts/{idx}/stream",
@@ -213,20 +332,50 @@ pub fn router(
             get(tail_attempt_stream),
         )
         // Flows
-        .route("/v1/flows", post(create_flow))
-        .route("/v1/flows/{id}/members", post(add_execution_to_flow))
-        .route("/v1/flows/{id}/cancel", post(cancel_flow))
-        .route("/v1/flows/{id}/edges", post(stage_dependency_edge))
-        .route("/v1/flows/{id}/edges/apply", post(apply_dependency_to_child))
+        .route(
+            "/v1/flows",
+            with_body_limit(post(create_flow), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/flows/{id}/members",
+            with_body_limit(post(add_execution_to_flow), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/flows/{id}/cancel",
+            with_body_limit(post(cancel_flow), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/flows/{id}/edges",
+            with_body_limit(post(stage_dependency_edge), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/flows/{id}/edges/apply",
+            with_body_limit(post(apply_dependency_to_child), BODY_LIMIT_CONTROL),
+        )
         // Budgets
-        .route("/v1/budgets", post(create_budget))
+        .route(
+            "/v1/budgets",
+            with_body_limit(post(create_budget), BODY_LIMIT_CONTROL),
+        )
         .route("/v1/budgets/{id}", get(get_budget_status))
-        .route("/v1/budgets/{id}/usage", post(report_usage))
-        .route("/v1/budgets/{id}/reset", post(reset_budget))
+        .route(
+            "/v1/budgets/{id}/usage",
+            with_body_limit(post(report_usage), BODY_LIMIT_CONTROL),
+        )
+        .route(
+            "/v1/budgets/{id}/reset",
+            with_body_limit(post(reset_budget), BODY_LIMIT_CONTROL),
+        )
         // Quotas
-        .route("/v1/quotas", post(create_quota_policy))
+        .route(
+            "/v1/quotas",
+            with_body_limit(post(create_quota_policy), BODY_LIMIT_CONTROL),
+        )
         // Admin: rotate waitpoint HMAC secret (RFC-004 §Waitpoint Security)
-        .route("/v1/admin/rotate-waitpoint-secret", post(rotate_waitpoint_secret))
+        .route(
+            "/v1/admin/rotate-waitpoint-secret",
+            with_body_limit(post(rotate_waitpoint_secret), BODY_LIMIT_CONTROL),
+        )
         // Health (always unauthenticated)
         .route("/healthz", get(healthz));
 

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -795,7 +795,7 @@ fn json_body_of_len(byte_len: usize) -> Vec<u8> {
     buf.extend_from_slice(b"{\"x\":\"");
     buf.extend(std::iter::repeat_n(b'a', filler));
     buf.extend_from_slice(b"\"}");
-    debug_assert_eq!(buf.len(), byte_len);
+    assert_eq!(buf.len(), byte_len);
     buf
 }
 
@@ -880,9 +880,9 @@ async fn test_api_body_limit_medium_payload_signal() {
 
 /// Control-plane category (64 KiB): exercised via
 /// `POST /v1/executions/{id}/cancel` as a representative control route.
-/// All other control-plane endpoints (priority, replay, claim, flows,
-/// budgets, quotas, rotate-secret) share the same tower layer so
-/// one route is enough.
+/// All other control-plane endpoints (priority, claim, flows, budgets,
+/// quotas, rotate-secret) share the same tower layer so one
+/// body-consuming route is enough for extractor-path coverage.
 #[tokio::test]
 #[serial_test::serial]
 async fn test_api_body_limit_control_cancel_execution() {
@@ -896,4 +896,39 @@ async fn test_api_body_limit_control_cancel_execution() {
         BODY_LIMIT_CONTROL,
     )
     .await;
+}
+
+/// Body-less routes — handlers that take `Path`/`State` but no body
+/// extractor. These rely on the `Content-Length` pre-check middleware
+/// (see PR#100 Copilot review) because `DefaultBodyLimit` alone is a
+/// no-op when the handler never reads the body. Covers one
+/// representative route per verb group.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_body_limit_control_replay_execution_bodyless() {
+    let api = TestApi::setup().await;
+    let eid = ExecutionId::solo(&LaneId::new(LANE), &ff_test::fixtures::TEST_PARTITION_CONFIG);
+    let path = format!("/v1/executions/{eid}/replay");
+    // `replay_execution` has no body extractor. A pre-fix request with
+    // Content-Length > BODY_LIMIT_CONTROL would have reached the handler
+    // and proceeded (the handler ignores the body). Post-fix the
+    // Content-Length check rejects with the structured 413.
+    let over = json_body_of_len(BODY_LIMIT_CONTROL + 1);
+    let resp = api
+        .client
+        .post(api.url(&path))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(over)
+        .send()
+        .await
+        .expect("over-limit replay failed to send");
+    assert_eq!(
+        resp.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "body-less /replay should 413 on over-limit",
+    );
+    let body: PayloadTooLargeBody = resp.json().await.expect("413 body parse");
+    assert_eq!(body.error, "payload_too_large");
+    assert_eq!(body.limit_bytes, BODY_LIMIT_CONTROL);
+    assert_eq!(body.route, "/v1/executions/{id}/replay");
 }

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -754,3 +754,146 @@ async fn test_stream_semaphore_returns_429_on_burst() {
 
     _abort.abort();
 }
+
+// ── Body-size limits (#97) ───────────────────────────────────────────
+//
+// Pre-fix behavior: `ff-server` mounted no per-route `DefaultBodyLimit`
+// override, so axum's silent 2 MiB default applied uniformly. A 10 MiB
+// JSON to `/v1/executions/{id}/cancel` would be accepted up to 2 MiB
+// before rejection, and bodies under 2 MiB on control-plane endpoints
+// had no protection at all.
+//
+// Post-fix: each route opts into one of three caps (large / medium /
+// control — see `api.rs`), and 413 responses carry the structured
+// `{"error":"payload_too_large","limit_bytes":N,"route":"..."}` body.
+//
+// One integration test per category — the cap is enforced by a single
+// tower layer so coverage of one route per limit value is sufficient.
+
+const BODY_LIMIT_LARGE_PAYLOAD: usize = 1024 * 1024;     // 1 MiB
+const BODY_LIMIT_MEDIUM_PAYLOAD: usize = 256 * 1024;     // 256 KiB
+const BODY_LIMIT_CONTROL: usize = 64 * 1024;             // 64 KiB
+
+#[derive(Deserialize)]
+struct PayloadTooLargeBody {
+    error: String,
+    limit_bytes: usize,
+    route: String,
+}
+
+/// Build a request body of exactly `byte_len` bytes that is valid JSON
+/// (`{"x":"aaaa..."}`). Returns the raw bytes. The body intentionally does
+/// NOT deserialize into any real handler arg struct — we only care that
+/// the body-limit gate lets `limit` through and blocks `limit + 1`. Past
+/// the gate, the handler produces 400 (invalid-input), which is still
+/// "not 413" for the purposes of these tests.
+fn json_body_of_len(byte_len: usize) -> Vec<u8> {
+    // `{"x":"` + filler + `"}` → 8 wrapper bytes; filler = byte_len - 8.
+    assert!(byte_len >= 8, "byte_len must be >= 8");
+    let filler = byte_len - 8;
+    let mut buf = Vec::with_capacity(byte_len);
+    buf.extend_from_slice(b"{\"x\":\"");
+    buf.extend(std::iter::repeat_n(b'a', filler));
+    buf.extend_from_slice(b"\"}");
+    debug_assert_eq!(buf.len(), byte_len);
+    buf
+}
+
+/// Post a raw body to `path`, asserting the cap reports `expected_route`
+/// in its 413 body. Runs at `limit - 1` (must NOT be 413) and
+/// `limit + 1` (MUST be 413 + structured body).
+async fn assert_body_limit(
+    api: &TestApi,
+    path: &str,
+    expected_route: &str,
+    limit: usize,
+) {
+    // Under-limit: the body-cap layer must let this through. The handler
+    // itself will 400 on the malformed JSON — that's fine, we only assert
+    // "not 413".
+    let under = json_body_of_len(limit - 1);
+    let resp = api
+        .client
+        .post(api.url(path))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(under)
+        .send()
+        .await
+        .expect("under-limit request failed to send");
+    assert_ne!(
+        resp.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "route {path}: {} bytes (limit - 1) unexpectedly returned 413",
+        limit - 1,
+    );
+
+    // Over-limit: must be 413 with the structured body.
+    let over = json_body_of_len(limit + 1);
+    let resp = api
+        .client
+        .post(api.url(path))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(over)
+        .send()
+        .await
+        .expect("over-limit request failed to send");
+    assert_eq!(
+        resp.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "route {path}: {} bytes (limit + 1) should have returned 413",
+        limit + 1,
+    );
+    let body: PayloadTooLargeBody = resp.json().await.expect("413 body JSON parse failed");
+    assert_eq!(body.error, "payload_too_large");
+    assert_eq!(body.limit_bytes, limit);
+    assert_eq!(body.route, expected_route);
+}
+
+/// Large-payload category (1 MiB): `POST /v1/executions` carries the
+/// worker's `input_payload`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_body_limit_large_payload_create_execution() {
+    let api = TestApi::setup().await;
+    assert_body_limit(&api, "/v1/executions", "/v1/executions", BODY_LIMIT_LARGE_PAYLOAD).await;
+}
+
+/// Medium-payload category (256 KiB): `POST /v1/executions/{id}/signal`
+/// carries an optional `Vec<u8>` signal payload.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_body_limit_medium_payload_signal() {
+    let api = TestApi::setup().await;
+    // Use any syntactically-valid execution-id shape — the handler will
+    // 400 on the body, but we only check that the body-limit gate
+    // enforces the 256 KiB cap upstream of that.
+    let eid = ExecutionId::solo(&LaneId::new(LANE), &ff_test::fixtures::TEST_PARTITION_CONFIG);
+    let path = format!("/v1/executions/{eid}/signal");
+    assert_body_limit(
+        &api,
+        &path,
+        "/v1/executions/{id}/signal",
+        BODY_LIMIT_MEDIUM_PAYLOAD,
+    )
+    .await;
+}
+
+/// Control-plane category (64 KiB): exercised via
+/// `POST /v1/executions/{id}/cancel` as a representative control route.
+/// All other control-plane endpoints (priority, replay, claim, flows,
+/// budgets, quotas, rotate-secret) share the same tower layer so
+/// one route is enough.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_api_body_limit_control_cancel_execution() {
+    let api = TestApi::setup().await;
+    let eid = ExecutionId::solo(&LaneId::new(LANE), &ff_test::fixtures::TEST_PARTITION_CONFIG);
+    let path = format!("/v1/executions/{eid}/cancel");
+    assert_body_limit(
+        &api,
+        &path,
+        "/v1/executions/{id}/cancel",
+        BODY_LIMIT_CONTROL,
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

Closes #97. Adds explicit per-route body-size caps to `ff-server`'s axum router so a misrouted multi-GB JSON no longer silently buffers up to axum's 2 MiB default (or gets charged against memory uniformly across every route). Three categories, picked per-route by the tightest cap that fits expected real traffic:

| Cap | Routes | Rationale |
| --- | --- | --- |
| **1 MiB** | `POST /v1/executions` | Carries application `input_payload` bytes. FlowFabric's Lua layer (`execution.lua`) has no size cap on `input_payload` — HTTP is the right layer to draw the line. 1 MiB sits an order of magnitude above typical JSON control envelopes and lines up with common workflow-engine conventions (AWS Step Functions: 256 KB; Temporal default: 2 MiB). |
| **256 KiB** | `POST /v1/executions/{id}/signal` | `DeliverSignalArgs` carries an optional `Vec<u8>` payload. Signals are notification-shaped (webhooks, approvals), not bulk data. Matches Step Functions' task-input ceiling. |
| **64 KiB** | all other POST/PUT routes — `cancel`, `priority` (PUT), `replay`, `revoke-lease`, `claim`, `flows` (create/members/cancel/edges/edges/apply), `budgets` (create/usage/reset), `quotas`, `admin/rotate-waitpoint-secret` | Control-plane JSON bodies are tiny fixed-shape records. 64 KiB leaves comfortable headroom for metadata-heavy bodies while capping DoS amplification ~32× vs the previous silent default. |

Lua cross-check: the only byte-length caps in `lua/*.lua` are `CAPS_MAX_BYTES=4096` / `CAPS_MAX_TOKENS=256` for capability lists (`lua/helpers.lua`). No other Lua path caps payload size, so HTTP owns the ceiling.

### Error shape

When a cap is exceeded, the server returns **HTTP 413 Payload Too Large** with a structured JSON body:

```json
{
  "error": "payload_too_large",
  "limit_bytes": 262144,
  "route": "/v1/executions/{id}/signal"
}
```

The `route` field uses axum's `MatchedPath` (the pattern with `{id}`, not the literal request path) so clients can match on a stable string. This shape is distinct from the existing 4xx `ErrorBody { error, kind?, retryable? }` — a new flat struct named `PayloadTooLargeBody` — because the 413 path has no `ServerError` kind and no retry semantics to convey.

### Scope notes

The issue description suggested `POST /v1/executions/{id}/complete` and `POST /v1/executions/{id}/append-frame` and `POST /v1/waitpoints/{id}/signal` — those routes don't exist in today's ff-server:

- There's no `/complete` HTTP endpoint; workers complete via direct Valkey FCALL in `ff-script`. `GET /v1/executions/{id}/result` reads the stored payload back, but that's a GET (no body).
- There's no append-frame HTTP endpoint — stream frames are written via FCALL.
- Signal delivery lives at `/v1/executions/{id}/signal`, not under `/v1/waitpoints/`.

The three categories above cover every extant JSON-bodied route.

## Test plan

- [x] `cargo build -p ff-server` clean
- [x] `cargo clippy -p ff-server --all-targets -- -D warnings` clean
- [x] `cargo clippy -p ff-test --tests -- -D warnings` clean
- [x] `cargo test -p ff-server --lib` — 35 passed
- [x] New integration tests in `crates/ff-test/tests/e2e_api.rs`:
  - [x] `test_api_body_limit_large_payload_create_execution` — 1 MiB cap on `/v1/executions`
  - [x] `test_api_body_limit_medium_payload_signal` — 256 KiB cap on signal delivery
  - [x] `test_api_body_limit_control_cancel_execution` — 64 KiB cap on cancel (representative of the whole control-plane category; all share the same tower layer)

  Each test asserts `limit - 1` bytes passes the body-limit gate (status != 413; the handler itself may still 400 on malformed JSON, which is fine) and `limit + 1` bytes returns 413 with the structured body.
- [x] `cargo test -p ff-test --test e2e_api` — all 16 tests pass (13 pre-existing + 3 new)
- [x] `cargo test -p ff-test --test admin_rotate_api --test result_api --test pending_waitpoints_api` — 11 passed (no regression in auth / result / waitpoint paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP request acceptance by introducing strict per-endpoint body caps (64KiB/256KiB/1MiB), which could break clients that previously sent larger payloads and now receive 413 responses.
> 
> **Overview**
> Adds **per-route request body-size enforcement** to `ff-server` by wrapping JSON-bodied endpoints with `DefaultBodyLimit` using three caps: **1 MiB** for `POST /v1/executions`, **256 KiB** for `POST /v1/executions/{id}/signal`, and **64 KiB** for all other POST/PUT control-plane routes.
> 
> Extends the custom `AppJson` extractor to return a **structured 413** response (`{"error":"payload_too_large","limit_bytes":...,"route":...}`) using axum’s `MatchedPath`, and adds e2e tests that assert under/over-limit behavior for one representative route per cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14ad41c1775a96f56ec638ab0c427b6a5f7ac2f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->