### PR TITLE
hotfix(v0.3.4): Option<CompletionBackend> on connect_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,34 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   wiring if needed via a future additive field. Breaking public-field
   removal accepted under pre-1.0 posture.
 
+## [0.3.4] - 2026-04-22
+
+### Fixed
+
+- **`FlowFabricWorker::connect_with` now takes `completion: Option<Arc<dyn CompletionBackend>>` as its third argument.** Breaking signature change.
+  - `Some(arc)` = caller-supplied completion backend (e.g. `Arc::clone(&valkey)` since `ValkeyBackend` impls both `EngineBackend` and `CompletionBackend`).
+  - `None` = this backend does not support push-based completion (future Postgres backend without LISTEN/NOTIFY; test mocks).
+  - Fixes 0.3.3 bug where `connect_with` silently nulled `completion_backend_handle` because `Arc<dyn EngineBackend>` can't be upcast to `Arc<dyn CompletionBackend>` in Rust's trait-object model. 0.3.4 makes the caller decide.
+
+  Migration:
+
+  ```rust
+  // Valkey (completion supported):
+  let valkey = Arc::new(ValkeyBackend::connect(backend_config).await?);
+  let worker = FlowFabricWorker::connect_with(
+      worker_config,
+      valkey.clone(),
+      Some(valkey),
+  ).await?;
+
+  // Backend without completion support:
+  let worker = FlowFabricWorker::connect_with(
+      worker_config,
+      backend,
+      None,
+  ).await?;
+  ```
+
 ## [0.3.3] - 2026-04-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "crc16",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "axum",
  "ferriskey",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "axum",
  "ferriskey",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "axum",
  "ferriskey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -33,16 +33,16 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.3.3", path = "crates/ff-core" }
