### PR TITLE
docs: complete env-var reference + DEPLOYMENT.md (#95)

### DIFF
--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -62,12 +62,14 @@ impl ServerConfig {
     /// the canonical rustdoc mirror of the identical table in the top-level
     /// `README.md`. `docs/DEPLOYMENT.md` references these names.
     ///
-    /// **Maintenance contract:** every `std::env::var(...)` call in the body
-    /// of `from_env` MUST have a row here. When you add, rename, or remove
-    /// an env var, update this table in the same commit. There is no
-    /// compile-time check — reviewers enforce it. Legacy aliases accepted
-    /// during a rename window (e.g. `FF_MAX_CONCURRENT_TAIL`) should be
-    /// listed alongside their preferred name.
+    /// **Maintenance contract:** every env var key this function consumes —
+    /// whether via a direct `std::env::var(...)` call or through the
+    /// `env_or` / `env_bool` / `env_u16` / `env_u16_positive` / `env_u64` /
+    /// `env_u32_positive` helpers — MUST have a row here. When you add,
+    /// rename, or remove an env var, update this table in the same commit.
+    /// There is no compile-time check — reviewers enforce it. Legacy
+    /// aliases accepted during a rename window (e.g. `FF_MAX_CONCURRENT_TAIL`)
+    /// should be listed alongside their preferred name.
     ///
     /// | Variable | Default | Description |
     /// |----------|---------|-------------|

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -58,22 +58,49 @@ pub struct ServerConfig {
 impl ServerConfig {
     /// Load configuration from environment variables.
     ///
+    /// The table below enumerates every variable this function reads. It is
+    /// the canonical rustdoc mirror of the identical table in the top-level
+    /// `README.md`. `docs/DEPLOYMENT.md` references these names.
+    ///
+    /// **Maintenance contract:** every `std::env::var(...)` call in the body
+    /// of `from_env` MUST have a row here. When you add, rename, or remove
+    /// an env var, update this table in the same commit. There is no
+    /// compile-time check — reviewers enforce it. Legacy aliases accepted
+    /// during a rename window (e.g. `FF_MAX_CONCURRENT_TAIL`) should be
+    /// listed alongside their preferred name.
+    ///
     /// | Variable | Default | Description |
     /// |----------|---------|-------------|
+    /// | `FF_WAITPOINT_HMAC_SECRET` | *required* | Hex-encoded HMAC signing secret for waitpoint tokens (RFC-004 §Waitpoint Security). Even-length hex; 64 chars (32 bytes) recommended. Boot fails without it. |
     /// | `FF_HOST` | `localhost` | Valkey host |
     /// | `FF_PORT` | `6379` | Valkey port |
-    /// | `FF_TLS` | `false` | Enable TLS (`1` or `true`) |
-    /// | `FF_CLUSTER` | `false` | Enable cluster mode (`1` or `true`) |
+    /// | `FF_TLS` | `false` | Enable TLS for Valkey (`1` or `true`) |
+    /// | `FF_CLUSTER` | `false` | Enable Valkey cluster mode (`1` or `true`) |
     /// | `FF_LISTEN_ADDR` | `0.0.0.0:9090` | API listen address |
-    /// | `FF_LANES` | `default` | Comma-separated lane names |
+    /// | `FF_LANES` | `default` | Comma-separated lane names; at least one non-empty lane required |
     /// | `FF_FLOW_PARTITIONS` | `256` | Flow partition count — authoritative; under RFC-011 hash-tag co-location, exec keys also route here |
     /// | `FF_BUDGET_PARTITIONS` | `32` | Budget partition count |
     /// | `FF_QUOTA_PARTITIONS` | `32` | Quota partition count |
-    /// | `FF_CORS_ORIGINS` | `*` | Comma-separated CORS origins (`*` = permissive) |
-    /// | `FF_API_TOKEN` | *(none)* | Shared-secret Bearer token. If set, all non-healthz requests require it. |
-    /// | `FF_LEASE_EXPIRY_INTERVAL_MS` | `1500` | Lease expiry scanner interval |
-    /// | `FF_DELAYED_PROMOTER_INTERVAL_MS` | `750` | Delayed promoter interval |
+    /// | `FF_CORS_ORIGINS` | `*` | Comma-separated CORS origins (`*` = permissive). Empty string is rejected; unset the var to get the default. |
+    /// | `FF_API_TOKEN` | *(none)* | Shared-secret Bearer token. If set, all non-`/healthz` requests require it. |
+    /// | `FF_WAITPOINT_HMAC_GRACE_MS` | `86400000` | Grace window (ms) during which tokens signed by the previous kid remain accepted after rotation. Default 24h. |
+    /// | `FF_MAX_CONCURRENT_STREAM_OPS` | `64` | Shared semaphore bound for `read_attempt_stream` + `tail_attempt_stream`. Legacy `FF_MAX_CONCURRENT_TAIL` is accepted as a fallback; if both are set, the new name wins. |
+    /// | `FF_MAX_CONCURRENT_TAIL` | *(legacy)* | Deprecated alias for `FF_MAX_CONCURRENT_STREAM_OPS`; accepted during the R4 rename window. |
+    /// | `FF_LEASE_EXPIRY_INTERVAL_MS` | `1500` | Lease-expiry scanner interval |
+    /// | `FF_DELAYED_PROMOTER_INTERVAL_MS` | `750` | Delayed-promoter scanner interval |
     /// | `FF_INDEX_RECONCILER_INTERVAL_S` | `45` | Index reconciler interval |
+    /// | `FF_ATTEMPT_TIMEOUT_INTERVAL_S` | `2` | Attempt-timeout scanner interval |
+    /// | `FF_SUSPENSION_TIMEOUT_INTERVAL_S` | `2` | Suspension-timeout scanner interval |
+    /// | `FF_PENDING_WP_EXPIRY_INTERVAL_S` | `5` | Pending-waitpoint expiry scanner interval |
+    /// | `FF_RETENTION_TRIMMER_INTERVAL_S` | `60` | Retention-trimmer scanner interval |
+    /// | `FF_BUDGET_RESET_INTERVAL_S` | `15` | Budget-reset scanner interval |
+    /// | `FF_BUDGET_RECONCILER_INTERVAL_S` | `30` | Budget reconciler interval |
+    /// | `FF_QUOTA_RECONCILER_INTERVAL_S` | `30` | Quota reconciler interval |
+    /// | `FF_UNBLOCK_INTERVAL_S` | `5` | Unblock scanner interval |
+    /// | `FF_DEPENDENCY_RECONCILER_INTERVAL_S` | `15` | DAG dependency reconciler interval (safety net behind push-based promotion) |
+    /// | `FF_FLOW_PROJECTOR_INTERVAL_S` | `15` | Flow projector scanner interval |
+    /// | `FF_EXECUTION_DEADLINE_INTERVAL_S` | `5` | Execution-deadline scanner interval |
+    /// | `FF_CANCEL_RECONCILER_INTERVAL_S` | `15` | Cancel reconciler scanner interval |
     pub fn from_env() -> Result<Self, ConfigError> {
         let host = env_or("FF_HOST", "localhost");
         let port = env_u16("FF_PORT", 6379)?;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,342 @@
+# FlowFabric deployment guide
+
+Minimum-viable production deployment. Covers the four components you need:
+one `ff-server`, one Valkey, N workers linked against `ff-sdk`, and a
+reverse proxy for TLS + rate limiting. FlowFabric is pre-1.0; treat this
+as guidance, not a contract.
+
+> For local development use `cargo run -p ff-server` with
+> `FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32)` — the README's
+> quickstart section is simpler than this guide.
+
+## Topology
+
+```
+             ┌──────────────┐
+             │ reverse proxy│  TLS, rate limit, (optional) auth mirror
+             │  (nginx /    │
+             │   Envoy)     │
+             └──────┬───────┘
+                    │ HTTP (plaintext, localhost or private net)
+                    ▼
+             ┌──────────────┐
+             │  ff-server   │  :9090 (axum) — stateless, horizontally
+             │ (1+ replica) │  scalable behind the proxy
+             └──────┬───────┘
+                    │ RESP (optionally TLS)
+                    ▼
+             ┌──────────────┐
+             │    Valkey    │  :6379 — the source of truth
+             │  (7.2 / 8)   │  standalone or cluster
+             └──────▲───────┘
+                    │ RESP (workers talk directly for claim/signal)
+                    │
+             ┌──────┴───────┐
+             │   workers    │  N processes linking ff-sdk
+             │ (your code)  │
+             └──────────────┘
+```
+
+Workers open their own Valkey connection via the SDK; they do **not** route
+execution traffic through `ff-server`. Keep this in mind when sizing the
+Valkey connection budget.
+
+## 1. Valkey
+
+FlowFabric targets [Valkey](https://valkey.io/) 7.2+. CI exercises 7.2 and 8.
+Redis 7.x works in practice today but is not part of the support matrix
+(module ABI and behaviour diverge post-fork).
+
+### Standalone vs cluster
+
+| Mode        | When to pick it                                                                 |
+| ----------- | ------------------------------------------------------------------------------- |
+| Standalone  | Development, single-tenant, throughput fits one node (< ~50k ops/s). Simplest.  |
+| Cluster     | Horizontal write-scale needed, operational experience with cluster ops on hand. |
+
+FlowFabric hash-tags every key (`{fp:N}`, `{p:N}`, `{bp:N}`, `{qp:N}`) so
+related keys always land on the same slot. Increasing `FF_FLOW_PARTITIONS`
+gives the cluster more slots to spread across without changing the model.
+
+### Persistence
+
+Valkey defaults (RDB snapshots only) are **not** safe for FlowFabric
+state. Turn on AOF with fsync-every-second or stronger:
+
+```conf
+# valkey.conf
+appendonly yes
+appendfsync everysec
+# Keep RDB for fast restarts:
+save 900 1
+save 300 10
+save 60 10000
+# Rewrite AOF in the background when it doubles:
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+```
+
+### Memory sizing
+
+Rough planning numbers (production, steady state):
+
+- Baseline overhead: ~50 MB per empty node.
+- Per in-flight attempt: ~4 KB (`exec_core` hash + indexes + stream frames
+  until trimmed by the retention scanner).
+- Per completed-but-retained attempt: ~1 KB until
+  `FF_RETENTION_TRIMMER_INTERVAL_S` reclaims it.
+- Budget / quota counters: negligible (tens of bytes each).
+
+For 10k concurrent attempts with a 1-hour retention window and ~20k
+completions/hour, plan for roughly 200 MB + headroom. Set `maxmemory`
+explicitly and pick an eviction policy that refuses writes rather than
+evicting state:
+
+```conf
+maxmemory 2gb
+maxmemory-policy noeviction
+```
+
+`noeviction` is mandatory — silent key eviction corrupts the scheduler's
+invariants.
+
+### Security
+
+- Bind to a private interface, or use `requirepass` + TLS.
+- TLS between `ff-server` and Valkey: set `FF_TLS=true` and point
+  `FF_HOST` at the TLS endpoint. The client uses rustls defaults
+  (platform trust store).
+
+## 2. ff-server
+
+Stateless HTTP API in front of Valkey. Runs the 14 background scanners
+that drive timeouts, promotions, reconciliation, and retention.
+
+### Required env vars
+
+| Variable                   | Purpose                                                                                               |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `FF_WAITPOINT_HMAC_SECRET` | Even-length hex signing secret for waitpoint tokens (RFC-004). **Server refuses to start without it.** 64 hex chars recommended. Source from a secret manager. |
+
+### Recommended env vars for any non-trivial deployment
+
+| Variable          | Typical value                          | Why                                                                         |
+| ----------------- | -------------------------------------- | --------------------------------------------------------------------------- |
+| `FF_HOST`         | Valkey hostname                        | Defaults to `localhost` — almost always wrong in production.                |
+| `FF_PORT`         | `6379`                                 | Set if you moved Valkey off the default port.                               |
+| `FF_TLS`          | `true`                                 | TLS to Valkey whenever the link crosses a trust boundary.                   |
+| `FF_CLUSTER`      | `true` when using Valkey cluster.      | Enables cluster-aware routing in the embedded client.                       |
+| `FF_LISTEN_ADDR`  | `0.0.0.0:9090` or `127.0.0.1:9090`     | Bind to loopback if a reverse proxy is on the same host.                    |
+| `FF_API_TOKEN`    | Random 32+ byte secret, base64.        | Without it, every route except `GET /healthz` is unauthenticated.           |
+| `FF_CORS_ORIGINS` | Comma-separated allowlist, or `*`      | Default is permissive (`*`). Tighten before exposing the API to browsers.   |
+
+The complete list of variables (all the scanner intervals, partition
+counts, etc.) is in the rustdoc for
+[`ServerConfig::from_env`](../crates/ff-server/src/config.rs) and mirrored
+in the project `README.md`. Both tables are kept in sync manually; the
+`from_env` rustdoc is the canonical reference.
+
+### Ports
+
+- `9090/tcp` — HTTP API (axum). Plaintext. Put it behind a proxy if it
+  crosses a trust boundary.
+- `GET /healthz` is unauthenticated and cheap — use it for liveness
+  probes.
+
+### Scaling ff-server horizontally
+
+`ff-server` is effectively stateless: state lives in Valkey. You can run
+multiple replicas behind the proxy. The background scanners are
+cooperative — running more than one replica is safe but does not speed up
+scanner work, since each scanner claims its partition shards via Lua.
+Two to three replicas is a reasonable HA target; going wider wastes
+cycles without changing throughput.
+
+## 3. Workers (ff-sdk)
+
+Workers are your code. They link against `ff-sdk`, declare capabilities,
+and process attempts claimed from the scheduler.
+
+### Sizing and placement
+
+- Start with one worker per capability class per host. Scale out
+  horizontally; workers are stateless.
+- `worker_id` **must be unique** across the deployment. Any string works;
+  `${hostname}-${pid}` or a UUID are both fine. Reusing a `worker_id`
+  after a crash is safe — the scheduler reclaims the previous lease via
+  `FF_LEASE_EXPIRY_INTERVAL_MS`.
+
+### Lease TTL tuning
+
+`lease_ttl_ms` (per-claim, set in the SDK call) controls how long a
+claim survives without a heartbeat.
+
+| Workload                 | Suggested `lease_ttl_ms` |
+| ------------------------ | ------------------------ |
+| Sub-second operations    | 5_000                    |
+| Seconds-to-minutes       | 30_000 – 60_000          |
+| Long-running (LLM, CI)   | 300_000 with heartbeats  |
+
+Rules of thumb:
+
+- Lease TTL must be longer than any non-heartbeat gap in your worker.
+- Longer leases slow crash recovery — a dead worker blocks retries until
+  the lease expires.
+- Heartbeats (`heartbeat_attempt`) refresh the lease without changing
+  its original TTL, so set the TTL once at claim time.
+
+### Capability declarations
+
+Each worker declares the capability set it can serve (see the
+coding-agent example under `examples/coding-agent/` for the canonical
+pattern). Capabilities route work; keep them deliberate and narrow.
+
+### Feature gates
+
+`ff-sdk`'s direct `claim_next()` bypasses budget/quota admission and is
+gated behind the `direct-valkey-claim` feature. Production deployments
+use `ff-scheduler`'s claim-grant cycle instead. Enable the direct path
+only for dev/test or trusted single-worker setups — see the README for
+the toggle.
+
+## 4. Reverse proxy (TLS + rate limit)
+
+`ff-server` serves plaintext HTTP and does not rate-limit. Both jobs
+belong to a proxy in front of it — nginx, Envoy, HAProxy, or a managed
+LB work.
+
+Minimum expectations for the proxy:
+
+- Terminate TLS.
+- Enforce rate limits per client. `ff-server` has no HTTP connection cap
+  either (axum accepts unbounded connections), so the proxy is also the
+  connection-limit point.
+- Forward `Authorization: Bearer <FF_API_TOKEN>` unmodified.
+- `GET /healthz` should be reachable without auth for probes.
+
+Example nginx snippet:
+
+```nginx
+upstream ff_server {
+    server 127.0.0.1:9090;
+    keepalive 32;
+}
+
+limit_req_zone $binary_remote_addr zone=ff_api:10m rate=100r/s;
+
+server {
+    listen 443 ssl http2;
+    server_name flowfabric.example.com;
+
+    ssl_certificate     /etc/ssl/certs/flowfabric.pem;
+    ssl_certificate_key /etc/ssl/private/flowfabric.key;
+
+    location = /healthz {
+        proxy_pass http://ff_server;
+    }
+
+    location / {
+        limit_req zone=ff_api burst=200 nodelay;
+        proxy_pass http://ff_server;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}
+```
+
+## 5. Docker Compose reference
+
+A minimum stack you can adapt. This runs Valkey with AOF, one
+`ff-server`, and leaves worker processes to your application image.
+
+```yaml
+# docker-compose.yml
+services:
+  valkey:
+    image: valkey/valkey:8-alpine
+    command: >
+      valkey-server
+      --appendonly yes
+      --appendfsync everysec
+      --maxmemory 2gb
+      --maxmemory-policy noeviction
+    volumes:
+      - valkey-data:/data
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  ff-server:
+    image: flowfabric/ff-server:latest  # build from this repo
+    depends_on:
+      valkey:
+        condition: service_healthy
+    environment:
+      FF_HOST: valkey
+      FF_PORT: "6379"
+      FF_LISTEN_ADDR: "0.0.0.0:9090"
+      FF_WAITPOINT_HMAC_SECRET: ${FF_WAITPOINT_HMAC_SECRET:?set via env or secret}
+      FF_API_TOKEN: ${FF_API_TOKEN:?set via env or secret}
+      FF_FLOW_PARTITIONS: "256"
+      RUST_LOG: "info,ff_server=info,ff_engine=info"
+    ports:
+      - "127.0.0.1:9090:9090"  # bind to loopback; proxy handles :443
+    restart: unless-stopped
+
+  # Example worker — replace with your own image.
+  worker:
+    image: yourorg/your-worker:latest
+    depends_on:
+      - ff-server
+    environment:
+      FF_HOST: valkey
+      FF_PORT: "6379"
+      FF_API_TOKEN: ${FF_API_TOKEN:?set via env or secret}
+      WORKER_ID: "${HOSTNAME}-worker-1"
+    restart: unless-stopped
+    deploy:
+      replicas: 4
+
+volumes:
+  valkey-data:
+```
+
+Generate the HMAC secret and API token once, out-of-band:
+
+```bash
+export FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32)
+export FF_API_TOKEN=$(openssl rand -base64 32)
+```
+
+## 6. Observability
+
+Today `ff-server` emits structured `tracing` logs to stderr; route them
+with `RUST_LOG` (e.g. `RUST_LOG=info,ff_engine=debug`). There is no
+Prometheus endpoint yet — metrics are tracked as
+[issue #94](https://github.com/HiveTechs/FlowFabric/issues/94). Until
+that lands, scrape log-derived metrics (e.g. via Vector or Loki) and
+use `GET /healthz` for liveness.
+
+Log lines worth alerting on:
+
+- `error` at `ff_server::server` — a request failed to complete.
+- `warn` containing `lease expired` — indicates workers dying or leases
+  set too short.
+- `warn` at `ff_engine::*` reconcilers — scanner-level errors;
+  occasional ones are normal, sustained ones mean Valkey pressure.
+
+## 7. Upgrade checklist
+
+1. Drain workers gracefully (stop claiming, finish in-flight attempts).
+2. Stop `ff-server` replicas; new versions will auto-reload the Lua
+   library on first use.
+3. Roll the new `ff-server` image.
+4. Start workers against the new server.
+5. Confirm `GET /healthz` is 200 and scanner intervals in the logs
+   match expectations.
+
+Rolling upgrades work when the release notes say so; otherwise treat
+every upgrade as stop-the-world until FlowFabric ships a documented
+rolling path.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -54,9 +54,11 @@ Redis 7.x works in practice today but is not part of the support matrix
 | Standalone  | Development, single-tenant, throughput fits one node (< ~50k ops/s). Simplest.  |
 | Cluster     | Horizontal write-scale needed, operational experience with cluster ops on hand. |
 
-FlowFabric hash-tags every key (`{fp:N}`, `{p:N}`, `{bp:N}`, `{qp:N}`) so
-related keys always land on the same slot. Increasing `FF_FLOW_PARTITIONS`
-gives the cluster more slots to spread across without changing the model.
+FlowFabric hash-tags every key — `{fp:N}` for flow + execution (RFC-011
+co-locates both families on the same tag), `{b:M}` for budgets, `{q:K}`
+for quotas — so related keys always land on the same slot. Increasing
+`FF_FLOW_PARTITIONS` gives the cluster more slots to spread across
+without changing the model.
 
 ### Persistence
 
@@ -109,8 +111,13 @@ invariants.
 
 ## 2. ff-server
 
-Stateless HTTP API in front of Valkey. Runs the 14 background scanners
-that drive timeouts, promotions, reconciliation, and retention.
+Stateless HTTP API in front of Valkey. Runs the 15 background scanners
+in `ff-engine` (attempt-timeout, budget-reset, budget-reconciler,
+cancel-reconciler, delayed-promoter, dependency-reconciler,
+execution-deadline, flow-projector, index-reconciler, lease-expiry,
+pending-waitpoint-expiry, quota-reconciler, retention-trimmer,
+suspension-timeout, unblock) plus an optional completion listener —
+they drive timeouts, promotions, reconciliation, and retention.
 
 ### Required env vars
 


### PR DESCRIPTION
## Summary

Closes #95. Two parts:

### Part A — `ServerConfig::from_env` rustdoc env-var drift

The rustdoc table in `crates/ff-server/src/config.rs` listed ~14 of the 24+ env vars that `from_env` actually reads. Regenerated the table straight from the body so every `std::env::var(...)` call has a row, marked the required var, listed the legacy alias, and added a maintenance-contract comment above the table telling future editors to update it in the same commit as the body.

Vars added with their `from_env` line numbers:

| Var | Line |
|-----|------|
| `FF_WAITPOINT_HMAC_SECRET` (required) | 117 |
| `FF_WAITPOINT_HMAC_GRACE_MS` | 139 |
| `FF_MAX_CONCURRENT_STREAM_OPS` + legacy `FF_MAX_CONCURRENT_TAIL` | 145 / 147 |
| `FF_ATTEMPT_TIMEOUT_INTERVAL_S` | 177 |
| `FF_SUSPENSION_TIMEOUT_INTERVAL_S` | 179 |
| `FF_PENDING_WP_EXPIRY_INTERVAL_S` | 181 |
| `FF_RETENTION_TRIMMER_INTERVAL_S` | 183 |
| `FF_BUDGET_RESET_INTERVAL_S` | 185 |
| `FF_BUDGET_RECONCILER_INTERVAL_S` | 187 |
| `FF_QUOTA_RECONCILER_INTERVAL_S` | 189 |
| `FF_UNBLOCK_INTERVAL_S` | 191 |
| `FF_DEPENDENCY_RECONCILER_INTERVAL_S` | 197 |
| `FF_FLOW_PROJECTOR_INTERVAL_S` | 219 |
| `FF_EXECUTION_DEADLINE_INTERVAL_S` | 222 |
| `FF_CANCEL_RECONCILER_INTERVAL_S` | 225 |

The table now matches the one in `README.md §Production considerations` (Worker C's PR #79 shipped that half earlier).

No compile-time check — the issue describes this as process-discipline and the comment block makes that explicit.

### Part B — `docs/DEPLOYMENT.md`

New file, ~340 lines. One section per component:

- **Topology** diagram showing workers talk to Valkey directly (not through ff-server).
- **Valkey** — 7.2+, standalone vs cluster guidance, AOF + `maxmemory noeviction` config, rough sizing numbers.
- **ff-server** — required env var (`FF_WAITPOINT_HMAC_SECRET`), recommended ones, ports, horizontal-scale note.
- **Workers (ff-sdk)** — worker_id uniqueness, `lease_ttl_ms` tuning table, capability declarations, feature-gate note.
- **Reverse proxy** — TLS termination + rate limiting, nginx snippet.
- **Docker Compose** reference stack with Valkey + ff-server + worker.
- **Observability** — tracing logs today; metrics cross-referenced to #94, not scaffolded.
- **Upgrade checklist.**

## Test plan

- [x] `cargo doc -p ff-server --no-deps` clean for `config.rs`. Two remaining warnings are pre-existing in `server.rs` (unresolved link `source`, private-item link `ParsedCancelFlow::AlreadyTerminal`) — not touched by this PR.
- [x] Rustdoc table cross-checked line-by-line against every `std::env::var(...)` call in `from_env`.
- [x] Rustdoc table matches README env-var table.
- [ ] `docs/DEPLOYMENT.md` — the docker-compose and nginx snippets were **not** executed end-to-end in this session; they are illustrative. The env-var content in the doc was validated against `config.rs`. Call this out in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation/rustdoc updates; no functional runtime behavior changes beyond clarifying/standardizing configuration documentation, so operational risk is low.
> 
> **Overview**
> Adds a new `docs/DEPLOYMENT.md` with a minimum production topology and operational guidance (Valkey persistence/sizing/security, `ff-server` env vars/ports/scaling, worker tuning, reverse proxy recommendations, and compose examples).
> 
> Updates `ServerConfig::from_env` rustdoc in `crates/ff-server/src/config.rs` to be a **complete, canonical** env-var table (including required `FF_WAITPOINT_HMAC_SECRET`, scanner interval knobs, and the `FF_MAX_CONCURRENT_STREAM_OPS`/legacy `FF_MAX_CONCURRENT_TAIL` alias) and introduces an explicit maintenance contract to keep the table in sync with `from_env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25fbb6ddabdf94a2167cd023ce84fa5d3f4dc8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->