### PR TITLE
refactor(ff-sdk,ff-script): structure Config + Parse errors (#98)

### DIFF
--- a/crates/ff-script/src/error.rs
+++ b/crates/ff-script/src/error.rs
@@ -441,9 +441,28 @@ pub enum ScriptError {
     #[error("valkey: {0}")]
     Valkey(#[from] ferriskey::Error),
 
-    /// Failed to parse FCALL return value.
-    #[error("parse error: {0}")]
-    Parse(String),
+    /// Failed to parse FCALL return value. `fcall` names the FCALL OR the
+    /// nearest semantic parser (e.g. `"parse_report_usage_result"`,
+    /// `"stream_tail_decode"`, `"decode_flow_snapshot"`). Never empty.
+    /// `execution_id` is populated at sites where the exec_id is in scope
+    /// (the 13 task.rs sites) and `None` elsewhere. `message` carries
+    /// expected-vs-got detail.
+    #[error("{}", fmt_parse(.fcall, .execution_id.as_deref(), .message))]
+    Parse {
+        fcall: String,
+        execution_id: Option<String>,
+        message: String,
+    },
+}
+
+/// Renders `ScriptError::Parse` as
+/// `parse error: <fcall>[<exec=...>]: <message>`. The `exec=` slot is
+/// omitted when `execution_id` is `None`.
+fn fmt_parse(fcall: &str, execution_id: Option<&str>, message: &str) -> String {
+    match execution_id {
+        Some(eid) => format!("parse error: {fcall}[exec={eid}]: {message}"),
+        None => format!("parse error: {fcall}: {message}"),
+    }
 }
 
 impl ScriptError {
@@ -511,7 +530,7 @@ impl ScriptError {
             | Self::InvalidTagKey(_)
             | Self::FenceRequired
             | Self::PartialFenceTriple
-            | Self::Parse(_) => ErrorClass::Terminal,
+            | Self::Parse { .. } => ErrorClass::Terminal,
 
             // Transport errors classify by their ferriskey ErrorKind —
             // IoError / FatalSend / TryAgain / BusyLoading / ClusterDown are
@@ -882,6 +901,42 @@ mod tests {
         assert!(matches!(
             ScriptError::from_code("partial_fence_triple"),
             Some(ScriptError::PartialFenceTriple)
+        ));
+    }
+
+    /// Regression (#98): `ScriptError::Parse` carries `fcall`, optional
+    /// `execution_id`, and `message` separately. Display renders
+    /// `parse error: <fcall>[exec=<id>]: <message>` when `execution_id`
+    /// is `Some`, and omits the `[exec=...]` slot when `None`. `fcall`
+    /// must never be empty.
+    #[test]
+    fn parse_structured_fields_render_and_match() {
+        let with_exec = ScriptError::Parse {
+            fcall: "ff_claim_execution".into(),
+            execution_id: Some("018f-abc".into()),
+            message: "expected Array".into(),
+        };
+        assert_eq!(
+            with_exec.to_string(),
+            "parse error: ff_claim_execution[exec=018f-abc]: expected Array"
+        );
+        assert!(matches!(
+            &with_exec,
+            ScriptError::Parse { execution_id: Some(e), .. } if e == "018f-abc"
+        ));
+
+        let no_exec = ScriptError::Parse {
+            fcall: "stream_tail_decode".into(),
+            execution_id: None,
+            message: "unexpected array length 3".into(),
+        };
+        assert_eq!(
+            no_exec.to_string(),
+            "parse error: stream_tail_decode: unexpected array length 3"
+        );
+        assert!(matches!(
+            &no_exec,
+            ScriptError::Parse { execution_id: None, fcall, .. } if !fcall.is_empty()
         ));
     }
 }

--- a/crates/ff-script/src/error.rs
+++ b/crates/ff-script/src/error.rs
@@ -456,7 +456,7 @@ pub enum ScriptError {
 }
 
 /// Renders `ScriptError::Parse` as
-/// `parse error: <fcall>[<exec=...>]: <message>`. The `exec=` slot is
+/// `parse error: <fcall>[exec=...]: <message>`. The `[exec=...]` slot is
 /// omitted when `execution_id` is `None`.
 fn fmt_parse(fcall: &str, execution_id: Option<&str>, message: &str) -> String {
     match execution_id {

--- a/crates/ff-script/src/functions/budget.rs
+++ b/crates/ff-script/src/functions/budget.rs
@@ -60,24 +60,36 @@ pub async fn ff_create_budget(
     let dim_count = args.dimensions.len();
     // Cap ARGV before allocation — see MAX_BUDGET_DIMENSIONS (#104).
     if dim_count > MAX_BUDGET_DIMENSIONS {
-        return Err(ScriptError::Parse(format!(
+        return Err(ScriptError::Parse {
+            fcall: "ff_create_budget".into(),
+            execution_id: None,
+            message: format!(
             "too_many_dimensions: limit={}, got={}",
             MAX_BUDGET_DIMENSIONS, dim_count
-        )));
+        ),
+        });
     }
     if args.hard_limits.len() != dim_count {
-        return Err(ScriptError::Parse(format!(
+        return Err(ScriptError::Parse {
+            fcall: "ff_create_budget".into(),
+            execution_id: None,
+            message: format!(
             "dimension_limit_array_mismatch: dimensions={} hard_limits={}",
             dim_count,
             args.hard_limits.len()
-        )));
+        ),
+        });
     }
     if args.soft_limits.len() != dim_count {
-        return Err(ScriptError::Parse(format!(
+        return Err(ScriptError::Parse {
+            fcall: "ff_create_budget".into(),
+            execution_id: None,
+            message: format!(
             "dimension_limit_array_mismatch: dimensions={} soft_limits={}",
             dim_count,
             args.soft_limits.len()
-        )));
+        ),
+        });
     }
     // ARGV: budget_id, scope_type, scope_id, enforcement_mode,
     //   on_hard_limit, on_soft_limit, reset_interval_ms, now_ms,
@@ -116,11 +128,19 @@ impl FromFcallResult for CreateBudgetResult {
         let r = FcallResult::parse(raw)?.into_success()?;
         let id_str = r.field_str(0);
         let budget_id = ff_core::types::BudgetId::parse(&id_str)
-            .map_err(|e| ScriptError::Parse(format!("invalid budget_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_create_budget".into(),
+                execution_id: None,
+                message: format!("invalid budget_id: {e}"),
+            })?;
         match r.status.as_str() {
             "OK" => Ok(CreateBudgetResult::Created { budget_id }),
             "ALREADY_SATISFIED" => Ok(CreateBudgetResult::AlreadySatisfied { budget_id }),
-            _ => Err(ScriptError::Parse(format!("unexpected status: {}", r.status))),
+            _ => Err(ScriptError::Parse {
+                fcall: "ff_create_budget".into(),
+                execution_id: None,
+                message: format!("unexpected status: {}", r.status),
+            }),
         }
     }
 }
@@ -148,17 +168,25 @@ pub async fn ff_report_usage_and_check(
     let dim_count = args.dimensions.len();
     // Cap ARGV before allocation — see MAX_BUDGET_DIMENSIONS (#104).
     if dim_count > MAX_BUDGET_DIMENSIONS {
-        return Err(ScriptError::Parse(format!(
+        return Err(ScriptError::Parse {
+            fcall: "ff_create_budget".into(),
+            execution_id: None,
+            message: format!(
             "too_many_dimensions: limit={}, got={}",
             MAX_BUDGET_DIMENSIONS, dim_count
-        )));
+        ),
+        });
     }
     if args.deltas.len() != dim_count {
-        return Err(ScriptError::Parse(format!(
+        return Err(ScriptError::Parse {
+            fcall: "ff_create_budget".into(),
+            execution_id: None,
+            message: format!(
             "dimension_delta_array_mismatch: dimensions={} deltas={}",
             dim_count,
             args.deltas.len()
-        )));
+        ),
+        });
     }
     let mut argv: Vec<String> = Vec::with_capacity(3 + dim_count * 2);
     argv.push(dim_count.to_string());
@@ -202,7 +230,11 @@ impl FromFcallResult for ReportUsageResult {
                     hard_limit: limit,
                 })
             }
-            _ => Err(ScriptError::Parse(format!("unknown budget status: {}", r.status))),
+            _ => Err(ScriptError::Parse {
+                fcall: "ff_report_usage".into(),
+                execution_id: None,
+                message: format!("unknown budget status: {}", r.status),
+            }),
         }
     }
 }

--- a/crates/ff-script/src/functions/budget.rs
+++ b/crates/ff-script/src/functions/budget.rs
@@ -169,7 +169,7 @@ pub async fn ff_report_usage_and_check(
     // Cap ARGV before allocation — see MAX_BUDGET_DIMENSIONS (#104).
     if dim_count > MAX_BUDGET_DIMENSIONS {
         return Err(ScriptError::Parse {
-            fcall: "ff_create_budget".into(),
+            fcall: "ff_report_usage_and_check".into(),
             execution_id: None,
             message: format!(
             "too_many_dimensions: limit={}, got={}",
@@ -179,7 +179,7 @@ pub async fn ff_report_usage_and_check(
     }
     if args.deltas.len() != dim_count {
         return Err(ScriptError::Parse {
-            fcall: "ff_create_budget".into(),
+            fcall: "ff_report_usage_and_check".into(),
             execution_id: None,
             message: format!(
             "dimension_delta_array_mismatch: dimensions={} deltas={}",
@@ -231,7 +231,7 @@ impl FromFcallResult for ReportUsageResult {
                 })
             }
             _ => Err(ScriptError::Parse {
-                fcall: "ff_report_usage".into(),
+                fcall: "ff_report_usage_and_check".into(),
                 execution_id: None,
                 message: format!("unknown budget status: {}", r.status),
             }),

--- a/crates/ff-script/src/functions/execution.rs
+++ b/crates/ff-script/src/functions/execution.rs
@@ -775,7 +775,7 @@ fn parse_public_state(s: &str) -> Result<PublicState, ScriptError> {
         "expired" => Ok(PublicState::Expired),
         "skipped" => Ok(PublicState::Skipped),
         _ => Err(ScriptError::Parse {
-            fcall: "ff_set_execution_tags".into(),
+            fcall: "parse_public_state".into(),
             execution_id: None,
             message: format!("unknown public_state: {s}"),
         }),

--- a/crates/ff-script/src/functions/execution.rs
+++ b/crates/ff-script/src/functions/execution.rs
@@ -211,14 +211,22 @@ impl FromFcallResult for CreateExecutionResult {
         if r.status == "DUPLICATE" {
             let eid_str = r.field_str(0);
             let eid = ExecutionId::parse(&eid_str)
-                .map_err(|e| ScriptError::Parse(format!("bad execution_id: {e}")))?;
+                .map_err(|e| ScriptError::Parse {
+                    fcall: "ff_create_execution".into(),
+                    execution_id: None,
+                    message: format!("bad execution_id: {e}"),
+                })?;
             return Ok(CreateExecutionResult::Duplicate { execution_id: eid });
         }
         let r = r.into_success()?;
         let eid_str = r.field_str(0);
         let ps_str = r.field_str(1);
         let eid = ExecutionId::parse(&eid_str)
-            .map_err(|e| ScriptError::Parse(format!("bad execution_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_create_execution".into(),
+                execution_id: None,
+                message: format!("bad execution_id: {e}"),
+            })?;
         let public_state = parse_public_state(&ps_str)?;
         Ok(CreateExecutionResult::Created {
             execution_id: eid,
@@ -278,21 +286,41 @@ impl FromFcallResult for ClaimExecutionResultPartial {
         let r = FcallResult::parse(raw)?.into_success()?;
         // ok(lease_id, epoch, expires_at, attempt_id, attempt_index, attempt_type)
         let lease_id = LeaseId::parse(&r.field_str(0))
-            .map_err(|e| ScriptError::Parse(format!("bad lease_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad lease_id: {e}"),
+            })?;
         let epoch = r
             .field_str(1)
             .parse::<u64>()
-            .map_err(|e| ScriptError::Parse(format!("bad epoch: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad epoch: {e}"),
+            })?;
         let expires_at = r
             .field_str(2)
             .parse::<i64>()
-            .map_err(|e| ScriptError::Parse(format!("bad expires_at: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad expires_at: {e}"),
+            })?;
         let attempt_id = AttemptId::parse(&r.field_str(3))
-            .map_err(|e| ScriptError::Parse(format!("bad attempt_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad attempt_id: {e}"),
+            })?;
         let attempt_index = r
             .field_str(4)
             .parse::<u32>()
-            .map_err(|e| ScriptError::Parse(format!("bad attempt_index: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad attempt_index: {e}"),
+            })?;
         let attempt_type = parse_attempt_type(&r.field_str(5))?;
 
         Ok(Self::Claimed(ClaimedExecutionPartial {
@@ -560,16 +588,24 @@ impl FromFcallResult for FailExecutionResult {
                 let delay_str = r.field_str(1);
                 let delay_ms: i64 = delay_str
                     .parse()
-                    .map_err(|e| ScriptError::Parse(format!("bad delay_until: {e}")))?;
+                    .map_err(|e| ScriptError::Parse {
+                        fcall: "ff_fail_execution".into(),
+                        execution_id: None,
+                        message: format!("bad delay_until: {e}"),
+                    })?;
                 Ok(FailExecutionResult::RetryScheduled {
                     delay_until: TimestampMs::from_millis(delay_ms),
                     next_attempt_index: AttemptIndex::new(0), // computed by claim_execution
                 })
             }
             "terminal_failed" => Ok(FailExecutionResult::TerminalFailed),
-            _ => Err(ScriptError::Parse(format!(
+            _ => Err(ScriptError::Parse {
+                fcall: "ff_fail_execution".into(),
+                execution_id: None,
+                message: format!(
                 "unexpected fail sub-status: {sub_status}"
-            ))),
+            ),
+            }),
         }
     }
 }
@@ -670,7 +706,11 @@ impl FromFcallResult for SetExecutionTagsResult {
         let count: u32 = r
             .field_str(0)
             .parse()
-            .map_err(|e| ScriptError::Parse(format!("bad tag count: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_set_execution_tags".into(),
+                execution_id: None,
+                message: format!("bad tag count: {e}"),
+            })?;
         Ok(SetExecutionTagsResult::Ok { count })
     }
 }
@@ -734,7 +774,11 @@ fn parse_public_state(s: &str) -> Result<PublicState, ScriptError> {
         "cancelled" => Ok(PublicState::Cancelled),
         "expired" => Ok(PublicState::Expired),
         "skipped" => Ok(PublicState::Skipped),
-        _ => Err(ScriptError::Parse(format!("unknown public_state: {s}"))),
+        _ => Err(ScriptError::Parse {
+            fcall: "ff_set_execution_tags".into(),
+            execution_id: None,
+            message: format!("unknown public_state: {s}"),
+        }),
     }
 }
 
@@ -745,7 +789,11 @@ fn parse_attempt_type(s: &str) -> Result<AttemptType, ScriptError> {
         "reclaim" => Ok(AttemptType::Reclaim),
         "replay" => Ok(AttemptType::Replay),
         "fallback" => Ok(AttemptType::Fallback),
-        _ => Err(ScriptError::Parse(format!("unknown attempt_type: {s}"))),
+        _ => Err(ScriptError::Parse {
+            fcall: "parse_attempt_type".into(),
+            execution_id: None,
+            message: format!("unknown attempt_type: {s}"),
+        }),
     }
 }
 

--- a/crates/ff-script/src/functions/flow.rs
+++ b/crates/ff-script/src/functions/flow.rs
@@ -63,11 +63,19 @@ impl FromFcallResult for CreateFlowResult {
         let r = FcallResult::parse(raw)?.into_success()?;
         let fid_str = r.field_str(0);
         let fid = ff_core::types::FlowId::parse(&fid_str)
-            .map_err(|e| ScriptError::Parse(format!("bad flow_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_create_flow".into(),
+                execution_id: None,
+                message: format!("bad flow_id: {e}"),
+            })?;
         match r.status.as_str() {
             "OK" => Ok(CreateFlowResult::Created { flow_id: fid }),
             "ALREADY_SATISFIED" => Ok(CreateFlowResult::AlreadySatisfied { flow_id: fid }),
-            _ => Err(ScriptError::Parse(format!("unexpected status: {}", r.status))),
+            _ => Err(ScriptError::Parse {
+                fcall: "ff_create_flow".into(),
+                execution_id: None,
+                message: format!("unexpected status: {}", r.status),
+            }),
         }
     }
 }
@@ -99,7 +107,11 @@ impl FromFcallResult for AddExecutionToFlowResult {
         match r.status.as_str() {
             "ALREADY_SATISFIED" => {
                 let eid = ff_core::types::ExecutionId::parse(&eid_str)
-                    .map_err(|e| ScriptError::Parse(format!("bad execution_id: {e}")))?;
+                    .map_err(|e| ScriptError::Parse {
+                        fcall: "ff_add_execution_to_flow".into(),
+                        execution_id: None,
+                        message: format!("bad execution_id: {e}"),
+                    })?;
                 let nc: u32 = nc_str.parse().unwrap_or(0);
                 Ok(AddExecutionToFlowResult::AlreadyMember {
                     execution_id: eid,
@@ -108,14 +120,22 @@ impl FromFcallResult for AddExecutionToFlowResult {
             }
             "OK" => {
                 let eid = ff_core::types::ExecutionId::parse(&eid_str)
-                    .map_err(|e| ScriptError::Parse(format!("bad execution_id: {e}")))?;
+                    .map_err(|e| ScriptError::Parse {
+                        fcall: "ff_add_execution_to_flow".into(),
+                        execution_id: None,
+                        message: format!("bad execution_id: {e}"),
+                    })?;
                 let nc: u32 = nc_str.parse().unwrap_or(0);
                 Ok(AddExecutionToFlowResult::Added {
                     execution_id: eid,
                     new_node_count: nc,
                 })
             }
-            _ => Err(ScriptError::Parse(format!("unexpected status: {}", r.status))),
+            _ => Err(ScriptError::Parse {
+                fcall: "ff_add_execution_to_flow".into(),
+                execution_id: None,
+                message: format!("unexpected status: {}", r.status),
+            }),
         }
     }
 }
@@ -280,7 +300,11 @@ impl FromFcallResult for ResolveDependencyResult {
             "satisfied" => Ok(ResolveDependencyResult::Satisfied),
             "impossible" => Ok(ResolveDependencyResult::Impossible),
             "already_resolved" => Ok(ResolveDependencyResult::AlreadyResolved),
-            other => Err(ScriptError::Parse(format!("unknown resolve status: {other}"))),
+            other => Err(ScriptError::Parse {
+                fcall: "ff_resolve_dependency".into(),
+                execution_id: None,
+                message: format!("unknown resolve status: {other}"),
+            }),
         }
     }
 }
@@ -386,9 +410,17 @@ impl FromFcallResult for StageDependencyEdgeResult {
     fn from_fcall_result(raw: &ferriskey::Value) -> Result<Self, ScriptError> {
         let r = FcallResult::parse(raw)?.into_success()?;
         let eid = ff_core::types::EdgeId::parse(&r.field_str(0))
-            .map_err(|e| ScriptError::Parse(format!("bad edge_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_stage_dependency_edge".into(),
+                execution_id: None,
+                message: format!("bad edge_id: {e}"),
+            })?;
         let rev: u64 = r.field_str(1).parse()
-            .map_err(|e| ScriptError::Parse(format!("bad graph_revision: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_stage_dependency_edge".into(),
+                execution_id: None,
+                message: format!("bad graph_revision: {e}"),
+            })?;
         Ok(StageDependencyEdgeResult::Staged {
             edge_id: eid,
             new_graph_revision: rev,
@@ -437,7 +469,11 @@ impl FromFcallResult for SetFlowTagsResult {
         let count: u32 = r
             .field_str(0)
             .parse()
-            .map_err(|e| ScriptError::Parse(format!("bad tag count: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_set_flow_tags".into(),
+                execution_id: None,
+                message: format!("bad tag count: {e}"),
+            })?;
         Ok(SetFlowTagsResult::Ok { count })
     }
 }

--- a/crates/ff-script/src/functions/lease.rs
+++ b/crates/ff-script/src/functions/lease.rs
@@ -23,7 +23,11 @@ impl FromFcallResult for RenewLeaseResult {
         let expires_str = r.field_str(0);
         let expires_ms: i64 = expires_str
             .parse()
-            .map_err(|_| ScriptError::Parse(format!("invalid expires_at: {expires_str}")))?;
+            .map_err(|_| ScriptError::Parse {
+                fcall: "ff_renew_lease".into(),
+                execution_id: None,
+                message: format!("invalid expires_at: {expires_str}"),
+            })?;
         Ok(RenewLeaseResult::Renewed {
             expires_at: TimestampMs::from_millis(expires_ms),
         })
@@ -39,9 +43,13 @@ impl FromFcallResult for MarkLeaseExpiredResult {
             "ALREADY_SATISFIED" => Ok(MarkLeaseExpiredResult::AlreadySatisfied {
                 reason: r.field_str(0),
             }),
-            other => Err(ScriptError::Parse(format!(
+            other => Err(ScriptError::Parse {
+                fcall: "ff_mark_lease_expired".into(),
+                execution_id: None,
+                message: format!(
                 "unexpected status from ff_mark_lease_expired_if_due: {other}"
-            ))),
+            ),
+            }),
         }
     }
 }
@@ -62,9 +70,13 @@ impl FromFcallResult for RevokeLeaseResult {
             "ALREADY_SATISFIED" => Ok(RevokeLeaseResult::AlreadySatisfied {
                 reason: r.field_str(0),
             }),
-            other => Err(ScriptError::Parse(format!(
+            other => Err(ScriptError::Parse {
+                fcall: "ff_revoke_lease".into(),
+                execution_id: None,
+                message: format!(
                 "unexpected status from ff_revoke_lease: {other}"
-            ))),
+            ),
+            }),
         }
     }
 }

--- a/crates/ff-script/src/functions/lease.rs
+++ b/crates/ff-script/src/functions/lease.rs
@@ -44,7 +44,7 @@ impl FromFcallResult for MarkLeaseExpiredResult {
                 reason: r.field_str(0),
             }),
             other => Err(ScriptError::Parse {
-                fcall: "ff_mark_lease_expired".into(),
+                fcall: "ff_mark_lease_expired_if_due".into(),
                 execution_id: None,
                 message: format!(
                 "unexpected status from ff_mark_lease_expired_if_due: {other}"

--- a/crates/ff-script/src/functions/quota.rs
+++ b/crates/ff-script/src/functions/quota.rs
@@ -44,11 +44,19 @@ impl FromFcallResult for CreateQuotaPolicyResult {
         let r = FcallResult::parse(raw)?.into_success()?;
         let id_str = r.field_str(0);
         let qid = ff_core::types::QuotaPolicyId::parse(&id_str)
-            .map_err(|e| ScriptError::Parse(format!("invalid quota_policy_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_create_quota_policy".into(),
+                execution_id: None,
+                message: format!("invalid quota_policy_id: {e}"),
+            })?;
         match r.status.as_str() {
             "OK" => Ok(CreateQuotaPolicyResult::Created { quota_policy_id: qid }),
             "ALREADY_SATISFIED" => Ok(CreateQuotaPolicyResult::AlreadySatisfied { quota_policy_id: qid }),
-            _ => Err(ScriptError::Parse(format!("unexpected status: {}", r.status))),
+            _ => Err(ScriptError::Parse {
+                fcall: "ff_create_quota_policy".into(),
+                execution_id: None,
+                message: format!("unexpected status: {}", r.status),
+            }),
         }
     }
 }
@@ -86,12 +94,20 @@ impl FromFcallResult for CheckAdmissionResult {
         // {"RATE_EXCEEDED", retry_after_ms}, {"CONCURRENCY_EXCEEDED"}
         let arr = match raw {
             ferriskey::Value::Array(arr) => arr,
-            _ => return Err(ScriptError::Parse("expected Array".into())),
+            _ => return Err(ScriptError::Parse {
+                fcall: "ff_check_admission".into(),
+                execution_id: None,
+                message: "expected Array".into(),
+            }),
         };
         let status = match arr.first() {
             Some(Ok(ferriskey::Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
             Some(Ok(ferriskey::Value::SimpleString(s))) => s.clone(),
-            _ => return Err(ScriptError::Parse("expected status string".into())),
+            _ => return Err(ScriptError::Parse {
+                fcall: "ff_check_admission".into(),
+                execution_id: None,
+                message: "expected status string".into(),
+            }),
         };
         match status.as_str() {
             "ADMITTED" => Ok(CheckAdmissionResult::Admitted),
@@ -110,9 +126,13 @@ impl FromFcallResult for CheckAdmissionResult {
                 })
             }
             "CONCURRENCY_EXCEEDED" => Ok(CheckAdmissionResult::ConcurrencyExceeded),
-            _ => Err(ScriptError::Parse(format!(
+            _ => Err(ScriptError::Parse {
+                fcall: "ff_check_admission".into(),
+                execution_id: None,
+                message: format!(
                 "unknown admission status: {status}"
-            ))),
+            ),
+            }),
         }
     }
 }

--- a/crates/ff-script/src/functions/scheduling.rs
+++ b/crates/ff-script/src/functions/scheduling.rs
@@ -67,7 +67,11 @@ impl FromFcallResult for IssueClaimGrantResult {
         // ok(execution_id)
         let eid_str = r.field_str(0);
         let eid = ExecutionId::parse(&eid_str)
-            .map_err(|e| ScriptError::Parse(format!("bad execution_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_issue_claim_grant".into(),
+                execution_id: None,
+                message: format!("bad execution_id: {e}"),
+            })?;
         Ok(IssueClaimGrantResult::Granted { execution_id: eid })
     }
 }

--- a/crates/ff-script/src/functions/signal.rs
+++ b/crates/ff-script/src/functions/signal.rs
@@ -119,7 +119,11 @@ impl FromFcallResult for DeliverSignalResult {
         if r.status == "DUPLICATE" {
             let sid_str = r.field_str(0);
             let sid = SignalId::parse(&sid_str)
-                .map_err(|e| ScriptError::Parse(format!("bad signal_id: {e}")))?;
+                .map_err(|e| ScriptError::Parse {
+                    fcall: "ff_deliver_signal".into(),
+                    execution_id: None,
+                    message: format!("bad signal_id: {e}"),
+                })?;
             return Ok(DeliverSignalResult::Duplicate {
                 existing_signal_id: sid,
             });
@@ -129,7 +133,11 @@ impl FromFcallResult for DeliverSignalResult {
         let sid_str = r.field_str(0);
         let effect = r.field_str(1);
         let sid = SignalId::parse(&sid_str)
-            .map_err(|e| ScriptError::Parse(format!("bad signal_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_deliver_signal".into(),
+                execution_id: None,
+                message: format!("bad signal_id: {e}"),
+            })?;
         Ok(DeliverSignalResult::Accepted {
             signal_id: sid,
             effect,
@@ -191,7 +199,11 @@ impl FromFcallResult for BufferSignalResult {
         if r.status == "DUPLICATE" {
             let sid_str = r.field_str(0);
             let sid = SignalId::parse(&sid_str)
-                .map_err(|e| ScriptError::Parse(format!("bad signal_id: {e}")))?;
+                .map_err(|e| ScriptError::Parse {
+                    fcall: "ff_buffer_signal".into(),
+                    execution_id: None,
+                    message: format!("bad signal_id: {e}"),
+                })?;
             return Ok(BufferSignalResult::Duplicate {
                 existing_signal_id: sid,
             });
@@ -200,7 +212,11 @@ impl FromFcallResult for BufferSignalResult {
         // ok(signal_id, "buffered_for_pending_waitpoint")
         let sid_str = r.field_str(0);
         let sid = SignalId::parse(&sid_str)
-            .map_err(|e| ScriptError::Parse(format!("bad signal_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_buffer_signal".into(),
+                execution_id: None,
+                message: format!("bad signal_id: {e}"),
+            })?;
         Ok(BufferSignalResult::Buffered { signal_id: sid })
     }
 }
@@ -250,15 +266,35 @@ impl FromFcallResult for ClaimResumedExecutionResultPartial {
         let r = FcallResult::parse(raw)?.into_success()?;
         // ok(lease_id, epoch, expires_at, attempt_id, attempt_index, "resumed")
         let lease_id = LeaseId::parse(&r.field_str(0))
-            .map_err(|e| ScriptError::Parse(format!("bad lease_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_resumed_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad lease_id: {e}"),
+            })?;
         let epoch = r.field_str(1).parse::<u64>()
-            .map_err(|e| ScriptError::Parse(format!("bad epoch: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_resumed_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad epoch: {e}"),
+            })?;
         let expires_at = r.field_str(2).parse::<i64>()
-            .map_err(|e| ScriptError::Parse(format!("bad expires_at: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_resumed_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad expires_at: {e}"),
+            })?;
         let attempt_id = AttemptId::parse(&r.field_str(3))
-            .map_err(|e| ScriptError::Parse(format!("bad attempt_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_resumed_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad attempt_id: {e}"),
+            })?;
         let attempt_index = r.field_str(4).parse::<u32>()
-            .map_err(|e| ScriptError::Parse(format!("bad attempt_index: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_claim_resumed_execution_result_partial".into(),
+                execution_id: None,
+                message: format!("bad attempt_index: {e}"),
+            })?;
 
         Ok(Self::Claimed(ClaimedResumedExecutionPartial {
             lease_id,

--- a/crates/ff-script/src/functions/stream.rs
+++ b/crates/ff-script/src/functions/stream.rs
@@ -49,7 +49,11 @@ impl FromFcallResult for AppendFrameResult {
         // ok(entry_id, frame_count)
         let entry_id = r.field_str(0);
         let frame_count = r.field_str(1).parse::<u64>()
-            .map_err(|e| ScriptError::Parse(format!("bad frame_count: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_append_frame".into(),
+                execution_id: None,
+                message: format!("bad frame_count: {e}"),
+            })?;
         Ok(AppendFrameResult::Appended {
             entry_id,
             frame_count,
@@ -83,8 +87,10 @@ impl FromFcallResult for ReadFramesResult {
         // - entries: array of [entry_id, [f1, v1, ...]]
         // - closed_at: string (ms timestamp) or "" if open
         // - closed_reason: string or "" if open
-        let entries = r.fields.first().ok_or_else(|| {
-            ScriptError::Parse("ff_read_attempt_stream: missing entries field".into())
+        let entries = r.fields.first().ok_or_else(|| ScriptError::Parse {
+            fcall: "ff_read_attempt_stream".into(),
+            execution_id: None,
+            message: "missing entries field".into(),
         })?;
         // XRANGE from a Valkey Function passes fields through as raw Lua
         // arrays — no ArrayOfPairs conversion, so always Flat here.
@@ -147,41 +153,52 @@ pub(crate) fn parse_entries(
         ferriskey::Value::Array(arr) => arr,
         ferriskey::Value::Nil => return Ok(Vec::new()),
         other => {
-            return Err(ScriptError::Parse(format!(
-                "XRANGE/XREAD entries: expected Array, got {other:?}"
-            )));
+            return Err(ScriptError::Parse {
+                fcall: "parse_entries".into(),
+                execution_id: None,
+                message: format!("XRANGE/XREAD entries: expected Array, got {other:?}"),
+            });
         }
     };
 
     let mut frames = Vec::with_capacity(entries.len());
     for entry in entries.iter() {
-        let entry = entry.as_ref().map_err(|e| {
-            ScriptError::Parse(format!("XRANGE entry error: {e}"))
+        let entry = entry.as_ref().map_err(|e| ScriptError::Parse {
+            fcall: "parse_entries".into(),
+            execution_id: None,
+            message: format!("XRANGE entry error: {e}"),
         })?;
         let parts = match entry {
             ferriskey::Value::Array(a) => a,
             other => {
-                return Err(ScriptError::Parse(format!(
-                    "XRANGE entry: expected Array, got {other:?}"
-                )));
+                return Err(ScriptError::Parse {
+                    fcall: "parse_entries".into(),
+                    execution_id: None,
+                    message: format!("XRANGE entry: expected Array, got {other:?}"),
+                });
             }
         };
         if parts.len() != 2 {
-            return Err(ScriptError::Parse(format!(
-                "XRANGE entry: expected 2 elements, got {}",
-                parts.len()
-            )));
+            return Err(ScriptError::Parse {
+                fcall: "parse_entries".into(),
+                execution_id: None,
+                message: format!("XRANGE entry: expected 2 elements, got {}", parts.len()),
+            });
         }
-        let id = value_to_string(parts[0].as_ref().ok()).ok_or_else(|| {
-            ScriptError::Parse("XRANGE entry: missing/invalid id".into())
+        let id = value_to_string(parts[0].as_ref().ok()).ok_or_else(|| ScriptError::Parse {
+            fcall: "parse_entries".into(),
+            execution_id: None,
+            message: "XRANGE entry: missing/invalid id".into(),
         })?;
 
         let field_val = match parts[1].as_ref() {
             Ok(v) => v,
             Err(e) => {
-                return Err(ScriptError::Parse(format!(
-                    "XRANGE entry fields error: {e}"
-                )));
+                return Err(ScriptError::Parse {
+                    fcall: "parse_entries".into(),
+                    execution_id: None,
+                    message: format!("XRANGE entry fields error: {e}"),
+                });
             }
         };
         let fields = parse_fields_kv(field_val, shape)?;
@@ -209,21 +226,33 @@ pub(crate) fn parse_fields_kv(
             let arr = match v {
                 ferriskey::Value::Array(arr) => arr,
                 other => {
-                    return Err(ScriptError::Parse(format!(
-                        "stream fields (Flat): expected Array, got {other:?}"
-                    )));
+                    return Err(ScriptError::Parse {
+                        fcall: "parse_fields_kv".into(),
+                        execution_id: None,
+                        message: format!(
+                            "stream fields (Flat): expected Array, got {other:?}"
+                        ),
+                    });
                 }
             };
             if !arr.len().is_multiple_of(2) {
-                return Err(ScriptError::Parse(format!(
-                    "stream fields (Flat): odd element count {}",
-                    arr.len()
-                )));
+                return Err(ScriptError::Parse {
+                    fcall: "parse_fields_kv".into(),
+                    execution_id: None,
+                    message: format!(
+                        "stream fields (Flat): odd element count {}",
+                        arr.len()
+                    ),
+                });
             }
             let mut i = 0;
             while i < arr.len() {
                 let k = value_to_string(arr[i].as_ref().ok())
-                    .ok_or_else(|| ScriptError::Parse("stream field: bad key".into()))?;
+                    .ok_or_else(|| ScriptError::Parse {
+                        fcall: "parse_fields_kv".into(),
+                        execution_id: None,
+                        message: "stream field: bad key".into(),
+                    })?;
                 let val = value_to_string(arr[i + 1].as_ref().ok()).unwrap_or_default();
                 out.insert(k, val);
                 i += 2;
@@ -233,28 +262,43 @@ pub(crate) fn parse_fields_kv(
             let arr = match v {
                 ferriskey::Value::Array(arr) => arr,
                 other => {
-                    return Err(ScriptError::Parse(format!(
-                        "stream fields (Pairs): expected Array, got {other:?}"
-                    )));
+                    return Err(ScriptError::Parse {
+                        fcall: "parse_fields_kv".into(),
+                        execution_id: None,
+                        message: format!(
+                            "stream fields (Pairs): expected Array, got {other:?}"
+                        ),
+                    });
                 }
             };
             for pair in arr.iter() {
                 let inner = match pair.as_ref() {
                     Ok(ferriskey::Value::Array(inner)) => inner,
                     _ => {
-                        return Err(ScriptError::Parse(
-                            "stream fields (Pairs): expected 2-element Array per entry".into(),
-                        ));
+                        return Err(ScriptError::Parse {
+                            fcall: "parse_fields_kv".into(),
+                            execution_id: None,
+                            message: "stream fields (Pairs): expected 2-element Array per entry"
+                                .into(),
+                        });
                     }
                 };
                 if inner.len() != 2 {
-                    return Err(ScriptError::Parse(format!(
-                        "stream fields (Pairs): expected len=2, got {}",
-                        inner.len()
-                    )));
+                    return Err(ScriptError::Parse {
+                        fcall: "parse_fields_kv".into(),
+                        execution_id: None,
+                        message: format!(
+                            "stream fields (Pairs): expected len=2, got {}",
+                            inner.len()
+                        ),
+                    });
                 }
                 let k = value_to_string(inner[0].as_ref().ok())
-                    .ok_or_else(|| ScriptError::Parse("stream field: bad key".into()))?;
+                    .ok_or_else(|| ScriptError::Parse {
+                        fcall: "parse_fields_kv".into(),
+                        execution_id: None,
+                        message: "stream field: bad key".into(),
+                    })?;
                 let val = value_to_string(inner[1].as_ref().ok()).unwrap_or_default();
                 out.insert(k, val);
             }
@@ -263,14 +307,22 @@ pub(crate) fn parse_fields_kv(
             let pairs = match v {
                 ferriskey::Value::Map(pairs) => pairs,
                 other => {
-                    return Err(ScriptError::Parse(format!(
-                        "stream fields (Map): expected Map, got {other:?}"
-                    )));
+                    return Err(ScriptError::Parse {
+                        fcall: "parse_fields_kv".into(),
+                        execution_id: None,
+                        message: format!(
+                            "stream fields (Map): expected Map, got {other:?}"
+                        ),
+                    });
                 }
             };
             for (k, vv) in pairs {
                 let key = value_to_string(Some(k))
-                    .ok_or_else(|| ScriptError::Parse("stream field: bad key".into()))?;
+                    .ok_or_else(|| ScriptError::Parse {
+                        fcall: "parse_fields_kv".into(),
+                        execution_id: None,
+                        message: "stream field: bad key".into(),
+                    })?;
                 let val = value_to_string(Some(vv)).unwrap_or_default();
                 out.insert(key, val);
             }

--- a/crates/ff-script/src/functions/suspension.rs
+++ b/crates/ff-script/src/functions/suspension.rs
@@ -455,7 +455,7 @@ fn parse_public_state(s: &str) -> Result<PublicState, ScriptError> {
         "expired" => Ok(PublicState::Expired),
         "skipped" => Ok(PublicState::Skipped),
         _ => Err(ScriptError::Parse {
-            fcall: "ff_waitpoint_hmac_kids".into(),
+            fcall: "parse_public_state".into(),
             execution_id: None,
             message: format!("unknown public_state: {s}"),
         }),

--- a/crates/ff-script/src/functions/suspension.rs
+++ b/crates/ff-script/src/functions/suspension.rs
@@ -83,9 +83,17 @@ impl FromFcallResult for SuspendExecutionResult {
         // ALREADY_SATISFIED: {1, "ALREADY_SATISFIED", suspension_id, waitpoint_id, waitpoint_key, waitpoint_token}
         if r.status == "ALREADY_SATISFIED" {
             let sid = SuspensionId::parse(&r.field_str(0))
-                .map_err(|e| ScriptError::Parse(format!("bad suspension_id: {e}")))?;
+                .map_err(|e| ScriptError::Parse {
+                    fcall: "ff_suspend_execution".into(),
+                    execution_id: None,
+                    message: format!("bad suspension_id: {e}"),
+                })?;
             let wid = WaitpointId::parse(&r.field_str(1))
-                .map_err(|e| ScriptError::Parse(format!("bad waitpoint_id: {e}")))?;
+                .map_err(|e| ScriptError::Parse {
+                    fcall: "ff_suspend_execution".into(),
+                    execution_id: None,
+                    message: format!("bad waitpoint_id: {e}"),
+                })?;
             let wkey = r.field_str(2);
             let token = WaitpointToken::new(r.field_str(3));
             return Ok(SuspendExecutionResult::AlreadySatisfied {
@@ -98,9 +106,17 @@ impl FromFcallResult for SuspendExecutionResult {
         let r = r.into_success()?;
         // ok(suspension_id, waitpoint_id, waitpoint_key, waitpoint_token)
         let sid = SuspensionId::parse(&r.field_str(0))
-            .map_err(|e| ScriptError::Parse(format!("bad suspension_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_suspend_execution".into(),
+                execution_id: None,
+                message: format!("bad suspension_id: {e}"),
+            })?;
         let wid = WaitpointId::parse(&r.field_str(1))
-            .map_err(|e| ScriptError::Parse(format!("bad waitpoint_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_suspend_execution".into(),
+                execution_id: None,
+                message: format!("bad waitpoint_id: {e}"),
+            })?;
         let wkey = r.field_str(2);
         let token = WaitpointToken::new(r.field_str(3));
         Ok(SuspendExecutionResult::Suspended {
@@ -195,7 +211,11 @@ impl FromFcallResult for CreatePendingWaitpointResult {
         let r = FcallResult::parse(raw)?.into_success()?;
         // ok(waitpoint_id, waitpoint_key, waitpoint_token)
         let wid = WaitpointId::parse(&r.field_str(0))
-            .map_err(|e| ScriptError::Parse(format!("bad waitpoint_id: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_create_pending_waitpoint".into(),
+                execution_id: None,
+                message: format!("bad waitpoint_id: {e}"),
+            })?;
         let wkey = r.field_str(1);
         let token = WaitpointToken::new(r.field_str(2));
         Ok(CreatePendingWaitpointResult::Created {
@@ -338,7 +358,11 @@ impl FromFcallResult for RotateWaitpointHmacSecretOutcome {
                 let gc_count = r
                     .field_str(3)
                     .parse::<u32>()
-                    .map_err(|e| ScriptError::Parse(format!("bad gc_count: {e}")))?;
+                    .map_err(|e| ScriptError::Parse {
+                        fcall: "ff_rotate_waitpoint_hmac_secret_outcome".into(),
+                        execution_id: None,
+                        message: format!("bad gc_count: {e}"),
+                    })?;
                 Ok(RotateWaitpointHmacSecretOutcome::Rotated {
                     previous_kid: if prev.is_empty() { None } else { Some(prev) },
                     new_kid,
@@ -348,9 +372,13 @@ impl FromFcallResult for RotateWaitpointHmacSecretOutcome {
             "noop" => Ok(RotateWaitpointHmacSecretOutcome::Noop {
                 kid: r.field_str(1),
             }),
-            other => Err(ScriptError::Parse(format!(
+            other => Err(ScriptError::Parse {
+                fcall: "ff_rotate_waitpoint_hmac_secret_outcome".into(),
+                execution_id: None,
+                message: format!(
                 "unexpected rotation outcome: {other}"
-            ))),
+            ),
+            }),
         }
     }
 }
@@ -379,14 +407,22 @@ impl FromFcallResult for WaitpointHmacKids {
         let n = r
             .field_str(1)
             .parse::<usize>()
-            .map_err(|e| ScriptError::Parse(format!("bad verifying count: {e}")))?;
+            .map_err(|e| ScriptError::Parse {
+                fcall: "ff_waitpoint_hmac_kids".into(),
+                execution_id: None,
+                message: format!("bad verifying count: {e}"),
+            })?;
         let mut verifying = Vec::with_capacity(n);
         for i in 0..n {
             let kid = r.field_str(2 + 2 * i);
             let exp = r
                 .field_str(2 + 2 * i + 1)
                 .parse::<i64>()
-                .map_err(|e| ScriptError::Parse(format!("bad expires_at_ms for kid {kid}: {e}")))?;
+                .map_err(|e| ScriptError::Parse {
+                    fcall: "ff_waitpoint_hmac_kids".into(),
+                    execution_id: None,
+                    message: format!("bad expires_at_ms for kid {kid}: {e}"),
+                })?;
             verifying.push(VerifyingKid {
                 kid,
                 expires_at_ms: exp,
@@ -418,6 +454,10 @@ fn parse_public_state(s: &str) -> Result<PublicState, ScriptError> {
         "cancelled" => Ok(PublicState::Cancelled),
         "expired" => Ok(PublicState::Expired),
         "skipped" => Ok(PublicState::Skipped),
-        _ => Err(ScriptError::Parse(format!("unknown public_state: {s}"))),
+        _ => Err(ScriptError::Parse {
+            fcall: "ff_waitpoint_hmac_kids".into(),
+            execution_id: None,
+            message: format!("unknown public_state: {s}"),
+        }),
     }
 }

--- a/crates/ff-script/src/result.rs
+++ b/crates/ff-script/src/result.rs
@@ -29,25 +29,31 @@ impl FcallResult {
             // Individual callers handle that; this parser is for the
             // standard {status_code, status_string, ...} convention.
             _ => {
-                return Err(ScriptError::Parse(format!(
-                    "expected Array, got {:?}",
-                    value_type_name(raw)
-                )));
+                return Err(ScriptError::Parse {
+                    fcall: "FcallResult::parse".into(),
+                    execution_id: None,
+                    message: format!("expected Array, got {:?}", value_type_name(raw)),
+                });
             }
         };
 
         if items.is_empty() {
-            return Err(ScriptError::Parse("empty FCALL result array".into()));
+            return Err(ScriptError::Parse {
+                fcall: "FcallResult::parse".into(),
+                execution_id: None,
+                message: "empty FCALL result array".into(),
+            });
         }
 
         // Element [0]: status code (Int 1 or 0)
         let status_code = match items.first() {
             Some(Ok(Value::Int(n))) => *n,
             other => {
-                return Err(ScriptError::Parse(format!(
-                    "expected Int at index 0, got {:?}",
-                    other
-                )));
+                return Err(ScriptError::Parse {
+                    fcall: "FcallResult::parse".into(),
+                    execution_id: None,
+                    message: format!("expected Int at index 0, got {:?}", other),
+                });
             }
         };
 
@@ -86,8 +92,10 @@ impl FcallResult {
         } else {
             let detail = value_to_string(self.fields.first());
             let err = ScriptError::from_code_with_detail(&self.status, &detail)
-                .unwrap_or_else(|| {
-                    ScriptError::Parse(format!("unknown error code: {}", self.status))
+                .unwrap_or_else(|| ScriptError::Parse {
+                    fcall: "FcallResult::into_success".into(),
+                    execution_id: None,
+                    message: format!("unknown error code: {}", self.status),
                 });
             Err(err)
         }

--- a/crates/ff-script/src/stream_tail.rs
+++ b/crates/ff-script/src/stream_tail.rs
@@ -190,9 +190,11 @@ fn parse_xread_reply(raw: &Value, stream_key: &str) -> Result<Vec<StreamFrame>, 
                 let entries_val = match pair[1].as_ref() {
                     Ok(v) => v,
                     Err(e) => {
-                        return Err(ScriptError::Parse(format!(
-                            "XREAD entries (RESP2): {e}"
-                        )));
+                        return Err(ScriptError::Parse {
+                            fcall: "stream_tail_decode".into(),
+                            execution_id: None,
+                            message: format!("XREAD entries (RESP2): {e}"),
+                        });
                     }
                 };
                 return parse_entries_any(entries_val);
@@ -207,9 +209,11 @@ fn parse_xread_reply(raw: &Value, stream_key: &str) -> Result<Vec<StreamFrame>, 
             return Ok(Vec::new());
         }
         other => {
-            return Err(ScriptError::Parse(format!(
-                "XREAD: expected Map/Nil/Array, got {other:?}"
-            )));
+            return Err(ScriptError::Parse {
+                fcall: "stream_tail_decode".into(),
+                execution_id: None,
+                message: format!("XREAD: expected Map/Nil/Array, got {other:?}"),
+            });
         }
     };
 
@@ -233,7 +237,11 @@ fn parse_xread_reply(raw: &Value, stream_key: &str) -> Result<Vec<StreamFrame>, 
                 let mut frames = Vec::with_capacity(entries.len());
                 for (id_v, field_v) in entries {
                     let id = value_to_string(Some(id_v))
-                        .ok_or_else(|| ScriptError::Parse("XREAD entry: bad id".into()))?;
+                        .ok_or_else(|| ScriptError::Parse {
+                            fcall: "stream_tail_decode".into(),
+                            execution_id: None,
+                            message: "XREAD entry: bad id".into(),
+                        })?;
                     let fields = parse_fields_kv(field_v, FieldShape::Pairs)?;
                     frames.push(StreamFrame { id, fields });
                 }
@@ -251,9 +259,11 @@ fn parse_xread_reply(raw: &Value, stream_key: &str) -> Result<Vec<StreamFrame>, 
             }
             Value::Nil => Vec::new(),
             other => {
-                return Err(ScriptError::Parse(format!(
-                    "XREAD entries: expected Map/Array, got {other:?}"
-                )));
+                return Err(ScriptError::Parse {
+                    fcall: "stream_tail_decode".into(),
+                    execution_id: None,
+                    message: format!("XREAD entries: expected Map/Array, got {other:?}"),
+                });
             }
         };
         return Ok(frames);
@@ -280,14 +290,20 @@ fn parse_entries_any(raw: &Value) -> Result<Vec<StreamFrame>, ScriptError> {
             let mut frames = Vec::with_capacity(map.len());
             for (id_v, field_v) in map {
                 let id = value_to_string(Some(id_v))
-                    .ok_or_else(|| ScriptError::Parse("XREAD entry: bad id".into()))?;
+                    .ok_or_else(|| ScriptError::Parse {
+                        fcall: "parse_entries_any".into(),
+                        execution_id: None,
+                        message: "XREAD entry: bad id".into(),
+                    })?;
                 let fields = parse_fields_kv(field_v, FieldShape::Pairs)?;
                 frames.push(StreamFrame { id, fields });
             }
             Ok(frames)
         }
-        other => Err(ScriptError::Parse(format!(
-            "XREAD entries: expected Array/Map/Nil, got {other:?}"
-        ))),
+        other => Err(ScriptError::Parse {
+            fcall: "parse_entries_any".into(),
+            execution_id: None,
+            message: format!("XREAD entries: expected Array/Map/Nil, got {other:?}"),
+        }),
     }
 }

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -83,19 +83,21 @@ impl FlowFabricAdminClient {
     ) -> Result<Self, SdkError> {
         let token_str = token.as_ref();
         if token_str.trim().is_empty() {
-            return Err(SdkError::Config(
-                "bearer token is empty or all-whitespace; use \
-                 FlowFabricAdminClient::new for unauthenticated access"
+            return Err(SdkError::Config {
+                context: "admin_client".into(),
+                field: Some("bearer_token".into()),
+                message: "is empty or all-whitespace; use \
+                          FlowFabricAdminClient::new for unauthenticated access"
                     .into(),
-            ));
+            });
         }
         let mut headers = reqwest::header::HeaderMap::new();
         let mut auth_value =
             reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token_str)).map_err(
-                |_| {
-                    SdkError::Config(
-                        "bearer token contains characters not valid in an HTTP header".into(),
-                    )
+                |_| SdkError::Config {
+                    context: "admin_client".into(),
+                    field: Some("bearer_token".into()),
+                    message: "contains characters not valid in an HTTP header".into(),
                 },
             )?;
         // Mark Authorization as sensitive so it doesn't appear in
@@ -137,15 +139,16 @@ impl FlowFabricAdminClient {
         // splicing it verbatim would produce malformed URLs or
         // misrouted paths. `Url::path_segments_mut().push` handles the
         // encoding natively.
-        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| {
-            SdkError::Config(format!("invalid base_url '{}': {e}", self.base_url))
+        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| SdkError::Config {
+            context: "admin_client: claim_for_worker".into(),
+            field: Some("base_url".into()),
+            message: format!("invalid base_url '{}': {e}", self.base_url),
         })?;
         {
-            let mut segs = url.path_segments_mut().map_err(|_| {
-                SdkError::Config(format!(
-                    "base_url cannot be a base URL: '{}'",
-                    self.base_url
-                ))
+            let mut segs = url.path_segments_mut().map_err(|_| SdkError::Config {
+                context: "admin_client: claim_for_worker".into(),
+                field: Some("base_url".into()),
+                message: format!("base_url cannot be a base URL: '{}'", self.base_url),
             })?;
             segs.extend(&["v1", "workers", &req.worker_id, "claim"]);
         }
@@ -427,7 +430,10 @@ mod tests {
         // Raw newline in the token would split the Authorization
         // header — must fail loudly at construction.
         let err = FlowFabricAdminClient::with_token("http://x", "tok\nevil").unwrap_err();
-        assert!(matches!(err, SdkError::Config(_)), "got: {err:?}");
+        assert!(
+            matches!(err, SdkError::Config { .. }),
+            "got: {err:?}"
+        );
     }
 
     #[test]
@@ -439,8 +445,8 @@ mod tests {
             let err = FlowFabricAdminClient::with_token("http://x", s)
                 .unwrap_err();
             assert!(
-                matches!(&err, SdkError::Config(msg) if msg.contains("empty")),
-                "token {s:?} should return Config(empty/whitespace); got: {err:?}"
+                matches!(&err, SdkError::Config { field: Some(f), .. } if f == "bearer_token"),
+                "token {s:?} should return Config with field=bearer_token; got: {err:?}"
             );
         }
     }

--- a/crates/ff-sdk/src/engine_error.rs
+++ b/crates/ff-sdk/src/engine_error.rs
@@ -680,7 +680,7 @@ impl From<ScriptError> for EngineError {
             S::AttemptNotInCreatedState => Self::Bug(BugKind::AttemptNotInCreatedState),
 
             // ── Transport (preserves source for Parse/Valkey) ──
-            e @ (S::Parse(_) | S::Valkey(_)) => Self::transport_script(e),
+            e @ (S::Parse { .. } | S::Valkey(_)) => Self::transport_script(e),
 
             // `ScriptError` is `#[non_exhaustive]`. A future variant
             // landed in ff-script before the mapping here was updated
@@ -817,13 +817,17 @@ mod tests {
 
     #[test]
     fn transport_preserves_parse() {
-        let err = EngineError::from(ScriptError::Parse("bad envelope".into()));
+        let err = EngineError::from(ScriptError::Parse {
+            fcall: "test_bad_envelope".into(),
+            execution_id: None,
+            message: "bad envelope".into(),
+        });
         match &err {
             EngineError::Transport { backend, source } => {
                 assert_eq!(*backend, "valkey");
                 assert!(matches!(
                     source.downcast_ref::<ScriptError>(),
-                    Some(ScriptError::Parse(_))
+                    Some(ScriptError::Parse { .. })
                 ));
             }
             other => panic!("{other:?}"),

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -106,9 +106,19 @@ pub enum SdkError {
     #[error("engine: {0}")]
     Engine(Box<EngineError>),
 
-    /// Configuration error.
-    #[error("config: {0}")]
-    Config(String),
+    /// Configuration error. `context` identifies the call site / logical
+    /// operation (e.g. `"describe_execution: exec_core"`, `"admin_client"`).
+    /// `field` names the specific offending field when the error is
+    /// field-scoped (e.g. `Some("public_state")`), or `None` for
+    /// whole-object validation (e.g. `"at least one lane is required"`).
+    /// `message` carries dynamic detail: source-error rendering, the
+    /// offending raw value, etc.
+    #[error("{}", fmt_config(.context, .field.as_deref(), .message))]
+    Config {
+        context: String,
+        field: Option<String>,
+        message: String,
+    },
 
     /// Worker is at its configured `max_concurrent_tasks` capacity —
     /// the caller should retry later. Returned by
@@ -177,6 +187,15 @@ pub enum SdkError {
     },
 }
 
+/// Renders `SdkError::Config` as `config: <context>[.<field>]: <message>`.
+/// The `field` slot is omitted when `None` (whole-object validation).
+fn fmt_config(context: &str, field: Option<&str>, message: &str) -> String {
+    match field {
+        Some(f) => format!("config: {context}.{f}: {message}"),
+        None => format!("config: {context}: {message}"),
+    }
+}
+
 /// Preserves the ergonomic `?`-propagation from FCALL sites that
 /// return `Result<_, ScriptError>`. Routes through `EngineError`'s
 /// typed classification so every call site gets the same
@@ -206,7 +225,7 @@ impl SdkError {
             // the admin path never touches Valkey directly from the
             // SDK side. Use `AdminApi.kind` for the server-supplied
             // label when present.
-            Self::Config(_) | Self::WorkerAtCapacity | Self::Http { .. } | Self::AdminApi { .. } => {
+            Self::Config { .. } | Self::WorkerAtCapacity | Self::Http { .. } | Self::AdminApi { .. } => {
                 None
             }
         }
@@ -242,7 +261,7 @@ impl SdkError {
             Self::AdminApi {
                 status, retryable, ..
             } => retryable.unwrap_or(matches!(*status, 429 | 502 | 503 | 504)),
-            Self::Config(_) => false,
+            Self::Config { .. } => false,
         }
     }
 }
@@ -285,7 +304,15 @@ mod tests {
             SdkError::from(ScriptError::LeaseExpired).valkey_kind(),
             None
         );
-        assert_eq!(SdkError::Config("bad host".into()).valkey_kind(), None);
+        assert_eq!(
+            SdkError::Config {
+                context: "worker_config".into(),
+                field: Some("bearer_token".into()),
+                message: "bad host".into(),
+            }
+            .valkey_kind(),
+            None
+        );
     }
 
     #[test]
@@ -307,9 +334,51 @@ mod tests {
         );
     }
 
+    /// Regression (#98): `SdkError::Config` carries `context`, optional
+    /// `field`, and `message` separately so consumers can pattern-match on
+    /// the offending field without parsing the Display string. Test covers
+    /// both the field-scoped and whole-object renderings.
+    #[test]
+    fn config_structured_fields_render_and_match() {
+        let with_field = SdkError::Config {
+            context: "admin_client".into(),
+            field: Some("bearer_token".into()),
+            message: "is empty or all-whitespace".into(),
+        };
+        assert_eq!(
+            with_field.to_string(),
+            "config: admin_client.bearer_token: is empty or all-whitespace"
+        );
+        assert!(matches!(
+            &with_field,
+            SdkError::Config { field: Some(f), .. } if f == "bearer_token"
+        ));
+
+        let whole_object = SdkError::Config {
+            context: "worker_config".into(),
+            field: None,
+            message: "at least one lane is required".into(),
+        };
+        assert_eq!(
+            whole_object.to_string(),
+            "config: worker_config: at least one lane is required"
+        );
+        assert!(matches!(
+            &whole_object,
+            SdkError::Config { field: None, .. }
+        ));
+    }
+
     #[test]
     fn is_retryable_config_false() {
-        assert!(!SdkError::Config("at least one lane is required".into()).is_retryable());
+        assert!(
+            !SdkError::Config {
+                context: "worker_config".into(),
+                field: None,
+                message: "at least one lane is required".into(),
+            }
+            .is_retryable()
+        );
     }
 
     #[test]

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -121,10 +121,11 @@ fn build_execution_snapshot(
     // corruption — surface it rather than silently constructing an
     // invalid LaneId that would mis-partition downstream.
     let lane_id = LaneId::try_new(opt_str(core, "lane_id").unwrap_or("")).map_err(|e| {
-        SdkError::Config(format!(
-            "describe_execution: exec_core.lane_id fails LaneId validation \
-             (key corruption?): {e}"
-        ))
+        SdkError::Config {
+            context: "describe_execution: exec_core".into(),
+            field: Some("lane_id".into()),
+            message: format!("fails LaneId validation (key corruption?): {e}"),
+        }
     })?;
 
     let namespace_str = opt_str(core, "namespace").unwrap_or("").to_owned();
@@ -133,11 +134,10 @@ fn build_execution_snapshot(
     let flow_id = opt_str(core, "flow_id")
         .filter(|s| !s.is_empty())
         .map(|s| {
-            FlowId::parse(s).map_err(|e| {
-                SdkError::Config(format!(
-                    "describe_execution: exec_core.flow_id is not a valid UUID \
-                     (key corruption?): {e}"
-                ))
+            FlowId::parse(s).map_err(|e| SdkError::Config {
+                context: "describe_execution: exec_core".into(),
+                field: Some("flow_id".into()),
+                message: format!("is not a valid UUID (key corruption?): {e}"),
             })
         })
         .transpose()?;
@@ -155,19 +155,17 @@ fn build_execution_snapshot(
     // corruption, not a valid pre-create state — fail loudly.
     let created_at =
         parse_ts(core, "describe_execution: exec_core", "created_at")?.ok_or_else(|| {
-            SdkError::Config(
-                "describe_execution: exec_core.created_at is missing or empty \
-                 (key corruption?)"
-                    .to_owned(),
-            )
+            SdkError::Config {
+                context: "describe_execution: exec_core".into(),
+                field: Some("created_at".into()),
+                message: "is missing or empty (key corruption?)".into(),
+            }
         })?;
     let last_mutation_at = parse_ts(core, "describe_execution: exec_core", "last_mutation_at")?
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_execution: exec_core.last_mutation_at is missing or empty \
-                 (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_execution: exec_core".into(),
+            field: Some("last_mutation_at".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?;
 
     let total_attempt_count: u32 =
@@ -180,11 +178,10 @@ fn build_execution_snapshot(
     let current_waitpoint = opt_str(core, "current_waitpoint_id")
         .filter(|s| !s.is_empty())
         .map(|s| {
-            WaitpointId::parse(s).map_err(|e| {
-                SdkError::Config(format!(
-                    "describe_execution: exec_core.current_waitpoint_id is not a \
-                     valid UUID (key corruption?): {e}"
-                ))
+            WaitpointId::parse(s).map_err(|e| SdkError::Config {
+                context: "describe_execution: exec_core".into(),
+                field: Some("current_waitpoint_id".into()),
+                message: format!("is not a valid UUID (key corruption?): {e}"),
             })
         })
         .transpose()?;
@@ -225,10 +222,10 @@ fn parse_ts(
     match opt_str(map, field).filter(|s| !s.is_empty()) {
         None => Ok(None),
         Some(raw) => {
-            let ms: i64 = raw.parse().map_err(|e| {
-                SdkError::Config(format!(
-                    "{context}.{field} is not a valid ms timestamp ('{raw}'): {e}"
-                ))
+            let ms: i64 = raw.parse().map_err(|e| SdkError::Config {
+                context: context.to_owned(),
+                field: Some(field.to_owned()),
+                message: format!("is not a valid ms timestamp ('{raw}'): {e}"),
             })?;
             Ok(Some(TimestampMs::from_millis(ms)))
         }
@@ -246,10 +243,10 @@ fn parse_u32_strict(
 ) -> Result<Option<u32>, SdkError> {
     match opt_str(map, field).filter(|s| !s.is_empty()) {
         None => Ok(None),
-        Some(raw) => Ok(Some(raw.parse().map_err(|e| {
-            SdkError::Config(format!(
-                "{context}.{field} is not a valid u32 ('{raw}'): {e}"
-            ))
+        Some(raw) => Ok(Some(raw.parse().map_err(|e| SdkError::Config {
+            context: context.to_owned(),
+            field: Some(field.to_owned()),
+            message: format!("is not a valid u32 ('{raw}'): {e}"),
         })?)),
     }
 }
@@ -262,10 +259,10 @@ fn parse_u64_strict(
 ) -> Result<Option<u64>, SdkError> {
     match opt_str(map, field).filter(|s| !s.is_empty()) {
         None => Ok(None),
-        Some(raw) => Ok(Some(raw.parse().map_err(|e| {
-            SdkError::Config(format!(
-                "{context}.{field} is not a valid u64 ('{raw}'): {e}"
-            ))
+        Some(raw) => Ok(Some(raw.parse().map_err(|e| SdkError::Config {
+            context: context.to_owned(),
+            field: Some(field.to_owned()),
+            message: format!("is not a valid u64 ('{raw}'): {e}"),
         })?)),
     }
 }
@@ -274,11 +271,10 @@ fn parse_public_state(raw: &str) -> Result<PublicState, SdkError> {
     // exec_core stores the snake_case literal (e.g. "waiting"). PublicState's
     // Deserialize accepts the JSON-quoted form, so wrap + delegate.
     let quoted = format!("\"{raw}\"");
-    serde_json::from_str(&quoted).map_err(|e| {
-        SdkError::Config(format!(
-            "describe_execution: exec_core.public_state '{raw}' is not a known \
-             public state: {e}"
-        ))
+    serde_json::from_str(&quoted).map_err(|e| SdkError::Config {
+        context: "describe_execution: exec_core".into(),
+        field: Some("public_state".into()),
+        message: format!("'{raw}' is not a known public state: {e}"),
     })
 }
 
@@ -289,11 +285,10 @@ fn build_attempt_summary(
         None => return Ok(None),
         Some(s) => s,
     };
-    let attempt_id = AttemptId::parse(attempt_id_str).map_err(|e| {
-        SdkError::Config(format!(
-            "describe_execution: exec_core.current_attempt_id is not a valid \
-             UUID: {e}"
-        ))
+    let attempt_id = AttemptId::parse(attempt_id_str).map_err(|e| SdkError::Config {
+        context: "describe_execution: exec_core".into(),
+        field: Some("current_attempt_id".into()),
+        message: format!("is not a valid UUID: {e}"),
     })?;
     // When `current_attempt_id` is set, `current_attempt_index` MUST be
     // set too — lua/execution.lua writes both atomically in
@@ -304,12 +299,10 @@ fn build_attempt_summary(
         "describe_execution: exec_core",
         "current_attempt_index",
     )?
-    .ok_or_else(|| {
-        SdkError::Config(
-            "describe_execution: exec_core.current_attempt_index is missing \
-             while current_attempt_id is set (key corruption?)"
-                .to_owned(),
-        )
+    .ok_or_else(|| SdkError::Config {
+        context: "describe_execution: exec_core".into(),
+        field: Some("current_attempt_index".into()),
+        message: "is missing while current_attempt_id is set (key corruption?)".into(),
     })?;
     Ok(Some(AttemptSummary::new(
         attempt_id,
@@ -333,12 +326,10 @@ fn build_lease_summary(core: &HashMap<String, String>) -> Result<Option<LeaseSum
     // sets/clears epoch atomically with wid + expires_at. Parse strictly
     // and require it: a missing epoch alongside a live wid is corruption.
     let epoch = parse_u64_strict(core, "describe_execution: exec_core", "current_lease_epoch")?
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_execution: exec_core.current_lease_epoch is missing \
-             while current_worker_instance_id is set (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_execution: exec_core".into(),
+            field: Some("current_lease_epoch".into()),
+            message: "is missing while current_worker_instance_id is set (key corruption?)".into(),
         })?;
     Ok(Some(LeaseSummary::new(
         LeaseEpoch::new(epoch),
@@ -441,48 +432,48 @@ fn build_flow_snapshot(
     // on-disk corruption or a caller accidentally reading the wrong key.
     let stored_flow_id_str = opt_str(raw, "flow_id")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.flow_id is missing or empty (key corruption?)".to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("flow_id".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?;
     if stored_flow_id_str != flow_id.to_string() {
-        return Err(SdkError::Config(format!(
-            "describe_flow: flow_core.flow_id '{stored_flow_id_str}' does not match \
-             requested flow_id '{flow_id}' (key corruption or wrong-key read?)"
-        )));
+        return Err(SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("flow_id".into()),
+            message: format!(
+                "'{stored_flow_id_str}' does not match requested flow_id \
+                 '{flow_id}' (key corruption or wrong-key read?)"
+            ),
+        });
     }
 
     // namespace and flow_kind are engine-written at create time; absent
     // or empty values indicate on-disk corruption.
     let namespace_str = opt_str(raw, "namespace")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.namespace is missing or empty (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("namespace".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?;
     let namespace = Namespace::new(namespace_str.to_owned());
 
     let flow_kind = opt_str(raw, "flow_kind")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.flow_kind is missing or empty (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("flow_kind".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?
         .to_owned();
 
     let public_flow_state = opt_str(raw, "public_flow_state")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.public_flow_state is missing or empty \
-                 (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("public_flow_state".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?
         .to_owned();
 
@@ -490,38 +481,42 @@ fn build_flow_snapshot(
     // counters; missing values indicate corruption (ff_create_flow
     // writes "0" to all three). Parse strictly.
     let graph_revision = parse_u64_strict(raw, "describe_flow: flow_core", "graph_revision")?
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.graph_revision is missing (key corruption?)".to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("graph_revision".into()),
+            message: "is missing (key corruption?)".into(),
         })?;
     let node_count =
         parse_u32_strict(raw, "describe_flow: flow_core", "node_count")?.ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.node_count is missing (key corruption?)".to_owned(),
-            )
+            SdkError::Config {
+                context: "describe_flow: flow_core".into(),
+                field: Some("node_count".into()),
+                message: "is missing (key corruption?)".into(),
+            }
         })?;
     let edge_count =
         parse_u32_strict(raw, "describe_flow: flow_core", "edge_count")?.ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.edge_count is missing (key corruption?)".to_owned(),
-            )
+            SdkError::Config {
+                context: "describe_flow: flow_core".into(),
+                field: Some("edge_count".into()),
+                message: "is missing (key corruption?)".into(),
+            }
         })?;
 
     // created_at + last_mutation_at are engine-maintained; absent values
     // indicate corruption (ff_create_flow writes both).
     let created_at = parse_ts(raw, "describe_flow: flow_core", "created_at")?.ok_or_else(|| {
-        SdkError::Config(
-            "describe_flow: flow_core.created_at is missing or empty (key corruption?)".to_owned(),
-        )
+        SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("created_at".into()),
+            message: "is missing or empty (key corruption?)".into(),
+        }
     })?;
     let last_mutation_at = parse_ts(raw, "describe_flow: flow_core", "last_mutation_at")?
-        .ok_or_else(|| {
-            SdkError::Config(
-                "describe_flow: flow_core.last_mutation_at is missing or empty \
-                 (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "describe_flow: flow_core".into(),
+            field: Some("last_mutation_at".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?;
 
     let cancelled_at = parse_ts(raw, "describe_flow: flow_core", "cancelled_at")?;
@@ -544,10 +539,14 @@ fn build_flow_snapshot(
         if is_namespaced_tag_key(k) {
             tags.insert(k.clone(), v.clone());
         } else {
-            return Err(SdkError::Config(format!(
-                "describe_flow: flow_core has unexpected field '{k}' — not an FF \
-                 field and not a namespaced tag (lowercase-alphanumeric-prefix + '.')"
-            )));
+            return Err(SdkError::Config {
+                context: "describe_flow: flow_core".into(),
+                field: None,
+                message: format!(
+                    "has unexpected field '{k}' — not an FF field and not a namespaced \
+                     tag (lowercase-alphanumeric-prefix + '.')"
+                ),
+            });
         }
     }
 
@@ -743,20 +742,22 @@ impl FlowFabricWorker {
         let Some(raw) = raw.filter(|s| !s.is_empty()) else {
             return Ok(None);
         };
-        let flow_id = FlowId::parse(&raw).map_err(|e| {
-            SdkError::Config(format!(
-                "list_edges: exec_core.flow_id '{raw}' is not a valid UUID \
-                 (key corruption?): {e}"
-            ))
+        let flow_id = FlowId::parse(&raw).map_err(|e| SdkError::Config {
+            context: "list_edges: exec_core".into(),
+            field: Some("flow_id".into()),
+            message: format!("'{raw}' is not a valid UUID (key corruption?): {e}"),
         })?;
         let flow_partition_index = flow_partition(&flow_id, self.partition_config()).index;
         if exec_partition.index != flow_partition_index {
-            return Err(SdkError::Config(format!(
-                "list_edges: exec_core.flow_id '{flow_id}' partition \
-                 {flow_partition_index} does not match execution partition \
-                 {} (RFC-011 co-location violation; key corruption?)",
-                exec_partition.index
-            )));
+            return Err(SdkError::Config {
+                context: "list_edges: exec_core".into(),
+                field: Some("flow_id".into()),
+                message: format!(
+                    "'{flow_id}' partition {flow_partition_index} does not match \
+                     execution partition {} (RFC-011 co-location violation; key corruption?)",
+                    exec_partition.index
+                ),
+            });
         }
         Ok(Some(flow_id))
     }
@@ -795,11 +796,10 @@ impl FlowFabricWorker {
         // before we spend a round trip on it.
         let mut edge_ids: Vec<EdgeId> = Vec::with_capacity(edge_id_strs.len());
         for raw in &edge_id_strs {
-            let parsed = EdgeId::parse(raw).map_err(|e| {
-                SdkError::Config(format!(
-                    "list_edges: adjacency SET has invalid edge_id '{raw}' \
-                     (key corruption?): {e}"
-                ))
+            let parsed = EdgeId::parse(raw).map_err(|e| SdkError::Config {
+                context: "list_edges: adjacency_set".into(),
+                field: Some("edge_id".into()),
+                message: format!("'{raw}' is not a valid EdgeId (key corruption?): {e}"),
             })?;
             edge_ids.push(parsed);
         }
@@ -831,10 +831,14 @@ impl FlowFabricWorker {
                 // Adjacency SET referenced an edge_hash that no longer
                 // exists. FF does not delete edge hashes today (staging
                 // is write-once), so this is corruption — fail loud.
-                return Err(SdkError::Config(format!(
-                    "list_edges: adjacency SET refers to edge_id '{edge_id}' \
-                     but its edge_hash is absent (key corruption?)"
-                )));
+                return Err(SdkError::Config {
+                    context: "list_edges: adjacency_set".into(),
+                    field: None,
+                    message: format!(
+                        "refers to edge_id '{edge_id}' but its edge_hash is absent \
+                         (key corruption?)"
+                    ),
+                });
             }
             let snap = build_edge_snapshot(flow_id, edge_id, &raw)?;
             // Cross-check: the edge hash's endpoint on the listed side
@@ -847,11 +851,15 @@ impl FlowFabricWorker {
                 AdjacencySide::Incoming => &snap.downstream_execution_id,
             };
             if endpoint != subject_eid {
-                return Err(SdkError::Config(format!(
-                    "list_edges: adjacency SET for execution '{subject_eid}' \
-                     (side={side:?}) contains edge '{edge_id}' whose stored \
-                     endpoint is '{endpoint}' (adjacency/edge-hash drift?)"
-                )));
+                return Err(SdkError::Config {
+                    context: "list_edges: adjacency_set".into(),
+                    field: None,
+                    message: format!(
+                        "for execution '{subject_eid}' (side={side:?}) contains edge \
+                         '{edge_id}' whose stored endpoint is '{endpoint}' \
+                         (adjacency/edge-hash drift?)"
+                    ),
+                });
             }
             out.push(snap);
         }
@@ -897,39 +905,50 @@ fn build_edge_snapshot(
     // silently drop data.
     for k in raw.keys() {
         if !EDGE_KNOWN_FIELDS.contains(&k.as_str()) {
-            return Err(SdkError::Config(format!(
-                "edge_snapshot: edge_hash has unexpected field '{k}' \
-                 (protocol drift or corruption?)"
-            )));
+            return Err(SdkError::Config {
+                context: "edge_snapshot: edge_hash".into(),
+                field: None,
+                message: format!(
+                    "has unexpected field '{k}' (protocol drift or corruption?)"
+                ),
+            });
         }
     }
 
     let stored_edge_id_str = opt_str(raw, "edge_id")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "edge_snapshot: edge_hash.edge_id is missing or empty (key corruption?)".to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("edge_id".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?;
     if stored_edge_id_str != edge_id.to_string() {
-        return Err(SdkError::Config(format!(
-            "edge_snapshot: edge_hash.edge_id '{stored_edge_id_str}' does not match \
-             requested edge_id '{edge_id}' (key corruption or wrong-key read?)"
-        )));
+        return Err(SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("edge_id".into()),
+            message: format!(
+                "'{stored_edge_id_str}' does not match requested edge_id \
+                 '{edge_id}' (key corruption or wrong-key read?)"
+            ),
+        });
     }
 
     let stored_flow_id_str = opt_str(raw, "flow_id")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "edge_snapshot: edge_hash.flow_id is missing or empty (key corruption?)".to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("flow_id".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?;
     if stored_flow_id_str != flow_id.to_string() {
-        return Err(SdkError::Config(format!(
-            "edge_snapshot: edge_hash.flow_id '{stored_flow_id_str}' does not match \
-             requested flow_id '{flow_id}' (key corruption or wrong-key read?)"
-        )));
+        return Err(SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("flow_id".into()),
+            message: format!(
+                "'{stored_flow_id_str}' does not match requested flow_id \
+                 '{flow_id}' (key corruption or wrong-key read?)"
+            ),
+        });
     }
 
     let upstream_execution_id = parse_eid(raw, "upstream_execution_id")?;
@@ -937,23 +956,19 @@ fn build_edge_snapshot(
 
     let dependency_kind = opt_str(raw, "dependency_kind")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "edge_snapshot: edge_hash.dependency_kind is missing or empty \
-                 (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("dependency_kind".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?
         .to_owned();
 
     let satisfaction_condition = opt_str(raw, "satisfaction_condition")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "edge_snapshot: edge_hash.satisfaction_condition is missing or empty \
-                 (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("satisfaction_condition".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?
         .to_owned();
 
@@ -965,29 +980,28 @@ fn build_edge_snapshot(
 
     let edge_state = opt_str(raw, "edge_state")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "edge_snapshot: edge_hash.edge_state is missing or empty (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("edge_state".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?
         .to_owned();
 
     let created_at =
         parse_ts(raw, "edge_snapshot: edge_hash", "created_at")?.ok_or_else(|| {
-            SdkError::Config(
-                "edge_snapshot: edge_hash.created_at is missing or empty (key corruption?)"
-                    .to_owned(),
-            )
+            SdkError::Config {
+                context: "edge_snapshot: edge_hash".into(),
+                field: Some("created_at".into()),
+                message: "is missing or empty (key corruption?)".into(),
+            }
         })?;
 
     let created_by = opt_str(raw, "created_by")
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(
-                "edge_snapshot: edge_hash.created_by is missing or empty (key corruption?)"
-                    .to_owned(),
-            )
+        .ok_or_else(|| SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some("created_by".into()),
+            message: "is missing or empty (key corruption?)".into(),
         })?
         .to_owned();
 
@@ -1008,16 +1022,15 @@ fn build_edge_snapshot(
 fn parse_eid(raw: &HashMap<String, String>, field: &str) -> Result<ExecutionId, SdkError> {
     let s = opt_str(raw, field)
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            SdkError::Config(format!(
-                "edge_snapshot: edge_hash.{field} is missing or empty (key corruption?)"
-            ))
+        .ok_or_else(|| SdkError::Config {
+            context: "edge_snapshot: edge_hash".into(),
+            field: Some(field.to_owned()),
+            message: "is missing or empty (key corruption?)".into(),
         })?;
-    ExecutionId::parse(s).map_err(|e| {
-        SdkError::Config(format!(
-            "edge_snapshot: edge_hash.{field} '{s}' is not a valid ExecutionId \
-             (key corruption?): {e}"
-        ))
+    ExecutionId::parse(s).map_err(|e| SdkError::Config {
+        context: "edge_snapshot: edge_hash".into(),
+        field: Some(field.to_owned()),
+        message: format!("'{s}' is not a valid ExecutionId (key corruption?): {e}"),
     })
 }
 
@@ -1079,7 +1092,9 @@ mod tests {
         let err =
             build_execution_snapshot(eid(), &minimal_core("bogus"), HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config(msg) => assert!(msg.contains("public_state"), "msg: {msg}"),
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("public_state"), "msg: {msg}");
+            }
             other => panic!("expected Config, got {other:?}"),
         }
     }
@@ -1092,22 +1107,24 @@ mod tests {
         core.insert("lane_id".to_owned(), "lane\nbroken".to_owned());
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config(msg) => assert!(msg.contains("lane_id"), "msg: {msg}"),
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("lane_id"), "msg: {msg}");
+            }
             other => panic!("expected Config, got {other:?}"),
         }
     }
 
     #[test]
     fn missing_required_timestamps_fail_loud() {
-        for field in ["created_at", "last_mutation_at"] {
+        for want in ["created_at", "last_mutation_at"] {
             let mut core = minimal_core("waiting");
-            core.remove(field);
+            core.remove(want);
             let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
             match err {
-                SdkError::Config(msg) => {
-                    assert!(msg.contains(field), "msg for {field}: {msg}")
+                SdkError::Config { field, message: msg, .. } => {
+                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
                 }
-                other => panic!("expected Config for {field}, got {other:?}"),
+                other => panic!("expected Config for {want}, got {other:?}"),
             }
         }
     }
@@ -1118,8 +1135,8 @@ mod tests {
         core.insert("total_attempt_count".to_owned(), "not-a-number".to_owned());
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
-                assert!(msg.contains("total_attempt_count"), "msg: {msg}")
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("total_attempt_count"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1136,8 +1153,8 @@ mod tests {
         );
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
-                assert!(msg.contains("current_attempt_index"), "msg: {msg}")
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("current_attempt_index"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1154,8 +1171,8 @@ mod tests {
         core.insert("lease_expires_at".to_owned(), "9000".to_owned());
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
-                assert!(msg.contains("current_lease_epoch"), "msg: {msg}")
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("current_lease_epoch"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1269,8 +1286,9 @@ mod tests {
         core.insert("bogus_future_field".to_owned(), "v".to_owned());
         let err = build_flow_snapshot(f, &core).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
-                assert!(msg.contains("bogus_future_field"), "msg: {msg}")
+            SdkError::Config { field, message: msg, .. } => {
+                assert!(field.is_none(), "expected whole-object error, got field={field:?}");
+                assert!(msg.contains("bogus_future_field"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1278,7 +1296,7 @@ mod tests {
 
     #[test]
     fn missing_required_fields_fail_loud() {
-        for field in [
+        for want in [
             "flow_id",
             "namespace",
             "flow_kind",
@@ -1291,15 +1309,15 @@ mod tests {
         ] {
             let f = fid();
             let mut core = minimal_flow_core(&f, "open");
-            core.remove(field);
+            core.remove(want);
             let err = build_flow_snapshot(f, &core).err().unwrap_or_else(|| {
-                panic!("field {field} should fail but build_flow_snapshot returned Ok")
+                panic!("field {want} should fail but build_flow_snapshot returned Ok")
             });
             match err {
-                SdkError::Config(msg) => {
-                    assert!(msg.contains(field), "msg for {field}: {msg}")
+                SdkError::Config { field, message: msg, .. } => {
+                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
                 }
-                other => panic!("expected Config for {field}, got {other:?}"),
+                other => panic!("expected Config for {want}, got {other:?}"),
             }
         }
     }
@@ -1308,18 +1326,18 @@ mod tests {
     fn empty_required_strings_fail_loud() {
         // opt_str + .filter(|s| !s.is_empty()) must treat an empty
         // value the same as a missing one for strict-parsed fields.
-        for field in ["flow_id", "namespace", "flow_kind", "public_flow_state"] {
+        for want in ["flow_id", "namespace", "flow_kind", "public_flow_state"] {
             let f = fid();
             let mut core = minimal_flow_core(&f, "open");
-            core.insert(field.to_owned(), String::new());
+            core.insert(want.to_owned(), String::new());
             let err = build_flow_snapshot(f, &core).err().unwrap_or_else(|| {
-                panic!("empty {field} should fail but build_flow_snapshot returned Ok")
+                panic!("empty {want} should fail but build_flow_snapshot returned Ok")
             });
             match err {
-                SdkError::Config(msg) => {
-                    assert!(msg.contains(field), "msg for {field}: {msg}")
+                SdkError::Config { field, message: msg, .. } => {
+                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
                 }
-                other => panic!("expected Config for {field}, got {other:?}"),
+                other => panic!("expected Config for {want}, got {other:?}"),
             }
         }
     }
@@ -1333,9 +1351,9 @@ mod tests {
         let core = minimal_flow_core(&other, "open");
         let err = build_flow_snapshot(requested, &core).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("flow_id"), "msg: {msg}");
                 assert!(msg.contains("does not match"), "msg: {msg}");
-                assert!(msg.contains("flow_id"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1348,8 +1366,8 @@ mod tests {
         core.insert("graph_revision".to_owned(), "not-a-number".to_owned());
         let err = build_flow_snapshot(f, &core).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
-                assert!(msg.contains("graph_revision"), "msg: {msg}")
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("graph_revision"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1421,7 +1439,10 @@ mod tests {
         raw.insert("bogus_future_field".into(), "v".into());
         let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
         match err {
-            SdkError::Config(msg) => assert!(msg.contains("bogus_future_field"), "msg: {msg}"),
+            SdkError::Config { field, message: msg, .. } => {
+                assert!(field.is_none(), "expected whole-object error, got field={field:?}");
+                assert!(msg.contains("bogus_future_field"), "msg: {msg}");
+            }
             other => panic!("expected Config, got {other:?}"),
         }
     }
@@ -1435,9 +1456,9 @@ mod tests {
         let raw = minimal_edge_hash(&other, &edge, &up, &down);
         let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("flow_id"), "msg: {msg}");
                 assert!(msg.contains("does not match"), "msg: {msg}");
-                assert!(msg.contains("flow_id"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1452,9 +1473,9 @@ mod tests {
         let raw = minimal_edge_hash(&f, &other_edge, &up, &down);
         let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("edge_id"), "msg: {msg}");
                 assert!(msg.contains("does not match"), "msg: {msg}");
-                assert!(msg.contains("edge_id"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1462,7 +1483,7 @@ mod tests {
 
     #[test]
     fn edge_missing_required_fields_fail_loud() {
-        for field in [
+        for want in [
             "edge_id",
             "flow_id",
             "upstream_execution_id",
@@ -1477,13 +1498,15 @@ mod tests {
             let edge = EdgeId::new();
             let (up, down) = eids_for_flow(&f);
             let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
-            raw.remove(field);
+            raw.remove(want);
             let err = build_edge_snapshot(&f, &edge, &raw)
                 .err()
-                .unwrap_or_else(|| panic!("missing {field} should fail"));
+                .unwrap_or_else(|| panic!("missing {want} should fail"));
             match err {
-                SdkError::Config(msg) => assert!(msg.contains(field), "msg for {field}: {msg}"),
-                other => panic!("expected Config for {field}, got {other:?}"),
+                SdkError::Config { field, message: msg, .. } => {
+                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
+                }
+                other => panic!("expected Config for {want}, got {other:?}"),
             }
         }
     }
@@ -1497,7 +1520,9 @@ mod tests {
         raw.insert("created_at".into(), "not-a-number".into());
         let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
         match err {
-            SdkError::Config(msg) => assert!(msg.contains("created_at"), "msg: {msg}"),
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("created_at"), "msg: {msg}");
+            }
             other => panic!("expected Config, got {other:?}"),
         }
     }
@@ -1511,8 +1536,8 @@ mod tests {
         raw.insert("upstream_execution_id".into(), "not-an-execution-id".into());
         let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
         match err {
-            SdkError::Config(msg) => {
-                assert!(msg.contains("upstream_execution_id"), "msg: {msg}")
+            SdkError::Config { field, message: msg, .. } => {
+                assert_eq!(field.as_deref(), Some("upstream_execution_id"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
         }

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -2234,14 +2234,16 @@ fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
         return Err(SdkError::Config {
             context: "read_stream_frames".into(),
             field: Some("count_limit".into()),
-            message: "must be >= 1".into(),
+            message: "count_limit must be >= 1".into(),
         });
     }
     if count_limit > STREAM_READ_HARD_CAP {
         return Err(SdkError::Config {
             context: "read_stream_frames".into(),
             field: Some("count_limit".into()),
-            message: format!("exceeds STREAM_READ_HARD_CAP ({STREAM_READ_HARD_CAP})"),
+            message: format!(
+                "count_limit exceeds STREAM_READ_HARD_CAP ({STREAM_READ_HARD_CAP})"
+            ),
         });
     }
     Ok(())

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -1537,17 +1537,21 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_report_usage_and_check: expected Array".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_report_usage_result".into(),
+                execution_id: None,
+                message: "ff_report_usage_and_check: expected Array".into(),
+            }));
         }
     };
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_report_usage_and_check: expected Int status code".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_report_usage_result".into(),
+                execution_id: None,
+                message: "ff_report_usage_and_check: expected Int status code".into(),
+            }));
         }
     };
     if status_code != 1 {
@@ -1555,7 +1559,11 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
         let detail = usage_field_str(arr, 2);
         return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
-                ScriptError::Parse(format!("ff_report_usage_and_check: {error_code}"))
+                ScriptError::Parse {
+                    fcall: "parse_report_usage_result".into(),
+                    execution_id: None,
+                    message: format!("ff_report_usage_and_check: {error_code}"),
+                }
             }),
         ));
     }
@@ -1579,9 +1587,13 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
                 hard_limit: limit,
             })
         }
-        _ => Err(SdkError::from(ScriptError::Parse(format!(
+        _ => Err(SdkError::from(ScriptError::Parse {
+            fcall: "parse_report_usage_result".into(),
+            execution_id: None,
+            message: format!(
             "ff_report_usage_and_check: unknown sub-status: {sub_status}"
-        )))),
+        ),
+        })),
     }
 }
 
@@ -1616,35 +1628,55 @@ fn parse_usage_u64(
     match arr.get(index) {
         Some(Ok(Value::Int(n))) => {
             u64::try_from(*n).map_err(|_| {
-                SdkError::from(ScriptError::Parse(format!(
+                SdkError::from(ScriptError::Parse {
+                    fcall: "parse_usage_u64".into(),
+                    execution_id: None,
+                    message: format!(
                     "ff_report_usage_and_check {sub_status}: {field_name} \
                      (index {index}) negative int {n} cannot be u64"
-                )))
+                ),
+                })
             })
         }
         Some(Ok(Value::BulkString(b))) => {
             let s = String::from_utf8_lossy(b);
             s.parse::<u64>().map_err(|_| {
-                SdkError::from(ScriptError::Parse(format!(
+                SdkError::from(ScriptError::Parse {
+                    fcall: "parse_usage_u64".into(),
+                    execution_id: None,
+                    message: format!(
                     "ff_report_usage_and_check {sub_status}: {field_name} \
                      (index {index}) not a u64 string: {s:?}"
-                )))
+                ),
+                })
             })
         }
         Some(Ok(Value::SimpleString(s))) => s.parse::<u64>().map_err(|_| {
-            SdkError::from(ScriptError::Parse(format!(
+            SdkError::from(ScriptError::Parse {
+                fcall: "parse_usage_u64".into(),
+                execution_id: None,
+                message: format!(
                 "ff_report_usage_and_check {sub_status}: {field_name} \
                  (index {index}) not a u64 string: {s:?}"
-            )))
+            ),
+            })
         }),
-        Some(_) => Err(SdkError::from(ScriptError::Parse(format!(
+        Some(_) => Err(SdkError::from(ScriptError::Parse {
+            fcall: "parse_usage_u64".into(),
+            execution_id: None,
+            message: format!(
             "ff_report_usage_and_check {sub_status}: {field_name} \
              (index {index}) wrong wire type (expected Int or String)"
-        )))),
-        None => Err(SdkError::from(ScriptError::Parse(format!(
+        ),
+        })),
+        None => Err(SdkError::from(ScriptError::Parse {
+            fcall: "parse_usage_u64".into(),
+            execution_id: None,
+            message: format!(
             "ff_report_usage_and_check {sub_status}: {field_name} \
              (index {index}) missing from response"
-        )))),
+        ),
+        })),
     }
 }
 
@@ -1667,9 +1699,11 @@ fn extract_pending_waitpoint_token(raw: &Value) -> Result<WaitpointToken, SdkErr
             _ => None,
         })
         .ok_or_else(|| {
-            SdkError::from(ScriptError::Parse(
-                "ff_create_pending_waitpoint: missing waitpoint_token in response".into(),
-            ))
+            SdkError::from(ScriptError::Parse {
+                fcall: "extract_pending_waitpoint_token".into(),
+                execution_id: None,
+                message: "ff_create_pending_waitpoint: missing waitpoint_token in response".into(),
+            })
         })?;
     Ok(WaitpointToken::new(token_str))
 }
@@ -1706,9 +1740,13 @@ fn resume_waitpoint_id_from_suspension(
         return Ok(None);
     }
     let waitpoint_id = WaitpointId::parse(wp_id_str).map_err(|e| {
-        SdkError::from(ScriptError::Parse(format!(
+        SdkError::from(ScriptError::Parse {
+            fcall: "resume_waitpoint_id_from_suspension".into(),
+            execution_id: None,
+            message: format!(
             "resume_signals: suspension_current.waitpoint_id is not a valid UUID: {e}"
-        )))
+        ),
+        })
     })?;
     Ok(Some(waitpoint_id))
 }
@@ -1717,24 +1755,36 @@ pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(format!(
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_success_result".into(),
+                execution_id: None,
+                message: format!(
                 "{function_name}: expected Array, got non-array"
-            ))));
+            ),
+            }));
         }
     };
 
     if arr.is_empty() {
-        return Err(SdkError::from(ScriptError::Parse(format!(
+        return Err(SdkError::from(ScriptError::Parse {
+            fcall: "parse_success_result".into(),
+            execution_id: None,
+            message: format!(
             "{function_name}: empty result array"
-        ))));
+        ),
+        }));
     }
 
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(format!(
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_success_result".into(),
+                execution_id: None,
+                message: format!(
                 "{function_name}: expected Int at index 0"
-            ))));
+            ),
+            }));
         }
     };
 
@@ -1767,7 +1817,11 @@ pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(
 
         let script_err = ScriptError::from_code_with_details(&error_code, &detail_refs)
             .unwrap_or_else(|| {
-                ScriptError::Parse(format!("{function_name}: unknown error: {error_code}"))
+                ScriptError::Parse {
+                    fcall: "parse_success_result".into(),
+                    execution_id: None,
+                    message: format!("{function_name}: unknown error: {error_code}"),
+                }
             });
 
         Err(SdkError::from(script_err))
@@ -1786,18 +1840,22 @@ fn parse_suspend_result(
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_suspend_execution: expected Array".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_suspend_result".into(),
+                execution_id: None,
+                message: "ff_suspend_execution: expected Array".into(),
+            }));
         }
     };
 
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_suspend_execution: bad status code".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_suspend_result".into(),
+                execution_id: None,
+                message: "ff_suspend_execution: bad status code".into(),
+            }));
         }
     };
 
@@ -1818,7 +1876,11 @@ fn parse_suspend_result(
         let detail = err_field_str(2);
         return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
-                ScriptError::Parse(format!("ff_suspend_execution: {error_code}"))
+                ScriptError::Parse {
+                    fcall: "parse_suspend_result".into(),
+                    execution_id: None,
+                    message: format!("ff_suspend_execution: {error_code}"),
+                }
             }),
         ));
     }
@@ -1846,9 +1908,11 @@ fn parse_suspend_result(
         })
         .map(WaitpointToken::new)
         .ok_or_else(|| {
-            SdkError::from(ScriptError::Parse(
-                "ff_suspend_execution: missing waitpoint_token in response".into(),
-            ))
+            SdkError::from(ScriptError::Parse {
+                fcall: "parse_suspend_result".into(),
+                execution_id: None,
+                message: "ff_suspend_execution: missing waitpoint_token in response".into(),
+            })
         })?;
 
     if sub_status == "ALREADY_SATISFIED" {
@@ -1875,18 +1939,22 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_deliver_signal: expected Array".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_signal_result".into(),
+                execution_id: None,
+                message: "ff_deliver_signal: expected Array".into(),
+            }));
         }
     };
 
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_deliver_signal: bad status code".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_signal_result".into(),
+                execution_id: None,
+                message: "ff_deliver_signal: bad status code".into(),
+            }));
         }
     };
 
@@ -1907,7 +1975,11 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
         let detail = err_field_str(2);
         return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
-                ScriptError::Parse(format!("ff_deliver_signal: {error_code}"))
+                ScriptError::Parse {
+                    fcall: "parse_signal_result".into(),
+                    execution_id: None,
+                    message: format!("ff_deliver_signal: {error_code}"),
+                }
             }),
         ));
     }
@@ -1955,9 +2027,13 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
         .unwrap_or_default();
 
     let signal_id = SignalId::parse(&signal_id_str).map_err(|e| {
-        SdkError::from(ScriptError::Parse(format!(
+        SdkError::from(ScriptError::Parse {
+            fcall: "parse_signal_result".into(),
+            execution_id: None,
+            message: format!(
             "ff_deliver_signal: invalid signal_id from Lua: {e}"
-        )))
+        ),
+        })
     })?;
 
     if effect == "resume_condition_satisfied" {
@@ -1972,18 +2048,22 @@ fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_append_frame: expected Array".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_append_frame_result".into(),
+                execution_id: None,
+                message: "ff_append_frame: expected Array".into(),
+            }));
         }
     };
 
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_append_frame: bad status code".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_append_frame_result".into(),
+                execution_id: None,
+                message: "ff_append_frame: bad status code".into(),
+            }));
         }
     };
 
@@ -2004,7 +2084,11 @@ fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError
         let detail = err_field_str(2);
         return Err(SdkError::from(
             ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
-                ScriptError::Parse(format!("ff_append_frame: {error_code}"))
+                ScriptError::Parse {
+                    fcall: "parse_append_frame_result".into(),
+                    execution_id: None,
+                    message: format!("ff_append_frame: {error_code}"),
+                }
             }),
         ));
     }
@@ -2042,18 +2126,22 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_fail_execution: expected Array".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_fail_result".into(),
+                execution_id: None,
+                message: "ff_fail_execution: expected Array".into(),
+            }));
         }
     };
 
     let status_code = match arr.first() {
         Some(Ok(Value::Int(n))) => *n,
         _ => {
-            return Err(SdkError::from(ScriptError::Parse(
-                "ff_fail_execution: bad status code".into(),
-            )));
+            return Err(SdkError::from(ScriptError::Parse {
+                fcall: "parse_fail_result".into(),
+                execution_id: None,
+                message: "ff_fail_execution: bad status code".into(),
+            }));
         }
     };
 
@@ -2075,7 +2163,11 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
         let detail_refs: Vec<&str> = details.iter().map(|s| s.as_str()).collect();
         return Err(SdkError::from(
             ScriptError::from_code_with_details(&error_code, &detail_refs).unwrap_or_else(|| {
-                ScriptError::Parse(format!("ff_fail_execution: {error_code}"))
+                ScriptError::Parse {
+                    fcall: "parse_fail_result".into(),
+                    execution_id: None,
+                    message: format!("ff_fail_execution: {error_code}"),
+                }
             }),
         ));
     }
@@ -2109,9 +2201,13 @@ fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
             })
         }
         "terminal_failed" => Ok(FailOutcome::TerminalFailed),
-        _ => Err(SdkError::from(ScriptError::Parse(format!(
+        _ => Err(SdkError::from(ScriptError::Parse {
+            fcall: "parse_fail_result".into(),
+            execution_id: None,
+            message: format!(
             "ff_fail_execution: unexpected sub-status: {sub_status}"
-        )))),
+        ),
+        })),
     }
 }
 
@@ -2135,12 +2231,18 @@ pub use ff_core::contracts::StreamFrames;
 
 fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
     if count_limit == 0 {
-        return Err(SdkError::Config("count_limit must be >= 1".to_owned()));
+        return Err(SdkError::Config {
+            context: "read_stream_frames".into(),
+            field: Some("count_limit".into()),
+            message: "must be >= 1".into(),
+        });
     }
     if count_limit > STREAM_READ_HARD_CAP {
-        return Err(SdkError::Config(format!(
-            "count_limit exceeds STREAM_READ_HARD_CAP ({STREAM_READ_HARD_CAP})"
-        )));
+        return Err(SdkError::Config {
+            context: "read_stream_frames".into(),
+            field: Some("count_limit".into()),
+            message: format!("exceeds STREAM_READ_HARD_CAP ({STREAM_READ_HARD_CAP})"),
+        });
     }
     Ok(())
 }
@@ -2274,9 +2376,11 @@ pub async fn tail_stream(
     count_limit: u64,
 ) -> Result<StreamFrames, SdkError> {
     if block_ms > MAX_TAIL_BLOCK_MS {
-        return Err(SdkError::Config(format!(
-            "block_ms exceeds {MAX_TAIL_BLOCK_MS}ms ceiling"
-        )));
+        return Err(SdkError::Config {
+            context: "tail_stream".into(),
+            field: Some("block_ms".into()),
+            message: format!("exceeds {MAX_TAIL_BLOCK_MS}ms ceiling"),
+        });
     }
     validate_stream_read_count(count_limit)?;
 

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -108,7 +108,11 @@ impl FlowFabricWorker {
     /// the library is already loaded.
     pub async fn connect(config: WorkerConfig) -> Result<Self, SdkError> {
         if config.lanes.is_empty() {
-            return Err(SdkError::Config("at least one lane is required".into()));
+            return Err(SdkError::Config {
+                context: "worker_config".into(),
+                field: None,
+                message: "at least one lane is required".into(),
+            });
         }
 
         let mut builder = ClientBuilder::new()
@@ -132,9 +136,11 @@ impl FlowFabricWorker {
             .await
             .map_err(|e| SdkError::ValkeyContext { source: e, context: "PING failed".into() })?;
         if pong != "PONG" {
-            return Err(SdkError::Config(format!(
-                "unexpected PING response: {pong}"
-            )));
+            return Err(SdkError::Config {
+                context: "worker_connect".into(),
+                field: None,
+                message: format!("unexpected PING response: {pong}"),
+            });
         }
 
         // Guard against two worker processes sharing the same
@@ -190,10 +196,14 @@ impl FlowFabricWorker {
                 context: "SET NX worker alive key".into(),
             })?;
         if set_result.is_none() {
-            return Err(SdkError::Config(format!(
-                "duplicate worker_instance_id '{}': another process already holds {alive_key}",
-                config.worker_instance_id
-            )));
+            return Err(SdkError::Config {
+                context: "worker_connect".into(),
+                field: Some("worker_instance_id".into()),
+                message: format!(
+                    "duplicate worker_instance_id '{}': another process already holds {alive_key}",
+                    config.worker_instance_id
+                ),
+            });
         }
 
         // Read partition config from Valkey (set by ff-server on startup).
@@ -242,14 +252,20 @@ impl FlowFabricWorker {
         #[cfg(feature = "direct-valkey-claim")]
         for cap in &config.capabilities {
             if cap.is_empty() {
-                return Err(SdkError::Config(
-                    "capability token must not be empty".into(),
-                ));
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: "capability token must not be empty".into(),
+                });
             }
             if cap.contains(',') {
-                return Err(SdkError::Config(format!(
-                    "capability token may not contain ',' (CSV delimiter): {cap:?}"
-                )));
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: format!(
+                        "capability token may not contain ',' (CSV delimiter): {cap:?}"
+                    ),
+                });
             }
             // Reject ASCII control bytes (0x00-0x1F, 0x7F) and any ASCII
             // whitespace (space, tab, LF, CR, FF, VT). UTF-8 printable
@@ -259,9 +275,14 @@ impl FlowFabricWorker {
             // never part of a multibyte continuation (only 0x80-0xBF are
             // continuations, ',' is 0x2C).
             if cap.chars().any(|c| c.is_control() || c.is_whitespace()) {
-                return Err(SdkError::Config(format!(
-                    "capability token must not contain whitespace or control characters: {cap:?}"
-                )));
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: format!(
+                        "capability token must not contain whitespace or control \
+                         characters: {cap:?}"
+                    ),
+                });
             }
         }
         #[cfg(feature = "direct-valkey-claim")]
@@ -273,19 +294,27 @@ impl FlowFabricWorker {
                 .filter(|s| !s.is_empty())
                 .collect();
             if set.len() > ff_core::policy::CAPS_MAX_TOKENS {
-                return Err(SdkError::Config(format!(
-                    "capability set exceeds CAPS_MAX_TOKENS ({}): {}",
-                    ff_core::policy::CAPS_MAX_TOKENS,
-                    set.len()
-                )));
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: format!(
+                        "capability set exceeds CAPS_MAX_TOKENS ({}): {}",
+                        ff_core::policy::CAPS_MAX_TOKENS,
+                        set.len()
+                    ),
+                });
             }
             let csv = set.into_iter().collect::<Vec<_>>().join(",");
             if csv.len() > ff_core::policy::CAPS_MAX_BYTES {
-                return Err(SdkError::Config(format!(
-                    "capability CSV exceeds CAPS_MAX_BYTES ({}): {}",
-                    ff_core::policy::CAPS_MAX_BYTES,
-                    csv.len()
-                )));
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: format!(
+                        "capability CSV exceeds CAPS_MAX_BYTES ({}): {}",
+                        ff_core::policy::CAPS_MAX_BYTES,
+                        csv.len()
+                    ),
+                });
             }
             csv
         };
@@ -526,9 +555,11 @@ impl FlowFabricWorker {
             };
 
             let execution_id = ExecutionId::parse(&execution_id_str).map_err(|e| {
-                SdkError::from(ff_script::error::ScriptError::Parse(format!(
-                    "bad execution_id in eligible set: {e}"
-                )))
+                SdkError::from(ff_script::error::ScriptError::Parse {
+                    fcall: "claim_execution_from_eligible_set".into(),
+                    execution_id: None,
+                    message: format!("bad execution_id in eligible set: {e}"),
+                })
             })?;
 
             // Step 1: Issue claim grant
@@ -838,18 +869,22 @@ impl FlowFabricWorker {
         let arr = match &raw {
             Value::Array(arr) => arr,
             _ => {
-                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
-                    "ff_claim_execution: expected Array".into(),
-                )));
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse {
+                    fcall: "ff_claim_execution".into(),
+                    execution_id: Some(execution_id.to_string()),
+                    message: "expected Array".into(),
+                }));
             }
         };
 
         let status_code = match arr.first() {
             Some(Ok(Value::Int(n))) => *n,
             _ => {
-                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
-                    "ff_claim_execution: bad status code".into(),
-                )));
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse {
+                    fcall: "ff_claim_execution".into(),
+                    execution_id: Some(execution_id.to_string()),
+                    message: "bad status code".into(),
+                }));
             }
         };
 
@@ -871,10 +906,10 @@ impl FlowFabricWorker {
 
             return Err(SdkError::from(
                 ff_script::error::ScriptError::from_code_with_detail(&error_code, &detail)
-                    .unwrap_or_else(|| {
-                        ff_script::error::ScriptError::Parse(format!(
-                            "ff_claim_execution: {error_code}"
-                        ))
+                    .unwrap_or_else(|| ff_script::error::ScriptError::Parse {
+                        fcall: "ff_claim_execution".into(),
+                        execution_id: Some(execution_id.to_string()),
+                        message: format!("unknown error: {error_code}"),
                     }),
             ));
         }
@@ -1178,18 +1213,22 @@ impl FlowFabricWorker {
         let arr = match &raw {
             Value::Array(arr) => arr,
             _ => {
-                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
-                    "ff_claim_resumed_execution: expected Array".into(),
-                )));
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse {
+                    fcall: "ff_claim_resumed_execution".into(),
+                    execution_id: Some(execution_id.to_string()),
+                    message: "expected Array".into(),
+                }));
             }
         };
 
         let status_code = match arr.first() {
             Some(Ok(Value::Int(n))) => *n,
             _ => {
-                return Err(SdkError::from(ff_script::error::ScriptError::Parse(
-                    "ff_claim_resumed_execution: bad status code".into(),
-                )));
+                return Err(SdkError::from(ff_script::error::ScriptError::Parse {
+                    fcall: "ff_claim_resumed_execution".into(),
+                    execution_id: Some(execution_id.to_string()),
+                    message: "bad status code".into(),
+                }));
             }
         };
 
@@ -1211,10 +1250,10 @@ impl FlowFabricWorker {
 
             return Err(SdkError::from(
                 ff_script::error::ScriptError::from_code_with_detail(&error_code, &detail)
-                    .unwrap_or_else(|| {
-                        ff_script::error::ScriptError::Parse(format!(
-                            "ff_claim_resumed_execution: {error_code}"
-                        ))
+                    .unwrap_or_else(|| ff_script::error::ScriptError::Parse {
+                        fcall: "ff_claim_resumed_execution".into(),
+                        execution_id: Some(execution_id.to_string()),
+                        message: format!("unknown error: {error_code}"),
                     }),
             ));
         }
@@ -1448,9 +1487,11 @@ async fn read_partition_config(client: &Client) -> Result<PartitionConfig, SdkEr
         .map_err(|e| SdkError::ValkeyContext { source: e, context: format!("HGETALL {key}") })?;
 
     if fields.is_empty() {
-        return Err(SdkError::Config(
-            "ff:config:partitions not found in Valkey".into(),
-        ));
+        return Err(SdkError::Config {
+            context: "read_partition_config".into(),
+            field: None,
+            message: "ff:config:partitions not found in Valkey".into(),
+        });
     }
 
     let parse = |field: &str, default: u16| -> u16 {

--- a/crates/ff-test/tests/describe_edge_api.rs
+++ b/crates/ff-test/tests/describe_edge_api.rs
@@ -424,7 +424,7 @@ async fn list_edges_detects_adjacency_endpoint_drift() {
         .await
         .expect_err("endpoint drift must surface");
     match err {
-        ff_sdk::SdkError::Config(msg) => {
+        ff_sdk::SdkError::Config { message: msg, .. } => {
             assert!(msg.contains("adjacency"), "msg: {msg}");
             assert!(
                 msg.contains("stored endpoint"),
@@ -468,7 +468,7 @@ async fn describe_edge_corrupt_state_surfaces_error() {
         .await
         .expect_err("unknown edge_hash field must surface as error");
     match err {
-        ff_sdk::SdkError::Config(msg) => {
+        ff_sdk::SdkError::Config { message: msg, .. } => {
             assert!(msg.contains("bogus_future_field"), "msg: {msg}");
         }
         other => panic!("expected SdkError::Config, got {other:?}"),

--- a/crates/ff-test/tests/describe_execution_api.rs
+++ b/crates/ff-test/tests/describe_execution_api.rs
@@ -332,10 +332,18 @@ async fn describe_execution_corrupt_public_state_surfaces_error() {
         .await
         .expect_err("corrupt public_state must surface as error");
     match err {
-        ff_sdk::SdkError::Config { message: msg, .. } => {
+        ff_sdk::SdkError::Config {
+            field: ref f,
+            message: ref msg,
+            ..
+        } => {
+            // Post-#98 structured shape: the field name lives in
+            // `field`, not interpolated into `message`. Verify the
+            // error names public_state in either slot so the test
+            // survives future rephrasings of the human-readable part.
             assert!(
-                msg.contains("public_state"),
-                "error message must name the field: {msg}"
+                f.as_deref() == Some("public_state") || msg.contains("public_state"),
+                "error must name the field (field={f:?}, msg={msg})"
             );
         }
         other => panic!("expected SdkError::Config, got {other:?}"),

--- a/crates/ff-test/tests/describe_execution_api.rs
+++ b/crates/ff-test/tests/describe_execution_api.rs
@@ -332,7 +332,7 @@ async fn describe_execution_corrupt_public_state_surfaces_error() {
         .await
         .expect_err("corrupt public_state must surface as error");
     match err {
-        ff_sdk::SdkError::Config(msg) => {
+        ff_sdk::SdkError::Config { message: msg, .. } => {
             assert!(
                 msg.contains("public_state"),
                 "error message must name the field: {msg}"

--- a/crates/ff-test/tests/describe_flow_api.rs
+++ b/crates/ff-test/tests/describe_flow_api.rs
@@ -278,7 +278,7 @@ async fn describe_flow_corrupt_state_surfaces_error() {
         .await
         .expect_err("unknown flat flow_core field must surface as error");
     match err {
-        ff_sdk::SdkError::Config(msg) => {
+        ff_sdk::SdkError::Config { message: msg, .. } => {
             assert!(
                 msg.contains("bogus_future_field"),
                 "error message must name the field: {msg}"


### PR DESCRIPTION
## Summary

Closes #98. Migrate `SdkError::Config(String)` → `SdkError::Config { context, field: Option<String>, message }` and `ScriptError::Parse(String)` → `ScriptError::Parse { fcall, execution_id: Option<String>, message }` so consumers can pattern-match on the failing field / FCALL without substring-parsing the Display string.

- `SdkError::Config` rendered as `config: <context>[.<field>]: <message>` (omits `.field` when `None` for whole-object validation).
- `ScriptError::Parse` rendered as `parse error: <fcall>[exec=<id>]: <message>` (omits `[exec=...]` when `None`).
- All construction + match sites updated atomically across `ff-sdk`, `ff-script`, and `ff-test`.
- `admin.rs:442` bearer-token matcher now uses the narrower `field: Some(f) if f == "bearer_token"` (was `msg.contains("empty")`).
- `execution_id` is populated on the `ff_claim_execution` / `ff_claim_resumed_execution` parse sites in `worker.rs` where `execution_id` is in scope; `None` elsewhere (parser helpers without the eid in scope).
- `fcall` is always non-empty — FCALL name when applicable (e.g. `ff_claim_execution`, `ff_suspend_execution`), semantic parser name otherwise (e.g. `parse_report_usage_result`, `stream_tail_decode`, `parse_entries_any`).

No new `SdkError` / `ScriptError` variants. No builder helpers — inline struct literals at every site per the locked spec.

## Breaking change

Consumers outside `ff-*` that pattern-match on `SdkError::Config(_)` or `ScriptError::Parse(_)` must update to the struct-variant form. **Owner to sync cairn-fabric** (peer team, per `feedback_peer_team_boundaries`).

`cargo-semver-checks` break is expected — enum-payload widen.

## Regression tests

Added one test per variant pinning both the structural pattern and the Display rendering:

- `crates/ff-sdk/src/lib.rs :: config_structured_fields_render_and_match` — covers both `Some(field)` and `None` branches.
- `crates/ff-script/src/error.rs :: parse_structured_fields_render_and_match` — covers both `Some(exec_id)` and `None` branches, asserts `fcall` is never empty.

**Validity**: stashed the variant struct-definitions and confirmed both tests fail to compile (field names change); restoring brings them green. Tests exercise Display + `matches!` destructure on exactly the API consumers like cairn-fabric will use.

## Test plan

- [x] `cargo build --workspace --all-features` green.
- [x] `cargo test --workspace --lib` green (workspace lib tests all pass).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green for FF crates (ferriskey upstream warnings unrelated).
- [ ] Integration tests (`cargo test --workspace`) — require live Valkey; will run in CI.
- [ ] 20 CI checks to sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it is a breaking public API change for downstream crates matching on `SdkError::Config` or `ScriptError::Parse`, and it touches error construction across many parsing/transport paths. Runtime behavior is mostly message/shape changes, but mismatched pattern updates could cause compile or handling regressions.
> 
> **Overview**
> **Structures error payloads for better matching.** `ScriptError::Parse` is changed from a string payload to `{ fcall, execution_id, message }` with consistent formatting via a new helper, and all parse/decoder sites in `ff-script` are updated to populate these fields.
> 
> **Improves SDK config diagnostics.** `SdkError::Config` is changed from a string payload to `{ context, field, message }` with a new formatter, and all config/validation/corruption checks across `ff-sdk` (admin client, worker connect/config validation, snapshot decoding, task parsers) plus affected tests/mappings are updated to construct and pattern-match the structured form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee58a1ccd2ea91c787f3ae764887fff54127b4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->