### PR TITLE
feat(ff-core,ff-sdk,ff-server): opaque StreamCursor on wire types (#92)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,6 @@ dependencies = [
  "ff-core",
  "ff-observability",
  "futures",
- "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -943,6 +943,210 @@ pub enum AppendFrameResult {
     },
 }
 
+// ─── StreamCursor (issue #92) ───
+
+/// Opaque cursor for attempt-stream reads/tails.
+///
+/// Replaces the bare `&str` / `String` stream-id parameters previously
+/// carried on `read_stream` / `tail_stream` / `ReadStreamParams` /
+/// `TailStreamParams`. The wire form is a flat string — serde is
+/// transparent via `try_from`/`into` — so `?from=start&to=end` and
+/// `?after=123-0` continue to work for REST clients.
+///
+/// # Public wire grammar
+///
+/// The ONLY accepted tokens are:
+///
+/// * `"start"` — first entry in the stream (XRANGE `-` equivalent).
+///   Valid in [`read_stream`] / `ReadStreamParams`.
+/// * `"end"` — latest entry in the stream (XRANGE `+` equivalent).
+///   Valid in [`read_stream`] / `ReadStreamParams`.
+/// * `"<ms>"` or `"<ms>-<seq>"` — a concrete Valkey Stream entry id.
+///   Valid everywhere.
+///
+/// The bare XRANGE/XREAD markers `"-"` and `"+"` are **NOT** accepted
+/// on the wire. The opaque `StreamCursor` grammar is the public
+/// contract; the Valkey `-`/`+` markers are an internal implementation
+/// detail carried only inside the Lua-adjacent [`ReadFramesArgs`] /
+/// `xread_block` path via [`StreamCursor::to_wire`].
+///
+/// For XREAD (tail), the documented "from the beginning" convention is
+/// `StreamCursor::At("0-0".into())` — use the convenience constructor
+/// [`StreamCursor::from_beginning`] which returns exactly that value.
+/// `Start` / `End` are rejected by the SDK's `tail_stream` boundary
+/// because XREAD does not accept `-` / `+` as cursors.
+///
+/// # Why an enum instead of a string
+///
+/// A string parameter lets malformed ids escape to the Lua/Valkey
+/// layer, surfacing as a script error and HTTP 500. An enum with
+/// fallible `FromStr` / `TryFrom<String>` catches every malformed input
+/// at the wire boundary with a structured error, and prevents bare `-`
+/// / `+` from leaking into consumer code as tacit extensions of the
+/// public API.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum StreamCursor {
+    /// First entry in the stream (XRANGE start marker).
+    Start,
+    /// Latest entry in the stream (XRANGE end marker).
+    End,
+    /// A concrete Valkey Stream entry id (`<ms>` or `<ms>-<seq>`).
+    ///
+    /// For XREAD-style tails, the documented "from the beginning"
+    /// convention is `At("0-0".to_owned())` — see
+    /// [`StreamCursor::from_beginning`].
+    At(String),
+}
+
+impl StreamCursor {
+    /// Convenience constructor for the XREAD-from-beginning convention
+    /// (`"0-0"`). XREAD's `last_id` is exclusive, so passing this as
+    /// the `after` cursor returns every entry in the stream.
+    pub fn from_beginning() -> Self {
+        Self::At("0-0".to_owned())
+    }
+
+    /// Serde default helper — emits `StreamCursor::Start`. Used as
+    /// `#[serde(default = "StreamCursor::start")]` on REST query
+    /// structs.
+    pub fn start() -> Self {
+        Self::Start
+    }
+
+    /// Serde default helper — emits `StreamCursor::End`.
+    pub fn end() -> Self {
+        Self::End
+    }
+
+    /// Serde default helper — emits
+    /// `StreamCursor::from_beginning()`. Used as the default for
+    /// `TailStreamParams::after`.
+    pub fn beginning() -> Self {
+        Self::from_beginning()
+    }
+
+    /// Internal-only: lower the cursor to the XRANGE/XREAD marker
+    /// string Valkey expects. `Start → "-"`, `End → "+"`,
+    /// `At(s) → s`.
+    ///
+    /// Used at the ff-script adapter edge (right before constructing
+    /// `ReadFramesArgs` or calling `xread_block`) to translate the
+    /// opaque wire grammar into the Lua-ABI form. NOT part of the
+    /// public wire — do not emit these raw characters to consumers.
+    pub fn to_wire(&self) -> &str {
+        match self {
+            Self::Start => "-",
+            Self::End => "+",
+            Self::At(s) => s.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for StreamCursor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Start => f.write_str("start"),
+            Self::End => f.write_str("end"),
+            Self::At(s) => f.write_str(s),
+        }
+    }
+}
+
+/// Error produced when parsing a [`StreamCursor`] from a string.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StreamCursorParseError {
+    /// Empty input.
+    Empty,
+    /// Input matched a rejected bare-marker alias (`"-"`, `"+"`).
+    /// The public wire requires `"start"` / `"end"`; the raw Valkey
+    /// markers are internal-only.
+    BareMarkerRejected(String),
+    /// Input was neither a recognized keyword nor a well-formed
+    /// Stream entry id. Entry ids must match `^\d+(?:-\d+)?$`.
+    Malformed(String),
+}
+
+impl std::fmt::Display for StreamCursorParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("stream cursor must not be empty"),
+            Self::BareMarkerRejected(s) => write!(
+                f,
+                "bare marker '{s}' is not a valid stream cursor; use 'start' or 'end'"
+            ),
+            Self::Malformed(s) => write!(
+                f,
+                "invalid stream cursor '{s}' (expected 'start', 'end', '<ms>', or '<ms>-<seq>')"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StreamCursorParseError {}
+
+impl std::str::FromStr for StreamCursor {
+    type Err = StreamCursorParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(StreamCursorParseError::Empty);
+        }
+        if s == "-" || s == "+" {
+            return Err(StreamCursorParseError::BareMarkerRejected(s.to_owned()));
+        }
+        if s == "start" {
+            return Ok(Self::Start);
+        }
+        if s == "end" {
+            return Ok(Self::End);
+        }
+        if !s.is_ascii() {
+            return Err(StreamCursorParseError::Malformed(s.to_owned()));
+        }
+        let (ms_part, seq_part) = match s.split_once('-') {
+            Some((ms, seq)) => (ms, Some(seq)),
+            None => (s, None),
+        };
+        let ms_ok = !ms_part.is_empty() && ms_part.bytes().all(|b| b.is_ascii_digit());
+        let seq_ok = seq_part
+            .map(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+            .unwrap_or(true);
+        if ms_ok && seq_ok {
+            Ok(Self::At(s.to_owned()))
+        } else {
+            Err(StreamCursorParseError::Malformed(s.to_owned()))
+        }
+    }
+}
+
+impl TryFrom<String> for StreamCursor {
+    type Error = StreamCursorParseError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        // Forward to the `&str` impl to avoid duplicating the grammar.
+        <Self as std::str::FromStr>::from_str(&s)
+    }
+}
+
+impl From<StreamCursor> for String {
+    fn from(c: StreamCursor) -> Self {
+        c.to_string()
+    }
+}
+
+impl Serialize for StreamCursor {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for StreamCursor {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
 // ─── read_attempt_stream / tail_attempt_stream ───
 
 /// Hard cap on the number of frames returned by a single read/tail call.
@@ -1892,6 +2096,126 @@ mod tests {
         let json = serde_json::to_string(&result).unwrap();
         let parsed: ClaimExecutionResult = serde_json::from_str(&json).unwrap();
         assert_eq!(result, parsed);
+    }
+
+    // ── StreamCursor (issue #92) ──
+
+    #[test]
+    fn stream_cursor_display_matches_wire_tokens() {
+        assert_eq!(StreamCursor::Start.to_string(), "start");
+        assert_eq!(StreamCursor::End.to_string(), "end");
+        assert_eq!(StreamCursor::At("123".into()).to_string(), "123");
+        assert_eq!(StreamCursor::At("123-4".into()).to_string(), "123-4");
+    }
+
+    #[test]
+    fn stream_cursor_to_wire_maps_to_valkey_markers() {
+        assert_eq!(StreamCursor::Start.to_wire(), "-");
+        assert_eq!(StreamCursor::End.to_wire(), "+");
+        assert_eq!(StreamCursor::At("0-0".into()).to_wire(), "0-0");
+        assert_eq!(StreamCursor::At("17-3".into()).to_wire(), "17-3");
+    }
+
+    #[test]
+    fn stream_cursor_from_str_accepts_wire_tokens() {
+        use std::str::FromStr;
+        assert_eq!(StreamCursor::from_str("start").unwrap(), StreamCursor::Start);
+        assert_eq!(StreamCursor::from_str("end").unwrap(), StreamCursor::End);
+        assert_eq!(
+            StreamCursor::from_str("123").unwrap(),
+            StreamCursor::At("123".into())
+        );
+        assert_eq!(
+            StreamCursor::from_str("0-0").unwrap(),
+            StreamCursor::At("0-0".into())
+        );
+        assert_eq!(
+            StreamCursor::from_str("1713100800150-0").unwrap(),
+            StreamCursor::At("1713100800150-0".into())
+        );
+    }
+
+    #[test]
+    fn stream_cursor_from_str_rejects_bare_markers() {
+        use std::str::FromStr;
+        assert!(matches!(
+            StreamCursor::from_str("-"),
+            Err(StreamCursorParseError::BareMarkerRejected(s)) if s == "-"
+        ));
+        assert!(matches!(
+            StreamCursor::from_str("+"),
+            Err(StreamCursorParseError::BareMarkerRejected(s)) if s == "+"
+        ));
+    }
+
+    #[test]
+    fn stream_cursor_from_str_rejects_empty() {
+        use std::str::FromStr;
+        assert_eq!(
+            StreamCursor::from_str(""),
+            Err(StreamCursorParseError::Empty)
+        );
+    }
+
+    #[test]
+    fn stream_cursor_from_str_rejects_malformed() {
+        use std::str::FromStr;
+        for bad in ["abc", "-1", "1-", "-1-2", "1-2-3", "1.2", "1 2", "Start", "END"] {
+            assert!(
+                matches!(
+                    StreamCursor::from_str(bad),
+                    Err(StreamCursorParseError::Malformed(_))
+                ),
+                "must reject {bad:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn stream_cursor_from_str_rejects_non_ascii() {
+        use std::str::FromStr;
+        assert!(matches!(
+            StreamCursor::from_str("1\u{2013}2"),
+            Err(StreamCursorParseError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn stream_cursor_serde_round_trip() {
+        for c in [
+            StreamCursor::Start,
+            StreamCursor::End,
+            StreamCursor::At("0-0".into()),
+            StreamCursor::At("1713100800150-0".into()),
+        ] {
+            let json = serde_json::to_string(&c).unwrap();
+            let back: StreamCursor = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, c);
+        }
+    }
+
+    #[test]
+    fn stream_cursor_serializes_as_bare_string() {
+        assert_eq!(serde_json::to_string(&StreamCursor::Start).unwrap(), r#""start""#);
+        assert_eq!(serde_json::to_string(&StreamCursor::End).unwrap(), r#""end""#);
+        assert_eq!(
+            serde_json::to_string(&StreamCursor::At("123-0".into())).unwrap(),
+            r#""123-0""#
+        );
+    }
+
+    #[test]
+    fn stream_cursor_deserialize_rejects_bare_markers() {
+        assert!(serde_json::from_str::<StreamCursor>(r#""-""#).is_err());
+        assert!(serde_json::from_str::<StreamCursor>(r#""+""#).is_err());
+    }
+
+    #[test]
+    fn stream_cursor_from_beginning_is_zero_zero() {
+        assert_eq!(
+            StreamCursor::from_beginning(),
+            StreamCursor::At("0-0".into())
+        );
     }
 }
 

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -958,9 +958,9 @@ pub enum AppendFrameResult {
 /// The ONLY accepted tokens are:
 ///
 /// * `"start"` — first entry in the stream (XRANGE `-` equivalent).
-///   Valid in [`read_stream`] / `ReadStreamParams`.
+///   Valid in `read_stream` / `ReadStreamParams`.
 /// * `"end"` — latest entry in the stream (XRANGE `+` equivalent).
-///   Valid in [`read_stream`] / `ReadStreamParams`.
+///   Valid in `read_stream` / `ReadStreamParams`.
 /// * `"<ms>"` or `"<ms>-<seq>"` — a concrete Valkey Stream entry id.
 ///   Valid everywhere.
 ///
@@ -974,7 +974,9 @@ pub enum AppendFrameResult {
 /// `StreamCursor::At("0-0".into())` — use the convenience constructor
 /// [`StreamCursor::from_beginning`] which returns exactly that value.
 /// `Start` / `End` are rejected by the SDK's `tail_stream` boundary
-/// because XREAD does not accept `-` / `+` as cursors.
+/// because XREAD does not accept `-` / `+` as cursors. The
+/// [`StreamCursor::is_concrete`] helper centralises this
+/// Start/End-vs-At decision for boundary-validation call sites.
 ///
 /// # Why an enum instead of a string
 ///
@@ -1033,12 +1035,41 @@ impl StreamCursor {
     /// `ReadFramesArgs` or calling `xread_block`) to translate the
     /// opaque wire grammar into the Lua-ABI form. NOT part of the
     /// public wire — do not emit these raw characters to consumers.
+    /// Hidden from the generated docs to discourage external use;
+    /// external consumers should never need to see the raw `-` / `+`.
+    #[doc(hidden)]
     pub fn to_wire(&self) -> &str {
         match self {
             Self::Start => "-",
             Self::End => "+",
             Self::At(s) => s.as_str(),
         }
+    }
+
+    /// Internal-only owned variant of [`Self::to_wire`] — moves the
+    /// inner `String` out of `At(s)` without cloning. Use at adapter
+    /// edges that construct an owned wire string (e.g.
+    /// `ReadFramesArgs.from_id`) from a `StreamCursor` that is about
+    /// to be dropped.
+    #[doc(hidden)]
+    pub fn into_wire_string(self) -> String {
+        match self {
+            Self::Start => "-".to_owned(),
+            Self::End => "+".to_owned(),
+            Self::At(s) => s,
+        }
+    }
+
+    /// True iff this cursor is a concrete entry id
+    /// (`"<ms>"` / `"<ms>-<seq>"`). False for the open markers
+    /// `Start` / `End`.
+    ///
+    /// Used by boundaries like XREAD (tailing) that do not accept
+    /// open markers — rejecting a cursor is equivalent to
+    /// `!cursor.is_concrete()`. Centralised here to keep the SDK and
+    /// REST guards in lock-step.
+    pub fn is_concrete(&self) -> bool {
+        matches!(self, Self::At(_))
     }
 }
 
@@ -1084,37 +1115,68 @@ impl std::fmt::Display for StreamCursorParseError {
 
 impl std::error::Error for StreamCursorParseError {}
 
+/// Shared grammar check — classifies `s` as `Start` / `End` / a
+/// concrete-id shape / malformed / empty, WITHOUT allocating. The
+/// owned vs borrowed entry points ([`StreamCursor::from_str`],
+/// [`StreamCursor::try_from`]) consume this classification and move
+/// the owned `String` into `At` when applicable, avoiding a
+/// round-trip `String → &str → String::to_owned` for the common
+/// REST-query path.
+enum StreamCursorClass {
+    Start,
+    End,
+    Concrete,
+    BareMarker,
+    Empty,
+    Malformed,
+}
+
+fn classify_stream_cursor(s: &str) -> StreamCursorClass {
+    if s.is_empty() {
+        return StreamCursorClass::Empty;
+    }
+    if s == "-" || s == "+" {
+        return StreamCursorClass::BareMarker;
+    }
+    if s == "start" {
+        return StreamCursorClass::Start;
+    }
+    if s == "end" {
+        return StreamCursorClass::End;
+    }
+    if !s.is_ascii() {
+        return StreamCursorClass::Malformed;
+    }
+    let (ms_part, seq_part) = match s.split_once('-') {
+        Some((ms, seq)) => (ms, Some(seq)),
+        None => (s, None),
+    };
+    let ms_ok = !ms_part.is_empty() && ms_part.bytes().all(|b| b.is_ascii_digit());
+    let seq_ok = seq_part
+        .map(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+        .unwrap_or(true);
+    if ms_ok && seq_ok {
+        StreamCursorClass::Concrete
+    } else {
+        StreamCursorClass::Malformed
+    }
+}
+
 impl std::str::FromStr for StreamCursor {
     type Err = StreamCursorParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.is_empty() {
-            return Err(StreamCursorParseError::Empty);
-        }
-        if s == "-" || s == "+" {
-            return Err(StreamCursorParseError::BareMarkerRejected(s.to_owned()));
-        }
-        if s == "start" {
-            return Ok(Self::Start);
-        }
-        if s == "end" {
-            return Ok(Self::End);
-        }
-        if !s.is_ascii() {
-            return Err(StreamCursorParseError::Malformed(s.to_owned()));
-        }
-        let (ms_part, seq_part) = match s.split_once('-') {
-            Some((ms, seq)) => (ms, Some(seq)),
-            None => (s, None),
-        };
-        let ms_ok = !ms_part.is_empty() && ms_part.bytes().all(|b| b.is_ascii_digit());
-        let seq_ok = seq_part
-            .map(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
-            .unwrap_or(true);
-        if ms_ok && seq_ok {
-            Ok(Self::At(s.to_owned()))
-        } else {
-            Err(StreamCursorParseError::Malformed(s.to_owned()))
+        match classify_stream_cursor(s) {
+            StreamCursorClass::Start => Ok(Self::Start),
+            StreamCursorClass::End => Ok(Self::End),
+            StreamCursorClass::Concrete => Ok(Self::At(s.to_owned())),
+            StreamCursorClass::BareMarker => {
+                Err(StreamCursorParseError::BareMarkerRejected(s.to_owned()))
+            }
+            StreamCursorClass::Empty => Err(StreamCursorParseError::Empty),
+            StreamCursorClass::Malformed => {
+                Err(StreamCursorParseError::Malformed(s.to_owned()))
+            }
         }
     }
 }
@@ -1123,8 +1185,21 @@ impl TryFrom<String> for StreamCursor {
     type Error = StreamCursorParseError;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        // Forward to the `&str` impl to avoid duplicating the grammar.
-        <Self as std::str::FromStr>::from_str(&s)
+        // Owned parsing path — the `At` variant moves `s` in directly,
+        // avoiding the `&str → String::to_owned` re-allocation that a
+        // blind forward to `FromStr::from_str(&s)` would force. Error
+        // paths still pay one allocation to describe the offending
+        // input.
+        match classify_stream_cursor(&s) {
+            StreamCursorClass::Start => Ok(Self::Start),
+            StreamCursorClass::End => Ok(Self::End),
+            StreamCursorClass::Concrete => Ok(Self::At(s)),
+            StreamCursorClass::BareMarker => {
+                Err(StreamCursorParseError::BareMarkerRejected(s))
+            }
+            StreamCursorClass::Empty => Err(StreamCursorParseError::Empty),
+            StreamCursorClass::Malformed => Err(StreamCursorParseError::Malformed(s)),
+        }
     }
 }
 
@@ -2215,6 +2290,25 @@ mod tests {
         assert_eq!(
             StreamCursor::from_beginning(),
             StreamCursor::At("0-0".into())
+        );
+    }
+
+    #[test]
+    fn stream_cursor_is_concrete_classifies_variants() {
+        assert!(!StreamCursor::Start.is_concrete());
+        assert!(!StreamCursor::End.is_concrete());
+        assert!(StreamCursor::At("0-0".into()).is_concrete());
+        assert!(StreamCursor::At("123-0".into()).is_concrete());
+        assert!(StreamCursor::from_beginning().is_concrete());
+    }
+
+    #[test]
+    fn stream_cursor_into_wire_string_moves_without_cloning() {
+        assert_eq!(StreamCursor::Start.into_wire_string(), "-");
+        assert_eq!(StreamCursor::End.into_wire_string(), "+");
+        assert_eq!(
+            StreamCursor::At("17-3".into()).into_wire_string(),
+            "17-3"
         );
     }
 }

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -89,8 +89,8 @@ pub use ff_core::backend::ResumeSignal;
 #[cfg(feature = "valkey-default")]
 pub use task::{
     read_stream, tail_stream, AppendFrameOutcome, ClaimedTask, ConditionMatcher, Signal,
-    SignalOutcome, StreamFrames, SuspendOutcome, TimeoutBehavior, MAX_TAIL_BLOCK_MS,
-    STREAM_READ_HARD_CAP,
+    SignalOutcome, StreamCursor, StreamFrames, SuspendOutcome, TimeoutBehavior,
+    MAX_TAIL_BLOCK_MS, STREAM_READ_HARD_CAP,
 };
 #[cfg(feature = "valkey-default")]
 pub use worker::FlowFabricWorker;

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -1861,6 +1861,30 @@ pub use ff_core::contracts::STREAM_READ_HARD_CAP;
 /// Re-export of `ff_core::contracts::StreamFrames` for SDK ergonomics.
 pub use ff_core::contracts::StreamFrames;
 
+/// Opaque cursor for [`read_stream`] / [`tail_stream`] — re-export of
+/// `ff_core::contracts::StreamCursor`. Wire tokens: `"start"`, `"end"`,
+/// `"<ms>"`, `"<ms>-<seq>"`. Bare `-` / `+` are rejected — use
+/// `StreamCursor::Start` / `StreamCursor::End` instead.
+pub use ff_core::contracts::StreamCursor;
+
+/// Reject `Start` / `End` cursors at the XREAD (`tail_stream`) boundary
+/// — XREAD does not accept the open markers. Pulled out as a bare
+/// function so unit tests can exercise the guard without constructing a
+/// live `ferriskey::Client`.
+fn validate_tail_cursor(after: &StreamCursor) -> Result<(), SdkError> {
+    if matches!(after, StreamCursor::Start | StreamCursor::End) {
+        return Err(SdkError::Config {
+            context: "tail_stream".into(),
+            field: Some("after".into()),
+            message: "XREAD cursor must be a concrete entry id; pass \
+                      StreamCursor::from_beginning() to start from the \
+                      beginning"
+                .into(),
+        });
+    }
+    Ok(())
+}
+
 fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
     if count_limit == 0 {
         return Err(SdkError::Config {
@@ -1883,8 +1907,10 @@ fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
 
 /// Read frames from a completed or in-flight attempt's stream.
 ///
-/// `from_id` / `to_id` accept XRANGE special markers (`"-"`, `"+"`) or
-/// entry IDs. `count_limit` MUST be in `1..=STREAM_READ_HARD_CAP` —
+/// `from` / `to` are [`StreamCursor`] values — `StreamCursor::Start` /
+/// `StreamCursor::End` are equivalent to XRANGE `-` / `+`, and
+/// `StreamCursor::At("<id>")` reads from a concrete entry id.
+/// `count_limit` MUST be in `1..=STREAM_READ_HARD_CAP` —
 /// `0` returns [`SdkError::Config`].
 ///
 /// Returns a [`StreamFrames`] including `closed_at`/`closed_reason` so
@@ -1909,8 +1935,8 @@ pub async fn read_stream(
     partition_config: &PartitionConfig,
     execution_id: &ExecutionId,
     attempt_index: AttemptIndex,
-    from_id: &str,
-    to_id: &str,
+    from: StreamCursor,
+    to: StreamCursor,
     count_limit: u64,
 ) -> Result<StreamFrames, SdkError> {
     use ff_core::contracts::{ReadFramesArgs, ReadFramesResult};
@@ -1920,11 +1946,14 @@ pub async fn read_stream(
     let ctx = ExecKeyContext::new(&partition, execution_id);
     let keys = ff_script::functions::stream::StreamOpKeys { ctx: &ctx };
 
+    // Lower the opaque cursor to the Valkey XRANGE marker at the
+    // adapter edge. `ReadFramesArgs` is string-typed — the Lua ABI is
+    // untouched.
     let args = ReadFramesArgs {
         execution_id: execution_id.clone(),
         attempt_index,
-        from_id: from_id.to_owned(),
-        to_id: to_id.to_owned(),
+        from_id: from.to_wire().to_owned(),
+        to_id: to.to_wire().to_owned(),
         count_limit,
     };
 
@@ -1937,8 +1966,12 @@ pub async fn read_stream(
 
 /// Tail a live attempt's stream.
 ///
-/// `last_id` is exclusive — XREAD returns entries with id strictly greater
-/// than `last_id`. Pass `"0-0"` to start from the beginning.
+/// `after` is an exclusive [`StreamCursor`] — XREAD returns entries
+/// with id strictly greater than `after`. Pass
+/// `StreamCursor::from_beginning()` (i.e. `At("0-0")`) to start from
+/// the beginning. `StreamCursor::Start` / `StreamCursor::End` are
+/// REJECTED at this boundary because XREAD does not accept `-` / `+`
+/// as cursors — an invalid `after` surfaces as [`SdkError::Config`].
 ///
 /// `block_ms == 0` → non-blocking peek. `block_ms > 0` → blocks up to that
 /// many ms. Rejects `block_ms > MAX_TAIL_BLOCK_MS` and `count_limit`
@@ -2005,7 +2038,7 @@ pub async fn tail_stream(
     partition_config: &PartitionConfig,
     execution_id: &ExecutionId,
     attempt_index: AttemptIndex,
-    last_id: &str,
+    after: StreamCursor,
     block_ms: u64,
     count_limit: u64,
 ) -> Result<StreamFrames, SdkError> {
@@ -2017,6 +2050,11 @@ pub async fn tail_stream(
         });
     }
     validate_stream_read_count(count_limit)?;
+    // XREAD does not accept `-` / `+` markers as cursors — reject at
+    // the SDK boundary with `SdkError::Config` rather than forwarding
+    // an invalid `-`/`+` into ferriskey (which would surface as an
+    // opaque server error).
+    validate_tail_cursor(&after)?;
 
     let partition = execution_partition(execution_id, partition_config);
     let ctx = ExecKeyContext::new(&partition, execution_id);
@@ -2027,12 +2065,53 @@ pub async fn tail_stream(
         client,
         &stream_key,
         &stream_meta_key,
-        last_id,
+        after.to_wire(),
         block_ms,
         count_limit,
     )
     .await
     .map_err(SdkError::from)
+}
+
+#[cfg(test)]
+mod tail_stream_boundary_tests {
+    use super::*;
+
+    // `validate_tail_cursor` rejects `StreamCursor::Start` and
+    // `StreamCursor::End` before `tail_stream` touches the client —
+    // same shape as the `count_limit` guard above. The matching
+    // full-path rejection on the REST layer is covered by
+    // `ff-server::api`.
+
+    #[test]
+    fn rejects_start_cursor() {
+        let err = validate_tail_cursor(&StreamCursor::Start)
+            .expect_err("Start must be rejected");
+        match err {
+            SdkError::Config { field, context, .. } => {
+                assert_eq!(field.as_deref(), Some("after"));
+                assert_eq!(context, "tail_stream");
+            }
+            other => panic!("expected SdkError::Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_end_cursor() {
+        let err = validate_tail_cursor(&StreamCursor::End)
+            .expect_err("End must be rejected");
+        assert!(matches!(err, SdkError::Config { .. }));
+    }
+
+    #[test]
+    fn accepts_at_cursor() {
+        validate_tail_cursor(&StreamCursor::At("0-0".into()))
+            .expect("At cursor must be accepted");
+        validate_tail_cursor(&StreamCursor::from_beginning())
+            .expect("from_beginning() must be accepted");
+        validate_tail_cursor(&StreamCursor::At("123-0".into()))
+            .expect("concrete id must be accepted");
+    }
 }
 
 #[cfg(test)]

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -1872,7 +1872,7 @@ pub use ff_core::contracts::StreamCursor;
 /// function so unit tests can exercise the guard without constructing a
 /// live `ferriskey::Client`.
 fn validate_tail_cursor(after: &StreamCursor) -> Result<(), SdkError> {
-    if matches!(after, StreamCursor::Start | StreamCursor::End) {
+    if !after.is_concrete() {
         return Err(SdkError::Config {
             context: "tail_stream".into(),
             field: Some("after".into()),
@@ -1952,8 +1952,8 @@ pub async fn read_stream(
     let args = ReadFramesArgs {
         execution_id: execution_id.clone(),
         attempt_index,
-        from_id: from.to_wire().to_owned(),
-        to_id: to.to_wire().to_owned(),
+        from_id: from.into_wire_string(),
+        to_id: to.into_wire_string(),
         count_limit,
     };
 

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -968,46 +968,15 @@ async fn claim_for_worker(
 
 #[derive(Deserialize)]
 struct ReadStreamParams {
-    #[serde(default = "default_from_id")]
-    from: String,
-    #[serde(default = "default_to_id")]
-    to: String,
+    #[serde(default = "ff_core::contracts::StreamCursor::start")]
+    from: ff_core::contracts::StreamCursor,
+    #[serde(default = "ff_core::contracts::StreamCursor::end")]
+    to: ff_core::contracts::StreamCursor,
     #[serde(default = "default_read_limit")]
     limit: u64,
 }
 
-fn default_from_id() -> String { "-".to_owned() }
-fn default_to_id() -> String { "+".to_owned() }
 fn default_read_limit() -> u64 { 100 }
-
-/// Reject malformed `from`/`to`/`after` stream IDs at the REST boundary so
-/// Valkey doesn't have to. Accepts `"-"`, `"+"`, and `<ms>` or `<ms>-<seq>`
-/// decimal IDs as Valkey XRANGE/XREAD does.
-///
-/// Without this, a request like `?from=abc` would round-trip to Valkey,
-/// surface as a script error, and return HTTP 500 — which is wrong for
-/// caller-input validation.
-fn validate_stream_id(s: &str, field: &str, allow_open_markers: bool) -> Result<(), ApiError> {
-    if allow_open_markers && (s == "-" || s == "+") {
-        return Ok(());
-    }
-    // Allowed: `<digits>` or `<digits>-<digits>`.
-    let (ms_part, seq_part) = match s.split_once('-') {
-        Some((ms, seq)) => (ms, Some(seq)),
-        None => (s, None),
-    };
-    let ms_valid = !ms_part.is_empty() && ms_part.chars().all(|c| c.is_ascii_digit());
-    let seq_valid = seq_part
-        .map(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
-        .unwrap_or(true);
-    if ms_valid && seq_valid {
-        Ok(())
-    } else {
-        Err(ApiError(ServerError::InvalidInput(format!(
-            "{field}: invalid stream ID '{s}' (expected '-', '+', '<ms>', or '<ms>-<seq>')"
-        ))))
-    }
-}
 
 #[derive(Serialize)]
 struct ReadStreamResponse {
@@ -1063,28 +1032,30 @@ async fn read_attempt_stream(
             "limit exceeds REST ceiling {REST_STREAM_LIMIT_CEILING}; paginate via from/to for larger spans"
         ))));
     }
-    validate_stream_id(&params.from, "from", true)?;
-    validate_stream_id(&params.to, "to", true)?;
-
     let eid = parse_execution_id(&id)?;
     let attempt_index = AttemptIndex::new(idx);
     let result = server
-        .read_attempt_stream(&eid, attempt_index, &params.from, &params.to, params.limit)
+        .read_attempt_stream(
+            &eid,
+            attempt_index,
+            params.from.to_wire(),
+            params.to.to_wire(),
+            params.limit,
+        )
         .await?;
     Ok(Json(result.into()))
 }
 
 #[derive(Deserialize)]
 struct TailStreamParams {
-    #[serde(default = "default_tail_after")]
-    after: String,
+    #[serde(default = "ff_core::contracts::StreamCursor::beginning")]
+    after: ff_core::contracts::StreamCursor,
     #[serde(default)]
     block_ms: u64,
     #[serde(default = "default_tail_limit")]
     limit: u64,
 }
 
-fn default_tail_after() -> String { "0-0".to_owned() }
 fn default_tail_limit() -> u64 { 50 }
 
 /// Ceiling on BLOCK duration for the tail endpoint. Kept below common LB
@@ -1117,13 +1088,31 @@ async fn tail_attempt_stream(
             "limit exceeds REST ceiling {REST_STREAM_LIMIT_CEILING}; paginate via after for larger spans"
         ))));
     }
-    // XREAD cursor must be a concrete ID — "-"/"+" are XRANGE-only.
-    validate_stream_id(&params.after, "after", false)?;
+    // XREAD cursor must be a concrete ID — `Start`/`End` are
+    // XRANGE-only. The opaque-cursor deserializer already rejects
+    // the bare `-`/`+` wire tokens; this boundary also rejects the
+    // structured `start`/`end` keywords because XREAD treats them
+    // as invalid ids.
+    if matches!(
+        params.after,
+        ff_core::contracts::StreamCursor::Start | ff_core::contracts::StreamCursor::End
+    ) {
+        return Err(ApiError(ServerError::InvalidInput(
+            "after: XREAD cursor must be a concrete entry id; pass '0-0' to start from the beginning"
+                .to_owned(),
+        )));
+    }
 
     let eid = parse_execution_id(&id)?;
     let attempt_index = AttemptIndex::new(idx);
     let result = server
-        .tail_attempt_stream(&eid, attempt_index, &params.after, params.block_ms, params.limit)
+        .tail_attempt_stream(
+            &eid,
+            attempt_index,
+            params.after.to_wire(),
+            params.block_ms,
+            params.limit,
+        )
         .await?;
     Ok(Json(result.into()))
 }

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -1092,11 +1092,9 @@ async fn tail_attempt_stream(
     // XRANGE-only. The opaque-cursor deserializer already rejects
     // the bare `-`/`+` wire tokens; this boundary also rejects the
     // structured `start`/`end` keywords because XREAD treats them
-    // as invalid ids.
-    if matches!(
-        params.after,
-        ff_core::contracts::StreamCursor::Start | ff_core::contracts::StreamCursor::End
-    ) {
+    // as invalid ids. Uses [`StreamCursor::is_concrete`] so the
+    // SDK + REST guards stay in lock-step.
+    if !params.after.is_concrete() {
         return Err(ApiError(ServerError::InvalidInput(
             "after: XREAD cursor must be a concrete entry id; pass '0-0' to start from the beginning"
                 .to_owned(),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -7802,8 +7802,8 @@ async fn test_read_stream_round_trips_append_frame_fields() {
         &config,
         &eid,
         AttemptIndex::new(att_idx.parse().unwrap()),
-        "-",
-        "+",
+        ff_sdk::StreamCursor::Start,
+        ff_sdk::StreamCursor::End,
         ff_sdk::STREAM_READ_HARD_CAP,
     )
     .await
@@ -7840,8 +7840,8 @@ async fn test_read_stream_empty_returns_empty() {
         &config,
         &eid,
         AttemptIndex::new(0),
-        "-",
-        "+",
+        ff_sdk::StreamCursor::Start,
+        ff_sdk::StreamCursor::End,
         100,
     )
     .await
@@ -7875,9 +7875,17 @@ async fn test_read_stream_slice_and_resume() {
 
     let att = AttemptIndex::new(att_idx.parse().unwrap());
 
-    let page1 = ff_sdk::read_stream(tc.client(), &config, &eid, att, "-", "+", 20)
-        .await
-        .expect("read page1");
+    let page1 = ff_sdk::read_stream(
+        tc.client(),
+        &config,
+        &eid,
+        att,
+        ff_sdk::StreamCursor::Start,
+        ff_sdk::StreamCursor::End,
+        20,
+    )
+    .await
+    .expect("read page1");
     assert_eq!(page1.frames.len(), 20);
 
     let last_id = page1.frames.last().unwrap().id.clone();
@@ -7886,9 +7894,17 @@ async fn test_read_stream_slice_and_resume() {
     let next_seq: u64 = seq.parse::<u64>().unwrap() + 1;
     let resume_from = format!("{ms}-{next_seq}");
 
-    let page2 = ff_sdk::read_stream(tc.client(), &config, &eid, att, &resume_from, "+", 100)
-        .await
-        .expect("read page2");
+    let page2 = ff_sdk::read_stream(
+        tc.client(),
+        &config,
+        &eid,
+        att,
+        ff_sdk::StreamCursor::At(resume_from),
+        ff_sdk::StreamCursor::End,
+        100,
+    )
+    .await
+    .expect("read page2");
     assert_eq!(page2.frames.len(), TOTAL - 20);
     assert_ne!(page2.frames[0].id, last_id, "resume must skip cursor entry");
 }
@@ -7909,7 +7925,7 @@ async fn test_tail_stream_timeout_returns_empty() {
         &config,
         &eid,
         AttemptIndex::new(0),
-        "0-0",
+        ff_sdk::StreamCursor::from_beginning(),
         200,
         50,
     )
@@ -7959,7 +7975,7 @@ async fn test_tail_stream_unblocks_on_write() {
         &config,
         &eid,
         AttemptIndex::new(att_idx.parse().unwrap()),
-        "0-0",
+        ff_sdk::StreamCursor::from_beginning(),
         2_000,
         50,
     )
@@ -7994,7 +8010,7 @@ async fn test_tail_stream_long_block_respects_ferriskey_timeout_extension() {
         &config,
         &eid,
         AttemptIndex::new(0),
-        "0-0",
+        ff_sdk::StreamCursor::from_beginning(),
         7_000, // deliberately > default 5s request_timeout
         50,
     )
@@ -8043,9 +8059,17 @@ async fn test_stream_closed_signal_propagates_to_read_and_tail() {
     let att = AttemptIndex::new(att_idx.parse().unwrap());
 
     // read_stream sees the frame AND the terminal markers.
-    let read = ff_sdk::read_stream(tc.client(), &config, &eid, att, "-", "+", 100)
-        .await
-        .expect("read_stream after complete");
+    let read = ff_sdk::read_stream(
+        tc.client(),
+        &config,
+        &eid,
+        att,
+        ff_sdk::StreamCursor::Start,
+        ff_sdk::StreamCursor::End,
+        100,
+    )
+    .await
+    .expect("read_stream after complete");
     assert_eq!(read.frames.len(), 1);
     assert!(read.is_closed(), "read_stream must report closed after complete");
     assert_eq!(read.closed_reason.as_deref(), Some("attempt_success"));
@@ -8054,9 +8078,17 @@ async fn test_stream_closed_signal_propagates_to_read_and_tail() {
     // tail_stream with block_ms=0 at the tip returns no new frames but
     // still reports closed — this is the signal consumers poll on.
     let tip = read.frames.last().unwrap().id.clone();
-    let tail = ff_sdk::tail_stream(tc.client(), &config, &eid, att, &tip, 0, 10)
-        .await
-        .expect("tail_stream at tip");
+    let tail = ff_sdk::tail_stream(
+        tc.client(),
+        &config,
+        &eid,
+        att,
+        ff_sdk::StreamCursor::At(tip),
+        0,
+        10,
+    )
+    .await
+    .expect("tail_stream at tip");
     assert!(tail.frames.is_empty());
     assert!(tail.is_closed(), "tail_stream must report closed after complete");
     assert_eq!(tail.closed_reason.as_deref(), Some("attempt_success"));
@@ -8095,7 +8127,13 @@ async fn test_lease_expired_closes_stream_meta() {
 
     let att = AttemptIndex::new(att_idx.parse().unwrap());
     let result = ff_sdk::read_stream(
-        tc.client(), &config, &eid, att, "-", "+", 100,
+        tc.client(),
+        &config,
+        &eid,
+        att,
+        ff_sdk::StreamCursor::Start,
+        ff_sdk::StreamCursor::End,
+        100,
     )
     .await
     .expect("read_stream after lease expiry");
@@ -8135,7 +8173,7 @@ async fn test_tail_stream_no_block_returns_available() {
         &config,
         &eid,
         AttemptIndex::new(att_idx.parse().unwrap()),
-        "0-0",
+        ff_sdk::StreamCursor::from_beginning(),
         0,
         50,
     )
@@ -8170,8 +8208,8 @@ async fn test_read_stream_rejects_zero_count_limit() {
         &config,
         &eid,
         AttemptIndex::new(0),
-        "-",
-        "+",
+        ff_sdk::StreamCursor::Start,
+        ff_sdk::StreamCursor::End,
         0,
     )
     .await
@@ -8198,7 +8236,7 @@ async fn test_tail_stream_rejects_zero_count_limit() {
         &config,
         &eid,
         AttemptIndex::new(0),
-        "0-0",
+        ff_sdk::StreamCursor::from_beginning(),
         0,
         0,
     )

--- a/examples/media-pipeline/Cargo.lock
+++ b/examples/media-pipeline/Cargo.lock
@@ -884,10 +884,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff-backend-valkey"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "ferriskey",
+ "ff-core",
+ "ff-script",
+ "futures-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ff-core"
 version = "0.3.0"
 dependencies = [
+ "async-trait",
  "crc16",
+ "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -911,6 +928,7 @@ name = "ff-sdk"
 version = "0.3.0"
 dependencies = [
  "ferriskey",
+ "ff-backend-valkey",
  "ff-core",
  "ff-script",
  "reqwest",

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -30,7 +30,7 @@ use anyhow::Context;
 use clap::Parser;
 use ff_sdk::{
     read_stream, ClaimedTask, ConditionMatcher, FlowFabricAdminClient, FlowFabricWorker,
-    SuspendOutcome, TimeoutBehavior, WorkerConfig, STREAM_READ_HARD_CAP,
+    StreamCursor, SuspendOutcome, TimeoutBehavior, WorkerConfig, STREAM_READ_HARD_CAP,
 };
 use llama_cpp_2::{
     context::params::LlamaContextParams,
@@ -285,8 +285,8 @@ async fn load_persisted_result(
         partition_config,
         task.execution_id(),
         task.attempt_index(),
-        "-",
-        "+",
+        StreamCursor::Start,
+        StreamCursor::End,
         STREAM_READ_HARD_CAP,
     )
     .await


### PR DESCRIPTION
## Summary

Issue #92: introduces `ff_core::contracts::StreamCursor` — an opaque enum (`Start` / `End` / `At(String)`) replacing the bare `&str` stream-id parameters on `read_stream` / `tail_stream` / `ReadStreamParams` / `TailStreamParams`. The public wire grammar is `"start"` / `"end"` / `"<ms>"` / `"<ms>-<seq>"`; the bare Valkey XRANGE/XREAD markers (`"-"` / `"+"`) are rejected at the wire boundary.

The Lua ABI (`ReadFramesArgs`, `xread_block`) stays string-typed — the cursor is lowered to `-` / `+` via `StreamCursor::to_wire()` at the ff-script adapter edge.

Commits (landed together):
1. `feat(ff-core)` — type introduction + 11 unit tests (Display, FromStr, serde, bare-marker rejection).
2. `refactor(ff-sdk,examples)` — SDK signature flip + `tail_stream` `Start`/`End` rejection guard + example-binary migration.
3. `refactor(ff-server)` — REST query-param flip, deletes the hand-rolled `validate_stream_id` / default-id helpers.
4. `test(ff-test)` — mechanical e2e fixture migration (12 call sites).

## Wire break

### `ReadStreamParams` (GET /v1/executions/{id}/attempts/{idx}/stream/frames)

Before:
```
GET .../stream/frames?from=-&to=+&limit=100
```
After:
```
GET .../stream/frames?from=start&to=end&limit=100
```
Concrete ids unchanged: `?from=1713100800150-0&to=1713100900000-0`.

### `TailStreamParams` (GET .../stream/tail)

Before:
```
GET .../stream/tail?after=0-0&block_ms=2000&limit=10
```
After (unchanged — `0-0` is a concrete id, not a bare marker):
```
GET .../stream/tail?after=0-0&block_ms=2000&limit=10
```
The `after` default is now `StreamCursor::from_beginning() = "0-0"`; the serialized JSON/query shape is identical. Bare `-`/`+` on `after` was already rejected pre-#92 (XREAD limitation) — now it's caught one layer earlier via `StreamCursor` parse rejection.

### SDK signatures

Before:
```rust
pub async fn read_stream(.., from_id: &str, to_id: &str, count_limit: u64) -> ..
pub async fn tail_stream(.., last_id: &str, block_ms: u64, count_limit: u64) -> ..
```
After:
```rust
pub async fn read_stream(.., from: StreamCursor, to: StreamCursor, count_limit: u64) -> ..
pub async fn tail_stream(.., after: StreamCursor, block_ms: u64, count_limit: u64) -> ..
```

### Migration snippet for cairn

```rust
// Before
ff_sdk::read_stream(&c, &pc, &eid, att, "-", "+", 100).await?;
ff_sdk::tail_stream(&c, &pc, &eid, att, "0-0", 2000, 50).await?;

// After
use ff_sdk::StreamCursor;
ff_sdk::read_stream(&c, &pc, &eid, att, StreamCursor::Start, StreamCursor::End, 100).await?;
ff_sdk::tail_stream(&c, &pc, &eid, att, StreamCursor::from_beginning(), 2000, 50).await?;

// With a concrete resume id:
ff_sdk::read_stream(&c, &pc, &eid, att, StreamCursor::At(tip), StreamCursor::End, 100).await?;
```

Peer-team boundary honored: no cairn-* files touched.

## Test-edit disclosure

`crates/ff-test/tests/e2e_lifecycle.rs` (12 call sites) — mechanical signature migration under the manager's per-issue allowance (decision 5). Every site + reason in the commit body of `test(ff-test): migrate e2e stream fixtures to StreamCursor (#92)`. Summary: read-stream sites swap `"-", "+"` → `Start, End`; tail-stream sites swap `"0-0"` → `from_beginning()`; `At(id)` preserves concrete-id resumes. `test_read_stream_rejects_over_hard_cap_at_lua` at line 8223 left UNCHANGED — it drives a raw FCALL with the Lua-ABI `-`/`+`, not the SDK.

New unit tests (not migrations):
- `ff-core::contracts::tests::stream_cursor_*` — 11 tests (display, to_wire, FromStr accept/reject, serde round-trip, bare-marker deserialize rejection, non-ASCII rejection, from_beginning).
- `ff-sdk::task::tail_stream_boundary_tests` — 3 tests (`validate_tail_cursor` rejects Start/End, accepts At).

## Stash-revert proof

1. Commit 1 (`3d0c283`) introduces `StreamCursor` + the 11 ff-core unit tests. No call site uses the type yet; the crate compiles clean and all 11 tests pass.
   - Verified: `cargo test -p ff-core --lib contracts::tests::stream_cursor` → 11/11 pass.
2. Without the SDK/REST flips (commits 2-4), the type is dead code but its serde + grammar are fully exercised. Reverting commits 2-4 and re-running step 1 keeps ff-core green and the SDK/server unchanged.
3. After all 4 commits, `cargo test --workspace --lib --all-features` passes (verified before push) and fixture tests compile.

## CI gate checklist

- [x] `cargo build --workspace --all-features`
- [x] `cargo build -p ff-sdk --no-default-features`
- [x] `cargo test -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey --all-features --lib`
- [x] `cargo test -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey --all-features --no-run` (all tests compile)
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey --all-targets --all-features -- -D warnings`
- [x] `cargo machete` — no new findings; pre-existing bench-crate items unchanged.
- [ ] `cargo semver-checks check-release --baseline-rev v0.2.0` — ff-core ran clean (0 checks due to major-change skip). ff-sdk + ff-server baseline build failed on a toolchain/crate-version issue in the v0.2.0 tree (aws-smithy-* requires rustc 1.91, we have 1.90); documented as environment-only, not a semver regression introduced by this PR.

## Notes

Pre-existing clippy errors in `examples/media-pipeline/src/bin/summarize.rs:191,244` (unnecessary `is_some` + `expect`) were NOT introduced by this PR — they exist on `origin/main` and live in code untouched by #92 (my only example edit is the `read_stream` call at line 283 + the import).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a wire/API-breaking change for stream cursor query params and SDK function signatures, and it touches both REST and SDK boundaries; main risk is client compatibility and edge-case cursor validation behavior.
> 
> **Overview**
> Introduces `ff_core::contracts::StreamCursor` (with serde + parsing/validation) to make stream read/tail cursors an *opaque, validated* wire type (`start`/`end`/`<ms>`/`<ms>-<seq>`), explicitly rejecting bare Valkey markers `-`/`+`.
> 
> Updates the SDK APIs `read_stream`/`tail_stream` to take `StreamCursor` (and re-exports it), lowers cursors to Valkey markers only at the adapter edge via `to_wire()`, and adds an SDK-side guard that rejects `Start`/`End` for `tail_stream`.
> 
> Updates REST query params for stream read/tail to deserialize directly into `StreamCursor`, removes the prior hand-rolled `validate_stream_id` and default marker helpers, and adjusts tests/examples/e2e fixtures to use the new cursor tokens/types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2789ab40b4f33965a7542ae6d7afe91c03e177. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->