### PR TITLE
fix(ff-script): wrap dedup_key with budget hash-tag in typed FCALL wrapper (#108)

### DIFF
--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -1072,7 +1072,10 @@ pub struct ReportUsageArgs {
     pub deltas: Vec<u64>,
     pub now: TimestampMs,
     /// Optional idempotency key to prevent double-counting on retries.
-    /// Must share the budget's `{b:M}` hash tag for cluster safety.
+    /// Pass the raw dedup id (e.g. `"retry-42"`); the typed FCALL wrapper
+    /// wraps it into `ff:usagededup:{b:M}:<id>` using the budget
+    /// partition's hash tag so it co-locates with the other budget keys
+    /// (#108).
     #[serde(default)]
     pub dedup_key: Option<String>,
 }

--- a/crates/ff-script/src/functions/budget.rs
+++ b/crates/ff-script/src/functions/budget.rs
@@ -2,7 +2,7 @@
 
 use ff_core::contracts::*;
 use crate::error::ScriptError;
-use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::keys::{usage_dedup_key, ExecKeyContext, IndexKeys};
 
 use crate::result::{FcallResult, FromFcallResult};
 
@@ -19,10 +19,17 @@ use crate::result::{FcallResult, FromFcallResult};
 pub const MAX_BUDGET_DIMENSIONS: usize = 64;
 
 /// Key context for budget operations on {b:M}.
+///
+/// `hash_tag` is the budget partition's Valkey hash-tag (e.g. `{b:3}`,
+/// braces included) so the typed wrapper can wrap any per-call `dedup_key`
+/// into a slot-co-located `ff:usagededup:{b:M}:<dedup_id>` key without the
+/// caller needing to know the wrapping format. Mirrors
+/// [`ff_core::keys::ExecKeyContext::hash_tag`] (#108).
 pub struct BudgetOpKeys<'a> {
     pub usage_key: &'a str,
     pub limits_key: &'a str,
     pub def_key: &'a str,
+    pub hash_tag: &'a str,
 }
 
 /// Key context for budget block/unblock on {p:N}.
@@ -197,7 +204,17 @@ pub async fn ff_report_usage_and_check(
         argv.push(delta.to_string());
     }
     argv.push(args.now.to_string());
-    argv.push(args.dedup_key.clone().unwrap_or_default());
+    // #108: wrap dedup_key with the budget hash-tag so it co-locates with
+    // `k.usage_key`/`k.limits_key`/`k.def_key` on the same cluster slot and
+    // matches the format produced by `ff-server` + `ff-sdk` at the REST
+    // boundary. Empty/missing dedup_key forwards as empty string
+    // (Lua disables dedup in that branch).
+    let dedup_key_val = args.dedup_key
+        .as_ref()
+        .filter(|s| !s.is_empty())
+        .map(|s| usage_dedup_key(k.hash_tag, s))
+        .unwrap_or_default();
+    argv.push(dedup_key_val);
 
     let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
     let argv_refs: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();

--- a/crates/ff-script/src/functions/budget.rs
+++ b/crates/ff-script/src/functions/budget.rs
@@ -23,8 +23,9 @@ pub const MAX_BUDGET_DIMENSIONS: usize = 64;
 /// `hash_tag` is the budget partition's Valkey hash-tag (e.g. `{b:3}`,
 /// braces included) so the typed wrapper can wrap any per-call `dedup_key`
 /// into a slot-co-located `ff:usagededup:{b:M}:<dedup_id>` key without the
-/// caller needing to know the wrapping format. Mirrors
-/// [`ff_core::keys::ExecKeyContext::hash_tag`] (#108).
+/// caller needing to know the wrapping format. The canonical source for
+/// the value to pass is [`ff_core::keys::BudgetKeyContext::hash_tag`]
+/// (#108).
 pub struct BudgetOpKeys<'a> {
     pub usage_key: &'a str,
     pub limits_key: &'a str,
