### PR TITLE
docs(benches): refresh baseline for v0.3.2

### DIFF
--- a/benches/results/baseline.md
+++ b/benches/results/baseline.md
@@ -1,6 +1,10 @@
-# Internal bench baseline — v0.1.0
+# Internal bench baseline — v0.3.2
 
-Internal reference numbers from the post-Batch-C run on commit `01f6327`.
+Internal reference numbers captured against v0.3.2 HEAD (`da89fa9`),
+re-run on 2026-04-22 to satisfy `docs/RELEASING.md` §Pre-flight (the
+baseline refresh was deferred during the v0.3.2 hotfix window and is
+being filled in retroactively).
+
 Use as a floor to detect regressions in future releases, not as public
 performance claims.
 
@@ -11,8 +15,13 @@ host class.
 ## Host
 - CPU: AMD EPYC 9R14, 16 cores
 - Mem: 30 GB
-- Profile: `release` with `lto = "fat"`, `codegen-units = 1`, `debug = 0`
-- Valkey 8.1.0 (source build, standalone, TLS off)
+- Profile: `release` with `lto = "thin"`, `codegen-units = 1`, `debug = 0`
+  (bench workspace profile; top-level product profile is `lto = "fat"`)
+- Valkey 8.1.0 (source build, standalone, TLS off, port 6389). Note: the
+  harness reports `valkey_version: "7.2.4"` in the JSON because Valkey
+  8.1.0 emits `redis_version:7.2.4` first in `INFO server` for client
+  back-compat and the reporter picks the first match. Server process
+  self-reports `valkey_version:8.1.0`.
 
 ## Scenario 1 — submit / claim / complete (10k tasks × 16 workers, 4 KiB payload)
 
@@ -21,81 +30,90 @@ host class.
 | redis-rs baseline  | 6f81926 | 14755.2 | 0.256  | 0.327  | 0.383  |
 | ferriskey baseline | ccff3ac |  7993.3 | 0.263  | 0.340  | 0.403  |
 | apalis-redis rc.7  | 1b2cce5 |    51.9 | n/a    | n/a    | n/a    |
-| **ff-server (v0.1.0)** | **01f6327** | **2171.6** | **0.41** | **0.89** | **1.11** |
+| **ff-server (v0.3.2)** | **da89fa9** | **2658.0** | **0.399** | **0.882** | **1.152** |
+| ff-server (v0.1.0) | 01f6327 |  2171.6 | 0.41   | 0.89   | 1.11   |
 | ff-server (pre-Batch-C) | 6fef93d |  3320.9 | 0.395  | 0.672  | 0.813  |
 
-The `01f6327` numbers were captured with the harness already minting
-via `ExecutionId::for_flow(fresh_fid)` — each exec spreads across
-partitions, matching the pre-RFC-011 bare-UUID distribution. Earlier
-intermediate runs that used `ExecutionId::solo(lane, ..)` pinned
-every exec to one partition and registered ~40 ops/s; those were
-artifacts of the mint choice, not a regression.
+Throughput +22% vs v0.1.0 (`01f6327`) at effectively unchanged latency
+percentiles. Captured with the RFC-011 minting path (`ExecutionId::for_flow`)
+so each exec spreads across partitions.
 
-Throughput drop vs `6fef93d` (-35%): the accepted Batch-C trade-off.
-ff_complete / fail / cancel now PUBLISH to `ff:dag:completions` on
-every flow-bound terminal transition (no-op for standalone execs),
-and the engine maintains a dedicated RESP3 SUBSCRIBE connection.
-Standalone execs don't emit, but the listener plumbing is always up.
-
-Latency p99 (+37%): traceable to the same SUBSCRIBE connection plus
-the push listener spawning dispatch per completion. Cost dominated
-by the extra tokio task spawn, not Valkey round-trips.
+The Batch-C trade-off remains: `ff_complete` / `fail` / `cancel`
+PUBLISH to `ff:dag:completions` on every flow-bound terminal
+transition (no-op for standalone execs), and the engine maintains a
+dedicated RESP3 SUBSCRIBE connection.
 
 ## Scenario 2 — cap_routed (1 iteration, cap_universe=10, 100 workers)
 
 | mode    | git_sha | correct_routing_rate | p50 ms    | p95 ms      | p99 ms      |
 |---------|---------|----------------------|-----------|-------------|-------------|
