### PR TITLE
chore(ff-core): reshape BackendRetry to match ferriskey ConnectionRetryStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Reshaped `BackendRetry` to match ferriskey's `ConnectionRetryStrategy`
+  (fields: `exponent_base`, `factor`, `number_of_retries`,
+  `jitter_percent`). Previous `max_attempts`/`base_backoff` were
+  semantically mismatched with the underlying retry primitive; the new
+  shape is a direct pass-through. Breaking field reshape; pre-1.0
+  posture accepts.
+
 ### Removed
 
 - **`BackendTimeouts.keepalive` field.** ferriskey handles TCP keepalive

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -572,16 +572,31 @@ pub struct BackendTimeouts {
     pub request: Option<Duration>,
 }
 
-/// Retry policy shared across backend connections. Additive; Stage 1a
-/// ships the minimal shape so the trait signatures can reference it.
+/// Retry policy shared across backend connections.
+///
+/// Matches ferriskey's `ConnectionRetryStrategy` shape (see
+/// `ferriskey/src/client/types.rs:151`) so Stage 1c's Valkey wiring is a
+/// direct pass-through — we don't reimplement what ferriskey already
+/// provides. The Postgres backend (future) interprets the same fields
+/// under its own retry semantics, or maps `None` to its own defaults.
+///
+/// Each field is `Option<u32>`: `None` ⇒ backend default (for Valkey,
+/// this means `ConnectionRetryStrategy::default()`); `Some(v)` ⇒ pass
+/// `v` straight through.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct BackendRetry {
-    /// Max retry attempts on transient transport errors. `None` ⇒
+    /// Exponent base for the backoff curve. `None` ⇒ backend default.
+    pub exponent_base: Option<u32>,
+    /// Multiplicative factor applied to each backoff step. `None` ⇒
     /// backend default.
-    pub max_attempts: Option<u32>,
-    /// Base backoff. `None` ⇒ backend default.
-    pub base_backoff: Option<Duration>,
+    pub factor: Option<u32>,
+    /// Maximum number of retry attempts on transient transport errors.
+    /// `None` ⇒ backend default.
+    pub number_of_retries: Option<u32>,
+    /// Jitter as a percentage of the computed backoff. `None` ⇒ backend
+    /// default.
+    pub jitter_percent: Option<u32>,
 }
 
 /// Valkey-specific connection parameters.


### PR DESCRIPTION
## Why

Don't reimplement what ferriskey already provides — accept its arguments and pass them through. The current `BackendRetry` ships `max_attempts: Option<u32>` + `base_backoff: Option<Duration>`, which is semantically mismatched with ferriskey's actual retry primitive. Stage 1c's Valkey wiring should be a direct pass-through, not an impedance-matching layer.

The abstraction still serves the next backend: Postgres (future) interprets the same u32s under its own retry semantics, or maps `None` to its own defaults.

## Reference

ferriskey's `ConnectionRetryStrategy` at `ferriskey/src/client/types.rs:151`:

```rust
pub struct ConnectionRetryStrategy {
    pub exponent_base: u32,
    pub factor: u32,
    pub number_of_retries: u32,
    pub jitter_percent: Option<u32>,
}
```

## Before

```rust
pub struct BackendRetry {
    pub max_attempts: Option<u32>,
    pub base_backoff: Option<Duration>,
}
```

## After

```rust
#[derive(Clone, Debug, Default, PartialEq, Eq)]
#[non_exhaustive]
pub struct BackendRetry {
    pub exponent_base: Option<u32>,
    pub factor: Option<u32>,
    pub number_of_retries: Option<u32>,
    pub jitter_percent: Option<u32>,
}
```

All fields `Option<u32>`: `None` ⇒ backend default (`ConnectionRetryStrategy::default()` on Valkey); `Some(v)` ⇒ pass through.

## Grep sweep

```
$ rg -n 'BackendRetry|max_attempts|base_backoff' crates/
crates/ff-script/src/loader.rs:70:                    max_attempts = MAX_ATTEMPTS,   # unrelated trace const
crates/ff-backend-valkey/src/lib.rs:91:    /// `BackendTimeouts`/`BackendRetry` wiring is a Stage 1c task.
crates/ff-core/src/backend.rs:...                  # reshaped here
```

No external call sites set `max_attempts` / `base_backoff` on `BackendRetry` — zero consumer impact beyond the reshape itself.

## Semver

`cargo semver-checks -p ff-core` flags the expected breaking change:

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---
  field max_attempts of struct BackendRetry
  field base_backoff of struct BackendRetry
```

Breaking field reshape; pre-1.0 posture accepts. No version bump in this PR (workspace stays at 0.3.3; reshape ships under Unreleased / next minor).

## CI gates (local)

- `cargo build --workspace --all-features` — clean
- `cargo build -p ff-sdk --no-default-features` — clean
- `cargo test --workspace --lib` — clean (backend_config_valkey_ctor asserts `BackendRetry::default()` and still passes unchanged because all fields are `None`)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo-machete` — only pre-existing findings in bench crates (untouched)
- `cargo-semver-checks` — flags expected breakage above

## Scope

Surgical: only `BackendRetry` reshape + CHANGELOG. `BackendTimeouts` / `BackendConfig` untouched. No Stage 1c wiring in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>