@@ -210,7 +211,7 @@ pub async fn ff_report_usage_and_check(
     // boundary. Empty/missing dedup_key forwards as empty string
     // (Lua disables dedup in that branch).
     let dedup_key_val = args.dedup_key
-        .as_ref()
+        .as_deref()
         .filter(|s| !s.is_empty())
         .map(|s| usage_dedup_key(k.hash_tag, s))
         .unwrap_or_default();

--- a/crates/ff-test/tests/budget_dedup_hashtag.rs
+++ b/crates/ff-test/tests/budget_dedup_hashtag.rs
@@ -1,0 +1,166 @@
+//! Regression test for #108: the typed FCALL wrapper
+//! `ff_script::functions::budget::ff_report_usage_and_check` must wrap the
+//! caller-supplied `dedup_key` into `ff:usagededup:{b:M}:<id>` — matching
+//! the format the REST layer (`ff-server`) and `ff-sdk` produce — so the
+//! dedup state lands on the same cluster slot as the budget keys.
+//!
+//! Pre-fix:
+//!   The wrapper forwarded `args.dedup_key.clone().unwrap_or_default()`
+//!   verbatim. Lua then wrote the dedup flag at the bare key (e.g.
+//!   `"retry-42"`). The test's post-condition GETs prove the bug:
+//!     GET "ff:usagededup:{b:0}:retry-42"  → nil   (not populated)
+//!     GET "retry-42"                      → "1"   (leaked at wrong key)
+//!
+//! Post-fix:
+//!   The wrapper builds the dedup key via
+//!   `usage_dedup_key(k.hash_tag, id)`. Lua writes at the wrapped key:
+//!     GET "ff:usagededup:{b:0}:retry-42"  → "1"   (correct)
+//!     GET "retry-42"                      → nil
+//!
+//! Cluster-mode manifestation: pre-fix, calling this against a cluster
+//! returns CROSSSLOT because the bare dedup key and the `{b:0}`-tagged
+//! budget keys hash to different slots. Post-fix, both share the `{b:0}`
+//! tag and hash to the same slot. The `TestCluster` harness uses
+//! `FF_CLUSTER` to switch between standalone and cluster — the shape
+//! assertion below holds in both modes; cluster additionally proves the
+//! CROSSSLOT path is closed because the FCALL does not error.
+
+use ferriskey::Value;
+use ff_core::contracts::ReportUsageArgs;
+use ff_core::types::TimestampMs;
+use ff_script::functions::budget::{ff_report_usage_and_check, BudgetOpKeys};
+use ff_test::fixtures::TestCluster;
+
+/// Inline `ff_create_budget` on the fixed `{b:0}` partition. Separate copy
+/// from `e2e_lifecycle.rs` to keep this test self-contained — budget
+/// helpers are test-private and not exported from `ff-test`.
+async fn fcall_create_budget_b0(
+    tc: &TestCluster,
+    budget_id: &str,
+    dim: &str,
+    hard: u64,
+) {
+    let def_key = format!("ff:budget:{{b:0}}:{budget_id}");
+    let limits_key = format!("ff:budget:{{b:0}}:{budget_id}:limits");
+    let usage_key = format!("ff:budget:{{b:0}}:{budget_id}:usage");
+    let resets_key = "ff:idx:{b:0}:budget_resets".to_string();
+    let policies_index = "ff:idx:{b:0}:budget_policies".to_string();
+
+    let now = TimestampMs::now();
+    let args: Vec<String> = vec![
+        budget_id.to_owned(),
+        "lane".to_owned(),
+        "test-lane".to_owned(),
+        "strict".to_owned(),
+        "fail".to_owned(),
+        "warn".to_owned(),
+        "0".to_owned(), // reset_interval_ms
+        now.to_string(),
+        "1".to_owned(), // dim_count
+        dim.to_owned(),
+        hard.to_string(),
+        "0".to_owned(), // soft
+    ];
+    let keys: Vec<String> = vec![def_key, limits_key, usage_key, resets_key, policies_index];
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_budget", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_create_budget");
+}
+
+/// The typed wrapper must wrap `dedup_key` with the budget hash-tag so the
+/// Lua-side `SET <dedup_key> 1 EX <ttl>` lands on the wrapped key, not on
+/// the bare caller-supplied id.
+#[tokio::test]
+#[serial_test::serial]
+async fn ff_report_usage_and_check_wraps_dedup_key_with_budget_hashtag() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let budget_id = "pr108-dedup-wrap";
+    fcall_create_budget_b0(&tc, budget_id, "tokens", 1000).await;
+
+    let usage_key = format!("ff:budget:{{b:0}}:{budget_id}:usage");
+    let limits_key = format!("ff:budget:{{b:0}}:{budget_id}:limits");
+    let def_key = format!("ff:budget:{{b:0}}:{budget_id}");
+    let hash_tag = "{b:0}";
+
+    let keys = BudgetOpKeys {
+        usage_key: &usage_key,
+        limits_key: &limits_key,
+        def_key: &def_key,
+        hash_tag,
+    };
+
+    let raw_dedup_id = "retry-42";
+    let args = ReportUsageArgs {
+        dimensions: vec!["tokens".to_owned()],
+        deltas: vec![10],
+        now: TimestampMs::now(),
+        dedup_key: Some(raw_dedup_id.to_owned()),
+    };
+
+    // The call itself must succeed — in cluster mode pre-fix this would
+    // have returned CROSSSLOT because `"retry-42"` is untagged.
+    let result = ff_report_usage_and_check(tc.client(), &keys, &args)
+        .await
+        .expect("typed wrapper must succeed (pre-fix: CROSSSLOT in cluster)");
+    // Sanity: first call against a fresh budget is Ok (or AlreadyApplied
+    // if the cleanup didn't wipe — cleanup is FLUSHDB-based so it did).
+    use ff_core::contracts::ReportUsageResult;
+    assert!(
+        matches!(result, ReportUsageResult::Ok),
+        "first dedup'd report must be Ok, got {result:?}"
+    );
+
+    // Key-shape post-condition: the wrapped key is populated, the bare key
+    // is NOT. Pre-fix these two assertions invert.
+    let wrapped_key = format!("ff:usagededup:{{b:0}}:{raw_dedup_id}");
+    let wrapped_val: Option<String> = tc
+        .client()
+        .cmd("GET")
+        .arg(wrapped_key.as_str())
+        .execute()
+        .await
+        .expect("GET wrapped dedup key");
+    assert_eq!(
+        wrapped_val.as_deref(),
+        Some("1"),
+        "post-fix: dedup flag must be written at `ff:usagededup:{{b:0}}:<id>` \
+         (co-located with budget keys on the `{{b:0}}` slot). Pre-fix this is nil.",
+    );
+
+    let bare_val: Option<String> = tc
+        .client()
+        .cmd("GET")
+        .arg(raw_dedup_id)
+        .execute()
+        .await
+        .expect("GET bare dedup key");
+    assert_eq!(
+        bare_val, None,
+        "post-fix: dedup flag must NOT leak at the bare caller-supplied id. \
+         Pre-fix this is Some(\"1\") — the symptom of the unwrapped forward.",
+    );
+
+    // Idempotency: repeating with the same dedup id must hit AlreadyApplied
+    // (proves the wrapped key is actually the one Lua reads for dedup, not
+    // just an orphan write).
+    let args2 = ReportUsageArgs {
+        dimensions: vec!["tokens".to_owned()],
+        deltas: vec![10],
+        now: TimestampMs::now(),
+        dedup_key: Some(raw_dedup_id.to_owned()),
+    };
+    let result2 = ff_report_usage_and_check(tc.client(), &keys, &args2)
+        .await
+        .expect("second call must succeed");
+    assert!(
+        matches!(result2, ReportUsageResult::AlreadyApplied),
+        "repeat with same dedup id must be AlreadyApplied, got {result2:?}",
+    );
+}


