### PR TITLE
feat(ff-sdk,ff-backend-valkey): RFC-012 Stage 1b — ClaimedTask ops through EngineBackend trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,7 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-script",
+ "serde_json",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,7 @@ dependencies = [
  "ferriskey",
  "ff-core",
  "ff-script",
+ "tracing",
 ]
 
 [[package]]
@@ -912,6 +913,7 @@ name = "ff-sdk"
 version = "0.3.0"
 dependencies = [
  "ferriskey",
+ "ff-backend-valkey",
  "ff-core",
  "ff-script",
  "reqwest",

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -16,3 +16,7 @@ ff-script = { workspace = true }
 ferriskey = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
+# RFC-012 Stage 1b — `fail_impl` reads the execution's retry policy
+# JSON and serialises the nested `retry_policy` field into an
+# FCALL ARGV. Mirrors ff-sdk's pre-migration `read_retry_policy_json`.
+serde_json = { workspace = true }

--- a/crates/ff-backend-valkey/src/handle_codec.rs
+++ b/crates/ff-backend-valkey/src/handle_codec.rs
@@ -1,0 +1,275 @@
+//! Internal [`HandleOpaque`] encoding for the Valkey backend.
+//!
+//! **RFC-012 Stage 1b, option A (synth_handle per op).** ff-sdk's
+//! `ClaimedTask` does not yet refactor its shape onto a `Handle` —
+//! that lands in Stage 1d. For Stage 1b the SDK encodes the minimal
+//! attempt-cookie fields into a `HandleOpaque` on every forwarder
+//! entry, and this crate decodes them back on every FCALL. The
+//! format is private to this crate — no consumer ever sees the bytes
+//! — so it can change freely across stages.
+//!
+//! # Wire layout (version-tagged)
+//!
+//! ```text
+//! [0]       u8    version tag (today: 0x01)
+//! [1..5]    u32   execution_id length (LE)
+//! [5..]     utf8  execution_id bytes
+//! [..+4]    u32   attempt_index (LE)
+//! [..+4]    u32   attempt_id length (LE)
+//! [..]      utf8  attempt_id bytes
+//! [..+4]    u32   lease_id length (LE)
+//! [..]      utf8  lease_id bytes
+//! [..+8]    u64   lease_epoch (LE)
+//! [..+8]    u64   lease_ttl_ms (LE)
+//! [..+4]    u32   lane_id length (LE)
+//! [..]      utf8  lane_id bytes
+//! [..+4]    u32   worker_instance_id length (LE)
+//! [..]      utf8  worker_instance_id bytes
+//! ```
+//!
+//! Length fields are `u32`s so any string up to 4 GiB encodes losslessly
+//! — far past realistic ExecutionId / UUID / lane lengths. The version
+//! tag is a forward-compat door: if the field set changes between
+//! Stage 1b and 1d, a future `0x02` branch can land additively without
+//! breaking in-flight handles (handles do not persist across process
+//! boundaries today, so even a hard switch would be safe — but the tag
+//! is cheap insurance).
+
+use ff_core::backend::{BackendTag, Handle, HandleKind, HandleOpaque};
+use ff_core::engine_error::EngineError;
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, WorkerInstanceId,
+};
+
+/// Decoded view of a `HandleOpaque` — the minimum set of fields every
+/// Stage 1b forwarder needs to construct its Lua KEYS + ARGV.
+///
+/// Produced by [`encode_handle`] (via `ClaimedTask::synth_handle`) and
+/// consumed by [`decode_handle`] on each trait method entry.
+#[derive(Clone, Debug)]
+pub(crate) struct HandleFields {
+    pub execution_id: ExecutionId,
+    pub attempt_index: AttemptIndex,
+    pub attempt_id: AttemptId,
+    pub lease_id: LeaseId,
+    pub lease_epoch: LeaseEpoch,
+    pub lease_ttl_ms: u64,
+    pub lane_id: LaneId,
+    pub worker_instance_id: WorkerInstanceId,
+}
+
+const VERSION_TAG: u8 = 0x01;
+
+/// Encode a `HandleFields` into a `Handle` carrying a Valkey-tagged
+/// `HandleOpaque`. Kind is caller-supplied (`Fresh` for `claim_next` /
+/// `claim_from_grant`, `Resumed` for `claim_from_reclaim_grant`).
+pub(crate) fn encode_handle(fields: &HandleFields, kind: HandleKind) -> Handle {
+    let mut buf: Vec<u8> = Vec::with_capacity(256);
+    buf.push(VERSION_TAG);
+    write_str(&mut buf, &fields.execution_id.to_string());
+    buf.extend_from_slice(&fields.attempt_index.0.to_le_bytes());
+    write_str(&mut buf, &fields.attempt_id.to_string());
+    write_str(&mut buf, &fields.lease_id.to_string());
+    buf.extend_from_slice(&fields.lease_epoch.0.to_le_bytes());
+    buf.extend_from_slice(&fields.lease_ttl_ms.to_le_bytes());
+    write_str(&mut buf, fields.lane_id.as_str());
+    write_str(&mut buf, fields.worker_instance_id.as_str());
+    Handle::new(BackendTag::Valkey, kind, HandleOpaque::new(buf.into_boxed_slice()))
+}
+
+/// Decode a `Handle` into its backing `HandleFields`. Returns
+/// `EngineError::Validation` on any shape / version / parse mismatch
+/// — the Valkey backend will not route an op on a malformed handle.
+pub(crate) fn decode_handle(handle: &Handle) -> Result<HandleFields, EngineError> {
+    if handle.backend != BackendTag::Valkey {
+        return Err(invalid("handle backend tag is not Valkey"));
+    }
+    let bytes = handle.opaque.as_bytes();
+    let mut cur = Cursor::new(bytes);
+    let version = cur.read_u8()?;
+    if version != VERSION_TAG {
+        return Err(invalid(&format!(
+            "handle version tag {version:#x} not recognised (expected {VERSION_TAG:#x})"
+        )));
+    }
+    let execution_id_str = cur.read_str()?;
+    let execution_id = ExecutionId::parse(&execution_id_str)
+        .map_err(|e| invalid(&format!("handle execution_id parse failed: {e}")))?;
+    let attempt_index = AttemptIndex::new(cur.read_u32()?);
+    let attempt_id_str = cur.read_str()?;
+    let attempt_id = AttemptId::parse(&attempt_id_str)
+        .map_err(|e| invalid(&format!("handle attempt_id parse failed: {e}")))?;
+    let lease_id_str = cur.read_str()?;
+    let lease_id = LeaseId::parse(&lease_id_str)
+        .map_err(|e| invalid(&format!("handle lease_id parse failed: {e}")))?;
+    let lease_epoch = LeaseEpoch(cur.read_u64()?);
+    let lease_ttl_ms = cur.read_u64()?;
+    let lane_id_str = cur.read_str()?;
+    let lane_id = LaneId::new(lane_id_str);
+    let worker_str = cur.read_str()?;
+    let worker_instance_id = WorkerInstanceId::new(worker_str);
+    cur.expect_eof()?;
+    Ok(HandleFields {
+        execution_id,
+        attempt_index,
+        attempt_id,
+        lease_id,
+        lease_epoch,
+        lease_ttl_ms,
+        lane_id,
+        worker_instance_id,
+    })
+}
+
+fn write_str(buf: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    let len: u32 = bytes
+        .len()
+        .try_into()
+        .expect("Stage 1b handle string exceeded 4 GiB — impossible at attempt-cookie scale");
+    buf.extend_from_slice(&len.to_le_bytes());
+    buf.extend_from_slice(bytes);
+}
+
+fn invalid(msg: &str) -> EngineError {
+    EngineError::Validation {
+        kind: ff_core::engine_error::ValidationKind::InvalidInput,
+        detail: format!("invalid Valkey backend handle: {msg}"),
+    }
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], EngineError> {
+        if self.pos + n > self.bytes.len() {
+            return Err(invalid(&format!(
+                "truncated handle: needed {n} bytes at offset {pos}, have {len}",
+                pos = self.pos,
+                len = self.bytes.len()
+            )));
+        }
+        let slice = &self.bytes[self.pos..self.pos + n];
+        self.pos += n;
+        Ok(slice)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, EngineError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn read_u32(&mut self) -> Result<u32, EngineError> {
+        let mut b = [0u8; 4];
+        b.copy_from_slice(self.take(4)?);
+        Ok(u32::from_le_bytes(b))
+    }
+
+    fn read_u64(&mut self) -> Result<u64, EngineError> {
+        let mut b = [0u8; 8];
+        b.copy_from_slice(self.take(8)?);
+        Ok(u64::from_le_bytes(b))
+    }
+
+    fn read_str(&mut self) -> Result<String, EngineError> {
+        let len = self.read_u32()? as usize;
+        let bytes = self.take(len)?;
+        String::from_utf8(bytes.to_vec())
+            .map_err(|e| invalid(&format!("handle string is not valid UTF-8: {e}")))
+    }
+
+    fn expect_eof(&self) -> Result<(), EngineError> {
+        if self.pos != self.bytes.len() {
+            return Err(invalid(&format!(
+                "trailing bytes in handle: pos={pos}, len={len}",
+                pos = self.pos,
+                len = self.bytes.len()
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_core::partition::PartitionConfig;
+    use ff_core::types::FlowId;
+
+    fn sample() -> HandleFields {
+        HandleFields {
+            execution_id: ExecutionId::solo(
+                &LaneId::new("default"),
+                &PartitionConfig::default(),
+            ),
+            attempt_index: AttemptIndex::new(3),
+            attempt_id: AttemptId::new(),
+            lease_id: LeaseId::new(),
+            lease_epoch: LeaseEpoch(7),
+            lease_ttl_ms: 30_000,
+            lane_id: LaneId::new("default"),
+            worker_instance_id: WorkerInstanceId::new("worker-1"),
+        }
+    }
+
+    #[test]
+    fn round_trip_fresh() {
+        let fields = sample();
+        let handle = encode_handle(&fields, HandleKind::Fresh);
+        assert_eq!(handle.backend, BackendTag::Valkey);
+        assert_eq!(handle.kind, HandleKind::Fresh);
+        let decoded = decode_handle(&handle).expect("round-trip");
+        assert_eq!(decoded.execution_id, fields.execution_id);
+        assert_eq!(decoded.attempt_index, fields.attempt_index);
+        assert_eq!(decoded.attempt_id, fields.attempt_id);
+        assert_eq!(decoded.lease_id, fields.lease_id);
+        assert_eq!(decoded.lease_epoch, fields.lease_epoch);
+        assert_eq!(decoded.lease_ttl_ms, fields.lease_ttl_ms);
+        assert_eq!(decoded.lane_id, fields.lane_id);
+        assert_eq!(decoded.worker_instance_id, fields.worker_instance_id);
+    }
+
+    #[test]
+    fn round_trip_resumed() {
+        let fields = sample();
+        let handle = encode_handle(&fields, HandleKind::Resumed);
+        assert_eq!(handle.kind, HandleKind::Resumed);
+        let _ = decode_handle(&handle).expect("resumed round-trip");
+    }
+
+    #[test]
+    fn truncated_handle_rejected() {
+        // Only version tag, no fields.
+        let handle = Handle::new(
+            BackendTag::Valkey,
+            HandleKind::Fresh,
+            HandleOpaque::new(Box::new([VERSION_TAG])),
+        );
+        let err = decode_handle(&handle).unwrap_err();
+        assert!(format!("{err}").contains("truncated"));
+    }
+
+    #[test]
+    fn bad_version_rejected() {
+        let handle = Handle::new(
+            BackendTag::Valkey,
+            HandleKind::Fresh,
+            HandleOpaque::new(Box::new([0xFF])),
+        );
+        let err = decode_handle(&handle).unwrap_err();
+        assert!(format!("{err}").contains("version tag"));
+    }
+
+    // FlowId is used elsewhere in the crate; touch it here to silence
+    // an unused-import warning if the tests file is added standalone.
+    #[allow(dead_code)]
+    fn _flow_id_touch() -> FlowId {
+        FlowId::new()
+    }
+}

--- a/crates/ff-backend-valkey/src/handle_codec.rs
+++ b/crates/ff-backend-valkey/src/handle_codec.rs
@@ -66,6 +66,16 @@ const VERSION_TAG: u8 = 0x01;
 pub(crate) fn encode_handle(fields: &HandleFields, kind: HandleKind) -> Handle {
     let mut buf: Vec<u8> = Vec::with_capacity(256);
     buf.push(VERSION_TAG);
+    // Every string field here is produced by an SDK type's `.to_string()`
+    // / `.as_str()`: UUID = 36 bytes, LaneId/WorkerInstanceId are
+    // config-bounded (WorkerConfig validator rejects >1KiB today),
+    // ExecutionId prefixed partition tag + UUID ≈ 50 bytes. None
+    // approach 4 GiB. `write_str` clamps at `u32::MAX`; on the
+    // vanishingly improbable path of an attacker-controlled
+    // oversized caller, the encoded slot length is clamped to
+    // u32::MAX and the trailing bytes are dropped — the `decode_handle`
+    // side detects the truncation (`Validation(InvalidInput)`) on the
+    // next op and the worker fails loudly rather than silently.
     write_str(&mut buf, &fields.execution_id.to_string());
     buf.extend_from_slice(&fields.attempt_index.0.to_le_bytes());
     write_str(&mut buf, &fields.attempt_id.to_string());
@@ -123,12 +133,21 @@ pub(crate) fn decode_handle(handle: &Handle) -> Result<HandleFields, EngineError
 
 fn write_str(buf: &mut Vec<u8>, s: &str) {
     let bytes = s.as_bytes();
-    let len: u32 = bytes
-        .len()
-        .try_into()
-        .expect("Stage 1b handle string exceeded 4 GiB — impossible at attempt-cookie scale");
+    // Clamp rather than panic: if a caller somehow hands in a
+    // >4 GiB string (impossible at the SDK's attempt-cookie scale),
+    // we write a u32::MAX length prefix + the first 4 GiB of bytes.
+    // `decode_handle` will detect the trailing truncation and return
+    // `EngineError::Validation(InvalidInput)` on the first op — the
+    // worker fails loudly at op time rather than on the spawn-path
+    // stack, which matches the crate-wide strict-parse posture
+    // (gemini-code-assist review finding on PR #119: avoid `expect`
+    // on storage-adjacent data paths).
+    let (len, take) = match u32::try_from(bytes.len()) {
+        Ok(n) => (n, bytes.len()),
+        Err(_) => (u32::MAX, u32::MAX as usize),
+    };
     buf.extend_from_slice(&len.to_le_bytes());
-    buf.extend_from_slice(bytes);
+    buf.extend_from_slice(&bytes[..take]);
 }
 
 fn invalid(msg: &str) -> EngineError {

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -173,13 +173,16 @@ impl ValkeyBackend {
     /// the encode onto the claim path itself (so `ClaimedTask` caches
     /// one `Handle` rather than synthesising per op).
     ///
-    /// `kind` is `HandleKind::Fresh` on `claim_next` /
-    /// `claim_from_grant` and `HandleKind::Resumed` on
-    /// `claim_from_reclaim_grant`. The Lua side does not inspect the
-    /// kind today; it is carried on the `Handle` so trait methods
-    /// that want to match on lifecycle state (`suspend` returns a
-    /// `HandleKind::Suspended`) can do so additively without a
-    /// second-dimension lookup.
+    /// `kind` today is always `HandleKind::Fresh` at the ff-sdk call
+    /// site — Stage 1b's 8 migrated ops do not dispatch on
+    /// `Handle.kind`, so the SDK does not yet distinguish
+    /// resumed-claim handles on the trait boundary. Stage 1d (or
+    /// the call-site that claims from a reclaim grant) will start
+    /// passing `HandleKind::Resumed` once a trait op needs the
+    /// distinction. The Lua side does not inspect the kind today;
+    /// it is carried on the `Handle` so trait methods that want to
+    /// match on lifecycle state (`suspend` returns a
+    /// `HandleKind::Suspended`) can do so additively.
     #[allow(clippy::too_many_arguments)]
     pub fn encode_handle(
         execution_id: ExecutionId,
@@ -895,7 +898,22 @@ async fn fail_impl(
 
     let retry_policy_json = read_retry_policy_json(client, &ctx, &f.execution_id).await?;
 
-    let error_category = failure_class_to_lua_string(classification);
+    // Category string resolution: prefer the caller's raw-string
+    // stash in `FailureReason.detail` (see ff-sdk's
+    // `ClaimedTask::fail` carrier note). When the detail bytes are
+    // valid UTF-8 and non-empty, Lua sees the caller's exact
+    // category. Otherwise fall through to the trait-enum mapping
+    // (Transient / Permanent / …) so trait-direct callers still
+    // get a sensible string. Stage 1d retires the stash once
+    // `FailureClass::Custom(String)` lands.
+    let category_owned: Option<String> = reason
+        .detail
+        .as_ref()
+        .filter(|d| !d.is_empty())
+        .and_then(|d| std::str::from_utf8(d).ok())
+        .map(String::from);
+    let error_category: String = category_owned
+        .unwrap_or_else(|| failure_class_to_lua_string(classification).to_owned());
 
     let args: Vec<String> = vec![
         f.execution_id.to_string(),
@@ -903,7 +921,7 @@ async fn fail_impl(
         f.lease_epoch.to_string(),
         f.attempt_id.to_string(),
         reason.message,
-        error_category.to_owned(),
+        error_category,
         retry_policy_json,
     ];
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -609,6 +609,459 @@ fn resume_waitpoint_id_from_suspension(
     Ok(Some(waitpoint_id))
 }
 
+// ── Tranche 2: terminal writes (delay, wait_children, complete, fail, cancel) ──
+
+/// Stage 1b — `delay` FCALL body. Migrated from
+/// `ff_sdk::task::ClaimedTask::delay_execution`. 9 KEYS, 5 ARGV.
+async fn delay_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    delay_until: TimestampMs,
+) -> Result<(), EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(f.attempt_index),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lease_expiry(),
+        idx.worker_leases(&f.worker_instance_id),
+        idx.lane_active(&f.lane_id),
+        idx.lane_delayed(&f.lane_id),
+        idx.attempt_timeout(),
+    ];
+
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+        f.attempt_id.to_string(),
+        delay_until.to_string(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_delay_execution", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    parse_success_only(&raw)
+}
+
+/// Stage 1b — `wait_children` FCALL body. Migrated from
+/// `ff_sdk::task::ClaimedTask::move_to_waiting_children`. 9 KEYS, 4
+/// ARGV.
+async fn wait_children_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+) -> Result<(), EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(f.attempt_index),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lease_expiry(),
+        idx.worker_leases(&f.worker_instance_id),
+        idx.lane_active(&f.lane_id),
+        idx.lane_blocked_dependencies(&f.lane_id),
+        idx.attempt_timeout(),
+    ];
+
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+        f.attempt_id.to_string(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_move_to_waiting_children", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    parse_success_only(&raw)
+}
+
+/// Stage 1b — `complete` FCALL body + replay reconciliation.
+/// Migrated from `ff_sdk::task::ClaimedTask::complete`. 12 KEYS, 5
+/// ARGV.
+///
+/// # Replay reconciliation
+///
+/// If the FCALL returns `ExecutionNotActive` AND the stored
+/// `terminal_outcome` is `"success"` AND `lease_epoch` +
+/// `attempt_id` match the caller's handle, the Ok path is taken:
+/// the prior commit landed and the network drop hit after commit.
+/// Any other `ExecutionNotActive` combination surfaces the error
+/// so the caller learns what actually happened.
+async fn complete_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    payload: Option<Vec<u8>>,
+) -> Result<(), EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(f.attempt_index),
+        idx.lease_expiry(),
+        idx.worker_leases(&f.worker_instance_id),
+        idx.lane_terminal(&f.lane_id),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lane_active(&f.lane_id),
+        ctx.stream_meta(f.attempt_index),
+        ctx.result(),
+        idx.attempt_timeout(),
+        idx.execution_deadline(),
+    ];
+
+    let result_bytes = payload.unwrap_or_default();
+    let result_str = String::from_utf8_lossy(&result_bytes);
+
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+        f.attempt_id.to_string(),
+        result_str.into_owned(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_complete_execution", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    let err = match parse_success_only(&raw) {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    if reconcile_terminal_replay(&err, f, "success") {
+        return Ok(());
+    }
+    Err(err)
+}
+
+/// Stage 1b — `cancel` FCALL body + replay reconciliation. Migrated
+/// from `ff_sdk::task::ClaimedTask::cancel_inner`. 21 KEYS (of which
+/// slots 9/10 depend on the `current_waitpoint_id` field in
+/// `exec_core`; if absent, a placeholder `WaitpointId` is used — the
+/// Lua side tolerates this), 5 ARGV. Reconciles to `Ok` when the
+/// stored `terminal_outcome == "cancelled"`.
+async fn cancel_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    reason: &str,
+) -> Result<(), EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    // Read `current_waitpoint_id` exactly as the SDK did; needed for
+    // slots 9 + 10. Falls back to a placeholder UUID for not-suspended
+    // executions; Lua tolerates the placeholder.
+    let wp_id_str: Option<String> = client
+        .hget(&ctx.core(), "current_waitpoint_id")
+        .await
+        .map_err(transport_fk)?;
+    let wp_id = match wp_id_str.as_deref().filter(|s| !s.is_empty()) {
+        Some(s) => match WaitpointId::parse(s) {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(
+                    execution_id = %f.execution_id,
+                    raw = %s,
+                    error = %e,
+                    "corrupt waitpoint_id in exec_core, using placeholder"
+                );
+                WaitpointId::new()
+            }
+        },
+        None => WaitpointId::default(),
+    };
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(f.attempt_index),
+        ctx.stream_meta(f.attempt_index),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lease_expiry(),
+        idx.worker_leases(&f.worker_instance_id),
+        ctx.suspension_current(),
+        ctx.waitpoint(&wp_id),
+        ctx.waitpoint_condition(&wp_id),
+        idx.suspension_timeout(),
+        idx.lane_terminal(&f.lane_id),
+        idx.attempt_timeout(),
+        idx.execution_deadline(),
+        idx.lane_eligible(&f.lane_id),
+        idx.lane_delayed(&f.lane_id),
+        idx.lane_blocked_dependencies(&f.lane_id),
+        idx.lane_blocked_budget(&f.lane_id),
+        idx.lane_blocked_quota(&f.lane_id),
+        idx.lane_blocked_route(&f.lane_id),
+        idx.lane_blocked_operator(&f.lane_id),
+    ];
+
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        reason.to_owned(),
+        "worker".to_owned(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_cancel_execution", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    let err = match parse_success_only(&raw) {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    if reconcile_terminal_replay(&err, f, "cancelled") {
+        return Ok(());
+    }
+    Err(err)
+}
+
+/// Stage 1b — `fail` FCALL body + replay reconciliation. Migrated
+/// from `ff_sdk::task::ClaimedTask::fail`. 12 KEYS, 7 ARGV.
+///
+/// The `FailureClass` is mapped to the Lua `error_category` string
+/// at the call boundary; the SDK's string shape was free-form so we
+/// pick the Lua-side canonical lower_snake_case for each enum
+/// variant. Future trait amendments (issue #117 family) may widen
+/// `FailureClass` with a `Custom(String)` arm; for now the 5 named
+/// variants cover every shape the SDK exercises today.
+///
+/// `FailureReason.message` maps to the `failure_reason` ARGV slot.
+/// `FailureReason.detail` is not yet surfaced to Lua — the SDK's
+/// pre-Stage-1b call site passed the reason string straight through
+/// and Lua records that as `failure_reason`; Stage 1b preserves the
+/// shape to keep a zero-behavior-change guarantee. A future commit
+/// can thread `detail` once Lua grows a slot for it.
+async fn fail_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    reason: FailureReason,
+    classification: FailureClass,
+) -> Result<FailOutcome, EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(f.attempt_index),
+        idx.lease_expiry(),
+        idx.worker_leases(&f.worker_instance_id),
+        idx.lane_terminal(&f.lane_id),
+        idx.lane_delayed(&f.lane_id),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lane_active(&f.lane_id),
+        ctx.stream_meta(f.attempt_index),
+        idx.attempt_timeout(),
+        idx.execution_deadline(),
+    ];
+
+    let retry_policy_json = read_retry_policy_json(client, &ctx, &f.execution_id).await?;
+
+    let error_category = failure_class_to_lua_string(classification);
+
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+        f.attempt_id.to_string(),
+        reason.message,
+        error_category.to_owned(),
+        retry_policy_json,
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_fail_execution", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    match parse_fail_result_engine(&raw) {
+        Ok(outcome) => Ok(outcome),
+        Err(err) => {
+            // Replay reconciliation: two shapes valid for fail.
+            //   - lifecycle=terminal, outcome=failed -> TerminalFailed
+            //   - lifecycle=runnable                 -> RetryScheduled { delay_until = 0 }
+            if let EngineError::Contention(
+                ff_core::engine_error::ContentionKind::ExecutionNotActive {
+                    ref terminal_outcome,
+                    ref lease_epoch,
+                    ref lifecycle_phase,
+                    ref attempt_id,
+                },
+            ) = err
+                && lease_epoch == &f.lease_epoch.to_string()
+            {
+                match (lifecycle_phase.as_str(), terminal_outcome.as_str()) {
+                    ("terminal", "failed") if attempt_id == &f.attempt_id.to_string() => {
+                        return Ok(FailOutcome::TerminalFailed);
+                    }
+                    ("runnable", _) => {
+                        return Ok(FailOutcome::RetryScheduled {
+                            delay_until: TimestampMs::from_millis(0),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            Err(err)
+        }
+    }
+}
+
+/// Reconcile a terminal-op `ExecutionNotActive` against the caller's
+/// handle: `true` iff the stored `terminal_outcome` matches
+/// `expected_outcome` AND the epoch + attempt both match this
+/// caller's claim. Shared by `complete` / `cancel`; `fail` has a
+/// two-shape path inlined above.
+fn reconcile_terminal_replay(
+    err: &EngineError,
+    f: &handle_codec::HandleFields,
+    expected_outcome: &str,
+) -> bool {
+    if let EngineError::Contention(
+        ff_core::engine_error::ContentionKind::ExecutionNotActive {
+            ref terminal_outcome,
+            ref lease_epoch,
+            ref attempt_id,
+            ..
+        },
+    ) = *err
+    {
+        terminal_outcome == expected_outcome
+            && lease_epoch == &f.lease_epoch.to_string()
+            && attempt_id == &f.attempt_id.to_string()
+    } else {
+        false
+    }
+}
+
+/// Parse `ff_fail_execution` success envelope into `FailOutcome`.
+/// Mirrors `ff_sdk::task::parse_fail_result` on the success side;
+/// errors route through `FcallResult`/`ScriptError`→`EngineError`.
+fn parse_fail_result_engine(raw: &ferriskey::Value) -> Result<FailOutcome, EngineError> {
+    let parsed = FcallResult::parse(raw)
+        .map_err(EngineError::from)?
+        .into_success()
+        .map_err(EngineError::from)?;
+    // `field_str(0)` is the sub_status (Lua returns:
+    //   ok("retry_scheduled", tostring(delay_until))
+    //   ok("terminal_failed")
+    // `FcallResult::into_success` strips the leading `1` + `"OK"`
+    // wrapper, so fields[0] here is the sub-status slot.
+    let sub_status = parsed.field_str(0);
+    match sub_status.as_str() {
+        "retry_scheduled" => {
+            let delay_str = parsed.field_str(1);
+            let delay_until = delay_str.parse::<i64>().unwrap_or(0);
+            Ok(FailOutcome::RetryScheduled {
+                delay_until: TimestampMs::from_millis(delay_until),
+            })
+        }
+        "terminal_failed" => Ok(FailOutcome::TerminalFailed),
+        other => Err(EngineError::from(ScriptError::Parse {
+            fcall: "ff_fail_execution".into(),
+            execution_id: None,
+            message: format!("unexpected sub-status: {other}"),
+        })),
+    }
+}
+
+/// Map the trait's `FailureClass` enum to the Lua-side `error_category`
+/// ARGV string. The 5 variants plus a non-exhaustive fallback cover
+/// every call site the SDK exercises today. When issue #117 or a
+/// follow-up RFC widens `FailureClass` with a `Custom(String)` arm,
+/// this match gains a pass-through for the new arm.
+fn failure_class_to_lua_string(c: FailureClass) -> &'static str {
+    match c {
+        FailureClass::Transient => "transient",
+        FailureClass::Permanent => "permanent",
+        FailureClass::InfraCrash => "infra_crash",
+        FailureClass::Timeout => "timeout",
+        FailureClass::Cancelled => "cancelled",
+        // `#[non_exhaustive]` — fall through to the least-destructive
+        // known category so a newly-added variant does not silently
+        // hard-fail an attempt. Follow-up RFCs that add variants must
+        // update this match explicitly.
+        _ => "transient",
+    }
+}
+
+/// Read the execution's retry policy JSON from `exec_policy`. Used by
+/// `fail_impl` — the FCALL's `retry_policy_json` ARGV is the
+/// serialised `retry_policy` key extracted from the stored policy
+/// JSON. Malformed stored JSON degrades to an empty string (matches
+/// the SDK's pre-migration behaviour — Lua then applies no-retry
+/// defaults).
+async fn read_retry_policy_json(
+    client: &ferriskey::Client,
+    ctx: &ExecKeyContext,
+    execution_id: &ExecutionId,
+) -> Result<String, EngineError> {
+    let policy_str: Option<String> = client
+        .get(&ctx.policy())
+        .await
+        .map_err(transport_fk)?;
+    match policy_str {
+        Some(json) => match serde_json::from_str::<serde_json::Value>(&json) {
+            Ok(policy) => {
+                if let Some(retry) = policy.get("retry_policy") {
+                    return Ok(serde_json::to_string(retry).unwrap_or_default());
+                }
+                Ok(String::new())
+            }
+            Err(e) => {
+                tracing::warn!(
+                    execution_id = %execution_id,
+                    error = %e,
+                    "malformed retry policy JSON, treating as no policy"
+                );
+                Ok(String::new())
+            }
+        },
+        None => Ok(String::new()),
+    }
+}
+
 #[async_trait]
 impl EngineBackend for ValkeyBackend {
     async fn claim(
@@ -648,23 +1101,26 @@ impl EngineBackend for ValkeyBackend {
 
     async fn complete(
         &self,
-        _handle: &Handle,
-        _payload: Option<Vec<u8>>,
+        handle: &Handle,
+        payload: Option<Vec<u8>>,
     ) -> Result<(), EngineError> {
-        Err(EngineError::Unavailable { op: "complete" })
+        let f = handle_codec::decode_handle(handle)?;
+        complete_impl(&self.client, &self.partition_config, &f, payload).await
     }
 
     async fn fail(
         &self,
-        _handle: &Handle,
-        _reason: FailureReason,
-        _classification: FailureClass,
+        handle: &Handle,
+        reason: FailureReason,
+        classification: FailureClass,
     ) -> Result<FailOutcome, EngineError> {
-        Err(EngineError::Unavailable { op: "fail" })
+        let f = handle_codec::decode_handle(handle)?;
+        fail_impl(&self.client, &self.partition_config, &f, reason, classification).await
     }
 
-    async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {
-        Err(EngineError::Unavailable { op: "cancel" })
+    async fn cancel(&self, handle: &Handle, reason: &str) -> Result<(), EngineError> {
+        let f = handle_codec::decode_handle(handle)?;
+        cancel_impl(&self.client, &self.partition_config, &f, reason).await
     }
 
     async fn suspend(
@@ -695,16 +1151,16 @@ impl EngineBackend for ValkeyBackend {
 
     async fn delay(
         &self,
-        _handle: &Handle,
-        _delay_until: TimestampMs,
+        handle: &Handle,
+        delay_until: TimestampMs,
     ) -> Result<(), EngineError> {
-        Err(EngineError::Unavailable { op: "delay" })
+        let f = handle_codec::decode_handle(handle)?;
+        delay_impl(&self.client, &self.partition_config, &f, delay_until).await
     }
 
-    async fn wait_children(&self, _handle: &Handle) -> Result<(), EngineError> {
-        Err(EngineError::Unavailable {
-            op: "wait_children",
-        })
+    async fn wait_children(&self, handle: &Handle) -> Result<(), EngineError> {
+        let f = handle_codec::decode_handle(handle)?;
+        wait_children_impl(&self.client, &self.partition_config, &f).await
     }
 
     async fn describe_execution(

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -14,6 +14,15 @@
 //! The `EngineBackend` trait stays object-safe; consumers can hold
 //! `Arc<dyn EngineBackend>`.
 
+// `EngineError` is ~200 bytes; the `EngineBackend` trait's method
+// signatures return `Result<_, EngineError>` throughout (that is the
+// public contract). Allow the lint crate-wide so intra-crate helpers
+// that mirror the trait's return shape don't need a per-fn allow.
+// A future PR can box `EngineError::Transport.source` / the larger
+// variants to shrink the `Err` side globally; that is a cross-crate
+// design change out of scope for Stage 1b.
+#![allow(clippy::result_large_err)]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,17 +31,23 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AdmissionDecision, BackendConfig, BackendConnection, CancelFlowPolicy, CancelFlowWait,
     CapabilitySet, ClaimPolicy, FailOutcome, FailureClass, FailureReason, Frame, Handle,
-    LeaseRenewal, ReclaimToken, ResumeSignal, UsageDimensions, WaitpointSpec,
+    HandleKind, LeaseRenewal, ReclaimToken, ResumeSignal, UsageDimensions, WaitpointSpec,
 };
 use ff_core::contracts::{CancelFlowArgs, CancelFlowResult, ExecutionSnapshot, FlowSnapshot};
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
-use ff_core::keys::{FlowIndexKeys, FlowKeyContext};
-use ff_core::partition::{flow_partition, PartitionConfig};
-use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
+use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, flow_partition, PartitionConfig};
+use ff_core::types::{
+    AttemptId, AttemptIndex, BudgetId, ExecutionId, FlowId, LaneId, LeaseEpoch, LeaseId,
+    SignalId, TimestampMs, WaitpointId, WorkerInstanceId,
+};
 use ff_script::engine_error_ext::transport_script;
 use ff_script::error::ScriptError;
 use ff_script::functions::flow::{ff_cancel_flow, FlowStructOpKeys};
+use ff_script::result::FcallResult;
+
+mod handle_codec;
 
 /// Valkey-FCALL–backed `EngineBackend`.
 ///
@@ -132,6 +147,62 @@ impl ValkeyBackend {
     /// trait rather than reach in here.
     pub fn client(&self) -> &ferriskey::Client {
         &self.client
+    }
+
+    /// Wrap an already-dialed `ferriskey::Client` + known
+    /// `PartitionConfig` into a `ValkeyBackend`. Used by ff-sdk's
+    /// legacy `FlowFabricWorker::connect` path (RFC-012 Stage 1b) to
+    /// synthesise a backend around the client it dialed itself,
+    /// rather than re-dialing through
+    /// [`ValkeyBackend::connect`]. Keeps the Stage 1b migration a
+    /// pure refactor — no new round-trips, no second Valkey
+    /// connection.
+    pub fn from_client_and_partitions(
+        client: ferriskey::Client,
+        partition_config: PartitionConfig,
+    ) -> Arc<dyn EngineBackend> {
+        Arc::new(Self {
+            client,
+            partition_config,
+        })
+    }
+
+    /// Encode the minimum set of attempt-cookie fields into a
+    /// Valkey-tagged [`Handle`]. Stage 1b's `ClaimedTask::synth_handle`
+    /// calls this on every trait-forwarder entry; Stage 1d will move
+    /// the encode onto the claim path itself (so `ClaimedTask` caches
+    /// one `Handle` rather than synthesising per op).
+    ///
+    /// `kind` is `HandleKind::Fresh` on `claim_next` /
+    /// `claim_from_grant` and `HandleKind::Resumed` on
+    /// `claim_from_reclaim_grant`. The Lua side does not inspect the
+    /// kind today; it is carried on the `Handle` so trait methods
+    /// that want to match on lifecycle state (`suspend` returns a
+    /// `HandleKind::Suspended`) can do so additively without a
+    /// second-dimension lookup.
+    #[allow(clippy::too_many_arguments)]
+    pub fn encode_handle(
+        execution_id: ExecutionId,
+        attempt_index: AttemptIndex,
+        attempt_id: AttemptId,
+        lease_id: LeaseId,
+        lease_epoch: LeaseEpoch,
+        lease_ttl_ms: u64,
+        lane_id: LaneId,
+        worker_instance_id: WorkerInstanceId,
+        kind: HandleKind,
+    ) -> Handle {
+        let fields = handle_codec::HandleFields {
+            execution_id,
+            attempt_index,
+            attempt_id,
+            lease_id,
+            lease_epoch,
+            lease_ttl_ms,
+            lane_id,
+            worker_instance_id,
+        };
+        handle_codec::encode_handle(&fields, kind)
     }
 }
 
@@ -255,6 +326,289 @@ fn now_ms_timestamp() -> TimestampMs {
     TimestampMs::from_millis(now)
 }
 
+/// Map a ferriskey transport error into an `EngineError::Transport` with
+/// the Valkey backend tag + a `ScriptError::Valkey` payload (so
+/// `valkey_kind()` downcasts still recover the `ErrorKind`). Used by
+/// every Stage 1b forwarder that bypasses the typed `ff_function!`
+/// wrappers in favour of direct `client.fcall(...)` to preserve
+/// byte-for-byte KEYS/ARGV parity with the SDK's pre-migration code.
+fn transport_fk(e: ferriskey::Error) -> EngineError {
+    transport_script(ScriptError::Valkey(e))
+}
+
+/// Parse a raw `{1, "OK", ...}` / `{0, "error", ...}` FCALL result into
+/// `EngineError` on the error path. The success path's field vector is
+/// discarded; callers that need fields fall through to
+/// `parse_success_fields` below.
+fn parse_success_only(raw: &ferriskey::Value) -> Result<(), EngineError> {
+    let _ = FcallResult::parse(raw)
+        .map_err(EngineError::from)?
+        .into_success()
+        .map_err(EngineError::from)?;
+    Ok(())
+}
+
+/// Stage 1b — `renew` FCALL body. Migrated from
+/// `ff_sdk::task::renew_lease_inner` with byte-for-byte KEYS/ARGV
+/// parity (lease_history_grace_ms = 5000, 4 KEYS, 7 ARGV). The
+/// `LeaseRenewal` return is synthesised from the Lua reply's
+/// `expires_at`; `lease_epoch` is threaded from the caller's handle
+/// (Lua's `ff_renew_lease` does not bump epoch, so the handle's value
+/// is still authoritative).
+async fn renew_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+) -> Result<LeaseRenewal, EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lease_expiry(),
+    ];
+
+    // `lease_history_grace_ms = 5000` preserved from the pre-Stage-1b
+    // SDK body (ff_sdk::task::renew_lease_inner). Diverges from the
+    // `RenewLeaseArgs::lease_history_grace_ms` serde default (60_000) —
+    // the SDK's 5_000 is load-bearing for cleanup timing and must not
+    // change under this refactor.
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.attempt_index.to_string(),
+        f.attempt_id.to_string(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+        f.lease_ttl_ms.to_string(),
+        "5000".to_string(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_renew_lease", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    let parsed = FcallResult::parse(&raw)
+        .map_err(EngineError::from)?
+        .into_success()
+        .map_err(EngineError::from)?;
+    // Lua returns: ok(new_expires_at_string). Surface parse failure
+    // as `Transport` (wraps `ScriptError::Parse`) so callers' existing
+    // error-handling paths (which already branch on transport +
+    // ScriptError::Parse downcast) continue to fire.
+    let expires_ms: i64 = parsed.field_str(0).parse().map_err(|_| {
+        EngineError::from(ScriptError::Parse {
+            fcall: "ff_renew_lease".into(),
+            execution_id: None,
+            message: format!("invalid expires_at: {}", parsed.field_str(0)),
+        })
+    })?;
+    Ok(LeaseRenewal::new(expires_ms.max(0) as u64, f.lease_epoch.0))
+}
+
+/// Stage 1b — `progress` FCALL body. Migrated from
+/// `ff_sdk::task::ClaimedTask::update_progress`. 1 KEY, 5 ARGV.
+async fn progress_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    percent: Option<u8>,
+    message: Option<&str>,
+) -> Result<(), EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+
+    let keys: Vec<String> = vec![ctx.core()];
+    // Pre-migration SDK always sent a pct byte and a message string.
+    // Preserve that wire by defaulting `None` to empty / 0 so the Lua
+    // function sees the exact same ARGV shape.
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+        percent.map(|p| p.to_string()).unwrap_or_else(|| "0".to_string()),
+        message.unwrap_or("").to_string(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_update_progress", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    parse_success_only(&raw)
+}
+
+/// Stage 1b — `observe_signals` body. Migrated from
+/// `ff_sdk::task::ClaimedTask::resume_signals`. Reads
+/// `suspension:current`, filters by `attempt_index`, pulls matched
+/// `signal_id`s via `HMGET`, then pipelines per-signal
+/// `HGETALL signal_hash` + `GET signal_payload`.
+async fn observe_signals_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+) -> Result<Vec<ResumeSignal>, EngineError> {
+    use std::collections::HashMap;
+
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+
+    let susp: HashMap<String, String> = client
+        .hgetall(&ctx.suspension_current())
+        .await
+        .map_err(transport_fk)?;
+
+    let Some(waitpoint_id) = resume_waitpoint_id_from_suspension(&susp, f.attempt_index)?
+    else {
+        return Ok(Vec::new());
+    };
+
+    let wp_cond_key = ctx.waitpoint_condition(&waitpoint_id);
+    let total_str: Option<String> = client
+        .hget(&wp_cond_key, "total_matchers")
+        .await
+        .map_err(transport_fk)?;
+    let total: usize = total_str
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    let mut signal_ids: Vec<SignalId> = Vec::new();
+    for i in 0..total {
+        let fields: Vec<Option<String>> = client
+            .cmd("HMGET")
+            .arg(&wp_cond_key)
+            .arg(format!("matcher:{i}:satisfied"))
+            .arg(format!("matcher:{i}:signal_id"))
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        let satisfied = fields.first().and_then(|o| o.as_deref());
+        if satisfied != Some("1") {
+            continue;
+        }
+        let Some(raw) = fields
+            .get(1)
+            .and_then(|o| o.as_deref())
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        match SignalId::parse(raw) {
+            Ok(sid) => signal_ids.push(sid),
+            Err(e) => {
+                tracing::warn!(
+                    execution_id = %f.execution_id,
+                    waitpoint_id = %waitpoint_id,
+                    raw = %raw,
+                    error = %e,
+                    "observe_signals: matcher signal_id failed to parse, skipping"
+                );
+            }
+        }
+    }
+
+    if signal_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut pipe = client.pipeline();
+    let mut slots = Vec::with_capacity(signal_ids.len());
+    for signal_id in &signal_ids {
+        let hash_slot = pipe
+            .cmd::<HashMap<String, String>>("HGETALL")
+            .arg(ctx.signal(signal_id))
+            .finish();
+        let payload_slot = pipe
+            .cmd::<Option<ferriskey::Value>>("GET")
+            .arg(ctx.signal_payload(signal_id))
+            .finish();
+        slots.push((hash_slot, payload_slot));
+    }
+    pipe.execute().await.map_err(transport_fk)?;
+
+    let mut out: Vec<ResumeSignal> = Vec::with_capacity(signal_ids.len());
+    for (signal_id, (hash_slot, payload_slot)) in signal_ids.into_iter().zip(slots) {
+        let sig: HashMap<String, String> = hash_slot.value().map_err(transport_fk)?;
+        if sig.is_empty() {
+            continue;
+        }
+        let payload_raw: Option<ferriskey::Value> =
+            payload_slot.value().map_err(transport_fk)?;
+        let payload: Option<Vec<u8>> = match payload_raw {
+            Some(ferriskey::Value::BulkString(b)) => Some(b.to_vec()),
+            Some(ferriskey::Value::SimpleString(s)) => Some(s.into_bytes()),
+            _ => None,
+        };
+        let accepted_at = sig
+            .get("accepted_at")
+            .and_then(|s| s.parse::<i64>().ok())
+            .map(TimestampMs::from_millis)
+            .unwrap_or_else(|| TimestampMs::from_millis(0));
+
+        out.push(ResumeSignal {
+            signal_id,
+            signal_name: sig.get("signal_name").cloned().unwrap_or_default(),
+            signal_category: sig.get("signal_category").cloned().unwrap_or_default(),
+            source_type: sig.get("source_type").cloned().unwrap_or_default(),
+            source_identity: sig.get("source_identity").cloned().unwrap_or_default(),
+            correlation_id: sig.get("correlation_id").cloned().unwrap_or_default(),
+            accepted_at,
+            payload,
+        });
+    }
+    Ok(out)
+}
+
+/// Port of `ff_sdk::task::resume_waitpoint_id_from_suspension` — same
+/// invariants, same error shape. Kept crate-local (module-private) so
+/// Stage 1c consolidation can decide whether to promote.
+fn resume_waitpoint_id_from_suspension(
+    susp: &std::collections::HashMap<String, String>,
+    claimed_attempt: AttemptIndex,
+) -> Result<Option<WaitpointId>, EngineError> {
+    if susp.is_empty() {
+        return Ok(None);
+    }
+    let susp_att: u32 = susp
+        .get("attempt_index")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(u32::MAX);
+    if susp_att != claimed_attempt.0 {
+        return Ok(None);
+    }
+    let close_reason = susp.get("close_reason").map(String::as_str).unwrap_or("");
+    if close_reason != "resumed" {
+        return Ok(None);
+    }
+    let wp_id_str = susp
+        .get("waitpoint_id")
+        .map(String::as_str)
+        .unwrap_or_default();
+    if wp_id_str.is_empty() {
+        return Ok(None);
+    }
+    let waitpoint_id = WaitpointId::parse(wp_id_str).map_err(|e| {
+        EngineError::from(ScriptError::Parse {
+            fcall: "observe_signals".into(),
+            execution_id: None,
+            message: format!(
+                "observe_signals: suspension_current.waitpoint_id is not a valid UUID: {e}"
+            ),
+        })
+    })?;
+    Ok(Some(waitpoint_id))
+}
+
 #[async_trait]
 impl EngineBackend for ValkeyBackend {
     async fn claim(
@@ -266,17 +620,26 @@ impl EngineBackend for ValkeyBackend {
         Err(EngineError::Unavailable { op: "claim" })
     }
 
-    async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
-        Err(EngineError::Unavailable { op: "renew" })
+    async fn renew(&self, handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+        let f = handle_codec::decode_handle(handle)?;
+        renew_impl(&self.client, &self.partition_config, &f).await
     }
 
     async fn progress(
         &self,
-        _handle: &Handle,
-        _percent: Option<u8>,
-        _message: Option<String>,
+        handle: &Handle,
+        percent: Option<u8>,
+        message: Option<String>,
     ) -> Result<(), EngineError> {
-        Err(EngineError::Unavailable { op: "progress" })
+        let f = handle_codec::decode_handle(handle)?;
+        progress_impl(
+            &self.client,
+            &self.partition_config,
+            &f,
+            percent,
+            message.as_deref(),
+        )
+        .await
     }
 
     async fn append_frame(&self, _handle: &Handle, _frame: Frame) -> Result<(), EngineError> {
@@ -315,11 +678,10 @@ impl EngineBackend for ValkeyBackend {
 
     async fn observe_signals(
         &self,
-        _handle: &Handle,
+        handle: &Handle,
     ) -> Result<Vec<ResumeSignal>, EngineError> {
-        Err(EngineError::Unavailable {
-            op: "observe_signals",
-        })
+        let f = handle_codec::decode_handle(handle)?;
+        observe_signals_impl(&self.client, &self.partition_config, &f).await
     }
 
     async fn claim_from_reclaim(

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -39,11 +39,19 @@ iam = ["ferriskey/iam"]
 # Pulls in the ferriskey transport + the SDK modules that depend on
 # it. Left as an explicit feature (on by default) so
 # `--no-default-features` builds can prove the agnosticism contract.
-valkey-default = ["dep:ferriskey"]
+valkey-default = ["dep:ferriskey", "dep:ff-backend-valkey"]
 
 [dependencies]
 ff-core = { workspace = true }
 ff-script = { workspace = true }
+# RFC-012 Stage 1b — ff-sdk's `ClaimedTask` forwards 9 of 12 ops
+# through the `EngineBackend` trait. The legacy
+# `FlowFabricWorker::connect` path still dials Valkey itself; it
+# wraps its own client in a `ValkeyBackend` (via
+# `from_client_and_partitions`) so `ClaimedTask` has a backend to
+# forward through. Gated on `valkey-default` so the agnosticism
+# build (`--no-default-features`) stays backend-free.
+ff-backend-valkey = { workspace = true, optional = true }
 ferriskey = { workspace = true, optional = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -165,11 +165,11 @@ pub struct ClaimedTask {
     /// `EngineBackend` the trait-migrated ops forward through.
     ///
     /// **RFC-012 Stage 1b.** Today this is always a `ValkeyBackend`
-    /// wrapping `client`. 9 of 12 ops now route through
-    /// `backend.*()`; the remaining 3 (`create_pending_waitpoint`,
-    /// `append_frame`, `suspend`) still use `client.fcall(...)`
-    /// directly — see issue #117 for the trait-shape alignment
-    /// that unblocks them.
+    /// wrapping `client`. 8 of 12 ops now route through
+    /// `backend.*()`; the remaining 4 (`create_pending_waitpoint`,
+    /// `append_frame`, `suspend`, `report_usage`) still use
+    /// `client.fcall(...)` directly — see issue #117 for the
+    /// trait-shape alignment that unblocks them.
     ///
     /// Stage 1c will migrate the FlowFabricWorker hot paths (claim,
     /// deliver_signal) through the same trait surface; Stage 1d
@@ -443,15 +443,18 @@ impl ClaimedTask {
     /// Releases the lease. The execution moves to `delayed` state.
     /// Consumes self — the task cannot be used after delay.
     pub async fn delay_execution(self, delay_until: TimestampMs) -> Result<(), SdkError> {
-        // RFC-012 Stage 1b: forwards through `backend.delay`.
+        // RFC-012 Stage 1b: forwards through `backend.delay`. Matches
+        // the pre-migration `stop_renewal` contract: called only when
+        // the FCALL round-tripped (Ok or a typed Lua/engine error);
+        // raw transport errors bubble up without stopping renewal so
+        // the `Drop` warning still fires if the caller later drops
+        // `self` without retrying.
         let handle = self.synth_handle();
-        let out = self
-            .backend
-            .delay(&handle, delay_until)
-            .await
-            .map_err(SdkError::from);
-        self.stop_renewal();
-        out
+        let out = self.backend.delay(&handle, delay_until).await;
+        if fcall_landed(&out) {
+            self.stop_renewal();
+        }
+        out.map_err(SdkError::from)
     }
 
     /// Move execution to waiting_children state.
@@ -460,14 +463,13 @@ impl ClaimedTask {
     /// Consumes self.
     pub async fn move_to_waiting_children(self) -> Result<(), SdkError> {
         // RFC-012 Stage 1b: forwards through `backend.wait_children`.
+        // See `delay_execution` for the stop_renewal contract.
         let handle = self.synth_handle();
-        let out = self
-            .backend
-            .wait_children(&handle)
-            .await
-            .map_err(SdkError::from);
-        self.stop_renewal();
-        out
+        let out = self.backend.wait_children(&handle).await;
+        if fcall_landed(&out) {
+            self.stop_renewal();
+        }
+        out.map_err(SdkError::from)
     }
 
     /// Complete the execution successfully.
@@ -493,13 +495,11 @@ impl ClaimedTask {
         // (match same epoch + attempt_id + outcome=="success" → Ok)
         // moved to `ff_backend_valkey::complete_impl`.
         let handle = self.synth_handle();
-        let out = self
-            .backend
-            .complete(&handle, result_payload)
-            .await
-            .map_err(SdkError::from);
-        self.stop_renewal();
-        out
+        let out = self.backend.complete(&handle, result_payload).await;
+        if fcall_landed(&out) {
+            self.stop_renewal();
+        }
+        out.map_err(SdkError::from)
     }
 
     /// Fail the execution with a reason and error category.
@@ -525,21 +525,36 @@ impl ClaimedTask {
         // The FCALL body + retry-policy read + the two-shape replay
         // reconciliation (terminal/failed → TerminalFailed, runnable
         // → RetryScheduled{0}) moved to
-        // `ff_backend_valkey::fail_impl`. Mapping the SDK's
-        // free-form `error_category: &str` to `FailureClass` is
-        // local-lossy (unknown strings fall through to
-        // `Transient`); see `error_category_to_class` — Stage 1d
-        // widens `FailureClass` so this translation is exact.
+        // `ff_backend_valkey::fail_impl`.
+        //
+        // **Preserving the caller's raw category string.** The
+        // pre-Stage-1b code passed `error_category` straight to the
+        // Lua `failure_category` ARGV. Real callers use arbitrary
+        // lower_snake_case strings (`"lease_stale"`, `"bad_signal"`,
+        // `"inference_error"`, …) that do not correspond to the 5
+        // named `FailureClass` variants. A lossy enum conversion
+        // would rewrite every non-canonical category to
+        // `Transient` — a real behavior change for
+        // ff-readiness-tests + the examples crates.
+        //
+        // Instead: pack the raw category bytes into
+        // `FailureReason.detail`; `fail_impl` reads them back and
+        // threads them to Lua verbatim. The `classification` enum
+        // is derived from the string for the few consumers who
+        // match on the trait return today (none in-workspace).
+        // Stage 1d (or issue #117) widens `FailureClass` with a
+        // `Custom(String)` arm; this stash carrier retires then.
         let handle = self.synth_handle();
-        let failure_reason = ff_core::backend::FailureReason::new(reason.to_owned());
+        let failure_reason = ff_core::backend::FailureReason::with_detail(
+            reason.to_owned(),
+            error_category.as_bytes().to_vec(),
+        );
         let classification = error_category_to_class(error_category);
-        let out = self
-            .backend
-            .fail(&handle, failure_reason, classification)
-            .await
-            .map_err(SdkError::from);
-        self.stop_renewal();
-        out
+        let out = self.backend.fail(&handle, failure_reason, classification).await;
+        if fcall_landed(&out) {
+            self.stop_renewal();
+        }
+        out.map_err(SdkError::from)
     }
 
     /// Cancel the execution.
@@ -562,13 +577,11 @@ impl ClaimedTask {
         // and the `ExecutionNotActive` → outcome=="cancelled" replay
         // reconciliation all moved to `ff_backend_valkey::cancel_impl`.
         let handle = self.synth_handle();
-        let out = self
-            .backend
-            .cancel(&handle, reason)
-            .await
-            .map_err(SdkError::from);
-        self.stop_renewal();
-        out
+        let out = self.backend.cancel(&handle, reason).await;
+        if fcall_landed(&out) {
+            self.stop_renewal();
+        }
+        out.map_err(SdkError::from)
     }
 
     // ── Non-terminal operations ──
@@ -943,6 +956,28 @@ impl ClaimedTask {
 
 }
 
+/// True iff the backend's FCALL result represents a round-trip that
+/// reached the Lua side. `Ok(_)` and typed engine errors (validation,
+/// contention, conflict, state, bug) all count as "landed" — the
+/// server either committed or rejected with a typed response. Only
+/// raw `Transport` errors (connection drops, request timeouts, parse
+/// failures) count as "did not land", which matches the pre-Stage-1b
+/// SDK's `fcall(...).await.map_err(SdkError::Valkey)?` short-circuit
+/// — those errors returned before `stop_renewal()` ran, preserving
+/// the `Drop` warning for genuine "lease will leak" cases.
+///
+/// Stage 1b terminal-op forwarders use this predicate to decide
+/// whether to call `stop_renewal()`: yes for landed responses, no
+/// for transport errors so the caller's retry path still sees a
+/// running renewal task.
+fn fcall_landed<T>(r: &Result<T, crate::EngineError>) -> bool {
+    match r {
+        Ok(_) => true,
+        Err(crate::EngineError::Transport { .. }) => false,
+        Err(_) => true,
+    }
+}
+
 /// Map the SDK's free-form `error_category: &str` to the typed
 /// `FailureClass` the trait's `fail` method takes. Unknown categories
 /// fall through to `Transient` — the Lua side already tolerated
@@ -991,6 +1026,27 @@ impl Drop for ClaimedTask {
 
 // ── Lease renewal ──
 
+/// Per-tick renewal: single `backend.renew(&handle)` call wrapped in
+/// the `renew_lease` tracing span so bench harnesses' on_enter / on_exit
+/// hooks still see one span per renewal (restores PR #119 Cursor
+/// Bugbot finding — the top-level `spawn_renewal_task` fires once at
+/// construction time, not per-tick).
+///
+/// See `benches/harness/src/bin/long_running.rs` for the bench
+/// consumer that depends on this span naming.
+#[tracing::instrument(
+    name = "renew_lease",
+    skip_all,
+    fields(execution_id = %execution_id)
+)]
+async fn renew_once(
+    backend: &dyn EngineBackend,
+    handle: &Handle,
+    execution_id: &ExecutionId,
+) -> Result<(), crate::EngineError> {
+    backend.renew(handle).await.map(|_| ())
+}
+
 /// Spawn a background tokio task that renews the lease at `ttl / 3`
 /// intervals.
 ///
@@ -998,17 +1054,13 @@ impl Drop for ClaimedTask {
 /// `EngineBackend` trait (`backend.renew(&handle)`) instead of calling
 /// `ff_renew_lease` via a direct FCALL. The Stage-1a `renew_lease_inner`
 /// free function was deleted; this task holds an `Arc<dyn EngineBackend>`
-/// + the encoded `Handle` instead.
+/// + the encoded `Handle` instead. Per-tick tracing lives on
+///   [`renew_once`]; this function itself is sync + one-shot.
 ///
 /// Stops when:
 /// - `stop_signal` is notified (complete/fail/cancel called)
 /// - Renewal fails with a terminal error (stale_lease, lease_expired, etc.)
 /// - The task handle is aborted (ClaimedTask dropped)
-#[tracing::instrument(
-    name = "renew_lease",
-    skip_all,
-    fields(execution_id = %execution_id)
-)]
 fn spawn_renewal_task(
     backend: Arc<dyn EngineBackend>,
     handle: Handle,
@@ -1017,7 +1069,13 @@ fn spawn_renewal_task(
     stop_signal: Arc<Notify>,
     failure_counter: Arc<AtomicU32>,
 ) -> JoinHandle<()> {
-    let interval = Duration::from_millis(lease_ttl_ms / 3);
+    // Clamp to ≥1ms so `tokio::time::interval(Duration::ZERO)` never
+    // panics if a caller (or a misconfigured test) passes a
+    // lease_ttl_ms < 3. The SDK config validator already enforces
+    // `lease_ttl_ms >= 1_000` for healthy deployments, but the clamp
+    // is a cheap belt-and-suspenders (Copilot review finding on
+    // PR #119).
+    let interval = Duration::from_millis((lease_ttl_ms / 3).max(1));
 
     tokio::spawn(async move {
         let mut tick = tokio::time::interval(interval);
@@ -1035,7 +1093,7 @@ fn spawn_renewal_task(
                     return;
                 }
                 _ = tick.tick() => {
-                    match backend.renew(&handle).await {
+                    match renew_once(backend.as_ref(), &handle, &execution_id).await {
                         Ok(_renewal) => {
                             failure_counter.store(0, Ordering::Relaxed);
                             tracing::trace!(

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -443,45 +443,15 @@ impl ClaimedTask {
     /// Releases the lease. The execution moves to `delayed` state.
     /// Consumes self — the task cannot be used after delay.
     pub async fn delay_execution(self, delay_until: TimestampMs) -> Result<(), SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-        let idx = IndexKeys::new(&partition);
-
-        // KEYS (9): exec_core, attempt_hash, lease_current, lease_history,
-        //           lease_expiry_zset, worker_leases, active_index,
-        //           delayed_zset, attempt_timeout_zset
-        let keys: Vec<String> = vec![
-            ctx.core(),
-            ctx.attempt_hash(self.attempt_index),
-            ctx.lease_current(),
-            ctx.lease_history(),
-            idx.lease_expiry(),
-            idx.worker_leases(&self.worker_instance_id),
-            idx.lane_active(&self.lane_id),
-            idx.lane_delayed(&self.lane_id),
-            idx.attempt_timeout(),
-        ];
-
-        // ARGV (5): execution_id, lease_id, lease_epoch, attempt_id, delay_until
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),
-            self.lease_id.to_string(),
-            self.lease_epoch.to_string(),
-            self.attempt_id.to_string(),
-            delay_until.to_string(),
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_delay_execution", &key_refs, &arg_refs)
+        // RFC-012 Stage 1b: forwards through `backend.delay`.
+        let handle = self.synth_handle();
+        let out = self
+            .backend
+            .delay(&handle, delay_until)
             .await
-            .map_err(SdkError::Valkey)?;
-
+            .map_err(SdkError::from);
         self.stop_renewal();
-        parse_success_result(&raw, "ff_delay_execution")
+        out
     }
 
     /// Move execution to waiting_children state.
@@ -489,44 +459,15 @@ impl ClaimedTask {
     /// Releases the lease. The execution waits for child dependencies to complete.
     /// Consumes self.
     pub async fn move_to_waiting_children(self) -> Result<(), SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-        let idx = IndexKeys::new(&partition);
-
-        // KEYS (9): exec_core, attempt_hash, lease_current, lease_history,
-        //           lease_expiry_zset, worker_leases, active_index,
-        //           blocked_deps_zset, attempt_timeout_zset
-        let keys: Vec<String> = vec![
-            ctx.core(),
-            ctx.attempt_hash(self.attempt_index),
-            ctx.lease_current(),
-            ctx.lease_history(),
-            idx.lease_expiry(),
-            idx.worker_leases(&self.worker_instance_id),
-            idx.lane_active(&self.lane_id),
-            idx.lane_blocked_dependencies(&self.lane_id),
-            idx.attempt_timeout(),
-        ];
-
-        // ARGV (4): execution_id, lease_id, lease_epoch, attempt_id
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),
-            self.lease_id.to_string(),
-            self.lease_epoch.to_string(),
-            self.attempt_id.to_string(),
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_move_to_waiting_children", &key_refs, &arg_refs)
+        // RFC-012 Stage 1b: forwards through `backend.wait_children`.
+        let handle = self.synth_handle();
+        let out = self
+            .backend
+            .wait_children(&handle)
             .await
-            .map_err(SdkError::Valkey)?;
-
+            .map_err(SdkError::from);
         self.stop_renewal();
-        parse_success_result(&raw, "ff_move_to_waiting_children")
+        out
     }
 
     /// Complete the execution successfully.
@@ -547,79 +488,18 @@ impl ClaimedTask {
     /// populated `terminal_outcome` so the caller can see what actually
     /// happened.
     pub async fn complete(self, result_payload: Option<Vec<u8>>) -> Result<(), SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-        let idx = IndexKeys::new(&partition);
-
-        // KEYS (12): must match lua/execution.lua ff_complete_execution positional order
-        // exec_core, attempt_hash, lease_expiry_zset, worker_leases,
-        // terminal_zset, lease_current, lease_history, active_index,
-        // stream_meta, result_key, attempt_timeout_zset, execution_deadline_zset
-        let keys: Vec<String> = vec![
-            ctx.core(),                                        // 1  exec_core
-            ctx.attempt_hash(self.attempt_index),              // 2  attempt_hash
-            idx.lease_expiry(),                                // 3  lease_expiry_zset
-            idx.worker_leases(&self.worker_instance_id),       // 4  worker_leases
-            idx.lane_terminal(&self.lane_id),                  // 5  terminal_zset
-            ctx.lease_current(),                               // 6  lease_current
-            ctx.lease_history(),                               // 7  lease_history
-            idx.lane_active(&self.lane_id),                    // 8  active_index
-            ctx.stream_meta(self.attempt_index),               // 9  stream_meta
-            ctx.result(),                                      // 10 result_key
-            idx.attempt_timeout(),                             // 11 attempt_timeout_zset
-            idx.execution_deadline(),                          // 12 execution_deadline_zset
-        ];
-
-        let result_bytes = result_payload.unwrap_or_default();
-        let result_str = String::from_utf8_lossy(&result_bytes);
-
-        // ARGV (5): must match lua/execution.lua ff_complete_execution positional order
-        // execution_id, lease_id, lease_epoch, attempt_id, result_payload
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),
-            self.lease_id.to_string(),
-            self.lease_epoch.to_string(),
-            self.attempt_id.to_string(),
-            result_str.into_owned(),
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_complete_execution", &key_refs, &arg_refs)
+        // RFC-012 Stage 1b: forwards through `backend.complete`.
+        // The FCALL body + the `ExecutionNotActive` replay reconciliation
+        // (match same epoch + attempt_id + outcome=="success" → Ok)
+        // moved to `ff_backend_valkey::complete_impl`.
+        let handle = self.synth_handle();
+        let out = self
+            .backend
+            .complete(&handle, result_payload)
             .await
-            .map_err(SdkError::Valkey)?;
-
+            .map_err(SdkError::from);
         self.stop_renewal();
-        // Terminal-op replay reconciliation: if this caller's own
-        // prior complete() already committed (same epoch + attempt_id)
-        // and the stored terminal_outcome is "success", return Ok —
-        // the network drop happened AFTER the server committed. Any
-        // other ExecutionNotActive combination (different epoch,
-        // different attempt, terminal_outcome!=success) is a real
-        // error the caller must see.
-        let err = match parse_success_result(&raw, "ff_complete_execution") {
-            Ok(()) => return Ok(()),
-            Err(e) => e,
-        };
-        if let SdkError::Engine(ref boxed) = err
-            && let crate::EngineError::Contention(
-                crate::ContentionKind::ExecutionNotActive {
-                    ref terminal_outcome,
-                    ref lease_epoch,
-                    ref attempt_id,
-                    ..
-                },
-            ) = **boxed
-            && terminal_outcome == "success"
-            && lease_epoch == &self.lease_epoch.to_string()
-            && attempt_id == &self.attempt_id.to_string()
-        {
-            return Ok(());
-        }
-        Err(err)
+        out
     }
 
     /// Fail the execution with a reason and error category.
@@ -641,96 +521,25 @@ impl ClaimedTask {
         reason: &str,
         error_category: &str,
     ) -> Result<FailOutcome, SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-        let idx = IndexKeys::new(&partition);
-
-        // KEYS (12): exec_core, attempt_hash, lease_expiry, worker_leases,
-        //            terminal_zset, delayed_zset, lease_current, lease_history,
-        //            active_index, stream_meta, attempt_timeout, execution_deadline
-        let keys: Vec<String> = vec![
-            ctx.core(),
-            ctx.attempt_hash(self.attempt_index),
-            idx.lease_expiry(),
-            idx.worker_leases(&self.worker_instance_id),
-            idx.lane_terminal(&self.lane_id),
-            idx.lane_delayed(&self.lane_id),
-            ctx.lease_current(),
-            ctx.lease_history(),
-            idx.lane_active(&self.lane_id),
-            ctx.stream_meta(self.attempt_index),
-            idx.attempt_timeout(),
-            idx.execution_deadline(),
-        ];
-
-        // ARGV (7): eid, lease_id, lease_epoch, attempt_id,
-        //           failure_reason, failure_category, retry_policy_json
-        let retry_policy_json = self.read_retry_policy_json(&ctx).await?;
-
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),
-            self.lease_id.to_string(),
-            self.lease_epoch.to_string(),
-            self.attempt_id.to_string(),
-            reason.to_owned(),
-            error_category.to_owned(),
-            retry_policy_json,
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_fail_execution", &key_refs, &arg_refs)
+        // RFC-012 Stage 1b: forwards through `backend.fail`.
+        // The FCALL body + retry-policy read + the two-shape replay
+        // reconciliation (terminal/failed → TerminalFailed, runnable
+        // → RetryScheduled{0}) moved to
+        // `ff_backend_valkey::fail_impl`. Mapping the SDK's
+        // free-form `error_category: &str` to `FailureClass` is
+        // local-lossy (unknown strings fall through to
+        // `Transient`); see `error_category_to_class` — Stage 1d
+        // widens `FailureClass` so this translation is exact.
+        let handle = self.synth_handle();
+        let failure_reason = ff_core::backend::FailureReason::new(reason.to_owned());
+        let classification = error_category_to_class(error_category);
+        let out = self
+            .backend
+            .fail(&handle, failure_reason, classification)
             .await
-            .map_err(SdkError::Valkey)?;
-
+            .map_err(SdkError::from);
         self.stop_renewal();
-        // Terminal-op replay reconciliation. Two valid replay shapes:
-        //   - lifecycle=terminal, outcome=failed    -> TerminalFailed
-        //   - lifecycle=runnable                    -> RetryScheduled
-        //
-        // Guard strength differs by branch because the Lua paths clear
-        // different fields:
-        //   - Terminal fail preserves both current_lease_epoch AND
-        //     current_attempt_id; we match on both (strongest guard).
-        //   - Retry-scheduled preserves current_lease_epoch but CLEARS
-        //     current_attempt_id to "" (execution.lua retry HSET). A
-        //     later re-claim bumps epoch to next_epoch, so epoch alone
-        //     is still a sufficient fence — if another worker has
-        //     claimed+processed since our fail, they'd have a different
-        //     epoch. RetryScheduled loses delay_until_ms (not persisted
-        //     on the replay error path); return 0 so callers see
-        //     "scheduled, exact delay unknown".
-        let err = match parse_fail_result(&raw) {
-            Ok(outcome) => return Ok(outcome),
-            Err(e) => e,
-        };
-        if let SdkError::Engine(ref boxed) = err
-            && let crate::EngineError::Contention(
-                crate::ContentionKind::ExecutionNotActive {
-                    ref terminal_outcome,
-                    ref lease_epoch,
-                    ref lifecycle_phase,
-                    ref attempt_id,
-                },
-            ) = **boxed
-            && lease_epoch == &self.lease_epoch.to_string()
-        {
-            match (lifecycle_phase.as_str(), terminal_outcome.as_str()) {
-                ("terminal", "failed") if attempt_id == &self.attempt_id.to_string() => {
-                    return Ok(FailOutcome::TerminalFailed);
-                }
-                ("runnable", _) => {
-                    return Ok(FailOutcome::RetryScheduled {
-                        delay_until: TimestampMs::from_millis(0),
-                    });
-                }
-                _ => {}
-            }
-        }
-        Err(err)
+        out
     }
 
     /// Cancel the execution.
@@ -748,109 +557,18 @@ impl ClaimedTask {
     /// `ExecutionNotActive` with the populated `terminal_outcome` so the
     /// caller can see that the cancel intent was NOT honored.
     pub async fn cancel(self, reason: &str) -> Result<(), SdkError> {
-        self.cancel_inner(reason).await
-    }
-
-    /// Internal cancel implementation (shared by cancel and fail-fallback).
-    async fn cancel_inner(self, reason: &str) -> Result<(), SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-        let idx = IndexKeys::new(&partition);
-
-        // ff_cancel_execution needs 21 KEYS. The Lua constructs active_index
-        // and suspended_key dynamically (C2 fix). KEYS[9]/[10] (waitpoint_hash,
-        // wp_condition) need the real waitpoint_id — read from exec_core.
-        // If no current_waitpoint_id (not suspended), use a placeholder.
-        let wp_id_str: Option<String> = self
-            .client
-            .hget(&ctx.core(), "current_waitpoint_id")
+        // RFC-012 Stage 1b: forwards through `backend.cancel`.
+        // The 21-KEYS FCALL body, the `current_waitpoint_id` pre-read,
+        // and the `ExecutionNotActive` → outcome=="cancelled" replay
+        // reconciliation all moved to `ff_backend_valkey::cancel_impl`.
+        let handle = self.synth_handle();
+        let out = self
+            .backend
+            .cancel(&handle, reason)
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "read current_waitpoint_id".into() })?;
-        let wp_id = match wp_id_str.as_deref().filter(|s| !s.is_empty()) {
-            Some(s) => match WaitpointId::parse(s) {
-                Ok(id) => id,
-                Err(e) => {
-                    tracing::warn!(
-                        execution_id = %self.execution_id,
-                        raw = %s,
-                        error = %e,
-                        "corrupt waitpoint_id in exec_core, using placeholder"
-                    );
-                    WaitpointId::new()
-                }
-            },
-            None => WaitpointId::default(),
-        };
-        let keys: Vec<String> = vec![
-            ctx.core(),                                        // 1
-            ctx.attempt_hash(self.attempt_index),              // 2
-            ctx.stream_meta(self.attempt_index),               // 3
-            ctx.lease_current(),                               // 4
-            ctx.lease_history(),                               // 5
-            idx.lease_expiry(),                                // 6
-            idx.worker_leases(&self.worker_instance_id),       // 7
-            ctx.suspension_current(),                          // 8
-            ctx.waitpoint(&wp_id),                             // 9
-            ctx.waitpoint_condition(&wp_id),                   // 10
-            idx.suspension_timeout(),                          // 11
-            idx.lane_terminal(&self.lane_id),                  // 12
-            idx.attempt_timeout(),                             // 13
-            idx.execution_deadline(),                          // 14
-            idx.lane_eligible(&self.lane_id),                  // 15
-            idx.lane_delayed(&self.lane_id),                   // 16
-            idx.lane_blocked_dependencies(&self.lane_id),      // 17
-            idx.lane_blocked_budget(&self.lane_id),            // 18
-            idx.lane_blocked_quota(&self.lane_id),             // 19
-            idx.lane_blocked_route(&self.lane_id),             // 20
-            idx.lane_blocked_operator(&self.lane_id),          // 21
-        ];
-
-        // ARGV (5): must match lua/execution.lua ff_cancel_execution positional order
-        // execution_id, reason, source, lease_id, lease_epoch
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),     // 1  execution_id
-            reason.to_owned(),                 // 2  reason
-            "worker".to_owned(),               // 3  source
-            self.lease_id.to_string(),         // 4  lease_id
-            self.lease_epoch.to_string(),      // 5  lease_epoch
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_cancel_execution", &key_refs, &arg_refs)
-            .await
-            .map_err(SdkError::Valkey)?;
-
+            .map_err(SdkError::from);
         self.stop_renewal();
-        // Terminal-op replay reconciliation for cancel: if this caller's
-        // own prior cancel() already committed (same epoch + attempt_id)
-        // and stored terminal_outcome is "cancelled", return Ok. A
-        // replay that finds outcome=success or outcome=failed means a
-        // different terminal op won the race — surface the error so
-        // the caller knows their cancel intent was NOT honored.
-        let err = match parse_success_result(&raw, "ff_cancel_execution") {
-            Ok(()) => return Ok(()),
-            Err(e) => e,
-        };
-        if let SdkError::Engine(ref boxed) = err
-            && let crate::EngineError::Contention(
-                crate::ContentionKind::ExecutionNotActive {
-                    ref terminal_outcome,
-                    ref lease_epoch,
-                    ref attempt_id,
-                    ..
-                },
-            ) = **boxed
-            && terminal_outcome == "cancelled"
-            && lease_epoch == &self.lease_epoch.to_string()
-            && attempt_id == &self.attempt_id.to_string()
-        {
-            return Ok(());
-        }
-        Err(err)
+        out
     }
 
     // ── Non-terminal operations ──
@@ -1201,35 +919,24 @@ impl ClaimedTask {
         self.renewal_stop.notify_one();
     }
 
-    /// Read the retry policy JSON from the execution's policy key.
-    async fn read_retry_policy_json(&self, ctx: &ExecKeyContext) -> Result<String, SdkError> {
-        let policy_str: Option<String> = self
-            .client
-            .get(&ctx.policy())
-            .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "read retry policy".into() })?;
+}
 
-        match policy_str {
-            Some(json) => {
-                match serde_json::from_str::<serde_json::Value>(&json) {
-                    Ok(policy) => {
-                        if let Some(retry) = policy.get("retry_policy") {
-                            return Ok(serde_json::to_string(retry).unwrap_or_default());
-                        }
-                        Ok(String::new())
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            execution_id = %self.execution_id,
-                            error = %e,
-                            "malformed retry policy JSON, treating as no policy"
-                        );
-                        Ok(String::new())
-                    }
-                }
-            }
-            None => Ok(String::new()),
-        }
+/// Map the SDK's free-form `error_category: &str` to the typed
+/// `FailureClass` the trait's `fail` method takes. Unknown categories
+/// fall through to `Transient` — the Lua side already tolerated
+/// arbitrary strings, so the worst a category drift does under the
+/// Stage 1b forwarder is reclassify a novel category as transient.
+/// Stage 1d (or issue #117) widens `FailureClass` with a
+/// `Custom(String)` arm for exact round-trip.
+fn error_category_to_class(s: &str) -> ff_core::backend::FailureClass {
+    use ff_core::backend::FailureClass;
+    match s {
+        "transient" => FailureClass::Transient,
+        "permanent" => FailureClass::Permanent,
+        "infra_crash" => FailureClass::InfraCrash,
+        "timeout" => FailureClass::Timeout,
+        "cancelled" => FailureClass::Cancelled,
+        _ => FailureClass::Transient,
     }
 }
 
@@ -1966,6 +1673,7 @@ fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError
 /// Parse ff_fail_execution result:
 ///   ok("retry_scheduled", delay_until)
 ///   ok("terminal_failed")
+#[allow(dead_code)]
 fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -606,6 +606,13 @@ impl ClaimedTask {
     /// Non-consuming — the worker can report usage multiple times.
     /// `dimensions` is a slice of `(dimension_name, delta)` pairs.
     /// `dedup_key` prevents double-counting on retries (auto-prefixed with budget hash tag).
+    // TODO(stage-1d-or-rfc-amendment): deferred from Stage 1b Tranche 3.
+    // `AdmissionDecision` (trait return) cannot losslessly encode
+    // `ReportUsageResult::{SoftBreach, HardBreach, AlreadyApplied}`
+    // — `SoftBreach` is a warning (not a rejection) and has no home
+    // in `Admitted / Throttled / Rejected`, and `HardBreach`'s
+    // structured dim/current/limit fields collapse to `Rejected { reason: String }`.
+    // Tracked in #117.
     pub async fn report_usage(
         &self,
         budget_id: &BudgetId,
@@ -658,6 +665,11 @@ impl ClaimedTask {
     /// Returns both the waitpoint_id AND the HMAC token required by external
     /// callers to buffer signals against this pending waitpoint
     /// (RFC-004 §Waitpoint Security).
+    // TODO(stage-1d-or-rfc-amendment): deferred from Stage 1b. The
+    // `EngineBackend` trait has no `create_pending_waitpoint` slot —
+    // RFC-012 §3.1 inventory does not list this op today. Needs
+    // either a new trait method or a reshape of `suspend` that covers
+    // the lease-retaining flow. Tracked in #117.
     pub async fn create_pending_waitpoint(
         &self,
         waitpoint_key: &str,
@@ -708,6 +720,10 @@ impl ClaimedTask {
     ///
     /// Non-consuming — the worker can append many frames during execution.
     /// The stream is created lazily on the first append.
+    // TODO(stage-1d-or-rfc-amendment): deferred from Stage 1b. Trait
+    // method `append_frame` returns `()`; this SDK method returns
+    // `AppendFrameOutcome { stream_id, frame_count }` — the return-type
+    // delta is a hard ABI break on the Stage-1a trait. Tracked in #117.
     pub async fn append_frame(
         &self,
         frame_type: &str,
@@ -774,6 +790,12 @@ impl ClaimedTask {
     /// returns `AlreadySatisfied` and the lease is NOT released.
     ///
     /// Consumes self — the task cannot be used after suspension.
+    // TODO(stage-1d-or-rfc-amendment): deferred from Stage 1b. Trait
+    // method `suspend` returns `Handle` (a resumed-kind attempt
+    // cookie); this SDK method returns `SuspendOutcome { suspension_id,
+    // waitpoint_id, waitpoint_key, waitpoint_token }` — semantically
+    // distinct return shapes. Also: SDK takes `&[ConditionMatcher]` +
+    // `TimeoutBehavior` with no `WaitpointSpec` mapping. Tracked in #117.
     pub async fn suspend(
         self,
         reason_code: &str,

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ferriskey::{Client, Value};
+use ff_core::backend::{Handle, HandleKind};
 use ff_core::contracts::ReportUsageResult;
+use ff_core::engine_backend::EngineBackend;
 use ff_script::error::ScriptError;
 use ff_core::keys::{usage_dedup_key, BudgetKeyContext, ExecKeyContext, IndexKeys};
 use ff_core::partition::{budget_partition, execution_partition, PartitionConfig};
@@ -160,6 +162,20 @@ pub use ff_core::backend::FailOutcome;
 pub struct ClaimedTask {
     /// Shared Valkey client.
     client: Client,
+    /// `EngineBackend` the trait-migrated ops forward through.
+    ///
+    /// **RFC-012 Stage 1b.** Today this is always a `ValkeyBackend`
+    /// wrapping `client`. 9 of 12 ops now route through
+    /// `backend.*()`; the remaining 3 (`create_pending_waitpoint`,
+    /// `append_frame`, `suspend`) still use `client.fcall(...)`
+    /// directly — see issue #117 for the trait-shape alignment
+    /// that unblocks them.
+    ///
+    /// Stage 1c will migrate the FlowFabricWorker hot paths (claim,
+    /// deliver_signal) through the same trait surface; Stage 1d
+    /// refactors this struct to carry a single `Handle` rather than
+    /// synthesising one per op via `synth_handle`.
+    backend: Arc<dyn EngineBackend>,
     /// Partition config for key construction.
     partition_config: PartitionConfig,
     /// Execution identity.
@@ -265,6 +281,7 @@ impl ClaimedTask {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         client: Client,
+        backend: Arc<dyn EngineBackend>,
         partition_config: PartitionConfig,
         execution_id: ExecutionId,
         attempt_index: AttemptIndex,
@@ -281,14 +298,24 @@ impl ClaimedTask {
         let renewal_stop = Arc::new(Notify::new());
         let renewal_failures = Arc::new(AtomicU32::new(0));
 
-        let renewal_handle = spawn_renewal_task(
-            client.clone(),
-            partition_config,
+        // Stage 1b: the renewal task forwards through `backend.renew(&handle)`.
+        // Build the handle once at construction time and hand both Arc clones
+        // into the spawned task.
+        let renewal_handle_cookie = ff_backend_valkey::ValkeyBackend::encode_handle(
             execution_id.clone(),
             attempt_index,
             attempt_id.clone(),
             lease_id.clone(),
             lease_epoch,
+            lease_ttl_ms,
+            lane_id.clone(),
+            worker_instance_id.clone(),
+            HandleKind::Fresh,
+        );
+        let renewal_handle = spawn_renewal_task(
+            backend.clone(),
+            renewal_handle_cookie,
+            execution_id.clone(),
             lease_ttl_ms,
             renewal_stop.clone(),
             renewal_failures.clone(),
@@ -296,6 +323,7 @@ impl ClaimedTask {
 
         Self {
             client,
+            backend,
             partition_config,
             execution_id,
             attempt_index,
@@ -359,6 +387,35 @@ impl ClaimedTask {
 
     pub fn lane_id(&self) -> &LaneId {
         &self.lane_id
+    }
+
+    /// Synthesise a Valkey-backend `Handle` encoding this task's
+    /// attempt-cookie fields. Private to the SDK — the trait
+    /// forwarders call this per op to produce the `&Handle` argument
+    /// the `EngineBackend` methods take.
+    ///
+    /// **RFC-012 Stage 1b option A.** Refactoring `ClaimedTask` to
+    /// carry one cached `Handle` instead of synthesising per op is
+    /// deferred to Stage 1d (issue #89 follow-up). The per-op cost is
+    /// a single allocation of a small byte buffer — negligible
+    /// compared to the FCALL round-trip that follows.
+    ///
+    /// Kind is always `HandleKind::Fresh` because today the 9
+    /// Stage-1b ops all treat the backend tag + opaque bytes as
+    /// authoritative; they do not dispatch on kind. Stage 1d routes
+    /// resumed-claim callers through a `Resumed` synth.
+    fn synth_handle(&self) -> Handle {
+        ff_backend_valkey::ValkeyBackend::encode_handle(
+            self.execution_id.clone(),
+            self.attempt_index,
+            self.attempt_id.clone(),
+            self.lease_id.clone(),
+            self.lease_epoch,
+            self.lease_ttl_ms,
+            self.lane_id.clone(),
+            self.worker_instance_id.clone(),
+            HandleKind::Fresh,
+        )
     }
 
     /// Check if the lease is likely still valid based on renewal success.
@@ -798,49 +855,32 @@ impl ClaimedTask {
 
     // ── Non-terminal operations ──
 
-    /// Manually renew the lease. Also called by the background renewal task.
+    /// Manually renew the lease.
+    ///
+    /// **RFC-012 Stage 1b.** Forwards through the `EngineBackend`
+    /// trait. The background renewal task calls
+    /// `backend.renew(&handle)` directly (see `spawn_renewal_task`);
+    /// this method is the public entry point for workers that want
+    /// to force a renew out-of-band.
     pub async fn renew_lease(&self) -> Result<(), SdkError> {
-        renew_lease_inner(
-            &self.client,
-            &self.partition_config,
-            &self.execution_id,
-            self.attempt_index,
-            &self.attempt_id,
-            &self.lease_id,
-            self.lease_epoch,
-            self.lease_ttl_ms,
-        )
-        .await
+        let handle = self.synth_handle();
+        self.backend
+            .renew(&handle)
+            .await
+            .map(|_renewal| ())
+            .map_err(SdkError::from)
     }
 
     /// Update progress (pct 0-100 and optional message).
+    ///
+    /// **RFC-012 Stage 1b.** Forwards through the `EngineBackend`
+    /// trait (`backend.progress(&handle, Some(pct), Some(msg))`).
     pub async fn update_progress(&self, pct: u8, message: &str) -> Result<(), SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-
-        // KEYS (1): exec_core
-        let keys: Vec<String> = vec![ctx.core()];
-
-        // ARGV (5): execution_id, lease_id, lease_epoch,
-        //           progress_pct, progress_message
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),
-            self.lease_id.to_string(),
-            self.lease_epoch.to_string(),
-            pct.to_string(),
-            message.to_owned(),
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_update_progress", &key_refs, &arg_refs)
+        let handle = self.synth_handle();
+        self.backend
+            .progress(&handle, Some(pct), Some(message.to_owned()))
             .await
-            .map_err(SdkError::Valkey)?;
-
-        parse_success_result(&raw, "ff_update_progress")
+            .map_err(SdkError::from)
     }
 
     /// Report usage against a budget and check limits.
@@ -1139,156 +1179,16 @@ impl ClaimedTask {
     /// `signal_id` set from `waitpoint_condition`'s `matcher:N:signal_id`
     /// fields and reads each signal's metadata + payload directly.
     pub async fn resume_signals(&self) -> Result<Vec<ResumeSignal>, SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-
-        let susp: HashMap<String, String> = self
-            .client
-            .hgetall(&ctx.suspension_current())
+        // RFC-012 Stage 1b: forwards through `backend.observe_signals`.
+        // Pre-migration body (HGETALL suspension_current + HMGET
+        // matchers + pipelined HGETALL signal_hash / GET
+        // signal_payload) lives in
+        // `ff_backend_valkey::observe_signals_impl`.
+        let handle = self.synth_handle();
+        self.backend
+            .observe_signals(&handle)
             .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "HGETALL suspension_current".into(),
-            })?;
-
-        let Some(waitpoint_id) =
-            resume_waitpoint_id_from_suspension(&susp, self.attempt_index)?
-        else {
-            return Ok(Vec::new());
-        };
-
-        // Bounded read of waitpoint_condition: HGET total_matchers first,
-        // then HMGET exactly the fields we need per matcher slot. Avoids an
-        // unbounded HGETALL (matcher:N:* fields grow with condition size).
-        let wp_cond_key = ctx.waitpoint_condition(&waitpoint_id);
-        let total_str: Option<String> = self
-            .client
-            .hget(&wp_cond_key, "total_matchers")
-            .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "HGET total_matchers".into(),
-            })?;
-        let total: usize = total_str
-            .as_deref()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let mut signal_ids: Vec<SignalId> = Vec::new();
-        for i in 0..total {
-            let fields: Vec<Option<String>> = self
-                .client
-                .cmd("HMGET")
-                .arg(&wp_cond_key)
-                .arg(format!("matcher:{i}:satisfied"))
-                .arg(format!("matcher:{i}:signal_id"))
-                .execute()
-                .await
-                .map_err(|e| SdkError::ValkeyContext {
-                    source: e,
-                    context: "HMGET matcher slot".into(),
-                })?;
-            let satisfied = fields.first().and_then(|o| o.as_deref());
-            if satisfied != Some("1") {
-                continue;
-            }
-            let Some(raw) = fields.get(1).and_then(|o| o.as_deref()).filter(|s| !s.is_empty())
-            else {
-                continue;
-            };
-            match SignalId::parse(raw) {
-                Ok(sid) => signal_ids.push(sid),
-                Err(e) => {
-                    tracing::warn!(
-                        execution_id = %self.execution_id,
-                        waitpoint_id = %waitpoint_id,
-                        raw = %raw,
-                        error = %e,
-                        "resume_signals: matcher signal_id failed to parse, skipping"
-                    );
-                }
-            }
-        }
-
-        if signal_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Pipeline HGETALL signal_hash + GET signal_payload for all matched
-        // signals into one round-trip (closes #36 item 1). Previous
-        // implementation did 2N sequential round-trips; the single-matcher
-        // happy path is unaffected (1 pipelined round-trip ≈ 2 sequential
-        // for N=1), and "all" conditions with N>1 matchers see ~N× latency
-        // reduction on a loaded cluster.
-        let mut pipe = self.client.pipeline();
-        let mut slots = Vec::with_capacity(signal_ids.len());
-        for signal_id in &signal_ids {
-            let hash_slot = pipe
-                .cmd::<HashMap<String, String>>("HGETALL")
-                .arg(ctx.signal(signal_id))
-                .finish();
-            let payload_slot = pipe
-                .cmd::<Option<Value>>("GET")
-                .arg(ctx.signal_payload(signal_id))
-                .finish();
-            slots.push((hash_slot, payload_slot));
-        }
-        pipe.execute()
-            .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "pipeline HGETALL signal + GET payload".into(),
-            })?;
-
-        let mut out: Vec<ResumeSignal> = Vec::with_capacity(signal_ids.len());
-        for (signal_id, (hash_slot, payload_slot)) in signal_ids.into_iter().zip(slots) {
-            let sig: HashMap<String, String> = hash_slot.value().map_err(|e| {
-                SdkError::ValkeyContext {
-                    source: e,
-                    context: format!("pipeline HGETALL signal_hash slot (signal_id={signal_id})"),
-                }
-            })?;
-            if sig.is_empty() {
-                // Signal hash was GC'd (not currently a code path, but
-                // defensive against future cleanup scanners). Skip.
-                continue;
-            }
-
-            // Read payload as raw Value so non-UTF-8 bytes survive intact.
-            // Previously this was `get::<Option<String>>` + `into_bytes`,
-            // which would panic/error on any non-UTF-8 payload (reachable
-            // via direct-FCALL callers that bypass the SDK's lossy
-            // UTF-8 encode path in deliver_signal).
-            let payload_raw: Option<Value> =
-                payload_slot.value().map_err(|e| SdkError::ValkeyContext {
-                    source: e,
-                    context: format!("pipeline GET signal_payload slot (signal_id={signal_id})"),
-                })?;
-            let payload: Option<Vec<u8>> = match payload_raw {
-                Some(Value::BulkString(b)) => Some(b.to_vec()),
-                Some(Value::SimpleString(s)) => Some(s.into_bytes()),
-                _ => None,
-            };
-
-            let accepted_at = sig
-                .get("accepted_at")
-                .and_then(|s| s.parse::<i64>().ok())
-                .map(TimestampMs::from_millis)
-                .unwrap_or_else(|| TimestampMs::from_millis(0));
-
-            out.push(ResumeSignal {
-                signal_id,
-                signal_name: sig.get("signal_name").cloned().unwrap_or_default(),
-                signal_category: sig.get("signal_category").cloned().unwrap_or_default(),
-                source_type: sig.get("source_type").cloned().unwrap_or_default(),
-                source_identity: sig.get("source_identity").cloned().unwrap_or_default(),
-                correlation_id: sig.get("correlation_id").cloned().unwrap_or_default(),
-                accepted_at,
-                payload,
-            });
-        }
-
-        Ok(out)
+            .map_err(SdkError::from)
     }
 
     /// Signal the renewal task to stop. Called by every terminal op
@@ -1362,80 +1262,28 @@ impl Drop for ClaimedTask {
 
 // ── Lease renewal ──
 
-/// Perform a single lease renewal via FCALL ff_renew_lease.
+/// Spawn a background tokio task that renews the lease at `ttl / 3`
+/// intervals.
 ///
-/// The span is named `renew_lease` with target `ff_sdk::task` so bench
-/// harnesses can attach a `tracing_subscriber::Layer` and measure
-/// renewal count + per-call duration via `on_enter` / `on_exit`
-/// without polluting the hot path with additional instrumentation.
-/// See `benches/harness/src/bin/long_running.rs` for the consumer.
-#[allow(clippy::too_many_arguments)]
-#[tracing::instrument(
-    name = "renew_lease",
-    skip_all,
-    fields(execution_id = %execution_id)
-)]
-async fn renew_lease_inner(
-    client: &Client,
-    partition_config: &PartitionConfig,
-    execution_id: &ExecutionId,
-    attempt_index: AttemptIndex,
-    attempt_id: &AttemptId,
-    lease_id: &LeaseId,
-    lease_epoch: LeaseEpoch,
-    lease_ttl_ms: u64,
-) -> Result<(), SdkError> {
-    let partition = execution_partition(execution_id, partition_config);
-    let ctx = ExecKeyContext::new(&partition, execution_id);
-    let idx = IndexKeys::new(&partition);
-
-    // KEYS: exec_core, lease_current, lease_history, lease_expiry_zset
-    let keys: Vec<String> = vec![
-        ctx.core(),
-        ctx.lease_current(),
-        ctx.lease_history(),
-        idx.lease_expiry(),
-    ];
-
-    // ARGV: execution_id, attempt_index, attempt_id, lease_id, lease_epoch,
-    //       lease_ttl_ms, lease_history_grace_ms
-    let lease_history_grace_ms = 5000_u64; // 5s grace for cleanup
-    let args: Vec<String> = vec![
-        execution_id.to_string(),
-        attempt_index.to_string(),
-        attempt_id.to_string(),
-        lease_id.to_string(),
-        lease_epoch.to_string(),
-        lease_ttl_ms.to_string(),
-        lease_history_grace_ms.to_string(),
-    ];
-
-    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-    let raw: Value = client
-        .fcall("ff_renew_lease", &key_refs, &arg_refs)
-        .await
-        .map_err(SdkError::Valkey)?;
-
-    parse_success_result(&raw, "ff_renew_lease")
-}
-
-/// Spawn a background tokio task that renews the lease at `ttl / 3` intervals.
+/// **RFC-012 Stage 1b.** The renewal loop now forwards through the
+/// `EngineBackend` trait (`backend.renew(&handle)`) instead of calling
+/// `ff_renew_lease` via a direct FCALL. The Stage-1a `renew_lease_inner`
+/// free function was deleted; this task holds an `Arc<dyn EngineBackend>`
+/// + the encoded `Handle` instead.
 ///
 /// Stops when:
 /// - `stop_signal` is notified (complete/fail/cancel called)
 /// - Renewal fails with a terminal error (stale_lease, lease_expired, etc.)
 /// - The task handle is aborted (ClaimedTask dropped)
-#[allow(clippy::too_many_arguments, dead_code)]
+#[tracing::instrument(
+    name = "renew_lease",
+    skip_all,
+    fields(execution_id = %execution_id)
+)]
 fn spawn_renewal_task(
-    client: Client,
-    partition_config: PartitionConfig,
+    backend: Arc<dyn EngineBackend>,
+    handle: Handle,
     execution_id: ExecutionId,
-    attempt_index: AttemptIndex,
-    attempt_id: AttemptId,
-    lease_id: LeaseId,
-    lease_epoch: LeaseEpoch,
     lease_ttl_ms: u64,
     stop_signal: Arc<Notify>,
     failure_counter: Arc<AtomicU32>,
@@ -1458,26 +1306,15 @@ fn spawn_renewal_task(
                     return;
                 }
                 _ = tick.tick() => {
-                    match renew_lease_inner(
-                        &client,
-                        &partition_config,
-                        &execution_id,
-                        attempt_index,
-                        &attempt_id,
-                        &lease_id,
-                        lease_epoch,
-                        lease_ttl_ms,
-                    )
-                    .await
-                    {
-                        Ok(()) => {
+                    match backend.renew(&handle).await {
+                        Ok(_renewal) => {
                             failure_counter.store(0, Ordering::Relaxed);
                             tracing::trace!(
                                 execution_id = %execution_id,
                                 "lease renewed"
                             );
                         }
-                        Err(SdkError::Engine(ref e)) if is_terminal_renewal_error(e) => {
+                        Err(e) if is_terminal_renewal_error(&e) => {
                             failure_counter.fetch_add(1, Ordering::Relaxed);
                             tracing::warn!(
                                 execution_id = %execution_id,
@@ -1712,6 +1549,15 @@ fn extract_pending_waitpoint_token(raw: &Value) -> Result<WaitpointToken, SdkErr
 /// (no record, stale prior-attempt, non-resumed close). Returns an error
 /// only for a present-but-malformed waitpoint_id, which indicates a Lua
 /// bug rather than a missing-data case.
+///
+/// RFC-012 Stage 1b: `ClaimedTask::resume_signals` now forwards through
+/// `EngineBackend::observe_signals`, which re-implements this invariant
+/// inside `ff_backend_valkey`. The SDK helper is retained with its unit
+/// tests so the parsing contract stays exercised at the SDK layer —
+/// Stage 1d will consolidate (either promote the helper into ff-core
+/// or drop these tests once the backend-side tests cover equivalent
+/// ground).
+#[allow(dead_code)]
 fn resume_waitpoint_id_from_suspension(
     susp: &HashMap<String, String>,
     claimed_attempt: AttemptIndex,

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -471,28 +471,33 @@ impl FlowFabricWorker {
         })
     }
 
-    /// Store a pre-built [`EngineBackend`] on the worker for Stages
-    /// 1b-1d to route through. Builds the worker via the legacy
-    /// [`FlowFabricWorker::connect`] path first (so the embedded
-    /// `ferriskey::Client` that Stage 1a hot paths still use is
-    /// dialed), then attaches the injected backend via
-    /// [`Self::backend`].
+    /// Store a pre-built [`EngineBackend`] on the worker. Builds
+    /// the worker via the legacy [`FlowFabricWorker::connect`] path
+    /// first (so the embedded `ferriskey::Client` that the Stage 1b
+    /// non-migrated hot paths still use is dialed), then replaces
+    /// the default `ValkeyBackend` wrapper with the caller-supplied
+    /// `Arc<dyn EngineBackend>`.
     ///
-    /// **Stage 1a scope — caveats consumers must know.** The
-    /// injected backend is *stored, not consumed* by Stage 1a's hot
-    /// paths: `claim_next`, `claim_from_grant`,
-    /// `claim_from_reclaim_grant`, `deliver_signal`, and the admin
-    /// queries all still go through the embedded `ferriskey::Client`
-    /// dialed from `config.host`/`config.port`. Consequently this
-    /// constructor is NOT a drop-in way to swap in a non-Valkey
-    /// backend today — it requires a reachable Valkey node
-    /// regardless. Stage 1c routes the hot paths through
-    /// [`Self::backend`]; Stage 1d removes the embedded client.
+    /// **Stage 1b scope — what the injected backend covers today.**
+    /// After this PR, `ClaimedTask`'s 8 migrated ops
+    /// (`renew_lease` / `update_progress` / `resume_signals` /
+    /// `delay_execution` / `move_to_waiting_children` /
+    /// `complete` / `cancel` / `fail`) route through the injected
+    /// backend. That's the first material use of `connect_with`: a
+    /// mock backend now genuinely sees the worker's per-task
+    /// write-surface calls. The 4 trait-shape-deferred ops
+    /// (`create_pending_waitpoint`, `append_frame`, `suspend`,
+    /// `report_usage`) still reach the embedded
+    /// `ferriskey::Client` directly until issue #117's trait
+    /// amendment lands; `claim_next` / `claim_from_grant` /
+    /// `claim_from_reclaim_grant` / `deliver_signal` / admin queries
+    /// are Stage 1c hot-path work. Stage 1d removes the embedded
+    /// client entirely.
     ///
-    /// A mock / non-Valkey backend can still be injected here so
-    /// tests holding `worker.backend()` exercise the trait surface;
-    /// the hot paths won't call into the injected backend until
-    /// Stage 1c.
+    /// Today's constructor is therefore NOT yet a drop-in way to swap
+    /// in a non-Valkey backend — it requires a reachable Valkey node
+    /// for the 4 deferred + hot-path ops. Tests that exercise only
+    /// the 8 migrated ops can run fully against a mock backend.
     ///
     /// [`EngineBackend`]: ff_core::engine_backend::EngineBackend
     pub async fn connect_with(

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -91,14 +91,24 @@ pub struct FlowFabricWorker {
     /// correctness because the sequence simply restarts a new cycle.
     #[cfg(feature = "direct-valkey-claim")]
     scan_cursor: AtomicUsize,
-    /// Optional [`EngineBackend`] handed in via
-    /// [`FlowFabricWorker::connect_with`]. Populated when the consumer
-    /// supplies a pre-constructed backend; `None` under the legacy
-    /// [`FlowFabricWorker::connect`] path, which continues to hold a
-    /// `ferriskey::Client` directly (Stage 1a hot-path behaviour
-    /// unchanged). Stage 1c migrates the hot path to go through the
-    /// trait uniformly.
-    backend: Option<Arc<dyn ff_core::engine_backend::EngineBackend>>,
+    /// The [`EngineBackend`] the Stage-1b trait forwarders route
+    /// through.
+    ///
+    /// **RFC-012 Stage 1b.** Always populated:
+    /// [`FlowFabricWorker::connect`] now wraps the worker's own
+    /// `ferriskey::Client` in a `ValkeyBackend` via
+    /// `ValkeyBackend::from_client_and_partitions`, and
+    /// [`FlowFabricWorker::connect_with`] replaces that default with
+    /// the caller-supplied `Arc<dyn EngineBackend>`. The
+    /// [`FlowFabricWorker::backend`] accessor still returns
+    /// `Option<&Arc<dyn EngineBackend>>` for API stability — Stage 1c
+    /// narrows the return type once consumers have migrated.
+    ///
+    /// Hot paths (claim, deliver_signal, admin queries) still use the
+    /// embedded `ferriskey::Client` directly at Stage 1b; Stage 1c
+    /// migrates them through this field, and Stage 1d removes the
+    /// embedded client.
+    backend: Arc<dyn ff_core::engine_backend::EngineBackend>,
 }
 
 /// Number of partitions scanned per `claim_next()` poll. Keeps idle Valkey
@@ -435,6 +445,15 @@ impl FlowFabricWorker {
             }
         }
 
+        // RFC-012 Stage 1b: wrap the dialed client in a
+        // ValkeyBackend so `ClaimedTask`'s trait forwarders have
+        // something to call. `from_client_and_partitions` reuses the
+        // already-dialed client — no second connection.
+        let backend = ff_backend_valkey::ValkeyBackend::from_client_and_partitions(
+            client.clone(),
+            partition_config,
+        );
+
         Ok(Self {
             client,
             config,
@@ -448,7 +467,7 @@ impl FlowFabricWorker {
             concurrency_semaphore,
             #[cfg(feature = "direct-valkey-claim")]
             scan_cursor: AtomicUsize::new(scan_cursor_init),
-            backend: None,
+            backend,
         })
     }
 
@@ -481,16 +500,19 @@ impl FlowFabricWorker {
         backend: Arc<dyn ff_core::engine_backend::EngineBackend>,
     ) -> Result<Self, SdkError> {
         let mut worker = Self::connect(config).await?;
-        worker.backend = Some(backend);
+        worker.backend = backend;
         Ok(worker)
     }
 
-    /// Borrow the `EngineBackend` handed in via
-    /// [`FlowFabricWorker::connect_with`], if any. Returns `None`
-    /// under the legacy [`FlowFabricWorker::connect`] construction
-    /// path.
+    /// Borrow the `EngineBackend` this worker forwards Stage-1b trait
+    /// ops through.
+    ///
+    /// **RFC-012 Stage 1b.** Always returns `Some(&self.backend)` —
+    /// the `Option` wrapper is retained for API stability with the
+    /// Stage-1a shape. Stage 1c narrows the return type to
+    /// `&Arc<dyn EngineBackend>`.
     pub fn backend(&self) -> Option<&Arc<dyn ff_core::engine_backend::EngineBackend>> {
-        self.backend.as_ref()
+        Some(&self.backend)
     }
 
     /// Get a reference to the underlying ferriskey client.
@@ -993,6 +1015,7 @@ impl FlowFabricWorker {
 
         Ok(ClaimedTask::new(
             self.client.clone(),
+            self.backend.clone(),
             self.partition_config,
             execution_id.clone(),
             attempt_index,
@@ -1332,6 +1355,7 @@ impl FlowFabricWorker {
 
         Ok(ClaimedTask::new(
             self.client.clone(),
+            self.backend.clone(),
             self.partition_config,
             execution_id.clone(),
             attempt_index,


### PR DESCRIPTION
## Summary

RFC-012 Stage 1b: migrates `ClaimedTask`'s write-surface ops onto the `EngineBackend` trait introduced in [Stage 1a](https://github.com/avifenesh/FlowFabric/pull/114). Zero SDK consumer API changes; zero existing test edits.

**Scope revised from the plan:** 8 of 12 methods migrated, 4 deferred. The plan called for 9 migrations + 3 deferrals; at implementation time a fourth method (`report_usage`) surfaced as a trait-shape blocker matching the plan's "encoding/decoding bug surfaces that requires a trait signature change" escape hatch. See **Non-goals** below and tracking issue #117 for the amendment.

## Architecture

**Option A: synth_handle per op** (LOCKED plan decision 3).
`ClaimedTask` does not yet carry a cached `Handle` — it synthesises one on each trait-forwarder entry via private `synth_handle(&self) -> Handle`. The Stage 1a `HandleOpaque` shape stays internal: `ValkeyBackend::encode_handle` is pub (so ff-sdk can construct the cookie without seeing the bytes), but the byte layout itself (version-tagged u8 + length-prefixed strings + LE u32/u64s) is crate-private to ff-backend-valkey.

Stage 1d consolidates: `ClaimedTask` refactors to carry one cached `Handle` per op, and `synth_handle` goes away.

**Renewal task stays on ClaimedTask** (LOCKED plan decision 4).
Background lease renewal holds an `Arc<dyn EngineBackend>` + the encoded `Handle`, calling `backend.renew(&handle)` inside the tokio loop. `renew_lease_inner` free function was deleted.

**ClaimedTask acquires `backend: Arc<dyn EngineBackend>`** (LOCKED plan decision 7).
- `FlowFabricWorker::connect(config)` wraps its dialed client via `ValkeyBackend::from_client_and_partitions` — no second connection, no new round-trips.
- `FlowFabricWorker::connect_with(backend)` stores the caller-supplied `Arc` directly.
- `FlowFabricWorker::backend()` still returns `Option<&Arc<dyn EngineBackend>>` for API stability; internally the field is always-populated. Stage 1c narrows the public accessor.

**`__dedup` carrier grep** (LOCKED plan decision 5).
Grepped `/home/ubuntu/FlowFabric` + the worktree across ff-script, ff-sdk, ff-test, ff-readiness-tests, and every ff-\* crate. **Zero collisions.** (No local cairn-fabric checkout was available to grep, but the worktree scan covers every crate this PR touches. Cairn consumes via trait signatures, not custom-map magic keys, so a post-merge collision is not plausible.) The carrier is still the plan's locked choice; it just doesn't ship in this PR because the `report_usage` return-type mismatch (new finding) blocks Tranche 3.

## Commit tranches

1. **`606413b`** — canaries: `renew_lease`, `update_progress`, `resume_signals` + synth_handle infrastructure (Tranche 1).
2. **`83b133a`** — terminal writes: `delay_execution`, `move_to_waiting_children`, `complete`, `cancel`, `fail` with replay reconciliation ported into the backend (Tranche 2).
3. **`9161dd6`** — `TODO(stage-1d-or-rfc-amendment)` comments on the 4 deferred methods (Tranche 3 was cut).

## Non-goals (deferred — see #117)

- **`create_pending_waitpoint`** — no `EngineBackend` trait slot.
- **`append_frame`** — SDK returns `AppendFrameOutcome { stream_id, frame_count }`; trait returns `()`. ABI break on the Stage 1a trait.
- **`suspend`** — SDK returns `SuspendOutcome`; trait returns `Handle`. Also: `&[ConditionMatcher]` + `TimeoutBehavior` don't map to `Vec<WaitpointSpec>`. Suspend atomicity (round-5 §7.17) remains deferred separately.
- **`report_usage`** *(new to this list)* — `AdmissionDecision` (trait return) cannot losslessly encode `ReportUsageResult::{SoftBreach, HardBreach, AlreadyApplied}`. Trait needs a richer `AdmissionDecision` shape. Full rationale in the #117 issue-comment added during the Stage 1b Tranche 3 pre-flight.

Each deferred method carries a single `TODO(stage-1d-or-rfc-amendment): ... #117` comment pointing at the tracking issue.

## Zero test edits statement

**No existing tests were modified.** The legacy SDK helper `resume_waitpoint_id_from_suspension` is retained with its 6 unit tests, marked `#[allow(dead_code)]` because prod now routes through `ff_backend_valkey::resume_waitpoint_id_from_suspension` which re-implements the same invariant. The SDK-side `parse_fail_result` is similarly marked `dead_code` — its unit test (`parse_fail_result_extracts_all_four_detail_slots`) still exercises the wire parser. Stage 1d can consolidate.

## Gates

- [x] `cargo build --workspace --all-features` green.
- [x] `cargo build -p ff-sdk --no-default-features` green (agnosticism preserved — `ff-backend-valkey` is an optional dep gated on `valkey-default`).
- [x] `cargo test --workspace` green for every ff-\* crate. Pre-existing `ferriskey` integration tests that require a live Valkey server fail without a live server — same as on main.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green. `#![allow(clippy::result_large_err)]` added at the ff-backend-valkey crate root — the trait's `Result<_, EngineError>` shape is load-bearing; a future PR can shrink `EngineError::Transport.source` globally (cross-crate design, out of scope for Stage 1b).
- [x] cargo-semver-checks: internal refactor only, no public type or method shape changes. `FlowFabricWorker::backend()` accessor signature unchanged. `ClaimedTask`'s public methods unchanged (the new `backend: Arc<dyn EngineBackend>` field is private).

## Test plan

- [ ] CI workspace build + test green on all 20 checks.
- [ ] cargo-semver-checks additive-only.
- [ ] Review pass: inline-comment sweep + reviews reply before admin-merge.
- [ ] Post-merge: Stage 1c plan-first cycle opens (FlowFabricWorker hot-path migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because critical task/lease lifecycle operations (`renew`, `complete`, `fail`, `cancel`, `delay`, `wait_children`, `progress`, `observe_signals`) are refactored to flow through new Valkey-backend implementations and a new opaque handle encoding, which could affect execution state transitions if wire parity or decoding fails.
> 
> **Overview**
> **RFC-012 Stage 1b refactor:** `ff-sdk::ClaimedTask` now forwards most write-surface operations through the `EngineBackend` trait instead of issuing direct Valkey FCALLs.
> 
> `ff-backend-valkey` implements these forwarded ops (`renew`, `progress`, `observe_signals`, `delay`, `wait_children`, `complete`, `cancel`, `fail`) by porting the SDK’s FCALL key/arg construction and replay-reconciliation logic into the backend, including retry-policy JSON extraction for `fail`.
> 
> To support trait calls, a new Valkey-private, versioned `HandleOpaque` codec is added (encode in SDK via `ValkeyBackend::encode_handle`, decode in backend), and `FlowFabricWorker::connect` now always wraps its existing Valkey client in a `ValkeyBackend` (no re-dial) while keeping the public `backend()` accessor signature stable. Several ops remain deferred due to trait-shape mismatches (`append_frame`, `suspend`, `create_pending_waitpoint`, `report_usage`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9161dd6fa218dad8bcb5d8850a13d8b8cfb0c10b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->