-| happy   | 01f6327 | 1.000                |   407.09  |    523.71   |    541.93   |
-| partial | 01f6327 | 0.956                | 11867.52  | 236849.39   | 281806.90   |
-| scarce  | 01f6327 | 0.917                |   396.62  |    505.07   | 175906.66   |
+| happy   | da89fa9 | 1.000                |   409.26  |    515.87   |    535.13   |
+| partial | da89fa9 | 0.961                | 14155.999 | 209212.961  | 274235.299  |
+| scarce  | da89fa9 | 0.921                |   416.56  |    535.67   | 117196.936  |
 
 Thresholds: happy==1.0, partial>=0.90, scarce>=0.85 — all three pass.
+
+`happy` numbers are flat vs v0.1.0 (407 → 409 ms p50). `partial` and
+`scarce` are adversarial-by-design distributions (see RFC-009 cap-routing
+convergence notes); their tails move significantly between runs because
+the promotion-cycle race is a coin flip per cycle. The p50 drift on
+`partial` (11867 → 14156 ms, +19%) is within the observed run-to-run
+variance for this mode — routing-rate (0.956 → 0.961) is the metric
+that characterises behaviour, not absolute latency. The `scarce` p99
+improvement (175906 → 117197 ms) falls in the same band.
 
 ## Scenario 3 — flow_dag_linear (100 flows × 10 nodes, 16 workers)
 
 | system         | git_sha | flows/s | p50 ms  | p95 ms  | p99 ms   |
 |----------------|---------|---------|---------|---------|----------|
-| ff-server      | 01f6327 |   8.18  |  347.63 | (n/a)   | 12055.19 |
+| ff-server      | da89fa9 |   8.16  |  352.95 | (n/a)   | 11948.56 |
+| ff-server (v0.1.0) | 01f6327 |   8.18 | 347.63  | (n/a)   | 12055.19 |
 | ff-server (pre-BatchC) | b4ec2c2 |   5.96 | 7348.79 | 8555.88 | 9350.30 |
 | apalis-approx  | 1b2cce5 |   1.02  | n/a     | n/a     | n/a      |
 
-**DAG latency improvement 21×** at p50 (7348ms → 347ms) from Batch C item 6
-push-based promotion replacing the `dependency_reconciler` scan interval
-as the per-stage floor. p99 shows tail growth — likely worker-pool
-contention on refill; investigation follow-up.
-
-apalis has no DAG primitive; apalis-approx is a hand-wired 10-stage chain
-(no data passing, no flow-level retry/cancel). Not apples-to-apples for
-features, but brackets order-of-magnitude.
+Flat vs v0.1.0 across all percentiles — the push-based promotion
+speedup (21× at p50 over pre-BatchC) holds. p99 tail growth still
+present; no follow-up investigation filed in this cycle.
 
 ## Scenario 4 — long_running_steady_state (300s, refill 20 tasks / 10s)
 
-| metric                       | v0.1.0 (01f6327) | pre-BatchC (6f81926) |
-|------------------------------|------------------|----------------------|
-| completed (count)            | 2580             | 2679                 |
-| failed (count)               | 101              | 102                  |
-| missed_deadline (count)      | 100              | 188 (~7.0%)          |
-| missed_deadline (% of completed) | 3.88%        | 7.01%                |
-| steady_state_ops/s           | 2.0              | n/a                  |
-| lease_renewal_overhead (%)   | 0.00015          | 0.00017              |
-| rss_min_mb / rss_max_mb      | 32 / 67          | 37 / 72              |
-| rss_slope_mb_per_min         | −4.41            | n/a                  |
+| metric                       | v0.3.2 (da89fa9) | v0.1.0 (01f6327) | pre-BatchC (6f81926) |
+|------------------------------|------------------|------------------|----------------------|
+| completed (count)            | 2680             | 2580             | 2679                 |
+| failed (count)               | 105              | 101              | 102                  |
+| missed_deadline (count)      | 205              | 100              | 188                  |
+| missed_deadline (% of completed) | **7.11%**    | 3.88%            | 7.01%                |
+| steady_state_ops/s           | 2.0              | 2.0              | n/a                  |
+| lease_renewal_overhead (%)   | 0.000178         | 0.00015          | 0.00017              |
+| rss_min_mb / rss_max_mb      | 34 / 69          | 32 / 67          | 37 / 72              |
+| rss_slope_mb_per_min         | −4.10            | −4.41            | n/a                  |
 
-Completion count roughly stable; lease renewal overhead unchanged.
+**Regression flag:** `missed_deadline_pct` nearly doubled vs v0.1.0
+(3.88% → 7.11%), back to the pre-BatchC 7.01% level. Completed count
+grew modestly (2580 → 2680) so the denominator didn't shrink; the
+numerator (missed_deadline) jumped from 100 → 205. Single-run
+observation, no diagnosis performed in this refresh cycle. A repeat
+run is recommended before v0.4 to distinguish single-run noise from a
+real regression, and if reproducible, a flame capture on the refill
+window is the right next step. Not blocking v0.3.2 (which has already
+shipped); flagged here per `benches/results/baseline.md` operating
+discipline.
+
+Lease renewal overhead and RSS profile both remain in the pre-v0.1.0
+envelope.
 
 ## Scenario 5 — suspend_signal_resume (100 samples)
 
