### PR TITLE
Hotfix v0.3.3: ScannerFilter builder + CompletionBackend accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to FlowFabric are documented here. Format loosely
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.3] - 2026-04-22
+
+### Fixed
+
+- **`ScannerFilter` now constructible from outside ff-core.** The type
+  is `#[non_exhaustive]` to preserve additive compatibility, but 0.3.2
+  shipped with no public constructors/setters — external consumers
+  (cairn) could only name `ScannerFilter::NOOP`, making the headline
+  filtered-completion-subscription surface unusable. Adds
+  `ScannerFilter::new()`, `.with_namespace(ns)`, and
+  `.with_instance_tag(key, value)` chainable setters. Discovered in
+  the 0.3.2 published-artifact smoke
+  (`rfcs/drafts/0.3.2-smoke-report.md` Finding 1).
+- **`CompletionBackend` now reachable through `FlowFabricWorker`.**
+  0.3.2's `worker.backend()` returned `&Arc<dyn EngineBackend>`, and
+  `CompletionBackend` is a sibling trait (not a supertrait), so
+  consumers could not call `subscribe_completions_filtered` through
+  the public worker handle. Adds
+  `FlowFabricWorker::completion_backend(&self) -> Option<Arc<dyn CompletionBackend>>`
+  populated from the bundled `ValkeyBackend` on the `valkey-default`
+  feature. Returns `None` on the `connect_with` path (caller-supplied
+  trait object cannot be re-upcast). Discovered in the 0.3.2
+  published-artifact smoke
+  (`rfcs/drafts/0.3.2-smoke-report.md` Finding 2).
+
+### Changed
+
+- `ff_backend_valkey::ValkeyBackend::from_client_and_partitions` now
+  returns `Arc<Self>` (was `Arc<dyn EngineBackend>`). Required so the
+  same concrete allocation can back both `EngineBackend` and
+  `CompletionBackend` trait-object views. Only caller is ff-sdk's
+  `FlowFabricWorker::connect`; any external caller that relied on
+  the old signature can reinstate it with a one-line coercion
+  (`let backend: Arc<dyn EngineBackend> = arc;`).
+
+### Docs
+
+- Crate-level `ff-sdk` rustdoc quickstart now uses `claim_from_grant`
+  (the production path) instead of `claim_next` (which is gated
+  behind the default-off `direct-valkey-claim` feature). Smoke
+  Finding 3.
+
 ## [0.3.2] - 2026-04-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "crc16",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "ferriskey",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "ferriskey",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "ferriskey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -33,16 +33,16 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.3.2", path = "crates/ff-core" }
