### PR TITLE
RFC-012 Round-7: trait-shape gap-fills (append_frame widen, create_waitpoint, report_usage replace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Breaking — `EngineBackend` trait (RFC-012 §R7, #117):**
+  - `append_frame` now returns `AppendFrameOutcome { stream_id,
+    frame_count }` (was `()`). The type moves from `ff_sdk::task`
+    to `ff_core::backend`; a `pub use` shim preserves the
+    `ff_sdk::task::AppendFrameOutcome` path through 0.4.x. Derives
+    widen from `Clone, Debug` to `Clone, Debug, PartialEq, Eq`
+    matching the `FailOutcome` precedent.
+  - New trait method `create_waitpoint(handle, waitpoint_key: &str,
+    expires_in: Duration) -> PendingWaitpoint`. `PendingWaitpoint`
+    is new in `ff_core::backend` (`#[non_exhaustive]`; carries
+    `waitpoint_id` + `hmac_token`).
+  - `report_usage` now returns `ReportUsageResult` (was
+    `AdmissionDecision`). `ReportUsageResult` gains
+    `#[non_exhaustive]` in the same bundle so the replace-over-
+    widen is atomic.
+  - `AdmissionDecision` removed.
+  - `UsageDimensions` gains `dedup_key: Option<String>`
+    (idempotency on trait-level `report_usage`; previously only
+    reachable via the SDK-private wire).
+  - Trait method count 15 → 16; `async fn` compile count 16 → 17.
+    `suspend` migration remains deferred to Stage 1d per §R7.1 /
+    §R7.6.1 (entangled with input-shape rework).
+  - External `EngineBackend` impls: none in tree.
+    `ff-backend-valkey`'s `append_frame`, `create_waitpoint`,
+    `report_usage` bodies move from `Unavailable` stubs to real
+    Lua-backed impls (byte-for-byte wire parity with the SDK's
+    pre-migration bodies).
+  - `ff-sdk::ClaimedTask::{report_usage, create_pending_waitpoint}`
+    become thin trait forwarders. Public SDK signatures unchanged.
+    `ClaimedTask::append_frame` stays direct-FCALL pending a
+    `Frame`-shape extension (to preserve the free-form `frame_type`
+    strings that 5 in-tree callers rely on); closes in Stage 1d
+    alongside `suspend` input-shape work.
 - Wired `BackendRetry` to ferriskey `ClientBuilder::retry_strategy` in
   `ValkeyBackend::connect`. All 4 fields honored when set; when
   all-`None`, ferriskey's builder default is used (no call to

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -686,6 +686,287 @@ fn resume_waitpoint_id_from_suspension(
     Ok(Some(waitpoint_id))
 }
 
+// ── RFC-012 §R7: append_frame / create_waitpoint / report_usage bodies ──
+
+/// Map `FrameKind` → the Lua-side `frame_type` string. The Lua wire is
+/// free-form (`ff_append_frame` stores `frame_type` opaquely), so the
+/// mapping is a stable encoding of the enum variant names matching the
+/// values the SDK callers used pre-migration.
+fn frame_kind_to_str(k: ff_core::backend::FrameKind) -> &'static str {
+    match k {
+        ff_core::backend::FrameKind::Stdout => "stdout",
+        ff_core::backend::FrameKind::Stderr => "stderr",
+        ff_core::backend::FrameKind::Event => "event",
+        ff_core::backend::FrameKind::Blob => "blob",
+        // `FrameKind` is `#[non_exhaustive]`. Unknown variants fall
+        // back to "event" (the most generic of the four) so a
+        // newly-added kind does not hard-fail an append on an
+        // intermediate-version backend; follow-up PRs that add a
+        // variant update this match explicitly.
+        _ => "event",
+    }
+}
+
+/// Round-7 — `append_frame` FCALL body. Migrated from
+/// `ff_sdk::task::ClaimedTask::append_frame`. 3 KEYS, 13 ARGV.
+///
+/// Byte-for-byte ARGV parity with the SDK's pre-migration call (see
+/// `crates/ff-sdk/src/task.rs` at the `ff_append_frame` FCALL site):
+/// retention_maxlen = "10000", source = "worker",
+/// max_payload_bytes = "65536", encoding = "utf8". A trait-level knob
+/// for those constants is future work (RFC-012 §R7.5.6 shape
+/// commitment — not changing the wire under this refactor).
+async fn append_frame_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    frame: Frame,
+) -> Result<AppendFrameOutcome, EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+
+    let now = now_ms_timestamp();
+    let payload_str = String::from_utf8_lossy(&frame.bytes).into_owned();
+    let frame_type = frame_kind_to_str(frame.kind);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.stream(f.attempt_index),
+        ctx.stream_meta(f.attempt_index),
+    ];
+
+    // ARGV (13): execution_id, attempt_index, lease_id, lease_epoch,
+    //            frame_type, ts, payload, encoding, correlation_id,
+    //            source, retention_maxlen, attempt_id, max_payload_bytes
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.attempt_index.to_string(),
+        f.lease_id.to_string(),
+        f.lease_epoch.to_string(),
+        frame_type.to_owned(),
+        now.to_string(),
+        payload_str,
+        "utf8".to_owned(),
+        String::new(), // correlation_id — trait `Frame` has no slot today
+        "worker".to_owned(),
+        "10000".to_owned(),
+        f.attempt_id.to_string(),
+        "65536".to_owned(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_append_frame", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    let parsed = FcallResult::parse(&raw)
+        .map_err(EngineError::from)?
+        .into_success()
+        .map_err(EngineError::from)?;
+
+    // ok(entry_id, frame_count) — `fields` is 0-indexed past status.
+    let stream_id = parsed.field_str(0);
+    let frame_count: u64 = parsed.field_str(1).parse().unwrap_or(0);
+
+    Ok(AppendFrameOutcome {
+        stream_id,
+        frame_count,
+    })
+}
+
+/// Round-7 — `create_waitpoint` FCALL body. Migrated from
+/// `ff_sdk::task::ClaimedTask::create_pending_waitpoint`. 4 KEYS, 5
+/// ARGV. Mints a fresh `WaitpointId` client-side and returns the
+/// server-assigned HMAC token.
+async fn create_waitpoint_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    waitpoint_key: &str,
+    expires_in: Duration,
+) -> Result<PendingWaitpoint, EngineError> {
+    let partition = execution_partition(&f.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &f.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let waitpoint_id = WaitpointId::new();
+    let expires_at =
+        TimestampMs::from_millis(now_ms_timestamp().0 + expires_in.as_millis() as i64);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.waitpoint(&waitpoint_id),
+        idx.pending_waitpoint_expiry(),
+        idx.waitpoint_hmac_secrets(),
+    ];
+
+    let args: Vec<String> = vec![
+        f.execution_id.to_string(),
+        f.attempt_index.to_string(),
+        waitpoint_id.to_string(),
+        waitpoint_key.to_owned(),
+        expires_at.to_string(),
+    ];
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_create_pending_waitpoint", &key_refs, &arg_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    let parsed = FcallResult::parse(&raw)
+        .map_err(EngineError::from)?
+        .into_success()
+        .map_err(EngineError::from)?;
+
+    // Response fields (after status+OK): waitpoint_id, waitpoint_key, waitpoint_token.
+    let token_str = parsed.field_str(2);
+    if token_str.is_empty() {
+        return Err(EngineError::from(ScriptError::Parse {
+            fcall: "ff_create_pending_waitpoint".into(),
+            execution_id: Some(f.execution_id.to_string()),
+            message: "missing waitpoint_token in response".into(),
+        }));
+    }
+
+    Ok(PendingWaitpoint::new(
+        waitpoint_id,
+        ff_core::backend::WaitpointHmac::new(token_str),
+    ))
+}
+
+/// Round-7 — `report_usage` FCALL body. Migrated from
+/// `ff_sdk::task::ClaimedTask::report_usage`. 3 KEYS, N ARGV (variable
+/// by dimension count).
+///
+/// `UsageDimensions::custom` carries `(dim_name, delta)` pairs; the
+/// trait today exposes only the `custom` map (plus `input_tokens /
+/// output_tokens / wall_ms` as reserved fields). The wire transmits
+/// only the caller-supplied custom dimensions in the same format the
+/// SDK used pre-migration: dim_count, dim_1..N, delta_1..N, now_ms,
+/// dedup_key. `input_tokens`/`output_tokens`/`wall_ms` are currently
+/// reserved-but-inert on the wire — the SDK never surfaced them
+/// either, so preserving that behaviour keeps byte-for-byte wire
+/// parity.
+async fn report_usage_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    f: &handle_codec::HandleFields,
+    budget: &BudgetId,
+    dimensions: UsageDimensions,
+) -> Result<ReportUsageResult, EngineError> {
+    use ff_core::keys::{usage_dedup_key, BudgetKeyContext};
+    use ff_core::partition::budget_partition;
+
+    let partition = budget_partition(budget, partition_config);
+    let bctx = BudgetKeyContext::new(&partition, budget);
+
+    let keys: Vec<String> = vec![bctx.usage(), bctx.limits(), bctx.definition()];
+
+    let now = now_ms_timestamp();
+    let dim_count = dimensions.custom.len();
+    let mut argv: Vec<String> = Vec::with_capacity(3 + dim_count * 2);
+    argv.push(dim_count.to_string());
+    for name in dimensions.custom.keys() {
+        argv.push(name.clone());
+    }
+    for delta in dimensions.custom.values() {
+        argv.push(delta.to_string());
+    }
+    argv.push(now.to_string());
+    let dedup_key_val = dimensions
+        .dedup_key
+        .as_deref()
+        .filter(|k| !k.is_empty())
+        .map(|k| usage_dedup_key(bctx.hash_tag(), k))
+        .unwrap_or_default();
+    argv.push(dedup_key_val);
+
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let argv_refs: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
+
+    let raw = client
+        .fcall::<ferriskey::Value>("ff_report_usage_and_check", &key_refs, &argv_refs)
+        .await
+        .map_err(transport_fk)?;
+
+    parse_report_usage(&raw, &f.execution_id)
+}
+
+/// Parse a `ff_report_usage_and_check` reply into `ReportUsageResult`.
+///
+/// Lua wire: `{1, "OK"}`, `{1, "ALREADY_APPLIED"}`,
+/// `{1, "SOFT_BREACH", dim, current, limit}`,
+/// `{1, "HARD_BREACH", dim, current, limit}`; `{0, <code>, …}` on
+/// failure. The status code is always `1` on any recognised outcome
+/// (the breach shapes are sub-statuses of success on the wire —
+/// `ReportUsageResult` IS the outcome space, and the `Err` path is
+/// reserved for transport/invariant faults).
+fn parse_report_usage(
+    raw: &ferriskey::Value,
+    execution_id: &ExecutionId,
+) -> Result<ReportUsageResult, EngineError> {
+    let parsed = FcallResult::parse(raw)
+        .map_err(EngineError::from)?
+        .into_success()
+        .map_err(EngineError::from)?;
+
+    match parsed.status.as_str() {
+        "OK" => Ok(ReportUsageResult::Ok),
+        "ALREADY_APPLIED" => Ok(ReportUsageResult::AlreadyApplied),
+        "SOFT_BREACH" => {
+            let dim = parsed.field_str(0);
+            let current = parse_u64_field(&parsed, 1, "SOFT_BREACH", "current_usage", execution_id)?;
+            let limit = parse_u64_field(&parsed, 2, "SOFT_BREACH", "soft_limit", execution_id)?;
+            Ok(ReportUsageResult::SoftBreach {
+                dimension: dim,
+                current_usage: current,
+                soft_limit: limit,
+            })
+        }
+        "HARD_BREACH" => {
+            let dim = parsed.field_str(0);
+            let current = parse_u64_field(&parsed, 1, "HARD_BREACH", "current_usage", execution_id)?;
+            let limit = parse_u64_field(&parsed, 2, "HARD_BREACH", "hard_limit", execution_id)?;
+            Ok(ReportUsageResult::HardBreach {
+                dimension: dim,
+                current_usage: current,
+                hard_limit: limit,
+            })
+        }
+        other => Err(EngineError::from(ScriptError::Parse {
+            fcall: "ff_report_usage_and_check".into(),
+            execution_id: Some(execution_id.to_string()),
+            message: format!("unknown sub-status: {other}"),
+        })),
+    }
+}
+
+/// Parse a required u64 field from a `FcallResult` wire reply. Loud
+/// failure on missing/non-numeric — see the SDK-side parser for the
+/// rationale (silent coercion hides producer/consumer drift).
+fn parse_u64_field(
+    parsed: &FcallResult,
+    index: usize,
+    sub_status: &str,
+    field_name: &str,
+    execution_id: &ExecutionId,
+) -> Result<u64, EngineError> {
+    let s = parsed.field_str(index);
+    s.parse::<u64>().map_err(|_| {
+        EngineError::from(ScriptError::Parse {
+            fcall: "ff_report_usage_and_check".into(),
+            execution_id: Some(execution_id.to_string()),
+            message: format!("{sub_status}: {field_name} (index {index}) not a u64: {s:?}"),
+        })
+    })
+}
+
 // ── Tranche 2: terminal writes (delay, wait_children, complete, fail, cancel) ──
 
 /// Stage 1b — `delay` FCALL body. Migrated from
