### PR TITLE
chore(ff-core): drop unused BackendTimeouts.keepalive field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to FlowFabric are documented here. Format loosely
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Removed
+
+- **`BackendTimeouts.keepalive` field.** ferriskey handles TCP keepalive
+  unconditionally with OS-default settings
+  (`ferriskey/src/connection/tokio.rs:33-36`); the field was never wired
+  and had no observable behavior. Consumers can re-add custom-interval
+  wiring if needed via a future additive field. Breaking public-field
+  removal accepted under pre-1.0 posture.
+
 ## [0.3.3] - 2026-04-22
 
 ### Fixed

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -559,7 +559,7 @@ pub enum FailOutcome {
 
 // ── Stage 1a: BackendConfig + sub-types ─────────────────────────────────
 
-/// Pool + keepalive timing shared across backend connections.
+/// Pool timing shared across backend connections.
 ///
 /// Fields are `#[non_exhaustive]` per project convention — connection
 /// tunables grow as new backends land. Default is the Phase-1 Valkey
@@ -570,8 +570,6 @@ pub enum FailOutcome {
 pub struct BackendTimeouts {
     /// Per-request timeout. `None` ⇒ backend default.
     pub request: Option<Duration>,
-    /// Idle-connection keepalive interval. `None` ⇒ backend default.
-    pub keepalive: Option<Duration>,
 }
 
 /// Retry policy shared across backend connections. Additive; Stage 1a


### PR DESCRIPTION
## Summary

Removes the dead `keepalive: Option<Duration>` field from `BackendTimeouts` in `ff-core::backend`. The field was speculative with zero read-sites. ferriskey already provides TCP keepalive unconditionally via `socket2::TcpKeepalive::new()` at `ferriskey/src/connection/tokio.rs:33-36` with OS-default settings, so there was no wiring to plumb this into. Worker FF audit (`rfcs/drafts/backend-timeouts-retry-audit.md`) confirmed the placeholder status. Consumers can re-add custom-interval wiring via a future additive field if a concrete need emerges.

## Grep sweep

`rg -n 'keepalive' crates/` before the change returned three hits, all in `crates/ff-core/src/backend.rs` (doc comment + field). Zero call sites set the field; zero read-sites. Outside `crates/`: only the upstream `ferriskey/src/connection/tokio.rs` (unrelated socket2 wiring), an nginx `keepalive 32` directive in `docs/DEPLOYMENT.md` (unrelated), and historical RFC-draft audits (left untouched per surgical scope).

## Semver

`cargo semver-checks -p ff-core` flags this as a breaking change (`struct_pub_field_missing`) -- expected and accepted under pre-1.0 posture. Workspace stays at 0.3.3 this PR; the 0.4.0 bump lands separately with the trait-amendment work per cadence.

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---
Failed in:
  field keepalive of struct BackendTimeouts ...
Summary semver requires new major version: 1 major and 0 minor checks failed
```

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo build -p ff-sdk --no-default-features`
- [x] `cargo test --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo machete`
- [x] `cargo semver-checks -p ff-core` (expected breaking-change flag documented above)
- [x] No test referenced `keepalive`; nothing to remove from tests.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>