-ff-script = { version = "0.3.2", path = "crates/ff-script" }
-ff-engine = { version = "0.3.2", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.3.2", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.3.2", path = "crates/ff-sdk" }
-ff-server = { version = "0.3.2", path = "crates/ff-server" }
+ff-core = { version = "0.3.3", path = "crates/ff-core" }
+ff-script = { version = "0.3.3", path = "crates/ff-script" }
+ff-engine = { version = "0.3.3", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.3.3", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.3.3", path = "crates/ff-sdk" }
+ff-server = { version = "0.3.3", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.3.2", path = "crates/ff-backend-valkey" }
-ff-observability = { version = "0.3.2", path = "crates/ff-observability" }
-ferriskey = { version = "0.3.2", path = "ferriskey" }
+ff-backend-valkey = { version = "0.3.3", path = "crates/ff-backend-valkey" }
+ff-observability = { version = "0.3.3", path = "crates/ff-observability" }
+ferriskey = { version = "0.3.3", path = "ferriskey" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/benches/results/baseline.md
+++ b/benches/results/baseline.md
@@ -1,6 +1,10 @@
-# Internal bench baseline — v0.1.0
+# Internal bench baseline — v0.3.2
 
-Internal reference numbers from the post-Batch-C run on commit `01f6327`.
+Internal reference numbers captured against v0.3.2 HEAD (`da89fa9`),
+re-run on 2026-04-22 to satisfy `docs/RELEASING.md` §Pre-flight (the
+baseline refresh was deferred during the v0.3.2 hotfix window and is
+being filled in retroactively).
+
 Use as a floor to detect regressions in future releases, not as public
 performance claims.
 
@@ -11,8 +15,13 @@ host class.
 ## Host
 - CPU: AMD EPYC 9R14, 16 cores
 - Mem: 30 GB
-- Profile: `release` with `lto = "fat"`, `codegen-units = 1`, `debug = 0`
-- Valkey 8.1.0 (source build, standalone, TLS off)
+- Profile: `release` with `lto = "thin"`, `codegen-units = 1`, `debug = 0`
+  (bench workspace profile; top-level product profile is `lto = "fat"`)
+- Valkey 8.1.0 (source build, standalone, TLS off, port 6389). Note: the
+  harness reports `valkey_version: "7.2.4"` in the JSON because Valkey
+  8.1.0 emits `redis_version:7.2.4` first in `INFO server` for client
+  back-compat and the reporter picks the first match. Server process
+  self-reports `valkey_version:8.1.0`.
 
 ## Scenario 1 — submit / claim / complete (10k tasks × 16 workers, 4 KiB payload)
 
@@ -21,81 +30,90 @@ host class.
 | redis-rs baseline  | 6f81926 | 14755.2 | 0.256  | 0.327  | 0.383  |
 | ferriskey baseline | ccff3ac |  7993.3 | 0.263  | 0.340  | 0.403  |
 | apalis-redis rc.7  | 1b2cce5 |    51.9 | n/a    | n/a    | n/a    |
-| **ff-server (v0.1.0)** | **01f6327** | **2171.6** | **0.41** | **0.89** | **1.11** |
+| **ff-server (v0.3.2)** | **da89fa9** | **2658.0** | **0.399** | **0.882** | **1.152** |
+| ff-server (v0.1.0) | 01f6327 |  2171.6 | 0.41   | 0.89   | 1.11   |
 | ff-server (pre-Batch-C) | 6fef93d |  3320.9 | 0.395  | 0.672  | 0.813  |
 
-The `01f6327` numbers were captured with the harness already minting
-via `ExecutionId::for_flow(fresh_fid)` — each exec spreads across
-partitions, matching the pre-RFC-011 bare-UUID distribution. Earlier
-intermediate runs that used `ExecutionId::solo(lane, ..)` pinned
-every exec to one partition and registered ~40 ops/s; those were
-artifacts of the mint choice, not a regression.
+Throughput +22% vs v0.1.0 (`01f6327`) at effectively unchanged latency
+percentiles. Captured with the RFC-011 minting path (`ExecutionId::for_flow`)
+so each exec spreads across partitions.
 
-Throughput drop vs `6fef93d` (-35%): the accepted Batch-C trade-off.
-ff_complete / fail / cancel now PUBLISH to `ff:dag:completions` on
-every flow-bound terminal transition (no-op for standalone execs),
-and the engine maintains a dedicated RESP3 SUBSCRIBE connection.
-Standalone execs don't emit, but the listener plumbing is always up.
-
-Latency p99 (+37%): traceable to the same SUBSCRIBE connection plus
-the push listener spawning dispatch per completion. Cost dominated
-by the extra tokio task spawn, not Valkey round-trips.
+The Batch-C trade-off remains: `ff_complete` / `fail` / `cancel`
+PUBLISH to `ff:dag:completions` on every flow-bound terminal
+transition (no-op for standalone execs), and the engine maintains a
+dedicated RESP3 SUBSCRIBE connection.
 
 ## Scenario 2 — cap_routed (1 iteration, cap_universe=10, 100 workers)
 
 | mode    | git_sha | correct_routing_rate | p50 ms    | p95 ms      | p99 ms      |
 |---------|---------|----------------------|-----------|-------------|-------------|
-| happy   | 01f6327 | 1.000                |   407.09  |    523.71   |    541.93   |
-| partial | 01f6327 | 0.956                | 11867.52  | 236849.39   | 281806.90   |
-| scarce  | 01f6327 | 0.917                |   396.62  |    505.07   | 175906.66   |
+| happy   | da89fa9 | 1.000                |   409.26  |    515.87   |    535.13   |
+| partial | da89fa9 | 0.961                | 14155.999 | 209212.961  | 274235.299  |
+| scarce  | da89fa9 | 0.921                |   416.56  |    535.67   | 117196.936  |
 
 Thresholds: happy==1.0, partial>=0.90, scarce>=0.85 — all three pass.
+
+`happy` numbers are flat vs v0.1.0 (407 → 409 ms p50). `partial` and
+`scarce` are adversarial-by-design distributions (see RFC-009 cap-routing
+convergence notes); their tails move significantly between runs because
+the promotion-cycle race is a coin flip per cycle. The p50 drift on
+`partial` (11867 → 14156 ms, +19%) is within the observed run-to-run
+variance for this mode — routing-rate (0.956 → 0.961) is the metric
+that characterises behaviour, not absolute latency. The `scarce` p99
+improvement (175906 → 117197 ms) falls in the same band.
 
 ## Scenario 3 — flow_dag_linear (100 flows × 10 nodes, 16 workers)
 
 | system         | git_sha | flows/s | p50 ms  | p95 ms  | p99 ms   |
 |----------------|---------|---------|---------|---------|----------|
-| ff-server      | 01f6327 |   8.18  |  347.63 | (n/a)   | 12055.19 |
+| ff-server      | da89fa9 |   8.16  |  352.95 | (n/a)   | 11948.56 |
+| ff-server (v0.1.0) | 01f6327 |   8.18 | 347.63  | (n/a)   | 12055.19 |
 | ff-server (pre-BatchC) | b4ec2c2 |   5.96 | 7348.79 | 8555.88 | 9350.30 |
 | apalis-approx  | 1b2cce5 |   1.02  | n/a     | n/a     | n/a      |
 
-**DAG latency improvement 21×** at p50 (7348ms → 347ms) from Batch C item 6
-push-based promotion replacing the `dependency_reconciler` scan interval
-as the per-stage floor. p99 shows tail growth — likely worker-pool
-contention on refill; investigation follow-up.
-
-apalis has no DAG primitive; apalis-approx is a hand-wired 10-stage chain
-(no data passing, no flow-level retry/cancel). Not apples-to-apples for
-features, but brackets order-of-magnitude.
+Flat vs v0.1.0 across all percentiles — the push-based promotion
+speedup (21× at p50 over pre-BatchC) holds. p99 tail growth still
+present; no follow-up investigation filed in this cycle.
 
 ## Scenario 4 — long_running_steady_state (300s, refill 20 tasks / 10s)
 
-| metric                       | v0.1.0 (01f6327) | pre-BatchC (6f81926) |
-|------------------------------|------------------|----------------------|
-| completed (count)            | 2580             | 2679                 |
-| failed (count)               | 101              | 102                  |
-| missed_deadline (count)      | 100              | 188 (~7.0%)          |
-| missed_deadline (% of completed) | 3.88%        | 7.01%                |
-| steady_state_ops/s           | 2.0              | n/a                  |
-| lease_renewal_overhead (%)   | 0.00015          | 0.00017              |
-| rss_min_mb / rss_max_mb      | 32 / 67          | 37 / 72              |
-| rss_slope_mb_per_min         | −4.41            | n/a                  |
+| metric                       | v0.3.2 (da89fa9) | v0.1.0 (01f6327) | pre-BatchC (6f81926) |
+|------------------------------|------------------|------------------|----------------------|
+| completed (count)            | 2680             | 2580             | 2679                 |
+| failed (count)               | 105              | 101              | 102                  |
+| missed_deadline (count)      | 205              | 100              | 188                  |
+| missed_deadline (% of completed) | **7.11%**    | 3.88%            | 7.01%                |
+| steady_state_ops/s           | 2.0              | 2.0              | n/a                  |
+| lease_renewal_overhead (%)   | 0.000178         | 0.00015          | 0.00017              |
+| rss_min_mb / rss_max_mb      | 34 / 69          | 32 / 67          | 37 / 72              |
+| rss_slope_mb_per_min         | −4.10            | −4.41            | n/a                  |
 
-Completion count roughly stable; lease renewal overhead unchanged.
+**Regression flag:** `missed_deadline_pct` nearly doubled vs v0.1.0
+(3.88% → 7.11%), back to the pre-BatchC 7.01% level. Completed count
+grew modestly (2580 → 2680) so the denominator didn't shrink; the
+numerator (missed_deadline) jumped from 100 → 205. Single-run
+observation, no diagnosis performed in this refresh cycle. A repeat
+run is recommended before v0.4 to distinguish single-run noise from a
+real regression, and if reproducible, a flame capture on the refill
+window is the right next step. Not blocking v0.3.2 (which has already
+shipped); flagged here per `benches/results/baseline.md` operating
+discipline.
+
+Lease renewal overhead and RSS profile both remain in the pre-v0.1.0
+envelope.
 
 ## Scenario 5 — suspend_signal_resume (100 samples)
 
-| metric     | git_sha | value  |
-|------------|---------|--------|
-| ops/s      | 01f6327 | 105.05 |
-| p50 ms     | 01f6327 |   9.52 |
-| p95 ms     | 01f6327 |  10.59 |
-| p99 ms     | 01f6327 |  11.91 |
+| metric     | git_sha | value  | v0.1.0 (01f6327) |
+|------------|---------|--------|------------------|
+| ops/s      | da89fa9 | 108.34 | 105.05           |
+| p50 ms     | da89fa9 |   9.23 |   9.52           |
+| p95 ms     | da89fa9 |   9.93 |  10.59           |
+| p99 ms     | da89fa9 |  10.76 |  11.91           |
 
 Measured with `claim_poll_interval_ms=1`; production default (1000ms)
-adds ~500ms on the re-claim leg, so production-projected p50 ≈ 510 ms.
-+5% over pre-Batch-C — the terminal-op `PUBLISH` from Batch C item 6
-adds a single Valkey round-trip per suspend / signal / resume cycle.
+adds ~500ms on the re-claim leg, so production-projected p50 ≈ 509 ms.
+Small improvement across all percentiles; no regression.
 
 ## Comparison rules for next release
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -171,7 +171,7 @@ impl ValkeyBackend {
     pub fn from_client_and_partitions(
         client: ferriskey::Client,
         partition_config: PartitionConfig,
-    ) -> Arc<dyn EngineBackend> {
+    ) -> Arc<Self> {
         Arc::new(Self {
             client,
             partition_config,

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -728,6 +728,32 @@ impl ScannerFilter {
         instance_tag: None,
     };
 
+    /// Create an empty filter (equivalent to [`Self::NOOP`]).
+    ///
+    /// Provided for external-crate consumers: `ScannerFilter` is
+    /// `#[non_exhaustive]`, so struct-literal and functional-update
+    /// construction are unavailable across crate boundaries. Start
+    /// from `new()` and chain `with_*` setters to build a filter.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the tenant-scope namespace filter dimension. Consumes
+    /// and returns `self` for chaining.
+    pub fn with_namespace(mut self, ns: Namespace) -> Self {
+        self.namespace = Some(ns);
+        self
+    }
+
+    /// Set the exact-match exec-tag filter dimension. Consumes and
+    /// returns `self` for chaining. At filter time, scanners read
+    /// the `ff:exec:{p:N}:<eid>:tags` hash and compare the value at
+    /// `key` byte-for-byte against `value`.
+    pub fn with_instance_tag(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.instance_tag = Some((key.into(), value.into()));
+        self
+    }
+
     /// True iff the filter has no dimensions set — every candidate
     /// passes. Callers use this to short-circuit filtered subscribe
     /// paths back to the unfiltered ones.
@@ -1014,6 +1040,30 @@ mod tests {
         assert!(!f.matches(Some(&Namespace::new("tenant-a")), Some("i-2")));
         assert!(!f.matches(Some(&Namespace::new("tenant-b")), Some("i-1")));
         assert!(!f.matches(None, Some("i-1")));
+    }
+
+    #[test]
+    fn scanner_filter_builder_construction() {
+        // Simulates external-crate usage: only public constructors
+        // and chainable setters (no struct-literal access to the
+        // `#[non_exhaustive]` fields).
+        let empty = ScannerFilter::new();
+        assert!(empty.is_noop());
+        assert_eq!(empty, ScannerFilter::NOOP);
+
+        let ns_only = ScannerFilter::new().with_namespace(Namespace::new("tenant-a"));
+        assert!(!ns_only.is_noop());
+        assert!(ns_only.matches(Some(&Namespace::new("tenant-a")), None));
+
+        let tag_only = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-1");
+        assert!(!tag_only.is_noop());
+        assert!(tag_only.matches(None, Some("i-1")));
+
+        let both = ScannerFilter::new()
+            .with_namespace(Namespace::new("tenant-a"))
+            .with_instance_tag("cairn.instance_id", "i-1");
+        assert!(both.matches(Some(&Namespace::new("tenant-a")), Some("i-1")));
+        assert!(!both.matches(Some(&Namespace::new("tenant-b")), Some("i-1")));
     }
 
     #[test]

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -8,9 +8,17 @@
 //!
 //! # Quick start
 //!
+//! The production claim path is
+//! [`FlowFabricWorker::claim_from_grant`]: obtain a
+//! [`ClaimGrant`] from `ff_scheduler::Scheduler::claim_for_worker`
+//! (the scheduler enforces budget, quota, and capability checks),
+//! then hand it to the SDK. `claim_next` is gated behind the
+//! default-off `direct-valkey-claim` feature and bypasses admission
+//! control — fine for benchmarks, not production.
+//!
 //! ```rust,ignore
 //! use ff_sdk::{FlowFabricWorker, WorkerConfig};
-//! use std::time::Duration;
+//! use ff_core::types::LaneId;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), ff_sdk::SdkError> {
@@ -24,19 +32,17 @@
 //!     );
 //!
 //!     let worker = FlowFabricWorker::connect(config).await?;
+//!     let lane = LaneId::new("main");
 //!
-//!     loop {
-//!         match worker.claim_next().await? {
-//!             Some(task) => {
-//!                 println!("claimed: {}", task.execution_id());
-//!                 // Process task...
-//!                 task.complete(Some(b"done".to_vec())).await?;
-//!             }
-//!             None => {
-//!                 tokio::time::sleep(Duration::from_secs(1)).await;
-//!             }
-//!         }
-//!     }
+//!     // In a real deployment `grant` is obtained from the
+//!     // scheduler's `claim_for_worker` RPC/helper; it carries the
+//!     // execution id, capability match, and admission result.
+//!     # let grant: ff_core::contracts::ClaimGrant = unimplemented!();
+//!     let task = worker.claim_from_grant(lane, grant).await?;
+//!     println!("claimed: {}", task.execution_id());
+//!     // Process task...
+//!     task.complete(Some(b"done".to_vec())).await?;
+//!     Ok(())
 //! }
 //! ```
 //!

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -109,6 +109,16 @@ pub struct FlowFabricWorker {
     /// migrates them through this field, and Stage 1d removes the
     /// embedded client.
     backend: Arc<dyn ff_core::engine_backend::EngineBackend>,
+    /// Optional upcast to the same underlying backend viewed as a
+    /// [`CompletionBackend`](ff_core::completion_backend::CompletionBackend).
+    /// Populated by [`Self::connect`] from the bundled
+    /// `ValkeyBackend` (which implements the trait); cleared by
+    /// [`Self::connect_with`] because a caller-supplied
+    /// `Arc<dyn EngineBackend>` cannot be re-upcast. Cairn and other
+    /// completion-subscription consumers reach this through
+    /// [`Self::completion_backend`].
+    completion_backend_handle:
+        Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>,
 }
 
 /// Number of partitions scanned per `claim_next()` poll. Keeps idle Valkey
@@ -449,10 +459,18 @@ impl FlowFabricWorker {
         // ValkeyBackend so `ClaimedTask`'s trait forwarders have
         // something to call. `from_client_and_partitions` reuses the
         // already-dialed client — no second connection.
-        let backend = ff_backend_valkey::ValkeyBackend::from_client_and_partitions(
-            client.clone(),
-            partition_config,
-        );
+        // Share the concrete `Arc<ValkeyBackend>` across the two
+        // trait objects — one allocation, both accessors yield
+        // identity-equivalent handles.
+        let valkey_backend: Arc<ff_backend_valkey::ValkeyBackend> =
+            ff_backend_valkey::ValkeyBackend::from_client_and_partitions(
+                client.clone(),
+                partition_config,
+            );
+        let backend: Arc<dyn ff_core::engine_backend::EngineBackend> = valkey_backend.clone();
+        let completion_backend_handle: Option<
+            Arc<dyn ff_core::completion_backend::CompletionBackend>,
+        > = Some(valkey_backend);
 
         Ok(Self {
             client,
@@ -468,6 +486,7 @@ impl FlowFabricWorker {
             #[cfg(feature = "direct-valkey-claim")]
             scan_cursor: AtomicUsize::new(scan_cursor_init),
             backend,
+            completion_backend_handle,
         })
     }
 
@@ -506,6 +525,12 @@ impl FlowFabricWorker {
     ) -> Result<Self, SdkError> {
         let mut worker = Self::connect(config).await?;
         worker.backend = backend;
+        // The caller-supplied trait object cannot be upcast to
+        // `CompletionBackend` without loss of identity; clear the
+        // default `ValkeyBackend`-derived handle so
+        // `completion_backend()` reports `None`, reflecting that
+        // the caller-supplied backend owns the surface now.
+        worker.completion_backend_handle = None;
         Ok(worker)
     }
 
@@ -518,6 +543,30 @@ impl FlowFabricWorker {
     /// `&Arc<dyn EngineBackend>`.
     pub fn backend(&self) -> Option<&Arc<dyn ff_core::engine_backend::EngineBackend>> {
         Some(&self.backend)
+    }
+
+    /// Handle to the completion-event subscription backend, for
+    /// consumers that need to observe execution completions (DAG
+    /// reconcilers, tenant-isolated subscribers).
+    ///
+    /// Returns `Some` when the worker was built through
+    /// [`Self::connect`] on the default `valkey-default` feature
+    /// (the bundled `ValkeyBackend` implements
+    /// [`CompletionBackend`](ff_core::completion_backend::CompletionBackend)).
+    /// Returns `None` when the worker was built via
+    /// [`Self::connect_with`] (the caller-supplied
+    /// `Arc<dyn EngineBackend>` cannot be re-upcast to
+    /// `CompletionBackend`), or for hypothetical future backends
+    /// that don't support push-based completion streams.
+    ///
+    /// The returned handle shares the same underlying allocation as
+    /// [`Self::backend`]; calls through it (e.g.
+    /// `subscribe_completions_filtered`) hit the same connection
+    /// the worker itself uses.
+    pub fn completion_backend(
+        &self,
+    ) -> Option<Arc<dyn ff_core::completion_backend::CompletionBackend>> {
+        self.completion_backend_handle.clone()
     }
 
     /// Get a reference to the underlying ferriskey client.
@@ -1596,6 +1645,27 @@ async fn read_partition_config(client: &Client) -> Result<PartitionConfig, SdkEr
         num_budget_partitions: parse("num_budget_partitions", 32),
         num_quota_partitions: parse("num_quota_partitions", 32),
     })
+}
+
+#[cfg(test)]
+mod completion_accessor_type_tests {
+    //! Type-level compile check that
+    //! [`FlowFabricWorker::completion_backend`] returns an
+    //! `Option<Arc<dyn CompletionBackend>>`. No Valkey required —
+    //! the assertion is at the function-pointer type level and the
+    //! #[test] body exists solely so the compiler elaborates it.
+    use super::FlowFabricWorker;
+    use ff_core::completion_backend::CompletionBackend;
+    use std::sync::Arc;
+
+    #[test]
+    fn completion_backend_accessor_signature() {
+        // If this line compiles, the public accessor returns the
+        // advertised type. The function is never called (no live
+        // worker), so no I/O happens.
+        let _f: fn(&FlowFabricWorker) -> Option<Arc<dyn CompletionBackend>> =
+            FlowFabricWorker::completion_backend;
+    }
 }
 
 #[cfg(all(test, feature = "direct-valkey-claim"))]

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

0.3.2 shipped cleanly to crates.io (all 9 crates) but Worker X's
published-artifact smoke test
([`rfcs/drafts/0.3.2-smoke-report.md`](../blob/main/rfcs/drafts/0.3.2-smoke-report.md))
uncovered two critical external-consumer blockers — cairn and other
downstream crates cannot use the headline 0.3.x
filtered-completion-subscription surface. This hotfix unblocks them.

### Smoke findings addressed

Quoted from `0.3.2-smoke-report.md`:

> **Finding 1 (CRITICAL, blocks cairn migration): `ScannerFilter` is
> unbuildable from outside ff-core.** With `#[non_exhaustive]` plus
> `pub` fields but no public constructor/setters/builder, external
> consumers can only name `ScannerFilter::NOOP`. `subscribe_completions_filtered`
> is therefore unusable from any crate other than ff-core itself.

> **Finding 2 (CRITICAL): `CompletionBackend` not reachable from
> `FlowFabricWorker`.** `worker.backend()` returns `&Arc<dyn EngineBackend>`
> and `CompletionBackend` is a sibling (not a supertrait). From the
> ff-sdk surface a consumer cannot call `subscribe_completions_filtered`
> — the method advertised in 0.3.x release notes is unreachable via
> the public worker handle.

Finding 3 (medium; rustdoc quickstart showed a feature-gated method)
is fixed alongside as a small doc improvement.

## Fixes

### 1. `ScannerFilter` builder methods (`ff-core`)

**Before.** `#[non_exhaustive]` blocked struct-literal and
functional-update construction; only `ScannerFilter::NOOP` reachable.

**After.** Added chainable setters:

```rust
let filter = ScannerFilter::new()
    .with_namespace(Namespace::new("tenant-a"))
    .with_instance_tag("cairn.instance_id", "i-1");
```

`ScannerFilter::new()`, `.with_namespace(ns)`,
`.with_instance_tag(key, value)`. Preserves `#[non_exhaustive]` for
future additive compatibility. Unit test exercises only the public
builder surface (simulates external-crate semantics).

### 2. `CompletionBackend` accessor on `FlowFabricWorker` (`ff-sdk` + internal `ff-backend-valkey` refactor)

**Before.** Only `worker.backend() -> &Arc<dyn EngineBackend>` was
public; `CompletionBackend` was not a supertrait.

**After.**

```rust
pub fn completion_backend(&self)
    -> Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>
```

Returns `Some(...)` when built via `connect()` on the default
`valkey-default` feature. Returns `None` on the `connect_with()`
path, since a caller-supplied `Arc<dyn EngineBackend>` can't be
re-upcast without loss of identity.

**Internal refactor.** `ValkeyBackend::from_client_and_partitions`
now returns `Arc<Self>` (was `Arc<dyn EngineBackend>`). Only caller
is ff-sdk's own `connect()`, which now produces the concrete Arc
once and shares it across both trait-object views (same allocation,
no second subscriber connection, no re-dial).

### 3. rustdoc quickstart (`ff-sdk/src/lib.rs`)

**Before.** Crate-level example showed `worker.claim_next()`, gated
behind default-off `direct-valkey-claim` feature.

**After.** Example uses `claim_from_grant` (the production path),
with a short intro noting `claim_next` is benchmark-only.

## Test evidence

- `cargo test --workspace --lib` — green, including new
  `ScannerFilter` builder test and `completion_backend` type-level
  compile check.
- `cargo build -p ff-sdk --no-default-features` — green.
- `cargo build --workspace` — green at 0.3.3 cohort.

## Cargo package audit

All 9 publishable crates package cleanly at 0.3.3:

```
Packaging ferriskey v0.3.3          (65 files, 432.5 KiB)
Packaging ff-core v0.3.3            (17 files,  73.7 KiB)
Packaging ff-script v0.3.3          (24 files, 118.1 KiB)
Packaging ff-backend-valkey v0.3.3  ( 7 files,  33.4 KiB)
Packaging ff-observability v0.3.3   ( 7 files,   8.7 KiB)
Packaging ff-engine v0.3.3          (25 files,  60.3 KiB)
Packaging ff-scheduler v0.3.3       ( 6 files,  31.5 KiB)
Packaging ff-sdk v0.3.3             (11 files,  87.8 KiB)
Packaging ff-server v0.3.3          (12 files,  96.6 KiB)
```

Run: `cargo package --workspace --allow-dirty --exclude ff-readiness-tests --exclude ff-test`
(two excluded crates are `publish = false` dev-only).

## Pre-merge operator checklist (manager-driven)

- [ ] Dry-run the release workflow against this branch.
- [ ] Admin-merge via the standard release-hotfix flow.
- [ ] Tag `v0.3.3` on the post-merge main commit.
- [ ] Publish cohort (9 crates).

## Test plan

- [x] Unit test for `ScannerFilter::{new, with_namespace, with_instance_tag}`
- [x] Type-level compile check for `FlowFabricWorker::completion_backend`
- [x] `cargo build -p ff-sdk --no-default-features` green
- [x] `cargo test --workspace --lib` green
- [x] `cargo package --workspace` green (9 publishable crates)
- [ ] Consumer-side smoke (cairn) once merged + published

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>