@@ -1189,10 +1470,11 @@ impl EngineBackend for ValkeyBackend {
 
     async fn append_frame(
         &self,
-        _handle: &Handle,
-        _frame: Frame,
+        handle: &Handle,
+        frame: Frame,
     ) -> Result<AppendFrameOutcome, EngineError> {
-        Err(EngineError::Unavailable { op: "append_frame" })
+        let f = handle_codec::decode_handle(handle)?;
+        append_frame_impl(&self.client, &self.partition_config, &f, frame).await
     }
 
     async fn complete(
@@ -1230,13 +1512,19 @@ impl EngineBackend for ValkeyBackend {
 
     async fn create_waitpoint(
         &self,
-        _handle: &Handle,
-        _waitpoint_key: &str,
-        _expires_in: Duration,
+        handle: &Handle,
+        waitpoint_key: &str,
+        expires_in: Duration,
     ) -> Result<PendingWaitpoint, EngineError> {
-        Err(EngineError::Unavailable {
-            op: "create_waitpoint",
-        })
+        let f = handle_codec::decode_handle(handle)?;
+        create_waitpoint_impl(
+            &self.client,
+            &self.partition_config,
+            &f,
+            waitpoint_key,
+            expires_in,
+        )
+        .await
     }
 
     async fn observe_signals(
@@ -1299,13 +1587,12 @@ impl EngineBackend for ValkeyBackend {
 
     async fn report_usage(
         &self,
-        _handle: &Handle,
-        _budget: &BudgetId,
-        _dimensions: UsageDimensions,
+        handle: &Handle,
+        budget: &BudgetId,
+        dimensions: UsageDimensions,
     ) -> Result<ReportUsageResult, EngineError> {
-        Err(EngineError::Unavailable {
-            op: "report_usage",
-        })
+        let f = handle_codec::decode_handle(handle)?;
+        report_usage_impl(&self.client, &self.partition_config, &f, budget, dimensions).await
     }
 }
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -29,11 +29,14 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use ff_core::backend::{
-    AdmissionDecision, BackendConfig, BackendConnection, CancelFlowPolicy, CancelFlowWait,
+    AppendFrameOutcome, BackendConfig, BackendConnection, CancelFlowPolicy, CancelFlowWait,
     CapabilitySet, ClaimPolicy, FailOutcome, FailureClass, FailureReason, Frame, Handle,
-    HandleKind, LeaseRenewal, ReclaimToken, ResumeSignal, UsageDimensions, WaitpointSpec,
+    HandleKind, LeaseRenewal, PendingWaitpoint, ReclaimToken, ResumeSignal, UsageDimensions,
+    WaitpointSpec,
 };
-use ff_core::contracts::{CancelFlowArgs, CancelFlowResult, ExecutionSnapshot, FlowSnapshot};
+use ff_core::contracts::{
+    CancelFlowArgs, CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
+};
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
@@ -1184,7 +1187,11 @@ impl EngineBackend for ValkeyBackend {
         .await
     }
 
-    async fn append_frame(&self, _handle: &Handle, _frame: Frame) -> Result<(), EngineError> {
+    async fn append_frame(
+        &self,
+        _handle: &Handle,
+        _frame: Frame,
+    ) -> Result<AppendFrameOutcome, EngineError> {
         Err(EngineError::Unavailable { op: "append_frame" })
     }
 
@@ -1219,6 +1226,17 @@ impl EngineBackend for ValkeyBackend {
         _timeout: Option<Duration>,
     ) -> Result<Handle, EngineError> {
         Err(EngineError::Unavailable { op: "suspend" })
+    }
+
+    async fn create_waitpoint(
+        &self,
+        _handle: &Handle,
+        _waitpoint_key: &str,
+        _expires_in: Duration,
+    ) -> Result<PendingWaitpoint, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "create_waitpoint",
+        })
     }
 
     async fn observe_signals(
@@ -1284,7 +1302,7 @@ impl EngineBackend for ValkeyBackend {
         _handle: &Handle,
         _budget: &BudgetId,
         _dimensions: UsageDimensions,
-    ) -> Result<AdmissionDecision, EngineError> {
+    ) -> Result<ReportUsageResult, EngineError> {
         Err(EngineError::Unavailable {
             op: "report_usage",
         })

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -391,19 +391,6 @@ pub struct UsageDimensions {
     pub dedup_key: Option<String>,
 }
 
-/// Admission outcome returned by `report_usage`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum AdmissionDecision {
-    /// Usage accepted; caller may continue.
-    Admitted,
-    /// Rate-limited or concurrency-capped; retry after the suggested
-    /// interval.
-    Throttled { retry_after_ms: u64 },
-    /// Rejected outright — budget exhausted or policy violation.
-    Rejected { reason: String },
-}
-
 // ── §3.3.0 Reclaim / lease types ────────────────────────────────────────
 
 /// Opaque cookie returned by the reclaim scanner; consumed by
@@ -977,18 +964,6 @@ mod tests {
         assert_eq!(u.clone(), u);
         assert_eq!(UsageDimensions::default().input_tokens, 0);
         assert_eq!(UsageDimensions::default().dedup_key, None);
-    }
-
-    #[test]
-    fn admission_decision_derives() {
-        let a = AdmissionDecision::Admitted;
-        let t = AdmissionDecision::Throttled { retry_after_ms: 25 };
-        let r = AdmissionDecision::Rejected {
-            reason: "quota".into(),
-        };
-        assert_eq!(a.clone(), a);
-        assert_eq!(t.clone(), t);
-        assert_ne!(a, r);
     }
 
     #[test]

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -276,6 +276,29 @@ impl std::fmt::Debug for WaitpointHmac {
     }
 }
 
+/// Handle returned by `create_waitpoint` — the id of the newly-minted
+/// pending waitpoint plus its HMAC token. Signals targeted at the
+/// waitpoint must present the token; a later `suspend` call transitions
+/// the waitpoint from `pending` to `active` (RFC-012 §R7.2.2).
+///
+/// `WaitpointHmac` redacts on `Debug`/`Display`, so deriving `Debug`
+/// here cannot leak the raw digest.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PendingWaitpoint {
+    pub waitpoint_id: crate::types::WaitpointId,
+    pub hmac_token: WaitpointHmac,
+}
+
+impl PendingWaitpoint {
+    pub fn new(waitpoint_id: crate::types::WaitpointId, hmac_token: WaitpointHmac) -> Self {
+        Self {
+            waitpoint_id,
+            hmac_token,
+        }
+    }
+}
+
 /// One waitpoint inside a suspend request. `suspend` takes a
 /// `Vec<WaitpointSpec>`; the resume condition (`any` / `all`) lives on
 /// the enclosing suspend args in the Phase-1 contract.
@@ -360,6 +383,12 @@ pub struct UsageDimensions {
     /// iteration order (important for dedup-key derivation on some
     /// budget schemes).
     pub custom: BTreeMap<String, u64>,
+    /// Optional caller-supplied idempotency key. When set, the backend
+    /// rejects a repeat application of the same key with
+    /// `ReportUsageResult::AlreadyApplied` rather than double-counting
+    /// (RFC-012 §R7.4; Lua `ff_report_usage_and_check` threads this as
+    /// the trailing ARGV). `None` / empty string disables dedup.
+    pub dedup_key: Option<String>,
 }
 
 /// Admission outcome returned by `report_usage`.
@@ -555,6 +584,32 @@ pub enum FailOutcome {
     },
     /// No retries left — execution is terminal failed.
     TerminalFailed,
+}
+
+// ── RFC-012 §R7: AppendFrameOutcome move ────────────────────────────────
+
+/// Outcome of an `append_frame()` call.
+///
+/// **RFC-012 §R7.2.1:** moved from `ff_sdk::task::AppendFrameOutcome`
+/// to `ff_core::backend::AppendFrameOutcome` so it is nameable by the
+/// `EngineBackend::append_frame` trait return. `ff_sdk::task` retains
+/// a `pub use` shim preserving the `ff_sdk::task::AppendFrameOutcome`
+/// path through 0.4.x.
+///
+/// Derive set matches the `FailOutcome` precedent
+/// (`Clone, Debug, PartialEq, Eq`). Not `#[non_exhaustive]`:
+/// construction is internal to the backend today (parser in
+/// `ff-backend-valkey`), and no external constructors are anticipated
+/// (consumer-shape evidence per §R7.2.1 / MN3).
+///
+/// `stream_id: String` is a stable shape commitment — a future typed
+/// `StreamId` newtype would be its own breaking change (§R7.5.6 / MD2).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppendFrameOutcome {
+    /// Valkey Stream entry ID assigned to this frame (e.g. `1234567890-0`).
+    pub stream_id: String,
+    /// Total frame count in the stream after this append.
+    pub frame_count: u64,
 }
 
 // ── Stage 1a: BackendConfig + sub-types ─────────────────────────────────
