### PR TITLE
rfc: RFC-012 Round-7 amendment — #117 Stage 1b deferrals (#117)

### DIFF
--- a/rfcs/RFC-012-engine-backend-trait.md
+++ b/rfcs/RFC-012-engine-backend-trait.md
@@ -1,6 +1,6 @@
 # RFC-012: `EngineBackend` trait — abstracting FlowFabric's write surface
 
-**Status:** Accepted (round-4) + round-5 micro-amendment (peer lease-releasing methods `delay` + `wait_children`).
+**Status:** Accepted (round-4) + round-5 micro-amendment (peer lease-releasing methods `delay` + `wait_children`) + round-7 amendment (Stage 1b deferral resolutions — `create_waitpoint` add, `append_frame` return widen, `report_usage` return replace; `suspend` deferred to Stage 1d).
 **Created:** 2026-04-22
 **Supersedes:** issue #89 (trait-extraction plan) on acceptance.
 **Related:** issues #87, #88, #90, #91, #92, #93 (concrete follow-up work this RFC authorises).
@@ -11,6 +11,26 @@
 During the issue #89 Phase-1 method inventory, Worker I discovered two lease-releasing `ClaimedTask` operations that the round-4 inventory did not elevate to peer trait methods: `delay_execution` (`crates/ff-sdk/src/task.rs:414`) and `move_to_waiting_children` (`crates/ff-sdk/src/task.rs:460`). Both are structurally peers of `suspend` — they hand back the lease, run a single FCALL (`ff_delay_execution`, `ff_move_to_waiting_children`) under the fence triple, and leave the attempt in a non-terminal state awaiting a later event (wall-clock time; child-dependency completion). Omitting them would force Stage 1 to ship an incomplete trait and file a follow-up RFC to bolt them on, compounding call-site debt (§1.3 bullet 3).
 
 This amendment adds them as methods 14 and 15 in §3.1.1. Trait count goes from 13 → 15. No other sections change; Stage-0 type inventory (§3.3.0) is untouched (the new methods' signatures reuse existing types: `TimestampMs` from `ff-core::types`, `Handle`, `EngineError`). The amendment is additive to the accepted round-4 shape.
+
+### Round-7 amendment summary (post Stage 1b — issue #117 deferral resolutions)
+
+Stage 1b (shipped `6f54f9b`, PR #119) migrated 8 of the 12 `ClaimedTask` SDK methods onto the `EngineBackend` trait as thin forwarders. Four methods could not land as thin forwarders: three because the trait's return type was strictly less expressive than the SDK's, and one because the trait had no slot at all. Issue [#117](https://github.com/avifenesh/FlowFabric/issues/117) tracks the gap.
+
+This amendment ships **three of the four** deferred methods:
+
+* **`create_waitpoint`** — new trait method (method **16** in §3.1.1). Issues a pending waitpoint; activation happens via a later `suspend` call (Lua `use_pending_waitpoint` ARGV flag). Introduces new type `PendingWaitpoint` in `ff-core::backend`.
+* **`append_frame`** — return type widens from `()` to `AppendFrameOutcome { stream_id, frame_count }`. Moves `AppendFrameOutcome` from `ff-sdk::task` to `ff-core::backend` (Stage-0-style type move with `pub use` shim), mirroring the Stage-1a `FailOutcome` precedent.
+* **`report_usage`** — return type replaces `AdmissionDecision` with `ReportUsageResult { Ok, AlreadyApplied, SoftBreach, HardBreach }`. `AdmissionDecision` is removed. `ReportUsageResult` gains `#[non_exhaustive]` in the same commit (atomic — no semver-two-step).
+
+**`suspend` is deferred to Stage 1d** (tracked under #117). Round-3 review (Worker M) established that any trait `SuspendOutcome` shape preserving the existing Round-4 `HandleKind::Suspended` contract entangles with the SDK wire parser `parse_suspend_result` at `crates/ff-sdk/src/task.rs:1557-1562`, which constructs `Suspended` exhaustively from wire bytes with no access to `Handle`'s opaque payload. Stage 1d bundles `suspend`'s return-type widening with the input-shape rework (`ConditionMatcher`↔`WaitpointSpec` / typed `ResumeCondition`); round-7 ships what can ship independently.
+
+**Envelope prose.** Round-5 already relaxed the §3.1 "15 in spirit" envelope from round-4's 13. Round-7 relaxes further: trait grows 15 → 16 lifecycle ops (`async fn` count 16 → 17 including `create_waitpoint`). `create_waitpoint` is a gap-fill add, not a split-for-honesty; earlier round-2/round-5 prose is not rewritten, but readers should treat the "in spirit" envelope as "17 current trait methods" as of Round-5+Round-7.
+
+**Shape.** Trait-surface breaking. Widens 1 existing return type, replaces 1 existing return type, adds 1 new method, adds 1 new type in `ff-core::backend`, adds `#[non_exhaustive]` to 1 existing contract enum. No Lua / wire changes.
+
+**Target release: 0.4.0** — `report_usage`'s `AdmissionDecision → ReportUsageResult` swap is unambiguously breaking and forces the minor bump on its own. Lands INDEPENDENTLY of Stage 1c (not a sub-stage; parallel RFC-amendment-only landing).
+
+§3.1.1 (method 16), §3.3.0 (type inventory), §3.3 (signatures), and §5 (stage map) are updated in place. Full content and challenger record are captured in §R7 at the end of this RFC; exploration trail lives in `rfcs/drafts/RFC-012-amendment-117-deferrals.{K,L,M}-challenge.md`.
 
 ### Round-4 revision summary (post Worker M CHALLENGE at `183c10f`)
 
@@ -104,9 +124,9 @@ This RFC defines a trait shape. It is explicitly not:
 
 ## §3 Proposed `EngineBackend` trait shape
 
-### §3.1 Operation inventory (15 methods — round-5 amended)
+### §3.1 Operation inventory (16 methods — round-5 + round-7 amended)
 
-The owner's decision pins the granularity target at ~10-12 business-operation methods; round-2 revisions (K#2 split of `resume`, K#6 split of `progress`) brought the count to 13, and round-5's amendment adds the two missing lease-releasing peers of `suspend` (`delay`, `wait_children`) for a final count of 15. The owner's "~10-12" remains a range, not a hard ceiling; 15 is within the spirit of the decision — every count-growth step is a splits-for-honesty move, not a granularity creep (the `progress`/`append_frame` split replaces a fused method whose atomicity was unsound; `observe_signals`/`claim_from_reclaim` replaces one method whose multi-round-trip honesty was broken; `delay` and `wait_children` elevate two call sites that are structural peers of `suspend`). Below is the round-5 inventory.
+The owner's decision pins the granularity target at ~10-12 business-operation methods; round-2 revisions (K#2 split of `resume`, K#6 split of `progress`) brought the count to 13; round-5's amendment added the two missing lease-releasing peers of `suspend` (`delay`, `wait_children`) for a count of 15; round-7's amendment adds one gap-fill method (`create_waitpoint`, §R7) for a final count of 16. The owner's "~10-12" remains a range, not a hard ceiling; 16 is within the spirit of the decision — splits-for-honesty moves dominate (the `progress`/`append_frame` split replaces a fused method whose atomicity was unsound; `observe_signals`/`claim_from_reclaim` replaces one method whose multi-round-trip honesty was broken; `delay` and `wait_children` elevate two call sites that are structural peers of `suspend`), with `create_waitpoint` the one gap-fill add (the trait had no slot for pending-waitpoint issuance; see §R7.2.2). The `async fn` compile-count is 17 (one higher than the method count because method 3/3b are two `async fn`s under one taxonomy slot). Below is the round-5 + round-7 inventory.
 
 The inventory assumes one trait (not multiple domain-split traits) per §6.2; a consumer holding a `Backend: EngineBackend` gets the full write surface without composing four traits.
 
@@ -177,6 +197,14 @@ This also addresses K#3's reclaim-third-path concern: `claim` is fresh, `claim_f
 
 *Round-5 note:* as with method 14, round-4 omitted this. It is a structural peer of `suspend` (9 KEYS, 4 ARGV; fence triple; attempt-timeout zset membership). Included in the amendment for the same reason.
 
+**16. `create_waitpoint(handle, waitpoint_key, expires_in) -> Result<PendingWaitpoint, EngineError>`.** Issues a pending waitpoint for future signal delivery. Waitpoints have two wire states — **pending** (token issued, not yet backing a suspension) and **active** (bound to a suspension). This method creates a waitpoint in the pending state; a later `suspend` transitions pending → active via the Lua `use_pending_waitpoint` ARGV flag (`flowfabric.lua:3603,3641,3690`). If buffered signals already satisfy the condition, `suspend` returns `AlreadySatisfied` and the waitpoint activates without the lease being released. Pending-waitpoint expiry is a first-class terminal error on the wire (`PendingWaitpointExpired` at `ff-script/src/error.rs:170,403-408`).
+
+*Returns a `PendingWaitpoint { waitpoint_id, hmac_token }`*, where `hmac_token: WaitpointHmac` reuses the existing `ff-core::backend::WaitpointHmac` (Debug-redacts; no Display impl).
+
+*Maps to:* `ff_create_pending_waitpoint`. Call site: `ClaimedTask::create_pending_waitpoint` (`crates/ff-sdk/src/task.rs:686`).
+
+*Round-7 note:* added by the round-7 amendment (issue #117). Placed in §3.1.1 alongside other lifecycle ops (no new sub-bucket); the trait does not grow a "waitpoint management" §3.1.4 bucket for one method. Naming kept as `create_waitpoint` (not `create_pending_waitpoint`) — the trait surface describes the caller's business op, with the pending-vs-active disambiguation in the method's rustdoc. See §R7.2.2 for the full rationale and §R7.6.3 for the naming discussion. The `suspend`-side migration (return type widen + input-shape rework) is explicitly NOT part of round-7; it defers to Stage 1d per §R7.1 / §R7.6.1.
+
 #### §3.1.2 Read-path ops (leveraging Phase 1)
 
 **10. `describe_execution(id) -> Result<Option<ExecutionSnapshot>, EngineError>`.** Uses `ff_core::contracts::ExecutionSnapshot` directly; no reshaping. Already shipped by Phase 1 as an inherent method; promoted to trait here to round out the read surface.
@@ -215,9 +243,9 @@ Four categories of write-like operation are omitted from `EngineBackend` deliber
 
 **Completion pubsub subscription.** Issue #90 files a `CompletionStream` trait. This RFC folds the trait's return-types into `EngineBackend`'s shape — specifically, any trait method that today returns a "subscribe to completions for this entity" side-effect returns a `CompletionStream` typed by the associated type (§4). The stream type itself is this RFC's responsibility (it shapes return types); the subscription mechanism for bulk-tailing the completion channel is #90's trait.
 
-### §3.3.0 Type inventory for the trait signatures (round-4, per M3)
+### §3.3.0 Type inventory for the trait signatures (round-4, per M3; round-7 addendum)
 
-The §3.3 signatures reference 17 supporting types. Honesty requires naming which exist today and which are Stage-0 deliverables.
+The §3.3 signatures reference 17 supporting types. Honesty requires naming which exist today and which are Stage-0 deliverables. Round-7 amendment adds two type-moves/introductions (`AppendFrameOutcome`, `PendingWaitpoint`), marks `AdmissionDecision` for removal, and adds `#[non_exhaustive]` to `ReportUsageResult`. See §R7.2 for rationale.
 
 **Exists in-tree today (no change needed):**
 
@@ -244,10 +272,19 @@ The §3.3 signatures reference 17 supporting types. Honesty requires naming whic
 | `BudgetId` | `ff-core::types` | Newtype over `String` (matches `LaneId` / `FlowId` discipline). | **Erratum (Stage 1a):** already lives in `ff-core::types` via the `cf_id!` macro (`crates/ff-core/src/types.rs:278`); no new-type work needed. This row is a no-op for Stage 0 / 1a. |
 | `ReclaimToken` | `ff-core::contracts` | Newtype wrapping whatever bytes the reclaim scanner issues (today a `ReclaimGrant` struct in `ff-core::contracts:161`). Likely `ReclaimToken(ReclaimGrant)`. | May be pure re-export if `ReclaimGrant` proves sufficient. |
 | `LeaseRenewal` | `ff-core::contracts` | `{ expires_at_ms: u64, lease_epoch: u64 }`. | |
-| `AdmissionDecision` | `ff-core::contracts` | Enum: `{ Admitted, Throttled { retry_after_ms: u64 }, Rejected { reason } }`. | Returned by `report_usage`. |
+| `AdmissionDecision` | `ff-core::contracts` | Enum: `{ Admitted, Throttled { retry_after_ms: u64 }, Rejected { reason } }`. | Returned by `report_usage` at round-4; **REMOVED by round-7** — replaced by `ReportUsageResult` (see §R7.2.3). |
 | `CancelFlowPolicy` | `ff-core::contracts` | Today this shape lives inside `CancelFlowArgs` (`contracts.rs:1233`) — extract the policy enum as a named type; keep `CancelFlowArgs` as the REST wrapper. | |
 | `CancelFlowWait` | `ff-core::contracts` | Enum: `{ NoWait, WaitTimeout(Duration), WaitIndefinite }`. | |
 | `CompletionPayload` | `ff-core::contracts` | Struct: `{ execution_id, outcome, payload_bytes, produced_at_ms, … }`. | Also deliverable from issue #90. |
+
+**Round-7 addendum — type deltas for the #117 deferrals amendment (Stage-0-style, landing in the same PR as the trait changes).**
+
+| Type | Target crate | Round-7 change | Notes |
+|------|--------------|----------------|-------|
+| `AppendFrameOutcome` | `ff-core::backend` | **Stage-0-style MOVE** from `ff-sdk::task` (`task.rs:137-143`). Derives widen from `Clone, Debug` to `Clone, Debug, PartialEq, Eq` matching `FailOutcome` precedent. `pub use ff_core::backend::AppendFrameOutcome` shim at old path through 0.4.x. | Shape: `{ stream_id: String, frame_count: u64 }`. No `#[non_exhaustive]` — construction is internal to `ff-sdk`; no external constructors anticipated (consumer-shape evidence, per §R7.2.1 / MN3). `stream_id: String` is a stable shape commitment — a future typed `StreamId` newtype would be its own breaking change (§R7.5.6 / MD2). |
+| `PendingWaitpoint` | `ff-core::backend` | **NEW type** for `create_waitpoint`'s return. | Shape: `{ waitpoint_id: WaitpointId, hmac_token: WaitpointHmac }`. `#[non_exhaustive]` (new type; preserves additivity). `WaitpointHmac` already exists at `crates/ff-core/src/backend.rs:247-277` (Debug-redacts; no Display impl). |
+| `ReportUsageResult` | `ff-core::contracts` | **Gains `#[non_exhaustive]`** at `contracts.rs:1400`. Becomes the new return type of `report_usage` (replacing `AdmissionDecision`). Both deltas land in one atomic commit — no semver-two-step (§R7.7 / M3). | Existing variants: `Ok | AlreadyApplied | SoftBreach { … } | HardBreach { … }` (`contracts.rs:1400-1418`). Wire-fed by Lua `ff_report_usage_and_check` (parser at `task.rs:1194-1213`). |
+| `AdmissionDecision` | `ff-core::contracts` | **REMOVED.** | In-tree references unwind together: type def (`backend.rs:367-376`), trait sig (`engine_backend.rs:192-197`), stub impl (`ff-backend-valkey/src/lib.rs:1240-1249`), three test constructions (`backend.rs:888-890`). See §R7.2.3. |
 
 **Correction to §5.1's landing gate.** Round-2 said Stage 1 is "no public-surface changes beyond additive." That claim conflates trait-extraction with type-plumbing. Round-4 split:
 
@@ -303,7 +340,7 @@ pub trait EngineBackend: Send + Sync + 'static {
         &self,
         handle: &Handle,
         frame: Frame,
-    ) -> Result<(), EngineError>;
+    ) -> Result<AppendFrameOutcome, EngineError>; // round-7: widened from ()
 
     async fn complete(
         &self,
@@ -375,7 +412,16 @@ pub trait EngineBackend: Send + Sync + 'static {
         handle: &Handle,
         budget: &BudgetId,
         dimensions: UsageDimensions,
-    ) -> Result<AdmissionDecision, EngineError>;
+    ) -> Result<ReportUsageResult, EngineError>; // round-7: replaces AdmissionDecision
+
+    // Round-7 amendment: pending-waitpoint issuance (gap-fill for SDK
+    // ClaimedTask::create_pending_waitpoint). See §R7.2.2.
+    async fn create_waitpoint(
+        &self,
+        handle: &Handle,
+        waitpoint_key: &str,
+        expires_in: Duration,
+    ) -> Result<PendingWaitpoint, EngineError>;
 }
 ```
 
@@ -534,10 +580,12 @@ The trait extraction is staged. Each stage is independently landable, with an ac
 Round-4 restructures the staging per M6 (fuse trait + config) and M1/M2/M3/M4 (acknowledge Stage 0 type-plumbing as its own stage):
 
 * **Stage 0** — additive type plumbing + `EngineError` broadening + `ResumeSignal` crate move. Public-surface-touching but strictly additive / shim-compatible.
-* **Stage 1** — trait extraction + `BackendConfig` in one landing (formerly Stages 1 & 2). Single migration event for consumers.
+* **Stage 1** — trait extraction + `BackendConfig` in one landing (formerly Stages 1 & 2). Single migration event for consumers. Landing in sub-stages 1a → 1b (issue #119, shipped) → 1c.
 * **Stage 2** (former Stage 3) — experimental `ff-backend-postgres`.
 * **Stage 3** (former Stage 4) — cairn migration (cairn-team timeline).
 * **Stage 4** (former Stage 5) — seal `ff_core::keys`.
+
+**Round-7 amendment landing (parallel, independent of Stage 1c).** The #117 deferrals amendment (§R7) is NOT a Stage 1 sub-stage. It is a parallel, RFC-amendment-only landing: one commit touches trait signatures (`append_frame`, `report_usage`, new `create_waitpoint`), `ff-core::backend` type moves/introductions (`AppendFrameOutcome` move, `PendingWaitpoint` new, `AdmissionDecision` removed), `contracts.rs` (`ReportUsageResult` gets `#[non_exhaustive]`), and the Valkey backend impls (routes three methods to real bodies; `suspend` stays stubbed `EngineError::Unavailable`). Sequencing relative to Stage 1c is not constrained — either may land first; the round-7 deltas are shape-local. **Target release: 0.4.0** (breaking change on `report_usage` return type forces the minor bump on its own, independent of `suspend` deferral and any other Stage 1c scope).
 
 ### §5.0 Stage 0 — Type plumbing + `EngineError` broadening + `ResumeSignal` move
 
