### PR TITLE
chore(rfcs): archive RFC-012 namespace-amendment exploration

### DIFF
--- a/rfcs/drafts/README.md
+++ b/rfcs/drafts/README.md
@@ -1,0 +1,25 @@
+# RFC drafts — exploration record
+
+This directory holds RFC drafts that were explored but **not merged as RFCs**. They are preserved as an exploration-and-reasoning record, not as authoritative design documents. Do not cite them as policy.
+
+Each cluster of files represents one exploration. Conventions:
+
+- `RFC-<NNN>-amendment-<topic>.md` — the draft under revision.
+- `RFC-<NNN>-amendment-<topic>.<letter>-challenge.md` — a named challenger's adversarial review.
+
+## Index
+
+### RFC-012 namespace amendment (explored 2026-04-22, not pursued)
+
+Tracks issue [#122](https://github.com/avifenesh/FlowFabric/issues/122) (cairn's multi-tenant isolation ask).
+
+- `RFC-012-amendment-namespace.md` — draft v5 of a backend-level namespace-prefix amendment.
+- `RFC-012-amendment-namespace.{K,L,M,P}-challenge.md` — four adversarial review rounds.
+
+**Outcome:** the amendment grew to ~500 lines for one cairn request. After round-4 (Worker P) surfaced that `Namespace` already existed in `ff-core::types`, a peer-team dialog with cairn (in the #122 thread) right-sized the fix to a `ScannerFilter { namespace, instance_tag }` construction-time filter — no key-shape change, no RFC amendment. Shipped as PR [#127](https://github.com/avifenesh/FlowFabric/pull/127).
+
+The draft is kept for three reasons:
+
+1. Chain-of-reasoning for why the full prefix amendment was wrong-sized.
+2. Record of the four-round challenger discipline pattern (K → L → M → P), reusable for future high-impact amendments.
+3. Reference for if operator-level isolation (distinct from cairn's tenant/instance filter) becomes needed later.

--- a/rfcs/drafts/RFC-012-amendment-namespace.K-challenge.md
+++ b/rfcs/drafts/RFC-012-amendment-namespace.K-challenge.md
@@ -1,0 +1,241 @@
+# Round-6 CHALLENGE against RFC-012 namespace amendment (draft v2)
+
+**Challenger:** Worker K. Style: adversarial, file:line-cited, parallels Round-4 Worker M.
+**Scope of review:** `/home/ubuntu/FlowFabric/rfcs/drafts/RFC-012-amendment-namespace.md` v2.
+**Tree head:** `origin/main` `69de6a5` (fetched fresh). Stages 0/1a/1b landed (`ca8ee39`, `81e08dc`, `6f54f9b`).
+
+Bottom line: the amendment is **structurally sound but factually contaminated**. Two of its central claims about the code ("Rust-side keygen owns the prefix, Lua transparent" and "migration tool detects workers via `ff:lease:*`") are provably false against the tree. Several contract gaps (idempotency keys, HMAC secrets, bus events, rogue SCAN sites) are not covered by §R6.2's invariant wording. Validation regex deserves deliberate debate, not "locked." Fix the factual errors in-place and surface the debated ones to the owner.
+
+---
+
+## MUST-FIX
+
+### #K1: "FCALL KEYS array propagation" claim is false — Lua has dozens of hardcoded `ff:` literal key constructions
+Draft §R6.2 lines 42-43: *"Rust-side keygen owns the prefix, Lua `KEYS[i]` receives already-prefixed keys. The Lua library does NOT receive the namespace as a separate ARGV slot — it is transparent to Lua."*
+
+Evidence (these are **genuine key constructions in Lua**, not debug comments or already-prefixed-argument checks):
+
+- `crates/ff-script/src/flowfabric.lua:476` — `local stream_meta_key = "ff:stream:" .. tag .. ":" .. eid`
+- `crates/ff-script/src/flowfabric.lua:1663` — `local att_key = "ff:attempt:" .. tag .. ":" .. A.execution_id .. ":" .. tostring(next_att_idx)`
+- `crates/ff-script/src/flowfabric.lua:1920,2128,2558,3014` — `redis.call("PUBLISH", "ff:dag:completions", payload)` (4 sites)
+- `crates/ff-script/src/flowfabric.lua:1994-1995` — active_index_key / suspended_key built as `"ff:idx:" .. tag .. ...`
+- `crates/ff-script/src/flowfabric.lua:2669,2794,2894` — `"ff:idx:" .. tag_wl .. ":worker:" .. wiid .. ":leases"` (SREM sites)
+- `crates/ff-script/src/flowfabric.lua:2678` — `terminal_key = "ff:idx:" .. tag .. ":lane:" .. lane .. ":terminal"`
+- `crates/ff-script/src/flowfabric.lua:2714` — per-attempt key like #1663
+- `crates/ff-script/src/flowfabric.lua:2942-2958` — 7 ZREM sites building `"ff:idx:" .. tag .. ":lane:" .. lane .. ":<blocked-axis>"`
+
+And on the Rust side, `crates/ff-script/src/functions/lease.rs:97,121,138,139` also `format!("ff:idx:…")` directly — outside `ff-core::keys`. The §R6.4 Stage 1c scope says *"every `format!("ff:…")` call in `crates/ff-core/src/keys.rs`"* — but Stage 1c must also touch `crates/ff-script/src/functions/lease.rs` and the Lua library itself.
+
+**Required fix.**
+1. §R6.2 rewrite: do NOT claim Lua is transparent. State plainly: "Lua PUBLISH channel names and any Lua-literal-constructed key strings (currently ~18 sites) must also be threaded. The standard remediation passes the namespace as a dedicated ARGV slot (e.g. `ARGV[1] = namespace_prefix`, empty string for EMPTY namespace) and prepends it in Lua: `local NS_PREFIX = ARGV[1]; redis.call("PUBLISH", NS_PREFIX .. "ff:dag:completions", payload)`." (Alternative: move all literal-constructed keys Rust-side into KEYS, but that explodes KEYS cardinality on suspend/complete FCALLs.)
+2. §R6.4 Stage 1c scope row: extend to "keygen in `ff-core::keys` + `ff-script::functions::lease` + `flowfabric.lua` literal-key/channel sites (grep-gated)."
+3. §R6.8 Q11 "I have not pre-grepped this" is a red flag. Pre-grep **now** — Worker K has done it; the surface is finite and bounded. Fold the count into the draft.
+
+This is the single biggest hole. An implementer reading v2 would ship Stage 1c with Lua literals still bare-`ff:` and declare the invariant satisfied — subscribers to `ff:dag:completions` would still see every namespace's completions.
+
+### #K2: Migration-tool worker detection uses a key pattern that does not exist
+Draft §R6.5 line 133: *"Tool errors if any FF worker is observably connected (SCAN for `ff:lease:*` with recent expiries)."*
+
+Evidence: `grep -rn "ff:lease:" crates/` returns nothing. The actual lease-bearing keys are:
+- `crates/ff-core/src/keys.rs:63-64` — `ff:exec:{p:N}:<eid>:lease:current`
+- `crates/ff-core/src/keys.rs:68-69` — `ff:exec:{p:N}:<eid>:lease:history`
+- `ff:idx:{p:N}:lease_expiry` (index ZSET, referenced in issue #122 body and `crates/ff-engine/src/scanner/unblock.rs`)
+
+There is no `ff:lease:*` top-level prefix. The proposed SCAN pattern matches **zero keys** and will succeed trivially on any live cluster — the tool would proceed even with workers actively connected. That is the opposite of the intended guard.
+
+Additionally, even with the *right* pattern, "recent expiries" is not a reliable liveness signal: a worker that crashed two minutes ago still has a live lease-expiry entry. Conversely, an idle worker between claims has no lease key at all. Lease presence is a proxy for *claims*, not for *connections*.
+
+**Required fix.**
+1. Correct the key pattern: use `SCAN MATCH "*ff:idx:*:lease_expiry"` (trailing, with namespace-agnostic leading wildcard since we're *in* the old namespace), and check `ZCARD`/`ZRANGEBYSCORE`.
+2. Acknowledge this is a *heuristic*, not a guarantee. Document an operator-side affirmation step: the tool prints expected-idle evidence and requires a `--i-have-stopped-all-workers` acknowledgement flag, or integrates with a `CLIENT LIST` check (`CLIENT LIST TYPE normal` filtered by a well-known `CLIENT SETNAME ff-worker-*` prefix if one exists).
+3. Or flip the design: tool does a `CLIENT KILL`-then-`CLIENT PAUSE` window and accepts the risk itself rather than trying to infer from keyspace.
+
+### #K3: `§R6.2 "Persistent-state invariant"` wording omits several cross-namespace leak surfaces enumerated in the tree
+Draft §R6.2 line 25: *"every persistent key/row/object `A` writes is disjoint from every persistent key/row/object `B` writes."*
+
+That wording is correct. But §R6.2 then enumerates "what the invariant does NOT cover" (FUNCTION LOAD, contention) and silently drops several **cross-namespace-capable** surfaces that do exist in the tree and have non-obvious prefix requirements:
+
+1. **Idempotency / dedup keys that embed caller-supplied strings.** `keys.rs:609-610`:
+   ```
+   pub fn idempotency_key(tag: &str, namespace: &str, idem_key: &str) -> String {
+       format!("ff:idem:{}:{}:{}", tag, namespace, idem_key)
+   }
+   ```
+   Note: this function already has a parameter *named* `namespace`, which is **not the Namespace type we are adding** — it's an execution-domain idempotency namespace. This is a naming collision waiting to happen. If Stage 1c adds a `ns_prefix` argument and keeps the existing `namespace: &str` parameter, every call site reader will conflate them. Also `usage_dedup_key` (`keys.rs:644`) — no existing `namespace` argument, but needs threading.
+
+2. **HMAC-signed waitpoint tokens.** `keys.rs:275-276`: `pub fn waitpoint_hmac_secrets(&self) -> String { format!("ff:sec:{}:waitpoint_hmac", self.tag) }`. A waitpoint HMAC token issued under namespace A must not validate under namespace B. If the HMAC *secret* key is per-namespace (which it will be, once prefixed), tokens will naturally fail cross-namespace validation — **but only if the token-binding code reads the namespace-prefixed secret key, not the bare one**. This is a Stage 1c audit item; call it out.
+
+3. **SCAN sites that cross partitions.** `crates/ff-engine/src/scanner/unblock.rs:635` documents a `SCAN MATCH ff:worker:*:caps` pattern (though the code today uses a central set). Any SCAN-based code must use `{namespace}:ff:…*` (wildcard scope bounded by prefix) rather than `ff:…*` (wildcards across all namespaces).
+
+4. **Bus / completion events emitted by Lua PUBLISH.** Covered by #K1; restated here because §R6.2's pubsub invariant bullet (line 27) implies channel names are covered but the *implementation path* for Lua-side PUBLISH is not acknowledged.
+
+**Required fix.** Expand §R6.2's "covered" section to enumerate:
+- keys in `ff-core::keys` (exec/flow/lane/budget/quota/signal/idem/dedup/hmac/workerlease)
+- Lua-literal-constructed keys (per #K1)
+- Rust-literal-constructed keys outside `ff-core::keys` (per #K1 — `ff-script::functions::lease`, `ff-sdk::worker` lines 201/233/1572, `ff-sdk::admin:493`)
+- pubsub channels (PUBLISH from Lua + SUBSCRIBE in `ff-engine::completion_listener:43`)
+- SCAN patterns
+
+Rename `idempotency_key`'s `namespace: &str` argument to `idem_domain: &str` to avoid collision with the new type. Cheap rename PR, should ship alongside Stage 1a.1.
+
+### #K4: Stage 1c scope lists 3 key-context structs but the tree has 6
+Draft §R6.4 Stage 1c row: *"thread `namespace` through `ExecKeyContext::new`, `IndexKeys::new`, `FlowIndexKeys::new`, and every `format!("ff:…")` call in `crates/ff-core/src/keys.rs`."*
+
+Evidence — `crates/ff-core/src/keys.rs` has 6 key-context structs with `new(partition: &Partition, …)`:
+- `ExecKeyContext::new` (line 26)
+- `IndexKeys::new` (line 211)
+- `FlowKeyContext::new` (line 324) — MISSING FROM DRAFT
+- `FlowIndexKeys::new` (line 405)
+- `BudgetKeyContext::new` (line 438) — MISSING FROM DRAFT
+- `QuotaKeyContext::new` (line 495) — MISSING FROM DRAFT
+
+Plus the free functions `idempotency_key` (609), `usage_dedup_key` (644), and likely others. Total "format!(\"ff:" hits in keys.rs = 92 (not the 83 figure from issue #122; tree has drifted since #122 was filed on HEAD `3c5828e`).
+
+**Required fix.** §R6.4 Stage 1c scope: list all 6 key-context struct `new` functions and acknowledge free-function threading. Update the "~83 sites" estimate to 92 or re-grep on fused HEAD and cite the current figure.
+
+### #K5: "Interaction with #90" claim mis-describes #90's state
+Draft §R6.4 line 122: *"#90 moves the completion channel literal (`ff:dag:completions`) out of `ff-engine` into `ff-backend-valkey`. […] Stage 1c honours the prefix on the channel literal in its new home."*
+
+Evidence — `gh issue view 90`: #90's proposed shape is *"Define trait `CompletionStream: Stream<Item=CompletionPayload>` + symmetric `Backend::publish_completion`. Postgres impl = LISTEN/NOTIFY."* That's a **trait replacing the pubsub channel abstraction**, not a file-move of a string literal. The channel literal ends up *eliminated from the public surface*, not just relocated.
+
+Additionally: #90 explicitly enumerates *"4 Lua PUBLISH sites (flowfabric.lua:1854,2062,2448,2904)"* — these must still publish the completion event somehow. Those Lua PUBLISH sites are EXACTLY the sites flagged in #K1 (lines 1920, 2128, 2558, 3014 in current HEAD; #90's line numbers are pre-HEAD-drift but refer to the same 4 PUBLISH calls). So the "#90 merges first, Stage 1c threads namespace through" claim is slightly backwards: the Lua PUBLISH sites will **still exist** after #90 (Lua doesn't suddenly stop publishing — the Rust side just consumes through a trait); namespace threading applies to them regardless of whether #90 ships first.
+
+**Required fix.** Rewrite §R6.4's #90-interaction paragraph:
+- Drop "moves the literal into ff-backend-valkey."
+- State correctly: #90 hides the channel behind a trait. Lua PUBLISH sites persist. Namespace prefix applies to the PUBLISH channel name regardless of #90's merge order. #90 and #122 are **concurrent, not sequenced**; whichever merges second rebases over the first.
+
+### #K6: "Hash-tag preservation" encoding is ambiguous and the chosen encoding is not stated crisply
+Draft §R6.2 lines 39-41 gives `tenant_a:ff:exec:{fp:5}:1234…`. Issue #122 body explicitly offers two forms: `{namespace}:ff:...` **or** `ff:{namespace}:...`. The amendment picks the first silently without stating rationale.
+
+Both preserve the hash-tag (Valkey rule: bytes between first `{` and first `}` — neither `tenant_a:` nor `ff:tenant_a:` contains `{`). So the choice is a tooling convention, not a correctness question. But:
+
+- `tenant_a:ff:…` (chosen) makes ops `KEYS *ff:*` a cross-namespace scan — useful for inspection, dangerous for accidents.
+- `ff:tenant_a:…` (rejected) keeps the `ff:` sentinel first, which is friendlier to Redis/Valkey introspection tools that group by first segment.
+
+Neither is wrong. Pick deliberately.
+
+**Required fix.** §R6.2 add one sentence: *"We prepend the namespace BEFORE the `ff:` sentinel (`<ns>:ff:…`) rather than after (`ff:<ns>:…`) so that a single `FLUSHDB`-equivalent scan of one tenant (`SCAN MATCH <ns>:ff:*`) is unambiguous; the alternative `ff:<ns>:…` would require callers to write `SCAN MATCH ff:<ns>:*` which collides with legitimate segment-2 strings like `ff:idx:<ns>:…` under the current wildcard."* OR reverse the choice if the owner prefers the sentinel-first form. Either is defensible; the draft must declare the rationale.
+
+---
+
+## DESERVES-DEBATE
+
+### #KD1: `[A-Za-z0-9_]{1,64}` character set rules out real-world tenant identifiers
+Draft §R6.3 lines 54-55 + §R6.8 Q1 "locked": no dashes, 64-char limit.
+
+**Tradeoff: correctness safety (Postgres unquoted identifier rule) vs. caller ergonomics.**
+
+**Argument A (draft's position): keep locked.**
+- Postgres requires double-quoting identifiers that contain dashes (`SET search_path TO "foo-bar"` vs `SET search_path TO foo_bar`). Unquoted is simpler for the Postgres backend.
+- 64 chars is adequate for human-chosen names.
+- Forcing callers to normalise is a one-time cost.
+
+**Argument B: relax to allow dashes, extend length to 128.**
+- UUIDs are 36 chars and are the natural tenant ID for many systems (including cairn, per `cairn.instance_id` which is ULID-shaped — 26 chars, safe — but other consumers may use full UUIDs with dashes).
+- Subdomain-style names (`acme-prod`, `eu-west-1`) are idiomatic and will force callers to write lossy transforms (`acme-prod` → `acme_prod`).
+- Lossy transforms are dangerous: `acme-prod` and `acme_prod` collapse to the same namespace, silently sharing state.
+- 64 → 128 is free (hash-tag untouched, key-length budget #KD2 barely moved).
+- Postgres double-quoting is a mechanical concern the backend handles once, not a public-API concern.
+
+**Worker K lean: B.** Draft marks this "locked" via verbal owner answer, but the Postgres-unquoted-safe rationale is a backend implementation convenience that bubbles up into an API constraint that real callers will trip on. The better encoding: allow `[A-Za-z0-9_-]{1,128}`, reject leading `-`, backend double-quotes on the SQL side (one-time cost). Escalate to owner.
+
+### #KD2: Key-length budget at 10M+ keys — real concern or non-issue?
+Draft §R6.8 Q10: 80 bytes today + 65 bytes namespace (`<ns>:`) = 145 worst-case.
+
+**Tradeoff: memory cost vs. namespace-length ergonomics.**
+
+**Argument A (non-issue):** Valkey's sds overhead is ~3 bytes/key regardless of length; a 2x key-length increase at 10M keys = +650MB raw key memory. On a cluster sized for 10M executions the dataset is already ~10GB+ (payloads, results, streams); +650MB is ~6% overhead. Acceptable.
+
+**Argument B (concern):** Index ZSETs store keys as members (every exec-id is a key, and every per-exec *index entry* duplicates the hash-tag + ns prefix in its own key name). At 10M execs across 64 partitions with ~20 index sites per exec lifecycle, you hit ~200M ZSET members. 65-byte prefix × 200M = +13GB. That is not 6%.
+
+**Worker K lean:** Argument B is closer to reality for index-heavy deploys. At minimum, Q10's "document a keep-namespace-short operator note" should be tightened to "recommend ≤16 chars; budget 64 for flexibility." And the default validation cap should consider dropping to 32.
+
+Escalate; owner should pick the cap with the 200M-members math in mind.
+
+### #KD3: `Namespace::new("")` returns error — footgun or correct guard?
+Draft §R6.3 line 87, §R6.8 Q3 "locked."
+
+**Argument A (draft): catches bugs.** Caller reads `NAMESPACE` env var, forgets to set it, `.unwrap()`s → loud failure at startup. Better than silent unprefixed running.
+
+**Argument B (footgun): legitimate empty-from-config path.** Caller's config file has an optional `namespace` field; unset = use EMPTY = today's behaviour. Natural code: `Namespace::new(config.namespace.unwrap_or_default())` — now panics on empty config. Forces every caller to write `if s.is_empty() { Namespace::EMPTY } else { Namespace::new(s)? }`.
+
+**Worker K lean: draft is right, but ergonomics need a helper.** Add `Namespace::new_or_empty(s: impl Into<String>) -> Result<Self, NamespaceError>` that maps empty to `EMPTY` without error. Callers who want strict-mode use `new`; callers who want permissive-mode use `new_or_empty`. One extra fn, eliminates the footgun, preserves the guard. Amend §R6.3.
+
+### #KD4: Stage 1a.1 as "silently ignored field" — anti-pattern or staged rollout?
+Draft §R6.4 Stage 1a.1 row lines 114-115: *"Field is plumbed and silently ignored by all current callers."*
+
+**Argument A (anti-pattern):** Callers set `BackendConfig::with_namespace("tenant_a")` expecting isolation. Stage 1a.1 merges. Callers deploy. Keys are still bare-`ff:`. Cross-tenant leak continues. Callers *believe* they are isolated. This is exactly the class of bug the cairn read-layer filter is defense-in-depth AGAINST.
+
+**Argument B (staged rollout, defensible):** Stage 1a.1 is a small infra PR. No caller should be *using* it before Stage 1c. A prominent `#[doc(hidden)]` or explicit "not yet effective; see Stage 1c tracking issue" doc-comment on `with_namespace` mitigates. Unblocks Stage 1c planning without holding up for full keygen work.
+
+**Worker K lean: B is fine IF `with_namespace` is gated.** Options (pick one):
+- `#[doc(hidden)]` until Stage 1c.
+- Runtime warning `tracing::warn!("Namespace is plumbed but not yet effective (Stage 1c pending). Do not rely on this for isolation.")` emitted on first non-EMPTY construction.
+- Make `with_namespace` a `cfg(any())` stub until Stage 1c (landing as one-line-PR in Stage 1c).
+
+Escalate for owner pick. Status-quo v2 ("silently ignored") is the worst of the three.
+
+### #KD5: Rollback hazard documentation placement
+Draft §R6.5 line 139: *"Document prominently in the Stage 1c PR body."*
+
+PR body is ephemeral — anyone reading the code six months later won't see it. Better placements:
+- CHANGELOG entry for the Stage 1c release.
+- `cargo doc` comment on `Namespace` type: "WARNING: rolling back a namespace-bearing deploy to a namespace-ignoring build re-merges all keys into the unprefixed keyspace."
+- Runtime startup warning on any deploy where the running binary's stage is < 1c but `BackendConfig.namespace != EMPTY` — Stage 1a.1 gates this.
+
+Not a correctness question, but documentation-in-PR-body alone is weak.
+
+### #KD6: Round-4 M6 fusion analogy — does it hold?
+Draft §R6.7 #6: *"Same fusion rationale as round-4 M6."*
+
+M6 (parent RFC line 569) fused **Stage 1 trait extraction** with **Stage 2 BackendConfig move** because the round-2 split forced consumers to migrate twice: once to the new trait, once to the new config type. The fusion eliminated a *consumer migration event*.
+
+The amendment invokes M6 to justify fusing namespace-keygen into Stage 1c rather than RFC-013. Is this the same shape?
+
+**Worker K analysis: it's similar but not identical.** M6 was about consumer-side migration events (API call site changes). This amendment is about backend-internal keygen changes that consumers mostly don't see (the surface change is one additive field on `BackendConfig`). The "double migration event" cost is lower here because Stage 1c's keygen is mostly opaque to consumers. What this amendment actually avoids by fusing is **two backfill events for operators** (once for Stage 1c's keygen refactor, once for RFC-013's namespace thread) — and since Stage 1c is the first time keygen is materially refactored post-RFC-011, co-threading namespace at that point is cheaper than re-touching 92 sites later.
+
+The rationale is valid but the analogy mis-attributes the savings. **Fix suggested:** rewrite §R6.7 #6 as: *"Stage 1c already re-touches every `format!(\"ff:…\")` site as part of BackendConfig threading; co-threading namespace in the same pass avoids a second 92-site sweep. Similar in shape to round-4 M6's fusion rationale: avoid redundant migration sweeps when a natural co-touchpoint exists."*
+
+---
+
+## NITS
+
+### #KN1: §R6.2 "Called out explicitly because a naive reading" is weak hedging
+Line 30. Prefer declarative: *"The Valkey Function library is server-global; per-namespace function loads are explicitly rejected (§R6.7 #4)."* Drop the reader-modelling.
+
+### #KN2: §R6.3 `Display` rationale says "config-file emission" but amendment excludes config schema
+Line 88 says "config-file emission" is a `Display` use case. §R6.1 line 21 says config-file format is out-of-scope. Mildly self-contradictory. Prefer: *"`Display` for log/debug only; caller picks serde policy."*
+
+### #KN3: "Scope estimate unchanged in category but wall-time extended"
+§R6.4 Stage 1c row. This wording is squishy — either say "scope +N sites, +Mh" once #K4's full inventory lands, or say "scope to be re-estimated at Stage 1c planning" and commit to a number then. The halfway phrasing invites scope creep.
+
+### #KN4: "FCALL library name" naming inconsistency
+§R6.1 line 17 says `FUNCTION LOAD … "ff"`. §R6.7 #4 says `FUNCTION LOAD "ff_tenant_a"`. Minor: pick `FUNCTION LOAD ff` (no quotes — Valkey syntax is `FUNCTION LOAD <code>` with the library name inside the code's `#!lua name=ff` shebang, not a string arg). Pedantic but the current wording implies a string literal slot that doesn't exist.
+
+### #KN5: §R6.2 hash-tag rule statement
+Line 37: *"Valkey's hash-tag rule extracts bytes between the first `{` and first `}` in the key."* Spec-correct phrasing: *"between the first `{` and the FIRST `}` AFTER it, provided the bracket span is non-empty."* Empty `{}` does not form a hash-tag — if a namespace somehow ended with `{` and the rest started with `}`, the adjacent `{}` would be empty and the whole key would hash to its full byte-sum. Validation regex in the draft prevents this (brace-free), so it's a nit. But the sentence as written misses the empty-span case and is worth tightening.
+
+### #KN6: `NamespaceError` lacks `EmptyInput` constructor helper
+Minor ergonomics: `impl From<&str> for Namespace` would be a natural addition for test/const-context construction. Defer to Stage 1a.1 PR review; not RFC-level.
+
+---
+
+## Affirmative no-finding notes
+
+- **Hash-tag preservation mechanics (§R6.2 lines 37-41):** correct. Validation regex forbids braces; prepending a non-brace string preserves the first-`{`/first-`}` extraction. `crates/ff-core/src/keys.rs:10-14` and surrounding hash_tag comments confirm the invariant holds.
+- **§R6.7 alternative #3 (hash-tag namespacing):** correctly rejected; well-argued.
+- **§R6.7 alternative #5 (`SELECT N`):** correctly rejected on Cluster grounds.
+- **§R6.4 disjointness with #91 and #92:** verified disjoint (file sets don't overlap with `keys.rs`).
+- **Peer-team boundary with cairn's read-layer filter (§R6.1 final sentence + §R6.8 Q6):** correct and well-framed; matches `feedback_peer_team_boundaries.md` memory.
+
+---
+
+## Summary for owner
+
+Fix #K1–#K5 in-place before landing; each has file:line evidence of a factual error in v2. #K6 is a wording fix; pick an encoding and justify.
+
+Debate #KD1 (validation regex — worth revisiting despite the "locked" marker; dashes + UUID-sized namespaces are real-world) and #KD4 (Stage 1a.1 silent-field posture) before Stage 1a.1 opens as a PR.
+
+Nits are optional polish.
+
+Verdict: **CHALLENGE — amendment is not ready to land as v2.** Expect v3 with #K1–#K5 resolved and #KD1/#KD4 explicitly owner-adjudicated.

--- a/rfcs/drafts/RFC-012-amendment-namespace.L-challenge.md
+++ b/rfcs/drafts/RFC-012-amendment-namespace.L-challenge.md
@@ -1,0 +1,201 @@
+# Round-7 CHALLENGE against RFC-012 namespace amendment (draft v3)
+
+**Challenger:** Worker L. Independent adversarial review post-K.
+**Tree head:** `origin/main` `69de6a5`.
+**Scope:** flaws K missed + new flaws v3 introduced. No repetition of K's findings.
+
+Bottom line: v3 resolves K's major factual errors, but the fix for #K1 (ARGV[1] = namespace) was introduced without checking existing ARGV usage in the Lua library. **That claim is wire-breaking.** Several §R6.2.2 counts are also wrong in the other direction from v2 (v3 inflates 83 → 92 with no evidence; miscategorises methods as free functions). Additional cluster-slot, whitespace-input, and Postgres-query realism flaws below.
+
+---
+
+## MUST-FIX
+
+### #L1: v3's `ARGV[1] = namespace_prefix` collides with every existing FCALL's positional ARGV layout
+Draft §R6.2.4 line 68: *"FCALL signatures gain a dedicated ARGV slot carrying the namespace prefix: `ARGV[1] = namespace_prefix`."*
+
+Evidence — every registered Lua function in `crates/ff-script/src/flowfabric.lua` already uses `args[1..N]` as the caller-supplied positional argument array:
+
+- `flowfabric.lua:929-952` `ff_renew_lease`: `args[1]` = execution_id, `args[2]` = attempt_index, `args[3]` = attempt_id, `args[4]` = lease_id, `args[5]` = lease_epoch, `args[6]` = lease_ttl_ms, `args[7]` = lease_history_grace_ms.
+- Same pattern across all 47 `redis.register_function` calls (lines 908, 929, 1049, 1130, 1256, 1560, 1795, 1945, 2148, 2256, 2366, 2579, 2828, 3036, 3149, 3255, 3314, 3381, 3492, 3605, 3872, 3983, 4081, 4293, 4370, 4490, 4547, 4862, 5006, 5180, 5342, 5408, 5489, 5578, 5633, 5703, 5785, 5838, 5931, 6025, 6094, 6205, 6343, 6369, 6467, 6565, 6750, 6793, 6869, 7027…).
+- Rust-side callers in `crates/ff-script/src/functions/*` pack `ARGV` positionally to match. `ff_issue_claim_grant` specifically is documented at `flowfabric.lua:12` as `ARGV[9]`.
+
+Prepending `ARGV[1] = namespace_prefix` shifts **every single positional index** in **every function** AND every Rust caller. That is not "the ARGV-passed prefix" — it is a wire break across the full FCALL surface. The alternative rejected in §R6.2.4 ("move Lua-literal keys into KEYS[]") is correctly rejected, but v3's replacement is under-specified.
+
+**Required fix.** Two options:
+- **(Preferred) Append, don't prepend.** Each FCALL gains a trailing ARGV slot `args[#args]` or a documented fixed-name `NS_ARGV_SLOT` sentinel that callers place at a stable position *per function* (e.g. `args[N+1]` where N is the pre-amendment arg count). State this explicitly in §R6.2.4; forbid `ARGV[1]` shift.
+- **Alternative.** Adopt a `table.remove(args, 1)` shim at the top of every function that pops the prefix, then keeps the rest positional. But that still requires every Rust caller to inject the prefix at index 0 — mechanical but error-prone, and the "caller forgot" failure mode is silent key-path corruption.
+
+Either way, v3 cannot state `ARGV[1] = namespace_prefix` without qualifying that every existing `args[i]` access shifts to `args[i+1]`. Land the fix Stage-1c-atomically (single PR that updates Lua + every Rust caller) or field a grep-gate CI check.
+
+### #L2: §R6.2.2 count table is wrong in the other direction from v2
+Draft §R6.2.2 line 48: *"~92 (was ~83 in issue #122; tree drifted)"*.
+
+Evidence — `grep -c 'format!("ff:' crates/ff-core/src/keys.rs` on HEAD `69de6a5` returns **83**. Not 92. The tree has NOT drifted from the issue's count; v3 invented the 92 figure. K's challenge claimed "92 (not 83)" and v3 adopted that number without re-verifying.
+
+Additionally, §R6.2.2 row 2 lists `waitpoint_hmac_secrets` and `signal_dedup` as **free functions**. They are not:
+- `keys.rs:156`: `pub fn signal_dedup(&self, …)` — **method on `ExecKeyContext`** (receiver `&self`).
+- `keys.rs:275`: `pub fn waitpoint_hmac_secrets(&self) -> String` — **method on `ExecKeyContext`**.
+
+Actual free functions in `keys.rs` (grep `^pub fn`): `budget_attach_key` (471), `budget_resets_key` (476), `budget_policies_index` (482), `quota_policies_index` (535), `quota_attach_key` (540), `lane_config_key` (547), `lane_counts_key` (552), `worker_key` (557), `worker_caps_key` (568), `workers_index_key` (578), `workers_capability_key` (583), `lanes_index_key` (588), `global_config_partitions` (594), `namespace_executions_key` (601), `idempotency_key` (609), `noop_key` (618), `tag_index_key` (623), `waitpoint_key_resolution` (628), `usage_dedup_key` (644) — **19 free functions**, not "~8". V3 under-counts by more than half.
+
+§R6.2.2 row 1 cites `ExecKeyContext::new` at line 26 etc. — these lines are the `impl` block openers (25/210/323/404/437/494), not the `new` definitions (26/211/324/405/438/495). Minor but cites should be precise since the whole table's credibility hinges on exact line refs.
+
+**Required fix.**
+1. Change "~92" to "83" (or re-grep and cite exact, including `grep` incantation).
+2. Move `signal_dedup` and `waitpoint_hmac_secrets` out of the "free functions" row into the "key contexts" row (both are `ExecKeyContext` methods).
+3. Raise the free-function count to 19 and enumerate them, or at minimum change "~8 fns" to "~19 fns" with a note that Stage 1c re-greps.
+4. Fix line cites for `impl` vs `new`.
+
+### #L3: `new_or_empty` permissive claim is leaky on whitespace-only input
+Draft §R6.3 lines 111-114:
+```
+pub fn new_or_empty(s: impl Into<String>) -> Result<Self, NamespaceError> {
+    let s = s.into();
+    if s.is_empty() { Ok(Self::EMPTY) } else { Self::new(s) }
+}
+```
+Draft §R6.3 line 137: *"callers who want permissive-mode use `new_or_empty`."*
+
+Failure case: `Namespace::new_or_empty("   ")`. `"   ".is_empty()` = false. Falls through to `Namespace::new("   ")`, which per the `[A-Za-z0-9_-]{1,64}` regex rejects space character with `NamespaceError::InvalidChar(' ')`. A caller who wrote `Namespace::new_or_empty(std::env::var("NAMESPACE").unwrap_or_default())` and whose operator set `NAMESPACE=" "` (quoted whitespace, common in container env setups) gets an `Err`, not `EMPTY`. Permissive mode is not permissive.
+
+**Required fix.** Either:
+- `new_or_empty` pre-trims: `let s = s.into().trim().to_owned(); if s.is_empty() { EMPTY } else { new(s) }`. Document that whitespace is stripped for permissive mode only.
+- OR state explicitly in §R6.3 that `new_or_empty` is *only* permissive for genuinely empty (zero-length) strings and whitespace-only input errors. Caller is responsible for `.trim()`. The rationale in v3 that claims "eliminates the footgun" is partially false without this clarification.
+
+### #L4: Cluster hash-tag interaction not discussed for keys with no brace
+Draft §R6.2.3 line 60: *"Both forms are correctness-equivalent (Valkey hash-tag extraction between first `{` and first `}` is unaffected by either prefix shape since the validation regex forbids `{`/`}` in the namespace)."*
+
+That reasoning only holds for keys that **have** hash-tags. Not every FF key has braces:
+
+Evidence — `crates/ff-core/src/keys.rs`:
+- `:578-579` `workers_index_key() = "ff:idx:workers"`
+- `:588-589` `lanes_index_key() = "ff:idx:lanes"`
+- `:594-595` `global_config_partitions() = "ff:config:partitions"`
+
+These are global/config keys with no `{…}` hash-tag. Cluster routes them by CRC16 of the entire key. Prefixing with `<ns>:ff:idx:workers` changes the slot. That is **fine for correctness** (each namespace gets its own global key, as intended) but:
+
+1. Cross-cluster migration tool semantics change: `COPY` between differently-slotted keys on Cluster requires same-slot or cross-shard is rejected (`COPY` fails cross-slot on Cluster). The old key `ff:idx:workers` and the new `<ns>:ff:idx:workers` almost certainly hash to different slots.
+2. Any operator SCAN that expected `ff:idx:workers` to be in a known slot breaks.
+3. Future backend design (sharded Postgres) needs to know these keys are namespace-scoped, not cluster-global.
+
+V3 says migration uses `COPY`. `COPY` on Valkey Cluster **fails cross-slot by default** (`-CROSSSLOT` error). Unless the operator manually MIGRATEs the slot first or uses a non-cluster Valkey, the `--i-have-stopped-all-workers + COPY + DEL` recipe doesn't work for the no-hash-tag keys.
+
+**Required fix.**
+1. §R6.2.3 or §R6.2.5 add a subsection: *"No-hash-tag keys (ff:idx:workers, ff:idx:lanes, ff:config:partitions) are renamed but change slot under the namespace prefix. This is correct (per-namespace globals) but affects migration tooling."*
+2. §R6.5 migration-tool section acknowledge that `COPY` on Cluster is slot-bound and DOES NOT work cross-slot for these keys — the tool must either (a) `DUMP`+`RESTORE` through the client or (b) refuse to run against Cluster in v1 and document operator manual-migration for Cluster deploys.
+3. Confirm `COPY` is available in the targeted Valkey minimum version (Valkey 7.2+ / Redis 6.2+). State the min version explicitly.
+
+### #L5: Rollback posture — v3 says keys "stranded under old prefix," but in-flight leases/suspensions are worse than stranded
+Draft §R6.5 line 191: *"deploys that ran with non-EMPTY namespace have their keys stranded under the old prefix, and the rolled-back binary will create new keys under no prefix — if multiple namespaces were sharing the Valkey, they now all collide in the unprefixed keyspace."*
+
+Failure modes v3 doesn't enumerate:
+- **In-flight leases under old prefix.** A worker holding a lease on `<ns>:ff:exec:{fp:5}:EID:lease:current` when the binary is rolled back to a namespace-ignoring build: the rolled-back binary renews/revokes at `ff:exec:{fp:5}:EID:lease:current` (different key). The old lease sits orphaned at TTL (minutes to hours). The new binary sees no lease, potentially re-claims the same execution on another worker — **double-execution risk**, not "stranded".
+- **Suspended executions.** Suspension state at `<ns>:ff:exec:…:suspension:current` is invisible to rolled-back binary. On resume-signal delivery the rolled-back binary finds no suspension record; signal either NACKs or silently drops depending on code path. **Stuck executions**, not "stranded keys".
+- **HMAC-signed waitpoint tokens.** Tokens minted under `<ns>:ff:sec:{p:N}:waitpoint_hmac` fail HMAC validation under `ff:sec:{p:N}:waitpoint_hmac` (different secret key, even if same bytes — key identity matters for the read). All in-flight waitpoints become un-resolvable. User-visible as "resume never fires."
+- **Active-index ZSETs.** Rolled-back binary SCANs `ff:idx:{p:N}:active` and finds nothing (it's under old prefix); workloads that were mid-flight are invisible to operators, and the Valkey memory isn't freed because old keys still have TTL.
+
+**Required fix.** §R6.5 rollback bullet should list these four concrete modes, not just "collide in the unprefixed keyspace." Operators must understand rollback = suspend-all-work + drain + key-migrate, not just "restart."
+
+### #L6: Postgres `information_schema.schemata` claim needs qualification
+Draft §R6.4 Stage 2 line 168: *"`PostgresBackend::connect` verifies pre-existing via `SELECT 1 FROM information_schema.schemata WHERE schema_name = $1` (connection-search-path-agnostic)."*
+
+`information_schema.schemata` is NOT unconditionally connection-search-path-agnostic in the sense implied:
+
+1. `information_schema.schemata` filters by **privilege** — it only returns schemas the current role has USAGE or any non-zero privilege on. A role connecting to check a schema it doesn't yet have USAGE on (e.g. a bootstrap/admin role checking a per-tenant schema owned by another role) will see zero rows even if the schema exists. The result depends on `CREATE SCHEMA … AUTHORIZATION …` history and subsequent `GRANT USAGE`. Not schema existence per se.
+2. Row-Level Security (RLS) doesn't apply to `information_schema`, so not a concern there.
+3. `pg_namespace` (`SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = $1`) is the privilege-independent form and is what PG tools generally use for existence checks.
+
+**Required fix.** Change §R6.4 Stage 2 to `pg_catalog.pg_namespace`, OR document the privilege-coupling explicitly:
+*"Namespace check uses `pg_catalog.pg_namespace` to avoid the `information_schema` privilege filter — we want existence, not 'existence + this role has USAGE'."*
+
+Also state what connection role the check runs as, and whether Stage 2 requires that role to have `pg_read_all_settings`-equivalent visibility.
+
+### #L7: `Namespace` type placement is unspecified
+Draft §R6.3 lists the type but does not say what crate owns it.
+
+Evidence — `BackendConfig` lives in `crates/ff-core/src/backend.rs:611`. If `Namespace` is a sibling type (reasonable), it lives in `ff-core`. `crates/ff-core/Cargo.toml:18` confirms `thiserror = { workspace = true }` is already a dep, so the `#[derive(thiserror::Error)]` on `NamespaceError` compiles. Good — but the RFC doesn't say this, and an implementer reading v3 could put `Namespace` in `ff-sdk` or a new `ff-types` crate.
+
+**Required fix.** §R6.3 add one line: *"`Namespace` and `NamespaceError` live in `ff-core` (alongside `BackendConfig`). `ff-core` already depends on `thiserror` via the workspace."*
+
+Also: `BackendConfig::with_namespace` is called out as an added builder, but `BackendConfig` today has no `with_*` methods — the existing constructor is `BackendConfig::valkey(host, port)`. Confirm the builder pattern is new or adopt `BackendConfig::valkey(...).with_namespace(...)` as the new canonical idiom, and document non-Valkey constructors (future `BackendConfig::postgres(...)`).
+
+---
+
+## DESERVES-DEBATE
+
+### #LD1: `CLIENT SETNAME` / `CLIENT LIST` operator visibility not threaded
+K's #K2 suggested `CLIENT LIST` as a migration-tool liveness detection path. V3 adopted `--i-have-stopped-all-workers` and moved on, but did not address the broader point: a namespaced deployment benefits from workers identifying themselves via `CLIENT SETNAME ff-worker-<namespace>-<wiid>` so operators running `CLIENT LIST` can see which tenant's workers are connected.
+
+Argument A (add): cheap (~1 line per connection setup), gives operators grep-able output, addresses K's migration-tool concern properly.
+Argument B (defer): connection-identification is orthogonal to key namespacing; separate RFC when demand appears.
+
+**Worker L lean: defer, but call out in §R6.6 "does NOT do" so it's a known follow-up and not a silent gap.** Add: *"Does NOT modify CLIENT SETNAME / connection identification. A future RFC may propose per-namespace worker naming for operator CLIENT LIST visibility."*
+
+### #LD2: `usage_dedup_key(hash_tag, dedup_id)` has no `tag` arg — signature change is a break for 4 external call sites
+Draft §R6.2.2 lists `usage_dedup_key` as a free function to thread.
+
+Evidence — `keys.rs:644`: `pub fn usage_dedup_key(hash_tag: &str, dedup_id: &str) -> String`. No `tag` param (unlike `idempotency_key`).
+
+Callers (all must be updated):
+- `crates/ff-sdk/src/task.rs:11,655`
+- `crates/ff-script/src/functions/budget.rs:5,216`
+- `crates/ff-server/src/server.rs:22,1324`
+
+Threading namespace requires either (a) a `namespace: &Namespace` prefix arg added to every signature — 4 call-site breaks, or (b) currying via a context object (e.g. `KeysCtx { namespace }.usage_dedup_key(...)`).
+
+Option (b) is more ergonomic long-term but is a bigger refactor than v3 describes. Option (a) is straightforward but the Stage 1a.1 "add Namespace type" PR should then carry a follow-up signature-break PR in Stage 1c, not try to stay API-compatible via a default-namespace overload.
+
+**Required fix.** §R6.4 Stage 1c row acknowledge that threading namespace through free functions in `ff-core::keys` is a **breaking signature change** (not purely internal). ff-core has no external (non-workspace) users today per the project notes, so acceptable, but worth stating to avoid surprise at PR time. Escalate to owner if strong preference on (a) vs (b).
+
+### #LD3: Stage 1a.0 vs Stage 1a.1 ordering — is the micro-PR actually independent?
+Draft §R6.4 Stage 1a.0 renames `idempotency_key(tag, namespace, idem_key)` → `(tag, idem_domain, idem_key)` BEFORE Stage 1a.1 adds the `Namespace` type.
+
+Rationale in v3 is "avoid reviewer conflation." Reasonable. But:
+- The Stage 1a.0 PR touches every `idempotency_key` caller. Let me grep.
+
+Evidence — `grep -rn "idempotency_key" crates/ --include="*.rs"`: need to check call-site count. V3 says "one-liner cross-crate grep-and-rename" but doesn't cite the number. Implementers should know the count before reviewing "micro-PR" labelling.
+
+**Worker L lean: fine to land as sequenced, but v3 should cite the caller count so the "~1h micro-PR" labelling is verifiable.** Add to §R6.4: *"Stage 1a.0 touches N call sites (grep-verified at Stage 1a.0 planning)."*
+
+---
+
+## NITS
+
+### #LN1: §R6.2.2 "waitpoint_hmac_secrets (:275)" cite is a doc comment, not the fn
+Draft §R6.2.2 row 2 cites `waitpoint_hmac_secrets (:275)`. `keys.rs:275` is the `pub fn waitpoint_hmac_secrets(&self)` line — correct — but it's a method on `ExecKeyContext` (impl block at 25), which v3 already claims to enumerate in row 1. Double-counted across rows. Pick one row.
+
+### #LN2: §R6.2.2 estimates "~13 sites" for Lua-literal keys, but K enumerated 13 explicit line numbers and the total of UNIQUE ff: literal sites in the lua file is 14 (incl. the `ff:noop:` sentinel on 1299/1522 which K already flagged). V3 row 4 says "~13 sites" and row 7 separately lists `ff:noop:` as 2 sites. Split-counting is fine but row 4's "~13" should be a hard number (13 or 14) — the tilde invites drift.
+
+### #LN3: §R6.3 `Namespace::EMPTY` as `const` — `String::new()` is `const fn` as of Rust 1.39, so `Namespace(String::new())` compiles in a const context. Good. But v3 doesn't state MSRV, and some internal workspace crates may still be on older toolchains. Confirm MSRV ≥ 1.39 (trivially yes for modern Rust but call it out since the const declaration is load-bearing for the "Namespace::EMPTY" ergonomic claim).
+
+### #LN4: §R6.8 Q13 "as-shown or adapter?" — v3 answers "as-shown is simpler; adapter is over-engineered." Fair. But then reword as a decision, not a question: *"`new_or_empty` lands as a free method on `Namespace` (not behind a NamespacePolicy adapter). Locked."* Questions that are already answered should graduate out of the "Remaining open" block.
+
+### #LN5: §R6.2.2 header "grep-verified against HEAD `69de6a5`" — several cells in the table are NOT grep-verified (see #L2). Either re-run the greps and update the table, or soften the header to "grep-indicated, re-verified at Stage 1c planning."
+
+---
+
+## Affirmative no-finding notes (on K-raised or newly-checked areas)
+
+- **K's #K1 (Lua transparent claim false):** v3 §R6.2.4 now names the ARGV-plumbing remediation. Fix direction is correct (modulo #L1 collision with existing ARGV layout).
+- **K's #K2 (migration-tool SCAN pattern broken):** v3 §R6.5 replaces the broken `ff:lease:*` pattern with operator-affirmation + correct `<old>:ff:idx:*:lease_expiry` pattern. Clean fix.
+- **K's #K3 (enumerated leak surfaces):** v3 §R6.2.2 adds the inventory table. Structure is correct (modulo #L2 number errors).
+- **K's #K4 (6 key contexts, not 3):** v3 §R6.2.2 row 1 lists all 6. Clean fix (modulo impl-vs-new line cites in #L2).
+- **K's #K5 (#90 interaction):** v3 §R6.4 rewrite is accurate: Lua PUBLISH sites persist; namespace threading applies regardless of merge order.
+- **K's #K6 (encoding rationale):** v3 §R6.2.3 states the rationale explicitly. Clean fix.
+- **K's #KD1 (validation regex):** v3 relaxes to allow `-`, stays at 64 chars. Owner-adjudicated per §R6.8 Q1.
+- **K's #KD3 (new("") error footgun):** v3 adds `new_or_empty`. Direction correct (modulo #L3 whitespace leakage).
+- **K's #KD4 (silent-field anti-pattern):** v3 Stage 1a.1 emits `tracing::warn!`. Clean.
+- **K's #KD5 (rollback hazard placement):** v3 adopts triple-placement (CHANGELOG + rustdoc + startup warn). Clean.
+- **Hash-tag preservation (brace-bearing keys):** still correct. Validation regex forbids `{`/`}` in namespace; prefix preserves first-`{`/first-`}` extraction for all keys that HAVE braces. (The no-brace case is #L4.)
+- **§R6.7 alternatives 1–9:** all correctly framed. Alternative 9 (KEYS[] explosion) is the right rejection.
+- **Interaction with #91 and #92:** still disjoint. No file collisions.
+
+---
+
+## Summary for owner
+
+v3 fixed K's findings well, but introduced #L1 (ARGV index collision — wire-breaking as stated), #L3 (whitespace leak), #L4 (no-brace cluster slot + `COPY` cross-slot), #L5 (rollback in-flight state modes), and #L6 (Postgres `information_schema` privilege filter). #L2 is a factual error — 92 sites does not match the tree; the free-function row both undercounts and miscategorises methods.
+
+#L1 and #L6 are the two that can silently break implementation if left in v3. #L4 and #L5 are documentation/scope gaps that invite operator errors. #L2, #L3, #L7 are fixable in minutes.
+
+Verdict: **CHALLENGE — v3 not ready to land.** Expect v4 with #L1–#L7 resolved and #LD1/#LD2/#LD3 owner-adjudicated.

--- a/rfcs/drafts/RFC-012-amendment-namespace.M-challenge.md
+++ b/rfcs/drafts/RFC-012-amendment-namespace.M-challenge.md
@@ -1,0 +1,407 @@
+# Round-8 CHALLENGE against RFC-012 namespace amendment (draft v4)
+
+**Challenger:** Worker M. Third independent adversarial review; K did round-1 (v2),
+L did round-2 (v3), M does round-3 (v4). Challengers cycled to avoid capture.
+**Tree head:** `origin/main` `2552f5d`.
+**Posture:** pre-1.0, cairn sole consumer, CHANGELOG-only, no BC shims. Bias
+check: v4 dropped the migration tool + rollback + warning gate in response to
+the owner posture clarification. Does it still satisfy correctness properties
+that survive the posture change?
+
+Bottom line: v4 cleaned up K+L findings cleanly, but the **ARGV-append
+mechanism is wire-breaking against three existing Lua functions** that compute
+offsets from `#args` or parity of `#args`. The §R6.2.2 surface inventory also
+undercounts by ~79 `format!("ff:…")` sites living outside `ff-core::keys`
+(ff-engine scanners + ff-sdk + ff-server), which v4 silently omits. Fix
+those plus a small §R6.6 consistency bug and land.
+
+---
+
+## MUST-FIX
+
+### #M1: Appending namespace to ARGV breaks `ff_report_usage_and_check`, `ff_set_execution_tags`, `ff_set_flow_tags`, and the `ff_resolve_dependency` skipped-flow path
+
+v4 §R6.2.4 line 85: *"each FCALL gains a **trailing** ARGV slot carrying the
+namespace prefix. `ARGV[#ARGV]` (the last element) is `namespace_prefix`."*
+
+The append-not-prepend choice is correct for **positional-index-read** functions
+(which is most of the library). But four registered Lua functions compute slots
+from `#args` or require `#args` parity, and the append silently corrupts them:
+
+- `crates/ff-script/src/flowfabric.lua:3042` — `ff_set_execution_tags`:
+  ```lua
+  local n = #args
+  if n == 0 or (n % 2) ~= 0 then
+    return err("invalid_input", "tags must be non-empty even-length key/value pairs")
+  end
+  …
+  redis.call("HSET", K.tags_key, unpack(args))
+  ```
+  Appending namespace makes `#args` odd whenever the caller passed an
+  even-length key/value list. The parity check fails and every tag-set call
+  errors out. Even if the parity check were patched, `unpack(args)` would
+  pass the namespace string as a stray HSET argument, corrupting the hash.
+
+- `crates/ff-script/src/flowfabric.lua:7033` — `ff_set_flow_tags`: identical
+  `n = #args` parity guard + `unpack(args)`.
+
+- `crates/ff-script/src/flowfabric.lua:5489-5499` — `ff_report_usage_and_check`:
+  ```lua
+  local dim_count = require_number(args[1], "dim_count")
+  local now_ms = args[2 * dim_count + 2]
+  local dedup_key = args[2 * dim_count + 3] or ""
+  ```
+  Rust caller builds `[dim_count, dims…, deltas…, now_ms, dedup_key]`
+  (`budget.rs:199-218`). The Lua reads by fixed offset, so appending namespace
+  to `ARGV[#ARGV]` does *not* shift `dedup_key`; dedup still resolves at
+  `2*dim_count+3`. **This one happens to survive**, but only because the Rust
+  caller remains the authority on positions. Flag as "audit required" not
+  "known-safe" — the next edit that adds another trailing optional field to
+  this function will collide.
+
+- `crates/ff-script/src/flowfabric.lua:6919` — `ff_resolve_dependency` skipped-
+  flow branch: `local num_edges = #args - 2`. Appending namespace makes
+  `num_edges` off-by-one high; the loop then reads `args[2 + num_edges]` which
+  is the namespace string, treated as an edge id. Silent correctness bug.
+
+**Required fix.** §R6.2.4 must:
+
+1. Acknowledge the three `#args`-dependent sites by name and state the
+   required remediation: **rewrite each to pop the trailing namespace slot
+   before any `#args` check or `unpack`**. Canonical fix:
+   ```lua
+   local NS = table.remove(args)   -- pops tail, decrements #args
+   -- existing #args / unpack / offset logic continues unchanged
+   ```
+   This restores positional invariants without shifting indices. Forbid any
+   remediation that leaves namespace in-band while computing `#args`.
+
+2. Extend the §R6.2.4 Lua boilerplate example to use `table.remove(args)`
+   rather than `ARGV[#ARGV]` read-in-place, since the read-in-place pattern
+   is only correct for functions that neither iterate nor parity-check
+   `#args`. The uniform pattern is safer as a project rule.
+
+3. Add a Stage 1c test obligation: a CI grep-gate that rejects any new
+   `#args` / `#ARGV` / `unpack(args)` read in the Lua library unless
+   preceded by `table.remove(args)` on the same function-body scope.
+
+Without this, Stage 1c ships with three broken FCALLs.
+
+### #M2: §R6.2.2 surface inventory silently omits ~79 `format!("ff:…")` sites outside `ff-core::keys`
+
+v4 §R6.2.2 lists:
+- 83 `format!("ff:…")` sites in `keys.rs` ✓
+- 4 Rust-literal sites in `ff-script::functions::lease` ✓
+- 13 Lua-literal key sites + 4 PUBLISH sites ✓
+
+Evidence the inventory is incomplete — `grep -rn 'format!("ff:' crates/ff-engine/src/ crates/ff-sdk/src/ crates/ff-server/src/` returns **79 hits** across 15 files:
+
+- `crates/ff-engine/src/budget.rs:56-57`
+- `crates/ff-engine/src/scanner/suspension_timeout.rs:138-180` (multiple)
+- `crates/ff-engine/src/scanner/pending_wp_expiry.rs:131,142`
+- `crates/ff-engine/src/scanner/budget_reconciler.rs:121-123`
+- `crates/ff-engine/src/scanner/index_reconciler.rs:125`
+- `crates/ff-engine/src/scanner/flow_projector.rs:146-148,202`
+- `crates/ff-engine/src/scanner/delayed_promoter.rs:111`
+- `crates/ff-engine/src/scanner/retention_trimmer.rs` (multiple)
+- `crates/ff-engine/src/scanner/{quota_reconciler,lease_expiry,attempt_timeout,dependency_reconciler,budget_reset,unblock}.rs`
+- `crates/ff-sdk/src/worker.rs`
+- Plus `pub const COMPLETION_CHANNEL: &str = "ff:dag:completions"` at
+  `crates/ff-engine/src/completion_listener.rs:43` (subscribe side — must match
+  the namespaced publish name from Lua).
+
+These sites ARE cross-namespace leak surfaces: scanners iterate indices and
+materialise exec/flow/attempt keys by string-formatting bare `ff:` — a
+namespaced deploy will have its scanners reading/writing the unprefixed
+keyspace while its FCALL path writes to the prefixed keyspace. **Split-brain
+at the scanner layer.**
+
+Cairn's read-layer filter (the defense-in-depth referenced in §R6.1) does
+not protect scanner writes — scanners mutate `deps_meta`, `active-index`
+ZSETs, budget-reset hashes, etc. A scanner that reads `ff:idx:{p:N}:…` (bare)
+while FCALLs write `<ns>:ff:idx:{p:N}:…` will reconcile against an empty
+index and drop/rewrite state.
+
+**Required fix.**
+
+1. §R6.2.2 add a row: **"Rust-literal `ff:` sites outside `ff-core::keys` and
+   `ff-script`"** — enumerate the 15 files + ~79 sites, or cite the
+   `grep -rn 'format!("ff:' crates/ff-engine/ crates/ff-sdk/ crates/ff-server/`
+   incantation and count. These must be threaded in Stage 1c or the scanner
+   layer runs unnamespaced.
+
+2. §R6.4 Stage 1c scope extend to name `ff-engine::scanner::*` (13 files) +
+   `ff-engine::budget` + `ff-engine::completion_listener` + `ff-sdk::worker`
+   explicitly. Current wording lists only `keys.rs` + `ff-script` + Lua.
+
+3. Note the subscribe-side invariant for `COMPLETION_CHANNEL`: the engine's
+   SUBSCRIBE must use the namespaced channel name; the Lua PUBLISH (covered
+   in §R6.2.4) namespaces the publish side; both sides must stay in sync or
+   completion events are lost. Currently `completion_listener.rs:43` is a
+   bare `&'static str` constant — it becomes a `&Namespace`-parameterised
+   function call in Stage 1c.
+
+Without this, Stage 1c lands, the invariant §R6.2.1 is declared satisfied,
+and a scanner quietly reads the wrong keyspace in production.
+
+### #M3: §R6.6 `CLIENT SETNAME` follow-up contradicts v4 changelog + posture
+
+v4 changelog line 15 implies the CLIENT SETNAME follow-up is gone
+(v3→v4 removed triple-placement rollback and the whole rollback section,
+and the L-challenge #LD1 landed v3's "out-of-scope callout"). But v4 §R6.6
+line 232-234 still says:
+
+```
+- Does NOT modify `CLIENT SETNAME` / connection identification (see §R6.6 follow-up note below).
+
+**Follow-up not-in-scope:** per-namespace `CLIENT SETNAME ff-worker-<ns>-<wiid>`
+for operator `CLIENT LIST` visibility. Cheap, ~1 line per connection setup.
+Propose as separate RFC/issue when operator demand appears.
+```
+
+Not a correctness bug — but the round-7→round-8 prompt for M specifically
+flagged "v4 dropped the `CLIENT SETNAME` follow-up note entirely (user
+decision)." It did not. §R6.6 still carries the note. Either the owner's
+decision was to *keep* the note (benign) or to *remove* it (then §R6.6
+needs editing). Clarify in v5 or confirm §R6.6 is intended.
+
+**Required fix.** Either delete the §R6.6 follow-up paragraph, or update
+the v3→v4 changelog to accurately state the follow-up note was retained.
+One-line edit either way.
+
+---
+
+## DESERVES-DEBATE
+
+### #MD1: `Namespace::new("")` → `Ok(EMPTY)` vs. `InvalidChar(' ')` for `"   "` — documented but asymmetric
+
+v4 §R6.3 line 169: *"`new("")` → `Ok(EMPTY)`. Whitespace-only input (`"   "`)
+errors via `InvalidChar(' ')` — callers trim their own config input."*
+
+This is fine as a policy. But the rustdoc in §R6.3 (lines 140-150) is thin:
+
+```rust
+/// Construct and validate. Empty input returns `Namespace::EMPTY`
+/// without error — empty is a supported production config, not
+/// a caller bug.
+pub fn new(s: impl Into<String>) -> Result<Self, NamespaceError> {
+```
+
+The doc says "empty input returns EMPTY" but doesn't say "whitespace is NOT
+normalised to empty — `.trim()` is the caller's responsibility." A caller
+reading `env::var("NS").unwrap_or_default()` with `NS=" "` in the env file
+(common container pattern — `NS= ` or `NS="  "` in docker-compose) gets
+`InvalidChar(' ')` unexpectedly.
+
+**Debate.** Two positions:
+
+- **(A, v4's position)** Document the policy in rustdoc and let callers
+  `.trim()` themselves. Simplest. Preserves the "one constructor" posture
+  from L#3 resolution.
+- **(B)** Have `new` pre-`.trim()` silently. Whitespace collapses to empty.
+  One-line change. No asymmetry for callers.
+
+**Worker M lean: A, but rustdoc MUST state the whitespace-is-not-normalised
+rule.** The current rustdoc is "empty is allowed" — implying a caller might
+reasonably expect "empty-after-trim" is also allowed. Fix by appending:
+*"Whitespace-only input is not normalised to empty: `Namespace::new("   ")`
+errors with `InvalidChar(' ')`. Trim caller-provided config before passing."*
+
+Not a correctness bug in v4 — just rustdoc thinness that invited L#3 and
+will invite the same mistake from Stage 1c implementers if unwritten.
+
+### #MD2: No test-strategy commitment for §R6.2.1 isolation invariant
+
+v4 has no §R6.x that says *how Stage 1c will verify two backends with
+different namespaces stay disjoint.* The invariant §R6.2.1 is a correctness
+contract; a correctness contract without a verification commitment is a
+promise on paper.
+
+Natural test: spin two backends `A` (ns=`tenant_a`) and `B` (ns=`tenant_b`)
+against a single Valkey, exercise the full EngineBackend surface on both,
+assert `SCAN MATCH tenant_a:*` and `SCAN MATCH tenant_b:*` are disjoint and
+that `SCAN MATCH ff:*` (bare, unprefixed) is empty.
+
+**Debate.**
+
+- **(A)** Amend §R6.4 Stage 1c row to add a line: *"Integration-test
+  commitment: Stage 1c ships a two-backend disjointness test
+  (`tests/namespace_isolation.rs` in `ff-backend-valkey`) that fails if any
+  key/channel leaks across namespaces."*
+- **(B)** Leave test scope to Stage 1c planning; the RFC doesn't prescribe
+  test details.
+
+**Worker M lean: A.** The invariant is the whole point of the amendment.
+An implementer could satisfy §R6.2.2's threading scope mechanically and
+still miss a leak (cf. #M2's scanner surface). A disjointness test is
+the mechanical verification of the invariant. Commit to it in the RFC,
+not in a follow-up planning doc.
+
+### #MD3: v4 drops migration tool, but cairn's "what happens to my existing `ff:*` data" path is unstated
+
+v4 §R6.5 line 211-212: *"Operators wanting to switch an existing deploy to
+use a namespace: FLUSHDB-equivalent of the relevant partitions + redeploy
+with new `BackendConfig.namespace`. Any in-flight state is lost."*
+
+This is correct for the "switch" case. But cairn's actual path is different:
+cairn is currently running with `namespace=EMPTY` (implicit, because the
+feature doesn't exist yet). When Stage 1c lands, cairn's binary upgrades.
+Their existing data lives at `ff:*`. Do they:
+
+- (a) keep running with `namespace=EMPTY` (byte-identical keys per §R6.2.3),
+  in which case nothing changes — **this is the intended path and v4 is
+  silent that "keep namespace EMPTY" is the zero-migration option**, or
+- (b) adopt a namespace, which requires FLUSHDB — losing their in-flight
+  work.
+
+The CHANGELOG bullet "Existing deploys without a namespace config continue
+producing the same keys (byte-identical)" (v4 §R6.5 line 219) hints at (a)
+but buries it. The §R6.5 prose describes only (b).
+
+**Debate.** Add a §R6.5 lead sentence:
+
+> *"Cairn's zero-migration path: keep `BackendConfig.namespace = EMPTY` (the
+> default). Keys remain byte-identical. Adopting a non-EMPTY namespace is
+> opt-in and requires a keyspace reset."*
+
+or leave cairn's path to the CHANGELOG and the amendment's adoption-
+coordination conversation (peer-team boundary).
+
+**Worker M lean: add the lead sentence.** One sentence. Reassures peer-team
+reviewers (cairn) without crossing the boundary. Current §R6.5 implies
+migration is a FLUSHDB regardless of namespace choice, which is factually
+wrong for the EMPTY-stays-EMPTY case.
+
+---
+
+## NITS
+
+### #MN1: v4 §R6.2.2 row 6 `ff:noop:` audit deferral
+
+Line 60: *"Pre-fix scratchpads (`ff:noop:` sentinel) | `flowfabric.lua:1299,1522` | 2 sites (string-contains check; prefix-aware audit needed)"*.
+
+L already noted this wasn't enumerated crisply. v4 acknowledges "prefix-aware
+audit needed" but doesn't commit to doing it. Either rename the sentinel,
+fix-at-Stage-1c, or strike the "prefix-aware audit needed" parenthetical and
+resolve. Open-ended TODOs in an accepted RFC drift into the implementation
+phase as silent hazards. Nit, not a MUST — Stage 1c planning can audit.
+
+### #MN2: Proposed rename targets (`idem_domain`, `exec_domain`, `tag_domain`) don't exist in the codebase — safe to claim
+
+`grep -rn 'idem_domain\|exec_domain\|tag_domain' crates/` returns empty. The
+proposed Stage 1c renames are collision-free. v4 §R6.2.6 is safe.
+
+### #MN3: `fcall_with_namespace` helper — placement and trait bound not specified
+
+v4 §R6.2.4 line 96: *"a thin helper (`fcall_with_namespace(cmd, keys, args, &namespace)`) centralises the append."*
+
+Today's `ff_function!` macro (`crates/ff-script/src/macros.rs:34-71`) already
+centralises FCALL construction — it builds `argv: Vec<String>` and calls
+`conn.fcall::<Value>(name, &key_refs, &argv_refs)`. Extending the macro to
+append `namespace.as_str()` to every generated `argv` is a **5-line macro
+edit**, which is strictly better than a new free function helper (because
+it catches all callers including the `ff_function!`-generated ones).
+
+The manual FCALL sites (`ff_report_usage_and_check`, the tags functions, one
+in budget_reset) are few enough to edit inline. The `fcall_with_namespace`
+free helper adds a path that manual sites must remember to use; extending
+the macro guarantees generated sites are covered.
+
+**Suggested:** v4 §R6.2.4 should name the macro edit as the primary vehicle
+(`ff_function!` macro appends namespace automatically) and the helper as
+the secondary vehicle (for manual FCALL sites). Minor but clarifies the
+implementation path.
+
+### #MN4: Stage 2 Postgres check — `pg_catalog.pg_namespace` privilege note is fine
+
+v4 §R6.4 line 199 adopts L#6's `pg_catalog.pg_namespace` correction. Per
+Postgres docs, `pg_namespace` is readable by `PUBLIC` (default grant to
+`pg_database_owner` via cluster-bootstrap); the `SELECT 1 FROM pg_namespace
+WHERE nspname = $1` visibility returns rows regardless of USAGE on the
+named schema. Unlike `information_schema.schemata`, it's genuinely
+privilege-independent for existence checks. v4's claim stands.
+
+### #MN5: `Namespace` `new_or_empty` deletion — clean
+
+K#KD3 + L#3 arc closed cleanly. v4 has single `new` constructor + `EMPTY`
+const + `new("")` maps to `Ok(EMPTY)`. The whitespace asymmetry lives (see
+#MD1) but the helper-deletion was right.
+
+---
+
+## Affirmative no-findings (vs prior rounds + new angles)
+
+- **K#K1 (Lua not transparent):** v4 §R6.2.4 now correctly states Lua-side
+  propagation via ARGV tail. Fix direction correct modulo #M1 above (which
+  is a *new* gap in v4's append-direction claim, not a K regression).
+- **K#K2 (migration-tool SCAN pattern broken):** v4 deleted the tool. Fix
+  by removal. Correct per posture.
+- **K#K3 (enumerated leak surfaces):** v4 §R6.2.2 adds inventory table.
+  Structure correct — but #M2 shows inventory is still incomplete beyond
+  K's original enumeration.
+- **K#K4 (6 key contexts, not 3):** v4 lists all 6. Clean.
+- **K#K5 (#90 interaction):** v4 §R6.4 accurately says Lua PUBLISH sites
+  persist; namespace threading applies regardless of merge order. Clean.
+- **K#K6 (encoding rationale):** v4 §R6.2.3 states rationale. Clean.
+- **L#1 (ARGV[1] prepend wire-break):** v4 reverses to append. Fix direction
+  correct. But append introduces #M1's new collision with `#args`-dependent
+  functions — still wire-breaking, just via a different mechanism.
+- **L#2 (count table errors):** v4 corrects to 83 + 19. Line cites still
+  point to `impl` openers rather than `new` defs at some rows (L#LN1-style
+  nit) but v4's table is substantially accurate.
+- **L#3 (whitespace leak in `new_or_empty`):** v4 deletes `new_or_empty`.
+  Clean (modulo #MD1 rustdoc thinness).
+- **L#4 (no-hash-tag cluster-slot):** v4 §R6.2.3 discusses the 3 affected
+  keys explicitly. Greenfield posture acknowledges slot-change is correct.
+  Clean.
+- **L#5 (rollback hazard modes):** v4 deletes the rollback section entirely
+  per posture. Correct per posture; the four hazard modes (double-execution,
+  stuck suspensions, un-resolvable waitpoints, orphaned indices) become
+  CHANGELOG scope rather than RFC scope. Clean.
+- **L#6 (Postgres check):** v4 adopts `pg_catalog.pg_namespace`. Clean.
+- **L#7 (`Namespace` placement):** v4 §R6.3 line 124 names `ff-core`.
+  Clean.
+- **L#LD1 (CLIENT SETNAME):** v4 §R6.6 retains follow-up note. The v3→v4
+  changelog is slightly misleading on this (#M3) but the section itself is
+  consistent with L's preferred resolution.
+- **L#LD2 (`usage_dedup_key`):** v4 §R6.2.2 row 2 lists it as a free fn to
+  thread. Clean.
+- **L#LD3 (Stage 1a.0/1a.1 ordering):** v4 fuses into Stage 1c single
+  landing. Clean per v3→v4 changelog.
+- **Invariant #10 cross-namespace key *value* references:** checked — no
+  FCALL writes an `ff:` key name as the *value* of another key. All cross-
+  key references are reconstructed by Rust/Lua from tag + eid. Namespacing
+  the key does not leak via value embedding. Clean.
+- **`BackendConfig` `#[non_exhaustive]`:** verified at `backend.rs:610`.
+  Struct-literal construction is forbidden cross-crate per Rust reference.
+  v4's additive-field claim stands. Clean.
+- **Proposed rename targets:** no collisions (#MN2). Clean.
+- **ARGV-append via `ff_function!` macro feasibility:** macro at
+  `macros.rs:60` builds `argv: Vec<String>` locally — appending namespace
+  is a one-line edit. v4's "helper centralises the append" claim is
+  realistic (see #MN3 for placement refinement). Clean.
+- **#91 (PartitionKey) interaction:** v4 still says disjoint. Confirmed:
+  PR #91 merged at `2552f5d` on main; touched `contracts.rs` + `partition.rs`
+  + DTOs, not `keys.rs` + Lua. Disjoint holds. Clean.
+
+---
+
+## Summary for owner
+
+v4 is very close. Three MUST-FIX items:
+
+- **#M1** (append collides with `#args`-dependent Lua functions — wire-break,
+  same class as L#1 reversed) — requires §R6.2.4 remediation: mandate
+  `table.remove(args)` pattern, name the three affected functions.
+- **#M2** (§R6.2.2 inventory omits ~79 `format!("ff:…")` sites in ff-engine
+  scanners + ff-sdk + ff-server — scanner split-brain if unthreaded) —
+  requires §R6.2.2 row + §R6.4 Stage 1c scope extension.
+- **#M3** (§R6.6 `CLIENT SETNAME` follow-up contradicts v3→v4 changelog) —
+  one-line consistency fix.
+
+Three DESERVES-DEBATE: #MD1 (whitespace rustdoc), #MD2 (isolation test
+commitment), #MD3 (cairn zero-migration path sentence).
+
+Verdict: **CHALLENGE — v4 not ready to land.** Expect v5 with #M1–#M3
+resolved. If #M1 and #M2 are addressed, the amendment is landable; MD1/MD3
+are RFC-polish, MD2 is a test-scope commitment the owner picks.

--- a/rfcs/drafts/RFC-012-amendment-namespace.P-challenge.md
+++ b/rfcs/drafts/RFC-012-amendment-namespace.P-challenge.md
@@ -1,0 +1,357 @@
+# Round-9 CHALLENGE against RFC-012 namespace amendment (draft v5)
+
+**Challenger:** Worker P. Fourth adversarial review; K/L/M did rounds 1-3.
+**Tree head:** `origin/main` `2552f5d`.
+**Bias note:** disciplined to find only provably wrong items with file:line
+evidence. Affirmed convergence on K/L/M-covered ground; flagged 2 MUST-FIX
+items that three prior rounds missed (one structurally severe), plus 3
+debate items and 4 nits.
+
+Bottom line: **v5 collides head-on with a pre-existing `Namespace` type and
+a pre-existing `namespace` field on `WorkerConfig`.** The RFC proposes a new
+`Namespace` type in `ff-core::backend` with a fallible `new() -> Result`,
+but `ff-core::types` already defines a `Namespace` (via `string_id!` macro)
+with an infallible `new() -> Self`, called from 52 sites. The RFC's §R6.2.6
+also mis-diagnoses the three `namespace`-parameter `keys.rs` functions as a
+naming collision — they are not; they carry exactly the same tenant-scope
+concept that the RFC is introducing at the backend layer. Two layers of
+"namespace" are being threaded past each other. Neither K, L, nor M caught
+this.
+
+---
+
+## MUST-FIX
+
+### #P1: `Namespace` type already exists in `ff-core::types`; v5 §R6.3 would create a duplicate / incompatible definition
+
+Evidence:
+
+- `crates/ff-core/src/types.rs:423-426`:
+  ```rust
+  string_id! {
+      /// Tenant or workspace scope.
+      Namespace
+  }
+  ```
+  The `string_id!` macro (defined at `types.rs:48`) generates
+  `pub struct Namespace(pub String)` with an **infallible** `new(impl Into<String>) -> Self`.
+- `crates/ff-sdk/src/config.rs:1` imports `Namespace` from `ff_core::types`
+  and `crates/ff-sdk/src/config.rs:18` has `pub namespace: Namespace` on
+  `WorkerConfig` — a field with the same name and intended semantics the
+  RFC is trying to introduce at the BackendConfig layer.
+- `crates/ff-sdk/src/config.rs:48`: `namespace: Namespace::new(namespace)` —
+  current call is infallible.
+- `grep -rn 'Namespace::new' crates/ --include="*.rs"` returns **52 call
+  sites**, all using infallible form. Sample: `crates/ff-sdk/src/snapshot.rs:132,460`,
+  `crates/ff-test/tests/e2e_api.rs:133,188,252,328,574,622`,
+  `crates/ff-test/tests/e2e_lifecycle.rs:4279,4867,4955`.
+
+v5 §R6.3 (lines 144-171) proposes:
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct Namespace(String);  // private inner, not pub String
+impl Namespace {
+    pub const EMPTY: Namespace = Namespace(String::new());
+    pub fn new(s: impl Into<String>) -> Result<Self, NamespaceError> { ... }
+    ...
+}
+```
+
+This definition is **incompatible with the existing `Namespace`** on four
+axes:
+
+1. Inner field `String` is **private** vs existing `pub String`.
+2. `new` returns `Result<Self, NamespaceError>` vs existing `Self`.
+3. No `EMPTY` const today.
+4. Validation (charset, leading-`-`, length) is net-new; the existing
+   `string_id!` type accepts any `Into<String>`.
+
+v5 never states whether this is a replacement of the existing type or a
+new type. If replacement: 52 call sites break (all 52 must now handle
+`Result`). If new-type-alongside: naming collision forces a disambiguating
+alias somewhere and leaves the codebase with two `Namespace`s.
+
+**Required fix.** v5 must explicitly state one of:
+
+- **(a) Replace in place.** The existing `string_id! { Namespace }` at
+  `types.rs:423` is deleted; the new type moves to `ff-core::types` (not
+  `ff-core::backend`); all 52 sites migrate to `Namespace::new(s)?` or
+  `Namespace::new(s).expect(...)` with documented policy. Stage 1c scope
+  grows accordingly (52 sites, trivial mechanical but breaking).
+- **(b) Relocate the new type.** Rename the proposed backend-layer type to
+  something like `KeyPrefix` or `BackendNamespace` to avoid the collision.
+  But this is worse — the concept IS the same, and two types with the same
+  semantic concern is debt.
+- **(c) Extend the existing type.** Add validation + `EMPTY` + `Result`
+  variant to the existing `Namespace`; keep inner as `pub String` for
+  zero-break on field access, or migrate to accessor. Document on
+  `string_id!` macro that `Namespace` is special-cased.
+
+**(a) is the cleanest; v5 §R6.3 must say which.** Currently the RFC is
+silent on the pre-existing type — a Stage 1c implementer will collide on
+the first `use` statement.
+
+### #P2: §R6.2.6 "naming collision" mis-diagnosis — the three `namespace` parameters already are the namespace
+
+Evidence:
+
+- `crates/ff-core/src/keys.rs:601-602`:
+  ```rust
+  pub fn namespace_executions_key(namespace: &str) -> String {
+      format!("ff:ns:{}:executions", namespace)
+  }
+  ```
+- `crates/ff-core/src/keys.rs:609-610`:
+  ```rust
+  pub fn idempotency_key(tag: &str, namespace: &str, idem_key: &str) -> String {
+      format!("ff:idem:{}:{}:{}", tag, namespace, idem_key)
+  }
+  ```
+- `crates/ff-core/src/keys.rs:622-624`: `tag_index_key(namespace, key, value)` → `ff:tag:<namespace>:<key>:<value>`.
+- Call sites: `crates/ff-script/src/functions/execution.rs:184` calls
+  `ff_core::keys::idempotency_key(k.ctx.hash_tag(), args.namespace.as_str(), ik)`
+  where `args.namespace` is the **existing `Namespace`** from `ff-core::types`.
+  `crates/ff-server/src/server.rs:604` same pattern.
+
+These three functions are not "parameters accidentally sharing a name with
+the new `Namespace` type." They **already carry the existing tenant
+`Namespace`** (passed as `&str` via `as_str()`). The key format already
+embeds namespace in the key path (`ff:ns:<ns>:executions`,
+`ff:idem:{tag}:<ns>:<ik>`, `ff:tag:<ns>:<k>:<v>`).
+
+v5 §R6.2.6 proposes renaming these to `_domain` on the grounds that "the
+`Namespace` type we're adding" is different. But the concept is not
+different — both are tenant/workspace scope. The RFC is effectively
+proposing two parallel tenant-scoping mechanisms:
+
+- Application-layer: embedded mid-key (`ff:ns:<appns>:executions`), already
+  shipped.
+- Backend-layer: prepended (`<beNS>:ff:…`), net-new.
+
+This is a structural question the RFC must resolve, not a naming one.
+Options:
+
+- **Merge:** backend-layer namespace subsumes the application-layer one;
+  drop the mid-key `<ns>` segment from the three free functions (keys
+  become `ff:executions`, `ff:idem:{tag}:<ik>`, `ff:tag:<k>:<v>`) and rely
+  entirely on the `<ns>:` prefix. Breaking change to key format on top of
+  the breaking change already planned. Migration impact: **every idem key,
+  every tag index, every executions set** repoints.
+- **Keep both:** accept two redundant layers of namespacing. Confusing; v5
+  silently adopts this by proposing the `_domain` rename to paper over it.
+- **Drop the new backend-layer namespace in favour of tightening the
+  existing one:** i.e. the existing application namespace is *enough* if
+  also prepended to all keys/channels. No new type, no `BackendConfig`
+  field; instead `BackendConfig` takes an existing `Namespace` and
+  `ff-core::keys` free functions stop embedding `<ns>` mid-key and instead
+  return `<ns>:ff:…` form. This is closer to (merge) and avoids the P1
+  collision.
+
+**Required fix.** v5 must pick and justify one of the above. "Rename to
+`_domain`" hides the structural question. If the answer is "keep both
+layers," §R6.1 needs a paragraph explaining *why* (e.g. application ns
+needed for cross-backend user-visible naming while backend ns is for
+multi-tenant physical isolation — I don't find this convincing but the
+RFC should argue it).
+
+The cleanest answer is **merge**: one `Namespace`, one prefix, drop the
+mid-key embedding. But that's Stage 1c scope the RFC hasn't costed.
+
+---
+
+## DESERVES-DEBATE
+
+### #PD1: `ff-sdk/src/worker.rs:201` SET of `ff:worker:<id>:alive` is a writer, not just a reader
+
+v5 §R6.2.2 row 4 lists `ff-sdk/src/worker.rs` under **readers** ("79 `format!` sites
+are readers; without threading, scanners iterate bare `ff:` while FCALLs
+write `<ns>:ff:`"). But:
+
+- `crates/ff-sdk/src/worker.rs:201`: `let alive_key = format!("ff:worker:{}:alive", config.worker_instance_id);`
+- `crates/ff-sdk/src/worker.rs:203-209`: this is a `SET ... NX PX` — a **write**, with
+  a uniqueness check keyed on the bare key.
+
+If two deploys A and B share Valkey with namespace prefixes but this key
+stays bare, an alive-key collision between a tenant A worker and a tenant
+B worker claiming the same `worker_instance_id` produces a bogus
+"duplicate worker_instance_id" error in B when A is actually in a
+different namespace. Threading fixes it; omitting breaks tenant isolation
+for worker identity.
+
+**Debate.** Either:
+- (A) Reclassify the worker.rs hit as "writer site, same remediation as
+  readers." Correct.
+- (B) Explicitly declare `worker_instance_id` uniqueness is deploy-global
+  not namespace-scoped (weird, but defensible if operators allocate IDs
+  centrally).
+
+**Lean: (A).** The §R6.2.1 invariant says "every persistent key A writes is
+disjoint from B's." This SET is a persistent key. v5's reader-only framing
+of the 79 sites mis-describes this one.
+
+### #PD2: Isolation test must include same-flow_id cross-namespace cancel_flow case
+
+v5 §R6.5 lists: claim-to-complete, suspend-resume, budget report, waitpoint
+HMAC resolve, stream read, cancel_flow — but does not require the
+adversarial case.
+
+`crates/ff-script/src/flowfabric.lua:6205` `ff_cancel_flow` is keyed on
+`fp:N` hash-tag + flow_id. If two tenants independently generate the same
+flow_id (UUIDs collide with probability ~0 but string-shaped test IDs
+collide at probability 1: `"flow-1"` is a realistic test fixture), the
+test should prove cancel on A does not affect B.
+
+**Debate.** Add to §R6.5's test slice: "Same flow_id `flow-1` created in
+both A and B; assert `A.cancel_flow("flow-1")` does not cancel B's
+flow-1." One extra assertion; materially demonstrates the invariant where
+it's easiest to get wrong.
+
+### #PD3: Caller-owned serde of `Namespace` is unreachable — inner String is private
+
+v5 §R6.6: *"No Serialize/Deserialize in this amendment. Caller owns config
+serde."*
+
+But v5 §R6.3 makes inner `String` private (`pub struct Namespace(String);`
+line 145) and the only constructor is `pub fn new(s: impl Into<String>)`.
+A caller crate (e.g. cairn) implementing serde for their own config
+struct *containing* a `Namespace` can use
+`#[serde(try_from = "String")]` — but that requires `impl TryFrom<String>
+for Namespace` in **the defining crate** (Rust orphan rule forbids the
+caller). v5 doesn't list this impl.
+
+**Debate.** Either:
+- (A) Add `impl TryFrom<String> for Namespace` (and `TryFrom<&str>`) in
+  §R6.3. Two lines. Enables caller-owned serde without new crate deps.
+- (B) Add optional `serde` feature on ff-core for `Namespace`
+  `Serialize`/`Deserialize`. Feature-gated; zero runtime cost if off.
+  Arguably violates the "caller owns serde" posture but actually enables
+  it.
+
+**Lean: (A).** Minimal surface; keeps serde posture; makes the RFC
+internally consistent.
+
+---
+
+## NITS
+
+### #PN1: CHANGELOG path undefined
+
+`ls /home/ubuntu/FlowFabric/CHANGELOG*` returns no file (verified). v5
+§R6.5 commits to "CHANGELOG entry accompanying the Stage 1c release" but
+the file doesn't exist. Either a new commitment to create it (in what
+path? workspace root? per-crate?), or a misreference to the PR body /
+release-notes convention.
+
+**Suggested:** §R6.5 CHANGELOG paragraph should name the file path
+(e.g. `CHANGELOG.md` at workspace root) and state whether this is a
+new file or an existing one. One-line clarification.
+
+### #PN2: `Namespace::default()` via `#[derive(Default)]` equals `EMPTY` — confirmed consistent
+
+v5 §R6.3 line 144 derives `Default`. `String::default()` is `""`, so
+`Namespace::default() == Namespace(String::new()) == Namespace::EMPTY`.
+Consistent with `BackendConfig.namespace` field defaulting to `EMPTY` when
+the struct-level default is taken. Clean.
+
+(No fix — affirmative confirmation that one possible concern resolves
+correctly.)
+
+### #PN3: `table.remove(args)` is legal against Valkey Function `args` — confirmed
+
+Valkey Function callbacks receive `args` as a plain Lua table via
+`redis.register_function('name', function(keys, args) ... end)`
+(`flowfabric.lua:908` and similar). Unlike the global `ARGV` in
+`EVAL`-style scripts, this `args` table is a regular Lua table and
+supports mutation. `table.remove(args)` is safe.
+
+Prompt angle #1 concern is resolved — not a finding.
+
+### #PN4: `#[non_exhaustive]` on `BackendConfig` does NOT block within-crate struct literals
+
+v5 assumes additive `namespace` field is safe via `#[non_exhaustive]` at
+`backend.rs:610`. Confirmed: cross-crate struct-literal construction is
+forbidden, but **within ff-core** struct literals still compile. Only
+intra-crate construction site today is `backend.rs:621-626`:
+
+```rust
+pub fn valkey(host: ..., port: u16) -> Self {
+    Self { connection: ..., timeouts: ..., retry: ... }
+}
+```
+
+Adding `namespace: Namespace::EMPTY` to that literal is a one-line edit.
+No other in-crate construction. Test at `backend.rs:832` uses the
+`valkey()` factory. Additive claim stands. Clean.
+
+---
+
+## Affirmative no-findings
+
+- **K/L/M findings all addressed:** v5 changelog correctly reflects the
+  round-3 M fixes. Prior convergence is genuine.
+- **Lua `table.remove(args)` semantics:** safe per #PN3.
+- **`#[derive(Default)]` on `Namespace`:** consistent per #PN2.
+- **`#[non_exhaustive]` on `BackendConfig`:** correct per #PN4.
+- **Two-backend harness feasibility:** `ValkeyBackend::connect(config)` at
+  `crates/ff-backend-valkey/src/lib.rs:82` takes a `BackendConfig`,
+  instantiates a fresh `ferriskey::Client`; nothing prevents two
+  `ValkeyBackend` against the same Valkey. §R6.5 test is buildable
+  against today's harness. No prerequisite.
+- **Cairn zero-migration claim:** verified. Cairn's path through
+  `FlowFabricWorker::connect` (`ff-sdk/src/worker.rs:120`) takes
+  `WorkerConfig`, not `BackendConfig`. Today the BackendConfig is
+  synthesised internally (see `connect_with` at `worker.rs:503`). If
+  `BackendConfig.namespace` defaults to `EMPTY`, cairn is byte-identical.
+  Clean. Noting in #P1 that the *existing* `WorkerConfig.namespace` is
+  already tenant-scoped, cairn is already doing per-tenant deploys
+  through that — which raises the #P2 "two-layer" question.
+- **CompletionListener subscribe side:** M#2 already flagged; v5 adds the
+  79 reader sites. `ff-engine/src/completion_listener.rs:43` `COMPLETION_CHANNEL`
+  const is in scope for threading per v5 §R6.4 (covered by "ff-engine
+  scanners + ff-engine/budget.rs + ff-sdk/worker.rs" — but
+  `completion_listener.rs` is neither a scanner nor budget.rs nor
+  worker.rs. Falls through the list. **Almost-finding**: check whether
+  M#2's enumeration absorbed it or if v5 §R6.4 silently omitted it.)
+
+### #PN5 (follow-on to last bullet): `completion_listener.rs` not named in v5 Stage 1c scope
+
+v5 §R6.4 Stage 1c row lists "79 `format!("ff:…")` reader sites in
+`ff-engine` scanners + `ff-engine/budget.rs` + `ff-sdk/worker.rs`." But
+`crates/ff-engine/src/completion_listener.rs:43` has
+`pub const COMPLETION_CHANNEL: &str = "ff:dag:completions";` and is a
+SUBSCRIBE writer/reader pair with the Lua PUBLISH side. M#2's inventory
+flagged it as a required site; v5's §R6.4 wording drops it from the
+scope summary even though it's arguably in §R6.2.2's row 5 (4 PUBLISH
+sites) by symmetry.
+
+Not a must-fix (Stage 1c planner will grep and find it), but the Stage
+1c scope sentence in §R6.4 should name it explicitly: "... + `ff-sdk/worker.rs`
++ `ff-engine/completion_listener.rs` (SUBSCRIBE side of the Lua PUBLISH)".
+
+---
+
+## Summary for owner
+
+Two MUST-FIX items, both structural and missed by K/L/M:
+
+- **#P1** — `Namespace` already exists in `ff-core::types` with
+  incompatible API; 52 call sites. v5 §R6.3 proposes a conflicting type
+  without acknowledging the pre-existing one. RFC must pick replace /
+  relocate / extend explicitly.
+- **#P2** — Three `keys.rs` functions already embed tenant namespace
+  mid-key (`ff:ns:<ns>:executions`, `ff:idem:{tag}:<ns>:<ik>`,
+  `ff:tag:<ns>:<k>:<v>`). §R6.2.6's "rename to `_domain`" mis-diagnoses
+  this as a naming clash. It's a structural two-layer overlap. Pick
+  merge / keep-both / drop-new-layer with justification.
+
+Three DESERVES-DEBATE: #PD1 (reclassify SDK worker.rs as writer), #PD2
+(adversarial same-flow_id case), #PD3 (TryFrom for serde).
+
+Five NITS: #PN1 (CHANGELOG path), #PN2-#PN4 (affirmative confirmations
+of edge cases the RFC got right), #PN5 (completion_listener.rs missing
+from scope sentence).
+
+Verdict: **CHALLENGE — v5 not ready.** #P1 and #P2 are structural; the
+amendment can't land without resolving the two-Namespace-types question
+and the two-layers-of-namespacing question. Everything else is polish.

--- a/rfcs/drafts/RFC-012-amendment-namespace.md
+++ b/rfcs/drafts/RFC-012-amendment-namespace.md
@@ -1,0 +1,308 @@
+# RFC-012 — Round-6 amendment (DRAFT v5): namespace prefix on `BackendConfig`
+
+**Status:** DRAFT v5. Three rounds of challenger review (K, L, M) applied. Pre-1.0 posture locked by owner: CHANGELOG-only communication, no BC shims, no migration tool.
+**Tracks:** issue #122 (namespace prefix hook).
+**Shape:** additive to trait surface (`BackendConfig.namespace` field); breaking to `ff-core::keys` function signatures; breaking to FCALL ARGV layout (append + pop — see §R6.2.4).
+
+**v4 → v5 changelog (addresses round-3 M findings):**
+- **#M1 fix:** ARGV-append mechanism now specifies `local NS = table.remove(args)` at function entry, not `ARGV[#ARGV]` read-in-place. Three Lua functions (`ff_set_execution_tags`, `ff_set_flow_tags`, `ff_resolve_dependency`) iterate `#args` and `unpack(args)` variadically; leaving the prefix on the tail silently shifts their parity counts. `table.remove` restores `#args` before the existing bodies run.
+- **#M2 fix:** Inventory extended — 79 additional `format!("ff:…")` sites outside `ff-core::keys` across 15 files (all 13 `ff-engine/src/scanner/*`, `ff-engine/budget.rs`, `ff-sdk/worker.rs`). These are **readers**; without threading, scanners iterate bare `ff:` while FCALLs write `<ns>:ff:`, producing silent split-brain on namespaced deploys. Stage 1c scope extends accordingly.
+- **#M3 fix:** Dropped the `CLIENT SETNAME` follow-up note in §R6.6 (owner: not currently needed, not on backlog until requested).
+- **#MD1:** Rustdoc on `Namespace::new` now explicitly documents the `""→EMPTY` vs `"   "→InvalidChar` asymmetry.
+- **#MD2:** §R6.5 commits to a two-backend-same-Valkey isolation property test as Stage 1c acceptance gate.
+- **#MD3:** §R6.1 now explicitly calls out the cairn zero-migration path (`EMPTY` default = byte-identical = no config change required).
+
+---
+
+## §R6.1 Motivation
+
+Multiple logical FF instances sharing one Valkey backend observe each other's state. Mechanisms:
+
+- `ff_core::keys` emits every key as bare `ff:…`. No prefix hook. 83 format sites in `keys.rs`.
+- `flowfabric.lua` and `ff-script::functions::lease` construct keys/channels inline; 13 Lua-literal key sites + 4 Lua `PUBLISH` sites + 4 Rust-literal sites in `ff-script`.
+- Subscribers iterate `SCAN MATCH ff:idx:*` — matches every tenant.
+- Valkey Function library (`FUNCTION LOAD ff`) is server-global — stateless code; not a leak surface (§R6.7 #4).
+
+Cairn ships a read-layer `cairn.instance_id` exec-tag filter as immediate mitigation. This amendment is the storage-layer complement. We do not coordinate cairn's removal of the filter (peer-team boundary).
+
+**Cairn zero-migration path.** `BackendConfig.namespace` defaults to `Namespace::EMPTY`. Deploys that do not set the field produce byte-identical keys, channels, and wire bytes to today — including cairn's current deploy. Cairn opts into isolation only when they explicitly set a non-empty namespace in their next release; until then their existing data and in-flight executions are undisturbed. No forced migration event.
+
+**Stability posture.** Pre-1.0. Cairn is the only external consumer. Breaking changes land freely; CHANGELOG entry is the migration contract. No BC shims, no deprecation windows, no in-place migration tooling.
+
+Out of scope: env-var parsing, config-file schema, online data migration, backward compatibility of any kind.
+
+## §R6.2 Contract
+
+### §R6.2.1 Invariant
+
+Every `EngineBackend` implementation carries `namespace: Namespace` at construction. For two backend instances `A` and `B` with `A.namespace != B.namespace`:
+
+- Every persistent key/row/object `A` writes is disjoint from `B`'s.
+- Every pubsub/notification channel `A` publishes on is disjoint from `B`'s.
+- Every SCAN/range pattern `A` uses is scoped to `A`'s namespace.
+
+Empty namespace = today's behaviour (no prefix). `EMPTY` is a valid, supported value.
+
+### §R6.2.2 Covered surfaces (grep-verified against `origin/main` `69de6a5`)
+
+Verification: `grep -c 'format!("ff:' crates/ff-core/src/keys.rs` = 83.
+
+| Surface | Location | Count |
+|---------|----------|-------|
+| Key contexts (methods on these types) | `ExecKeyContext` (`keys.rs:25`; `new` at `:26`, incl. `signal_dedup` `:156`, `waitpoint_hmac_secrets` `:275`, and all other `&self` methods), `IndexKeys` (`:210`; `new` `:211`), `FlowKeyContext` (`:323`; `new` `:324`), `FlowIndexKeys` (`:404`; `new` `:405`), `BudgetKeyContext` (`:437`; `new` `:438`), `QuotaKeyContext` (`:494`; `new` `:495`) | 6 structs |
+| Free functions in `ff-core::keys` | `budget_attach_key` (471), `budget_resets_key` (476), `budget_policies_index` (482), `quota_policies_index` (535), `quota_attach_key` (540), `lane_config_key` (547), `lane_counts_key` (552), `worker_key` (557), `worker_caps_key` (568), `workers_index_key` (578), `workers_capability_key` (583), `lanes_index_key` (588), `global_config_partitions` (594), `namespace_executions_key` (601), `idempotency_key` (609), `noop_key` (618), `tag_index_key` (623), `waitpoint_key_resolution` (628), `usage_dedup_key` (644) | 19 fns |
+| `format!("ff:…")` sites in `keys.rs` | — | 83 |
+| Rust-literal `ff:` in `ff-script` | `ff-script::functions::lease:97,121,138-139` | 4 sites |
+| Rust-literal `ff:` reader sites (scanner + SDK) | All 13 `ff-engine/src/scanner/*.rs`, `ff-engine/src/budget.rs`, `ff-sdk/src/worker.rs` (grep: `grep -rn 'format!("ff:' crates/ff-engine crates/ff-sdk crates/ff-server`) | 79 sites / 15 files |
+| Lua-literal `ff:…` key sites | `flowfabric.lua:476,1663,1994-1995,2669,2678,2714,2794,2894,2942-2958` | 13 sites |
+| Lua-literal `ff:dag:completions` PUBLISH | `flowfabric.lua:1920,2128,2558,3014` | 4 sites |
+| Pre-fix scratchpads (`ff:noop:` sentinel) | `flowfabric.lua:1299,1522` | 2 sites (string-contains check; prefix-aware audit needed) |
+| SCAN patterns | audit via grep at Stage 1c start | — |
+
+### §R6.2.3 Prefix encoding
+
+**Chosen form: `<namespace>:ff:…`** (namespace prepended before the `ff:` sentinel).
+
+Rationale: single-tenant inspection scan is unambiguous as `SCAN MATCH <ns>:ff:*`. The alternative `ff:<ns>:…` collides with existing segment-2 names (`idx`, `sec`, `idem`, etc.) and forces brittle SCAN patterns. Both forms are correctness-equivalent.
+
+**Empty namespace** produces no leading colon — byte-identical to today's keys.
+
+**Brace-bearing keys (`{fp:N}` etc.) preserve their hash-tag.** Valkey extracts bytes between first `{` and first `}`; the validation regex forbids `{`/`}` in the namespace; prepending preserves the extraction. Cluster slot routing for partitioned keys is unchanged.
+
+**No-hash-tag keys change Cluster slot.** The following keys have no brace and are routed by CRC16 of the whole key:
+
+- `ff:idx:workers` (`keys.rs:578`)
+- `ff:idx:lanes` (`keys.rs:588`)
+- `ff:config:partitions` (`keys.rs:594`)
+
+Under the prefix, `<ns>:ff:idx:workers` hashes to a different slot than the unprefixed form. This is **correct** — per-namespace globals should route independently — but operators doing ad-hoc `CLIENT GETKEYS` or SCAN slot assumptions should know. No migration path is offered (greenfield posture).
+
+### §R6.2.4 Lua-side propagation — append, don't prepend
+
+Rust-side keygen owns the prefix for keys passed via `KEYS[]`. Lua inline key constructions and `PUBLISH` channel names construct strings locally and must be threaded.
+
+**Mechanism:** each FCALL gains a **trailing** ARGV slot carrying the namespace prefix. Lua functions **pop** the prefix before consuming remaining args:
+
+```lua
+-- At function entry, BEFORE any args[i] / #args read:
+local NS = table.remove(args)   -- pops the tail; #args is now back to pre-amendment value
+-- ... existing args[1..N] consumption unchanged ...
+redis.call("PUBLISH", NS .. "ff:dag:completions", payload)
+local att_key = NS .. "ff:attempt:" .. tag .. ":" .. eid .. ":" .. idx
+```
+
+**Pop, not read-in-place (round-3 M fix).** `ARGV[#ARGV]` read-in-place would silently break FCALLs that iterate variadic trailing args:
+
+- `ff_set_execution_tags` (`flowfabric.lua:3042`) — `n = #args` parity check + `unpack(args)` into HSET
+- `ff_set_flow_tags` (`flowfabric.lua:7033`) — same pattern
+- `ff_resolve_dependency` (`flowfabric.lua:6919`) — `num_edges = #args - 2`
+
+For these, leaving `namespace_prefix` on the tail poisons `#args` and `unpack`. `table.remove(args)` pops the tail and restores `#args` to its pre-amendment value; the existing variadic-consumer bodies then run unchanged.
+
+**Append, not prepend.** Prepending at ARGV[1] would shift every positional index in every registered function — 47 `redis.register_function` sites and every Rust caller. Appending + popping leaves existing positional indexing untouched.
+
+**Rust-side:** every FCALL caller in `ff-script` appends `namespace.as_str()` as the final ARGV element. A thin helper (`fcall_with_namespace(cmd, keys, args, &namespace)`) centralises the append to reduce per-site error surface.
+
+**Alternative rejected:** moving Lua-literal keys into Rust-built `KEYS[]`. Explodes `KEYS[]` cardinality; Valkey Cluster requires all `KEYS[]` entries to hash to one slot; multi-partition FCALLs would break.
+
+### §R6.2.5 Exclusions
+
+- **Valkey Function library (`FUNCTION LOAD ff`):** server-global; library is stateless code; per-namespace loads rejected in §R6.7 #4.
+- **FCALL latency / CPU contention:** not a correctness boundary.
+- **Intra-namespace multi-tenancy:** application-level concern.
+
+### §R6.2.6 Naming collisions to resolve
+
+Three `ff-core::keys` free functions take an argument literally named `namespace`, for execution-domain idempotency / tag-scoping purposes unrelated to the `Namespace` type we're adding:
+
+- `idempotency_key(tag, namespace, idem_key)` (`keys.rs:609`)
+- `namespace_executions_key(namespace)` (`keys.rs:601`)
+- `tag_index_key(namespace, key, value)` (`keys.rs:623`)
+
+Rename these parameters in Stage 1c (not as a prep PR — just do it as the first commit in the Stage 1c PR, alongside the signature threading). Proposed:
+
+- `idempotency_key(tag, idem_domain, idem_key)`
+- `namespace_executions_key(exec_domain)` — or rename the whole fn since "namespace" is now ambiguous
+- `tag_index_key(tag_domain, key, value)`
+
+Final names set at Stage 1c review; this amendment just flags that the renames must happen in the same commit that introduces the `Namespace` arg, to avoid reviewer conflation.
+
+## §R6.3 Type surface
+
+`Namespace` and `NamespaceError` live in **`ff-core`**, alongside `BackendConfig` (`crates/ff-core/src/backend.rs`). `ff-core` already depends on `thiserror` via workspace (`Cargo.toml:18`); no new crate deps.
+
+```rust
+/// Opaque namespace identifier threaded through every backend
+/// key-derivation and pubsub-channel site. Empty = no prefix.
+///
+/// Validation: `[A-Za-z0-9_-]{1,64}`, no leading `-`.
+///   - `-` allowed: UUID/ULID-shaped tenant IDs are common.
+///   - No leading `-`: Postgres identifier convention (backend
+///     double-quotes on the SQL side).
+///   - No `:`: parse ambiguity with key segments.
+///   - No `{`/`}`: Valkey hash-tag collision.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct Namespace(String);
+
+impl Namespace {
+    /// Empty namespace — no prefix. Supported, valid value.
+    pub const EMPTY: Namespace = Namespace(String::new());
+
+    /// Construct and validate.
+    ///
+    /// - `new("")` → `Ok(EMPTY)`. Empty is a supported production
+    ///   config (no-prefix deploy), not a caller bug.
+    /// - `new("   ")` → `Err(InvalidChar(' '))`. Whitespace-only
+    ///   input is NOT normalised to empty — callers are responsible
+    ///   for trimming their own config input. This asymmetry is
+    ///   intentional: an operator who explicitly sets
+    ///   `NAMESPACE=" "` has made a config error, not opted into
+    ///   no-prefix.
+    /// - Any other input is validated against `[A-Za-z0-9_-]{1,64}`
+    ///   with no leading `-`.
+    pub fn new(s: impl Into<String>) -> Result<Self, NamespaceError> {
+        let s = s.into();
+        if s.is_empty() { return Ok(Self::EMPTY); }
+        // ... length + char validation ...
+    }
+
+    pub fn as_str(&self) -> &str { &self.0 }
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+}
+
+impl fmt::Display for Namespace { /* emits as_str, log/debug only */ }
+
+#[derive(Debug, thiserror::Error)]
+pub enum NamespaceError {
+    #[error("namespace too long (max 64, got {0})")]
+    TooLong(usize),
+    #[error("namespace contains disallowed character: {0:?} (allowed: [A-Za-z0-9_-])")]
+    InvalidChar(char),
+    #[error("namespace must not start with '-'")]
+    LeadingDash,
+}
+```
+
+**Single constructor, permissive on empty.** No `new_or_empty` helper (v3's attempt had a whitespace footgun). `new("")` → `Ok(EMPTY)`. Whitespace-only input (`"   "`) errors via `InvalidChar(' ')` — callers trim their own config input.
+
+`BackendConfig` gains one field (additive; `#[non_exhaustive]` already in place):
+
+```rust
+pub struct BackendConfig {
+    pub connection: BackendConnection,
+    pub timeouts: BackendTimeouts,
+    pub retry: BackendRetry,
+    pub namespace: Namespace,          // NEW; default Namespace::EMPTY
+}
+
+impl BackendConfig {
+    pub fn with_namespace(mut self, ns: Namespace) -> Self {
+        self.namespace = ns;
+        self
+    }
+}
+```
+
+`BackendConfig::valkey(host, port)` signature unchanged; default namespace `EMPTY`. The builder idiom `BackendConfig::valkey(...).with_namespace(...)` becomes the canonical construction path; future `BackendConfig::postgres(...)` will mirror.
+
+## §R6.4 Stage mapping
+
+| Stage | State | Scope |
+|-------|-------|-------|
+| Stage 1a (merged `81e08dc`) | done | unchanged |
+| Stage 1b (merged `6f54f9b`) | done | unchanged |
+| **Stage 1c** (pending) | planning | **Absorbs all namespace work in one landing.** Scope: `Namespace` + `NamespaceError` type in `ff-core::backend`; `BackendConfig.namespace` field + `with_namespace` builder; rename the three `namespace`-named parameters + `namespace_executions_key` fn (§R6.2.6); thread `namespace: &Namespace` through 6 key contexts + 19 free functions + 83 `format!` sites in `keys.rs`; 4 Rust-literal sites in `ff-script::functions::lease`; **79 `format!("ff:…")` reader sites in `ff-engine` scanners + `ff-engine/budget.rs` + `ff-sdk/worker.rs`** (#M2 — scanners read what FCALLs write; skipping these produces silent split-brain); 13 Lua-literal key sites + 4 PUBLISH sites in `flowfabric.lua`; ARGV-append + `table.remove(args)` pop in every FCALL caller (`fcall_with_namespace` helper); SCAN-pattern grep audit; isolation property test (§R6.5). Scope is breaking to `ff-core::keys` signatures (acceptable per posture). Wall-time estimate set at Stage 1c planning — prior 25-35h was for keygen-only. |
+| Stage 1d (pending) | unchanged | snapshot + `.client()` removal do not touch keys |
+| Stage 2 (Postgres PoC) | future | Namespace maps to schema. `PostgresBackend::connect` verifies pre-existing via `SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = $1` (privilege-independent, unlike `information_schema.schemata`). Does NOT auto-CREATE. Clear error on missing schema. |
+| Stage 4 (seal `ff_core::keys`) | unchanged | |
+
+**Interaction with #90 (CompletionBackend, in flight):** #90 hides the `ff:dag:completions` channel behind a `CompletionBackend` trait. Lua PUBLISH sites persist; namespace threading applies to them regardless of merge order. #90 and this amendment are concurrent, not sequenced.
+
+**Interaction with #91 (PartitionKey, in flight):** disjoint. #91 touches `contracts.rs` + `partition.rs` + DTOs; this amendment touches `keys.rs` + Lua + `ff-script`.
+
+**Interaction with #92 (StreamCursor, in flight):** disjoint. #92 changes XRANGE/XREAD arg shape, not keys or channels.
+
+## §R6.5 Migration, rollback, and acceptance testing
+
+**Migration: not provided.** Pre-1.0 posture: breaking changes land freely, CHANGELOG documents them, cairn (sole external consumer) rebases on their next deploy. No migration tool, no online conversion, no rollback support.
+
+Cairn's default path requires no action: `EMPTY` namespace = byte-identical keys to today. Cairn opts into isolation by setting a non-empty namespace in a future release; any operator who wants to switch a running deploy does a FLUSHDB-equivalent and restarts (same as any other schema-changing pre-1.0 release).
+
+**Isolation acceptance test (Stage 1c gate, per #MD2).** Stage 1c does not merge until the following property test passes, added in `crates/ff-test/tests/namespace_isolation.rs`:
+
+- Spin two `ValkeyBackend` instances `A` and `B` against the same Valkey, with `A.namespace = "tenant_a"` and `B.namespace = "tenant_b"`.
+- Exercise a representative slice of the API through both: claim-to-complete, suspend-resume, budget report, waitpoint HMAC resolve, stream read, cancel_flow.
+- Assert after each step:
+  - `A.describe_execution(eid_b)` returns `NotFound` (A cannot see B's executions).
+  - Subscribers to `A`'s completion stream do not observe `B`'s completions.
+  - A SCAN under `A`'s prefix does not match any `B`-originated keys, and vice versa.
+- Additionally, run a third backend `C` with `namespace = EMPTY` and assert its SCAN/DESCRIBE surface is disjoint from both `A` and `B` (empty-prefix behaves as its own namespace, not as a catch-all view).
+
+The test is the acceptance gate for the full invariant in §R6.2.1. Stage 1c PR body must link to the test output.
+
+**CHANGELOG entry** accompanying the Stage 1c release must state:
+
+- `BackendConfig.namespace` field added; defaults to `EMPTY`.
+- `ff-core::keys` free-function signatures changed (19 functions; 3 parameter renames).
+- FCALL ARGV tail now carries `namespace_prefix`; Rust callers using the bundled helpers are unaffected; callers that construct ARGV manually must append.
+- Existing deploys without a namespace config continue producing the same keys (byte-identical).
+- Switching a live deploy to use a non-EMPTY namespace is a keyspace reset — no in-place migration.
+
+## §R6.6 What this amendment does NOT do
+
+- Does NOT define how operators source the namespace. Caller-side.
+- Does NOT add per-call namespace override. Construction-time only.
+- Does NOT change trait method signatures.
+- Does NOT address intra-namespace multi-tenancy.
+- Does NOT namespace the Valkey Function library.
+- Does NOT provide migration tooling.
+- Does NOT support rollback across the Stage 1c boundary.
+- Does NOT coordinate cairn's removal of the read-layer filter.
+
+## §R6.7 Alternatives considered
+
+1. **Env-var read inside `ff-core::keys`.** Rejected: violates construction-time-not-global; couples ff-core to process environment.
+2. **Namespace as a per-call arg on `EngineBackend`.** Rejected: every op carries an arg that never varies within a backend's lifetime.
+3. **Namespace inside the hash-tag (`{ns:fp:5}`).** Rejected: breaks Cluster routing (hash-tag == partition identifier assumption).
+4. **Per-namespace Valkey Function libraries (`FUNCTION LOAD ff_<ns>`).** Rejected: operational surface (who cleans up stale libs?); library is stateless code; KEYS/ARGV isolation is sufficient.
+5. **Separate Valkey databases (`SELECT N`).** Rejected: Cluster mode supports only DB 0.
+6. **New RFC-013 instead of amending.** Rejected: Stage 1c re-touches every keygen site and ARGV caller; co-threading namespace avoids a second sweep of the same ~83 sites + 47 FCALL sites. Same-pass fusion; cheaper than sequenced.
+7. **Hash-prefix instead of text prefix.** Rejected: loses human-readable/greppable property.
+8. **`ff:<namespace>:…` instead of `<namespace>:ff:…`.** Rejected: inspection SCAN collides with existing segment-2 names.
+9. **Move Lua-literal keys into Rust-built `KEYS[]`.** Rejected: explodes `KEYS[]` cardinality; Cluster requires single-slot.
+10. **`ARGV[1] = namespace_prefix` (prepend).** Rejected: shifts every positional index in every function; wire-breaking across all 47 FCALLs. Appending + popping at ARGV-tail is strictly better (§R6.2.4).
+11. **`new_or_empty` permissive helper.** Rejected: whitespace-leak bug; single constructor that maps empty→EMPTY is simpler.
+12. **`ARGV[#ARGV]` read-in-place (no pop).** Rejected: breaks `ff_set_execution_tags`, `ff_set_flow_tags`, `ff_resolve_dependency` which iterate `#args` / `unpack(args)` variadically. `table.remove(args)` pops the tail and restores `#args` for variadic consumers (§R6.2.4).
+
+## §R6.8 Open questions for owner
+
+**Locked (v3 + v4 adjudication):**
+
+1. Validation regex = `[A-Za-z0-9_-]{1,64}`, no leading `-`.
+2. Field name = `namespace`.
+3. `Namespace::EMPTY` const + single constructor (`new("")` → Ok(EMPTY), no helper).
+4. No migration tool.
+5. Postgres schema check = `pg_catalog.pg_namespace` (privilege-independent); require pre-existing; no auto-CREATE.
+6. Cairn coordination = none.
+7. Stage 1c is atomic — no Stage 1a.0 / 1a.1 split.
+8. Pubsub channels namespaced alongside keys.
+9. Valkey Function library stays server-global.
+10. Key-length recommendation: ≤16 chars operationally; 64 cap. Operators with index-heavy deploys (200M+ members) should stay short — a 65-byte prefix on 200M index members is ~13GB of key memory.
+11. Prefix placement = `<namespace>:ff:…`.
+12. FCALL ARGV plumbing = append-and-pop (`table.remove(args)` at function entry; not `ARGV[#ARGV]` read-in-place).
+13. Naming renames (`idempotency_key`, `namespace_executions_key`, `tag_index_key`) happen in Stage 1c's first commit.
+
+**Remaining open (v4, new):**
+
+14. **`namespace_executions_key` rename.** Locked: rename function to `exec_domain_key`; param to `exec_domain`. Same pass covers `tag_index_key(namespace, …)` → `tag_index_key(tag_domain, …)` and `idempotency_key(tag, namespace, …)` → `idempotency_key(tag, idem_domain, …)`. Grep-verified: no existing symbol collisions with any of the proposed `*_domain` names.
+
+## §R6.9 Landing
+
+- Amend RFC-012 in-place:
+  - Insert round-6 summary at top (after round-5).
+  - Extend §3.3.0 with `Namespace` row.
+  - Add Stage 1c scope note referencing §R6.2/§R6.4.
+  - Add §R6.2.4 ARGV-append mechanism as sub-note under §3.4.
+- Single PR titled `rfc: RFC-012 amendment — namespace prefix on BackendConfig (#122)`. Doc-only.
+- Co-author trailer: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- Stage 1c planning resumes against the amended RFC. No interim "type-plumb" PR.


### PR DESCRIPTION
## Summary

Archives the RFC-012 namespace-amendment exploration (draft v5 + four challenger reviews K/L/M/P) under \`rfcs/drafts/\` with a README explaining the outcome.

## Why keep it

1. **Chain-of-reasoning** for why a full backend-prefix amendment was wrong-sized for cairn's actual ask (issue #122).
2. **Reusable pattern**: four-round challenger discipline (K → L → M → P) for future high-impact amendments.
3. **Forward-reference**: if operator-level isolation (distinct from tenant/instance filtering) becomes needed later, the analysis is intact.

## Outcome in main

The cairn ask from #122 was right-sized to a \`ScannerFilter { namespace, instance_tag }\` construction-time filter (shipped in PR #127). No key-shape change, no RFC amendment needed.

## Test plan

- [x] No code changes — doc-only addition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only addition under `rfcs/drafts/` with no runtime or API changes, so risk is minimal aside from potential confusion if drafts are mistaken for authoritative RFCs.
> 
> **Overview**
> Archives an abandoned RFC-012 namespace-prefix amendment exploration under `rfcs/drafts/`, including the draft proposal (`RFC-012-amendment-namespace.md`) and four adversarial challenger reviews (`*.{K,L,M,P}-challenge.md`).
> 
> Adds `rfcs/drafts/README.md` to clarify these files are *non-authoritative* exploration records, index the materials, and document the outcome that the actual fix shipped separately (via a `ScannerFilter { namespace, instance_tag }` approach in PR `#127`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2868f2b3b6bdb00775ddd0ad08a2271d99b73506. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->