@@ -917,9 +972,11 @@ mod tests {
             output_tokens: 20,
             wall_ms: Some(150),
             custom: BTreeMap::from([("net_bytes".to_string(), 42)]),
+            dedup_key: Some("k1".into()),
         };
         assert_eq!(u.clone(), u);
         assert_eq!(UsageDimensions::default().input_tokens, 0);
+        assert_eq!(UsageDimensions::default().dedup_key, None);
     }
 
     #[test]

--- a/crates/ff-core/src/contracts.rs
+++ b/crates/ff-core/src/contracts.rs
@@ -1398,6 +1398,7 @@ pub struct ReportUsageArgs {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ReportUsageResult {
     /// All increments applied, no breach.
     Ok,

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -48,11 +48,11 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::backend::{
-    AdmissionDecision, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
-    FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, ReclaimToken,
-    ResumeSignal, WaitpointSpec,
+    AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
+    FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
+    ReclaimToken, ResumeSignal, WaitpointSpec,
 };
-use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot};
+use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult};
 use crate::engine_error::EngineError;
 use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 
@@ -60,7 +60,9 @@ use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 /// honours to serve a `FlowFabricWorker`.
 ///
 /// See RFC-012 §3.1 for the inventory rationale and §3.3 for the
-/// type-level shape. 15 methods.
+/// type-level shape. 16 methods (Round-7 added `create_waitpoint`;
+/// `append_frame` return widened; `report_usage` return replaced —
+/// RFC-012 §R7).
 ///
 /// # Note on `complete` payload shape
 ///
