### PR TITLE
test(ff-readiness-tests): fanout_fanin_flow (PR-D1c)

### DIFF
--- a/crates/ff-readiness-tests/tests/common/mod.rs
+++ b/crates/ff-readiness-tests/tests/common/mod.rs
@@ -1,0 +1,336 @@
+//! Shared helpers for the PR-D1c fanout/fanin DAG tests.
+//!
+//! Integration-test "common" module: each test file includes this
+//! via `mod common;` + `use common::*;`. Not part of the crate's
+//! public API — lives under `tests/common/mod.rs` per cargo's
+//! convention for shared integration-test code (see the Rust Book
+//! §Submodules in Integration Tests).
+//!
+//! Scope is deliberately narrow: the shape-builders and poll helpers
+//! used by both `fanout_fanin_flow_happy.rs` and
+//! `fanout_fanin_flow_fanin_skip.rs`. Nothing is re-exported beyond
+//! what those two files need.
+
+#![cfg(feature = "readiness")]
+// Both consumer files don't use every helper. Silencing is
+// preferable to per-fn `#[allow]` clutter — the module is
+// tests-only and not shipped.
+#![allow(dead_code)]
+
+use std::time::{Duration, Instant};
+
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, ApplyDependencyToChildArgs, CreateExecutionArgs, CreateFlowArgs,
+    StageDependencyEdgeArgs, StageDependencyEdgeResult,
+};
+use ff_core::partition::execution_partition;
+use ff_core::state::PublicState;
+use ff_core::types::*;
+use ff_readiness_tests::server::InProcessServer;
+use ff_readiness_tests::valkey::TEST_PARTITION_CONFIG;
+use ff_sdk::task::ClaimedTask;
+
+/// Diamond DAG handle: `A → {B, C} → D`, plus the flow id.
+pub struct Dag {
+    pub flow_id: FlowId,
+    pub a: ExecutionId,
+    pub b: ExecutionId,
+    pub c: ExecutionId,
+    pub d: ExecutionId,
+}
+
+/// Spawn an SDK worker against the lane + namespace.
+pub async fn spawn_worker(lane: &str, ns: &str, suffix: &str) -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
+        port: std::env::var("FF_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(6379),
+        tls: ff_readiness_tests::valkey::env_flag("FF_TLS"),
+        cluster: ff_readiness_tests::valkey::env_flag("FF_CLUSTER"),
+        worker_id: WorkerId::new(format!("readiness-fanout-worker-{suffix}")),
+        worker_instance_id: WorkerInstanceId::new(format!("readiness-fanout-inst-{suffix}")),
+        namespace: Namespace::new(ns),
+        lanes: vec![LaneId::new(lane)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 4,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg)
+        .await
+        .expect("FlowFabricWorker::connect")
+}
+
+/// Create flow + 4 members + 4 `success_only` edges (A→B, A→C, B→D,
+/// C→D). After `stage_dependency_edge` bumps graph_revision per edge,
+/// `apply_dependency_to_child` stamps the dep onto the downstream and
+/// marks it WaitingChildren. A starts Waiting (no incoming edges).
+pub async fn stage_diamond_dag(server: &InProcessServer, ns: &str, lane: &str) -> Dag {
+    let flow_id = FlowId::new();
+    let now = TimestampMs::now();
+
+    server
+        .server
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow_id.clone(),
+            flow_kind: "readiness-fanout".to_owned(),
+            namespace: Namespace::new(ns),
+            now,
+        })
+        .await
+        .expect("create_flow");
+
+    let a = create_member(server, &flow_id, ns, lane, "A", now).await;
+    let b = create_member(server, &flow_id, ns, lane, "B", now).await;
+    let c = create_member(server, &flow_id, ns, lane, "C", now).await;
+    let d = create_member(server, &flow_id, ns, lane, "D", now).await;
+
+    // Each create_member bumps graph_revision by 1 via
+    // ff_add_execution_to_flow → start at 4 for the first edge and
+    // climb by 1 per stage_dependency_edge.
+    let mut rev: u64 = 4;
+    let e_ab = stage_and_apply_edge(server, &flow_id, &a, &b, rev).await;
+    rev += 1;
+    let e_ac = stage_and_apply_edge(server, &flow_id, &a, &c, rev).await;
+    rev += 1;
+    let e_bd = stage_and_apply_edge(server, &flow_id, &b, &d, rev).await;
+    rev += 1;
+    let e_cd = stage_and_apply_edge(server, &flow_id, &c, &d, rev).await;
+
+    // Edge ids are recoverable at read-time via list_*_edges; not
+    // load-bearing for assertions, so don't stash them.
+    let _ = (e_ab, e_ac, e_bd, e_cd);
+
+    Dag { flow_id, a, b, c, d }
+}
+
+async fn create_member(
+    server: &InProcessServer,
+    flow_id: &FlowId,
+    ns: &str,
+    lane: &str,
+    tag: &str,
+    now: TimestampMs,
+) -> ExecutionId {
+    let eid = ExecutionId::for_flow(flow_id, &TEST_PARTITION_CONFIG);
+    let deadline_at = TimestampMs::from_millis(now.0 + 60_000);
+    server
+        .server
+        .create_execution(&CreateExecutionArgs {
+            execution_id: eid.clone(),
+            namespace: Namespace::new(ns),
+            lane_id: LaneId::new(lane),
+            execution_kind: format!("readiness-fanout-{tag}"),
+            input_payload: b"{}".to_vec(),
+            payload_encoding: Some("json".to_owned()),
+            priority: 0,
+            creator_identity: "readiness".to_owned(),
+            idempotency_key: None,
+            tags: std::collections::HashMap::new(),
+            policy: None,
+            delay_until: None,
+            execution_deadline_at: Some(deadline_at),
+            partition_id: execution_partition(&eid, &TEST_PARTITION_CONFIG).index,
+            now,
+        })
+        .await
+        .expect("create_execution");
+    server
+        .server
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow_id.clone(),
+            execution_id: eid.clone(),
+            now,
+        })
+        .await
+        .expect("add_execution_to_flow");
+    eid
+}
+
+/// Stage one `success_only` edge + apply it to the downstream. Both
+/// ops always happen together in this test, so one helper.
+async fn stage_and_apply_edge(
+    server: &InProcessServer,
+    flow_id: &FlowId,
+    up: &ExecutionId,
+    down: &ExecutionId,
+    expected_graph_revision: u64,
+) -> EdgeId {
+    let edge_id = EdgeId::new();
+    let now = TimestampMs::now();
+    let staged = server
+        .server
+        .stage_dependency_edge(&StageDependencyEdgeArgs {
+            flow_id: flow_id.clone(),
+            edge_id: edge_id.clone(),
+            upstream_execution_id: up.clone(),
+            downstream_execution_id: down.clone(),
+            dependency_kind: "success_only".to_owned(),
+            data_passing_ref: None,
+            expected_graph_revision,
+            now,
+        })
+        .await
+        .expect("stage_dependency_edge");
+    let new_rev = match staged {
+        StageDependencyEdgeResult::Staged { new_graph_revision, .. } => new_graph_revision,
+    };
+    server
+        .server
+        .apply_dependency_to_child(&ApplyDependencyToChildArgs {
+            flow_id: flow_id.clone(),
+            edge_id: edge_id.clone(),
+            downstream_execution_id: down.clone(),
+            upstream_execution_id: up.clone(),
+            graph_revision: new_rev,
+            dependency_kind: "success_only".to_owned(),
+            data_passing_ref: None,
+            now,
+        })
+        .await
+        .expect("apply_dependency_to_child");
+    edge_id
+}
+
+/// Poll `worker.claim_next` until the reclaimed task matches `eid`.
+/// Mirrors waitpoint_hmac_roundtrip's reclaim helper but scoped local.
+/// Claim the single eligible task on the worker's lane, matching
+/// `eid`. Panics if the next claim returns a different task — per
+/// caller invariant, only `eid` is expected to be eligible. If the
+/// test exposes concurrently-eligible executions (e.g. a fanout), use
+/// [`claim_any_of`] instead; dropping a wrongly-claimed task holds its
+/// 30 s lease and wedges subsequent `claim_specific(other_eid)` calls.
+pub async fn claim_specific(
+    worker: &ff_sdk::FlowFabricWorker,
+    eid: &ExecutionId,
+) -> ClaimedTask {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(t) = worker.claim_next().await.expect("claim_next Result") {
+                assert_eq!(
+                    t.execution_id(),
+                    eid,
+                    "claim_specific invariant violated: expected sole-eligible \
+                     {eid}, got {}. Another execution is concurrently eligible — \
+                     use claim_any_of() instead.",
+                    t.execution_id()
+                );
+                break t;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("claim_specific timed out waiting for {eid}"))
+}
+
+/// Claim whichever of `eids` the worker returns next. Panics if the
+/// claim is none of them. Used when the test drives a fanout where
+/// multiple downstreams become eligible in parallel and the caller
+/// wants to iterate through them in worker-claim order.
+///
+/// Returns `(idx, task)` where `idx` is the position in `eids` that
+/// matched, so callers can update their "remaining" set.
+pub async fn claim_any_of(
+    worker: &ff_sdk::FlowFabricWorker,
+    eids: &[&ExecutionId],
+) -> (usize, ClaimedTask) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(t) = worker.claim_next().await.expect("claim_next Result") {
+                let got = t.execution_id().clone();
+                match eids.iter().position(|e| *e == &got) {
+                    Some(i) => break (i, t),
+                    None => panic!(
+                        "claim_any_of: worker returned {got} which is not in \
+                         expected set {eids:?}"
+                    ),
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("claim_any_of timed out waiting for one of {eids:?}"))
+}
+
+/// One-shot public_state read.
+pub async fn read_public_state(
+    worker: &ff_sdk::FlowFabricWorker,
+    eid: &ExecutionId,
+) -> PublicState {
+    worker
+        .describe_execution(eid)
+        .await
+        .expect("describe_execution")
+        .unwrap_or_else(|| panic!("snapshot missing for {eid}"))
+        .public_state
+}
+
+/// Assert single-shot: current public_state matches.
+pub async fn assert_public_state(
+    worker: &ff_sdk::FlowFabricWorker,
+    eid: &ExecutionId,
+    expected: PublicState,
+) {
+    let got = read_public_state(worker, eid).await;
+    assert_eq!(
+        got, expected,
+        "{eid} expected public_state={expected:?}, got {got:?}"
+    );
+}
+
+/// Bounded poll until public_state becomes `expected`. Fails with a
+/// descriptive message on timeout so a push-promotion regression
+/// fails fast rather than hanging the ignored run.
+pub async fn await_public_state(
+    worker: &ff_sdk::FlowFabricWorker,
+    eid: &ExecutionId,
+    expected: PublicState,
+) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let got = read_public_state(worker, eid).await;
+        if got == expected {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for {eid} to become public_state={expected:?} (5s); \
+                 last public_state={got:?}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Invariant helper: for `ms` milliseconds (sampled at 100ms cadence),
+/// the execution's `public_state` must NOT become `Waiting` (i.e.
+/// must NOT be eligible-to-claim). If it does, that is a
+/// fanin-semantics violation — an `all_required` downstream was
+/// promoted before ALL of its parents reached a satisfying terminal
+/// state.
+///
+/// Single-shot checks against an async completion listener are racey,
+/// so we sample across the full window. `10x100ms` per the PR-D1c
+/// plan's D-eligibility-between-B-and-C invariant.
+pub async fn assert_not_waiting_for(
+    worker: &ff_sdk::FlowFabricWorker,
+    eid: &ExecutionId,
+    ms: u64,
+) {
+    let samples = (ms / 100).max(1) as usize;
+    for i in 0..samples {
+        let got = read_public_state(worker, eid).await;
+        assert_ne!(
+            got,
+            PublicState::Waiting,
+            "{eid} became Waiting at sample {i}/{samples} — fanin \
+             `all_required` violated (downstream promoted before all \
+             parents terminal); public_state={got:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/crates/ff-readiness-tests/tests/common/mod.rs
+++ b/crates/ff-readiness-tests/tests/common/mod.rs
@@ -87,17 +87,19 @@ pub async fn stage_diamond_dag(server: &InProcessServer, ns: &str, lane: &str) -
     let c = create_member(server, &flow_id, ns, lane, "C", now).await;
     let d = create_member(server, &flow_id, ns, lane, "D", now).await;
 
-    // Each create_member bumps graph_revision by 1 via
-    // ff_add_execution_to_flow → start at 4 for the first edge and
-    // climb by 1 per stage_dependency_edge.
+    // ff_add_execution_to_flow bumps graph_revision by 1 per member,
+    // so the first staged edge expects revision 4. After that, thread
+    // the authoritative new_graph_revision returned by
+    // stage_dependency_edge through each subsequent call — assuming a
+    // fixed +1 bump is brittle against future Lua changes.
     let mut rev: u64 = 4;
-    let e_ab = stage_and_apply_edge(server, &flow_id, &a, &b, rev).await;
-    rev += 1;
-    let e_ac = stage_and_apply_edge(server, &flow_id, &a, &c, rev).await;
-    rev += 1;
-    let e_bd = stage_and_apply_edge(server, &flow_id, &b, &d, rev).await;
-    rev += 1;
-    let e_cd = stage_and_apply_edge(server, &flow_id, &c, &d, rev).await;
+    let (e_ab, new_rev) = stage_and_apply_edge(server, &flow_id, &a, &b, rev).await;
+    rev = new_rev;
+    let (e_ac, new_rev) = stage_and_apply_edge(server, &flow_id, &a, &c, rev).await;
+    rev = new_rev;
+    let (e_bd, new_rev) = stage_and_apply_edge(server, &flow_id, &b, &d, rev).await;
+    rev = new_rev;
+    let (e_cd, _final_rev) = stage_and_apply_edge(server, &flow_id, &c, &d, rev).await;
 
     // Edge ids are recoverable at read-time via list_*_edges; not
     // load-bearing for assertions, so don't stash them.
@@ -150,14 +152,17 @@ async fn create_member(
 }
 
 /// Stage one `success_only` edge + apply it to the downstream. Both
-/// ops always happen together in this test, so one helper.
+/// ops always happen together in this test, so one helper. Returns
+/// `(edge_id, new_graph_revision)` so callers thread the server's
+/// authoritative revision into the next stage call rather than
+/// assuming a fixed +1 bump.
 async fn stage_and_apply_edge(
     server: &InProcessServer,
     flow_id: &FlowId,
     up: &ExecutionId,
     down: &ExecutionId,
     expected_graph_revision: u64,
-) -> EdgeId {
+) -> (EdgeId, u64) {
     let edge_id = EdgeId::new();
     let now = TimestampMs::now();
     let staged = server
@@ -191,7 +196,7 @@ async fn stage_and_apply_edge(
         })
         .await
         .expect("apply_dependency_to_child");
-    edge_id
+    (edge_id, new_rev)
 }
 
 /// Poll `worker.claim_next` until the reclaimed task matches `eid`.
@@ -306,31 +311,39 @@ pub async fn await_public_state(
     }
 }
 
-/// Invariant helper: for `ms` milliseconds (sampled at 100ms cadence),
-/// the execution's `public_state` must NOT become `Waiting` (i.e.
-/// must NOT be eligible-to-claim). If it does, that is a
-/// fanin-semantics violation — an `all_required` downstream was
-/// promoted before ALL of its parents reached a satisfying terminal
-/// state.
+/// Invariant helper: for `ms` milliseconds (sampled at 100 ms cadence),
+/// the execution's `public_state` must NOT become `Waiting` (i.e. must
+/// NOT be eligible-to-claim). If it does, that is a fanin-semantics
+/// violation — an `all_required` downstream was promoted before ALL of
+/// its parents reached a satisfying terminal state.
 ///
 /// Single-shot checks against an async completion listener are racey,
-/// so we sample across the full window. `10x100ms` per the PR-D1c
-/// plan's D-eligibility-between-B-and-C invariant.
+/// so we sample across the full window. Uses an `Instant`-based
+/// deadline so the window covers exactly `ms` milliseconds even for
+/// `ms` values that aren't multiples of 100 (e.g. 150 ms previously
+/// floored to a single sample via integer division).
 pub async fn assert_not_waiting_for(
     worker: &ff_sdk::FlowFabricWorker,
     eid: &ExecutionId,
     ms: u64,
 ) {
-    let samples = (ms / 100).max(1) as usize;
-    for i in 0..samples {
+    let deadline = Instant::now() + Duration::from_millis(ms);
+    let mut sample = 0usize;
+    loop {
         let got = read_public_state(worker, eid).await;
         assert_ne!(
             got,
             PublicState::Waiting,
-            "{eid} became Waiting at sample {i}/{samples} — fanin \
-             `all_required` violated (downstream promoted before all \
-             parents terminal); public_state={got:?}"
+            "{eid} became Waiting at sample {sample} within {ms}ms window \
+             — fanin `all_required` violated (downstream promoted before \
+             all parents terminal); public_state={got:?}"
         );
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        let now = Instant::now();
+        if now >= deadline {
+            return;
+        }
+        sample += 1;
+        let remaining = deadline.saturating_duration_since(now);
+        tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
     }
 }

--- a/crates/ff-readiness-tests/tests/fanout_fanin_flow_fanin_skip.rs
+++ b/crates/ff-readiness-tests/tests/fanout_fanin_flow_fanin_skip.rs
@@ -1,0 +1,131 @@
+//! PR-D1c / Test 5b — DAG-edge fanin-skip on upstream failure.
+//!
+//! Same diamond DAG as `fanout_fanin_flow_happy`, but B FAILS. The
+//! `success_only` edge B→D becomes Impossible, so D must reach
+//! terminal Skipped even after C completes successfully.
+//!
+//! Split from the happy subtest — see that file's header for the
+//! engine-pollution rationale.
+//!
+//! Graph:
+//!
+//!                 ┌── B (Fail) ──┐
+//!              A ─┤              ├─ D (Skipped)
+//!                 └── C ─────────┘
+//!
+//! Assertions:
+//!   * B reaches terminal Failed.
+//!   * C still reaches Completed (sibling-branch failure does not
+//!     poison C).
+//!   * D reaches terminal Skipped (impossibility propagates through
+//!     the `success_only` edge via ff_resolve_dependency).
+//!
+//! RED-proof: `tests/red-proofs/fanout_fanin_flow.log`. The break
+//! for this file flips the tail `await_public_state(D, Skipped)` to
+//! `Completed`; the bounded poll times out against the actual
+//! terminal (Skipped).
+//!
+//! Run with:
+//!   cargo test -p ff-readiness-tests --features readiness \
+//!       --test fanout_fanin_flow_fanin_skip -- --ignored --test-threads=1
+#![cfg(feature = "readiness")]
+
+mod common;
+use common::*;
+
+use std::time::Instant;
+
+use ff_core::state::PublicState;
+use ff_readiness_tests::evidence;
+use ff_readiness_tests::server::InProcessServer;
+use ff_readiness_tests::valkey::{probe_server_version, TestCluster};
+use ff_sdk::task::ClaimedTask;
+use serde_json::json;
+
+/// Finalise a sibling task: slot 0 = B (fail), slot 1 = C (complete).
+/// Kept alongside the test because the semantics (which sibling fails)
+/// are specific to the fanin-skip shape — not worth hoisting into
+/// `common/mod.rs`.
+async fn dispose_sibling(slot: usize, task: ClaimedTask) {
+    match slot {
+        0 => {
+            task.fail("synthetic-b-failure", "worker_error")
+                .await
+                .expect("fail B");
+        }
+        1 => {
+            task.complete(Some(b"C-ok".to_vec()))
+                .await
+                .expect("complete C");
+        }
+        other => panic!("dispose_sibling: unexpected slot {other}"),
+    }
+}
+
+const LANE: &str = "readiness-fanout-skip";
+const NS: &str = "readiness-fanout-skip-ns";
+const TEST_NAME: &str = "fanout_fanin_flow_fanin_skip";
+
+#[tokio::test]
+#[ignore]
+#[serial_test::serial]
+async fn fanout_fanin_flow_fanin_skip() {
+    let t_start = Instant::now();
+
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let valkey_version = probe_server_version(tc.client()).await;
+    let server = InProcessServer::start(LANE).await;
+    let worker = spawn_worker(LANE, NS, "skip").await;
+
+    let dag = stage_diamond_dag(&server, NS, LANE).await;
+    let Dag { a, b, c, d, .. } = &dag;
+
+    // Complete A so B + C unblock.
+    let task_a = claim_specific(&worker, a).await;
+    task_a.complete(Some(b"A-ok".to_vec())).await.expect("complete A");
+    await_public_state(&worker, a, PublicState::Completed).await;
+    await_public_state(&worker, b, PublicState::Waiting).await;
+    await_public_state(&worker, c, PublicState::Waiting).await;
+
+    // Claim B and C in worker-claim order (post-A-complete fanout makes
+    // both concurrently eligible; `claim_specific(b)` would drop C and
+    // hold its 30s lease if C came back first, wedging the next claim).
+    // Fail the one that corresponds to B, complete the one that
+    // corresponds to C — order-independent.
+    let siblings = [b, c];
+    let (first_idx, first_task) = claim_any_of(&worker, &siblings).await;
+    dispose_sibling(first_idx, first_task).await;
+    let second_idx = 1 - first_idx;
+    let (got_idx, second_task) = claim_any_of(&worker, &[siblings[second_idx]]).await;
+    assert_eq!(got_idx, 0, "single-sibling claim must match slot 0");
+    dispose_sibling(second_idx, second_task).await;
+
+    await_public_state(&worker, b, PublicState::Failed).await;
+    await_public_state(&worker, c, PublicState::Completed).await;
+
+    // D must reach Skipped. Push-promotion of an impossible edge flips
+    // D via ff_resolve_dependency→Impossible. Bounded.
+    await_public_state(&worker, d, PublicState::Skipped).await;
+
+    evidence::write(
+        TEST_NAME,
+        &json!({
+            "test": TEST_NAME,
+            "total_ms": t_start.elapsed().as_millis() as u64,
+            "valkey_version": valkey_version,
+            "flow_id": dag.flow_id.to_string(),
+            "executions": {
+                "A": a.to_string(),
+                "B": b.to_string(),
+                "C": c.to_string(),
+                "D": d.to_string(),
+            },
+            "assertions": {
+                "b_terminal_failed": true,
+                "c_terminal_completed": true,
+                "d_terminal_skipped": true,
+            },
+        }),
+    );
+}

--- a/crates/ff-readiness-tests/tests/fanout_fanin_flow_happy.rs
+++ b/crates/ff-readiness-tests/tests/fanout_fanin_flow_happy.rs
@@ -1,0 +1,165 @@
+//! PR-D1c / Test 5a — DAG-edge fanout + fanin, happy path.
+//!
+//! Pre-stages a small diamond DAG (A → {B, C} → D) through the typed
+//! Server API, runs it to terminal via the SDK worker, and asserts the
+//! engine's push-promotion path (completion_listener →
+//! partition_router → ff_resolve_dependency) unblocks downstream
+//! members in the expected shape.
+//!
+//! FF has no dynamic runtime `spawn_child`; fanout/fanin is an
+//! edge-on-a-pre-staged-graph concept. That is exactly what this test
+//! targets — the D-eligibility-between-B-and-C question is a claim
+//! about the graph's `all_required` satisfaction semantics, not
+//! dynamic spawn. (Confirmed with manager; RFC-007 §Flow DAG.)
+//!
+//! Split from the fanin-skip path into its own file to avoid
+//! cross-test engine-pollution: `InProcessServer::drop` does not
+//! shut the spawned engine down (engine tasks keep running on their
+//! own JoinSet), so two tests in the same binary end up with two
+//! concurrent completion_listeners racing on the same Valkey. The
+//! manager's PR-D1c plan explicitly flagged this as "split if we see
+//! it locally" — we saw it, so we split.
+//!
+//! Graph:
+//!
+//!                 ┌── B ──┐
+//!              A ─┤       ├─ D
+//!                 └── C ──┘
+//!
+//! Assertions:
+//!   * After A completes: B and C become Waiting in parallel
+//!     (push-promotion via completion_listener).
+//!   * While only ONE of {B, C} has completed, D stays
+//!     WaitingChildren (bounded-poll invariant — no single-shot race).
+//!   * After BOTH B and C complete, D becomes Waiting, claims, and
+//!     completes cleanly.
+//!
+//! Correctness only — no push-promotion-latency ceiling (manager
+//! decision; add a timing assertion later if push-promo regresses).
+//!
+//! RED-proof: `tests/red-proofs/fanout_fanin_flow.log` (shared with
+//! the fanin-skip subtest). The break for this file swaps the
+//! post-A-complete `await_public_state(B, Waiting)` for the
+//! single-shot `assert_public_state` — the async completion_listener
+//! hasn't promoted yet, so the assertion fires on WaitingChildren.
+//!
+//! Run with:
+//!   cargo test -p ff-readiness-tests --features readiness \
+//!       --test fanout_fanin_flow_happy -- --ignored --test-threads=1
+#![cfg(feature = "readiness")]
+
+mod common;
+use common::*;
+
+use std::time::Instant;
+
+use ff_core::state::PublicState;
+use ff_readiness_tests::evidence;
+use ff_readiness_tests::server::InProcessServer;
+use ff_readiness_tests::valkey::{probe_server_version, TestCluster};
+use serde_json::json;
+
+const LANE: &str = "readiness-fanout-happy";
+const NS: &str = "readiness-fanout-happy-ns";
+const TEST_NAME: &str = "fanout_fanin_flow_happy";
+
+#[tokio::test]
+#[ignore]
+#[serial_test::serial]
+async fn fanout_fanin_flow_happy() {
+    let t_start = Instant::now();
+
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    let valkey_version = probe_server_version(tc.client()).await;
+    let server = InProcessServer::start(LANE).await;
+    let worker = spawn_worker(LANE, NS, "happy").await;
+
+    // ── Build the DAG: A fans out to B + C, both fan in to D ──
+    let dag = stage_diamond_dag(&server, NS, LANE).await;
+    let Dag { a, b, c, d, .. } = &dag;
+
+    // Baseline: A Waiting (no deps); B, C, D all WaitingChildren.
+    assert_public_state(&worker, a, PublicState::Waiting).await;
+    assert_public_state(&worker, b, PublicState::WaitingChildren).await;
+    assert_public_state(&worker, c, PublicState::WaitingChildren).await;
+    assert_public_state(&worker, d, PublicState::WaitingChildren).await;
+
+    // ── Step 1: claim + complete A ──
+    let task_a = claim_specific(&worker, a).await;
+    task_a.complete(Some(b"A-ok".to_vec())).await.expect("complete A");
+    await_public_state(&worker, a, PublicState::Completed).await;
+
+    // ── Step 2: push-promotion should have unblocked B AND C ──
+    //    Completion listener is async, so bounded-poll both to Waiting.
+    await_public_state(&worker, b, PublicState::Waiting).await;
+    await_public_state(&worker, c, PublicState::Waiting).await;
+
+    // D must STILL be blocked — both upstream legs are not yet terminal.
+    assert_public_state(&worker, d, PublicState::WaitingChildren).await;
+
+    // ── Step 3: complete the first of {B, C} the worker returns,
+    //    then verify D is NOT eligible yet ──
+    //    B and C are concurrently eligible after A completes; the
+    //    worker's claim_next picks whichever lane_eligible ZRANGEBYSCORE
+    //    returns first. Claiming "specifically B" and dropping C (or
+    //    vice versa) would hold the wrongly-claimed task's lease for
+    //    30s, wedging the next claim. Use claim_any_of to consume them
+    //    in whatever order the scheduler serves.
+    let siblings = [b, c];
+    let (first_idx, first_task) = claim_any_of(&worker, &siblings).await;
+    let first_label = ["B", "C"][first_idx];
+    first_task
+        .complete(Some(format!("{first_label}-ok").into_bytes()))
+        .await
+        .unwrap_or_else(|e| panic!("complete first sibling ({first_label}): {e}"));
+    await_public_state(&worker, siblings[first_idx], PublicState::Completed).await;
+
+    // Invariant: only ONE of {B, C} is terminal → D must stay
+    // WaitingChildren. Bounded poll rather than single-shot — the
+    // engine's completion_listener is asynchronous and could flip D
+    // briefly if fanin semantics regress; if the invariant fails we
+    // want deterministic failure, not a race-dependent flake.
+    assert_not_waiting_for(&worker, d, 1_000).await;
+
+    // ── Step 4: complete the remaining sibling → D must become Waiting ──
+    let second_idx = 1 - first_idx;
+    let second_label = ["B", "C"][second_idx];
+    let (got_idx, second_task) = claim_any_of(&worker, &[siblings[second_idx]]).await;
+    assert_eq!(got_idx, 0, "single-sibling claim must match slot 0");
+    second_task
+        .complete(Some(format!("{second_label}-ok").into_bytes()))
+        .await
+        .unwrap_or_else(|e| panic!("complete second sibling ({second_label}): {e}"));
+    await_public_state(&worker, siblings[second_idx], PublicState::Completed).await;
+
+    await_public_state(&worker, d, PublicState::Waiting).await;
+
+    // ── Step 5: claim + complete D ──
+    let task_d = claim_specific(&worker, d).await;
+    task_d.complete(Some(b"D-ok".to_vec())).await.expect("complete D");
+    await_public_state(&worker, d, PublicState::Completed).await;
+
+    evidence::write(
+        TEST_NAME,
+        &json!({
+            "test": TEST_NAME,
+            "total_ms": t_start.elapsed().as_millis() as u64,
+            "valkey_version": valkey_version,
+            "flow_id": dag.flow_id.to_string(),
+            "executions": {
+                "A": a.to_string(),
+                "B": b.to_string(),
+                "C": c.to_string(),
+                "D": d.to_string(),
+            },
+            "assertions": {
+                "fanout_b_waiting_after_a": true,
+                "fanout_c_waiting_after_a": true,
+                "d_blocked_while_only_b_complete": true,
+                "d_waiting_after_both_parents": true,
+                "terminal_state_all": "Completed",
+            },
+        }),
+    );
+}

--- a/crates/ff-readiness-tests/tests/red-proofs/fanout_fanin_flow.log
+++ b/crates/ff-readiness-tests/tests/red-proofs/fanout_fanin_flow.log
@@ -1,0 +1,120 @@
+RED-PROOF transcripts for PR-D1c fanout/fanin DAG tests
+========================================================
+
+Covers both `tests/fanout_fanin_flow_happy.rs` and
+`tests/fanout_fanin_flow_fanin_skip.rs`. Each subtest was broken one
+at a time in-tree, run under the same cargo invocation as the green
+run, then restored. The panic messages below are the direct output of
+the broken runs.
+
+Both tests were initially co-located in a single file per the PR-D1c
+plan; local runs surfaced two discrete issues that the plan's
+"split if we see it locally" fallback covers:
+
+  1. Cross-test engine pollution — `InProcessServer::drop` only
+     aborts the axum handle, not the engine's JoinSet, so a second
+     in-binary test ended up with two concurrent completion_listeners
+     racing on the same Valkey.
+
+  2. `claim_specific` wedge on concurrent eligibility — after A
+     completes, B and C become eligible in parallel. A naïve
+     "claim B, drop anything else" loop holds the dropped sibling's
+     30 s lease, so the next `claim_specific(other)` times out at
+     10 s against a still-leased target. The happy and skip subtests
+     now use a new helper `claim_any_of` that consumes whichever
+     sibling the worker returns first.
+
+Both subtests now live in their own files and share helpers via
+`tests/common/mod.rs`.
+
+─── Subtest 1: fanout_fanin_flow_happy ──────────────────────────────
+
+BREAK: replace the post-A-complete bounded poll on B with a single-shot
+       assertion, so the async completion_listener hasn't yet promoted
+       B to Waiting.
+
+    -    await_public_state(&worker, b, PublicState::Waiting).await;
+    +    assert_public_state(&worker, b, PublicState::Waiting).await;
+
+CMD:   cargo test -p ff-readiness-tests --features readiness \
+           --test fanout_fanin_flow_happy -- --ignored --test-threads=1 --nocapture
+
+OUTPUT:
+
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.37s
+     Running tests/fanout_fanin_flow_happy.rs (target/debug/deps/fanout_fanin_flow_happy-37178f741946f5b0)
+
+running 1 test
+test fanout_fanin_flow_happy ...
+thread 'fanout_fanin_flow_happy' panicked at crates/ff-readiness-tests/tests/common/mod.rs:279:5:
+assertion `left == right` failed: {fp:3}:76c384f6-a745-4f76-b4e6-352f66745886 expected public_state=Waiting, got WaitingChildren
+  left: WaitingChildren
+ right: Waiting
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+FAILED
+
+failures:
+    fanout_fanin_flow_happy
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+Assertion that fired:
+    assert_eq!(
+        got, expected,
+        "{eid} expected public_state={expected:?}, got {got:?}"
+    );  // in `assert_public_state`, common/mod.rs
+
+This proves the happy-path assertion is exercising the real fanout
+push-promotion path: the single-shot check against the async listener
+reliably observes WaitingChildren before B flips to Waiting.
+
+─── Subtest 2: fanout_fanin_flow_fanin_skip ─────────────────────────
+
+BREAK: flip the expected terminal of D from Skipped to Completed, so
+       the bounded poll hits the 5 s deadline against the actual
+       terminal (Skipped, as the B→D edge was resolved Impossible).
+
+    -    await_public_state(&worker, d, PublicState::Skipped).await;
+    +    await_public_state(&worker, d, PublicState::Completed).await;
+
+CMD:   cargo test -p ff-readiness-tests --features readiness \
+           --test fanout_fanin_flow_fanin_skip -- --ignored --test-threads=1 --nocapture
+
+OUTPUT:
+
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.17s
+     Running tests/fanout_fanin_flow_fanin_skip.rs (target/debug/deps/fanout_fanin_flow_fanin_skip-9d7c0f277616e30c)
+
+running 1 test
+test fanout_fanin_flow_fanin_skip ...
+thread 'fanout_fanin_flow_fanin_skip' panicked at crates/ff-readiness-tests/tests/common/mod.rs:300:13:
+timed out waiting for {fp:2}:33e4bee7-731b-4c57-b1d8-2aeb03e84e53 to become public_state=Completed (5s); last public_state=Skipped
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+FAILED
+
+failures:
+    fanout_fanin_flow_fanin_skip
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.09s
+
+Assertion that fired (the timeout branch of `await_public_state`):
+    panic!(
+        "timed out waiting for {eid} to become public_state={expected:?} (5s); \
+         last public_state={got:?}"
+    );
+
+The message confirms the engine actually drove D to Skipped via the
+`success_only` impossibility propagation from B's failure — exactly
+the semantic the subtest is asserting.
+
+─── Restoration + green ─────────────────────────────────────────────
+
+Both breaks were reverted in-place. 8 consecutive FLUSHDB-then-run
+cycles of the full fanout_fanin_flow suite passed both subtests:
+
+    for i in {1..8}; do
+        valkey-cli FLUSHDB
+        cargo test -p ff-readiness-tests --features readiness \
+            -- --ignored fanout_fanin_flow --test-threads=1
+    done
+    # → 8/8 green (2 passed per run)


### PR DESCRIPTION
## Summary

Adds the PR-D1c readiness test for DAG-edge fanout + fanin. Pre-stages a diamond DAG `A → {B, C} → D` via the typed Server API (`create_flow`, `create_execution`, `stage_dependency_edge`, `apply_dependency_to_child`) and drives it to terminal through the SDK worker, asserting the engine's push-promotion path (`completion_listener` → `partition_router` → `ff_resolve_dependency`) unblocks downstream members in the expected shape.

Two subtests in separate files:

- **`fanout_fanin_flow_happy`** — A completes → both B and C become Waiting via push-promotion. D stays WaitingChildren while only one parent is terminal (bounded-poll invariant — single-shot checks against the async completion_listener are racey, so `assert_not_waiting_for` samples across a 1 s window). D flips to Waiting once both parents complete, then runs to Completed.
- **`fanout_fanin_flow_fanin_skip`** — B fails, so the `success_only` edge B→D is made Impossible. C still completes cleanly, and D reaches terminal Skipped via `ff_resolve_dependency`'s impossibility path.

### Design notes

**Split into two files, not one**: `InProcessServer::drop` only aborts the axum handle, not the engine's JoinSet. Two tests in the same binary end up with concurrent completion_listeners racing on the same Valkey when the second test starts. The manager's PR-D1c plan explicitly called this out as a "split if we see it locally" fallback; local runs surfaced it, so the subtests live in their own test binaries and share helpers via `tests/common/mod.rs`.

**`claim_any_of` alongside `claim_specific`**: when post-A fanout makes B and C eligible in parallel, the naïve "claim B, drop anything else" loop holds the wrongly-claimed sibling's 30 s lease and wedges the follow-up `claim_specific(other)` at its 10 s timeout. The new helper consumes whichever sibling the worker returns first and dispatches by slot. `claim_specific` stays for single-eligible scenarios but now panics loudly if a different task comes back, rather than silently dropping it.

**Correctness only**: no push-promotion-latency ceiling per the approved plan. Add a timing assertion later if push-promo regresses.

## RED-proof

Transcript: `crates/ff-readiness-tests/tests/red-proofs/fanout_fanin_flow.log`.

- Happy break: swap `await_public_state(B, Waiting)` post-A-complete for single-shot `assert_public_state` → panics on `got WaitingChildren`.
- Skip break: flip tail `await_public_state(D, Skipped)` to `Completed` → times out at 5 s against actual terminal (Skipped).

Both breaks were reverted in-place; 8 consecutive `FLUSHDB` + full-suite runs were green.

## Test plan

- [x] `cargo build -p ff-readiness-tests --tests --features readiness` — green
- [x] `cargo build -p ff-readiness-tests --tests` (no feature) — green, tests are no-ops
- [x] `cargo clippy -p ff-readiness-tests --tests --features readiness -- -D warnings` — clean
- [x] `cargo test -p ff-readiness-tests --features readiness -- --ignored fanout_fanin_flow --test-threads=1` — 2 passed (8× in a row)
- [ ] CI: all 20 checks green on `worker-d/pr-d1c-fanout-fanin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to ignored `ff-readiness-tests` integration tests and shared test helpers, with no production code or runtime behavior modifications.
> 
> **Overview**
> Adds a new PR-D1c readiness suite that pre-stages a diamond DAG (`A → {B,C} → D`) and drives it through an SDK worker to validate push-promotion and fanin semantics.
> 
> Introduces shared test helpers in `tests/common/mod.rs` for DAG staging, worker spawning, safer task claiming (`claim_specific` + `claim_any_of`), and bounded state polling/invariants; then adds two ignored serial tests: a happy-path fanout/fanin run and a failure-path run that asserts downstream `Skipped` when a `success_only` parent fails. Includes a `red-proofs/fanout_fanin_flow.log` transcript documenting the negative-proof breaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a950ee70e0ab0eb93bcd636ce616b80a1a0a2ba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->