-| metric     | git_sha | value  |
-|------------|---------|--------|
-| ops/s      | 01f6327 | 105.05 |
-| p50 ms     | 01f6327 |   9.52 |
-| p95 ms     | 01f6327 |  10.59 |
-| p99 ms     | 01f6327 |  11.91 |
+| metric     | git_sha | value  | v0.1.0 (01f6327) |
+|------------|---------|--------|------------------|
+| ops/s      | da89fa9 | 108.34 | 105.05           |
+| p50 ms     | da89fa9 |   9.23 |   9.52           |
+| p95 ms     | da89fa9 |   9.93 |  10.59           |
+| p99 ms     | da89fa9 |  10.76 |  11.91           |
 
 Measured with `claim_poll_interval_ms=1`; production default (1000ms)
-adds ~500ms on the re-claim leg, so production-projected p50 ≈ 510 ms.
-+5% over pre-Batch-C — the terminal-op `PUBLISH` from Batch C item 6
-adds a single Valkey round-trip per suspend / signal / resume cycle.
+adds ~500ms on the re-claim leg, so production-projected p50 ≈ 509 ms.
+Small improvement across all percentiles; no regression.
 
 ## Comparison rules for next release
 


### PR DESCRIPTION
## Summary

Refresh `benches/results/baseline.md` to reflect v0.3.2 HEAD (`da89fa9`),
per `docs/RELEASING.md` §Pre-flight. The refresh was deferred during
the v0.3.2 hotfix window and is being filled in retroactively.

All 5 scenarios re-run on the same EPYC 9R14 host class used for v0.1.0,
against Valkey 8.1.0 standalone. No source changes — only the tracked
baseline doc.

## Results vs v0.1.0

| Scenario | v0.1.0 (01f6327) | v0.3.2 (da89fa9) | Δ |
|---|---|---|---|
| 1 — submit/claim/complete (ops/s) | 2171.6 | **2658.0** | **+22%** |
| 2 — cap_routed happy (p50 ms) | 407.09 | 409.26 | flat |
| 2 — cap_routed partial (routing rate) | 0.956 | 0.961 | flat |
| 2 — cap_routed scarce (routing rate) | 0.917 | 0.921 | flat |
| 3 — flow_dag (flows/s) | 8.18 | 8.16 | flat |
| 4 — long_running missed_deadline_pct | 3.88% | **7.11%** | **REGRESSION ×1.8** |
| 5 — suspend_signal_resume (p50 ms) | 9.52 | 9.23 | -3% (small improvement) |

## Regression flag (Scenario 4)

`long_running_steady_state.missed_deadline_pct` nearly doubled
(3.88% → 7.11%), landing back at the pre-Batch-C level of 7.01%.
Completed count grew modestly (2580 → 2680) so denominator didn't
shrink; `missed_deadline` count went 100 → 205.

Single-run observation. Per `feedback_perf_honesty.md` discipline this
is **not** dismissed as variance — it's flagged here for follow-up.
Per bench-refresh scope, no diagnosis performed in this PR; a repeat
run + (if reproducible) flame capture on the refill window is
recommended before v0.4. Not blocking v0.3.2 (already shipped).

## Surprises

- Harness reports `valkey_version: "7.2.4"` because Valkey 8.1.0 emits
  `redis_version:7.2.4` first in `INFO server` for client back-compat
  and the reporter returns the first match. Noted inline in the doc.
- Scenario 2 `partial` and `scarce` hit the 300s deadline cap in both
  runs — this is design behaviour (adversarial-mode slow convergence
  per RFC-009), not a regression.

## Run durations

- Scenario 1: ~75s (criterion warmup + 2 sizes)
- Scenario 2: ~605s (happy 1s + partial 300s + scarce 300s)
- Scenario 3: ~12s
- Scenario 4: 300s
- Scenario 5: ~14s

## Test plan

- [x] `valkey-cli PING` → PONG
- [x] `ff-server` built from HEAD sources (da89fa9), backed by Valkey 8.1.0
- [x] All 5 bench scenarios produced `benches/results/*.json` (gitignored)
- [x] `baseline.md` updated; header "v0.3.2" + `measured at da89fa9`
- [ ] Reviewer: sanity-check the regression flag and decide whether to
      repeat-run Scenario 4 before v0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)