@@ -99,8 +101,13 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<(), EngineError>;
 
     /// Append one stream frame. Distinct from [`progress`](Self::progress)
-    /// per RFC-012 §3.1.1 K#6.
-    async fn append_frame(&self, handle: &Handle, frame: Frame) -> Result<(), EngineError>;
+    /// per RFC-012 §3.1.1 K#6. Returns the backend-assigned stream entry
+    /// id and post-append frame count (RFC-012 §R7.2.1).
+    async fn append_frame(
+        &self,
+        handle: &Handle,
+        frame: Frame,
+    ) -> Result<AppendFrameOutcome, EngineError>;
 
     /// Terminal success. Borrows `handle` (round-4 M-D2) so callers
     /// can retry under `EngineError::Transport` without losing the
@@ -132,6 +139,31 @@ pub trait EngineBackend: Send + Sync + 'static {
         waitpoints: Vec<WaitpointSpec>,
         timeout: Option<Duration>,
     ) -> Result<Handle, EngineError>;
+
+    /// Issue a pending waitpoint for future signal delivery.
+    ///
+    /// Waitpoints have two states in the Valkey wire contract:
+    /// **pending** (token issued, not yet backing a suspension) and
+    /// **active** (bound to a suspension). This method creates a
+    /// waitpoint in the **pending** state. A later `suspend` call
+    /// transitions a pending waitpoint to active (see Lua
+    /// `use_pending_waitpoint` ARGV flag at
+    /// `flowfabric.lua:3603,3641,3690`) — or, if buffered signals
+    /// already satisfy its condition, the suspend call returns
+    /// `SuspendOutcome::AlreadySatisfied` and the waitpoint activates
+    /// without ever releasing the lease.
+    ///
+    /// Pending-waitpoint expiry is a first-class terminal error on
+    /// the wire (`PendingWaitpointExpired` at
+    /// `ff-script/src/error.rs:170,403-408`). The attempt retains its
+    /// lease while the waitpoint is pending; signals delivered to
+    /// this waitpoint are buffered server-side (RFC-012 §R7.2.2).
+    async fn create_waitpoint(
+        &self,
+        handle: &Handle,
+        waitpoint_key: &str,
+        expires_in: Duration,
+    ) -> Result<PendingWaitpoint, EngineError>;
 
     /// Non-mutating observation of signals that satisfied the handle's
     /// resume condition.
