### PR TITLE
Hotfix v0.3.2: add ff-backend-valkey to publish set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,10 @@
 #     `publish-new` + `publish-update`.
 #   - GITHUB_TOKEN is auto-provided by GHA; `gh release create` uses it.
 #
-# Publish set (8 crates, topologically ordered):
+# Publish set (9 crates, topologically ordered):
 #   ferriskey -> ff-core -> ff-script -> ff-observability
-#     -> ff-engine -> ff-scheduler -> ff-sdk -> ff-server
+#     -> ff-backend-valkey -> ff-engine -> ff-scheduler
+#     -> ff-sdk -> ff-server
 # ff-test is dev-only (publish = false) and not in the set.
 # The former telemetrylib sub-crate was inlined into ferriskey
 # during the Tier 1 envelope collapse (PR #18).
@@ -23,6 +24,11 @@
 # v0.3.0 release partial-published (ff-engine requires it as a
 # workspace dep and failed the publish step when it was missing
 # from crates.io).
+# ff-backend-valkey was added to the publish set in v0.3.2 after
+# v0.3.1 partial-published (ff-sdk requires it as a workspace dep
+# and failed the publish step when it was missing from crates.io).
+# Introduced in RFC-012 Stage 1a (PR #114) as a separate crate from
+# ff-sdk.
 #
 # Partial-publish recovery:
 #   If publish succeeds for crate N but fails for crate N+1, the workflow
@@ -128,11 +134,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
       # Ordering respects path->version deps. ferriskey is a leaf after
       # the Tier 1 envelope collapse (PR #18) inlined the former
-      # telemetrylib sub-crate. ff-script, ff-sdk, ff-server, ff-engine,
-      # ff-scheduler all depend on ferriskey. ff-core is a leaf.
-      # ff-observability is a leaf that ff-engine depends on (added to
-      # the publish set in v0.3.1 after v0.3.0 partial-published).
-      # ff-server closes the chain.
+      # telemetrylib sub-crate. ff-core is a leaf. ff-script depends on
+      # ff-core. ff-observability is a leaf (added in v0.3.1 after v0.3.0
+      # partial-published). ff-backend-valkey depends on ff-core + ff-script
+      # (added in v0.3.2 after v0.3.1 partial-published). ff-engine depends
+      # on ff-core + ff-observability. ff-scheduler depends on ff-core +
+      # ff-script + ff-observability. ff-sdk depends on ff-core + ff-script
+      # and optionally ff-backend-valkey. ff-server closes the chain
+      # (depends on all of ff-core, ff-script, ff-engine, ff-backend-valkey,
+      # ff-scheduler, ff-observability).
       # `--no-verify` is safe because `verify` already built + clippied +
       # tested the same ref. Without it every `cargo publish` re-builds
       # from scratch.
@@ -181,6 +191,20 @@ jobs:
             exit 1
           }
       - run: sleep 30
+      - name: publish ff-backend-valkey
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          VER="${TAG_VERSION#v}"
+          cargo publish -p ff-backend-valkey --no-verify || {
+            echo "::error::cargo publish ff-backend-valkey failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
+            echo "::error::  cargo yank --version ${VER} ff-observability"
+            exit 1
+          }
+      - run: sleep 30
       - name: publish ff-engine
         env:
           TAG_VERSION: ${{ github.ref_name }}
@@ -192,6 +216,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             exit 1
           }
       - run: sleep 30
@@ -206,6 +231,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             exit 1
           }
