### PR TITLE
chore(ci): publish-list drift check against workspace

### DIFF
--- a/.github/workflows/security-and-quality.yml
+++ b/.github/workflows/security-and-quality.yml
@@ -225,15 +225,62 @@ jobs:
             -p ff-core -p ff-script -p ff-engine -p ff-scheduler \
             -p ff-sdk -p ff-server
 
+  publish-list-drift:
+    name: publish-list drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Guards against the class of release failure we hit on v0.3.0
+    # (missed ff-observability) and v0.3.1 (missed ff-backend-valkey):
+    # someone adds a publishable crate to the workspace without
+    # updating the explicit publish list in release.yml, and the tag
+    # push partially publishes before failing. This gate fails the
+    # PR at review time instead of at release time.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - name: Diff publishable workspace crates against release.yml publish list
+        run: |
+          # Publishable == Cargo.toml has no `publish = false` and no
+          # `publish = ["<registry>"]` restriction. cargo metadata
+          # normalizes these to publish=null (unrestricted) or
+          # publish=[] (publish=false) or publish=["<r>", ...]
+          # (registry-restricted). Only null and true are free-to-publish.
+          WORKSPACE_CRATES=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.publish == null or .publish == true) | .name' \
+            | sort -u)
+
+          # Extract crate names from the explicit `cargo publish -p <name>`
+          # invocations in the release workflow. Grep pattern requires
+          # the `cargo publish -p ` prefix so comments/echo lines don't
+          # match; step-name text is ignored.
+          RELEASE_YAML_CRATES=$(grep -oP '(?<=cargo publish -p )[a-z][a-z0-9-]*' \
+            .github/workflows/release.yml | sort -u)
+
+          if ! diff <(echo "$WORKSPACE_CRATES") <(echo "$RELEASE_YAML_CRATES") >/dev/null; then
+            echo "::error::publish list in .github/workflows/release.yml is out of sync with publishable workspace crates"
+            echo "--- publishable workspace crates (cargo metadata) ---"
+            echo "$WORKSPACE_CRATES"
+            echo "--- release.yml publish list ---"
+            echo "$RELEASE_YAML_CRATES"
+            echo "--- diff (workspace vs release.yml) ---"
+            diff <(echo "$WORKSPACE_CRATES") <(echo "$RELEASE_YAML_CRATES") || true
+            echo
+            echo "Fix: either mark the new crate publish = false in its Cargo.toml,"
+            echo "or add a 'cargo publish -p <crate>' step to release.yml (and"
+            echo "update docs/RELEASING.md + release.toml if they enumerate crates)."
+            exit 1
+          fi
+          echo "publish list in release.yml matches $(echo "$WORKSPACE_CRATES" | wc -l) publishable workspace crates"
+
   # Always-runs sentinel. Branch protection should list
-  # `quality-gates-complete` as the required check — NOT the six
+  # `quality-gates-complete` as the required check — NOT the seven
   # gates individually — so doc-only PRs (matched by paths-ignore)
   # still report green here and can merge. A gate that actually
   # fails will flip this job to `failure` via the `needs.*.result`
   # aggregate below.
   quality-gates-complete:
     name: quality-gates-complete
-    needs: [audit, deny, geiger, codeql-gate, machete, semver-checks]
+    needs: [audit, deny, geiger, codeql-gate, machete, semver-checks, publish-list-drift]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -245,6 +292,7 @@ jobs:
           R_CODEQL: ${{ needs.codeql-gate.result }}
           R_MACHETE: ${{ needs.machete.result }}
           R_SEMVER: ${{ needs.semver-checks.result }}
+          R_PUBLIST: ${{ needs.publish-list-drift.result }}
         run: |
           fail=0
           for pair in \
@@ -253,7 +301,8 @@ jobs:
               "geiger:$R_GEIGER" \
               "codeql-gate:$R_CODEQL" \
               "machete:$R_MACHETE" \
-              "semver-checks:$R_SEMVER"; do
+              "semver-checks:$R_SEMVER" \
+              "publish-list-drift:$R_PUBLIST"; do
             name="${pair%%:*}"
             result="${pair#*:}"
             case "$result" in


### PR DESCRIPTION
## Problem

Two consecutive releases shipped incomplete crate sets to crates.io because the explicit publish list in `.github/workflows/release.yml` drifted from the set of publishable workspace crates:

- **v0.3.0** missed `ff-observability`
- **v0.3.1** missed `ff-backend-valkey`

Every workspace crate without `publish = false` in `Cargo.toml` is implicitly publishable, so adding a crate without also editing `release.yml` silently creates a partial-publish time bomb that only detonates at tag push.

## How the check works

New `publish-list-drift` job in `.github/workflows/security-and-quality.yml`, runs on every PR alongside the other gates. Added to the `quality-gates-complete` sentinel so branch protection keeps gating on one required check.

The script:

```bash
WORKSPACE_CRATES=$(cargo metadata --no-deps --format-version 1 \
  | jq -r '.packages[] | select(.publish == null or .publish == true) | .name' \
  | sort -u)

RELEASE_YAML_CRATES=$(grep -oP '(?<=cargo publish -p )[a-z][a-z0-9-]*' \
  .github/workflows/release.yml | sort -u)

diff <(echo "$WORKSPACE_CRATES") <(echo "$RELEASE_YAML_CRATES") || exit 1
```

`publish` shape in cargo metadata: `null` (implicitly publishable), `true` (explicitly publishable), `[]` (== `publish = false` in Cargo.toml), `["registry", ...]` (registry-restricted). The filter only accepts the first two — anything restricted or marked false is excluded, matching the "free to go to crates.io" semantics release.yml operates on.

No compile step; cargo metadata + jq + grep + diff completes in seconds.

## Self-test evidence

**Green path** (current main, parity intact):

```
WORKSPACE:
ferriskey
ff-backend-valkey
ff-core
ff-engine
ff-observability
ff-scheduler
ff-script
ff-sdk
ff-server
RELEASE:
ferriskey
ff-backend-valkey
ff-core
ff-engine
ff-observability
ff-scheduler
ff-script
ff-sdk
ff-server
PARITY OK
```

**Red path** (simulated drop of `ff-observability` from release.yml by filtering it out of the grep result pre-diff):

```
5d4
< ff-observability
FAILED AS EXPECTED
```

Exactly the v0.3.0 failure mode — caught at PR time instead of at tag push.

## Notes

- Vendored `ferriskey` at `/ferriskey` is included because it's a workspace member via the root `Cargo.toml` `members = [..., "ferriskey"]`; `cargo metadata --no-deps` enumerates it correctly.
- `ff-test` and `ff-readiness-tests` both carry `publish = false` and are correctly excluded by the filter.
- No admin-merge; manager reviews and merges.