@@ -185,16 +217,17 @@ pub trait EngineBackend: Send + Sync + 'static {
 
     // ── Budget ──
 
-    /// Report usage and check admission. Returns the admission
-    /// decision; backends enforce idempotency via the caller-supplied
-    /// dedup key embedded in `UsageDimensions::custom` (today's
-    /// `ff_report_usage_and_check` contract).
+    /// Report usage against a budget and check limits. Returns the
+    /// typed [`ReportUsageResult`] variant; backends enforce
+    /// idempotency via the caller-supplied
+    /// [`UsageDimensions::dedup_key`] (RFC-012 §R7.2.3 — replaces
+    /// the pre-Round-7 `AdmissionDecision` return).
     async fn report_usage(
         &self,
         handle: &Handle,
         budget: &BudgetId,
         dimensions: crate::backend::UsageDimensions,
-    ) -> Result<AdmissionDecision, EngineError>;
+    ) -> Result<ReportUsageResult, EngineError>;
 }
 
 /// Object-safety assertion: `dyn EngineBackend` compiles iff every

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -134,13 +134,14 @@ impl SignalOutcome {
 pub use ff_core::backend::ResumeSignal;
 
 /// Outcome of `append_frame()`.
-#[derive(Clone, Debug)]
-pub struct AppendFrameOutcome {
-    /// Valkey Stream entry ID assigned to this frame.
-    pub stream_id: String,
-    /// Total frame count in the stream after this append.
-    pub frame_count: u64,
-}
+///
+/// **RFC-012 §R7.2.1:** canonical definition moved to
+/// [`ff_core::backend::AppendFrameOutcome`]; this `pub use` shim
+/// preserves the `ff_sdk::task::AppendFrameOutcome` path through the
+/// 0.4.x window. Existing consumers construct + match exhaustively
+/// without change. The derive set widened from `Clone, Debug` to
+/// `Clone, Debug, PartialEq, Eq` matching the `FailOutcome` precedent.
+pub use ff_core::backend::AppendFrameOutcome;
 
 /// Outcome of a `fail()` call.
 ///

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -8,8 +8,8 @@ use ff_core::backend::{Handle, HandleKind};
 use ff_core::contracts::ReportUsageResult;
 use ff_core::engine_backend::EngineBackend;
 use ff_script::error::ScriptError;
-use ff_core::keys::{usage_dedup_key, BudgetKeyContext, ExecKeyContext, IndexKeys};
-use ff_core::partition::{budget_partition, execution_partition, PartitionConfig};
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, PartitionConfig};
 use ff_core::types::*;
 use tokio::sync::{Notify, OwnedSemaphorePermit};
 use tokio::task::JoinHandle;