### PR DESCRIPTION
## Summary
Closes #108. The typed FCALL wrapper `ff_script::functions::budget::ff_report_usage_and_check` was forwarding `args.dedup_key` verbatim, while the REST boundary in `ff-server` and `ff-sdk` wrap it via `usage_dedup_key(bctx.hash_tag(), id)`. Direct wrapper callers (tests, tools, alternate services) therefore produced an untagged dedup key — CROSSSLOT in cluster, silently-misrouted dedup state in standalone.

- Add `hash_tag: &'a str` to `BudgetOpKeys` (Option A from the plan, symmetric with `ExecKeyContext::hash_tag()`; zero non-test construction sites confirmed).
- Wrap `dedup_key` via the existing `ff_core::keys::usage_dedup_key` helper. Empty/missing forwards as empty string (Lua disables dedup).
- Update `ReportUsageArgs::dedup_key` doc — callers pass the raw id; the wrapper does the wrapping.
- New test `crates/ff-test/tests/budget_dedup_hashtag.rs` (uses `TestCluster`) asserts post-fix key shape plus an `AlreadyApplied` idempotency check.

## Validity proof
With the body reverted to `argv.push(args.dedup_key.clone().unwrap_or_default())` (struct field retained so the test compiles):

```
assertion `left == right` failed: post-fix: dedup flag must be written at
`ff:usagededup:{b:0}:<id>` (co-located with budget keys on the `{b:0}` slot).
Pre-fix this is nil.
  left: None
 right: Some("1")
```

