### PR TITLE
chore(rfcs): archive 2026-04-22 session exploration records

### DIFF
--- a/rfcs/drafts/0.3.2-smoke-report.md
+++ b/rfcs/drafts/0.3.2-smoke-report.md
@@ -1,0 +1,179 @@
+# FlowFabric 0.3.2 published-artifact smoke report
+
+**Date:** 2026-04-22
+**Smoke crate (throwaway, deleted after report):** `/tmp/ff-smoke-0.3.2`,
+`/tmp/ff-smoke-nodefault`
+**Driver:** ff-sdk 0.3.2 via `cargo add` from crates.io, no workspace path deps.
+
+## Environment
+
+- Rust: `rustc 1.90.0 (1159e78c4 2025-09-14)`, cargo 1.90.0
+- Valkey: `valkey_version:7.2.12` (`redis_version:7.2.4`) on 127.0.0.1:6379,
+  pre-existing local instance (podman/docker not installed; host had valkey-cli
+  + service already running).
+- Crates pulled at 0.3.2: ff-sdk, ff-core, ff-backend-valkey, ff-script,
+  ferriskey (all from crates.io index).
+
+## What worked
+
+- `cargo add ff-sdk@0.3.2 ff-backend-valkey@0.3.2 ff-core@0.3.2` resolves
+  cleanly to a single 0.3.2 cohort — no version-pin drift.
+- `WorkerConfig::new(host, port, worker_id, worker_instance_id, ns, lane)`
+  — headline constructor from rustdoc compiles and runs.
+- `FlowFabricWorker::connect(config)` — full handshake against live Valkey
+  succeeds; `FUNCTION LOAD` runs under the hood with no operator step.
+- `worker.backend()` returns `Some(Arc<dyn EngineBackend>)` under default
+  features.
+- `worker.partition_config()` returns sane defaults
+  (`num_flow_partitions: 256, num_budget_partitions: 32, num_quota_partitions: 32`).
+- `StreamCursor::{Start, End, At(_), from_beginning()}` all constructible from
+  the `ff_sdk` re-export.
+- `ScannerFilter::NOOP` + `is_noop()` reachable.
+- `ff_sdk::admin::ClaimForWorkerResponse` deserializes from synthetic JSON;
+  `partition_key: PartitionKey` round-trips through `.parse()` to
+  `Partition { family: Flow, index: 7 }` for `{fp:7}` wire format.
+- **Duplicate-worker-instance guard** (`config:
+  worker_connect.worker_instance_id: duplicate worker_instance_id '...':
+  another process already holds ff:worker:<id>:alive`) fires cleanly with a
+  useful error message — caught a stale key from a prior run.
+- `cargo build --no-default-features` with `ff-sdk` + `ff-core` succeeds;
+  ff-core-native re-exports (`SdkError::{Config, WorkerAtCapacity}`,
+  `EngineError`, `FailOutcome`, `ResumeSignal`, `BugKind::AttemptNotInCreatedState`)
+  reachable.
+
+## What didn't — compile-blocking
+
+### Finding 1 (CRITICAL, blocks cairn migration): `ScannerFilter` is unbuildable from outside ff-core
+
+`/tmp/ff-smoke-0.3.2/src/main.rs:48-51` (original attempt):
+
+```rust
+let filter = ScannerFilter {
+    namespace: Some(Namespace::new("smoke-ns")),
+    instance_tag: Some(("tenant".to_string(), "acme".to_string())),
+};
+```
+
+Error: `error[E0639]: cannot create non-exhaustive struct using struct expression`.
+Functional-update (`..ScannerFilter::NOOP`) also rejected — `#[non_exhaustive]`
+blocks both struct literal AND FRU across crate boundaries (rustc §unstable-book).
+
+`ScannerFilter` (ff-core 0.3.2 `src/backend.rs:709-719`) is `#[non_exhaustive]`
+with `pub namespace` and `pub instance_tag` fields but **no public constructor,
+no setters, no builder**. External consumers can only name `ScannerFilter::NOOP`.
+This makes `subscribe_completions_filtered` unusable from any crate other than
+ff-backend-valkey / ff-core itself. Any cairn code that would install a
+per-tenant `namespace` filter cannot compile.
+
+**Root cause:** `#[non_exhaustive]` added to preserve additive compatibility,
+but no builder / `::new()` / `::with_namespace()` chain shipped alongside.
+
+**Minimum-viable fix for 0.3.3:** add
+`ScannerFilter::builder() -> ScannerFilterBuilder` with
+`.namespace(ns) / .instance_tag(k, v) / .build()`, OR a ctor
+`ScannerFilter::new_filtered(namespace, instance_tag)`. Either unblocks
+consumers without retracting `#[non_exhaustive]`.
+
+### Finding 2 (CRITICAL): `CompletionBackend` not reachable from `FlowFabricWorker`
+
+`worker.backend()` returns `Option<&Arc<dyn ff_core::engine_backend::EngineBackend>>`.
+`EngineBackend` is not a super-trait of `CompletionBackend` (ff-core 0.3.2
+`src/engine_backend.rs:76` vs `src/completion_backend.rs:76`), and no
+`as_completion_backend()` / `completion()` accessor is exposed on
+`FlowFabricWorker` or `EngineBackend`. So from the ff-sdk surface a consumer
+CANNOT call `subscribe_completions_filtered` — the method advertised in
+0.3.x release notes is unreachable via the public worker handle.
+
+**Minimum-viable fix for 0.3.3:** expose
+`FlowFabricWorker::completion_backend(&self) -> Option<&Arc<dyn CompletionBackend>>`
+that downcasts the concrete `ValkeyBackend` (or make `EngineBackend:
+CompletionBackend` if every backend is expected to implement it).
+
+### Finding 3 (MEDIUM): `ff-sdk --no-default-features` is not Valkey-agnostic
+
+`cargo tree --no-default-features -i ferriskey` shows ferriskey is pulled
+transitively via `ff-script` (which is an unconditional dep of ff-sdk), even
+with `valkey-default` off. Also `reqwest`, `rustls`, `hyper`, `tokio-rustls`
+compile. So the `--no-default-features` mode removes `ff-backend-valkey` but
+keeps the GLIDE client crate in the dep graph — weight and build-time savings
+are small, and the "agnostic" framing is misleading for a Postgres-backend
+future.
+
+**Fix:** feature-gate `ferriskey` in ff-script behind a `valkey-default`
+feature mirroring ff-sdk's, and have ff-sdk only enable it when its own
+`valkey-default` is on.
+
+## What didn't — runtime / DX friction
+
+### Finding 4 (MEDIUM): `ff_sdk::admin::ClaimForWorkerResponse` required `grant_key` without being obvious
+
+First synthetic JSON round-trip failed with `missing field grant_key at line 9
+column 5`. The `partition_key` wire format is **also** non-obvious: a bare
+`"p0"` parses as `PartitionKey` but then `parse()` returns
+`PartitionKeyParseError::MissingBraces`. Correct wire form is `"{fp:7}"`. Not
+documented on `ClaimForWorkerResponse.partition_key` rustdoc beyond referring
+to `PartitionKey` — a doctest with the concrete `{fp:N}` shape would save
+cairn an hour of grep.
+
+### Finding 5 (LOW): no consumer-facing helper for creating executions
+
+End-to-end lifecycle smoke (claim → progress → complete) was not achievable
+without dropping to `FCALL ff_create_execution` directly against the ferriskey
+client. ff-sdk exposes the worker side and the admin rotate/claim-grant side,
+but not an execution-submit helper. Cairn presumably goes through ff-server's
+HTTP API, but ff-server is not published as a consumer library — so a
+downstream unit test that wants to exercise a full lifecycle against an
+in-memory or real Valkey has no SDK-level path. This is consistent with the
+intended architecture but worth flagging in the 0.3.x migration guide.
+
+### Finding 6 (LOW): `direct-valkey-claim` feature lives on ff-sdk but `claim_next` rustdoc points at it from the crate-level example
+
+`lib.rs:29` shows `worker.claim_next()` in the quickstart but the method is
+`#[cfg(feature = "direct-valkey-claim")]`-gated. A fresh consumer who pastes
+the quickstart will see "method not found" under default features. Either
+un-gate `claim_next` (it's already documented as the deprecated path) or
+move the quickstart to `claim_from_grant`.
+
+## DX friction notes
+
+- ~40 lines from zero to `FlowFabricWorker::connect` returning, including
+  imports. Reasonable.
+- `WorkerConfig::new` takes six positional strings of distinct semantic types
+  (worker_id vs worker_instance_id vs namespace vs lane) — trivially easy to
+  swap two args silently. A typed builder would help.
+- Error from duplicate-instance is excellent — structured `SdkError::Config`
+  with context + field + message renders cleanly.
+- `ff-script` is effectively a hidden transitive for error types —
+  `ScriptError` is documented as an escape hatch but there's no re-export
+  from ff-sdk. Consumers who need `ScriptError` must add a direct dep on
+  ff-script, which is awkward when ff-sdk owns the error surface.
+
+## Recommendations (prioritized)
+
+**Ship in 0.3.3 (blockers for cairn rebase):**
+
+1. Finding 1 — `ScannerFilter` builder / constructor. Without this,
+   `subscribe_completions_filtered` is a dead API.
+2. Finding 2 — accessor from `FlowFabricWorker` to `CompletionBackend`.
+3. Finding 6 — un-gate `claim_next` or update the quickstart; current state
+   breaks the first copy-paste.
+
+**Defer to 0.3.4 / 0.4.0:**
+
+4. Finding 3 — feature-gate ferriskey in ff-script; real Valkey-agnosticism.
+5. Finding 4 — doctest the `{fp:N}` wire shape on
+   `ClaimForWorkerResponse.partition_key`; mention `grant_key` in the
+   migration guide.
+6. Finding 5 — consumer-facing execution-submit helper (either via
+   ff-server-client crate or a documented FCALL wrapper on ff-sdk).
+7. Typed WorkerConfig builder.
+
+## Summary for manager
+
+Dep resolution clean, connect + FUNCTION LOAD work on first try, worker-side
+lifecycle primitives compile. **Two critical compile blockers** in the new
+0.3.x "filtered completion subscription" surface — `ScannerFilter` cannot
+be built from outside ff-core and `CompletionBackend` cannot be reached from
+`FlowFabricWorker`. Cairn's rebase plan should assume
+`subscribe_completions_filtered` is unusable on 0.3.2 and plan for a 0.3.3
+patch. All other findings are DX-grade, not blocking.

--- a/rfcs/drafts/87-88-scope-carveout.md
+++ b/rfcs/drafts/87-88-scope-carveout.md
@@ -1,0 +1,103 @@
+# #87/#88 scope carve-out (2026-04-22)
+
+Worker BB, read-only investigation. No code changes. All findings cite `file:line` against `main` at commit `47ef2b0`.
+
+## Issue summary
+
+**#87 — Seal `ferriskey::Client` leak on `FlowFabricWorker` + stream free-fns.**
+Body (verbatim): "`FlowFabricWorker::client()` (worker.rs:418) + free fns `read_stream`/`tail_stream` (task.rs:2184,2280) leak raw `ferriskey::Client`. Hide public `Client`; reshape stream fns as methods on worker OR opaque `BackendHandle`. Scope: public API only — `ClaimedTask` internal field stays." Blocking HIGH · Breaking HIGH · Effort M. Audit: Worker F 2026-04-22.
+
+**#88 — Seal `ferriskey::Error` leak on `SdkError` and `ServerError`.**
+Body (verbatim): "`SdkError::Valkey(ferriskey::Error)`, `ValkeyContext { source: ferriskey::Error }`, `valkey_kind() -> Option<ErrorKind>` (lib.rs:86-94,175) force consumers onto ferriskey. Wrap in internal `BackendError`; expose `valkey_kind` as method returning None for non-Valkey. Extends `EngineError` pattern from 58.6." Blocking HIGH · Breaking HIGH · Effort M. Audit: Worker F 2026-04-22.
+
+Note: issue **#88 title already names `ServerError`** as a target alongside `SdkError`, but its body only enumerates `SdkError` fields (`lib.rs:86-94,175`). The `ServerError` leak is in-scope per the title and per the memory checkpoint's "second leak surface in ff-server" hypothesis — this report confirms that second surface exists and tabulates it.
+
+## Leak surface inventory
+
+Public-API leaks only (non-pub / internal uses of `ferriskey::*` are fine and are omitted — those close naturally when Stage 1c migrates hot-path callers). "Blocks-on" is per RFC-012 §5 stage map.
+
+| file:line | crate | symbol | public? | blocks-on |
+|---|---|---|---|---|
+| `crates/ff-sdk/src/worker.rs:524` | ff-sdk | `FlowFabricWorker::client() -> &Client` | pub | Stage 1c (backend-handle method replaces it) |
+| `crates/ff-sdk/src/task.rs:1933-1941` | ff-sdk | `pub async fn read_stream(client: &Client, …)` | pub free fn | Stage 1c (reshape as worker method / opaque handle) |
+| `crates/ff-sdk/src/task.rs:2036-2044` | ff-sdk | `pub async fn tail_stream(client: &Client, …)` | pub free fn | Stage 1c (same) |
+| `crates/ff-sdk/src/lib.rs:105` | ff-sdk | `SdkError::Valkey(#[from] ferriskey::Error)` | pub enum variant | Stage 1c/d (wrap in `BackendError`) |
+| `crates/ff-sdk/src/lib.rs:110-113` | ff-sdk | `SdkError::ValkeyContext { source: ferriskey::Error, … }` | pub enum variant | Stage 1c/d |
+| `crates/ff-sdk/src/lib.rs:240` | ff-sdk | `SdkError::valkey_kind() -> Option<ferriskey::ErrorKind>` | pub method | Stage 1c/d (keep method, return `None` for non-Valkey) |
+| `crates/ff-server/src/server.rs:577` | ff-server | `Server::client() -> &Client` | pub (re-exported `pub use server::Server`) | **INDEPENDENT** — callers are ff-server bin + ff-test + ff-readiness-tests only |
+| `crates/ff-server/src/server.rs:219` | ff-server | `ServerError::Valkey(#[from] ferriskey::Error)` | pub enum variant (`pub use server::ServerError`) | **INDEPENDENT** |
+| `crates/ff-server/src/server.rs:222-226` | ff-server | `ServerError::ValkeyContext { source: ferriskey::Error, … }` | pub enum variant | **INDEPENDENT** |
+| `crates/ff-server/src/server.rs:268` | ff-server | `ServerError::valkey_kind() -> Option<ferriskey::ErrorKind>` | pub method | **INDEPENDENT** |
+| `crates/ff-scheduler/src/claim.rs:306` | ff-scheduler | `Scheduler::new(client: ferriskey::Client, …)` | pub fn | **INDEPENDENT** (ff-server-only caller) |
+| `crates/ff-scheduler/src/claim.rs:1226` | ff-scheduler | `SchedulerError::Valkey(#[from] ferriskey::Error)` | pub enum variant | **INDEPENDENT** |
+| `crates/ff-scheduler/src/claim.rs:1229-1233` | ff-scheduler | `SchedulerError::ValkeyContext { source: ferriskey::Error, … }` | pub enum variant | **INDEPENDENT** |
+| `crates/ff-scheduler/src/claim.rs:1244` | ff-scheduler | `SchedulerError::valkey_kind() -> Option<ferriskey::ErrorKind>` | pub method | **INDEPENDENT** |
+| `crates/ff-engine/src/lib.rs:160` | ff-engine | `Engine::start(config, client: ferriskey::Client)` | pub fn | **INDEPENDENT** (ff-server-only caller) |
+| `crates/ff-engine/src/budget.rs:34` | ff-engine | `BudgetChecker::new(client: ferriskey::Client, …)` | pub fn | **INDEPENDENT** |
+| `crates/ff-script/src/error.rs:442` | ff-script | `ScriptError::Valkey(#[from] ferriskey::Error)` | pub enum variant | SEE NOTE |
+| `crates/ff-script/src/error.rs:470` | ff-script | `ScriptError::valkey_kind() -> Option<ferriskey::ErrorKind>` | pub method | SEE NOTE |
+| `crates/ff-script/src/retry.rs:30,48` | ff-script | `is_retryable_kind(kind: ferriskey::ErrorKind)`, `kind_to_stable_str(…)` | pub fns | SEE NOTE |
+| `crates/ff-script/src/engine_error_ext.rs:51` | ff-script | `valkey_kind(err: &EngineError) -> Option<ferriskey::ErrorKind>` | pub fn | SEE NOTE |
+| `crates/ff-backend-valkey/src/lib.rs:159` | ff-backend-valkey | `ValkeyBackend::client() -> &ferriskey::Client` | pub fn | Intentional per RFC-012 §1.3: "backend-internal access; external callers go through trait" — this is the **correct** public escape hatch for the Valkey backend impl, **not a leak**. |
+| `crates/ff-readiness-tests/src/valkey.rs:11` | ff-readiness-tests | `probe_server_version(client: &ferriskey::Client)` | pub fn | Internal harness — `ff-readiness-tests` is a first-party probe crate, no external consumers. Low priority; could be sealed opportunistically. |
+
+**Note on ff-script.** `ScriptError` and `retry::is_retryable_kind` / `kind_to_stable_str` are the canonical Valkey-error vocabulary for the whole workspace. RFC-012 §5.4 (Stage 4) and `crates/ff-script/src/error.rs:4-15` comments explicitly position `ff-script` as the Valkey-transport-aware layer below `ff-core`. Sealing ferriskey out of `ff-script` means deleting `ff-script` as a concept (merging into `ff-backend-valkey`). Out of scope for #87/#88. `ff-sdk::SdkError::valkey_kind` is meant to abstract over `ff-script`, not duplicate the leak.
+
+## Stage-1c-blocked sites (ff-sdk)
+
+Six sites, exactly matching #87 + #88 issue bodies:
+
+* `crates/ff-sdk/src/worker.rs:524` — `FlowFabricWorker::client()`
+* `crates/ff-sdk/src/task.rs:1933` — `pub async fn read_stream(client: &Client, …)`
+* `crates/ff-sdk/src/task.rs:2036` — `pub async fn tail_stream(client: &Client, …)`
+* `crates/ff-sdk/src/lib.rs:105,110-113,240` — `SdkError::{Valkey,ValkeyContext,valkey_kind}`
+
+**Confirmed blocked.** RFC-012 §5.1 Stage 1 scope (at `rfcs/RFC-012-engine-backend-trait.md:561-580`) explicitly converts `ClaimedTask`/`FlowFabricWorker` inherent impls into a `ValkeyBackend` impl of the `EngineBackend` trait and makes SDK wrappers "thin forwarders to the trait." At that point `client()` is replaceable with a trait-level `BackendHandle`, and `SdkError::Valkey(ferriskey::Error)` naturally narrows to `EngineError::Transport { backend, source: Box<dyn Error> }` per §5.0 bullet 2 (the Stage-0 `Transport` broadening). `worker.rs:515-521` already has the Stage-1b `backend()` getter, confirming the migration path is scaffolded.
+
+## Independent sites (ff-server / ff-engine / ff-scheduler)
+
+**RFC-012 §5 does NOT mention `ServerError` or `SchedulerError`.** §5.0 scopes the error broadening to `EngineError::Transport` (in `ff-core`), and §5.1's migration event is framed entirely around `FlowFabricWorker` + `ClaimedTask` + `BackendConfig`. The HTTP-layer error types in `ff-server` and `ff-scheduler` live outside the worker path and are not naturally closed by Stage 1c/d.
+
+Independent set, ranked by accessibility:
+
+1. **ff-server `ServerError` + `Server::client()` (4 sites, server.rs:219-226, 268, 577).** `pub use server::{Server, ServerError}` in `crates/ff-server/src/lib.rs:11` makes both public to any external consumer that links `ff-server` as a library. Current Rust consumers are first-party only (ff-server bin, ff-test, ff-readiness-tests — verified by `rg 'use ff_server' crates/`), but the surface is published. HTTP consumers (cairn-fabric) don't see `ServerError` directly — `crates/ff-server/src/api.rs:228` converts via `IntoResponse` — so this is a Rust-API leak, not a wire-protocol leak.
+
+2. **ff-scheduler `SchedulerError` + `Scheduler::new(client)` (4 sites, claim.rs:306, 1226, 1229-1233, 1244).** `pub use claim::{…, Scheduler, SchedulerError}` in `crates/ff-scheduler/src/lib.rs:5`. Only ff-server consumes it today.
+
+3. **ff-engine `Engine::start(client)` + `BudgetChecker::new(client)` (lib.rs:160, budget.rs:34).** Both pub, both take `ferriskey::Client` by value. ff-server-only caller.
+
+**Size estimate.** ~10-12 public-API edits across 3 crates. Pattern is mechanical and already established by RFC-012 Stage 0's `EngineError::Transport` broadening: introduce a `BackendError` / reuse `EngineError::Transport { backend: "valkey", source: Box<dyn Error + Send + Sync> }`; retain `valkey_kind()` returning `Option<ferriskey::ErrorKind>` by downcasting (or gate behind `#[cfg(feature = "valkey-default")]` like `ff-sdk` at `lib.rs:239`). The `client()` getters are harder to seal cleanly without a `BackendHandle` abstraction — ff-server's case is the test-fixture convenience path (`crates/ff-test/src/helpers.rs` has ~10 call sites; search hit count in `Server::client()` grep). Sealing `ff-server::Server::client()` cleanly requires either (a) moving test helpers onto a `pub(crate)` accessor + `#[cfg(test)]` export, or (b) waiting for RFC-012 to define the backend-handle trait and reusing it.
+
+**Complexity per site.**
+* **Low (error types):** 8 sites (3× enum variants + 1× method, ×2 crates) — pure type wrapping, same pattern as Stage 0's `Transport` broadening. Estimated 3-5h each, mostly mechanical.
+* **Medium (client getters):** 3 sites (`Server::client`, `Engine::start`, `Scheduler::new`, `BudgetChecker::new`). Sealing `client()` getters is blocked on having somewhere for callers to go; these effectively wait for Stage 1c's backend-handle shape OR get an interim `pub(crate)` + test-helper refactor.
+
+## Recommendation
+
+**Option A (wait for Stage 1c/d) — recommended.**
+
+Rationale:
+
+1. The **error-type leaks** (8 low-complexity sites across ff-server + ff-scheduler) are structurally identical to the ff-sdk leak RFC-012 §5.0 already schedules. Landing them in a separate PR *before* Stage 0's `EngineError::Transport` broadening means doing the wrapping work twice — once with an ad-hoc `BackendError` or direct `EngineError` threading, then again when Stage 0's canonical shape lands. That violates the "don't defer design debt" memory but more importantly violates "RFC phases vs CI" — splitting the error-broadening work across stages multiplies consumer-migration events for no benefit.
+
+2. The **client-getter leaks** (3 medium sites) cannot be sealed cleanly without the backend-handle abstraction that Stage 1c/d defines. An interim `pub(crate)` seal would force test helpers onto a duplicate accessor that Stage 1c would immediately rewrite.
+
+3. Publishing impact is low: **no external Rust consumer links `ff-server` / `ff-scheduler` / `ff-engine` as a library** (verified `rg 'use ff_server' crates/` → ff-readiness-tests + ff-test + ff-server bin only; no external crates in-tree; no cairn checkout found at `/home/ubuntu/cairn-rs`). Cairn consumes ff-server via HTTP, and the HTTP surface (`ApiError::IntoResponse` at `api.rs:228`) already hides `ferriskey::Error` behind stable JSON shapes. The leak is Rust-API-only, and the Rust consumers are all first-party.
+
+4. Worker F's 2026-04-22 audit (per RFC-012 §1.2) catalogues these as part of the same "`ferriskey::Error` leaking through `SdkError`" class — they are one problem, not two; splitting them weakens the migration event.
+
+**Option B (ship ff-server PR now) — not recommended.**
+
+Would seal 8 error-type sites in ff-server + ff-scheduler via ad-hoc wrapping, leave the 3 client-getter sites open, and pre-empt Stage 0's canonical `EngineError::Transport` design. Violates "Approve against RFC, not plan" (RFC-012 §5.0 is the accepted shape) and produces throwaway code.
+
+**Action item.** Extend RFC-012 §5.0 (Stage 0) or §5.1 (Stage 1) to **explicitly** include `ServerError`, `SchedulerError`, and the `Engine::start` / `Scheduler::new` / `BudgetChecker::new` client-accepting constructors in scope. Currently these are implicit — a reader tracking #87/#88 against §5 alone would miss them. A 1-paragraph amendment naming the 3 crates + 10-ish sites closes the gap without redesign. This is cheaper than a separate PR and keeps the migration event coherent.
+
+## Open questions
+
+1. **Should `ff-scheduler::SchedulerError` fold into `EngineError` entirely?** It has only 3 variants (`Valkey`, `ValkeyContext`, `Config`); two map to `EngineError::Transport` and one to `EngineError::Validation`. The crate exists mostly for ff-server internals — collapsing the error hierarchy would simplify Stage 0. Flag for Worker I to consider in Stage 0 scope.
+
+2. **Is `ff-server::Server::client()` a test-helper convenience or a supported public API?** If the former, `#[cfg(feature = "test-helpers")]` is an immediate Option-B-lite win (gates the leak behind a test-only feature). If the latter, it waits for Stage 1c. `crates/ff-test/src/helpers.rs:153-332` has ~10 call sites, all test-only — leans test-helper. Worth asking the RFC-012 owner before Stage 0 lands.
+
+3. **`ff-backend-valkey::ValkeyBackend::client()` at `lib.rs:159` is documented as intentional** ("backend-internal access … RFC-012 §1.3"). Confirm this is the stable escape hatch post-Stage 1c and not itself a leak to seal. Comment at `lib.rs:158` says so, but worth an explicit call-out in RFC-012.
+
+4. **`ff-readiness-tests::valkey::probe_server_version` takes `&ferriskey::Client` at `crates/ff-readiness-tests/src/valkey.rs:11`.** First-party readiness probe — sealing has no external benefit, but should probably migrate to the backend trait once Stage 1c lands to keep the probe backend-agnostic (needed for Postgres-backend readiness at Stage 2+).

--- a/rfcs/drafts/README.md
+++ b/rfcs/drafts/README.md
@@ -9,6 +9,19 @@ Each cluster of files represents one exploration. Conventions:
 
 ## Index
 
+### 2026-04-22 session records (v0.3.x release saga + investigations)
+
+Retrospective, audit, and investigation artifacts from the 2026-04-22 v0.3.x release saga and concurrent Stage 1c / cairn-unblock work. Not normative RFCs — preserved as chain-of-reasoning, retrospective, and evidence. Cross-references PRs #119, #120–#124, #126–#128, #130–#136.
+
+- `release-saga-2026-04-22-post-mortem.md` — Worker JJ's post-mortem of the v0.3.x release saga (what failed, what held, what changed).
+- `0.3.2-smoke-report.md` — Worker X's smoke finding that caught the ScannerFilter + CompletionBackend blockers before tag.
+- `stage-1c-scope-audit.md` — Worker EE's Stage 1c scope inventory (what's in, what's out, what's deferred).
+- `backend-timeouts-retry-audit.md` — Worker FF's `BackendTimeouts` / `BackendRetry` field audit (which fields are wired, which are placeholders).
+- `scenario-4-regression-investigation.md` — Worker DD's Scenario 4 bisect finding: methodology artifact, not a regression.
+- `bridge-event-audit.md` — Worker V's bridge-event audit surfacing GAP-1 + GAP-2 that shipped in v0.3.1.
+- `87-88-scope-carveout.md` — Worker BB's #87/#88 scope audit and carve-out.
+- `RFC-012-amendment-117-deferrals.{K,L,M}-challenge.md` — challenger records for the #117 amendment (amendment itself landed in PR #135; challengers kept as exploration record).
+
 ### RFC-012 #117 deferrals amendment (explored 2026-04-22, promoted as Round-7)
 
 Tracks issue [#117](https://github.com/avifenesh/FlowFabric/issues/117) (Stage 1b deferrals — three `ClaimedTask` methods that couldn't land as thin forwarders).

--- a/rfcs/drafts/backend-timeouts-retry-audit.md
+++ b/rfcs/drafts/backend-timeouts-retry-audit.md
@@ -1,0 +1,116 @@
+# BackendTimeouts / BackendRetry wiring audit (2026-04-22)
+
+Investigation-only, Worker FF. Scope: verify the "placeholder" status flagged
+by Worker EE's Stage 1c scope audit so Stage 1c planning has empirical
+evidence of what is plumbed-but-ignored today, and whether ferriskey exposes
+the knobs Stage 1c will need to thread through.
+
+Checkout: `/home/ubuntu/ff-worker-a-58.6/` (worktree used this session).
+
+## Type definitions
+
+From `crates/ff-core/src/backend.rs:568-587`:
+
+```rust
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BackendTimeouts {
+    pub request: Option<Duration>,      // :572
+    pub keepalive: Option<Duration>,    // :574
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BackendRetry {
+    pub max_attempts: Option<u32>,      // :584
+    pub base_backoff: Option<Duration>, // :586
+}
+```
+
+Both `#[non_exhaustive]`, both `Default`. `None` documented as "backend
+default" per field doc-comments. Embedded on `BackendConfig` at
+`crates/ff-core/src/backend.rs:637-638`.
+
+## Current reference sites
+
+| File:line | Reference | Role |
+|-----------|-----------|------|
+| `crates/ff-core/src/backend.rs:570` | `pub struct BackendTimeouts` | definition |
+| `crates/ff-core/src/backend.rs:581` | `pub struct BackendRetry` | definition |
+| `crates/ff-core/src/backend.rs:637-638` | fields on `BackendConfig` | pass-through storage |
+| `crates/ff-core/src/backend.rs:647-648` | `BackendTimeouts::default()` / `BackendRetry::default()` in `BackendConfig::valkey` | construction (defaults only) |
+| `crates/ff-core/src/backend.rs:1080-1081` | `assert_eq!(..., ::default())` in `backend_config_valkey_ctor` test | asserts defaults, does not exercise behaviour |
+| `crates/ff-backend-valkey/src/lib.rs:91` | doc-comment "Stage 1c task" | placeholder marker only |
+
+No **read** of `config.timeouts` or `config.retry` anywhere in the codebase.
+`ValkeyBackend::connect` destructures `config.connection` and drops the other
+two fields on the floor (`crates/ff-backend-valkey/src/lib.rs:92-154`): dial
+goes through URL-based `ferriskey::Client::connect` / `connect_cluster`
+which cannot accept timeout or retry overrides.
+
+No test — unit, integration, or e2e — exercises a non-default
+`BackendTimeouts` or `BackendRetry`. The single reference in the `#[cfg(test)]`
+block at `crates/ff-core/src/backend.rs:1080-1081` only asserts that
+`BackendConfig::valkey` produces defaults.
+
+**Classification:** pure placeholder. This is exactly the shape Worker EE
+flagged — structurally identical to the 0.3.2 ScannerFilter namespace field
+regression (field present on the public API, silently ignored at the
+backend layer).
+
+## ferriskey ClientBuilder capabilities
+
+From `ferriskey/src/ferriskey_client.rs` (`ClientBuilder`, lines 28–580ish)
+and `ferriskey/src/client/types.rs`:
+
+| Knob | Available? | Shape |
+|------|-----------|-------|
+| Per-request timeout | Yes | `ClientBuilder::request_timeout(Duration)` at `ferriskey_client.rs:445` → `ConnectionRequest::request_timeout: Option<u32>` ms |
+| Connect timeout | Yes | `ClientBuilder::connect_timeout(Duration)` at `ferriskey_client.rs:439` |
+| Blocking-command extension | Yes | `ClientBuilder::blocking_cmd_timeout_extension(Duration)` at `ferriskey_client.rs:465` |
+| Idle / socket keepalive | **No** | No `keepalive`/`tcp_keepalive` on `ClientBuilder` or `ConnectionRequest` (`grep` empty across `ferriskey/src/`) |
+| TCP_NODELAY | Yes | `ClientBuilder::tcp_nodelay()` at `ferriskey_client.rs:519` |
+| Max in-flight | Yes | `ClientBuilder::max_inflight(u32)` at `ferriskey_client.rs:471` |
+| Connection retry strategy | Yes (reconnect only) | `ClientBuilder::retry_strategy(ConnectionRetryStrategy)` at `ferriskey_client.rs:477`; struct at `client/types.rs:151`: `exponent_base: u32`, `factor: u32`, `number_of_retries: u32`, `jitter_percent: Option<u32>` |
+| Per-operation retry loop | **No** | `ConnectionRetryStrategy` only drives **reconnect** after transport loss; no first-class retry loop around user commands (only pipeline-specific `PipelineRetryStrategy` on `send_pipeline`, `client/mod.rs:1071`) |
+| Automatic reconnect | Yes | `ReconnectingConnection` (`ferriskey/src/client/reconnecting_connection.rs`); driven by the `ConnectionRetryStrategy` above |
+
+## Gap analysis per field
+
+| Field | ferriskey mapping | Stage 1c action |
+|-------|-------------------|-----------------|
+| `BackendTimeouts.request` | Direct: `ClientBuilder::request_timeout` | **Mechanical wiring.** Thread through `connect`. Requires migrating `ValkeyBackend::connect` off `Client::connect(url)` onto `ClientBuilder::url(url)?.request_timeout(..).build().await`. |
+| `BackendTimeouts.keepalive` | **None** | **Semantic decision + possible upstream change.** Options: (a) drop the field (and un-ship from `#[non_exhaustive]` API — tolerable since field is additive and never read); (b) add `tcp_keepalive` to ferriskey `ClientBuilder` (upstream-ish, owner-auth); (c) clarify semantics — is this intended as OS-level `SO_KEEPALIVE`, application-level PING cadence, or RESP3 push-channel heartbeat? Doc-comment says "idle-connection keepalive interval" which most naturally maps to TCP keepalive not present in ferriskey. **Recommend: clarify semantics first; if TCP keepalive, land on ferriskey ClientBuilder before Stage 1c wiring.** |
+| `BackendRetry.max_attempts` | Partial: maps to `ConnectionRetryStrategy.number_of_retries` **but only for reconnect**, not per-operation retry | **Semantic decision.** Two candidate meanings: (1) reconnect attempts on transport loss — maps cleanly to `ConnectionRetryStrategy.number_of_retries`; (2) per-operation retry attempts for transient errors — **ferriskey has no such loop**, Stage 1c would have to BUILD one inside `ff-backend-valkey` (wrap every FCALL; decide which `EngineError` variants are retriable). The `base_backoff` pairing suggests (2). Owner call needed. |
+| `BackendRetry.base_backoff` | Partial: maps to `ConnectionRetryStrategy.factor` (ms) if reconnect-semantics; no mapping if per-operation-semantics | Same as above; ferriskey's backoff formula is `factor * exponent_base^attempt + jitter` — richer than a single base `Duration`, so even the reconnect mapping loses fidelity (no exponent/jitter knobs on `BackendRetry`). |
+
+**Summary:** 1 of 4 fields (`timeouts.request`) is a mechanical pass-through.
+The other 3 need semantic clarification or behaviour-side implementation
+before Stage 1c can wire them without repeating the ScannerFilter-namespace
+regression.
+
+## Open questions for Stage 1c planning
+
+1. **`BackendTimeouts.keepalive` semantics.** Is this intended to mean OS TCP
+   keepalive (not exposed by ferriskey), application-level PING cadence (not
+   implemented), or something else? If ferriskey-upstream work is required,
+   does it land before or alongside Stage 1c? Punt-and-remove is an option
+   since the field has zero callers.
+2. **`BackendRetry` scope: reconnect vs. per-operation retry.** Field names
+   (`max_attempts`, `base_backoff`) read as per-operation, but ferriskey's
+   only retry primitive (`ConnectionRetryStrategy`) is reconnect-only. Stage
+   1c either (a) narrows the docs to "reconnect attempts" and maps to
+   ferriskey directly, or (b) commits to building an FF-side retry loop in
+   `ff-backend-valkey` and defining which `EngineError` variants are
+   retriable (`Transport`? `Unavailable`? not `Conflict`/`NotFound`).
+3. **Fidelity loss on backoff.** Even under reconnect-semantics,
+   `BackendRetry.base_backoff: Option<Duration>` cannot express ferriskey's
+   `factor * exponent_base^attempt + jitter` formula. Does Stage 1c extend
+   `BackendRetry` with `exponent_base` / `jitter_percent` fields now (under
+   `#[non_exhaustive]` this is additive), or accept the fidelity loss and
+   default the other knobs?
+
+Adjacent but out-of-scope flags:
+
+- **`WorkerConfig` forwarding** (RFC-012 §5.1) — migrating `WorkerConfig::host/port/tls/cluster` onto `BackendConfig` is the named Stage 1c job per the type's doc (`backend.rs:626-632`); the timeouts/retry wiring audited here rides that same stage.
+- **Cluster dial path.** `ValkeyBackend::connect` at `crates/ff-backend-valkey/src/lib.rs:113-121` uses `Client::connect_cluster(&[url])` which, like `Client::connect`, takes zero timing options. Stage 1c must also migrate this path to a `ClientBuilder`-shaped equivalent, or ferriskey must grow a `connect_cluster_with(request)` entry — worth a ferriskey-API question during Stage 1c planning.

--- a/rfcs/drafts/bridge-event-audit.md
+++ b/rfcs/drafts/bridge-event-audit.md
@@ -1,0 +1,229 @@
+# Bridge-event completeness audit (FF-side, 2026-04-22)
+
+## Scope
+
+Systematic review of all `exec_core`/`flow_core` state-mutating FCALL entry
+points in `crates/ff-script/src/flowfabric.lua` against bridge-event
+emissions on the `ff:dag:completions` channel, which is the sole wire feed
+for `CompletionBackend::subscribe_completions` (post-#90). Audit covers
+terminal transitions (success / failed / cancelled / expired / skipped),
+non-terminal transitions that are consumer-observable (suspend / resume /
+delay / block-unblock / priority / tags / progress), and the `flow_core`
+lifecycle (`public_flow_state`). Not audited: lease-epoch/renewal detail,
+attempt stream content, budget/quota bookkeeping — these are status fields
+rather than DAG bridge events.
+
+Repo HEAD: `47ef2b0` (origin/main, fully synced before audit). Lua file
+7,085 lines, 51 `redis.register_function` entries. `CompletionPayload`
+shape: `{ execution_id, flow_id, outcome, payload_bytes (None today),
+produced_at_ms (0 today) }` — consumer reads `execution_id + flow_id +
+outcome`.
+
+## Method
+
+`grep -n 'register_function'` → 51 FCALLs. `grep -n 'PUBLISH'` → 4 emit
+sites (lines 1920, 2128, 2558, 3014). `grep -n 'public_state\s*=\|
+lifecycle_phase\s*=\|terminal_outcome\s*=\|HSET.*core'` → state-mutation
+map. For each `HSET K.core_key` that sets `lifecycle_phase="terminal"` or
+`public_state=…`, confirmed whether a `PUBLISH` follows in the same
+atomic FCALL. Every emit site is gated by `if is_set(core.flow_id)` —
+standalone executions are intentionally silent (cairn-fabric requires a
+`flow_id` field and the subscriber `parse_push` drops payloads whose
+`flow_id` fails `FlowId::parse`, so a standalone emit would be discarded
+anyway). Cross-checked consumer parse at
+`crates/ff-backend-valkey/src/completion.rs:315` and struct at
+`crates/ff-core/src/backend.rs:468`.
+
+## FCALL → state-mutation → emission table
+
+Scope-limited to FCALLs that write `lifecycle_phase` or `terminal_outcome`
+in a consumer-observable way. Operational-only mutations (lease renewal,
+HMAC rotation, tag writes, progress bumps) are listed under "Affirmative
+no-findings".
+
+| FCALL | Lua line | state mutation | emit? | payload | gap assessment |
+|-------|----------|----------------|-------|---------|----------------|
+| ff_complete_execution | 1866 | phase=terminal, outcome=success, public_state=completed | YES @ 1920 | eid, flow_id, outcome=success | OK |
+| ff_cancel_execution | 2087 | phase=terminal, outcome=cancelled, public_state=cancelled | YES @ 2128 (skip if source=="flow_cascade") | eid, flow_id, outcome=cancelled | OK |
+| ff_fail_execution (retry path) | 2463 | phase=runnable, public_state=delayed | NO | — | accept — non-terminal, not a DAG bridge event |
+| ff_fail_execution (terminal path) | 2512 | phase=terminal, outcome=failed, public_state=failed | YES @ 2558 | eid, flow_id, outcome=failed | OK |
+| ff_expire_execution | 2975 | phase=terminal, outcome=expired, public_state=expired | YES @ 3014 | eid, flow_id, outcome=expired | OK |
+| ff_expire_suspension (fail/cancel/expire) | 4225 | phase=terminal, outcome∈{failed,cancelled,expired} | **NO** | — | **GAP-1** |
+| ff_resolve_dependency (impossible → child skip) | 6722 | phase=terminal, outcome=skipped, public_state=skipped | **NO** | — | **GAP-2** (see note) |
+| ff_suspend_execution | 3786 | phase=suspended, public_state=suspended | NO | — | accept — non-terminal |
+| ff_resume_execution | 3923 | phase=runnable, public_state=waiting\|delayed | NO | — | accept — non-terminal |
+| ff_expire_suspension (auto_resume) | 4143 | phase=runnable, public_state=waiting | NO | — | accept — non-terminal |
+| ff_expire_suspension (escalate) | 4181 | preserve suspended, blocking_reason=paused_by_operator | NO | — | accept — observability only |
+| ff_deliver_signal (resume path) | 4770 | phase=runnable | NO | — | accept — non-terminal |
+| ff_claim_resumed_execution | 5107 | phase=active, ownership=leased | NO | — | accept — non-terminal |
+| ff_delay_execution | 2195 | phase=runnable, public_state=delayed | NO | — | accept — non-terminal |
+| ff_move_to_waiting_children | 2302 | phase=runnable, public_state=waiting_children | NO | — | accept — non-terminal |
+| ff_reclaim_execution | 2643 | phase=active, new lease/attempt | NO | — | accept — non-terminal |
+| ff_replay_execution | 6945 / 6979 | terminal→runnable (reverse terminal) | NO | — | see GAP-3 note |
+| ff_promote_delayed | 3433 | phase=runnable, eligibility=eligible_now | NO | — | accept — non-terminal |
+| ff_stage_dependency_edge | 6528 | public_state=waiting_children | NO | — | accept — non-terminal |
+| ff_resolve_dependency (satisfied path) | 6652 | public_state=waiting, eligibility=eligible_now | NO | — | accept — non-terminal |
+| ff_promote_blocked_to_eligible | 6837 | eligibility=eligible_now | NO | — | accept — non-terminal |
+| ff_unblock_execution | 5675 | eligibility update | NO | — | accept — non-terminal |
+| ff_block_execution_for_admission | 5748 | eligibility=blocked_by_* | NO | — | accept — non-terminal |
+| ff_apply_dependency_to_child | — | edge write, no core | NO | — | accept |
+| ff_cancel_flow | 6270 | flow_core public_flow_state=cancelled | NO | — | see GAP-4 note |
+| ff_claim_execution | 1713 | phase=active, ownership=leased | NO | — | accept — non-terminal |
+| ff_create_execution | 1411 | creates new core | NO | — | accept — creation is not a bridge event (historical SessionCreated gap, cairn PR #26, still correctly not emitted) |
+| ff_revoke_lease | 1191 | ownership=lease_revoked | NO | — | accept — operational |
+| ff_mark_lease_expired_if_due | 1014 | lease-only fields | NO | — | accept — operational |
+
+## Findings
+
+### GAP-1: ff_expire_suspension terminal paths do not PUBLISH
+
+**Evidence:** `crates/ff-script/src/flowfabric.lua:4225-4280`
+(`ff_expire_suspension`, `fail`/`cancel`/`expire` branches).
+
+After writing `lifecycle_phase="terminal"`, `terminal_outcome ∈
+{failed, cancelled, expired}`, `public_state=public_state_val`,
+`ZADD terminal_key`, the function returns `ok(behavior, public_state_val)`
+without any `redis.call("PUBLISH", "ff:dag:completions", …)`. The other
+three terminal-writing FCALLs (`ff_complete_execution`,
+`ff_fail_execution` terminal branch, `ff_expire_execution`) and
+`ff_cancel_execution` all emit.
+
+**Consumer impact:** A flow-bound execution whose suspension times out
+with `timeout_behavior ∈ {fail, cancel, expire}` reaches a terminal
+state that downstream DAG children are blocked on, but no push arrives
+on `ff:dag:completions`. Children unblock only via the
+`dependency_reconciler` safety-net scan (default 15s), producing a
+latency spike identical in class to the one issue #44 closed for
+`ff_expire_execution`. cairn-fabric's completion subscriber never sees
+the terminal outcome, so any in-flight cairn await-completion / step
+observer on a suspended-then-timed-out member will block until the
+reconciler fallback.
+
+The adjacent `auto_resume` branch (4143) and `escalate` branch (4181)
+do not write terminal state and correctly do not emit.
+
+**Recommendation:** FIX. Add an `if is_set(core.flow_id) then
+PUBLISH ff:dag:completions { execution_id, flow_id, outcome =
+terminal_outcome }` block after the `ZADD terminal_key` at line 4278,
+mirroring the issue #44 pattern at 3008-3015. Scope: ~8 lines of Lua +
+1 regression test in `ff-test/tests/` (parallel to
+`expire_publish_dag.rs`). This is the same class of gap #44 fixed —
+suspension timeout is the third scanner-driven terminal path.
+
+### GAP-2: ff_resolve_dependency child-skip does not PUBLISH
+
+**Evidence:** `crates/ff-script/src/flowfabric.lua:6722-6737`
+(`ff_resolve_dependency`, impossible path → child skipped).
+
+When a child's last required dependency resolves `impossible` and the
+child is not yet terminal, the function sets `terminal_outcome=skipped`,
+`public_state=skipped`, `ZADD terminal_zset` — all signs of a terminal
+transition — but does not publish. Note that the FCALL is already
+executing *because of* a PUBLISH (the engine's CompletionListener called
+`dispatch_dependency_resolution`) — this is a cascaded terminal.
+
+**Consumer impact:** Grandchildren (child-of-child) of the originally-
+failed upstream do not receive a push event when their parent is
+cascade-skipped. The `dependency_reconciler` still catches it. Under a
+wide fan-out where layer N fails and layers N+1, N+2, … are all skipped,
+the reconciler must walk each layer — the push-based fast path cuts off
+at layer N+1. This is latency, not correctness, and is bounded by the
+reconciler interval. Cairn-side impact: step observers on grandchildren
+wait up to one reconciler cycle.
+
+**Recommendation:** FIX, but lower priority than GAP-1. Add an emit
+after `ZADD terminal_zset` at line 6735 gated on `is_set(core.flow_id)`
+with `outcome="skipped"`. Consumer parser already tolerates arbitrary
+outcome strings (it's a `String`, not an enum). Scope: ~8 lines Lua.
+Mild caution: skipped cascades fan out exponentially on diamond graphs,
+so the PUBLISH volume could multiply; acceptable because each push is
+tiny and `ff:dag:completions` already carries cancel-cascade traffic
+(modulo the `flow_cascade` suppression at 2122).
+
+### GAP-3 (note, not a gap — accept): ff_replay_execution terminal→runnable reverse does not emit
+
+**Evidence:** lines 6945 and 6979. Replay pulls a terminal execution
+back to `lifecycle_phase=runnable`. No PUBLISH, no other bus emit.
+
+**Assessment:** Accept. Replay is an operator action with its own RPC
+audit trail (lease_history_key carries a `replay_initiated` event).
+Consumers that need to know an execution resurrected from terminal rely
+on either polling the flow summary or resubscribing; the completion
+channel semantically is "forward transitions into terminal", not "any
+transition". Flag: no consumer has asked for this yet (cairn
+smoke-tests did not catch it).
+
+### GAP-4 (note, not a gap — accept): ff_cancel_flow does not emit per-member PUBLISH
+
+**Evidence:** line 6270. `ff_cancel_flow` sets flow_core
+`public_flow_state=cancelled`, drains members into `pending_cancels`,
+returns the member list. No PUBLISH; per-member emits happen later when
+`cancel_member_execution` → `ff_cancel_execution` fires (and that path
+suppresses PUBLISH for `source="flow_cascade"` at line 2122 by design).
+
+**Assessment:** Accept. The `flow_cascade` suppression is explicit —
+the engine already knows the fan-out and doesn't need the push. Cairn
+observes the flow-level cancel via the scheduled member-cancels, not
+the flow_core hash directly. If that changes (cairn wants flow-level
+cancel events), it's a new requirement, not a gap.
+
+## Affirmative no-findings
+
+Paths where absence of PUBLISH is correct as-is:
+
+- `ff_create_execution` — creation is not a bridge event (validates
+  historical SessionCreated decision from cairn PR #26).
+- `ff_claim_execution` / `ff_reclaim_execution` / `ff_claim_resumed_execution`
+  — ownership changes, not terminal.
+- `ff_renew_lease` / `ff_revoke_lease` / `ff_mark_lease_expired_if_due`
+  — lease bookkeeping.
+- `ff_suspend_execution` / `ff_resume_execution` /
+  `ff_deliver_signal` / `ff_expire_suspension` (auto_resume + escalate)
+  — non-terminal phase transitions; consumers that need these observe
+  via stream_tail or direct HGET.
+- `ff_delay_execution` / `ff_promote_delayed` /
+  `ff_move_to_waiting_children` — eligibility bookkeeping.
+- `ff_resolve_dependency` (satisfied) / `ff_stage_dependency_edge` /
+  `ff_apply_dependency_to_child` / `ff_promote_blocked_to_eligible` —
+  DAG mechanics, not terminal.
+- `ff_block_execution_for_admission` / `ff_unblock_execution` —
+  admission control.
+- `ff_set_execution_tags` / `ff_set_flow_tags` / `ff_update_progress` /
+  `ff_change_priority` / `ff_append_frame` — metadata / stream writes.
+- `ff_create_budget` / `ff_report_usage_and_check` / `ff_reset_budget` /
+  `ff_create_quota_policy` / `ff_check_admission_and_record` /
+  `ff_release_admission` — budget/quota.
+- `ff_issue_claim_grant` / `ff_issue_reclaim_grant` /
+  `ff_rotate_waitpoint_hmac_secret` / `ff_list_waitpoint_hmac_kids` /
+  `ff_create_pending_waitpoint` / `ff_close_waitpoint` /
+  `ff_buffer_signal_for_pending_waitpoint` — grant/waitpoint plumbing.
+- `ff_create_flow` / `ff_add_execution_to_flow` / `ff_ack_cancel_member`
+  — flow membership / ack.
+- `ff_version` / `ff_read_attempt_stream` — read-only.
+- `ff_fail_execution` retry branch (non-terminal) — correctly silent.
+- `ff_cancel_execution` with `source="flow_cascade"` — intentional
+  suppression (comment at 2116-2121 documents the rationale).
+
+Payload-shape check: all 4 existing emits use identical field set
+`{execution_id, flow_id, outcome}`. Consumer `parse_push` tolerates this
+fully; `payload_bytes` and `produced_at_ms` are documented as
+not-yet-populated in `backend.rs:462-465`. No payload-field gaps.
+
+## Recommendations
+
+Ordered by consumer impact:
+
+1. **GAP-1 (fix):** `ff_expire_suspension` terminal paths — add
+   `is_set(core.flow_id)`-gated PUBLISH for fail/cancel/expire branches.
+   Mirrors issue #44. Scope: ~8 Lua lines + 1 integration test. Closes
+   the last scanner-driven terminal path that bypasses the push channel.
+2. **GAP-2 (fix, lower priority):** `ff_resolve_dependency` child-skip —
+   add PUBLISH with `outcome="skipped"`. Cuts reconciler latency on
+   cascaded skips on deep DAGs. Scope: ~8 Lua lines + 1 test. Worth
+   coordinating with cairn to confirm they want `skipped` as a distinct
+   outcome (or a synthetic `failed` to match existing consumer code).
+3. No other fix-worthy gaps.
+
+Total: 2 emit sites to add. Both are the same pattern as the 4 existing
+emits (identical gate, identical payload shape), so no design work
+required.

--- a/rfcs/drafts/release-saga-2026-04-22-post-mortem.md
+++ b/rfcs/drafts/release-saga-2026-04-22-post-mortem.md
@@ -1,0 +1,191 @@
+# v0.3.x release saga post-mortem (2026-04-22)
+
+Author: Worker JJ. Scope: single-session retrospective of the v0.3.0 → v0.3.3
+release cycle on 2026-04-22, its three yanks, and the infrastructure added
+in response.
+
+## Timeline
+
+All times Europe/Jerusalem (commit `%ci` timestamps).
+
+| Event | Time | Ref |
+|---|---|---|
+| v0.3.0 tagged (first attempt) | prior to 16:35 | tag `v0.3.0` |
+| v0.3.0 publish run fails at `ff-engine` (ff-observability missing from crates.io); 3 of 7 crates published (`ferriskey`, `ff-core`, `ff-script`) | prior to 16:35 | `.github/workflows/release.yml:23-27` (post-fix comment documents the failure); CHANGELOG.md:86-93 |
+| v0.3.0 yank of the 3 partial crates | — | CHANGELOG.md:91 |
+| PR #130 "Hotfix v0.3.1: release workflow + bridge-event gaps" merged, adds `ff-observability` publish step | 17:42:57 | commit 68c1b5b |
+| v0.3.1 tagged (second attempt) | 17:42–18:17 | tag `v0.3.1`; CHANGELOG.md:68-75 |
+| v0.3.1 publish run fails at `ff-sdk` (ff-backend-valkey missing); 6 of 9 crates published (`ferriskey`, `ff-core`, `ff-script`, `ff-observability`, `ff-engine`, `ff-scheduler`) | 18:17–18:35 | CHANGELOG.md:62-65 |
+| v0.3.1 yank of the 6 partial crates | — | CHANGELOG.md:62-65 |
+| PR #131 "Hotfix v0.3.2: add ff-backend-valkey to publish set" merged | 18:35:12 | commit da89fa9 |
+| v0.3.2 tagged (third attempt) — all 9 crates publish clean | 18:35–19:29 | tag `v0.3.2`; CHANGELOG.md:48-66 |
+| v0.3.2 published-artifact smoke (Worker X) finds `ScannerFilter` unconstructible + `CompletionBackend` unreachable through `FlowFabricWorker` | 19:29 window | CHANGELOG.md:8-29; PR #134 body |
+| PR #132 "add publish-list drift check against workspace" merged (preventive, catches failure class of v0.3.0/0.3.1 at PR time) | 19:29:19 | commit ba7459d |
+| PR #134 "Hotfix v0.3.3: ScannerFilter builder + CompletionBackend accessor" merged | 19:53:50 | commit 23d3ce3 |
+| v0.3.3 tagged (fourth attempt) — clean | 19:53+ | tag `v0.3.3` |
+| PR #136 follow-on: drop unused `BackendTimeouts.keepalive` placeholder | 21:16:35 | commit 37a1ea0 |
+
+Yank incantation (from in-workflow error blocks at `.github/workflows/release.yml:164-168, 246-255`):
+`cargo yank --version ${VER} <crate>` for each partial-published crate.
+
+## Root causes
+
+1. **Publish-list drift between workspace and release workflow.** New
+   publishable crates added to the workspace were not added to the explicit
+   `cargo publish -p <name>` list in `.github/workflows/release.yml`. v0.3.0
+   failed because `ff-observability` (introduced in PR #94 — observability
+   metrics endpoint) was never added to the publish set. v0.3.1 failed the
+   same way because `ff-backend-valkey` (introduced in RFC-012 Stage 1a,
+   PR #114) was also missing. Both are called out in the workflow header
+   comments (`release.yml:23-31`) and in `feedback_release_publish_list_drift.md`.
+   The topological publish order in the workflow (ferriskey → ff-core →
+   ff-script → ff-observability → ff-backend-valkey → ff-engine → ff-scheduler
+   → ff-sdk → ff-server) is correct; the bug was that the list was incomplete,
+   not mis-ordered.
+
+2. **In-workspace tests use crate-private access and miss external-consumer
+   breakage.** v0.3.2 shipped `ScannerFilter` (PR #127) with
+   `#[non_exhaustive]` + `pub` fields and zero public constructors. Every
+   in-tree test passed because struct-literal construction is legal inside
+   the defining crate. External crates (cairn) could only name
+   `ScannerFilter::NOOP`. Similarly, `subscribe_completions_filtered` was
+   reachable via the `CompletionBackend` trait (PR #124) but
+   `FlowFabricWorker::backend()` returned `Arc<dyn EngineBackend>` — and
+   `CompletionBackend` is a sibling trait, not a supertrait, so no upcast
+   path existed on the public SDK surface. The headline filtered-completion-
+   subscription API was GA-dead. CHANGELOG.md:8-29; `feedback_smoke_after_publish.md`.
+
+3. **Placeholder-plumbed fields invite the ScannerFilter class of miss.**
+   Public fields/options wired into the type system but unread by any code
+   path give consumers the impression of functionality that doesn't exist.
+   `ScannerFilter`'s initial commit (PR #127) before #134 fit the pattern
+   (fields present, no way to set them from outside). `BackendTimeouts.keepalive`
+   (dropped in commit 37a1ea0, PR #136) and the original `BackendRetry`
+   shape (Worker II follow-on) were the same anti-pattern — placeholder
+   knobs consumers could set that no downstream code honored.
+
+## What fixed the class of bug
+
+- **Publish-list drift CI (PR #132, commit ba7459d).** Added to
+  `.github/workflows/security-and-quality.yml` as a required gate, wired
+  into the `quality-gates-complete` sentinel. Diffs `cargo metadata
+  --no-deps` publishable-crate names against the `cargo publish -p <name>`
+  list grepped from `release.yml`. Catches root cause (1) at PR-review time
+  for every new or removed workspace crate.
+
+- **Smoke-after-publish discipline (post-v0.3.2).** Codified in
+  `feedback_smoke_after_publish.md`: spawn a smoke agent in a scratch dir,
+  `cargo add ff-sdk@X.Y.Z`, exercise every new or changed public type end-
+  to-end. Catches root cause (2) at release-close time. Already proved its
+  value — the 0.3.2 smoke (report at `rfcs/drafts/0.3.2-smoke-report.md`
+  per CHANGELOG.md:17,28) produced Findings 1 and 2 that drove v0.3.3.
+
+- **Remove-dead-placeholder-fields reflex (PR #136 and Worker II's
+  `BackendRetry` reshape).** Documented in the backend-timeouts audit
+  (`rfcs/drafts/backend-timeouts-retry-audit.md`, present in this worktree).
+  Catches root cause (3) at code-review time by deleting fields that
+  haven't been wired within one release window rather than retaining them
+  "for future use."
+
+## What would have caught it earlier
+
+Honest retrospective — these were absent at v0.3.0 and could have prevented
+one or more cycles.
+
+- **Dry-run publish against a private registry before tag push.** The
+  release workflow exercises `cargo package` via `--no-verify` publishes,
+  but it does not pre-simulate resolution against an empty registry that
+  would surface the ff-observability / ff-backend-valkey gaps. A private-
+  registry dry-run would have caught root cause (1) before the real tag.
+  Not implemented post-saga; publish-list drift CI (#132) is the cheaper
+  substitute but only catches drift that mentions a new crate file, not
+  arbitrary resolution issues.
+
+- **`cargo package --workspace --allow-dirty` as an operator pre-tag
+  ritual.** Called out in the release doc checklist but skipped on v0.3.0.
+  `feedback_release_publish_list_drift.md` raises this to the "How to apply"
+  list and PR #131 introduced it as a documented pre-tag step. Would have
+  caught (1) with zero CI investment.
+
+- **Manual external-constructibility audit for every new public type.**
+  The PR review for #127 (ScannerFilter) had no bot comment on the
+  `#[non_exhaustive]` + private-constructor combination because the rule
+  is subtle — rustc only rejects at the external call site. The human
+  reviewer (manager) missed it. Policy now: any new public type on a
+  public surface requires an explicit note during review of how an
+  external crate constructs it. The smoke agent catches this empirically;
+  the review-time policy catches it before it ships.
+
+## Lessons applied
+
+Concrete policy for future releases, not generic:
+
+1. **Every release tag runs `cargo package --workspace` as the final
+   pre-tag check.** Operator-executed; any failure aborts the tag.
+   Codified in PR #131's release-doc update and in
+   `feedback_release_publish_list_drift.md`.
+
+2. **Every release tag runs a published-artifact smoke in a scratch dir
+   before the changelog is closed.** Target is every new or changed
+   public type in the release. Failures that block external consumers
+   trigger an immediate v0.(patch+1) hotfix rather than waiting for a
+   consumer bug report. Codified in `feedback_smoke_after_publish.md`.
+
+3. **Every new public type on a public surface needs a smoke-grade
+   external-construction test, not just an in-crate struct-literal test.**
+   `#[non_exhaustive]` + `pub` fields without a constructor is the exact
+   trap ScannerFilter fell into; it must be audited at PR-review time and
+   re-checked at smoke time.
+
+4. **Placeholder fields that aren't wired within one release are
+   removed, not retained.** `BackendTimeouts.keepalive` (PR #136) and
+   `BackendRetry`'s original shape set the precedent. Retained
+   placeholders ship as dead API surface that consumers will set and
+   silently rely on.
+
+## Cost
+
+- **Release cycles spent:** 4 (v0.3.0, v0.3.1, v0.3.2, v0.3.3) to ship
+  what was targeted for 1.
+- **Yanks issued:** 9 crate-versions across 3 bumps (3 from v0.3.0,
+  6 from v0.3.1, plus v0.3.2 superseded by v0.3.3 for the ScannerFilter
+  hotfix — v0.3.2's 9 crates were not yanked because a second yank of an
+  already-used version is structurally fine with consumers re-resolving).
+- **Elapsed wall time:** v0.3.0 pre-16:35 → v0.3.3 at 19:53. Roughly
+  3h30m from the first failed publish to the clean v0.3.3 publish, plus
+  PR #136 follow-on at 21:16 for the placeholder cleanup. Call it
+  ~4 hours of elapsed time.
+- **Opportunity cost:** Worker X (smoke-after-publish discovery), the
+  author of #130, #131, #132, and #134, plus the manager review time on
+  each hotfix. Rough order-of-magnitude ~4 agent-hours of hotfix work
+  that would not have been needed if the pre-tag ritual had run on
+  v0.3.0.
+- **Net outcome:** v0.3.3 is externally-usable; three pieces of standing
+  infrastructure now guard the next release (publish-list drift CI,
+  smoke-after-publish policy, placeholder-removal reflex). The saga was
+  expensive but the class of bug is now closed at three distinct layers
+  (PR-time, release-time, code-review-time).
+
+## Links (PRs, commits, issues)
+
+- PR #94 — observability /metrics endpoint (introduced ff-observability;
+  root cause 1.a) — commit 03910f5.
+- PR #114 — RFC-012 Stage 1a EngineBackend trait (introduced
+  ff-backend-valkey; root cause 1.b) — commit 81e08dc.
+- PR #124 — CompletionBackend trait — commit dd70982.
+- PR #127 — ScannerFilter (root cause 2.a) — commit a8c8923.
+- PR #130 — Hotfix v0.3.1: add ff-observability to publish set —
+  commit 68c1b5b; `release.yml:182-193`.
+- PR #131 — Hotfix v0.3.2: add ff-backend-valkey to publish set —
+  commit da89fa9; `release.yml:194-206`.
+- PR #132 — publish-list drift CI — commit ba7459d;
+  `.github/workflows/security-and-quality.yml` (55-line addition).
+- PR #134 — Hotfix v0.3.3: ScannerFilter builder + `FlowFabricWorker::completion_backend()` —
+  commit 23d3ce3.
+- PR #136 — drop unused `BackendTimeouts.keepalive` — commit 37a1ea0.
+- Memory: `feedback_release_publish_list_drift.md`,
+  `feedback_smoke_after_publish.md`.
+- Smoke report referenced in CHANGELOG.md:17,28:
+  `rfcs/drafts/0.3.2-smoke-report.md`.
+- Related audit in this worktree:
+  `rfcs/drafts/backend-timeouts-retry-audit.md`.

--- a/rfcs/drafts/scenario-4-regression-investigation.md
+++ b/rfcs/drafts/scenario-4-regression-investigation.md
@@ -1,0 +1,92 @@
+# Scenario 4 long_running regression investigation (2026-04-22)
+
+**Investigator:** Worker DD
+**Worktree:** `/home/ubuntu/ff-worker-dd-bisect` (branch `worker-dd/scenario4-bisect`, from `origin/main` at `23d3ce3`)
+**Host:** local AMD EPYC (same class as documented baseline); Valkey **7.2.12** on port 6379 (NOT 8.1.0 — see §Caveat)
+**Bench invocation:** `FF_BENCH_LANE=bench FF_BENCH_SERVER=http://localhost:9090 ./target/release/long_running --duration 300`, preceded by `valkey-cli -p 6379 FLUSHALL`.
+
+## TL;DR
+
+Regression in `missed_deadline_pct` (3.88% → 7.11%) **does not reproduce as a regression**. `missed_deadline_pct` is ~7% at HEAD *and* at the claimed-good commit `01f6327`, *and* at every bisected commit between them. The "3.88% at v0.1.0" baseline in `benches/results/baseline.md` appears to be a single-run outlier that never represented stable behavior on this host class.
+
+## Reproduction
+
+Two fresh runs at HEAD (`23d3ce3`, `main` post-#133/#134):
+
+- **Run 1:** `completed=2680  failed=102  missed_count=202  missed_pct=7.0090%`
+- **Run 2:** `completed=2680  failed=104  missed_count=203  missed_pct=7.0413%`
+
+Both > 5% → regression is "real" in the sense that HEAD is genuinely at ~7%. Proceeded to bisect `da89fa9` (bad) vs `01f6327` (good, per `baseline.md`).
+
+## Bisect log
+
+Range size: `git log --oneline 01f6327..da89fa9 | wc -l` = 49 commits (~6 steps). Each step: checkout → `sed` the `REQUIRED_VALKEY_MAJOR` constant from 8 to 7 (local Valkey is 7.2.12; older commits require major≥8 and refuse to start) → rebuild `ff-server` + `long_running` → `FLUSHALL` → 300s scenario.
+
+| step | commit    | title                                                                 | missed_pct | verdict |
+|------|-----------|-----------------------------------------------------------------------|------------|---------|
+| 0    | `23d3ce3` | HEAD (main, Run 1)                                                    | 7.01%      | bad     |
+| 0b   | `23d3ce3` | HEAD (main, Run 2)                                                    | 7.04%      | bad     |
+| 1    | `183c10f` | `perf(ff-scheduler): bound partition scan + rotation cursor (#86)`    | 6.98%      | bad     |
+| 2    | `077a3c8` | `feat(ff-sdk): describe_execution + ExecutionSnapshot (#62)`          | 7.04%      | bad     |
+| 3    | `d3361a6` | `fix(ff-script): reclaim must SREM execution from old worker (#54)`   | 7.04%      | bad     |
+| 4    | `00608ef` | `fix(ff-script): embed flowfabric.lua in crate for v0.1.1 (#48)`      | 7.04%      | bad     |
+| 5    | `aeea6cc` | `chore(release): fix v0.1.0 publish pipeline + runbook (#47)`         | 7.07%      | bad     |
+| 6    | `4192664` | `bench: v0.1.0 baseline refresh + RFC-011 harness compat fix (#46)`   | 7.04%      | bad     |
+| 7    | composite | `01f6327` **server** + `4192664` **bench** (the doc-implied baseline) | 6.98%      | bad     |
+
+First-bad per `git bisect` = `4192664` (PR #46).
+
+## Why PR #46 is a bisect artifact, not the regression
+
+`git diff 01f6327..4192664 --stat` shows **zero changes in `crates/`**. The diff is:
+
+- `benches/harness/src/workload.rs` (+ `runners/flowfabric.rs`, `bin/cap_routed.rs`) — mint bench ExecutionIds via `ExecutionId::for_flow(fresh_fid)` instead of the broken bare-UUID that returned HTTP 422 at `01f6327`.
+- `benches/results/baseline.md` — the v0.1.0 numbers table.
+- `benches/Cargo.lock`.
+
+At `01f6327` the old bench harness **could not submit executions at all** (422 rejected by the post-RFC-011 server). The only way the "3.88%" number could have been produced at `01f6327` is by running the **post-#46 harness** against the `01f6327` server — the same composite I reconstructed in step 7 above.
+
+That composite produces 6.98%, not 3.88%.
+
+### Hypothesis for the 3.88% number in baseline.md
+
+Most likely a **single-run lucky timing** captured during the PR #46 authoring window. The scenario uses `REFILL_TOPUP = 20` tasks every `REFILL_EVERY_MS = 10_000`, and every task in a batch shares the same `submit_ms` — so whether a batch slips past the 60s deadline is highly bimodal with respect to the phase alignment of refill vs steady-state drain. A single 300s run samples ~30 refill windows, and the miss rate has a visible jaggedness at that cadence. The scenario's own comment block flags this:
+
+> `missed_deadline_pct` is submit-to-complete; refill batches cause per-batch spikes because every task in a batch shares `submit_ms`, so the rate smooths only over windows >> refill_interval_ms.
+
+3.88% vs 7.0% is almost exactly a factor of 2, consistent with "about half the refill batches miss vs. all of them". A single 5-minute run is an insufficient sample to distinguish these regimes — the doc itself acknowledges "single-run observation" and recommends a repeat.
+
+The three "reference" points in `baseline.md` — v0.1.0 3.88%, v0.3.2 7.11%, pre-Batch-C 7.01% — are each single-run snapshots. My 8 runs across the full 01f6327..23d3ce3 range all land in 6.98%-7.07%. **The cluster of 7 reproductions across 6 distinct commits is strong evidence this is the stable regime and the 3.88% number was the outlier.**
+
+## Caveat: Valkey version mismatch
+
+`baseline.md` notes the reference host ran **Valkey 8.1.0**. My local Valkey is **7.2.12** (same `redis_version: 7.2.4` string but different server binary). Older commits in the bisect range enforce `REQUIRED_VALKEY_MAJOR = 8`, which I relaxed via `sed` during each bisect build. This is the one environmental delta that could plausibly matter:
+
+- If Valkey 8 changes its scheduling of `BLMPOP` tail latency or `ZRANGEBYSCORE` tail latency in the eligible-queue scanner, deadline behavior could differ.
+- No evidence either way from this investigation.
+
+If the person who captured the 3.88% baseline still has access to a Valkey-8.1.0 host, a single reproduction run there would be dispositive. Until then, the regression claim is unsupported on a Valkey-7.2 host.
+
+## Suspect PR + mechanism hypothesis
+
+**None pinned.** The bisect mathematically fingers PR #46, but that PR's diff contains no product code — it only unblocked the bench from returning HTTP 422 at `01f6327`. There is no plausible mechanism by which #46 altered engine behavior.
+
+Candidates previously flagged in the task description — RFC-012 Stage 1a trait forwarding (#114), bridge-event PUBLISH in v0.3.1 GAP-1 (#130), ScannerFilter per-candidate HGETs (#122) — were all bisected past (each commit downstream of `01f6327` already showed ~7% miss rate), so none of them *introduced* the regression. They may all individually add small overheads, but the floor was already ~7% before any of them landed.
+
+## Recommendation
+
+**Not reproducible as a regression.** `missed_deadline_pct` is stable at ~7% across the entire 01f6327..23d3ce3 range on this host class. Three concrete follow-ups:
+
+1. **Treat the `baseline.md` v0.1.0 "3.88%" entry as an outlier.** Mark it clearly as single-run or replace it with the median of ≥5 runs. The current text already warns single-run; the warning should be load-bearing enforcement (N≥5 required before entering `baseline.md`) not advisory.
+2. **Rebench on Valkey 8.1.0** to rule out the version mismatch caveat before closing. If 8.1.0 also shows ~7%, close as "not a regression, fix baseline doc".
+3. **Lower variance of the scenario itself.** The 10s refill cadence + 60s deadline is right at the bimodal tipping point. Either (a) jitter per-task submit_ms within a refill batch, or (b) lengthen the run to ≥ 30 minutes so the sample is ≥ 180 refill cycles. Current 30-cycle sample is too short for a stable percent.
+
+No product code change recommended. No further bisect required.
+
+## Time accounting
+
+- Reproduction (2 × 300s runs + build): ~14 min
+- Bisect (6 × [~1 min build + 5 min run]): ~36 min
+- Composite-verify (01f6327 server + current bench): ~6 min
+- Diff/doc analysis: ~4 min
+- **Total bench + analysis time: ~60 min**, well under the 2-hour HALT budget.

--- a/rfcs/drafts/stage-1c-scope-audit.md
+++ b/rfcs/drafts/stage-1c-scope-audit.md
@@ -1,0 +1,162 @@
+# RFC-012 Stage 1c scope audit (2026-04-22)
+
+Worker EE, pre-planning investigation. Read-only. Cites `file:line` on `main` at `47ef2b0` ("archive RFC-012 namespace-amendment exploration"). No plan, no implementation — this only sizes the scope-surface so manager can decide how to shape the Stage 1c PR.
+
+## Scope summary
+
+Stage 1c is scoped, post the #122 ScannerFilter shipping and the namespace-amendment exploration being archived (`47ef2b0`), to the **original round-4 §5.1 scope**: migrate the `FlowFabricWorker` + free-fn hot paths off the embedded `ferriskey::Client` and behind the `EngineBackend` trait, fold in issue #93 (`BackendConfig` carved out of `WorkerConfig`'s connection fields), and wire `BackendTimeouts` / `BackendRetry` (placeholders landed in Stage 1a at `crates/ff-core/src/backend.rs:570-587`). No namespace / no ScannerFilter work — that landed in #122 via a separate mechanism. The four `ClaimedTask` ops deferred from Stage 1b (`create_pending_waitpoint`, `append_frame`, `suspend`, `report_usage`) are blocked on issue #117's trait-shape amendment and are **out of scope** for 1c unless #117 lands first.
+
+## Hot-path method inventory
+
+Direct `ferriskey::Client` / `self.client.{cmd,fcall,get,hget,...}` usage inside `ff-sdk` method bodies. Stage-1b-migrated sites (route through `self.backend.*`) are **omitted** — they're already done. Row shape: op → current site → migration target.
+
+### `FlowFabricWorker` (crates/ff-sdk/src/worker.rs)
+
+| Op | Site | Current shape | Stage-1c target |
+|---|---|---|---|
+| `connect` PING check | worker.rs:151-155 | `client.cmd("PING").execute()` | backend has no `ping`; either add or keep as Valkey-internal inside `ValkeyBackend::connect` |
+| `connect` duplicate-instance guard | worker.rs:203-215 | `SET NX PX` via `client.cmd("SET")` | worker-guard primitive — candidate for `backend.register_worker_instance(id, ttl)` OR stays in the Valkey backend's connect path |
+| `connect` caps advertisement (DEL + SREM) | worker.rs:401-415 | `client.cmd("DEL")` + `cmd("SREM")` | backend-internal (caps index is a Valkey implementation detail); move into `ValkeyBackend::advertise_capabilities` helper |
+| `connect` caps advertisement (SET + SADD) | worker.rs:425-444 | `client.cmd("SET")` + `cmd("SADD")` | same as above |
+| `read_partition_config` (free fn) | worker.rs:1571-1599 | `client.hgetall(ff:config:partitions)` | `backend.partition_config()` — `ValkeyBackend::connect` already reads this; move the read into the backend and expose via trait |
+| `claim_next` ZRANGEBYSCORE scan | worker.rs:616-627 | `client.cmd("ZRANGEBYSCORE")` | `backend.peek_eligible(lane, partition, limit)` — new trait method OR fold into a composite `claim_next` on the trait |
+| `issue_claim_grant` | worker.rs:788-792 | `client.fcall("ff_issue_claim_grant", …)` | `backend.issue_claim_grant(…)` — composite trait op OR bundled into `claim_next` |
+| `block_route` | worker.rs:832-836 | `client.fcall::<Value>("ff_block_execution_for_admission", …)` | `backend.block_execution(…)` |
+| `claim_execution` (HGET total_attempt_count) | worker.rs:884-890 | `client.cmd("HGET")` | backend-internal; absorbed by `backend.claim(lane, partition)` |
+| `claim_execution` FCALL | worker.rs:938-942 | `client.fcall("ff_claim_execution", …)` | `backend.claim(…)` — Stage-1a §3.1.1 slot already reserved |
+| `claim_resumed_execution` (HGET current_attempt_index) | worker.rs:1250-1256 | `client.cmd("HGET")` | backend-internal; absorbed by `backend.claim_resumed(…)` |
+| `claim_resumed_execution` FCALL | worker.rs:1293-1297 | `client.fcall("ff_claim_resumed_execution", …)` | `backend.claim_resumed(…)` |
+| `read_execution_context` GET payload | worker.rs:1401-1405 | `client.get(&ctx.payload())` | backend-internal; absorbed by the claim result shape OR `backend.read_execution_context(…)` |
+| `read_execution_context` HGET kind | worker.rs:1409-1413 | `client.hget(&ctx.core(), "execution_kind")` | same |
+| `read_execution_context` HGETALL tags | worker.rs:1417-1421 | `client.hgetall(&ctx.tags())` | same |
+| `deliver_signal` lane pre-read | worker.rs:1447-1451 | `client.hget(&ctx.core(), "lane_id")` | backend-internal; absorbed |
+| `deliver_signal` FCALL | worker.rs:1520-1524 | `client.fcall("ff_deliver_signal", …)` | `backend.deliver_signal(…)` — new trait method |
+
+**Subtotal worker.rs: 17 direct-client sites** (plus `ClaimedTask::new(self.client.clone(), …)` at worker.rs:1022 and 1372 — passes the client through to `ClaimedTask`, gone once Stage 1d removes the embedded field).
+
+### `ClaimedTask` — deferred-from-1b ops (crates/ff-sdk/src/task.rs)
+
+These four are direct-client today **and** flagged `TODO(stage-1d-or-rfc-amendment)` / `#117`. Listed for completeness; **gated on #117** (trait-shape amendment), not naturally in Stage 1c:
+
+| Op | Site | FCALL |
+|---|---|---|
+| `report_usage` | task.rs:662-666 | `ff_report_usage_and_check` |
+| `create_pending_waitpoint` | task.rs:718-722 | `ff_create_pending_waitpoint` |
+| `append_frame` | task.rs:782-786 | `ff_append_frame` |
+| `suspend` | task.rs:905-909 | `ff_suspend_execution` |
+
+### Free functions (crates/ff-sdk/src/task.rs, admin.rs)
+
+| Fn | Site | Client use | Stage-1c target |
+|---|---|---|---|
+| `read_stream` | task.rs:1933-1964 | takes `client: &Client`, calls `ff_script::functions::stream::ff_read_attempt_stream(client, …)` | reshape as `FlowFabricWorker::read_stream(&self, …)` OR accept `&dyn StreamBackend` (issue #92 already laid the `StreamBackend` ground — see §6.2). **Closes #87.** |
+| `tail_stream` | task.rs:2036-2074 | takes `client: &Client`, calls `ff_script::stream_tail::xread_block(client, …)` | same shape; **closes #87**. Head-of-line doc requires a dedicated connection — migration shape must preserve that knob |
+| `rotate_waitpoint_hmac_secret_all_partitions` | admin.rs:493-519 | takes `client: &ferriskey::Client`, calls `ff_script::functions::suspension::ff_rotate_waitpoint_hmac_secret(client, …)` | reshape as a method on `FlowFabricAdminClient` OR on a new `AdminBackend` trait (RFC-012 §3.2). Not listed in #87's original site list — **additional leak**, same fix |
+
+### snapshot.rs pipeline uses
+
+| Site | Shape |
+|---|---|
+| snapshot.rs:77 | `self.client().pipeline()` (calls through `FlowFabricWorker::client()`) |
+| snapshot.rs:810 | same |
+
+Both consume the `client()` getter — closing `client()` (worker.rs:524) is blocked on re-shaping these two pipeline callers to go through the backend (pipelines are a Valkey primitive; likely needs a `backend.read_snapshot(…)` trait method OR a `pub(crate)` escape hatch at the Valkey backend boundary).
+
+**Total Stage-1c hot-path migration surface: ~17 `FlowFabricWorker` sites + 2 free-fn reshapes + 1 admin free-fn reshape + 2 snapshot.rs sites = ~22 sites / ~8-10 trait methods.** For comparison Stage 1b migrated 8 `ClaimedTask` methods (per `worker.rs:94-110` comment).
+
+## WorkerConfig field split (for BackendConfig migration, #93)
+
+`WorkerConfig` at `crates/ff-sdk/src/config.rs:1-61`. Stage-1a `BackendConfig` already exists at `crates/ff-core/src/backend.rs:635` with `ValkeyConnection` covering `host/port/tls/cluster`.
+
+| Field | config.rs line | Category |
+|---|---|---|
+| `host` | 6 | connection → `BackendConfig` |
+| `port` | 8 | connection → `BackendConfig` |
+| `tls` | 10 | connection → `BackendConfig` |
+| `cluster` | 12 | connection → `BackendConfig` |
+| `worker_id` | 14 | policy (worker identity) → stays |
+| `worker_instance_id` | 16 | policy (process identity) → stays |
+| `namespace` | 18 | policy (tenant scope) → stays |
+| `lanes` | 20 | policy (routing) → stays |
+| `capabilities` | 22 | policy (routing) → stays |
+| `lease_ttl_ms` | 24 | policy (timing) → stays |
+| `claim_poll_interval_ms` | 26 | policy (timing) → stays |
+| `max_concurrent_tasks` | 28 | policy (concurrency) → stays |
+
+**4 fields move, 8 stay.** Exact split as forecast in `backend.rs:625-632` doc comment. No mixed fields.
+
+`WorkerConfig::renewal_interval_ms()` helper (config.rs:58) is pure-policy, stays.
+
+## FCALL caller sites in ff-sdk
+
+`ff_script::functions::*` + direct `.fcall("ff_…", …)` sites in `crates/ff-sdk/src/**`:
+
+| Site | FCALL | Stage |
+|---|---|---|
+| admin.rs:515 | `ff_script::functions::suspension::ff_rotate_waitpoint_hmac_secret` | 1c (admin path) |
+| task.rs:664 | `ff_report_usage_and_check` | deferred (#117) |
+| task.rs:720 | `ff_create_pending_waitpoint` | deferred (#117) |
+| task.rs:784 | `ff_append_frame` | deferred (#117) |
+| task.rs:907 | `ff_suspend_execution` | deferred (#117) |
+| task.rs:1961 | `ff_script::functions::stream::ff_read_attempt_stream` (via `read_stream`) | 1c |
+| worker.rs:790 | `ff_issue_claim_grant` | 1c |
+| worker.rs:834 | `ff_block_execution_for_admission` | 1c |
+| worker.rs:940 | `ff_claim_execution` | 1c |
+| worker.rs:1295 | `ff_claim_resumed_execution` | 1c |
+| worker.rs:1522 | `ff_deliver_signal` | 1c |
+
+**11 FCALL sites total, 7 in scope for Stage 1c proper, 4 deferred behind #117.** Adding in `stream_tail::xread_block` (not an FCALL but a direct transport call) → 8 Stage-1c migrations. This is in the same range as Stage 1b (8 methods) — the stage is not obviously over-large.
+
+## #87/#88 overlap
+
+Cross-reference against Worker BB's `87-88-scope-carveout.md` "Stage-1c-blocked sites" section (lines 46-55):
+
+### Closed by Stage 1c (naturally, in-scope)
+
+| Site | BB's classification | Closed how |
+|---|---|---|
+| `crates/ff-sdk/src/worker.rs:524` — `FlowFabricWorker::client() -> &Client` | "Stage 1c (backend-handle method replaces it)" | Closes once hot-path migration removes the embedded client; `backend()` getter at worker.rs:519 is the replacement (Stage 1c narrows its return type per the doc comment at worker.rs:516-518) |
+| `crates/ff-sdk/src/task.rs:1933` — `pub async fn read_stream(client: &Client, …)` | "Stage 1c (reshape as worker method / opaque handle)" | Reshape as `FlowFabricWorker::read_stream` — same pattern |
+| `crates/ff-sdk/src/task.rs:2036` — `pub async fn tail_stream(client: &Client, …)` | "Stage 1c (same)" | Same |
+
+**3 of the 6 BB-listed ff-sdk sites close in Stage 1c.**
+
+### Still open after Stage 1c (needs Stage 1d or separate work)
+
+| Site | BB's classification | Why not 1c |
+|---|---|---|
+| `crates/ff-sdk/src/lib.rs:105` — `SdkError::Valkey(ferriskey::Error)` | "Stage 1c/d (wrap in BackendError)" | Error-type broadening is a separate axis — Stage 0 `EngineError::Transport` broadening is the canonical home; wrapping at SdkError is mechanical but can land separately |
+| `crates/ff-sdk/src/lib.rs:110-113` — `SdkError::ValkeyContext { source: ferriskey::Error, … }` | same | same |
+| `crates/ff-sdk/src/lib.rs:240` — `SdkError::valkey_kind()` | "Stage 1c/d (keep method, return None for non-Valkey)" | Same. BB recommends Option A — bundle error-type work across crates |
+
+**Additional leak BB did not list** (worth flagging for manager): `crates/ff-sdk/src/admin.rs:493-519` — `rotate_waitpoint_hmac_secret_all_partitions(client: &ferriskey::Client, …)` — same shape as `read_stream` / `tail_stream`. Should be reshaped alongside them in Stage 1c.
+
+## Risk flags
+
+- **Lua impact: NO.** All Stage-1c migrations preserve the existing FCALL names + KEYS/ARGV. The trait method shape is Rust-side; the Valkey backend impl still calls the same `ff_issue_claim_grant` / `ff_claim_execution` / `ff_deliver_signal` FCALLs. `lua/*.lua` is untouched. (Verified: `rg -n "ARGV\[|KEYS\[" lua/` patterns would need to change for ARGV-shape expansion; none of the 8 in-scope sites requires that — they are 1:1 trait wrappers around the current FCALL.)
+- **BackendTimeouts/BackendRetry: placeholder.** Types exist at `crates/ff-core/src/backend.rs:570-587`; `BackendConfig` carries them at line 637-638. `ValkeyBackend::connect` at `crates/ff-backend-valkey/src/lib.rs:92` pattern-matches on `BackendConnection::Valkey(v)` but **ignores `config.timeouts` and `config.retry`** — the comment at `lib.rs:91` explicitly names Stage 1c as the wiring point ("Full `BackendTimeouts`/`BackendRetry` wiring is a Stage 1c task"). **Stage 1c must wire these through to `ClientBuilder::connect_timeout` / `request_timeout`** at `worker.rs:136-139` (today hard-coded at 10s connect / 5s request) or they remain dead code — this is the same class of bug as the original namespace-field plumbing miss.
+- **Backend-handle coverage for `client()` getter.** Closing worker.rs:524 needs the `backend()` getter at worker.rs:519 to narrow its return type (already scaffolded) AND the two `snapshot.rs` pipeline callers (lines 77, 810) to stop reaching into `self.client().pipeline()`. Snapshot-read may need a new trait method OR a documented `pub(crate)` escape on `ValkeyBackend` — a small design question for the Stage-1c plan.
+- **Snapshot pipelines depend on ferriskey `pipeline()`.** `snapshot.rs:77, 810` use `client().pipeline()` — pipelines are inherently Valkey-shaped. Migration likely needs a `backend.pipeline_snapshot_read(…)` or an out-of-trait `ValkeyBackend::pipeline()` accessor. Flag for manager: this is the trickiest design call in the stage.
+- **connect-path primitives (PING, SET-NX alive key, caps index SET/SADD/DEL/SREM) don't fit cleanly into the lifecycle-op trait.** These are worker-registration primitives. Options: (a) bundle into a `backend.register_worker(&config)` trait method; (b) leave inside `ValkeyBackend::connect` (which already loads partition config at `lib.rs:133-148` — precedent exists); (c) expose a small `WorkerLifecycleBackend` sub-trait. Design call for Stage-1c plan.
+
+## Effort estimate
+
+Rough sizing based on site counts + 1a/1b comparisons:
+
+- **Hot-path migration (17 `FlowFabricWorker` sites, 7 FCALL wrappers + connect-path primitives + snapshot pipelines):** 18-24h. Larger than Stage 1b (8 methods, 20-28h actual) only if the backend-handle + snapshot pipeline design problem forces a sub-trait or new pipeline method; smaller if we can bundle.
+- **#93 `BackendConfig` carveout:** 3-5h. Mechanical field split; `BackendConfig::valkey(host, port)` already exists. The back-compat `WorkerConfig::new(host, port, …)` shim per RFC §5.1 is **1-2h**; BB's carve-out + pre-1.0 CHANGELOG-only posture likely lets us just break the API and update the 20-ish call sites in-tree. Call-site fanout: 20 struct-literal `WorkerConfig { … }` sites + 1 `WorkerConfig::new` doc reference — all first-party (ff-test, ff-readiness-tests). Breaking the API saves ~1h net and removes a future-removal chore.
+- **`BackendTimeouts` / `BackendRetry` wiring:** 2-4h. Thread `config.timeouts.request` → `ClientBuilder::request_timeout`, `config.timeouts.keepalive` → `ClientBuilder::ping_interval` (if ferriskey exposes it; check), `config.retry.*` → a retry wrapper on transient errors. Writing the tests that actually verify the plumbing (lesson learned from the namespace-field dead-code miss) is ~half the time.
+- **#87/#88 closure for the 3 in-scope sites (`FlowFabricWorker::client()`, `read_stream`, `tail_stream`):** absorbed into hot-path migration — not incremental.
+- **Admin-path `rotate_waitpoint_hmac_secret_all_partitions`:** 2-3h. Reshape as method on `FlowFabricAdminClient` or gate behind an `AdminBackend` trait.
+
+**Total: 25-38h.** Slightly below round-4's §5.1 estimate of 25-35h if we scope down (leave error-type broadening to a separate small PR per BB's Option A), slightly above if we bundle the error work in. Stage 1b landed at ~24h; 1c is comparable-to-slightly-larger.
+
+## Open questions for Stage 1c planning
+
+1. **`WorkerConfig::new(host, port, …)` back-compat shim: keep or break?** RFC-012 §5.1 says keep. BB's carve-out and the pre-1.0 CHANGELOG-only posture (project_ff_release_decisions.md lock at 2026-04-22) suggest break. 20 first-party call sites only; no external consumers of the ff-sdk Rust API. Recommendation: break. Needs owner confirmation.
+2. **`BackendTimeouts::keepalive` — what does ferriskey expose?** `ClientBuilder` at worker.rs:136-139 uses `.connect_timeout` + `.request_timeout` only. If ferriskey has no keepalive-interval knob, the field plumbs to nothing — repeat of the namespace miss. Needs an empirical ferriskey API check before 1c lands.
+3. **Snapshot `pipeline()` — trait method or Valkey escape hatch?** The two snapshot.rs sites are the hardest design call. Trait method `backend.pipeline_snapshot()` commits us to an awkward abstraction; `ValkeyBackend::pipeline()` leaves a leak, just one the backend crate owns.
+4. **Connect-path primitives (PING, alive-key SET-NX, caps-index SET/SADD/DEL/SREM) — absorb into `backend.connect` or expose as trait methods?** Precedent: `ValkeyBackend::connect` already pulls `ff:config:partitions` into itself at `lib.rs:133-148`. Suggest: absorb all of them symmetrically. Needs a decision before planning.
+5. **Bundle `#88` error-type wrapping in 1c, or separate PR?** BB recommends separate (Option A); 1c is already sizable. Decision affects the 1c PR size by ~3-5h and the error-type sweep's home (ff-server/ff-scheduler/ff-sdk all land together, or staggered).
+6. **Is `admin.rs`'s `rotate_waitpoint_hmac_secret_all_partitions` in 1c scope or separate?** Not listed in BB's #87/#88 carveout but is the same leak class. Cheap to bundle; noting the additional scope now prevents a 1d discovery.
+7. **#117 timing.** Four `ClaimedTask` deferred ops (`create_pending_waitpoint`, `append_frame`, `suspend`, `report_usage`) still do direct `client.fcall(…)`. If #117 lands before 1c starts, bundle. If after, leave for 1d. Not a hard blocker either way — just affects 1c size.


### PR DESCRIPTION
## Summary

Archive 7 retrospective / audit / investigation artifacts produced during the 2026-04-22 v0.3.x release saga and concurrent Stage 1c + cairn-unblock work, plus update `rfcs/drafts/README.md` to index them. Exploration records, not normative RFCs — preserved for chain-of-reasoning, retrospective, and evidence.

Files added under `rfcs/drafts/`:

- `release-saga-2026-04-22-post-mortem.md` (Worker JJ) — v0.3.x release saga post-mortem
- `0.3.2-smoke-report.md` (Worker X) — smoke finding that caught ScannerFilter + CompletionBackend blockers
- `stage-1c-scope-audit.md` (Worker EE) — Stage 1c scope inventory
- `backend-timeouts-retry-audit.md` (Worker FF) — `BackendTimeouts`/`BackendRetry` field audit
- `scenario-4-regression-investigation.md` (Worker DD) — Scenario 4 bisect (methodology, not regression)
- `bridge-event-audit.md` (Worker V) — bridge-event audit (GAP-1 + GAP-2 shipped in v0.3.1)
- `87-88-scope-carveout.md` (Worker BB) — #87/#88 scope carve-out

The three `RFC-012-amendment-117-deferrals.{K,L,M}-challenge.md` challenger records are already tracked in main; the README's new session-record section indexes them alongside the new files for completeness.

Cross-references session PRs: #119, #120–#124, #126–#128, #130–#136. Follows the archive pattern established by PR #128 (RFC-012 namespace amendment archive).

## Test plan

- [x] No code changes — docs-only additions under `rfcs/drafts/`
- [x] `git status` clean on staged files (only `rfcs/drafts/` additions + README update committed)
- [ ] Manager admin-merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)