@@ -620,53 +620,31 @@ impl ClaimedTask {
     /// Non-consuming — the worker can report usage multiple times.
     /// `dimensions` is a slice of `(dimension_name, delta)` pairs.
     /// `dedup_key` prevents double-counting on retries (auto-prefixed with budget hash tag).
-    // TODO(stage-1d-or-rfc-amendment): deferred from Stage 1b Tranche 3.
-    // `AdmissionDecision` (trait return) cannot losslessly encode
-    // `ReportUsageResult::{SoftBreach, HardBreach, AlreadyApplied}`
-    // — `SoftBreach` is a warning (not a rejection) and has no home
-    // in `Admitted / Throttled / Rejected`, and `HardBreach`'s
-    // structured dim/current/limit fields collapse to `Rejected { reason: String }`.
-    // Tracked in #117.
+    ///
+    /// **RFC-012 §R7.2.3:** forwards through
+    /// [`EngineBackend::report_usage`](ff_core::engine_backend::EngineBackend::report_usage).
+    /// The trait's `UsageDimensions.dedup_key` carries the raw key;
+    /// the backend impl applies the `usage_dedup_key(hash_tag, k)`
+    /// wrap so the dedup state co-locates with the budget partition
+    /// (PR #108).
     pub async fn report_usage(
         &self,
         budget_id: &BudgetId,
         dimensions: &[(&str, u64)],
         dedup_key: Option<&str>,
     ) -> Result<ReportUsageResult, SdkError> {
-        let partition = budget_partition(budget_id, &self.partition_config);
-        let bctx = BudgetKeyContext::new(&partition, budget_id);
-
-        // KEYS (3): budget_usage, budget_limits, budget_def
-        let keys: Vec<String> = vec![bctx.usage(), bctx.limits(), bctx.definition()];
-
-        // ARGV: dim_count, dim_1..dim_N, delta_1..delta_N, now_ms, [dedup_key]
-        let now = TimestampMs::now();
-        let dim_count = dimensions.len();
-        let mut argv: Vec<String> = Vec::with_capacity(3 + dim_count * 2);
-        argv.push(dim_count.to_string());
-        for (dim, _) in dimensions {
-            argv.push((*dim).to_string());
+        let handle = self.synth_handle();
+        let mut dims = ff_core::backend::UsageDimensions::default();
+        for (name, delta) in dimensions {
+            dims.custom.insert((*name).to_owned(), *delta);
         }
-        for (_, delta) in dimensions {
-            argv.push(delta.to_string());
-        }
-        argv.push(now.to_string());
-        let dedup_key_val = dedup_key
+        dims.dedup_key = dedup_key
             .filter(|k| !k.is_empty())
-            .map(|k| usage_dedup_key(bctx.hash_tag(), k))
-            .unwrap_or_default();
-        argv.push(dedup_key_val);
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let argv_refs: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_report_usage_and_check", &key_refs, &argv_refs)
+            .map(|k| k.to_owned());
+        self.backend
+            .report_usage(&handle, budget_id, dims)
             .await
-            .map_err(SdkError::Valkey)?;
-
-        parse_report_usage_result(&raw)
+            .map_err(SdkError::from)
     }
 
     /// Create a pending waitpoint for future signal delivery.
@@ -679,53 +657,31 @@ impl ClaimedTask {
     /// Returns both the waitpoint_id AND the HMAC token required by external
     /// callers to buffer signals against this pending waitpoint
     /// (RFC-004 §Waitpoint Security).
-    // TODO(stage-1d-or-rfc-amendment): deferred from Stage 1b. The
-    // `EngineBackend` trait has no `create_pending_waitpoint` slot —
-    // RFC-012 §3.1 inventory does not list this op today. Needs
-    // either a new trait method or a reshape of `suspend` that covers
-    // the lease-retaining flow. Tracked in #117.
+    ///
+    /// **RFC-012 §R7.2.2:** forwards through
+    /// [`EngineBackend::create_waitpoint`](ff_core::engine_backend::EngineBackend::create_waitpoint).
+    /// The trait returns
+    /// [`PendingWaitpoint`](ff_core::backend::PendingWaitpoint) whose
+    /// `hmac_token` is the same wire HMAC this method has always
+    /// produced; the SDK unwraps it back to the historical
+    /// `(WaitpointId, WaitpointToken)` tuple for caller-shape parity.
     pub async fn create_pending_waitpoint(
         &self,
         waitpoint_key: &str,
         expires_in_ms: u64,
     ) -> Result<(WaitpointId, WaitpointToken), SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-        let idx = IndexKeys::new(&partition);
-
-        let waitpoint_id = WaitpointId::new();
-        let expires_at = TimestampMs::from_millis(TimestampMs::now().0 + expires_in_ms as i64);
-
-        // KEYS (4): exec_core, waitpoint_hash, pending_wp_expiry_zset, hmac_secrets
-        let keys: Vec<String> = vec![
-            ctx.core(),
-            ctx.waitpoint(&waitpoint_id),
-            idx.pending_waitpoint_expiry(),
-            idx.waitpoint_hmac_secrets(),
-        ];
-
-        // ARGV (5): execution_id, attempt_index, waitpoint_id, waitpoint_key, expires_at
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),
-            self.attempt_index.to_string(),
-            waitpoint_id.to_string(),
-            waitpoint_key.to_owned(),
-            expires_at.to_string(),
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_create_pending_waitpoint", &key_refs, &arg_refs)
+        let handle = self.synth_handle();
+        let expires_in = std::time::Duration::from_millis(expires_in_ms);
+        let pending = self
+            .backend
+            .create_waitpoint(&handle, waitpoint_key, expires_in)
             .await
-            .map_err(SdkError::Valkey)?;
-
-        // Response: {1, "OK", waitpoint_id, waitpoint_key, waitpoint_token}.
-        // Extract the token (the waitpoint_id is the one we generated locally).
-        let token = extract_pending_waitpoint_token(&raw)?;
-        Ok((waitpoint_id, token))
+            .map_err(SdkError::from)?;
+        // `WaitpointHmac` wraps the canonical `WaitpointToken`; the
+        // `.token()` accessor borrows the underlying
+        // `WaitpointToken`, which is the caller's historical return
+        // shape.
+        Ok((pending.waitpoint_id, pending.hmac_token.token().clone()))
     }
 
     // ── Phase 4: Streaming ──
@@ -734,10 +690,23 @@ impl ClaimedTask {
     ///
     /// Non-consuming — the worker can append many frames during execution.
     /// The stream is created lazily on the first append.
-    // TODO(stage-1d-or-rfc-amendment): deferred from Stage 1b. Trait
-    // method `append_frame` returns `()`; this SDK method returns
-    // `AppendFrameOutcome { stream_id, frame_count }` — the return-type
-    // delta is a hard ABI break on the Stage-1a trait. Tracked in #117.
+    //
+    // RFC-012 §R7.2.1 widened `EngineBackend::append_frame`'s return
+    // to `AppendFrameOutcome` — that half of the trait alignment is
+    // done. The SDK-side migration remains direct-FCALL for now
+    // because the trait's `Frame { kind: FrameKind, bytes, seq }`
+    // input shape does not carry the SDK-public `frame_type: &str`
+    // (free-form) or `metadata: Option<&str>` (wire `correlation_id`)
+    // arguments — 5 in-tree example callers pass frame_type strings
+    // ("delta", "log", "agent_step", "summary_token", etc.) that
+    // don't map onto `FrameKind::{Stdout,Stderr,Event,Blob}` without
+    // a silent wire regression. Closing this gap needs a `Frame`-
+    // shape extension (adds `frame_type: String` + `correlation_id:
+    // Option<String>`) — tracked for Stage 1d alongside the `suspend`
+    // input-shape rework. Until then the SDK keeps byte-for-byte
+    // wire parity by issuing `ff_append_frame` directly; the trait's
+    // `append_frame_impl` in ff-backend-valkey covers the
+    // FrameKind-based call sites.
     pub async fn append_frame(
         &self,
         frame_type: &str,
@@ -1301,34 +1270,6 @@ fn parse_usage_u64(
         ),
         })),
     }