-ff-script = { version = "0.3.3", path = "crates/ff-script" }
-ff-engine = { version = "0.3.3", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.3.3", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.3.3", path = "crates/ff-sdk" }
-ff-server = { version = "0.3.3", path = "crates/ff-server" }
+ff-core = { version = "0.3.4", path = "crates/ff-core" }
+ff-script = { version = "0.3.4", path = "crates/ff-script" }
+ff-engine = { version = "0.3.4", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.3.4", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.3.4", path = "crates/ff-sdk" }
+ff-server = { version = "0.3.4", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.3.3", path = "crates/ff-backend-valkey" }
-ff-observability = { version = "0.3.3", path = "crates/ff-observability" }
-ferriskey = { version = "0.3.3", path = "ferriskey" }
+ff-backend-valkey = { version = "0.3.4", path = "crates/ff-backend-valkey" }
+ff-observability = { version = "0.3.4", path = "crates/ff-observability" }
+ferriskey = { version = "0.3.4", path = "ferriskey" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -109,13 +109,15 @@ pub struct FlowFabricWorker {
     /// migrates them through this field, and Stage 1d removes the
     /// embedded client.
     backend: Arc<dyn ff_core::engine_backend::EngineBackend>,
-    /// Optional upcast to the same underlying backend viewed as a
+    /// Optional handle to the same underlying backend viewed as a
     /// [`CompletionBackend`](ff_core::completion_backend::CompletionBackend).
     /// Populated by [`Self::connect`] from the bundled
-    /// `ValkeyBackend` (which implements the trait); cleared by
-    /// [`Self::connect_with`] because a caller-supplied
-    /// `Arc<dyn EngineBackend>` cannot be re-upcast. Cairn and other
-    /// completion-subscription consumers reach this through
+    /// `ValkeyBackend` (which implements the trait); supplied by the
+    /// caller on [`Self::connect_with`] as an explicit
+    /// `Option<Arc<dyn CompletionBackend>>` — `None` means "this
+    /// backend does not support push-based completion" (e.g. a future
+    /// Postgres backend without LISTEN/NOTIFY, or a test mock). Cairn
+    /// and other completion-subscription consumers reach this through
     /// [`Self::completion_backend`].
     completion_backend_handle:
         Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>,
@@ -490,12 +492,56 @@ impl FlowFabricWorker {
         })
     }
 
-    /// Store a pre-built [`EngineBackend`] on the worker. Builds
-    /// the worker via the legacy [`FlowFabricWorker::connect`] path
-    /// first (so the embedded `ferriskey::Client` that the Stage 1b
-    /// non-migrated hot paths still use is dialed), then replaces
-    /// the default `ValkeyBackend` wrapper with the caller-supplied
-    /// `Arc<dyn EngineBackend>`.
+    /// Store pre-built [`EngineBackend`] and (optional)
+    /// [`CompletionBackend`] handles on the worker. Builds the worker
+    /// via the legacy [`FlowFabricWorker::connect`] path first (so the
+    /// embedded `ferriskey::Client` that the Stage 1b non-migrated hot
+    /// paths still use is dialed), then replaces the default
+    /// `ValkeyBackend` wrapper with the caller-supplied trait objects.
+    ///
+    /// The `completion` argument is explicit: 0.3.3 previously accepted
+    /// only `backend` and `completion_backend()` silently returned
+    /// `None` on this path because `Arc<dyn EngineBackend>` cannot be
+    /// upcast to `Arc<dyn CompletionBackend>` without loss of
+    /// trait-object identity. 0.3.4 lets the caller decide.
+    ///
+    /// - `Some(arc)` — caller supplies a completion backend.
+    ///   [`Self::completion_backend`] returns `Some(clone)`.
+    /// - `None` — this backend does not support push-based completion
+    ///   (future Postgres backend without LISTEN/NOTIFY, test mocks).
+    ///   [`Self::completion_backend`] returns `None`.
+    ///
+    /// When the underlying backend implements both traits (as
+    /// `ValkeyBackend` does), pass the same `Arc` twice — the two
+    /// trait-object views share one allocation:
+    ///
+    /// ```rust,ignore
+    /// use std::sync::Arc;
+    /// use ff_backend_valkey::ValkeyBackend;
+    /// use ff_sdk::{FlowFabricWorker, WorkerConfig};
+    ///
+    /// # async fn doc(worker_config: WorkerConfig,
+    /// #              backend_config: ff_backend_valkey::BackendConfig)
+    /// #     -> Result<(), ff_sdk::SdkError> {
+    /// // Valkey (completion supported):
+    /// let valkey = Arc::new(ValkeyBackend::connect(backend_config).await?);
+    /// let worker = FlowFabricWorker::connect_with(
+    ///     worker_config,
+    ///     valkey.clone(),
+    ///     Some(valkey),
+    /// ).await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// Backend without completion support:
+    ///
+    /// ```rust,ignore
+    /// let worker = FlowFabricWorker::connect_with(
+    ///     worker_config,
+    ///     backend,
+    ///     None,
+    /// ).await?;
+    /// ```
     ///
     /// **Stage 1b scope — what the injected backend covers today.**
     /// After this PR, `ClaimedTask`'s 8 migrated ops
@@ -519,18 +565,15 @@ impl FlowFabricWorker {
     /// the 8 migrated ops can run fully against a mock backend.
     ///
     /// [`EngineBackend`]: ff_core::engine_backend::EngineBackend
+    /// [`CompletionBackend`]: ff_core::completion_backend::CompletionBackend
     pub async fn connect_with(
         config: WorkerConfig,
         backend: Arc<dyn ff_core::engine_backend::EngineBackend>,
+        completion: Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>,
     ) -> Result<Self, SdkError> {
         let mut worker = Self::connect(config).await?;
         worker.backend = backend;
-        // The caller-supplied trait object cannot be upcast to
-        // `CompletionBackend` without loss of identity; clear the
-        // default `ValkeyBackend`-derived handle so
-        // `completion_backend()` reports `None`, reflecting that
-        // the caller-supplied backend owns the surface now.
-        worker.completion_backend_handle = None;
+        worker.completion_backend_handle = completion;
         Ok(worker)
     }
 
@@ -552,12 +595,12 @@ impl FlowFabricWorker {
     /// Returns `Some` when the worker was built through
     /// [`Self::connect`] on the default `valkey-default` feature
     /// (the bundled `ValkeyBackend` implements
-    /// [`CompletionBackend`](ff_core::completion_backend::CompletionBackend)).
-    /// Returns `None` when the worker was built via
-    /// [`Self::connect_with`] (the caller-supplied
-    /// `Arc<dyn EngineBackend>` cannot be re-upcast to
-    /// `CompletionBackend`), or for hypothetical future backends
-    /// that don't support push-based completion streams.
+    /// [`CompletionBackend`](ff_core::completion_backend::CompletionBackend)),
+    /// or via [`Self::connect_with`] with a `Some(..)` completion
+    /// handle. Returns `None` when the caller passed `None` to
+    /// [`Self::connect_with`] — i.e. the backend does not support
+    /// push-based completion streams (future Postgres without
+    /// LISTEN/NOTIFY, test mocks).
     ///
     /// The returned handle shares the same underlying allocation as
     /// [`Self::backend`]; calls through it (e.g.

--- a/docs/cairn-migration-v0.4.0.md
+++ b/docs/cairn-migration-v0.4.0.md
@@ -97,25 +97,32 @@ Namespace does **not** live on `BackendConfig`; it lives on
 ## 5. `FlowFabricWorker` + completion subscription
 
 ```rust
-let worker = FlowFabricWorker::connect_with(config, backend).await?;
+// Valkey impls both EngineBackend and CompletionBackend, so the same
+// Arc flows through both positions — one allocation, two trait views.
+let valkey = Arc::new(ValkeyBackend::connect(backend_config).await?);
+let worker = FlowFabricWorker::connect_with(
+    config,
+    valkey.clone(),
+    Some(valkey),
+).await?;
 
 let completion = worker
     .completion_backend()
-    .expect("valkey-default feature provides CompletionBackend impl");
+    .expect("Some(..) was passed to connect_with");
 
 let stream = completion.subscribe_completions_filtered(&filter).await?;
 ```
 
-**Important caveat on `connect_with` + `completion_backend()`:**
-`connect_with(config, Arc<dyn EngineBackend>)` clears the default
-`CompletionBackend` handle because a caller-supplied `Arc<dyn
-EngineBackend>` cannot be re-upcast. Consequently
-`worker.completion_backend()` returns `None` on that path
-(`crates/ff-sdk/src/worker.rs:522-569`).
+**`connect_with` + `completion_backend()` (0.3.4):** the third argument
+is an explicit `Option<Arc<dyn CompletionBackend>>`. Pass `Some(arc)`
+when the backend supports push-based completion; pass `None` for
+backends that do not (future Postgres without LISTEN/NOTIFY, test
+mocks). `worker.completion_backend()` returns whatever was passed.
 
-If you need completion subscription, use `FlowFabricWorker::connect`
-(the default path) under the `valkey-default` feature instead, and call
-`completion_backend()` on the result — that returns `Some(...)`.
+Pre-0.3.4 (`connect_with(config, backend)`) silently returned `None`
+from `completion_backend()` on this path because `Arc<dyn
+EngineBackend>` cannot be re-upcast to `Arc<dyn CompletionBackend>` in
+Rust's trait-object model. 0.3.4 makes the caller decide.
 
 ## 6. Gotchas
 

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

- **Breaking fix:** `FlowFabricWorker::connect_with` now takes `completion: Option<Arc<dyn CompletionBackend>>` as its third argument. Fixes 0.3.3 bug where `connect_with` silently nulled `completion_backend_handle` with no escape hatch for callers.
- `Some(arc)` = caller-supplied completion backend (Valkey impls both traits, so pass the same `Arc` twice).
- `None` = this backend does not support push-based completion (future Postgres without LISTEN/NOTIFY; test mocks). Keeps RFC-012 Stage 2 open.
- Workspace bump to `0.3.4`; CHANGELOG entry; cairn migration doc updated to reflect new shape.

## Why Option, not required

Cairn flagged a required `CompletionBackend` arg as blocking RFC-012 Stage 2 (Postgres backend, which lacks Valkey-style pub/sub). `Option<...>` lets non-pubsub backends pass `None` honestly instead of writing dummy impls that break semantic contract.

## Call-site migration

```rust
// Valkey (completion supported) — one allocation, two trait views:
let valkey = Arc::new(ValkeyBackend::connect(backend_config).await?);
let worker = FlowFabricWorker::connect_with(
    worker_config,
    valkey.clone(),
    Some(valkey),
).await?;

// Backend without completion support:
let worker = FlowFabricWorker::connect_with(worker_config, backend, None).await?;
```

No in-tree Rust callers to update (zero `connect_with(` uses in `crates/` or `examples/` — method is freshly introduced in 0.3.3 and only reached by consumers). Docs-only update in `docs/cairn-migration-v0.4.0.md`.

## Test plan

- [x] `cargo build --workspace` green
- [x] `cargo build --workspace --no-default-features` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `cargo test --workspace --lib` green
- [x] `cargo package --workspace --allow-dirty` — all 9 publishable crates packaged cleanly (ff-readiness-tests is `publish = false`, expected)
- [ ] CI semver-checks will flag the breaking signature change (expected — hotfix owns the break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)