@@ -221,6 +247,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             exit 1
@@ -237,6 +264,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             echo "::error::  cargo yank --version ${VER} ff-sdk"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to FlowFabric are documented here. Format loosely
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.2] - 2026-04-22
+
+### Fixed
+
+- Release workflow now publishes `ff-backend-valkey` (9 crates total,
+  up from 8). `ff-sdk` depends on `ff-backend-valkey` as an optional
+  workspace dep; omitting it from the publish set caused the v0.3.1
+  release to partial-publish at `ff-sdk`. `ff-backend-valkey` was
+  introduced in RFC-012 Stage 1a (PR #114).
+
+### Notes
+
+- v0.3.1 was yanked after partial-publishing (`ferriskey`, `ff-core`,
+  `ff-script`, `ff-observability`, `ff-engine`, `ff-scheduler` —
+  6 of 9). Operators should re-resolve against 0.3.2.
+- v0.3.0 had been similarly yanked after missing `ff-observability`;
+  see the v0.3.1 changelog entry.
+- v0.3.2 is the first usable 0.3.x release.
+
 ## [0.3.1] - 2026-04-22
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "crc16",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "ferriskey",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "ferriskey",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "ferriskey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -33,16 +33,16 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.3.1", path = "crates/ff-core" }
-ff-script = { version = "0.3.1", path = "crates/ff-script" }
-ff-engine = { version = "0.3.1", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.3.1", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.3.1", path = "crates/ff-sdk" }
-ff-server = { version = "0.3.1", path = "crates/ff-server" }
+ff-core = { version = "0.3.2", path = "crates/ff-core" }
+ff-script = { version = "0.3.2", path = "crates/ff-script" }
+ff-engine = { version = "0.3.2", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.3.2", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.3.2", path = "crates/ff-sdk" }
+ff-server = { version = "0.3.2", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.3.1", path = "crates/ff-backend-valkey" }
-ff-observability = { version = "0.3.1", path = "crates/ff-observability" }
-ferriskey = { version = "0.3.1", path = "ferriskey" }
+ff-backend-valkey = { version = "0.3.2", path = "crates/ff-backend-valkey" }
+ff-observability = { version = "0.3.2", path = "crates/ff-observability" }
+ferriskey = { version = "0.3.2", path = "ferriskey" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,7 @@ This doc covers the operator workflow for cutting a release. Tooling lives in
 
 ## What gets published
 
-Eight crates, all pinned to the same version, published in topological order:
+Nine crates, all pinned to the same version, published in topological order:
 
 1. `ferriskey`       — Valkey client (reparented fork of glide-core;
    the former `telemetrylib` sub-crate was inlined during the Tier 1
@@ -17,15 +17,20 @@ Eight crates, all pinned to the same version, published in topological order:
    shim. Added to the publish set in v0.3.1 after v0.3.0
    partial-published (ff-engine depends on it as a workspace dep
    and its publish step fails without it being on crates.io).
-5. `ff-engine`       — cross-partition dispatch + scanners
+5. `ff-backend-valkey` — RFC-012 EngineBackend trait Valkey impl,
+   separated from ff-sdk in RFC-012 Stage 1a. Added to the publish
+   set in v0.3.2 after v0.3.1 partial-published (ff-sdk depends on
+   it as a workspace dep and its publish step fails without it
+   being on crates.io).
+6. `ff-engine`       — cross-partition dispatch + scanners
    (includes the `completion_listener` module for push-based DAG
    promotion; see [`rfc011-operator-runbook.md`](rfc011-operator-runbook.md)
    §"DAG promotion: push listener + safety-net reconciler")
-6. `ff-scheduler`    — claim-grant scheduler
-7. `ff-sdk`          — worker SDK. `direct-valkey-claim` feature is
+7. `ff-scheduler`    — claim-grant scheduler
+8. `ff-sdk`          — worker SDK. `direct-valkey-claim` feature is
    off by default; production deployments use the scheduler-routed
    HTTP path via `FlowFabricWorker::claim_via_server`
-8. `ff-server`       — HTTP server library + binary
+9. `ff-server`       — HTTP server library + binary
 
 Excluded from publish:
 
@@ -52,7 +57,7 @@ Before cutting a release, verify:
 - [ ] `CARGO_REGISTRY_TOKEN` is configured in repo settings (Settings →
       Secrets and variables → Actions). Generate at
       <https://crates.io/me> → API Tokens with scope `publish-new` +
-      `publish-update`. The token must have upload rights to all eight
+      `publish-update`. The token must have upload rights to all nine
       crate names — claim them on crates.io first if they are new.
 - [ ] Working on a release branch (`main` or `release/*`).
 - [ ] Working tree is clean.

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]

--- a/release.toml
+++ b/release.toml
@@ -2,12 +2,13 @@
 #
 # This config drives `cargo release <level>` to perform a consolidated,
 # workspace-wide version bump across the publishable crates:
-#   ferriskey, ff-core, ff-script, ff-observability, ff-engine,
-#   ff-scheduler, ff-sdk, ff-server
+#   ferriskey, ff-core, ff-script, ff-observability, ff-backend-valkey,
+#   ff-engine, ff-scheduler, ff-sdk, ff-server
 # The former telemetrylib sub-crate was inlined into ferriskey in
 # PR #18; it is no longer a separate publish target. ff-observability
 # was added to the publish set in v0.3.1 after v0.3.0
-# partial-published.
+# partial-published. ff-backend-valkey was added to the publish set
+# in v0.3.2 after v0.3.1 partial-published (ff-sdk depends on it).
 #
 # Intentionally excluded from the bump (via [package.metadata.release]
 # release = false in each crate's Cargo.toml):


### PR DESCRIPTION
## What failed in v0.3.1

Tag-triggered workflow on `v0.3.1` partial-published. 6 of the 9 workspace crates reached crates.io at 0.3.1:

- Published: `ferriskey`, `ff-core`, `ff-script`, `ff-observability`, `ff-engine`, `ff-scheduler`
- Failed at: `ff-sdk` — `no matching package named 'ff-backend-valkey' found on crates.io index`
- Never attempted: `ff-sdk`, `ff-server`

Root cause: `ff-backend-valkey` was introduced in RFC-012 Stage 1a (`81e08dc` / PR #114) as a separate crate from `ff-sdk`, but was never added to `.github/workflows/release.yml`, `docs/RELEASING.md`, or `release.toml`. `ff-sdk` workspace-depends on `ff-backend-valkey` (optional) and could not resolve against the registry.

Same failure class as v0.3.0 (missing `ff-observability`, fixed by #130).

## Fix

Release workflow grows 8 → 9 crates. `ff-backend-valkey` is inserted at position 5 — between `ff-observability` and `ff-engine` — matching the topological dep graph (depends only on `ff-core` + `ff-script`, which are already upstream; `ff-sdk` + `ff-server` depend on it downstream). Yank-recovery `::error::` messages are updated in every subsequent step to list it.

## Dep-graph audit (verified by reading every `crates/*/Cargo.toml`)

| # | Crate | ff-* deps |
|---|---|---|
| 1 | ferriskey | (none) |
| 2 | ff-core | (none) |
| 3 | ff-observability | (none) |
| 4 | ff-script | ff-core |
| 5 | ff-backend-valkey | ff-core, ff-script |
| 6 | ff-engine | ff-core, ff-observability |
| 7 | ff-scheduler | ff-core, ff-script, ff-observability |
| 8 | ff-sdk | ff-core, ff-script, ff-backend-valkey (optional) |
| 9 | ff-server | ff-core, ff-script, ff-engine, ff-backend-valkey, ff-scheduler, ff-observability |

Audit matches the spec exactly — no discrepancies found. `ff-observability`'s position (pre-existing, post-#130) is kept at slot 3 (after `ff-core`, before `ff-script`); it is dep-valid there since it has no ff-* deps. `ff-backend-valkey` must come after `ff-script` (its dep).

## `cargo package --workspace --allow-dirty` audit (Part C)

All 9 publishable crates packaged cleanly:

```
Packaging ferriskey v0.3.2         (65 files, 5.1MiB  / 432.5KiB compressed)
Packaging ff-core v0.3.2           (17 files, 291.3KiB / 73.2KiB compressed)
Packaging ff-script v0.3.2         (24 files, 549.0KiB / 118.1KiB compressed)
Packaging ff-backend-valkey v0.3.2 (7 files,  124.8KiB / 33.4KiB compressed)
Packaging ff-observability v0.3.2  (7 files,  27.5KiB  / 8.7KiB compressed)
Packaging ff-engine v0.3.2         (25 files, 264.0KiB / 60.3KiB compressed)
Packaging ff-sdk v0.3.2            (11 files, 358.4KiB / 86.7KiB compressed)
Packaging ff-scheduler v0.3.2      (6 files,  113.7KiB / 31.5KiB compressed)
Packaging ff-server v0.3.2         (12 files, 382.8KiB / 96.6KiB compressed)
```

`cargo package --workspace` errored on `ff-readiness-tests` (`dependency 'ff-test' does not specify a version`). This is **pre-existing on `main`** (verified via checkout + re-run), unrelated to this hotfix, and non-blocking: `ff-readiness-tests` is `publish = false` and not in the release workflow's publish set.

## CI gate checklist (all green locally)

- [x] `cargo build --workspace --all-features`
- [x] `cargo build -p ff-sdk --no-default-features`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` (45 + 7 + others passed; no failures)
- [x] `cargo-machete` — no new findings (only pre-existing benches/comparisons/*)
- [x] `cargo package --workspace --allow-dirty` — 9/9 publishable crates green

## Pre-merge operator checklist

- [ ] Yank the 6 over-published 0.3.1 crates:
  - `cargo yank --version 0.3.1 ferriskey`
  - `cargo yank --version 0.3.1 ff-core`
  - `cargo yank --version 0.3.1 ff-script`
  - `cargo yank --version 0.3.1 ff-observability`
  - `cargo yank --version 0.3.1 ff-engine`
  - `cargo yank --version 0.3.1 ff-scheduler`
- [ ] Optional: dry-run the workflow on this branch (Actions → Release → Run workflow → `dry_run: true`)
- [ ] Admin-merge this PR to `main`
- [ ] Tag `v0.3.2` on the merge commit; push tag to fire release workflow

## Hard rules adhered

- Zero code changes; only release-infra edits, version bumps, CHANGELOG
- No tag pushed
- No `--no-verify` used
- No cairn-* touches
- Co-author trailer on every commit