-}
-
-/// Parse a standard {1, "OK", ...} / {0, "error", ...} FCALL result.
-/// Extract the waitpoint_token (field index 4 in the 0-indexed response array)
-/// from an `ff_create_pending_waitpoint` reply. Runs `parse_success_result`
-/// first so error cases produce the usual typed error, not a parse failure.
-fn extract_pending_waitpoint_token(raw: &Value) -> Result<WaitpointToken, SdkError> {
-    parse_success_result(raw, "ff_create_pending_waitpoint")?;
-    let arr = match raw {
-        Value::Array(arr) => arr,
-        _ => unreachable!("parse_success_result would have rejected non-array"),
-    };
-    // Layout: [0]=1, [1]="OK", [2]=waitpoint_id, [3]=waitpoint_key, [4]=waitpoint_token
-    let token_str = arr
-        .get(4)
-        .and_then(|v| match v {
-            Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-            Ok(Value::SimpleString(s)) => Some(s.clone()),
-            _ => None,
-        })
-        .ok_or_else(|| {
-            SdkError::from(ScriptError::Parse {
-                fcall: "extract_pending_waitpoint_token".into(),
-                execution_id: None,
-                message: "ff_create_pending_waitpoint: missing waitpoint_token in response".into(),
-            })
-        })?;
-    Ok(WaitpointToken::new(token_str))
 }
 
 /// Pure helper: decide whether `suspension:current` represents a