@@ -669,6 +717,248 @@ The three-method shape stays.
 ### §6.6 Shared implementations across backends via a base trait
 
 **Rejected as premature.** A hierarchy like `trait Backend { ... default impls ... }` + `trait EngineBackend: Backend` sharing commonalities across future backend impls (e.g., fence-triple verification logic) is worth considering once a second backend exists. Today, exactly one backend exists (Valkey); the default-impl slots would all be `unimplemented!()` placeholders. Deferred to post-Stage-3 when the Postgres backend has materialised and shared surfaces become visible.
+
+---
+
+## §R7 Round-7 amendment — Stage 1b deferral resolutions (issue #117)
+
+This appendix is the permanent record of the round-7 amendment. Top-of-RFC summary lives in the "Round-7 amendment summary" block above; the full reasoning, evidence log, and alternatives-considered trail live here. Challenger discipline (K → L → M) is preserved in `rfcs/drafts/RFC-012-amendment-117-deferrals.{K,L,M}-challenge.md`.
+
+**Tracks:** issue [#117](https://github.com/avifenesh/FlowFabric/issues/117). Originates from RFC-012 Stage 1b (shipped `6f54f9b`, PR #119 — 8 of 12 `ClaimedTask` ops migrated).
+**Shape:** trait-surface breaking. Widens 1 existing method return type, replaces 1 existing method return type, adds 1 new method, adds 1 new type in `ff-core::backend`, adds `#[non_exhaustive]` to 1 existing contract enum. No Lua / wire changes. Pre-1.0 posture: CHANGELOG-only communication, no BC shims beyond `pub use` path-preservation.
+**Base commit:** `da89fa9` (post-0.3.2 hotfix). Ships 3 of 4 deferred methods; `suspend` deferred wholesale to Stage 1d.
+**Manager adjudication on editorial opens (this PR):** §R7.6.2 — insert `create_waitpoint` as method 16 in §3.1.1 alongside other lifecycle ops (no new sub-bucket); §R7.6.3 — keep `create_waitpoint` name (rustdoc cites Lua `use_pending_waitpoint` ARGV flag for disambiguation); §R7.6.4 — envelope prose not rewritten; "15 in spirit" envelope relaxed to "17 current trait methods" as of Round-5+Round-7 (noted in this summary and the Round-7 top-of-RFC summary).
+
+### §R7.1 Motivation
+
+Stage 1b migrated 8 of the 12 `ClaimedTask` SDK methods onto the `EngineBackend` trait as thin forwarders (`crates/ff-sdk/src/task.rs:166-178` docstring). Four methods could not land as thin forwarders: three because the trait's return type is strictly less expressive than the SDK's, and one because the trait has no slot at all.
+
+This amendment ships **three of the four**. `suspend` is deferred to Stage 1d:
+
+| # | SDK site | SDK return | Trait return | Gap | Addressed here? |
+|---|----------|-----------|--------------|-----|-----------------|
+| 1 | `ClaimedTask::create_pending_waitpoint` (`task.rs:686`) | `(WaitpointId, WaitpointToken)` | **no slot** | Trait lacks a pending-waitpoint op entirely. | **Yes** — §R7.2.2 |
+| 2 | `ClaimedTask::append_frame` (`task.rs:740`) | `AppendFrameOutcome { stream_id, frame_count }` (`task.rs:136-143`) | `()` (`engine_backend.rs:103`) | Trait discards backend-emitted stream id + frame count. | **Yes** — §R7.2.1 |
+| 3 | `ClaimedTask::suspend` (`task.rs:812`) | `SuspendOutcome::{Suspended, AlreadySatisfied}` (`task.rs:72-90`) | fresh `Handle` (`engine_backend.rs:129-134`) | Trait cannot express the `AlreadySatisfied` (lease-retained) branch; return-type widening entangles with the SDK wire parser. | **Deferred — Stage 1d** |
+| 4 | `ClaimedTask::report_usage` (`task.rs:629`) | `ReportUsageResult::{Ok, AlreadyApplied, SoftBreach{…}, HardBreach{…}}` (`contracts.rs:1400-1418`) | `AdmissionDecision::{Admitted, Throttled{…}, Rejected{…}}` (`backend.rs:367-376`) | Variant sets don't overlap; structured breach fields collapse to `Rejected{reason: String}`. | **Yes** — §R7.2.3 |
+
+**Why `suspend` defers.** Round-3 review (M1) established that any trait `SuspendOutcome` shape that preserves the existing Round-4 `HandleKind::Suspended` contract (`engine_backend.rs:126-128`, `backend.rs:50,788`) entangles with the SDK's internal wire parser `parse_suspend_result` at `crates/ff-sdk/src/task.rs:1465,1557-1562`, which constructs `Suspended` exhaustively from wire bytes with no access to `Handle`'s opaque payload (`backend.rs:60-69`). The only clean options are (a) rewrite the SDK forwarder in the same PR — which in turn requires the `ConditionMatcher`↔`WaitpointSpec` input-shape work (§R7.6.1) — or (b) ship a weakened `Option<Handle>` shape. Both defeat the amendment's thin-forwarder intent. Stage 1d does the input shape anyway; `suspend` rides with it.
+
+Each TODO at the SDK site references `#117`. The `report_usage`, `append_frame`, and `suspend` trait impls are stubbed `EngineError::Unavailable` at `crates/ff-backend-valkey/src/lib.rs:1145-1147, 1173-1180, 1240-1249` — evidence the current trait shape is not usable, not merely unused.
+
+**Why round-7 and not Stage 1d-as-planned.** RFC-012 Stage-1 landing gate said "no public-surface change beyond additive" (§5.1, §3.3.0). Fixing these three requires breaking two existing trait signatures and adding one method. That's a round-7 amendment, not an implementation detail.
+
+### §R7.2 Proposed trait deltas
+
+#### §R7.2.1 `append_frame` — widen return
+
+**Current** (`crates/ff-core/src/engine_backend.rs:103`):
+```rust
+async fn append_frame(&self, handle: &Handle, frame: Frame) -> Result<(), EngineError>;
+```
+
+**Proposed:**
+```rust
+async fn append_frame(
+    &self,
+    handle: &Handle,
+    frame: Frame,
+) -> Result<AppendFrameOutcome, EngineError>;
+```
+
+**Type move.** `AppendFrameOutcome` moves from `ff-sdk::task` (`task.rs:137-143`) to `ff-core::backend`, mirroring the Stage-1a `FailOutcome` move (`backend.rs:546-558`, `task.rs:152`: `pub use ff_core::backend::FailOutcome`). Keep a `pub use` shim at `ff_sdk::task::AppendFrameOutcome` through 0.4.x. Derive set widens from SDK's `Clone, Debug` to match `FailOutcome` precedent (§R7.5.6):
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppendFrameOutcome {
+    pub stream_id: String,
+    pub frame_count: u64,
+}
+```
+
+**No `#[non_exhaustive]`.** Today's `AppendFrameOutcome` construction is internal to `ff-sdk` (parser at `task.rs:1747`); future external constructors are not anticipated, matching `FailOutcome`'s consumer-shape rationale (`backend.rs:546-550`). Consumer-shape evidence, not just FailOutcome-consistency (MN3). Diverges from v1's silent addition (K3).
+
+**Rationale.** `append_frame`'s backend emission (Valkey XADD returns entry id, XLEN returns frame count — SDK parser at `task.rs:1678`) carries real caller-useful state.
+
+**Placement in §3.1.1.** Method 3b, unchanged.
+
+**Breakage scope.** Current `ff-backend-valkey::append_frame` returns `Err(EngineError::Unavailable { op: "append_frame" })` (`crates/ff-backend-valkey/src/lib.rs:1145-1147`) — a stub, not `()`-success. Zero direct trait-level consumers.
+
+#### §R7.2.2 `create_waitpoint` — new trait method
+
+**Current.** No slot. `ClaimedTask::create_pending_waitpoint` (`crates/ff-sdk/src/task.rs:686-728`) bypasses the trait via `self.client.fcall("ff_create_pending_waitpoint", …)`.
+
+**Proposed new method:**
+```rust
+/// Issue a pending waitpoint for future signal delivery.
+///
+/// Waitpoints have two states in the Valkey wire contract:
+/// **pending** (token issued, not yet backing a suspension) and
+/// **active** (bound to a suspension). This method creates a waitpoint
+/// in the **pending** state. A later `suspend` call transitions a
+/// pending waitpoint to active (see Lua `use_pending_waitpoint` ARGV
+/// flag at `flowfabric.lua:3603,3641,3690`) — or, if buffered signals
+/// already satisfy its condition, the suspend call returns
+/// `SuspendOutcome::AlreadySatisfied` and the waitpoint activates
+/// without ever releasing the lease.
+///
+/// Pending-waitpoint expiry is a first-class terminal error on the wire
+/// (`PendingWaitpointExpired` at `ff-script/src/error.rs:170,403-408`).
+/// The attempt retains its lease while the waitpoint is pending;
+/// signals delivered to this waitpoint are buffered server-side.
+async fn create_waitpoint(
+    &self,
+    handle: &Handle,
+    waitpoint_key: &str,
+    expires_in: Duration,
+) -> Result<PendingWaitpoint, EngineError>;
+```
+
+**New type in `ff-core::backend`:**
+```rust
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PendingWaitpoint {
+    pub waitpoint_id: WaitpointId,
+    pub hmac_token: WaitpointHmac,
+}
+```
+
+`WaitpointHmac` already exists at `crates/ff-core/src/backend.rs:247-277` — Debug-redacts, **no Display impl** (KN2 fix verified).
+
+**Naming decision — L2 resolved as option (c), manager adjudicated as final (§R7.6.3).** Keep `create_waitpoint`. v2's "pending is Valkey-internal" was factually wrong — "pending" is load-bearing in Rust contract code (`ff-script/src/error.rs:170,403-408`) and Lua (`flowfabric.lua:801-823,3641,3690`). Correct rationale:
+- The method creates the pending-kind exclusively; the docstring above disambiguates vs `suspend`'s waitpoint-activation path.
+- The trait surface describes the caller's business op ("issue a waitpoint I'll hand to a signal deliverer"), not the internal state machine. Symmetry with `suspend` as the activation path lives in prose, not in the method name.
+- Alternatives considered: (a) `create_pending_waitpoint` — verbose, matches SDK; (b) `issue_pending_waitpoint` — echoes "issue" but trait peer is `claim_from_reclaim`. Either is acceptable. `create_waitpoint` + explicit docstring wins on brevity.
+
+**Placement in §3.1.1** (lifecycle ops, KD4 accepted — no new sub-bucket; manager adjudicated §R7.6.2). RFC-§3.1 taxonomy count: 15 (pre) → 16 (post); `async fn` compile count: 16 (pre) → 17 (post). Both framings stated per K4 / LN2.
+
+**Rationale for placement vs alternatives.**
+- *Alt A: fold into `suspend`.* Rejected: SDK flow creates the waitpoint first (hand token to external signal deliverer), `suspend` later. Folding breaks the external-delivery handshake.
+- *Alt B: `AdminBackend`.* Rejected: worker-scoped op (requires lease-holder handle).
+- *Alt C: leave off-trait permanently.* Rejected: violates §5.4 sealability precondition.
+
+#### §R7.2.3 `report_usage` — replace `AdmissionDecision` with `ReportUsageResult`
+
+**Current** (`crates/ff-core/src/engine_backend.rs:192-197`):
+```rust
+async fn report_usage(&self, handle: &Handle, budget: &BudgetId,
+    dimensions: UsageDimensions) -> Result<AdmissionDecision, EngineError>;
+```
+with `AdmissionDecision::{Admitted, Throttled{retry_after_ms}, Rejected{reason}}` at `backend.rs:367-376`.
+
+**Proposed:**
+```rust
+async fn report_usage(&self, handle: &Handle, budget: &BudgetId,
+    dimensions: UsageDimensions) -> Result<ReportUsageResult, EngineError>;
+```
+
+`ReportUsageResult` defined at `crates/ff-core/src/contracts.rs:1400-1418` (`Ok | SoftBreach{…} | HardBreach{…} | AlreadyApplied`).
+
+**K1 fix: add `#[non_exhaustive]` to `ReportUsageResult` in this same PR.** Verified missing today (first `non_exhaustive` in `contracts.rs` is at line 1803 on an unrelated struct). Without it, replace-over-widen collapses. Landed atomically with the return-type swap in a single commit per M3 (§R7.7).
+
+**`AdmissionDecision` fate.** Delete. In-tree references: type def (`backend.rs:367-376`), trait sig (`engine_backend.rs:192-197`), stub impl (`ff-backend-valkey/src/lib.rs:1240-1249`), three test constructions (`backend.rs:888-890`). All move together.
+
+**Rationale — replace vs widen.** `AdmissionDecision`'s `Throttled`/`Rejected` variants are emitted by nobody (Lua `ff_report_usage_and_check` emits `Ok / ALREADY_APPLIED / SOFT_BREACH / HARD_BREACH` per `lua/budget.lua:99` + parser `task.rs:1194-1213`). `#[non_exhaustive]` preserves future additivity. `CheckAdmissionResult` (`contracts.rs:1447-1457`) already owns admission-rails (KD3).
+
+**Placement in §3.1.3.** Method 13, signature change only.
+
+### §R7.3 Migration path
+
+**External consumers** of the three methods: none. No direct `EngineBackend` impls outside `ff-backend-valkey` (in-tree verifiable; cross-repo claim dropped per KD2).
+
+**Internal consumers, one PR (atomic single commit per M3):**
+
+1. `crates/ff-backend-valkey/src/lib.rs` — route `append_frame` and `report_usage` impls to real bodies (currently stubbed `Unavailable`); add `create_waitpoint` impl. `suspend` impl untouched (still `Unavailable` — migration deferred to Stage 1d).
+2. `crates/ff-sdk/src/task.rs` — collapse `append_frame`, `create_pending_waitpoint`, `report_usage` TODO-#117 sites into trait forwarders. `suspend` site stays direct-FCALL (Stage 1d).
+3. `crates/ff-core/src/backend.rs` — delete `AdmissionDecision`, move `AppendFrameOutcome` in from `ff-sdk::task`, add `PendingWaitpoint`.
+4. `crates/ff-core/src/contracts.rs` — add `#[non_exhaustive]` to `ReportUsageResult` at line 1400.
+5. `crates/ff-core/src/engine_backend.rs` — touch 3 trait methods (2 updates, 1 add); re-verify `_assert_dyn_compatible` at `:205-206`.
+6. `crates/ff-sdk/src/task.rs` top — add `pub use ff_core::backend::AppendFrameOutcome` shim, matching `FailOutcome` at `:152`.
+
+**Envelope prose (§R7.6.4, manager adjudicated).** Do not rewrite earlier round prose in §3.1. The top-of-RFC Round-7 summary and §3.1's updated intro both note the envelope is relaxed to "17 current trait methods" as of Round-5+Round-7. No separate §3.1-prose edit needed.
+
+**CHANGELOG entry (0.4.0) — drafted for the trait-implementation PR, NOT this doc-only amendment PR:**
+> **Breaking — `EngineBackend`:** `append_frame` now returns `AppendFrameOutcome`; `report_usage` now returns `ReportUsageResult` (replaces `AdmissionDecision`). New trait method `create_waitpoint` (trait grows 16→17 `async fn`; RFC-taxonomy 15→16). `ReportUsageResult` gains `#[non_exhaustive]`. `AdmissionDecision` removed. `suspend` migration deferred to a later release (tracked under #117 Stage 1d). External consumers: none. See #117.
+
+### §R7.4 Non-goals
+
+- Not migrating `suspend` (deferred to Stage 1d per §R7.1 / §R7.6.1).
+- Not changing `UsageDimensions.dedup_key` reservation.
+- Not reserving variants on `ReportUsageResult` for hypothetical rate-limit backends. `#[non_exhaustive]` handles future additions (K1).
+- Not adding `AdminBackend::create_waitpoint`. Pending-waitpoint creation is worker-scoped.
+- Not extending `report_usage` to carry admission rails. `CheckAdmissionResult` already owns that role (KD3).
+- Not touching Lua. Wire shapes unchanged.
+- Not editing CHANGELOG in this PR (doc-only; actual 0.4.0 CHANGELOG entries land with the trait-implementation PR).
+
+### §R7.5 Alternatives considered
+
+#### §R7.5.1 `report_usage` replace vs widen
+Replace chosen (§R7.2.3). Widen rejected under K1-fix. KD3 citation: `CheckAdmissionResult` at `contracts.rs:1447-1457`.
+
+#### §R7.5.2 `create_waitpoint` new method vs fold
+New method (§R7.2.2 Alt A/B/C).
+
+#### §R7.5.3 `append_frame` widen vs `()` + separate stream_position op
+Widen. Two-op variant contradicts §3.4 atomicity.
+
+#### §R7.5.4 Split into two amendments
+Considered. Rejected: single landing PR, single CHANGELOG. (With `suspend` already deferred, the amendment is already the smaller of the two candidate splits.)
+
+#### §R7.5.5 Defer the whole amendment to Stage 1d
+Rejected. `report_usage`'s `AdmissionDecision → ReportUsageResult` swap is independent of `suspend`'s input-shape entanglement; ship what can ship. Stage 1d handles `suspend` only.
+
+#### §R7.5.6 Canonical derive posture for trait outcome types (LD3)
+`FailOutcome` (`backend.rs:546-558`), `AppendFrameOutcome`, `PendingWaitpoint` all use `Clone, Debug, PartialEq, Eq`. `ReportUsageResult` adds `Serialize, Deserialize` (wire parser corroboration). `#[non_exhaustive]` for types new-to-trait (`PendingWaitpoint`) or already-public-and-match-consumed (`ReportUsageResult`); absent for `FailOutcome` / `AppendFrameOutcome` (construction is SDK-internal today per MN3; exhaustive-construction desired).
+
+**Shape-commitment note (MD2).** `AppendFrameOutcome.stream_id: String` is a stable shape assumption — the field carries Valkey Stream entry ids (e.g. `1234567890-0`). A future normalisation (typed `StreamId` newtype, suffix-stripping) would be its own breaking change. Flagged so a later author isn't surprised.
+
+### §R7.6 Open questions
+
+#### §R7.6.1 `suspend` deferred — Stage 1d tracking
+`suspend`'s return-type widening (`SuspendOutcome`) and input-shape rework (SDK `&[ConditionMatcher]` + `TimeoutBehavior` → trait `Vec<WaitpointSpec>` + `Option<Duration>`, or a typed `ResumeCondition`) land together in Stage 1d. Entanglement with SDK `parse_suspend_result` at `task.rs:1465,1557-1562` makes partial migration net-negative (M1). **Owner question (Stage 1d):** typed `ResumeCondition` on trait in round-8, or ARGV-JSON in backend impl?
+
+#### §R7.6.2 `create_waitpoint` §3.1 placement — closed
+Manager adjudication (this PR): insert as method 16 in §3.1.1 alongside other lifecycle ops. Do NOT create a new §3.1.4 "waitpoint management" sub-bucket — one method doesn't warrant one. Trait async-fn count goes 16 → 17.
+
+#### §R7.6.3 `create_waitpoint` naming — closed
+Manager adjudication (this PR): keep `create_waitpoint`. Do not veto to `create_pending_waitpoint`. Rustdoc explicitly cites the Lua `use_pending_waitpoint` ARGV flag as context (§R7.2.2; per Worker Z-v3's fix).
+
+#### §R7.6.4 Envelope prose — closed
+Manager adjudication (this PR): acknowledge the "15 in spirit" envelope is relaxed to "17 current trait methods" as of Round-5+Round-7. Do not rewrite earlier round prose; the top-of-RFC Round-7 summary and §3.1's updated intro carry the note.
+
+(Previously v3 §R7.6.3, §R7.6.4, §R7.6.5, §R7.6.7 closed. v3 §R7.6.6 closed in-tree. v3 §R7.6.8 renumbered to §R7.6.4.)
+
+### §R7.7 Landing plan
+
+**Stage.** Parallel RFC-amendment-only landing, independent of Stage 1c (§5 stage-map addendum).
+
+**Atomicity.** Single commit, single 0.4.0 release cut. `ReportUsageResult`'s `#[non_exhaustive]` addition and the `report_usage` return-type replacement are one breaking-change event; no semver-two-step (M3). The release lane is 0.4.0 regardless of other open questions — `report_usage`'s `AdmissionDecision → ReportUsageResult` swap is unambiguously breaking and forces the minor bump on its own (MD1).
+
+**Acceptance gate.**
+1. All three in-amendment methods route through `EngineBackend` (no remaining `self.client.fcall("ff_*", …)` in `ClaimedTask` for `append_frame`, `create_pending_waitpoint`, `report_usage`). `suspend` not covered (deferred to Stage 1d).
+2. `cargo test --workspace` green; `ff-test` green against real Valkey.
+3. a. Static: `_assert_dyn_compatible` + `ValkeyBackend::_dyn_compatible` compile cleanly.
+   b. Runtime: `Arc<dyn EngineBackend>` smoke test exercising `create_waitpoint` dispatches and returns a valid `PendingWaitpoint`.
+4. CHANGELOG entry drafted for 0.4.0 (lands with the trait-implementation PR, not this doc-only amendment PR).
+
+**Rollback.** Clean. Stage 0 + 1a/b types stay. Three-method delta + one attribute-addition unwind mechanically.
+
+**Estimated effort.** 7-10h (3-delta scope; suspend's 3-6h deferred with it).
+
+**Challenger discipline.** K applied (v1→v2); L applied (v2→v3); M applied (v3→v4). Three rounds sufficient — M1 was the last structural finding and was decidable in-place.
+
+### §R7.8 Evidence log
+
+All line numbers against `da89fa9`; suspend-related entries retained only where `suspend` deferral is justified.
+
+- `crates/ff-sdk/src/task.rs:136-143` (`AppendFrameOutcome`), `:152` (`FailOutcome` shim), `:169` (Stage-1b doc), `:629-669` (`report_usage` + #117 TODO), `:686-728` (`create_pending_waitpoint`), `:740-789` (`append_frame`), `:1194-1213` (`parse_report_usage_result`), `:1465` (`parse_suspend_result` entry — referenced only to justify suspend deferral), `:1557-1562` (exhaustive `SuspendOutcome::Suspended` construction — the M1 evidence), `:1678` / `:1747` (`AppendFrameOutcome` parser + constructor).
+- `crates/ff-core/src/engine_backend.rs:103` (`append_frame` sig), `:192-197` (`report_usage` sig), `:205-206` (`_assert_dyn_compatible`). 16 `async fn` by `grep -c "^    async fn " …`.
+- `crates/ff-core/src/backend.rs:60-69` (`Handle` opaque payload — referenced in M1 deferral justification), `:247-277` (`WaitpointHmac` — Debug only, no Display), `:367-376` (`AdmissionDecision`, `#[non_exhaustive]`), `:546-558` (`FailOutcome` precedent), `:888-890` (`AdmissionDecision` test constructions).
+- `crates/ff-core/src/contracts.rs:1400-1418` (`ReportUsageResult` — NOT `#[non_exhaustive]` today), `:1447-1457` (`CheckAdmissionResult`).
+- `crates/ff-backend-valkey/src/lib.rs:1145-1147, 1173-1180, 1240-1249` (`append_frame` / `suspend` / `report_usage` stubs — `Unavailable`).
+- `crates/ff-script/src/error.rs:170` (`PendingWaitpointExpired`), `:403-408` (`WaitpointNotTokenBound` TERMINAL doc).
+- `crates/ff-script/src/flowfabric.lua:801-823` (`validate_pending_waitpoint` — pending vs active), `:3603` (ARGV contract), `:3641` (`use_pending_waitpoint` parse), `:3690` (pending activation branch).
 
 ---
 

--- a/rfcs/drafts/README.md
+++ b/rfcs/drafts/README.md
@@ -9,6 +9,14 @@ Each cluster of files represents one exploration. Conventions:
 
 ## Index
 
+### RFC-012 #117 deferrals amendment (explored 2026-04-22, promoted as Round-7)
+
+Tracks issue [#117](https://github.com/avifenesh/FlowFabric/issues/117) (Stage 1b deferrals — three `ClaimedTask` methods that couldn't land as thin forwarders).
+
+- `RFC-012-amendment-117-deferrals.{K,L,M}-challenge.md` — three adversarial review rounds (Worker K round-1, Worker L round-2, Worker M round-3).
+
+**Outcome:** draft v4 promoted to `rfcs/RFC-012-engine-backend-trait.md` §R7 as the Round-7 amendment. The draft body was folded into the RFC; the three challenger reports are preserved here as the exploration-and-reasoning record. The amendment ships `create_waitpoint` (new method), `append_frame` (return widen), `report_usage` (return replace); `suspend` is deferred wholesale to Stage 1d.
+
 ### RFC-012 namespace amendment (explored 2026-04-22, not pursued)
 
 Tracks issue [#122](https://github.com/avifenesh/FlowFabric/issues/122) (cairn's multi-tenant isolation ask).

--- a/rfcs/drafts/RFC-012-amendment-117-deferrals.K-challenge.md
+++ b/rfcs/drafts/RFC-012-amendment-117-deferrals.K-challenge.md
@@ -1,0 +1,298 @@
+# Round-1 CHALLENGE against RFC-012 amendment #117 deferrals (draft v1)
+
+Reviewer: Worker K. Base: `da89fa9` (matches draft). Read-only.
+
+## MUST-FIX
+
+### #K1: `ReportUsageResult` is NOT `#[non_exhaustive]` — the §R7.2.4 and §R7.5.1 YAGNI argument is built on a false premise
+
+Draft §R7.2.4 (line 200): "`#[non_exhaustive]` stays on the enum so future
+`Throttled` / `Rejected` additions are additive."
+Draft §R7.5.1 (line 231): "`#[non_exhaustive]` makes those additive later."
+
+**Evidence.** `crates/ff-core/src/contracts.rs:1400-1401`:
+```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReportUsageResult {
+```
+No `#[non_exhaustive]`. Grep confirms — the only `non_exhaustive` attributes in
+the file are on admin-surface args, not on `ReportUsageResult`.
+
+**Why it's load-bearing.** The draft's replace-over-widen case rests on
+"speculative variants can come back later because `#[non_exhaustive]`." Without
+the attribute, adding `Throttled` / `Rejected` post-replace is itself a
+breaking change on `ReportUsageResult`, re-opening exactly the cost the replace
+was supposed to amortise.
+
+**Required fix.** Either (a) the amendment's trait edits MUST include
+`#[non_exhaustive]` on `ReportUsageResult` at landing time (add to §R7.3's
+consumer-update list and spell it out in the trait-delta section), or (b) the
+replace-vs-widen argument needs a different justification (e.g. "we accept
+that Throttled will be a second breaking change if it ever lands"). Option (a)
+is strictly better; pick it and flag that the ff-core type grows an attribute.
+
+---
+
+### #K2: `SuspendOutcome` proposed shape contradicts the same section's design note — `suspension_id` is in the prose, missing from the enum
+
+Draft §R7.2.2 lines 86-103 (proposed enum) lists variant fields:
+- `Suspended { handle, waitpoint_id, waitpoint_key, waitpoint_token }`
+- `AlreadySatisfied { waitpoint_id, waitpoint_key, waitpoint_token }`
+
+Draft §R7.2.2 line 106: "Preserve it on the trait type. It's caller-visible
+for observability and is already on the wire."
+
+**Evidence that the SDK variants DO carry `suspension_id`.**
+`crates/ff-sdk/src/task.rs:71-90`:
+```
+pub enum SuspendOutcome {
+    Suspended { suspension_id: SuspensionId, waitpoint_id, waitpoint_key, waitpoint_token },
+    AlreadySatisfied { suspension_id: SuspensionId, waitpoint_id, waitpoint_key, waitpoint_token },
+}
+```
+
+SDK construction at `crates/ff-sdk/src/task.rs:1550-1562` wires `suspension_id`
+into both variants. Every consumer that currently matches (examples,
+ff-readiness-tests, resume_signals_integration.rs) can ask for it.
+
+**Required fix.** Either add `suspension_id: SuspensionId` to both variants in
+the proposed shape (match §R7.6.3's lean toward keeping it), OR remove the
+design note on line 106 so the draft is internally consistent. The two cannot
+both stand.
+
+---
+
+### #K3: Moving `AppendFrameOutcome` to `ff-core::backend` is NOT "field shape unchanged" — derive set changes and `#[non_exhaustive]` is net-new
+
+Draft §R7.2.1 line 43: "Field shape unchanged."
+
+**Evidence — current shape.** `crates/ff-sdk/src/task.rs:137-143`:
+```
+#[derive(Clone, Debug)]
+pub struct AppendFrameOutcome { pub stream_id: String, pub frame_count: u64 }
+```
+
+**Draft proposed shape** (lines 45-51):
+```
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct AppendFrameOutcome { pub stream_id: String, pub frame_count: u64 }
+```
+
+Adds `#[non_exhaustive]`. Drops no derives, but the FailOutcome precedent
+(`crates/ff-core/src/backend.rs:546-551`) ships with `PartialEq, Eq` for
+test-asserting consumers and deliberately NOT non_exhaustive (the
+in-file comment is explicit: "Not `#[non_exhaustive]` because existing
+consumers ... construct and match this enum exhaustively"). The draft invokes
+the FailOutcome precedent to justify the move but then breaks the precedent's
+two deliberate choices without discussion.
+
+**Required fix.** Either (a) match FailOutcome (no `non_exhaustive`, add
+`PartialEq, Eq` for ergonomics), or (b) keep `non_exhaustive` and explicitly
+document why this type chooses differently from FailOutcome. Don't silently
+diverge.
+
+---
+
+### #K4: Trait method count is off by one — amendment lands at 17 `async fn`, not 16
+
+Draft §R7.2.3 line 150: "Updated inventory count: **16 methods** (was 15 post
+round-5)."
+
+**Evidence.** `grep -c "^\s*async fn " crates/ff-core/src/engine_backend.rs`
+returns **16** today. The RFC §3.1 headline reads "15 methods" because it
+counts `append_frame` as method "3b" (a sub-number of `progress`). By
+`async fn` count, trait is already at 16. Adding `create_waitpoint` = 17.
+
+Draft can keep the "16 methods" RFC-taxonomy framing if it names it
+consistently (3b stays 3b), but §R7.6.2 also flags the sub-bucket question.
+Pick one: either own "17 `async fn`" publicly with a CHANGELOG-friendly
+sentence, or explicitly clarify the numbering convention matches §3.1's
+"3b"-style counting.
+
+**Why this matters.** §R7.6.2 asks the owner whether a `§3.1.4` sub-bucket is
+needed. If the owner reads "16 methods" and thinks "same as today's 16," the
+question is mis-framed. The real move is 16 → 17 concrete trait methods.
+
+---
+
+### #K5: Factual error — `ff-backend-valkey::append_frame` returns `Unavailable`, not `Ok(())`
+
+Draft §R7.2.1 line 57: "`ff-backend-valkey::append_frame`; currently returns
+`Ok(())`".
+
+**Evidence.** `crates/ff-backend-valkey/src/lib.rs:1145-1147`:
+```
+async fn append_frame(&self, _handle: &Handle, _frame: Frame) -> Result<(), EngineError> {
+    Err(EngineError::Unavailable { op: "append_frame" })
+}
+```
+
+The same is true of `suspend` (`:1173-1180`) — all four Stage-1b deferrals
+are stubbed `Unavailable`, not `Ok(())` / silent success. This is only a
+factual error, not a structural one, but it undermines the draft's
+"Breakage scope" credibility. Fix to match reality. (Note: draft correctly
+reports the `report_usage` stub as `Unavailable` at §R7.1 line 21, so the
+sloppy phrasing is isolated to §R7.2.1 line 57.)
+
+---
+
+## DESERVES-DEBATE
+
+### #KD1: Scoping-out the `suspend` input mapping leaves the trait method still structurally unimplementable
+
+Draft §R7.2.2 line 112 / §R7.4 line 219 / §R7.6.1 scope the
+`(ConditionMatcher, TimeoutBehavior) → (Vec<WaitpointSpec>, Option<Duration>)`
+mapping to Stage 1d.
+
+**Evidence trait is currently `Unavailable` for a reason.**
+`crates/ff-backend-valkey/src/lib.rs:1173-1180` — `suspend` is stubbed because
+the SDK call site at `crates/ff-sdk/src/task.rs:812-818` cannot construct
+`Vec<WaitpointSpec>` from its caller-supplied `&[ConditionMatcher]` +
+`TimeoutBehavior` without going through the inline resume-condition-JSON
+builder at `:836-850`. The SDK today builds the JSON payload *itself* and
+passes it as ARGV, bypassing the `WaitpointSpec` shape.
+
+**Debate question.** If round-7 lands the return-type widen but the input
+shape is still unworkable, the `ff-backend-valkey::suspend` impl will stay
+`Unavailable`-stubbed through Stage 1c. That means the SDK forwarder collapse
+claimed in §R7.3.2 cannot actually happen for `suspend` — the SDK will still
+`client.fcall(...)` directly, and the Stage-1d hot-path migration accrues the
+cost the amendment promised to discharge.
+
+**Possible resolutions.**
+1. Acknowledge in §R7.7 that `suspend` is return-type-only and the SDK
+   forwarder collapse for `suspend` specifically blocks on Stage 1d — i.e. one
+   of the four deferrals stays half-deferred.
+2. Expand the amendment to co-specify the input shape.
+3. Land return-type only and accept that §R7.7's acceptance gate (1) "no
+   remaining `client.fcall("ff_*", ...)` in `ClaimedTask`" cannot be met by
+   this PR.
+
+Pick one and say so. The draft currently implies all four lift cleanly, but
+suspend won't.
+
+---
+
+### #KD2: Draft asserts cairn has zero consumers but cairn tree is not accessible in this checkout
+
+Draft §R7.2.4 line 190: "Grep confirms no external consumers."
+Draft §R7.3 line 203: "Cairn-fabric does not consume `EngineBackend` directly
+today (they consume `ClaimedTask` via the SDK)."
+
+**Evidence — non-dismissive.** `find / -maxdepth 4 -name cairn-fabric`
+returns empty in this worktree. The draft's grep was run against `crates/` +
+`ferriskey/`. If cairn is a peer-team tree not present locally, the "zero
+consumers" claim is untested against cairn. The claim may be correct (cairn
+depending on `ClaimedTask` not `EngineBackend` is consistent with RFC-012
+posture), but the draft implies a grep-proof when it's actually an
+architectural inference.
+
+**Debate question.** Is the grep-across-peer-trees check part of the round-7
+acceptance gate, or does the "cairn uses SDK not trait" architectural fact
+suffice? The answer is probably the latter (consumers hit the SDK pub-use
+shims, not the trait directly), but the draft should say so rather than
+invoking a grep it can't reproduce in this checkout.
+
+**Suggested fix.** Replace §R7.3's "per grep across `crates/` and
+`ferriskey/`" with "peer consumers route through `ClaimedTask` (the SDK
+forwarders stay shape-stable; `AppendFrameOutcome` / `SuspendOutcome` keep
+`pub use` shims); grep in the FlowFabric repo confirms no direct
+`EngineBackend` impls outside `ff-backend-valkey`."
+
+---
+
+### #KD3: `CheckAdmissionResult` already exists as the admission-rails type — strengthens replace-over-widen but draft doesn't cite it
+
+`crates/ff-core/src/contracts.rs:1447-1457` defines
+`CheckAdmissionResult::{Admitted, AlreadyAdmitted, RateExceeded, ConcurrencyExceeded}`.
+This is exactly the rate-limit / policy-reject shape the draft's §R7.5.1
+gestures at as "a hypothetical future rate-limit backend."
+
+**Why it matters.** The draft rejects widen on the grounds that `Throttled` /
+`Rejected` are speculative. But the admission-rails op already exists as a
+separate type — future rate-limit logic plugs into `check_admission_and_record`
+paths, not `report_usage`. This is STRONGER evidence for the replace than the
+draft gives itself. Worth citing as corroboration in §R7.5.1: "the
+admission-gating role already has its own type (`CheckAdmissionResult`)
+and is conceptually a distinct op, not a variant of usage-reporting."
+
+This is a debate item, not a must-fix — the draft reaches the right verdict,
+just under-cites.
+
+---
+
+### #KD4: `§3.1.4 waitpoint-management` sub-bucket — no, don't add it
+
+§R7.6.2 asks whether to split §3.1.1 into a new "waitpoint management"
+sub-bucket.
+
+**Pushback.** The §3.1 taxonomy is "Claim + lifecycle" vs "Read-path" vs
+"Out-of-band." `create_waitpoint` + `suspend` + `observe_signals` all live on
+the lease-held path — they are lifecycle ops. A fourth bucket for one new
+method is optics not structure; the draft itself observes the new method
+"is created on the lease-held path" (line 150) which IS §3.1.1. Keep it in
+§3.1.1. Owner can veto.
+
+---
+
+## NITS
+
+### #KN1: "create_waitpoint" naming — collision claim is Lua-scoped not trait-scoped
+
+§R7.2.3 cites collision with `issue_claim_grant` which is a Lua FCALL name
+(`crates/ff-script/src/functions/scheduling.rs:43`), NOT a trait method. The
+only trait peer is `claim_from_reclaim` (`engine_backend.rs:144`). Verdict
+(`create_waitpoint`) is fine; weaken the collision framing.
+
+### #KN2: `WaitpointHmac` has no Display impl — Debug redacts, Display is absent
+
+Draft §R7.2.3 line 143 says "redacts on Debug/Display."
+`crates/ff-core/src/backend.rs:273-277` defines only `impl Debug`. No Display
+impl exists on `WaitpointHmac`. The safety property holds (nothing to leak
+through), but phrase as "has no Display; Debug redacts via the wrapped
+`WaitpointToken` at `types.rs:570-586`."
+
+### #KN3: `SuspendOutcome::AlreadySatisfied` is NOT net-new behaviour
+
+§R7.2.2 line 108 calls it "net-new trait surface." The Lua wire contract
+(`task.rs:1549-1555`) and SDK shape (`task.rs:84-89`) have carried it since
+pending-waitpoint work landed. Rephrase as "trait grows to match existing
+wire contract."
+
+### #KN4: §R7.6.4 resolve in favour of `Duration` — no open question
+
+`Duration` matches `suspend(timeout: Option<Duration>)`. SDK's `u64 ms`
+(`task.rs:689`) is a compat artefact. Resolve, don't leave open.
+
+---
+
+## Affirmative no-findings
+
+- **#K8 investigation (suspend `AlreadySatisfied` as "widening behaviour
+  contract").** NOT a finding. The Lua contract at
+  `ff_suspend_execution` already emits `ALREADY_SATISFIED`; the SDK already
+  returns it. Draft correctly exposes existing behaviour; see #KN3 for the
+  phrasing tweak.
+- **#K7 investigation (HMAC redaction).** Shape-correct; see #KN2 for the
+  Display nit. The structural guarantee holds.
+- **#K1 investigation (zero external consumers of `AdmissionDecision`).**
+  Grep across `crates/` + RFC text returns only 4 in-tree sites (type def,
+  trait sig, stub impl, unit tests), all self-contained. Draft's verdict is
+  sound; see #KD2 for the cairn-verification phrasing fix.
+- **§R7.5 alternatives.** All four alternatives (replace vs widen, suspend
+  widen vs split, create_waitpoint new-method vs fold, append_frame widen vs
+  two-op) are well-argued with correctly-cited rejections. No disagreement.
+- **Dyn-safety treatment (§R7.6.5).** Correct that concrete types + no
+  associated types + no `impl Trait` returns preserve object-safety;
+  `_assert_dyn_compatible` at `engine_backend.rs:205-206` and
+  `_dyn_compatible` at `ff-backend-valkey::lib.rs:1286` will re-verify at
+  compile. The proposal to add an explicit smoke-test is good hygiene;
+  accept.
+
+---
+
+## Verdict
+
+**Accept with changes.** Structural case sound; findings correctable in-place.
+Blockers before promotion: #K1, #K2, #K3, #K4, #KD1. #K5 is one-line. Rest editorial.

--- a/rfcs/drafts/RFC-012-amendment-117-deferrals.L-challenge.md
+++ b/rfcs/drafts/RFC-012-amendment-117-deferrals.L-challenge.md
@@ -1,0 +1,293 @@
+# Round-2 CHALLENGE against RFC-012 amendment #117 deferrals (draft v2)
+
+Reviewer: Worker L. Base: `da89fa9` (matches draft). Read-only.
+K's round-1 findings reviewed; no repetition. Focus: flaws K missed, and
+flaws v2 introduced while fixing K.
+
+---
+
+## MUST-FIX
+
+### #L1: `SuspendOutcome::Suspended { handle: Handle, … }` is a NET-NEW FIELD, not "matching SDK" — v2 conflates two separate data-model changes
+
+v2 §R7.2.2 lines 110-116 propose:
+```
+Suspended {
+    suspension_id: SuspensionId,
+    handle: Handle,             // ← new-vs-SDK
+    waitpoint_id: WaitpointId,
+    waitpoint_key: String,
+    waitpoint_token: WaitpointToken,
+}
+```
+
+v2's line 10 framing ("K2 addressed … matching `crates/ff-sdk/src/task.rs:71-90`")
+and line 102 ("variant fields match SDK exhaustively") are both **false**.
+
+**Evidence — current SDK shape** (`crates/ff-sdk/src/task.rs:71-90`):
+```
+Suspended {
+    suspension_id: SuspensionId,
+    waitpoint_id: WaitpointId,
+    waitpoint_key: String,
+    waitpoint_token: WaitpointToken,
+}
+```
+No `handle` field today. SDK's `suspend` consumes `self` (`task.rs:813`, docstring
+line 806), so there is no handle to return.
+
+The trait's current `suspend` returns bare `Handle` (`engine_backend.rs:129-134`).
+v2's proposed enum **merges both** — it introduces a `Handle` field that was
+never in the SDK shape.
+
+**Why this matters.** v2 treats this as a neutral move ("matching SDK wire
+contract", §R7.2.2 line 132). It is not. Three independent things are happening:
+1. Trait widens to typed outcome (fine).
+2. SDK exhaustive-construction sites get a new required field (breaking for any
+   out-of-tree consumer that mirrors the SDK shape — `pub use` shim preserves
+   the path but not the construction contract).
+3. `Handle` semantics — the docstring (v2 line 111) says "Returned `Handle`
+   supersedes the caller's pre-suspend handle (kind = Suspended)" — is a
+   fresh behaviour contract that needs wire verification. `ff_suspend_execution`
+   today returns `{1, "OK"|"ALREADY_SATISFIED", suspension_id, waitpoint_id,
+   waitpoint_key, waitpoint_token}` per `crates/ff-script/src/functions/suspension.rs:83`
+   — **no handle in the wire response.** If the backend impl must synthesise a
+   Handle post-hoc, state that explicitly. If not, the `handle` field cannot be
+   populated and must drop.
+
+**Required fix.** Either:
+(a) Drop `handle` from `Suspended` to actually match SDK and state that the
+    trait outcome has no superseding-handle slot (parallels `AlreadySatisfied`
+    which also has no handle). SDK forwarder in Stage 1d would then mint a
+    Suspended-kind handle locally from the returned fields.
+(b) Keep `handle` but acknowledge in §R7.2.2 that (i) SDK construction sites
+    grow a new field, (ii) the backend impl synthesises the handle from
+    wire-returned `suspension_id` + `execution_id`, not from the FCALL response
+    directly, and (iii) the `pub use` shim does NOT preserve the SDK's exhaustive
+    constructibility — which contradicts v2 §R7.3's "External consumers: none."
+    claim since the shape diverges.
+
+Current v2 framing is not internally consistent.
+
+---
+
+### #L2: `create_waitpoint` rename drops load-bearing "pending" semantics — the Lua wire distinguishes pending vs activated, the trait method name now hides that
+
+v2 §R7.2.3 lines 169-171 justify rename: "'pending' is Valkey-internal
+terminology … Generic trait callers don't need 'pending' vs 'active' framing."
+
+**Evidence "pending" is NOT Valkey-internal.** Grep `crates/ff-script/`:
+- `crates/ff-script/src/error.rs:170` — `PendingWaitpointExpired` as an
+  FCALL error code (`"pending_waitpoint_expired"`).
+- `crates/ff-script/src/error.rs:403-408` — TERMINAL error semantics for
+  "activating a pending waitpoint whose [state] invalid … pending waitpoint
+  is unrecoverable without a fresh one."
+- `crates/ff-script/src/flowfabric.lua:801-823` — `validate_pending_waitpoint`
+  distinguishes pending-but-not-activated state from a suspension-activated
+  waitpoint; `pending_waitpoint_expired` is a distinct error arm.
+- `crates/ff-script/src/flowfabric.lua:3641, 3690` — `use_pending_waitpoint`
+  as a first-class ARGV flag on `ff_suspend_execution`.
+
+There are TWO states: (1) pending waitpoint (token issued, not yet backing a
+suspension) and (2) active waitpoint (bound to a suspension). `create_waitpoint`
+creates only the **pending** kind. The active kind is created by `suspend`.
+
+**Why the rename is a footgun.** A consumer reading `EngineBackend` sees
+`create_waitpoint(...)` and `suspend(..., waitpoints: Vec<WaitpointSpec>, ...)`.
+Which one creates "the waitpoint"? Both. The SDK method name
+(`create_pending_waitpoint`) disambiguates; the trait rename makes the two
+appear to compete. The collision isn't `issue_claim_grant` (a Lua FCALL, per
+KN1) — the real collision is with `suspend`'s own waitpoint-creation path.
+
+**Required fix.** Either:
+(a) Keep `create_pending_waitpoint` on the trait (matches SDK + Lua, verbose
+    but unambiguous).
+(b) Rename to `issue_pending_waitpoint` (distinguishes "issue a token for
+    future delivery" from "suspend and wait on signals").
+(c) Keep `create_waitpoint` but document IN THE METHOD DOCSTRING (v2 lines
+    146-149 gesture at it, but don't spell out the pending/active contrast)
+    that the method creates the pending-kind and that `suspend` creates the
+    active-kind — plus rename the wire-level Lua error arm references in the
+    RFC prose to match the trait.
+
+v2's current rationale (line 169) is factually wrong about "pending" being
+Valkey-internal; fix the rationale or fix the name.
+
+---
+
+## DESERVES-DEBATE
+
+### #LD1: Trait `suspend` method becomes USED-BY-NOBODY after landing — a breaking trait signature change with zero runtime exercise
+
+v2 §R7.2.2 line 136 ("ff-backend-valkey::suspend remains Unavailable-stubbed
+after this PR") + §R7.3 line 235 ("suspend site stays direct-FCALL until
+Stage 1d") + §R7.7 acceptance-gate (1) excluding suspend ⇒ after the amendment
+lands:
+
+- Trait signature changes (`Handle` → `SuspendOutcome`).
+- ff-backend-valkey impl: returns `Err(EngineError::Unavailable)`.
+- SDK `ClaimedTask::suspend`: bypasses the trait entirely (direct-FCALL).
+- NO production caller exercises `EngineBackend::suspend`'s new return type.
+
+Evidence the Unavailable stub will survive: `crates/ff-backend-valkey/src/lib.rs:1173-1180`
+returns Unavailable today; per v2 line 234 "`suspend` return type ONLY (KD1:
+body stays `Unavailable` until input-shape work lands)."
+
+**Debate question.** Is landing a breaking trait signature change whose real
+body is stubbed and whose real caller bypasses the trait acceptable? Three
+framings:
+
+1. *Yes — shape-reservation is the purpose.* Locks in the return-type contract
+   now so Stage 1d's input-shape work is purely additive on the signature
+   side. OK if we accept that CI will not catch regressions on the shape.
+
+2. *No — co-land the input-shape work.* Amendment grows to cover §R7.6.1.
+   Heavier, but the trait method is actually exercised on merge.
+
+3. *No — defer `suspend` from this amendment.* Land the 3 clean cases now
+   (`append_frame`, `report_usage`, `create_waitpoint`). `suspend`'s typed
+   outcome ships with Stage 1d. Amendment's scope is more honest
+   ("3 deferrals resolved, 1 remaining") and matches what actually ships.
+
+v2 chose (1) implicitly but didn't name the tradeoff. Owner needs to endorse.
+
+---
+
+### #LD2: Envelope creep framing — "15 in spirit" → 17 `async fn` is a real jump, and `create_waitpoint` is NOT a "splits-for-honesty" move
+
+RFC-012 §3.1 line 109 justifies the 13→15 envelope stretch as:
+"every count-growth step is a splits-for-honesty move, not a granularity creep
+(the `progress`/`append_frame` split replaces a fused method whose atomicity
+was unsound; `observe_signals`/`claim_from_reclaim` replaces one method whose
+multi-round-trip honesty was broken; `delay` and `wait_children` elevate two
+call sites that are structural peers of `suspend`)."
+
+v2's open-question #5 (line 311) flags the envelope concern but doesn't resolve
+it. Crucial distinction K didn't probe:
+
+**`create_waitpoint` is a net-new business op, not a split.** Every prior
+growth step was: one op that was dishonestly fused → split into honest
+siblings. Method count grows but the business-op count was unchanged
+(or shrank). Adding `create_waitpoint` grows both method count AND business-op
+count. It's a precedent shift on the envelope framing.
+
+**Debate question.** Does the "15 in spirit" envelope language in §3.1 need
+explicit relaxation in this amendment's RFC text (e.g. amending §3.1 to read
+"~10-12, up to ~17, with splits-for-honesty AND gap-fills"), or is the
+envelope's "in spirit" qualifier elastic enough as-stated? If the former,
+§R7.3 needs a bullet for RFC-012 §3.1 text update.
+
+---
+
+### #LD3: `AppendFrameOutcome` derive posture drift
+
+v2 §R7.2.1 line 72 widens `AppendFrameOutcome` from SDK's `Clone, Debug` to
+`Clone, Debug, PartialEq, Eq`. Non-breaking (both fields impl `PartialEq+Eq`).
+Soft concern: v2 pulls this type out of the SDK's minimal-derive posture to
+match `FailOutcome`, and `PendingWaitpoint` follows the same expanded posture.
+Document the new canonical posture in §R7.4 or §R7.5 to avoid silent drift.
+
+---
+
+## NITS
+
+### #LN1: v2's §R7.3 bullet 5 "update 4 signatures" miscounts
+
+v2 line 238: "update 4 signatures, add `create_waitpoint`".
+
+Amendment changes 3 signatures (`append_frame`, `suspend`, `report_usage`) and
+adds 1 (`create_waitpoint`). The 4th "signature" v2 is counting is
+`create_waitpoint` itself, which is ALSO the "add" item. Either "update 3
+signatures, add `create_waitpoint`" or "touch 4 trait methods (3 updates, 1
+add)" — pick one to not double-count.
+
+### #LN2: v2 line 17 grep count attribution
+
+v2 line 17 claims `grep -c "^    async fn " crates/ff-core/src/engine_backend.rs`
+returns 16. Verified empirically (16 matches at `da89fa9`). Good. But the
+related claim "RFC §3.1 taxonomy (which counts `append_frame` as '3b')
+separately reads 16" — RFC §3.1 line 107 reads "15 methods — round-5 amended",
+not 16. The 3b numbering makes the count 15 in the RFC-taxonomy, not 16.
+v2's parenthetical is off by one. Fix to: "RFC §3.1 taxonomy reads 15 (counts
+`append_frame` as '3b'); `async fn` compile count reads 16; post-amendment:
+16 / 17 respectively."
+
+### #LN3: §R7.6.5's dyn-safety smoke test recommendation should be elevated
+
+v2 line 309 recommends "yes" on the smoke test but leaves it as a question.
+§R7.7 acceptance-gate (3) already requires `_assert_dyn_compatible` + `_dyn_compatible`
+compile cleanly — those are static assertions. The smoke test is stricter
+(exercises dispatch). Either include it in gate (3) or drop from the open-
+question list. Currently inconsistent.
+
+### #LN4: v2 line 314 "Challenger discipline. K-round applied (v1 → v2). Next: L / M / P" is presumptuous
+
+L/M/P is a four-round ritual from the namespace amendment. This amendment may
+or may not need all four. Suggest: "Next: L (this document), then M/P if
+material findings remain."
+
+---
+
+## Affirmative no-findings (including K's findings correctly addressed)
+
+- **K1 (`ReportUsageResult` `#[non_exhaustive]` landing):** v2 §R7.2.4 lines
+  213-215 land the attribute at amendment time, §R7.3 bullet 4 lists it as a
+  consumer-update, §R7.5.1 no longer hand-waves. Resolved. **Downstream-match
+  audit**: grep for `ReportUsageResult::` across crates finds no cross-crate
+  exhaustive match without a wildcard (ff-sdk `task.rs:2157,2170` use
+  `other => panic!()`; ff-test uses `matches!`; ff-script / ff-server construct,
+  do not match). Adding `#[non_exhaustive]` breaks nothing in-tree. Clean.
+- **K2 (`suspension_id` on both variants):** Present on both variants (v2
+  lines 111, 120). See #L1 for the ORTHOGONAL concern about `handle` — K2
+  itself is cleanly addressed.
+- **K3 (`AppendFrameOutcome` derive alignment with `FailOutcome`):** v2
+  line 65 matches FailOutcome precedent (`Clone, Debug, PartialEq, Eq`, NO
+  `#[non_exhaustive]`). Divergence-from-v1 spelled out at line 72. Clean.
+  See #LD3 for a soft consistency question.
+- **K4 (16/17 method-count framing):** v2 §R7.2.3 line 173 names both
+  framings explicitly (17 `async fn` compile-count; 16 RFC-taxonomy). See
+  #LN2 for a one-word fix in the parenthetical.
+- **K5 (`append_frame` stub reality):** v2 §R7.2.1 line 78 correctly reports
+  `Err(EngineError::Unavailable { op: "append_frame" })`. Fixed.
+- **KD1 (suspend input-shape scope-out):** v2 §R7.7 acceptance-gate (1)
+  excludes suspend explicitly, §R7.2.2 line 136 owns the "Unavailable-stubbed
+  after this PR" consequence, Stage 1d tracker at §R7.6.1. Resolved — though
+  see #LD1 for the shape-reservation tradeoff owner should endorse.
+- **KD2 (cairn grep-across-peer-trees):** v2 §R7.3 line 230 rephrased to
+  "no direct `EngineBackend` impls outside `ff-backend-valkey`" (in-tree
+  verifiable). Cross-repo grep claim dropped. Clean.
+- **KD3 (`CheckAdmissionResult` corroboration):** v2 §R7.5.1 line 257 cites
+  `contracts.rs:1447-1457`. Verified — type exists with the variant set K
+  described. Clean.
+- **KD4 (§3.1.1 sub-bucket):** v2 §R7.6.2 line 277 accepts "keep in §3.1.1,
+  no new sub-bucket." Clean.
+- **KN1 (collision framing):** v2 line 171 weakened to "optics; `create_`
+  stays the neutral verb." Clean at the Lua-vs-trait distinction. See #L2
+  for a DIFFERENT collision concern.
+- **KN2 (`WaitpointHmac` no Display):** v2 line 167 states "no Display impl
+  (KN2 fix — v1 draft misstated this)." Verified at `backend.rs:273-277` —
+  only `impl Debug` exists. Clean.
+- **KN3 (`AlreadySatisfied` reframe):** v2 line 132 "trait growth to match
+  existing wire." Verified at `crates/ff-script/src/functions/suspension.rs:83-84`
+  (wire emits `ALREADY_SATISFIED` today). Clean.
+- **KN4 (`Duration` resolution):** v2 §R7.6.4 line 281 resolved to Duration.
+  Clean.
+- **Dyn-safety posture:** Proposed shapes use concrete types only. Static
+  assertions will re-verify. See #LN3 for the smoke-test promotion.
+- **`ReportUsageResult` non_exhaustive landing does NOT break in-tree
+  matches:** Verified via exhaustive grep of all `match` and `matches!` sites
+  across `crates/`; every cross-crate match either uses a wildcard arm or
+  `matches!`-with-single-variant. In-crate (same-crate-as-definition) matches
+  are unaffected by `#[non_exhaustive]`. Safe.
+
+---
+
+## Verdict
+
+**Accept with changes.** v2 cleanly resolved all five of K's must-fixes and
+eight of K's debate/nit items. Two fresh must-fixes surfaced — #L1 (phantom
+`handle` field on `SuspendOutcome::Suspended`) is the load-bearing one: v2's
+"matching SDK" claim is factually wrong and papers over a genuine data-model
+decision the owner needs to make. #L2 (pending vs create rename) is a
+docstring-or-rename fix. #LD1 and #LD2 deserve owner adjudication before
+landing. Remaining items are editorial. Structural case still sound.

--- a/rfcs/drafts/RFC-012-amendment-117-deferrals.M-challenge.md
+++ b/rfcs/drafts/RFC-012-amendment-117-deferrals.M-challenge.md
@@ -1,0 +1,149 @@
+# Round-3 CHALLENGE against RFC-012 amendment #117 deferrals (draft v3)
+
+Reviewer: Worker M2. Base: `da89fa9` (worktree at `23d3ce3` — v3 citations still match). Read-only.
+K (round-1) + L (round-2) findings not re-litigated. Focus: flaws in v3's resolutions + net-new hazards v3 introduced.
+
+---
+
+## MUST-FIX
+
+### #M1: SDK's own `parse_suspend_result` constructs `SuspendOutcome::Suspended` EXHAUSTIVELY — v3's "handle synthesis post-FCALL" story doesn't fit this site
+
+v3 §R7.2.2 line 127 states: "Backend-side handle synthesis. Lua wire returns no handle in the FCALL response today. The backend impl synthesises a `Handle { kind: HandleKind::Suspended, … }` post-FCALL from `suspension_id` + `execution_id` + `backend_tag`."
+
+v3 §R7.3 bullet 3 moves `SuspendOutcome` into `ff-core::backend` and bullet 6 adds `pub use ff_core::backend::SuspendOutcome` in `ff-sdk::task`. §R7.2.2 line 128 claims "every `SuspendOutcome::Suspended` match in `crates/` uses `{ .. }` rest-patterns or wildcard arms."
+
+The v3 argument is about `match` sites. It skips `construct` sites. Evidence:
+
+`crates/ff-sdk/src/task.rs:1557-1562`:
+```rust
+Ok(SuspendOutcome::Suspended {
+    suspension_id,
+    waitpoint_id,
+    waitpoint_key,
+    waitpoint_token,
+})
+```
+
+This is the SDK's internal wire parser (`parse_suspend_result` at `:1465`), called by the SDK-level `ClaimedTask::suspend` forwarder (`:818`) which v3 §R7.3 bullet 2 says "stays direct-FCALL until Stage 1d." So the SDK constructor site remains live AND exhaustive, AND it has no `Handle` to supply — `parse_suspend_result` is a pure wire parser with no access to `backend_tag` / `lease_id` / the rest of the Handle's opaque payload (`backend.rs:60-69`).
+
+Consequence for v3 as drafted:
+1. Adding `handle: Handle` as a required field on `SuspendOutcome::Suspended` in the moved type breaks `task.rs:1557` compile.
+2. Making `handle` optional (`Option<Handle>`) re-weakens the contract v3 says it is preserving.
+3. Splitting construction paths (ff-core variant keeps handle, SDK keeps old shape) defeats the `pub use` shim — the shim's entire purpose is path-preservation with a single canonical type.
+
+Similar exhaustive construction at `crates/ff-sdk/src/task.rs:1550-1555` for `AlreadySatisfied` — not affected (no new field there), but the pattern confirms the SDK parser doesn't use rest-patterns in constructors.
+
+**Required fix.** Either (a) drop `handle` from `Suspended` and acknowledge the trait's existing `HandleKind::Suspended` contract is not preserved end-to-end until Stage 1d collapses the SDK forwarder (owner decision under §R7.6.7), OR (b) keep `handle` but spell out in §R7.3 that bullet 2 grows: the SDK `suspend` forwarder at `task.rs:812-818` (including `parse_suspend_result` at `:1465`) must be rewritten in the same PR — which contradicts "suspend site stays direct-FCALL until Stage 1d." This tension is load-bearing for §R7.6.7's (b)-lean: the divergence v3 owns forces partial SDK migration anyway.
+
+### #M2: v3 cites wrong line numbers for `SuspendOutcome` match sites
+
+v3 §R7.2.2 line 128 claims in-tree `SuspendOutcome::Suspended` matches at "`task.rs:2157,2170` (wildcard-armed — still compile)". Those lines are `ReportUsageResult::SoftBreach` and `ReportUsageResult::HardBreach` match arms in `parse_report_usage_result` tests (verified at `crates/ff-sdk/src/task.rs:2157,2170`), NOT `SuspendOutcome` sites.
+
+Actual in-tree `SuspendOutcome::Suspended` match sites:
+- `crates/ff-readiness-tests/tests/waitpoint_hmac_roundtrip.rs:337-342` — uses `{ .. }` rest + `other => panic!(..)` arm. Safe against new field.
+- `crates/ff-test/tests/resume_signals_integration.rs:143, 213, 286` — all use `{ waitpoint_id, waitpoint_key, waitpoint_token, .. }`. Safe.
+- `crates/ff-test/tests/e2e_lifecycle.rs:5476-5482` — uses `{ …, .. }` rest + explicit `AlreadySatisfied { .. }`. Safe.
+
+So the match-sites claim (every match is rest-patterned) is CORRECT after re-verification, but the cited evidence is wrong. This matters because K's whole `#[non_exhaustive]` audit discipline depends on accurate match-site enumeration; a reviewer chasing v3's citation lands on unrelated code.
+
+**Required fix.** Replace line-128 citations with the actual sites above; keep the conclusion, which holds.
+
+### #M3: `ReportUsageResult` gains `#[non_exhaustive]` but v3 does not specify ordering vs return-type replace
+
+v3 §R7.2.4 / §R7.3 bullet 4 do two things to `ReportUsageResult` in the same PR:
+1. Add `#[non_exhaustive]` at `contracts.rs:1400` (K1 fix).
+2. Become the replacement return type for `report_usage` (core delta).
+
+Ordering question v3 doesn't answer: if the PR lands in separate commits — attribute-first or trait-signature-first — both are fine in isolation because `ReportUsageResult` is already pub and already used by SDK parsers. But v3 should say the landing is atomic (single commit) to avoid a reviewer assuming "add attribute, wait for dependent minor, then cut trait change" — which is a semver-two-step that contradicts the 0.4.0 framing. Not a blocker, but the CHANGELOG entry (§R7.3 line 234) bundles both deltas, so the landing plan should too.
+
+**Required fix.** One sentence in §R7.3 or §R7.7: "All five consumer-update bullets land in a single commit / single 0.4.0 release cut; attribute + return-type are one breaking-change event."
+
+---
+
+## DESERVES-DEBATE
+
+### #MD1: Semver lane — v3 says "0.4.0" in CHANGELOG but §R7.1 / §R7.4 framing is "pre-1.0 posture, CHANGELOG-only communication"
+
+v3 §R7.3 CHANGELOG entry reads `(0.4.0)`. v3 line 5 says "Pre-1.0 posture: CHANGELOG-only communication, no BC shims beyond `pub use` path-preservation." Today's released line (per `git log`) is 0.3.3-hotfix.
+
+Two questions v3 should decide, not leave implicit:
+1. Does this amendment ship in 0.3.x (minor bump over 0.3.3) or 0.4.0 (breaking bump)? Rust-ecosystem convention: breaking change on a public trait pre-1.0 is a minor bump (0.3 → 0.4). `EngineBackend` is pub. v3's CHANGELOG line says 0.4.0, which is correct under that convention — but §R7.1's "round-7 amendment" framing and Stage-1b framing don't connect to the release cut.
+2. Does `suspend` shape-reservation (§R7.6.7 (a)) still justify a 0.4.0 cut, or does deferring `suspend` (b) let the other three land in a 0.3.x minor? The answer depends on whether `append_frame`'s `() → AppendFrameOutcome` is itself trait-breaking enough to force 0.4.0.
+
+It is: `report_usage` replace (`AdmissionDecision → ReportUsageResult`) is unambiguously breaking. So the release cut is 0.4.0 regardless of §R7.6.7. Say so explicitly.
+
+**Debate question.** Bless "lands in 0.4.0 regardless of §R7.6.7 outcome" in §R7.7 to collapse this question.
+
+### #MD2: `AppendFrameOutcome` derive widen to `PartialEq, Eq` — field coverage verified, but `stream_id: String` semantic-equality is a shape commitment
+
+v3 §R7.2.1 line 60-65:
+```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppendFrameOutcome { pub stream_id: String, pub frame_count: u64 }
+```
+
+Both fields trivially impl `PartialEq + Eq` (String, u64). Compile-safe. But `stream_id` is a Valkey Stream entry id (e.g. `1234567890-0` per XADD semantics). `PartialEq` on it is byte-equality; in downstream assert-eq tests that's almost always what the author wants. Concern: if a future wire change normalises `stream_id` (e.g. drops the `-0` suffix for sequence-0 entries, or adopts a typed `StreamId` newtype), the canonical-derive commitment locks the field at `String`. v3 should note in §R7.5.6 that `stream_id: String` is the stable shape assumption and a future typed-stream-id migration would be its own breaking change.
+
+Soft concern, not a blocker. Derive widen is correct.
+
+### #MD3: §R7.6.7 should be closed by this amendment, not escalated
+
+v3 provisionally leans (b) (defer `suspend`) and flags "owner must endorse before landing." But the in-tree evidence is now complete enough to decide without owner input:
+
+- #M1 establishes that option (a) (shape-reservation) requires SDK `parse_suspend_result` rewrite in the same PR OR an Option-typed handle that weakens the contract.
+- Option (b) (defer) has no such hazard.
+- v3 already leans (b).
+- Owner's concerns are structural, not data-driven — and the data now points cleanly to (b).
+
+Escalating (b) to owner on a question the evidence has decided is a coordination tax. Close §R7.6.7 as (b) in v4, note in §R7.7 "owner may reopen if shape-reservation preferred." Same principle as the feedback memory item on deferred design debt — decidable questions shouldn't sit in open-questions lists.
+
+Not quite a must-fix because the escalation has zero cost to correctness; but v3's "Remaining open questions" list at lines 316-324 has 6 items, 3 of which (R7.6.6, R7.6.7, L1 confirmation) are effectively decidable in-tree. Collapse what can be collapsed.
+
+---
+
+## NITS
+
+### #MN1: §R7.7 acceptance gate (3) still describes two tests as one
+
+v3 §R7.7 gate (3): "`_assert_dyn_compatible` + `ValkeyBackend::_dyn_compatible` compile cleanly AND an `Arc<dyn EngineBackend>` runtime smoke test exercising `create_waitpoint` dispatches and returns a valid `PendingWaitpoint`."
+
+Two distinct gates are ANDed into one bullet. Split to (3a) static dyn-safety assertion compiles and (3b) runtime smoke test passes. CI interprets gates bullet-wise; a single failing sub-bullet inside a compound bullet is easy to under-report.
+
+### #MN2: "Envelope prose" LD2 item — §R7.3 bullet 7 is conditional on §R7.6.8, but §R7.6.8 isn't closed
+
+v3 §R7.3 bullet 7: "`rfcs/RFC-012-engine-backend-trait.md` §3.1 — relax envelope prose per LD2/§R7.6.8 to admit gap-fill adds alongside splits-for-honesty."
+
+v3 §R7.6.8 says "if amended, §R7.3 bullet 7 applies; if not, drop bullet 7."
+
+As written, §R7.3 bullet 7 is conditional text inside a normative landing-plan list. Readers scanning §R7.3 will count 7 items; readers scanning §R7.6.8 will see it's optional. Make §R7.3 bullet 7 explicitly conditional ("(§R7.6.8-conditional) RFC-012 §3.1 prose relaxation …") or move to §R7.6.8 and note §R7.3 grows by 1 bullet on owner elect.
+
+### #MN3: `AppendFrameOutcome` absence of `#[non_exhaustive]` deserves a one-line explicit rationale at §R7.2.1
+
+v3 line 67 says "No `#[non_exhaustive]` (matches `FailOutcome` comment at `backend.rs:546-550`). Diverges from v1's silent addition (K3)." Good — but the `FailOutcome` precedent comment explains the choice ("existing consumers construct and match exhaustively") and `AppendFrameOutcome` does not inherit that justification automatically: today there are no `AppendFrameOutcome`-construction sites outside the SDK parser (`task.rs:1747`). v3 is relying on consistency-with-FailOutcome rather than consumer-shape evidence. State one line: "Current `AppendFrameOutcome` construction is internal to `ff-sdk`; future external constructors are not anticipated, matching `FailOutcome`'s consumer-shape rationale." Keeps the precedent defensible under later scrutiny.
+
+---
+
+## Affirmative no-findings
+
+- **L1 resolution — `handle` divergence ownership.** v3 owns the divergence (§R7.2.2 lines 124-128), cites the trait's existing Round-4 contract correctly (verified at `engine_backend.rs:126-128` and `backend.rs:50,788`), and spells out the `pub use` shim's construction-contract limitation. Conceptually sound. See #M1 for the concrete SDK-parser construction site that escalates this into a Stage-1b-scope problem.
+- **L2 resolution — `create_waitpoint` naming.** v3 recants v2's "pending is Valkey-internal" framing, cites Rust + Lua "pending" evidence correctly (verified at `ff-script/src/error.rs:170,403-408` and `flowfabric.lua:801-823,3641,3690`), and documents the pending-vs-active contrast in the method docstring (§R7.2.3). The layered-design argument (trait describes caller's business op) is coherent. Option (a) / (b) / (c) all remain defensible; (c) is justified. Not impedance mismatch.
+- **LD2 / LD3 resolutions.** §R7.5.6 canonical-derive posture is clean. §R7.6.8 escalates the envelope-prose question correctly (this one IS an owner call — §3.1's "in spirit" is editorial discretion).
+- **K1, K2, K3, K4, K5 resolutions.** All confirmed fixed per L's round-2 affirmative no-findings; re-verified against code at `da89fa9`:
+  - `ReportUsageResult` lacks `#[non_exhaustive]` today (`contracts.rs:1400`); v3 adds it (§R7.3 bullet 4). Correct.
+  - `SuspendOutcome::{Suspended, AlreadySatisfied}` carry `suspension_id` (`task.rs:76,85`). Correct.
+  - `FailOutcome` shape at `backend.rs:546-550`: `Clone, Debug, PartialEq, Eq`, no `#[non_exhaustive]`. Matches v3's canonical-derive statement.
+  - `async fn` count is 16 today (`grep -c "^    async fn " engine_backend.rs` = 16). Post-amendment 17. Matches v3.
+  - All four stubs return `EngineError::Unavailable`. Matches v3.
+- **§R7.5.7 (keep-handle).** Alternatives-considered correctly lists drop-handle as rejected for the right reason (silently weakens Round-4). The alternative is genuinely worse — even though the keep-handle path has its own hazard (#M1), the analysis of the alternative is sound.
+- **`SuspendOutcome` variants exhaustiveness.** The Lua wire at `ff-script/src/functions/suspension.rs:80-128` has exactly two success arms (`ALREADY_SATISFIED` and the unlabeled ok-path). SDK parser at `task.rs:1549-1563` mirrors exactly those two. `Suspended` + `AlreadySatisfied` are complete; no hidden third arm (`Timeout` is expressed as an error, not a success-outcome variant — correctly).
+- **`AppendFrameOutcome` field-level `PartialEq, Eq` coverage.** Both `String` and `u64` impl `PartialEq + Eq` via std. Compile-safe. See #MD2 for a soft shape-commitment concern.
+- **Acceptance gate (1) / (2) / (4).** Gate (1) correctly excludes `suspend` per §R7.6.7 (b) lean. Gate (2) is the standard workspace test bar. Gate (4) is CHANGELOG hygiene. Sufficient for this amendment's scope when (a) is rejected. See #MN1 for a sub-bullet split on (3).
+
+---
+
+## Verdict
+
+**Accept with targeted fixes.** v3 resolves L1 / L2 / LD1-3 cleanly at the RFC level. Two residual must-fixes: #M1 (SDK `parse_suspend_result` exhaustive construction site interacts with the moved `SuspendOutcome` + new `handle` field — forces §R7.6.7 toward (b)) and #M2 (citation error on match-site line numbers). #M3 is a one-line landing-atomicity clarification. #MD1-3 are owner-touch items; #MD3 in particular argues v3 can close §R7.6.7 as (b) on the evidence rather than escalate.
+
+Three rounds (K + L + M) is sufficient — #M1 is the last structural finding and is decidable in-place. No need for P.


### PR DESCRIPTION
## Summary

Promotes the v4 `#117` deferrals draft (in `rfcs/drafts/`) into an in-place Round-7 amendment to RFC-012. Doc-only PR: no `.rs` files touched. `suspend` remains deferred wholesale to Stage 1d.

Round-7 lands INDEPENDENTLY of Stage 1c — it is a parallel RFC-amendment-only PR, not a Stage 1 sub-stage.

## Scope

Three trait deltas (all atomic in one future implementation commit, cut as 0.4.0):

- **`create_waitpoint`** (new) — method 16 in §3.1.1; returns new `PendingWaitpoint { waitpoint_id, hmac_token }` in `ff-core::backend`.
- **`append_frame`** (widen) — return type `()` → `AppendFrameOutcome { stream_id, frame_count }`; type moves from `ff-sdk::task` to `ff-core::backend` with `pub use` shim.
- **`report_usage`** (replace) — return type `AdmissionDecision` → `ReportUsageResult { Ok | AlreadyApplied | SoftBreach | HardBreach }`. `ReportUsageResult` gains `#[non_exhaustive]`. `AdmissionDecision` removed.

**`suspend` deferred to Stage 1d.** Round-3 (Worker M, finding #M1) established that any trait `SuspendOutcome` shape preserving the Round-4 `HandleKind::Suspended` contract entangles with the SDK wire parser `parse_suspend_result` (`crates/ff-sdk/src/task.rs:1557-1562`), which constructs `Suspended` exhaustively from wire bytes with no access to `Handle`'s opaque payload. Stage 1d bundles the return-type widen with the input-shape rework (`ConditionMatcher` ↔ `WaitpointSpec` / typed `ResumeCondition`).

## Manager adjudication on editorial opens

v4 left three genuinely-editorial open questions; the manager's calls are incorporated:

- **§R7.6.2 (placement):** `create_waitpoint` inserted as method 16 in §3.1.1 alongside other lifecycle ops. No new §3.1.4 sub-bucket — one method doesn't warrant one. Trait `async fn` count 16 → 17.
- **§R7.6.3 (naming):** kept as `create_waitpoint` (not `create_pending_waitpoint`). Rustdoc cites the Lua `use_pending_waitpoint` ARGV flag (`flowfabric.lua:3603,3641,3690`) for pending-vs-active disambiguation.
- **§R7.6.4 (envelope prose):** §3.1 "15 in spirit" envelope is relaxed to "17 current trait methods" as of Round-5+Round-7. Noted in the top-of-RFC Round-7 summary and §3.1 intro; earlier-round prose not rewritten.

## Target release

**0.4.0.** The `report_usage` return-type replace (`AdmissionDecision` → `ReportUsageResult`) is unambiguously breaking on a public trait and forces the minor bump on its own, independent of `suspend` deferral and any other Stage 1c scope.

## Challenger record

Three adversarial review rounds preserved in `rfcs/drafts/` (same pattern as the archived namespace amendment):

- [`rfcs/drafts/RFC-012-amendment-117-deferrals.K-challenge.md`](../blob/rfc/RFC-012-round-7-117-deferrals/rfcs/drafts/RFC-012-amendment-117-deferrals.K-challenge.md) — Worker K round-1.
- [`rfcs/drafts/RFC-012-amendment-117-deferrals.L-challenge.md`](../blob/rfc/RFC-012-round-7-117-deferrals/rfcs/drafts/RFC-012-amendment-117-deferrals.L-challenge.md) — Worker L round-2.
- [`rfcs/drafts/RFC-012-amendment-117-deferrals.M-challenge.md`](../blob/rfc/RFC-012-round-7-117-deferrals/rfcs/drafts/RFC-012-amendment-117-deferrals.M-challenge.md) — Worker M round-3 (finding #M1 forced the `suspend` deferral).

The v4 draft body itself is deleted from `rfcs/drafts/`; its content is the new §R7 appendix in RFC-012.

## Pre-merge operator checklist

- [x] Manager adjudication on the 3 editorial opens incorporated.
- [x] RFC-012 §R7 content matches the v4 draft body (minus the dropped `suspend` content).
- [x] Challenger records K/L/M preserved in `rfcs/drafts/`.
- [x] Drafts README updated with the #117 exploration-index entry.
- [x] CHANGELOG entry NOT added in this PR (amendment is doc-only; actual 0.4.0 CHANGELOG entries come with the trait-implementation PR).
- [x] Target release stated explicitly as 0.4.0 in §R7.

## Test plan

- [ ] `cargo test --workspace` — doc-only PR, should pass trivially (no `.rs` files touched).
- [ ] CI link-check (if any) passes against the moved draft filename and the RFC's new §R7 anchors.
- [ ] Reviewer spot-check: top-of-RFC Round-7 summary consistent with §R7 appendix; method 16 in §3.1.1 renders with correct numbering; §3.3 code block compiles as prose (round-4 convention — signatures are illustrative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)