### PR TITLE
fix(ff-server): cap budget dimensions to bound FCALL ARGV (#104)

### DIFF
--- a/crates/ff-script/src/functions/budget.rs
+++ b/crates/ff-script/src/functions/budget.rs
@@ -6,9 +6,16 @@ use ff_core::keys::{ExecKeyContext, IndexKeys};
 
 use crate::result::{FcallResult, FromFcallResult};
 
-/// Mirror of `ff_server::server::MAX_BUDGET_DIMENSIONS` (#104). Duplicated
-/// here so direct script-helper callers (tests, tools) don't bypass the cap
-/// when they reach Valkey without traversing the HTTP server layer.
+/// Single source of truth for the budget dimension cap (#104).
+///
+/// Enforced at both the HTTP boundary in `ff-server` (which re-exports this
+/// constant) and inside the typed FCALL wrappers below, so direct
+/// script-helper callers (tests, tools, alternate services) cannot reach
+/// Valkey with an unbounded `dim_count` by skipping the REST layer.
+///
+/// 64 is generously above any legitimate scoping dimension count
+/// (org/tenant/project/region/lane/tier/…) while bounding worst-case
+/// FCALL ARGV to ~200 strings — well below Valkey argv limits.
 pub const MAX_BUDGET_DIMENSIONS: usize = 64;
 
 /// Key context for budget operations on {b:M}.

--- a/crates/ff-script/src/functions/budget.rs
+++ b/crates/ff-script/src/functions/budget.rs
@@ -6,6 +6,11 @@ use ff_core::keys::{ExecKeyContext, IndexKeys};
 
 use crate::result::{FcallResult, FromFcallResult};
 
+/// Mirror of `ff_server::server::MAX_BUDGET_DIMENSIONS` (#104). Duplicated
+/// here so direct script-helper callers (tests, tools) don't bypass the cap
+/// when they reach Valkey without traversing the HTTP server layer.
+pub const MAX_BUDGET_DIMENSIONS: usize = 64;
+
 /// Key context for budget operations on {b:M}.
 pub struct BudgetOpKeys<'a> {
     pub usage_key: &'a str,
@@ -46,6 +51,27 @@ pub async fn ff_create_budget(
     ];
 
     let dim_count = args.dimensions.len();
+    // Cap ARGV before allocation — see MAX_BUDGET_DIMENSIONS (#104).
+    if dim_count > MAX_BUDGET_DIMENSIONS {
+        return Err(ScriptError::Parse(format!(
+            "too_many_dimensions: limit={}, got={}",
+            MAX_BUDGET_DIMENSIONS, dim_count
+        )));
+    }
+    if args.hard_limits.len() != dim_count {
+        return Err(ScriptError::Parse(format!(
+            "dimension_limit_array_mismatch: dimensions={} hard_limits={}",
+            dim_count,
+            args.hard_limits.len()
+        )));
+    }
+    if args.soft_limits.len() != dim_count {
+        return Err(ScriptError::Parse(format!(
+            "dimension_limit_array_mismatch: dimensions={} soft_limits={}",
+            dim_count,
+            args.soft_limits.len()
+        )));
+    }
     // ARGV: budget_id, scope_type, scope_id, enforcement_mode,
     //   on_hard_limit, on_soft_limit, reset_interval_ms, now_ms,
     //   dim_count, dim_1..dim_N, hard_1..hard_N, soft_1..soft_N
@@ -113,6 +139,20 @@ pub async fn ff_report_usage_and_check(
 
     // Build flat ARGV: [dim_count, dim1..dimN, delta1..deltaN, now_ms, dedup_key]
     let dim_count = args.dimensions.len();
+    // Cap ARGV before allocation — see MAX_BUDGET_DIMENSIONS (#104).
+    if dim_count > MAX_BUDGET_DIMENSIONS {
+        return Err(ScriptError::Parse(format!(
+            "too_many_dimensions: limit={}, got={}",
+            MAX_BUDGET_DIMENSIONS, dim_count
+        )));
+    }
+    if args.deltas.len() != dim_count {
+        return Err(ScriptError::Parse(format!(
+            "dimension_delta_array_mismatch: dimensions={} deltas={}",
+            dim_count,
+            args.deltas.len()
+        )));
+    }
     let mut argv: Vec<String> = Vec::with_capacity(3 + dim_count * 2);
     argv.push(dim_count.to_string());
     for dim in &args.dimensions {

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -39,6 +39,83 @@ use crate::config::ServerConfig;
 /// returns the full list; retries only need a sample.
 const ALREADY_TERMINAL_MEMBER_CAP: usize = 1000;
 
+/// Upper bound on the number of dimensions a single budget policy may declare,
+/// and on the number of dimensions a single `report_usage` call may touch.
+///
+/// The limit exists to cap FCALL ARGV allocation: both `create_budget` and
+/// `report_usage` build argv whose length is linear in `dimensions.len()`,
+/// so an untrusted caller could otherwise request an unbounded `Vec`
+/// allocation (CodeQL `rust/uncontrolled-allocation-size`, issue #104).
+///
+/// 64 is generously above any legitimate scoping dimension count
+/// (org/tenant/project/region/lane/tier/…) while bounding worst-case
+/// ARGV to ~200 strings — well below Valkey argv limits.
+pub(crate) const MAX_BUDGET_DIMENSIONS: usize = 64;
+
+/// Validate `create_budget` dimension inputs before building the FCALL argv.
+///
+/// Rejects:
+///   * more than [`MAX_BUDGET_DIMENSIONS`] dimensions (prevents unbounded
+///     `Vec::with_capacity` allocation on attacker-controlled length);
+///   * parallel-array length mismatches between `dimensions`, `hard_limits`,
+///     and `soft_limits` — these are positional inputs the Lua side indexes
+///     by `i = 1..dim_count`, so a mismatch silently corrupts limits rather
+///     than raising.
+fn validate_create_budget_dimensions(
+    dimensions: &[String],
+    hard_limits: &[u64],
+    soft_limits: &[u64],
+) -> Result<(), ServerError> {
+    let dim_count = dimensions.len();
+    if dim_count > MAX_BUDGET_DIMENSIONS {
+        return Err(ServerError::InvalidInput(format!(
+            "too_many_dimensions: limit={}, got={}",
+            MAX_BUDGET_DIMENSIONS, dim_count
+        )));
+    }
+    if hard_limits.len() != dim_count {
+        return Err(ServerError::InvalidInput(format!(
+            "dimension_limit_array_mismatch: dimensions={} hard_limits={}",
+            dim_count,
+            hard_limits.len()
+        )));
+    }
+    if soft_limits.len() != dim_count {
+        return Err(ServerError::InvalidInput(format!(
+            "dimension_limit_array_mismatch: dimensions={} soft_limits={}",
+            dim_count,
+            soft_limits.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Validate `report_usage` dimension inputs before building the FCALL argv.
+///
+/// Same class of defense as [`validate_create_budget_dimensions`]: caps
+/// argv length and enforces the `dimensions`/`deltas` parallel-array
+/// invariant the Lua side relies on.
+fn validate_report_usage_dimensions(
+    dimensions: &[String],
+    deltas: &[u64],
+) -> Result<(), ServerError> {
+    let dim_count = dimensions.len();
+    if dim_count > MAX_BUDGET_DIMENSIONS {
+        return Err(ServerError::InvalidInput(format!(
+            "too_many_dimensions: limit={}, got={}",
+            MAX_BUDGET_DIMENSIONS, dim_count
+        )));
+    }
+    if deltas.len() != dim_count {
+        return Err(ServerError::InvalidInput(format!(
+            "dimension_delta_array_mismatch: dimensions={} deltas={}",
+            dim_count,
+            deltas.len()
+        )));
+    }
+    Ok(())
+}
+
 /// FlowFabric server — connects everything together.
 ///
 /// Manages the Valkey connection, Lua library loading, background scanners,
@@ -1017,6 +1094,12 @@ impl Server {
         &self,
         args: &CreateBudgetArgs,
     ) -> Result<CreateBudgetResult, ServerError> {
+        // Cap ARGV before allocation — see MAX_BUDGET_DIMENSIONS (#104).
+        validate_create_budget_dimensions(
+            &args.dimensions,
+            &args.hard_limits,
+            &args.soft_limits,
+        )?;
         let partition = budget_partition(&args.budget_id, &self.config.partition_config);
         let bctx = BudgetKeyContext::new(&partition, &args.budget_id);
         let resets_key = keys::budget_resets_key(bctx.hash_tag());
@@ -1186,6 +1269,8 @@ impl Server {
         budget_id: &BudgetId,
         args: &ReportUsageArgs,
     ) -> Result<ReportUsageResult, ServerError> {
+        // Cap ARGV before allocation — see MAX_BUDGET_DIMENSIONS (#104).
+        validate_report_usage_dimensions(&args.dimensions, &args.deltas)?;
         let partition = budget_partition(budget_id, &self.config.partition_config);
         let bctx = BudgetKeyContext::new(&partition, budget_id);
 
@@ -4192,6 +4277,110 @@ mod tests {
 
     fn mk_fk_err(kind: ErrorKind) -> ferriskey::Error {
         ferriskey::Error::from((kind, "synthetic"))
+    }
+
+    // ── Budget dimension-cap validation (issue #104) ──
+
+    #[test]
+    fn create_budget_rejects_over_cap_dimension_count() {
+        let n = MAX_BUDGET_DIMENSIONS + 1;
+        let dims: Vec<String> = (0..n).map(|i| format!("d{i}")).collect();
+        let hard = vec![1u64; n];
+        let soft = vec![0u64; n];
+        let err = validate_create_budget_dimensions(&dims, &hard, &soft).unwrap_err();
+        match err {
+            ServerError::InvalidInput(msg) => {
+                assert!(msg.contains("too_many_dimensions"), "got: {msg}");
+                assert!(msg.contains(&format!("limit={}", MAX_BUDGET_DIMENSIONS)), "got: {msg}");
+                assert!(msg.contains(&format!("got={n}")), "got: {msg}");
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_budget_accepts_exactly_cap_dimensions() {
+        let n = MAX_BUDGET_DIMENSIONS;
+        let dims: Vec<String> = (0..n).map(|i| format!("d{i}")).collect();
+        let hard = vec![1u64; n];
+        let soft = vec![0u64; n];
+        assert!(validate_create_budget_dimensions(&dims, &hard, &soft).is_ok());
+    }
+
+    #[test]
+    fn create_budget_rejects_hard_limit_length_mismatch() {
+        let dims = vec!["a".to_string(), "b".to_string()];
+        let hard = vec![1u64]; // too short
+        let soft = vec![0u64, 0u64];
+        let err = validate_create_budget_dimensions(&dims, &hard, &soft).unwrap_err();
+        match err {
+            ServerError::InvalidInput(msg) => {
+                assert!(msg.contains("dimension_limit_array_mismatch"), "got: {msg}");
+                assert!(msg.contains("hard_limits=1"), "got: {msg}");
+                assert!(msg.contains("dimensions=2"), "got: {msg}");
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_budget_rejects_soft_limit_length_mismatch() {
+        let dims = vec!["a".to_string(), "b".to_string()];
+        let hard = vec![1u64, 2u64];
+        let soft = vec![0u64, 0u64, 0u64]; // too long
+        let err = validate_create_budget_dimensions(&dims, &hard, &soft).unwrap_err();
+        match err {
+            ServerError::InvalidInput(msg) => {
+                assert!(msg.contains("dimension_limit_array_mismatch"), "got: {msg}");
+                assert!(msg.contains("soft_limits=3"), "got: {msg}");
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn report_usage_rejects_over_cap_dimension_count() {
+        let n = MAX_BUDGET_DIMENSIONS + 1;
+        let dims: Vec<String> = (0..n).map(|i| format!("d{i}")).collect();
+        let deltas = vec![1u64; n];
+        let err = validate_report_usage_dimensions(&dims, &deltas).unwrap_err();
+        match err {
+            ServerError::InvalidInput(msg) => {
+                assert!(msg.contains("too_many_dimensions"), "got: {msg}");
+                assert!(msg.contains(&format!("limit={}", MAX_BUDGET_DIMENSIONS)), "got: {msg}");
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn report_usage_accepts_exactly_cap_dimensions() {
+        let n = MAX_BUDGET_DIMENSIONS;
+        let dims: Vec<String> = (0..n).map(|i| format!("d{i}")).collect();
+        let deltas = vec![1u64; n];
+        assert!(validate_report_usage_dimensions(&dims, &deltas).is_ok());
+    }
+
+    #[test]
+    fn report_usage_rejects_delta_length_mismatch() {
+        let dims = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let deltas = vec![1u64, 2u64]; // too short
+        let err = validate_report_usage_dimensions(&dims, &deltas).unwrap_err();
+        match err {
+            ServerError::InvalidInput(msg) => {
+                assert!(msg.contains("dimension_delta_array_mismatch"), "got: {msg}");
+                assert!(msg.contains("dimensions=3"), "got: {msg}");
+                assert!(msg.contains("deltas=2"), "got: {msg}");
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn report_usage_accepts_empty_dimensions() {
+        // Edge case: zero-dimension report_usage is a no-op that should pass
+        // validation (Lua handles dim_count=0 correctly).
+        assert!(validate_report_usage_dimensions(&[], &[]).is_ok());
     }
 
     #[test]

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -39,18 +39,16 @@ use crate::config::ServerConfig;
 /// returns the full list; retries only need a sample.
 const ALREADY_TERMINAL_MEMBER_CAP: usize = 1000;
 
-/// Upper bound on the number of dimensions a single budget policy may declare,
-/// and on the number of dimensions a single `report_usage` call may touch.
+/// Re-export of the budget dimension cap.
 ///
-/// The limit exists to cap FCALL ARGV allocation: both `create_budget` and
-/// `report_usage` build argv whose length is linear in `dimensions.len()`,
-/// so an untrusted caller could otherwise request an unbounded `Vec`
-/// allocation (CodeQL `rust/uncontrolled-allocation-size`, issue #104).
-///
-/// 64 is generously above any legitimate scoping dimension count
-/// (org/tenant/project/region/lane/tier/…) while bounding worst-case
-/// ARGV to ~200 strings — well below Valkey argv limits.
-pub(crate) const MAX_BUDGET_DIMENSIONS: usize = 64;
+/// Defined as the single source of truth in `ff_script::functions::budget` so
+/// the typed FCALL wrappers and the REST boundary cannot silently drift
+/// (PR #106 review). The limit exists to cap FCALL ARGV allocation: both
+/// `create_budget` and `report_usage` build argv whose length is linear in
+/// `dimensions.len()`, so an untrusted caller could otherwise request an
+/// unbounded `Vec` allocation (CodeQL `rust/uncontrolled-allocation-size`,
+/// issue #104).
+pub(crate) use ff_script::functions::budget::MAX_BUDGET_DIMENSIONS;
 
 /// Validate `create_budget` dimension inputs before building the FCALL argv.
 ///


### PR DESCRIPTION
## Summary

Fixes #104: CodeQL rule `rust/uncontrolled-allocation-size` flagged `Vec::with_capacity(9 + dim_count * 3)` in `create_budget` (server.rs:1038-1039) where `dim_count` is attacker-controllable via the REST boundary (`CreateBudgetArgs.dimensions`). The sibling `Vec::with_capacity(3 + dim_count * 2)` in `report_usage` (server.rs:1196-1197) has the same class of untrusted-input-sized allocation and is fixed in the same PR.

### Changes

- **New constant** `MAX_BUDGET_DIMENSIONS = 64` — generously above legitimate scoping (org/tenant/project/region/lane/tier/…) while bounding worst-case ARGV to ~200 strings.
- **`create_budget`**: rejects `dim_count > 64`, plus parallel-length mismatches between `dimensions`/`hard_limits`/`soft_limits` (Lua indexes these positionally; a mismatch would silently corrupt limits).
- **`report_usage`**: rejects `dim_count > 64`, plus `dimensions`/`deltas` length mismatch.
- **Error shape preserved**: uses `ServerError::InvalidInput(String)` to avoid pre-empting #98's structured-error restructure. Error codes:
  - `too_many_dimensions: limit=64, got=N`
  - `dimension_limit_array_mismatch: dimensions=N hard_limits=M`
  - `dimension_limit_array_mismatch: dimensions=N soft_limits=M`
  - `dimension_delta_array_mismatch: dimensions=N deltas=M`
- **ff-script mirror** (`crates/ff-script/src/functions/budget.rs`): same cap + validators applied to the typed FCALL wrappers so direct callers (tests, tools, alternate services) can't bypass the cap. Uses `ScriptError::Parse` (Terminal class) with the same error codes.
- **Unit tests** in `crates/ff-server/src/server.rs` for every rejection path and cap-boundary (validation is pure — no Valkey needed). Happy path stays covered by existing e2e.

### Rationale for 64

64 is well above any legitimate scoping-dimension count a policy would declare and well below anything that would make Valkey argv-counts concerning. The CodeQL finding is about allocation-growth being unbounded, not about some tight performance envelope, so the cap just needs to be finite and sensible.

### Test validity

Confirmed by stubbing both validators to `Ok(())` and re-running:

```
failures:
    server::tests::create_budget_rejects_hard_limit_length_mismatch
    server::tests::create_budget_rejects_over_cap_dimension_count
    server::tests::create_budget_rejects_soft_limit_length_mismatch
    server::tests::report_usage_rejects_delta_length_mismatch
    server::tests::report_usage_rejects_over_cap_dimension_count
test result: FAILED. 3 passed; 5 failed
```

All 5 rejection-path tests fail as expected; the 3 happy-path tests (accepts_cap, accepts_empty) correctly stay green. Validators restored, 43/43 pass.

## Test plan

- [x] `cargo build --workspace --all-features` — clean
- [x] `cargo test -p ff-server --lib` — 43/43 pass (9 new)
- [x] `cargo test -p ff-script --lib` — 43/43 pass
- [x] Test-validity stash: rejection tests fail with validators no-op'd; restored
- [ ] CI green on PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new input validation on budget create/usage paths that can reject previously-accepted requests, which may affect clients relying on large dimension lists or mismatched parallel arrays. Changes are localized but sit on request-handling boundaries and influence error behavior.
> 
> **Overview**
> Prevents unbounded FCALL ARGV allocations in budget operations by introducing a hard cap of **64 dimensions** and rejecting invalid parallel-array inputs.
> 
> `ff-server` now validates `CreateBudgetArgs` and `ReportUsageArgs` before building argv (new `validate_create_budget_dimensions` / `validate_report_usage_dimensions`) and includes unit tests covering cap boundaries and mismatch cases.
> 
> `ff-script` mirrors the same cap and length checks in the typed budget FCALL helpers so direct Valkey callers (tests/tools) can’t bypass the server-side limit, returning `ScriptError::Parse` with consistent error codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6604e7870a88a42783ed1ad6bf1f8cf9307e48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->