Restore the fix → `test ... ok. 1 passed`.

## Cluster-mode note
`TestCluster` supports cluster via `FF_CLUSTER=1`; the same test runs there. Pre-fix would CROSSSLOT at FCALL time (the bare id hashes to a different slot than `{b:0}`); post-fix both the FCALL success and the key-shape assertions hold. The standalone CI run asserts the key shape as proxy; the cluster CI job (same matrix) proves CROSSSLOT is closed.

## Out of scope (per approved plan)
- `PartitionKey` / ff-core type work (#91)
- `UsageDimensions::custom["__dedup"]` carrier (Worker I Stage 1b)
- `ff-server` / `ff-sdk` budget paths (they already wrap correctly)
- `lua/budget.lua`

## Test plan
- [x] `cargo build --workspace --all-features` — green
- [x] `cargo test -p ff-script` — 58 passed
- [x] `cargo test -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server --features ff-sdk/direct-valkey-claim` — all green
- [x] `cargo test -p ff-test -- --test-threads=1` — all green (standalone, local Valkey)
- [x] `cargo clippy -p ff-core -p ff-script -p ff-test --all-features --all-targets -- -D warnings` — clean
- [x] Validity proof: pre-fix body FAILS, post-fix body PASSES
- [ ] CI matrix (standalone + cluster, linux + macos)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `dedup_key` is transformed into a Valkey key for `ff_report_usage_and_check`, which directly affects idempotency and budget usage accounting behavior (especially in cluster mode). Scope is small but touches correctness-critical budget enforcement paths.
> 
> **Overview**
> Ensures `ff_script::functions::budget::ff_report_usage_and_check` no longer forwards `dedup_key` verbatim; it now wraps the caller-provided id via `usage_dedup_key(k.hash_tag, id)` so the Lua-side dedup flag is written/read at `ff:usagededup:{b:M}:<id>` on the same cluster slot as the budget keys.
> 
> Extends `BudgetOpKeys` with `hash_tag` to support this wrapping, updates `ReportUsageArgs::dedup_key` docs to clarify callers pass the raw id, and adds a regression test (`budget_dedup_hashtag.rs`) that asserts key shape + `AlreadyApplied` behavior (and prevents CROSSSLOT in cluster mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fd811207bb53c1fa7f7c442efe67ee48da4c89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->