### PR TITLE
feat(ff-core,ff-server,ff-sdk): opaque PartitionKey on wire types (#91)

### DIFF
--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -758,10 +758,10 @@ mod tests {
     fn reclaim_token_wraps_grant() {
         let grant = ReclaimGrant {
             execution_id: ExecutionId::solo(&LaneId::new("default"), &Default::default()),
-            partition: Partition {
+            partition_key: crate::partition::PartitionKey::from(&Partition {
                 family: PartitionFamily::Flow,
                 index: 0,
-            },
+            }),
             grant_key: "gkey".into(),
             expires_at_ms: 123,
             lane_id: LaneId::new("default"),

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -108,13 +108,36 @@ pub enum IssueClaimGrantResult {
 pub struct ClaimGrant {
     /// The execution that was granted.
     pub execution_id: ExecutionId,
-    /// The partition where this execution lives.
-    pub partition: crate::partition::Partition,
+    /// Opaque partition handle for this execution's hash-tag slot.
+    ///
+    /// Public wire type: consumers pass it back to FlowFabric but
+    /// must not parse the interior hash tag for routing decisions.
+    /// Internal consumers that need the typed
+    /// [`crate::partition::Partition`] call [`Self::partition`].
+    pub partition_key: crate::partition::PartitionKey,
     /// The Valkey key holding the grant hash (for the worker to
     /// reference).
     pub grant_key: String,
     /// When the grant expires if not consumed.
     pub expires_at_ms: u64,
+}
+
+impl ClaimGrant {
+    /// Parse `partition_key` into a typed
+    /// [`crate::partition::Partition`]. Intended for internal
+    /// consumers (scheduler emitter, SDK worker claim path) that
+    /// need the family/index pair. Fails only on malformed keys
+    /// (which indicates a producer bug).
+    ///
+    /// Alias collapse applies: a grant issued against `Execution`
+    /// family round-trips to `Flow` (see [`crate::partition::PartitionKey`]
+    /// for the rationale — routing is preserved, only the metadata
+    /// family label normalises).
+    pub fn partition(
+        &self,
+    ) -> Result<crate::partition::Partition, crate::partition::PartitionKeyParseError> {
+        self.partition_key.parse()
+    }
 }
 
 /// A reclaim grant issued for a resumed (attempt_interrupted) execution.
@@ -161,8 +184,12 @@ pub struct ClaimGrant {
 pub struct ReclaimGrant {
     /// The execution granted for resumption.
     pub execution_id: ExecutionId,
-    /// The partition the execution lives on.
-    pub partition: crate::partition::Partition,
+    /// Opaque partition handle for this execution's hash-tag slot.
+    ///
+    /// Same wire-opacity contract as [`ClaimGrant::partition_key`].
+    /// Internal consumers call [`Self::partition`] for the parsed
+    /// form.
+    pub partition_key: crate::partition::PartitionKey,
     /// Valkey key of the grant hash — same key shape as
     /// [`ClaimGrant`].
     pub grant_key: String,
@@ -173,6 +200,17 @@ pub struct ReclaimGrant {
     /// `ff_claim_resumed_execution` for `KEYS[3]` (eligible_zset)
     /// and `KEYS[9]` (active_index).
     pub lane_id: LaneId,
+}
+
+impl ReclaimGrant {
+    /// Parse `partition_key` into a typed
+    /// [`crate::partition::Partition`]. See [`ClaimGrant::partition`]
+    /// for the alias-collapse note.
+    pub fn partition(
+        &self,
+    ) -> Result<crate::partition::Partition, crate::partition::PartitionKeyParseError> {
+        self.partition_key.parse()
+    }
 }
 
 // ─── claim_execution ───

--- a/crates/ff-core/src/partition.rs
+++ b/crates/ff-core/src/partition.rs
@@ -5,8 +5,11 @@
 //! Public wire surfaces carry [`PartitionKey`] — an opaque
 //! `#[serde(transparent)]` newtype over the hash-tag literal
 //! (`"{fp:7}"`) — rather than the internal [`Partition`] struct. The
-//! `PartitionFamily` enum (with its `Execution` / `Flow` alias) stays
-//! entirely internal; consumers never deserialize it off the wire.
+//! [`PartitionFamily`] enum (including its `Execution` / `Flow`
+//! alias) remains a public `ff-core` type — in-tree consumers that
+//! construct a [`Partition`] directly still name it — but it is no
+//! longer part of the HTTP / SDK wire DTOs, so external consumers
+//! never deserialize it off the wire.
 //!
 //! ## Migration note (0.2 → 0.3)
 //!
@@ -170,11 +173,16 @@ impl std::fmt::Display for Partition {
 ///
 /// Consumers MUST treat a `PartitionKey` as opaque: pass it back to
 /// FlowFabric on subsequent calls, but do NOT parse the interior hash
-/// tag to make routing or policy decisions. FlowFabric may narrow the
-/// accepted shape (e.g. hash-tag alphabet, length bounds) in future
-/// versions without a semver bump. Consumers that need the parsed
-/// form call [`PartitionKey::parse`] / [`Self::as_partition`], which
-/// returns a typed error on malformed input.
+/// tag to make routing or policy decisions. Compatibility is only
+/// guaranteed for opaque round-tripping of keys PRODUCED by
+/// FlowFabric — consumers must not hand-construct hash-tag strings
+/// nor rely on non-canonical shapes being accepted. FlowFabric may
+/// narrow the accepted shape (e.g. hash-tag alphabet, length bounds)
+/// in future minor releases for producer-minted keys without a
+/// semver bump, because every such key still round-trips under the
+/// new rules. Consumers that need the parsed form call
+/// [`PartitionKey::parse`] / [`Self::as_partition`], which returns a
+/// typed error on malformed input.
 ///
 /// # Round-trip + alias collapse
 ///

--- a/crates/ff-core/src/partition.rs
+++ b/crates/ff-core/src/partition.rs
@@ -108,6 +108,155 @@ impl std::fmt::Display for Partition {
     }
 }
 
+/// Opaque routing handle for a partition, as exchanged on public wire
+/// surfaces.
+///
+/// `PartitionKey` is the hash-tag literal (`"{fp:7}"`, `"{b:0}"`, ...)
+/// wrapped in a `#[serde(transparent)]` newtype. It is the wire form
+/// of [`Partition`] on the public API — crates like `ff-server` and
+/// `ff-sdk` exchange `PartitionKey`, not [`Partition`], so the
+/// internal `PartitionFamily` enum (with its RFC-011 §11 alias
+/// between `Flow` and `Execution`) is never exposed on the wire.
+///
+/// # Opaque-ness contract
+///
+/// Consumers MUST treat a `PartitionKey` as opaque: pass it back to
+/// FlowFabric on subsequent calls, but do NOT parse the interior hash
+/// tag to make routing or policy decisions. FlowFabric may narrow the
+/// accepted shape (e.g. hash-tag alphabet, length bounds) in future
+/// versions without a semver bump. Consumers that need the parsed
+/// form call [`PartitionKey::parse`] / [`Self::as_partition`], which
+/// returns a typed error on malformed input.
+///
+/// # Round-trip + alias collapse
+///
+/// `From<&Partition> -> PartitionKey` is infallible (hash-tag
+/// construction never fails). `PartitionKey::parse` → `Partition` is
+/// fallible (rejects malformed keys). The round trip
+/// `Partition -> PartitionKey -> Partition` is **lossy for the
+/// `Execution` alias** — a `Partition { family: Execution, .. }`
+/// produces `"{fp:N}"`, which parses back to
+/// `Partition { family: Flow, .. }`. Routing and key construction are
+/// unaffected (both families emit identical hash tags under RFC-011
+/// §11), but consumers that read `grant.partition()?.family` for
+/// logging will see `Flow` where `Execution` previously appeared.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PartitionKey(String);
+
+impl PartitionKey {
+    /// Return the underlying hash-tag literal (`"{fp:7}"`). Intended
+    /// for consumers that pass the key through to another FlowFabric
+    /// call; NOT for parsing out the partition family/index.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Parse a hash-tag literal into a typed [`Partition`]. Accepts
+    /// the exact shape produced by [`Partition::hash_tag`] (`{fp:N}`,
+    /// `{b:N}`, `{q:N}` where `N` is a `u16`).
+    pub fn parse(&self) -> Result<Partition, PartitionKeyParseError> {
+        Partition::try_from(self)
+    }
+
+    /// Convenience alias for [`Self::parse`]. Present so callers
+    /// reading a `ClaimGrant.partition()` helper can chain without
+    /// naming the conversion explicitly.
+    pub fn as_partition(&self) -> Result<Partition, PartitionKeyParseError> {
+        self.parse()
+    }
+}
+
+impl std::fmt::Display for PartitionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&Partition> for PartitionKey {
+    fn from(p: &Partition) -> Self {
+        Self(p.hash_tag())
+    }
+}
+
+impl From<Partition> for PartitionKey {
+    fn from(p: Partition) -> Self {
+        Self::from(&p)
+    }
+}
+
+/// Errors produced when parsing a [`PartitionKey`] back into a
+/// [`Partition`].
+///
+/// The key is treated as opaque on the wire; parsing failures surface
+/// as `Err` so malformed producer output fails loudly instead of
+/// silently routing to a ghost partition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PartitionKeyParseError {
+    /// Key did not start with `{` and end with `}` (e.g. missing braces).
+    MissingBraces,
+    /// Interior did not split into exactly `<prefix>:<index>`.
+    MalformedBody,
+    /// `<prefix>` did not match a known family (`fp`, `b`, `q`).
+    UnknownFamilyPrefix(String),
+    /// `<index>` did not parse as a `u16`.
+    InvalidIndex(String),
+}
+
+impl std::fmt::Display for PartitionKeyParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingBraces => {
+                f.write_str("partition key must be wrapped in '{...}'")
+            }
+            Self::MalformedBody => {
+                f.write_str("partition key body must be '<prefix>:<index>'")
+            }
+            Self::UnknownFamilyPrefix(p) => {
+                write!(f, "unknown partition family prefix '{p}' (expected 'fp', 'b', 'q')")
+            }
+            Self::InvalidIndex(s) => {
+                write!(f, "partition index '{s}' is not a valid u16")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PartitionKeyParseError {}
+
+impl TryFrom<&PartitionKey> for Partition {
+    type Error = PartitionKeyParseError;
+
+    fn try_from(key: &PartitionKey) -> Result<Self, Self::Error> {
+        let s = key.as_str();
+        let inner = s
+            .strip_prefix('{')
+            .and_then(|rest| rest.strip_suffix('}'))
+            .ok_or(PartitionKeyParseError::MissingBraces)?;
+        let (prefix, index_s) = inner
+            .split_once(':')
+            .ok_or(PartitionKeyParseError::MalformedBody)?;
+        let family = match prefix {
+            // `fp` collapses to `Flow`; the `Execution` alias is lost
+            // on round-trip by design (RFC-011 §11 — both produce the
+            // same hash tag, so routing is preserved; only the
+            // metadata-layer family label diverges).
+            "fp" => PartitionFamily::Flow,
+            "b" => PartitionFamily::Budget,
+            "q" => PartitionFamily::Quota,
+            other => {
+                return Err(PartitionKeyParseError::UnknownFamilyPrefix(
+                    other.to_owned(),
+                ));
+            }
+        };
+        let index: u16 = index_s
+            .parse()
+            .map_err(|_| PartitionKeyParseError::InvalidIndex(index_s.to_owned()))?;
+        Ok(Partition { family, index })
+    }
+}
+
 /// Compute CRC16-CCITT of the given bytes, same algorithm as Valkey Cluster.
 fn crc16_ccitt(bytes: &[u8]) -> u16 {
     crc16::State::<crc16::XMODEM>::calculate(bytes)
@@ -533,5 +682,102 @@ mod tests {
         // Bare UUID fails Deserialize.
         let bare = r#""550e8400-e29b-41d4-a716-446655440000""#;
         assert!(serde_json::from_str::<ExecutionId>(bare).is_err());
+    }
+
+    // ── PartitionKey (issue #91) ──
+
+    #[test]
+    fn partition_key_from_partition_matches_hash_tag() {
+        for (family, expected_prefix) in [
+            (PartitionFamily::Flow, "fp"),
+            (PartitionFamily::Execution, "fp"),
+            (PartitionFamily::Budget, "b"),
+            (PartitionFamily::Quota, "q"),
+        ] {
+            let p = Partition { family, index: 42 };
+            let k: PartitionKey = (&p).into();
+            assert_eq!(k.as_str(), &format!("{{{expected_prefix}:42}}"));
+            assert_eq!(k.as_str(), p.hash_tag());
+        }
+    }
+
+    #[test]
+    fn partition_key_round_trip_flow_budget_quota() {
+        // Exact round-trip for non-alias families.
+        for family in [
+            PartitionFamily::Flow,
+            PartitionFamily::Budget,
+            PartitionFamily::Quota,
+        ] {
+            let p = Partition { family, index: 7 };
+            let k = PartitionKey::from(&p);
+            let back = k.parse().expect("must parse");
+            assert_eq!(back, p, "round-trip must be identity for {family:?}");
+        }
+    }
+
+    /// RFC-011 §11 alias collapse: `Execution` round-trips to `Flow`.
+    /// Routing is preserved (same hash tag, same `count_for`), only
+    /// the metadata-layer label differs. This test pins the documented
+    /// collapse so consumers can't quietly depend on `Execution`
+    /// surviving a wire hop.
+    #[test]
+    fn partition_key_collapses_execution_to_flow_on_parse() {
+        let p_exec = Partition { family: PartitionFamily::Execution, index: 3 };
+        let k = PartitionKey::from(&p_exec);
+        assert_eq!(k.as_str(), "{fp:3}");
+        let back = k.parse().expect("must parse");
+        // Alias collapse: index preserved, family normalises to Flow.
+        assert_eq!(back.family, PartitionFamily::Flow);
+        assert_eq!(back.index, 3);
+        // Routing equivalence: both produce identical hash tags.
+        assert_eq!(back.hash_tag(), p_exec.hash_tag());
+    }
+
+    #[test]
+    fn partition_key_serde_transparent() {
+        let p = Partition { family: PartitionFamily::Flow, index: 9 };
+        let k = PartitionKey::from(&p);
+        let json = serde_json::to_string(&k).unwrap();
+        assert_eq!(json, r#""{fp:9}""#, "must serialise as a bare string");
+        let parsed: PartitionKey = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, k);
+    }
+
+    #[test]
+    fn partition_key_parse_rejects_missing_braces() {
+        let k = PartitionKey("fp:0".to_owned());
+        assert_eq!(k.parse(), Err(PartitionKeyParseError::MissingBraces));
+    }
+
+    #[test]
+    fn partition_key_parse_rejects_malformed_body() {
+        let k = PartitionKey("{fp0}".to_owned());
+        assert_eq!(k.parse(), Err(PartitionKeyParseError::MalformedBody));
+    }
+
+    #[test]
+    fn partition_key_parse_rejects_unknown_prefix() {
+        let k = PartitionKey("{zz:0}".to_owned());
+        match k.parse() {
+            Err(PartitionKeyParseError::UnknownFamilyPrefix(p)) => assert_eq!(p, "zz"),
+            other => panic!("expected UnknownFamilyPrefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn partition_key_parse_rejects_invalid_index() {
+        // Non-numeric
+        let k = PartitionKey("{fp:xx}".to_owned());
+        assert!(matches!(
+            k.parse(),
+            Err(PartitionKeyParseError::InvalidIndex(_))
+        ));
+        // u16 overflow
+        let k = PartitionKey("{fp:65536}".to_owned());
+        assert!(matches!(
+            k.parse(),
+            Err(PartitionKeyParseError::InvalidIndex(_))
+        ));
     }
 }

--- a/crates/ff-core/src/partition.rs
+++ b/crates/ff-core/src/partition.rs
@@ -1,3 +1,51 @@
+//! Partition families, keys, and routing helpers.
+//!
+//! # Opaque wire keys (issue #91)
+//!
+//! Public wire surfaces carry [`PartitionKey`] — an opaque
+//! `#[serde(transparent)]` newtype over the hash-tag literal
+//! (`"{fp:7}"`) — rather than the internal [`Partition`] struct. The
+//! `PartitionFamily` enum (with its `Execution` / `Flow` alias) stays
+//! entirely internal; consumers never deserialize it off the wire.
+//!
+//! ## Migration note (0.2 → 0.3)
+//!
+//! The HTTP response body for `POST /v1/workers/{id}/claim` changed
+//! from
+//!
+//! ```json
+//! {
+//!   "execution_id": "{fp:7}:...",
+//!   "partition_family": "flow",
+//!   "partition_index": 7,
+//!   "grant_key": "...",
+//!   "expires_at_ms": 0
+//! }
+//! ```
+//!
+//! to
+//!
+//! ```json
+//! {
+//!   "execution_id": "{fp:7}:...",
+//!   "partition_key": "{fp:7}",
+//!   "grant_key": "...",
+//!   "expires_at_ms": 0
+//! }
+//! ```
+//!
+//! Consumers that need the parsed family/index call
+//! [`PartitionKey::parse`] (or [`crate::contracts::ClaimGrant::partition`] /
+//! [`crate::contracts::ReclaimGrant::partition`]) — these return a
+//! typed [`Partition`] so routing code stays unchanged.
+//!
+//! The `Execution` family label collapses to `Flow` on round-trip
+//! (both produce `{fp:N}` under RFC-011 §11 co-location). Consumers
+//! that read `grant.partition()?.family` for LOGGING will see
+//! `Flow` where `Execution` previously appeared — cosmetically
+//! visible, routing-equivalent. See [`PartitionKey`] rustdoc for
+//! the full contract.
+
 use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, QuotaPolicyId};
 use serde::{Deserialize, Serialize};
 

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -798,7 +798,7 @@ impl Scheduler {
                     );
                     return Ok(Some(ClaimGrant {
                         execution_id: eid,
-                        partition,
+                        partition_key: ff_core::partition::PartitionKey::from(&partition),
                         grant_key: grant_key.clone(),
                         expires_at_ms: now_ms + grant_ttl_ms,
                     }));

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -480,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn into_grant_accepts_all_known_families() {
+    fn into_grant_preserves_all_known_partition_key_shapes() {
         // Post-#91: families collapse into opaque PartitionKey literals.
         // Flow and Execution both produce "{fp:N}"; Budget is "{b:N}";
         // Quota is "{q:N}". The DTO preserves the wire string as-is;

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -343,15 +343,13 @@ pub struct ClaimForWorkerRequest {
 
 /// Response body for `POST /v1/workers/{worker_id}/claim`.
 ///
-/// Wire shape of `ff_core::contracts::ClaimGrant`. The core type is
-/// not serde-derived (carries a `Partition` with a non-scalar family
-/// enum) so the SDK decodes into this DTO and reconstructs the core
-/// type via [`Self::into_grant`].
+/// Wire shape of `ff_core::contracts::ClaimGrant`. Carries the opaque
+/// [`ff_core::partition::PartitionKey`] directly on the wire (issue
+/// #91); the SDK reconstructs the core type via [`Self::into_grant`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct ClaimForWorkerResponse {
     pub execution_id: String,
-    pub partition_family: String,
-    pub partition_index: u16,
+    pub partition_key: ff_core::partition::PartitionKey,
     pub grant_key: String,
     pub expires_at_ms: u64,
 }
@@ -360,9 +358,13 @@ impl ClaimForWorkerResponse {
     /// Convert the wire DTO into a typed
     /// [`ff_core::contracts::ClaimGrant`] for handoff to
     /// [`crate::FlowFabricWorker::claim_from_grant`]. Returns
-    /// [`SdkError::AdminApi`] on malformed execution_id / unknown
-    /// partition_family (server and SDK have drifted; fail loud so
-    /// callers don't route to a ghost partition).
+    /// [`SdkError::AdminApi`] on malformed execution_id — a drift
+    /// signal that the server and SDK disagree on the wire shape, so
+    /// failing loud prevents routing to a ghost partition.
+    ///
+    /// The `partition_key` itself is not eagerly parsed here: it is
+    /// carried opaquely to the `claim_from_grant` hot path, which
+    /// parses it there and surfaces a typed error on malformed keys.
     pub fn into_grant(self) -> Result<ff_core::contracts::ClaimGrant, SdkError> {
         let execution_id = ff_core::types::ExecutionId::parse(&self.execution_id)
             .map_err(|e| SdkError::AdminApi {
@@ -375,29 +377,9 @@ impl ClaimForWorkerResponse {
                 retryable: Some(false),
                 raw_body: String::new(),
             })?;
-        let family = match self.partition_family.as_str() {
-            "flow" => ff_core::partition::PartitionFamily::Flow,
-            "execution" => ff_core::partition::PartitionFamily::Execution,
-            "budget" => ff_core::partition::PartitionFamily::Budget,
-            "quota" => ff_core::partition::PartitionFamily::Quota,
-            other => {
-                return Err(SdkError::AdminApi {
-                    status: 200,
-                    message: format!(
-                        "claim_for_worker: unknown partition_family '{other}'"
-                    ),
-                    kind: Some("malformed_response".to_owned()),
-                    retryable: Some(false),
-                    raw_body: String::new(),
-                });
-            }
-        };
         Ok(ff_core::contracts::ClaimGrant {
             execution_id,
-            partition: ff_core::partition::Partition {
-                family,
-                index: self.partition_index,
-            },
+            partition_key: self.partition_key,
             grant_key: self.grant_key,
             expires_at_ms: self.expires_at_ms,
         })
@@ -485,11 +467,13 @@ mod tests {
 
     // ── ClaimForWorkerResponse::into_grant ──
 
-    fn sample_claim_response(family: &str) -> ClaimForWorkerResponse {
+    fn sample_claim_response(partition_key: &str) -> ClaimForWorkerResponse {
         ClaimForWorkerResponse {
             execution_id: "{fp:5}:11111111-1111-1111-1111-111111111111".to_owned(),
-            partition_family: family.to_owned(),
-            partition_index: 5,
+            partition_key: serde_json::from_str(
+                &serde_json::to_string(partition_key).unwrap(),
+            )
+            .unwrap(),
             grant_key: "ff:exec:{fp:5}:11111111-1111-1111-1111-111111111111:claim_grant".to_owned(),
             expires_at_ms: 1_700_000_000_000,
         }
@@ -497,32 +481,35 @@ mod tests {
 
     #[test]
     fn into_grant_accepts_all_known_families() {
-        for family in ["flow", "execution", "budget", "quota"] {
-            let g = sample_claim_response(family).into_grant().unwrap_or_else(|e| {
-                panic!("family {family} should parse: {e:?}")
+        // Post-#91: families collapse into opaque PartitionKey literals.
+        // Flow and Execution both produce "{fp:N}"; Budget is "{b:N}";
+        // Quota is "{q:N}". The DTO preserves the wire string as-is;
+        // into_grant hands it opaquely to the core type.
+        for key_str in ["{fp:5}", "{b:5}", "{q:5}"] {
+            let g = sample_claim_response(key_str).into_grant().unwrap_or_else(|e| {
+                panic!("key {key_str} should parse: {e:?}")
             });
-            assert_eq!(g.partition.index, 5);
+            assert_eq!(g.partition_key.as_str(), key_str);
             assert_eq!(g.expires_at_ms, 1_700_000_000_000);
         }
     }
 
     #[test]
-    fn into_grant_rejects_unknown_family() {
-        let resp = sample_claim_response("nonsense");
-        let err = resp.into_grant().unwrap_err();
-        match err {
-            SdkError::AdminApi { message, kind, .. } => {
-                assert!(message.contains("unknown partition_family"),
-                    "msg: {message}");
-                assert_eq!(kind.as_deref(), Some("malformed_response"));
-            }
-            other => panic!("expected AdminApi, got {other:?}"),
-        }
+    fn into_grant_preserves_opaque_partition_key() {
+        // The SDK does NOT eagerly parse the partition_key on the
+        // admin boundary — malformed keys are caught at the
+        // claim_from_grant hot path where the typed Partition is
+        // actually needed. This test pins the opacity contract.
+        let resp = sample_claim_response("{zz:0}");
+        let g = resp.into_grant().expect("SDK must not parse partition_key");
+        assert_eq!(g.partition_key.as_str(), "{zz:0}");
+        // Parsing surfaces the error explicitly.
+        assert!(g.partition().is_err());
     }
 
     #[test]
     fn into_grant_rejects_malformed_execution_id() {
-        let mut resp = sample_claim_response("flow");
+        let mut resp = sample_claim_response("{fp:5}");
         resp.execution_id = "not-a-valid-eid".to_owned();
         let err = resp.into_grant().unwrap_err();
         match err {
@@ -533,5 +520,21 @@ mod tests {
             }
             other => panic!("expected AdminApi, got {other:?}"),
         }
+    }
+
+    // ── ClaimForWorkerResponse wire shape (issue #91) ──
+
+    #[test]
+    fn claim_for_worker_response_deserialises_opaque_partition_key() {
+        // Exact shape the server emits post-#91.
+        let raw = r#"{
+            "execution_id": "{fp:7}:11111111-1111-1111-1111-111111111111",
+            "partition_key": "{fp:7}",
+            "grant_key": "ff:exec:{fp:7}:11111111-1111-1111-1111-111111111111:claim_grant",
+            "expires_at_ms": 1700000000000
+        }"#;
+        let r: ClaimForWorkerResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(r.partition_key.as_str(), "{fp:7}");
+        assert_eq!(r.expires_at_ms, 1_700_000_000_000);
     }
 }

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1099,8 +1099,13 @@ impl FlowFabricWorker {
             .map_err(|_| SdkError::WorkerAtCapacity)?;
 
         let now = TimestampMs::now();
+        let partition = grant.partition().map_err(|e| SdkError::Config {
+            context: "claim_from_grant".to_owned(),
+            field: Some("partition_key".to_owned()),
+            message: e.to_string(),
+        })?;
         let mut task = self
-            .claim_execution(&grant.execution_id, &lane, &grant.partition, now)
+            .claim_execution(&grant.execution_id, &lane, &partition, now)
             .await?;
         task.set_concurrency_permit(permit);
         Ok(task)
@@ -1206,11 +1211,16 @@ impl FlowFabricWorker {
 
         // Grant carries partition + lane_id so no round-trip is needed
         // to resolve them before the FCALL.
+        let partition = grant.partition().map_err(|e| SdkError::Config {
+            context: "claim_from_reclaim_grant".to_owned(),
+            field: Some("partition_key".to_owned()),
+            message: e.to_string(),
+        })?;
         let mut task = self
             .claim_resumed_execution(
                 &grant.execution_id,
                 &grant.lane_id,
-                &grant.partition,
+                &partition,
             )
             .await?;
         task.set_concurrency_permit(permit);

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -878,31 +878,22 @@ struct ClaimForWorkerBody {
     grant_ttl_ms: u64,
 }
 
-/// Wire shape for `ff_core::contracts::ClaimGrant`. Core type is not
-/// serde-derived (it carries a `Partition` with a non-scalar family
-/// enum); keep a DTO here so we own the HTTP shape without touching
-/// the core contract.
+/// Wire shape for `ff_core::contracts::ClaimGrant`. Carries the
+/// opaque [`ff_core::partition::PartitionKey`] on the wire; consumers
+/// never see the internal `PartitionFamily` enum (issue #91).
 #[derive(Serialize)]
 struct ClaimGrantDto {
     execution_id: String,
-    partition_family: &'static str,
-    partition_index: u16,
+    partition_key: ff_core::partition::PartitionKey,
     grant_key: String,
     expires_at_ms: u64,
 }
 
 impl From<ff_core::contracts::ClaimGrant> for ClaimGrantDto {
     fn from(g: ff_core::contracts::ClaimGrant) -> Self {
-        let family = match g.partition.family {
-            ff_core::partition::PartitionFamily::Flow => "flow",
-            ff_core::partition::PartitionFamily::Execution => "execution",
-            ff_core::partition::PartitionFamily::Budget => "budget",
-            ff_core::partition::PartitionFamily::Quota => "quota",
-        };
         Self {
             execution_id: g.execution_id.to_string(),
-            partition_family: family,
-            partition_index: g.partition.index,
+            partition_key: g.partition_key,
             grant_key: g.grant_key,
             expires_at_ms: g.expires_at_ms,
         }
@@ -1463,5 +1454,55 @@ mod cors_tests {
             "Authorization should not be advertised when auth is off; got: {allow_headers}"
         );
         assert!(allow_headers.contains("content-type"));
+    }
+}
+
+#[cfg(test)]
+mod claim_grant_dto_tests {
+    //! Wire-shape tests for `ClaimGrantDto` (issue #91).
+    //!
+    //! Pins the exact JSON shape the server emits on the
+    //! `POST /v1/workers/{id}/claim` 200 response so any drift shows
+    //! up at compile-adjacent test time rather than on a live SDK.
+    use super::*;
+    use ff_core::contracts::ClaimGrant;
+    use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
+    use ff_core::types::{ExecutionId, FlowId};
+
+    fn sample_grant(family: PartitionFamily) -> ClaimGrant {
+        let config = ff_core::partition::PartitionConfig::default();
+        let fid = FlowId::new();
+        let eid = ExecutionId::for_flow(&fid, &config);
+        let p = Partition { family, index: 7 };
+        ClaimGrant {
+            execution_id: eid,
+            partition_key: PartitionKey::from(&p),
+            grant_key: "ff:exec:{fp:7}:deadbeef:claim_grant".to_owned(),
+            expires_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn claim_grant_dto_emits_opaque_partition_key() {
+        let dto = ClaimGrantDto::from(sample_grant(PartitionFamily::Flow));
+        let json = serde_json::to_value(&dto).unwrap();
+        // `partition_key` serialises transparent: a bare string, not
+        // an object, not a `partition_family`/`partition_index` pair.
+        assert_eq!(json["partition_key"], serde_json::json!("{fp:7}"));
+        assert!(json.get("partition_family").is_none());
+        assert!(json.get("partition_index").is_none());
+        assert_eq!(json["expires_at_ms"], serde_json::json!(1_700_000_000_000u64));
+    }
+
+    #[test]
+    fn claim_grant_dto_collapses_execution_alias_on_wire() {
+        // RFC-011 §11 alias: Execution-family grants emit the same
+        // `{fp:N}` hash tag as Flow. This test pins the wire-level
+        // equivalence.
+        let dto_flow = ClaimGrantDto::from(sample_grant(PartitionFamily::Flow));
+        let dto_exec = ClaimGrantDto::from(sample_grant(PartitionFamily::Execution));
+        let jf = serde_json::to_value(&dto_flow).unwrap();
+        let je = serde_json::to_value(&dto_exec).unwrap();
+        assert_eq!(jf["partition_key"], je["partition_key"]);
     }
 }

--- a/crates/ff-test/tests/claim_grant_wire.rs
+++ b/crates/ff-test/tests/claim_grant_wire.rs
@@ -49,8 +49,8 @@ fn server_side_json(g: &ClaimGrant) -> String {
     // in ff-server::api::claim_grant_dto_tests.
     serde_json::json!({
         "execution_id": g.execution_id.to_string(),
-        "partition_key": g.partition_key,
-        "grant_key": g.grant_key,
+        "partition_key": g.partition_key.as_str(),
+        "grant_key": g.grant_key.as_str(),
         "expires_at_ms": g.expires_at_ms,
     })
     .to_string()
@@ -77,7 +77,7 @@ fn claim_grant_round_trips_flow_family() {
     let resp: ff_sdk::admin::ClaimForWorkerResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(resp.partition_key.as_str(), "{fp:42}");
     let rebuilt = resp.into_grant().expect("into_grant must succeed");
-    assert_eq!(rebuilt.partition_key, grant.partition_key);
+    assert_eq!(rebuilt.partition_key.as_str(), grant.partition_key.as_str());
     assert_eq!(rebuilt.expires_at_ms, grant.expires_at_ms);
     assert_eq!(rebuilt.grant_key, grant.grant_key);
 }

--- a/crates/ff-test/tests/claim_grant_wire.rs
+++ b/crates/ff-test/tests/claim_grant_wire.rs
@@ -1,0 +1,120 @@
+//! End-to-end wire round-trip for [`ff_core::contracts::ClaimGrant`]
+//! (issue #91).
+//!
+//! Exercises the full chain:
+//!
+//!   1. Scheduler issues a `ClaimGrant` carrying an opaque
+//!      [`ff_core::partition::PartitionKey`].
+//!   2. `ff-server` serializes it into the `POST /v1/workers/{id}/claim`
+//!      200 response body.
+//!   3. `ff-sdk::ClaimForWorkerResponse` deserializes the body.
+//!   4. `into_grant()` reconstructs a `ClaimGrant` with the same
+//!      partition-key string.
+//!
+//! Pins the opaque contract at the wire boundary: the JSON payload
+//! carries the hash-tag literal (`{fp:N}`, `{b:N}`, `{q:N}`) as a
+//! bare string, never a structured `{family, index}` pair.
+//!
+//! This is a pure type-level round-trip — no live Valkey, no HTTP
+//! transport. We serialize the server's DTO, feed the bytes into the
+//! SDK's DTO, and compare. Any drift in either side's field set
+//! surfaces here rather than on a live deploy.
+
+use ff_core::contracts::ClaimGrant;
+use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
+use ff_core::types::{ExecutionId, FlowId};
+
+/// Construct a sample ClaimGrant for a given family. Index is pinned
+/// so the wire-shape assertions below can match on the exact string.
+fn sample_grant(family: PartitionFamily) -> ClaimGrant {
+    let config = ff_core::partition::PartitionConfig::default();
+    let fid = FlowId::new();
+    let eid = ExecutionId::for_flow(&fid, &config);
+    let p = Partition { family, index: 42 };
+    ClaimGrant {
+        execution_id: eid,
+        partition_key: PartitionKey::from(&p),
+        grant_key: "ff:exec:{fp:42}:00000000-0000-0000-0000-000000000000:claim_grant".to_owned(),
+        expires_at_ms: 1_700_000_000_000,
+    }
+}
+
+/// Manually construct the JSON the server emits (ClaimGrantDto is
+/// crate-private in ff-server, so we spell out the exact shape here
+/// — any drift in either side surfaces as this test failing).
+fn server_side_json(g: &ClaimGrant) -> String {
+    // The server's ClaimGrantDto fields: execution_id (string),
+    // partition_key (transparent string), grant_key (string),
+    // expires_at_ms (u64). This shape is pinned by the inline tests
+    // in ff-server::api::claim_grant_dto_tests.
+    serde_json::json!({
+        "execution_id": g.execution_id.to_string(),
+        "partition_key": g.partition_key,
+        "grant_key": g.grant_key,
+        "expires_at_ms": g.expires_at_ms,
+    })
+    .to_string()
+}
+
+#[test]
+fn claim_grant_round_trips_flow_family() {
+    let grant = sample_grant(PartitionFamily::Flow);
+    let json = server_side_json(&grant);
+    // Wire shape: bare string partition_key.
+    assert!(
+        json.contains(r#""partition_key":"{fp:42}""#),
+        "wire must carry opaque hash tag, got: {json}"
+    );
+    assert!(
+        !json.contains("partition_family"),
+        "post-#91 must not carry partition_family, got: {json}"
+    );
+    assert!(
+        !json.contains("partition_index"),
+        "post-#91 must not carry partition_index, got: {json}"
+    );
+
+    let resp: ff_sdk::admin::ClaimForWorkerResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(resp.partition_key.as_str(), "{fp:42}");
+    let rebuilt = resp.into_grant().expect("into_grant must succeed");
+    assert_eq!(rebuilt.partition_key, grant.partition_key);
+    assert_eq!(rebuilt.expires_at_ms, grant.expires_at_ms);
+    assert_eq!(rebuilt.grant_key, grant.grant_key);
+}
+
+#[test]
+fn claim_grant_round_trips_budget_and_quota() {
+    for (family, expected) in [
+        (PartitionFamily::Budget, "{b:42}"),
+        (PartitionFamily::Quota, "{q:42}"),
+    ] {
+        let grant = sample_grant(family);
+        let json = server_side_json(&grant);
+        let resp: ff_sdk::admin::ClaimForWorkerResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(resp.partition_key.as_str(), expected);
+        let rebuilt = resp.into_grant().expect("into_grant must succeed");
+        assert_eq!(rebuilt.partition_key.as_str(), expected);
+        // Parsed partition routes through correctly.
+        let parsed = rebuilt.partition().expect("key must parse");
+        assert_eq!(parsed.index, 42);
+    }
+}
+
+#[test]
+fn claim_grant_execution_alias_collapses_on_round_trip() {
+    // RFC-011 §11 alias: a grant minted with Execution family emits
+    // `{fp:N}` and parses back to Flow. Routing is preserved (same
+    // hash tag, same index); only the metadata family label
+    // normalises.
+    let grant_exec = sample_grant(PartitionFamily::Execution);
+    assert_eq!(grant_exec.partition_key.as_str(), "{fp:42}");
+
+    let json = server_side_json(&grant_exec);
+    let resp: ff_sdk::admin::ClaimForWorkerResponse = serde_json::from_str(&json).unwrap();
+    let rebuilt = resp.into_grant().unwrap();
+    let parsed = rebuilt.partition().unwrap();
+    assert_eq!(parsed.family, PartitionFamily::Flow, "alias collapses to Flow");
+    assert_eq!(parsed.index, 42);
+    // The routing-relevant hash tag matches what we sent.
+    assert_eq!(parsed.hash_tag(), "{fp:42}");
+}

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4969,7 +4969,9 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     // Valkey key.
     let rebuilt_g2 = ff_core::contracts::ClaimGrant {
         execution_id: eid_b.clone(),
-        partition: ff_core::partition::execution_partition(&eid_b, &test_config()),
+        partition_key: ff_core::partition::PartitionKey::from(
+            &ff_core::partition::execution_partition(&eid_b, &test_config()),
+        ),
         grant_key: g2_key.clone(),
         // expires_at_ms is advisory on the consumer side; Lua
         // enforces the real expiry via its own TIME read, so
@@ -8853,7 +8855,7 @@ async fn suspend_resume_setup_with_grant(
 
     ff_core::contracts::ReclaimGrant {
         execution_id: eid.clone(),
-        partition,
+        partition_key: ff_core::partition::PartitionKey::from(&partition),
         grant_key,
         expires_at_ms,
         lane_id,
@@ -9025,7 +9027,7 @@ async fn test_claim_from_reclaim_grant_not_resumed() {
 
     let grant = ff_core::contracts::ReclaimGrant {
         execution_id: eid.clone(),
-        partition,
+        partition_key: ff_core::partition::PartitionKey::from(&partition),
         grant_key,
         expires_at_ms,
         lane_id: LaneId::new(LANE),


### PR DESCRIPTION
## Summary

Closes #91. Replaces the leaked internal `Partition` struct on
`ff_core::contracts::ClaimGrant` and `ff_core::contracts::ReclaimGrant`
(and their HTTP wire DTOs) with a new opaque
`ff_core::partition::PartitionKey` — a `#[serde(transparent)]`
newtype over the hash-tag literal (`"{fp:7}"`). The internal
`PartitionFamily` enum — with its RFC-011 §11 `Execution` / `Flow`
alias — stays entirely internal and never crosses the wire.

What's preserved:

- Routing behavior is byte-identical. `Partition::hash_tag()` is
  the single source of truth; the wire carries exactly that
  string.
- Internal consumers (scheduler emitter, SDK worker claim path)
  still get a typed `Partition` via `grant.partition()?`.
- The `Execution` alias remains available on internal
  construction (cairn-fabric callers unchanged).

What's new:

- Typed round-trip errors (`PartitionKeyParseError`) replace
  silent family-string parsing on the SDK side.

## Wire break

**Before** (`POST /v1/workers/{id}/claim` 200 response):
```json
{
  "execution_id": "{fp:7}:abc...",
  "partition_family": "flow",
  "partition_index": 7,
  "grant_key": "ff:exec:...",
  "expires_at_ms": 1700000000000
}
```

**After**:
```json
{
  "execution_id": "{fp:7}:abc...",
  "partition_key": "{fp:7}",
  "grant_key": "ff:exec:...",
  "expires_at_ms": 1700000000000
}
```

**Migration snippet for cairn / other consumers** (if you currently
read `partition_family` / `partition_index` out of the claim
response):

```rust
// Before:
// let family = response.partition_family;
// let index  = response.partition_index;

// After (if you just need to route): pass partition_key back opaquely.
// After (if you need the typed Partition — e.g. for key construction):
use ff_core::partition::PartitionKey;
let key: PartitionKey = serde_json::from_str(&raw_key)?;
let partition = key.parse()?;  // Result<Partition, PartitionKeyParseError>
```

The SDK's own `ff_sdk::admin::ClaimForWorkerResponse::into_grant()`
handles this transparently — callers get a typed `ClaimGrant` with
an opaque `partition_key`, and call `grant.partition()?` when they
need the parsed form.

## Execution→Flow cosmetic note (RFC-011 §11)

Consumers that read `grant.partition()?.family` **for LOGGING** will
now see `PartitionFamily::Flow` where `PartitionFamily::Execution`
previously appeared. This is the documented round-trip collapse —
both families produce `{fp:N}` hash-tags under RFC-011 co-location,
so routing is byte-identical. Only the metadata-layer label differs.
Cairn consumers that read this value for structured logs / metric
labels will see the name flip but the key space is unchanged.

## Test validity proof

The new tests reference symbols that do not exist on pre-fix HEAD
(`6f54f9b`): the `PartitionKey` type, the `partition_key` field,
and the `.partition()` accessor. Compiling them against that SHA
fails with `cannot find type 'PartitionKey' in crate
ff_core::partition` / `no field 'partition_key' on ClaimGrant` —
stronger proof than a runtime assertion would be. Ran `git stash`
+ checkout-main locally to confirm.

## Commits

1. `feat(ff-core)`: opaque `PartitionKey` newtype + error enum +
   round-trip unit tests. Standalone-buildable.
2. `refactor(ff-core,ff-server,ff-sdk,ff-scheduler,ff-test)`: atomic
   internal-field flip + HTTP DTO flip + integration test
   (`ff-test::claim_grant_wire`). Squashes plan §2+§3 — the two
   could not be split without a throw-away intermediate state.
3. `docs(ff-core)`: module-level rustdoc with migration note +
   before/after JSON.

Merged plan §2+§3 because the `From<ClaimGrant> for ClaimGrantDto` impl
reads fields off the core struct; decoupling them would require a
temporary both-fields state that is strictly uglier than the atomic
flip.

## CI gate checklist

- [x] `cargo build --workspace --all-features` — green
- [x] `cargo test --workspace --all-features --lib` — green (all
      crates, 580+ tests pass)
- [x] `cargo test -p ff-test --test claim_grant_wire` — green (3
      tests)
- [x] `cargo clippy` (CI-exact invocation, `-D warnings`) — green
- [x] `cargo semver-checks check-release --baseline-rev v0.2.0 -p
      ff-core` — green (0 checks fail; major change baseline)

## Test plan

- [ ] Wait for CI matrix to confirm green across all runners.
- [ ] Peer review on the Execution→Flow collapse — confirm no
      in-tree consumer dispatches on `family` (grep for
      `PartitionFamily::Execution` outside ff-core/scheduler/sdk
      came back clean).
- [ ] Coordinate cairn-fabric migration ack before cut (peer-team
      boundary: no cairn code touched here; migration snippet is
      the only handoff).

Fixes #91.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wire-format change for `POST /v1/workers/{id}/claim` and related SDK/core types could break external consumers expecting `partition_family`/`partition_index`, and introduces new parsing/error paths at claim time.
> 
> **Overview**
> Switches `ff_core::contracts::ClaimGrant` and `ReclaimGrant` from carrying a typed `Partition` to carrying an opaque `PartitionKey`, with internal helpers (`grant.partition()`) to parse back to `Partition` when needed.
> 
> Updates the scheduler, server claim endpoint response, and SDK admin/worker claim flows to emit/consume `partition_key` (removing `partition_family`/`partition_index`), and adds unit + integration tests to pin the new JSON wire shape and the `Execution`→`Flow` alias-collapse behavior on round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f346db144ce18942c56a713caca990e30d04864. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->