--- a/crates/ff-test/tests/r7_backend_report_usage.rs
+++ b/crates/ff-test/tests/r7_backend_report_usage.rs
@@ -1,0 +1,198 @@
+//! RFC-012 §R7.2.3 integration test.
+//!
+//! Exercises `EngineBackend::report_usage` against a live Valkey,
+//! asserting:
+//!
+//! 1. The trait dispatches through `ValkeyBackend::report_usage_impl`
+//!    to the `ff_report_usage_and_check` Lua function with the ARGV
+//!    shape the Lua expects (dim_count, dims, deltas, now, dedup_key).
+//! 2. The new `UsageDimensions.dedup_key: Option<String>` field
+//!    threads to the wire — a second call with the same key returns
+//!    `ReportUsageResult::AlreadyApplied` (idempotency round-trip).
+//! 3. The round-7 return-type swap from `AdmissionDecision` to
+//!    `ReportUsageResult` carries the structured `SoftBreach` /
+//!    `HardBreach` variants end-to-end (wire → trait → caller).
+//!
+//! Run with: `cargo test -p ff-test --test r7_backend_report_usage -- --test-threads=1`
+
+use std::collections::BTreeMap;
+
+use ferriskey::Value;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::{HandleKind, UsageDimensions};
+use ff_core::contracts::ReportUsageResult;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{
+    AttemptId, AttemptIndex, BudgetId, LaneId, LeaseEpoch, LeaseId, TimestampMs,
+    WorkerInstanceId,
+};
+use ff_test::fixtures::TestCluster;
+
+/// Inline `ff_create_budget` on the `{b:0}` partition. Mirrors
+/// `budget_dedup_hashtag.rs` — budget fixture helpers are test-private
+/// and not exported from `ff-test`.
+async fn fcall_create_budget_b0(
+    tc: &TestCluster,
+    budget_id: &str,
+    dim: &str,
+    hard: u64,
+    soft: u64,
+) {
+    let def_key = format!("ff:budget:{{b:0}}:{budget_id}");
+    let limits_key = format!("ff:budget:{{b:0}}:{budget_id}:limits");
+    let usage_key = format!("ff:budget:{{b:0}}:{budget_id}:usage");
+    let resets_key = "ff:idx:{b:0}:budget_resets".to_string();
+    let policies_index = "ff:idx:{b:0}:budget_policies".to_string();
+
+    let now = TimestampMs::now();
+    let args: Vec<String> = vec![
+        budget_id.to_owned(),
+        "lane".to_owned(),
+        "test-lane".to_owned(),
+        "strict".to_owned(),
+        "fail".to_owned(),
+        "warn".to_owned(),
+        "0".to_owned(),
+        now.to_string(),
+        "1".to_owned(),
+        dim.to_owned(),
+        hard.to_string(),
+        soft.to_string(),
+    ];
+    let keys: Vec<String> = vec![def_key, limits_key, usage_key, resets_key, policies_index];
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_budget", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_create_budget");
+}
+
+/// A `num_budget_partitions = 1` config so the fixture's hard-coded
+/// `{b:0}` partition matches what `budget_partition(bid, &config)`
+/// hashes to. Production `ff_report_usage_and_check` is
+/// lease-independent, so the synthesised handle does not need a real
+/// lease — the Lua never reads it.
+fn single_budget_partition_config() -> PartitionConfig {
+    PartitionConfig {
+        num_flow_partitions: 1,
+        num_budget_partitions: 1,
+        num_quota_partitions: 1,
+    }
+}
+
+async fn backend() -> std::sync::Arc<ValkeyBackend> {
+    let tc = TestCluster::connect().await;
+    // `connect` to Valkey through the backend so the dialled client +
+    // a pinned partition config land in the Arc the trait uses.
+    ValkeyBackend::from_client_and_partitions(
+        tc.client().clone(),
+        single_budget_partition_config(),
+    )
+}
+
+/// Round-7 end-to-end: a succession of calls through
+/// `EngineBackend::report_usage` produces each of the four
+/// `ReportUsageResult` variants, including the dedup-key-driven
+/// `AlreadyApplied` path on a repeat invocation with the same
+/// `UsageDimensions.dedup_key`.
+#[tokio::test]
+#[serial_test::serial]
+async fn r7_report_usage_trait_round_trip() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Use a deterministic uuid so the fixture key (`{b:0}:<uuid>`)
+    // matches what `BudgetKeyContext::new(partition, &bid)` builds
+    // inside the trait impl.
+    let bid = BudgetId::new();
+    let budget_id_str = bid.to_string();
+    // hard=100, soft=50 — exercises SoftBreach + HardBreach variants.
+    fcall_create_budget_b0(&tc, &budget_id_str, "tokens", 100, 50).await;
+
+    let backend = backend().await;
+
+    // Synthesise a handle. `report_usage` is lease-independent, so
+    // none of these fields need to match a live lease.
+    let exec_id = ff_core::types::ExecutionId::solo(
+        &LaneId::new("test-lane"),
+        &single_budget_partition_config(),
+    );
+    let handle = ValkeyBackend::encode_handle(
+        exec_id,
+        AttemptIndex::new(0),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch::new(0),
+        30_000,
+        LaneId::new("test-lane"),
+        WorkerInstanceId::new("test-worker"),
+        HandleKind::Fresh,
+    );
+
+    // ── 1. Ok path ────────────────────────────────────────────────
+    let mut dims = UsageDimensions::default();
+    dims.custom = BTreeMap::from([("tokens".to_owned(), 10)]);
+    dims.dedup_key = Some("round-trip-1".to_owned());
+    let r = backend
+        .report_usage(&handle, &bid, dims.clone())
+        .await
+        .expect("report_usage Ok");
+    assert!(matches!(r, ReportUsageResult::Ok), "first call Ok, got {r:?}");
+
+    // ── 2. AlreadyApplied (same dedup_key) ────────────────────────
+    let r = backend
+        .report_usage(&handle, &bid, dims.clone())
+        .await
+        .expect("report_usage AlreadyApplied");
+    assert!(
+        matches!(r, ReportUsageResult::AlreadyApplied),
+        "repeat with same dedup_key must be AlreadyApplied, got {r:?}"
+    );
+
+    // ── 3. SoftBreach: current=10, +45 = 55 > soft(50) ───────────
+    dims.custom.insert("tokens".to_owned(), 45);
+    dims.dedup_key = Some("round-trip-2".to_owned());
+    let r = backend
+        .report_usage(&handle, &bid, dims.clone())
+        .await
+        .expect("report_usage SoftBreach");
+    match r {
+        ReportUsageResult::SoftBreach {
+            dimension,
+            current_usage,
+            soft_limit,
+        } => {
+            assert_eq!(dimension, "tokens");
+            // new current: 55 (after increment applied — SoftBreach
+            // is advisory, not rejecting)
+            assert_eq!(current_usage, 55);
+            assert_eq!(soft_limit, 50);
+        }
+        other => panic!("expected SoftBreach, got {other:?}"),
+    }
+
+    // ── 4. HardBreach: current=55, +50 = 105 > hard(100) ─────────
+    dims.custom.insert("tokens".to_owned(), 50);
+    dims.dedup_key = Some("round-trip-3".to_owned());
+    let r = backend
+        .report_usage(&handle, &bid, dims)
+        .await
+        .expect("report_usage HardBreach");
+    match r {
+        ReportUsageResult::HardBreach {
+            dimension,
+            current_usage,
+            hard_limit,
+        } => {
+            assert_eq!(dimension, "tokens");
+            // HardBreach is NOT applied — current stays at 55.
+            assert_eq!(current_usage, 55);
+            assert_eq!(hard_limit, 100);
+        }
+        other => panic!("expected HardBreach, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Lands the three trait-shape deltas from RFC-012 §R7 (amendment #117) so
the last Stage-1b trait-migration-blocked SDK methods
(`append_frame`, `create_pending_waitpoint`, `report_usage`) can
become thin forwarders. `suspend` migration remains deferred to
Stage 1d per §R7.1 / §R7.6.1 (entangled with input-shape rework).

Delivered as 5 tranches on this PR:

1. **Type prerequisites (landed 8f52f71)** — `PendingWaitpoint` +
   `AppendFrameOutcome` move to `ff_core::backend`,
   `UsageDimensions.dedup_key`, `ReportUsageResult` gains
   `#[non_exhaustive]`.
2. Trait deltas — widen `append_frame` return, add `create_waitpoint`,
   replace `AdmissionDecision` → `ReportUsageResult` on `report_usage`,
   delete `AdmissionDecision`.
3. `ff-backend-valkey` bodies for the three methods + `ff-test`
   integration tests.
4. `ff-sdk::ClaimedTask` trait-forwarder migration for the three
   methods (hot-path cleanup of the TODO-#117 sites).
5. CHANGELOG 0.4.0 bundle entries.

Drop-in: shims preserve `ff_sdk::task::AppendFrameOutcome` through
0.4.x; Lua wire unchanged.

## Test plan

- [x] Tranche 1: `cargo check --workspace --all-features`, CI clippy
      matrix green locally, `ff-core` unit tests pass.
- [ ] Tranches 2-4: per-tranche `cargo check` / `clippy` / unit tests.
- [ ] Tranche 3 ships ff-test integration tests exercising
      `EngineBackend::{append_frame, create_waitpoint, report_usage}`
      against a live Valkey.
- [ ] Full CI matrix green before merge.

Refs #117, RFC-012 §R7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)