### PR TITLE
feat(ff-sdk): RFC-012 Stage 1c — BackendConfig carveout + ff-core feature scaffold (tranche 1 of ~4)

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -172,6 +172,17 @@ jobs:
       - name: cargo check
         run: cargo check --workspace --all-features
 
+      # RFC-012 Stage 1c tranche 1: feature-matrix floor. ff-core
+      # declares default = ["core", "streaming", "suspension",
+      # "budget"]; backend crates may opt into a strict subset.
+      # Exercise the minimal backend shape (core alone) so a future
+      # trait-method add with a forgotten cfg-gate fails CI rather
+      # than silently widening the mandatory-implementation surface.
+      # Feature bodies are empty today — tranches 2-5 add the
+      # cfg-gated methods.
+      - name: cargo check -p ff-core --no-default-features --features core
+        run: cargo check -p ff-core --no-default-features --features core
+
       - name: cargo clippy
         run: |
           cargo clippy \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,20 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tranche 1). Pre-1.0 clean break — no deprecated shim. Construct via
   struct literal.
 
+- **Snapshot decoders return `EngineError::Validation { Corruption }`
+  (RFC-012 Stage 1c T3).** `describe_execution`, `describe_flow`,
+  `describe_edge`, `list_incoming_edges`, and `list_outgoing_edges`
+  used to surface on-disk-corruption parse failures as
+  `SdkError::Config { field, message, .. }`. They now surface as
+  `SdkError::Engine(Box<EngineError::Validation { kind:
+  ValidationKind::Corruption, detail, .. }>)`. The decoders and
+  `FLOW_CORE_KNOWN_FIELDS` moved from `ff-sdk::snapshot` into
+  `ff_core::contracts::decode`. Callers matching on the `Config` shape
+  must migrate to `Engine(Validation::Corruption)` — see
+  `docs/cairn-migration-v0.4.0.md` §6. `SdkError::Config` is retained
+  for SDK-side input validation. Breaking error-shape change; pre-1.0
+  posture accepts.
+
 - Reshaped `BackendRetry` to match ferriskey's `ConnectionRetryStrategy`
   (fields: `exponent_base`, `factor`, `number_of_retries`,
   `jitter_percent`). Previous `max_attempts`/`base_backoff` were
@@ -161,6 +175,13 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `ValkeyBackend::connect`. All 4 fields honored when set; when
   all-`None`, ferriskey's builder default is used (no call to
   `.retry_strategy`).
+- **`ValkeyBackend::describe_execution` and `::describe_flow` are now
+  wired (RFC-012 Stage 1c T3).** Previously returned
+  `EngineError::Unavailable`. Implementation uses the same HGETALL
+  pipeline ff-sdk owned pre-T3, now routing every parse failure
+  through the relocated `ff-core` decoders. `ff-sdk`'s
+  `FlowFabricWorker::describe_execution` / `describe_flow` /
+  `list_*_edges` collapse to thin forwarders over the trait.
 
 ## [0.3.4] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,25 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     strings that 5 in-tree callers rely on); closes in Stage 1d
     alongside `suspend` input-shape work.
 
+- **`WorkerConfig` split (RFC-012 Stage 1c tranche 1).** The four
+  Valkey-specific fields (`host`, `port`, `tls`, `cluster`) moved into
+  the nested `backend: BackendConfig` field, which also carries
+  `BackendTimeouts` + `BackendRetry` policy. Worker-policy fields
+  (`worker_id`, `worker_instance_id`, `namespace`, `lanes`,
+  `capabilities`, `lease_ttl_ms`, `claim_poll_interval_ms`,
+  `max_concurrent_tasks`) stay on `WorkerConfig`. Breaking struct
+  reshape; pre-1.0 posture accepts.
+
+  Migration: construct `WorkerConfig { backend:
+  BackendConfig::valkey(host, port), worker_id: ..., ... }`. For TLS
+  or cluster mode, build a `ValkeyConnection` with the flags set and
+  overwrite `BackendConfig.connection`. For tuned request timeouts /
+  retry, populate `BackendConfig.timeouts` / `BackendConfig.retry`.
+
+- **`WorkerConfig::new` constructor removed** (RFC-012 Stage 1c
+  tranche 1). Pre-1.0 clean break — no deprecated shim. Construct via
+  struct literal.
+
 - Reshaped `BackendRetry` to match ferriskey's `ConnectionRetryStrategy`
   (fields: `exponent_base`, `factor`, `number_of_retries`,
   `jitter_percent`). Previous `max_attempts`/`base_backoff` were
@@ -107,8 +126,37 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   wiring if needed via a future additive field. Breaking public-field
   removal accepted under pre-1.0 posture.
 
+### Added
+
+- **`ff-core` feature-flag scaffold (RFC-012 Stage 1c tranche 1).**
+  `[features]` section declared with
+  `default = ["core", "streaming", "suspension", "budget"]`. Feature
+  bodies are intentionally empty at tranche 1; tranches 2-5 add
+  `#[cfg(feature = …)]` gates on `EngineBackend` trait methods so
+  backend crates may opt into a strict subset (e.g. a hypothetical
+  Postgres backend without `suspension`). Consumer API through
+  `ff-sdk` is unchanged — `ff-sdk` pulls default features.
+- **CI: `cargo check -p ff-core --no-default-features --features
+  core`** job in `matrix.yml` so a forgotten `cfg` gate on a future
+  trait-method add fails CI rather than silently widening the
+  mandatory-implementation surface.
+- **`ff_test::fixtures::backend_config_from_env`** helper (and a
+  re-export from `ff_readiness_tests::valkey`) that reads the same
+  `FF_HOST` / `FF_PORT` / `FF_TLS` / `FF_CLUSTER` env vars as
+  `build_client_from_env` and returns a `BackendConfig`. Used by
+  integration tests that construct `WorkerConfig` through the new
+  nested-backend shape.
+- **`ff_backend_valkey::build_client`** is now `pub`. `FlowFabricWorker::connect`
+  reuses it so the `BackendConfig` → `ferriskey::Client` mapping lives
+  in exactly one place.
+
 ### Changed
 
+- **`FlowFabricWorker::connect` now routes through
+  `ff_backend_valkey::build_client`** instead of carrying its own
+  `ClientBuilder` chain. Host/port, TLS, cluster mode, request
+  timeout, and retry strategy now all wire through one code path
+  shared with `ValkeyBackend::connect`.
 - Wired `BackendRetry` to ferriskey `ClientBuilder::retry_strategy` in
   `ValkeyBackend::connect`. All 4 fields honored when set; when
   all-`None`, ferriskey's builder default is used (no call to

--- a/benches/harness/benches/submit_claim_complete.rs
+++ b/benches/harness/benches/submit_claim_complete.rs
@@ -181,16 +181,24 @@ async fn drive_worker(
 ) -> anyhow::Result<Vec<u64>> {
     use std::sync::atomic::Ordering;
 
-    let mut config = WorkerConfig::new(
-        &env.valkey_host,
-        env.valkey_port,
-        format!("bench-worker-{wi}"),
-        format!("bench-worker-{wi}-{}", uuid::Uuid::new_v4()),
-        &env.namespace,
-        &env.lane,
-    );
-    // Keep poll interval tight so drains don't get dragged by backoff.
-    config.claim_poll_interval_ms = POLL_INTERVAL_MS;
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(
+            env.valkey_host.clone(),
+            env.valkey_port,
+        ),
+        worker_id: ff_core::types::WorkerId::new(format!("bench-worker-{wi}")),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
+            "bench-worker-{wi}-{}",
+            uuid::Uuid::new_v4()
+        )),
+        namespace: ff_core::types::Namespace::new(&env.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&env.lane)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        // Keep poll interval tight so drains don't get dragged by backoff.
+        claim_poll_interval_ms: POLL_INTERVAL_MS,
+        max_concurrent_tasks: 1,
+    };
     let worker = FlowFabricWorker::connect(config).await?;
 
     // Per-worker buffer: no lock, no contention. Merged by the driver

--- a/benches/harness/benches/suspend_signal_resume.rs
+++ b/benches/harness/benches/suspend_signal_resume.rs
@@ -170,15 +170,20 @@ async fn measure_one_inner(
     // state from the prior iteration's lease-renewal timer; fresh is
     // cleaner for latency sampling.
     let instance_id = format!("bench-susp-{}", uuid::Uuid::new_v4());
-    let mut config = WorkerConfig::new(
-        &env.valkey_host,
-        env.valkey_port,
-        "bench-susp-worker",
-        &instance_id,
-        &env.namespace,
-        &env.lane,
-    );
-    config.claim_poll_interval_ms = TIGHT_LOOP_POLL_MS;
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(
+            env.valkey_host.clone(),
+            env.valkey_port,
+        ),
+        worker_id: ff_core::types::WorkerId::new("bench-susp-worker"),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
+        namespace: ff_core::types::Namespace::new(&env.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&env.lane)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: TIGHT_LOOP_POLL_MS,
+        max_concurrent_tasks: 1,
+    };
     let worker = FlowFabricWorker::connect(config).await?;
 
     let eid = ff_bench::workload::create_execution(

--- a/benches/harness/src/bin/cap_routed.rs
+++ b/benches/harness/src/bin/cap_routed.rs
@@ -777,16 +777,20 @@ async fn drive_worker(
 ) -> Result<()> {
     let worker_caps: BTreeSet<String> = caps.iter().cloned().collect();
     let instance_id = format!("cap-w{wi}-{}", uuid::Uuid::new_v4());
-    let mut config = WorkerConfig::new(
-        &env.valkey_host,
-        env.valkey_port,
-        format!("cap-w{wi}"),
-        &instance_id,
-        &env.namespace,
-        &env.lane,
-    );
-    config.capabilities = caps.clone();
-    config.claim_poll_interval_ms = 50;
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(
+            env.valkey_host.clone(),
+            env.valkey_port,
+        ),
+        worker_id: ff_core::types::WorkerId::new(format!("cap-w{wi}")),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
+        namespace: ff_core::types::Namespace::new(&env.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&env.lane)],
+        capabilities: caps.clone(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 50,
+        max_concurrent_tasks: 1,
+    };
     let worker = FlowFabricWorker::connect(config).await?;
 
     loop {

--- a/benches/harness/src/bin/long_running.rs
+++ b/benches/harness/src/bin/long_running.rs
@@ -1050,16 +1050,20 @@ async fn drive_worker(
     cap: usize,
 ) -> Result<WorkerOutcome> {
     let instance_id = format!("bench-worker-{wi}-{}", uuid::Uuid::new_v4());
-    let mut config = WorkerConfig::new(
-        &env.valkey_host,
-        env.valkey_port,
-        format!("bench-worker-{wi}"),
-        instance_id,
-        &env.namespace,
-        &env.lane,
-    );
-    config.claim_poll_interval_ms = POLL_INTERVAL_MS;
-    config.lease_ttl_ms = LEASE_TTL_MS;
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(
+            env.valkey_host.clone(),
+            env.valkey_port,
+        ),
+        worker_id: ff_core::types::WorkerId::new(format!("bench-worker-{wi}")),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(instance_id),
+        namespace: ff_core::types::Namespace::new(&env.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&env.lane)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: LEASE_TTL_MS,
+        claim_poll_interval_ms: POLL_INTERVAL_MS,
+        max_concurrent_tasks: 1,
+    };
     let worker = FlowFabricWorker::connect(config).await?;
 
     let mut out = WorkerOutcome {

--- a/benches/harness/src/runners/flowfabric.rs
+++ b/benches/harness/src/runners/flowfabric.rs
@@ -522,15 +522,23 @@ async fn echo_worker_loop(
     env: BenchEnv,
     shutdown_rx: Arc<tokio::sync::watch::Receiver<bool>>,
 ) -> Result<()> {
-    let mut config = WorkerConfig::new(
-        &env.valkey_host,
-        env.valkey_port,
-        format!("bench-echo-{wi}"),
-        format!("bench-echo-{wi}-{}", uuid::Uuid::new_v4()),
-        &env.namespace,
-        &env.lane,
-    );
-    config.claim_poll_interval_ms = 50;
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(
+            env.valkey_host.clone(),
+            env.valkey_port,
+        ),
+        worker_id: ff_core::types::WorkerId::new(format!("bench-echo-{wi}")),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
+            "bench-echo-{wi}-{}",
+            uuid::Uuid::new_v4()
+        )),
+        namespace: ff_core::types::Namespace::new(&env.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&env.lane)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 50,
+        max_concurrent_tasks: 1,
+    };
     let worker = FlowFabricWorker::connect(config).await?;
     let _ = AttemptIndex::new(0); // compile-time guard that the SDK type alias still exists
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -34,20 +34,22 @@ use ff_core::backend::{
     HandleKind, LeaseRenewal, PendingWaitpoint, ReclaimToken, ResumeSignal, UsageDimensions,
     WaitpointSpec,
 };
+use ff_core::contracts::decode::build_edge_snapshot;
 use ff_core::contracts::{
-    CancelFlowArgs, CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
+    CancelFlowArgs, CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
+    ReportUsageResult,
 };
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
-use ff_core::partition::{execution_partition, flow_partition, PartitionConfig};
+use ff_core::partition::{PartitionConfig, execution_partition, flow_partition};
 use ff_core::types::{
-    AttemptId, AttemptIndex, BudgetId, ExecutionId, FlowId, LaneId, LeaseEpoch, LeaseId,
+    AttemptId, AttemptIndex, BudgetId, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch, LeaseId,
     SignalId, TimestampMs, WaitpointId, WorkerInstanceId,
 };
 use ff_script::engine_error_ext::transport_script;
 use ff_script::error::ScriptError;
-use ff_script::functions::flow::{ff_cancel_flow, FlowStructOpKeys};
+use ff_script::functions::flow::{FlowStructOpKeys, ff_cancel_flow};
 use ff_script::result::FcallResult;
 
 pub mod backend_error;
@@ -361,14 +363,120 @@ async fn cancel_flow_fcall(
         .map_err(EngineError::from)
 }
 
+/// Read all edges adjacent to `subject_eid` on the requested side.
+///
+/// Mirrors the ff-sdk free-fn `list_edges_from_set` pipeline shape
+/// (`SMEMBERS adj_set` + pipelined `HGETALL edge_hash`) but routes
+/// every parse / identity failure through
+/// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`]
+/// via [`ff_core::contracts::decode::build_edge_snapshot`]. The
+/// caller's `flow_id` is trusted — unlike the ff-sdk free-fn there
+/// is no `HGET exec_core.flow_id` resolution round trip; the trait
+/// method requires callers to pass the flow id they already know.
+///
+/// The adjacency SET's endpoint cross-check still runs here (the
+/// returned edge's `upstream_execution_id` for Outgoing, or
+/// `downstream_execution_id` for Incoming, must match
+/// `direction.subject()`) so a drifted SET entry does not silently
+/// surface an unrelated edge to the caller.
+async fn list_edges_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    flow_id: &FlowId,
+    direction: EdgeDirection,
+) -> Result<Vec<EdgeSnapshot>, EngineError> {
+    let partition = flow_partition(flow_id, partition_config);
+    let fctx = FlowKeyContext::new(&partition, flow_id);
+
+    let (adj_key, subject_eid, side_is_outgoing) = match &direction {
+        EdgeDirection::Outgoing { from_node } => (fctx.outgoing(from_node), from_node, true),
+        EdgeDirection::Incoming { to_node } => (fctx.incoming(to_node), to_node, false),
+    };
+
+    let edge_id_strs: Vec<String> = client
+        .cmd("SMEMBERS")
+        .arg(&adj_key)
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    if edge_id_strs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Parse every edge id up front so a corrupt SET entry fails loud
+    // before we spend a round trip on it. Mirrors the ff-sdk posture.
+    let mut edge_ids: Vec<EdgeId> = Vec::with_capacity(edge_id_strs.len());
+    for raw in &edge_id_strs {
+        let parsed = EdgeId::parse(raw).map_err(|e| EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::Corruption,
+            detail: format!(
+                "list_edges: adjacency_set: edge_id: '{raw}' is not a valid EdgeId \
+                 (key corruption?): {e}"
+            ),
+        })?;
+        edge_ids.push(parsed);
+    }
+
+    let mut pipe = client.pipeline();
+    let slots: Vec<_> = edge_ids
+        .iter()
+        .map(|eid| {
+            pipe.cmd::<HashMap<String, String>>("HGETALL")
+                .arg(fctx.edge(eid))
+                .finish()
+        })
+        .collect();
+    pipe.execute().await.map_err(transport_fk)?;
+
+    let mut out: Vec<EdgeSnapshot> = Vec::with_capacity(edge_ids.len());
+    for (edge_id, slot) in edge_ids.iter().zip(slots) {
+        let raw = slot.value().map_err(transport_fk)?;
+        if raw.is_empty() {
+            // Adjacency SET references an edge hash that no longer
+            // exists. FF never deletes edge hashes (staging is
+            // write-once) so treat as corruption.
+            return Err(EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail: format!(
+                    "list_edges: adjacency_set: refers to edge_id '{edge_id}' but its \
+                     edge_hash is absent (key corruption?)"
+                ),
+            });
+        }
+        let snap = build_edge_snapshot(flow_id, edge_id, &raw)?;
+        // Endpoint cross-check: the decoded edge's endpoint on the
+        // listed side must match the subject execution.
+        let endpoint = if side_is_outgoing {
+            &snap.upstream_execution_id
+        } else {
+            &snap.downstream_execution_id
+        };
+        if endpoint != subject_eid {
+            let side = if side_is_outgoing {
+                "Outgoing"
+            } else {
+                "Incoming"
+            };
+            return Err(EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail: format!(
+                    "list_edges: adjacency_set: for execution '{subject_eid}' \
+                     (side={side}) contains edge '{edge_id}' whose stored endpoint is \
+                     '{endpoint}' (adjacency/edge-hash drift?)"
+                ),
+            });
+        }
+        out.push(snap);
+    }
+    Ok(out)
+}
+
 /// Read the deployment's partition config from
 /// `ff:config:partitions`. Keeps `ValkeyBackend` aligned with
 /// ff-server's published `num_flow_partitions` / budget / quota
 /// counts. Mirrors the ff-sdk `worker::read_partition_config` helper
 /// (Stage 1c will deduplicate once the hot-path migration lands).
-async fn load_partition_config(
-    client: &ferriskey::Client,
-) -> Result<PartitionConfig, EngineError> {
+async fn load_partition_config(client: &ferriskey::Client) -> Result<PartitionConfig, EngineError> {
     let key = ff_core::keys::global_config_partitions();
     let fields: HashMap<String, String> = client
         .hgetall(&key)
@@ -513,7 +621,9 @@ async fn progress_impl(
         f.execution_id.to_string(),
         f.lease_id.to_string(),
         f.lease_epoch.to_string(),
-        percent.map(|p| p.to_string()).unwrap_or_else(|| "0".to_string()),
+        percent
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "0".to_string()),
         message.unwrap_or("").to_string(),
     ];
 
@@ -548,8 +658,7 @@ async fn observe_signals_impl(
         .await
         .map_err(transport_fk)?;
 
-    let Some(waitpoint_id) = resume_waitpoint_id_from_suspension(&susp, f.attempt_index)?
-    else {
+    let Some(waitpoint_id) = resume_waitpoint_id_from_suspension(&susp, f.attempt_index)? else {
         return Ok(Vec::new());
     };
 
@@ -623,8 +732,7 @@ async fn observe_signals_impl(
         if sig.is_empty() {
             continue;
         }
-        let payload_raw: Option<ferriskey::Value> =
-            payload_slot.value().map_err(transport_fk)?;
+        let payload_raw: Option<ferriskey::Value> = payload_slot.value().map_err(transport_fk)?;
         let payload: Option<Vec<u8>> = match payload_raw {
             Some(ferriskey::Value::BulkString(b)) => Some(b.to_vec()),
             Some(ferriskey::Value::SimpleString(s)) => Some(s.into_bytes()),
@@ -1279,8 +1387,8 @@ async fn fail_impl(
         .filter(|d| !d.is_empty())
         .and_then(|d| std::str::from_utf8(d).ok())
         .map(String::from);
-    let error_category: String = category_owned
-        .unwrap_or_else(|| failure_class_to_lua_string(classification).to_owned());
+    let error_category: String =
+        category_owned.unwrap_or_else(|| failure_class_to_lua_string(classification).to_owned());
 
     let args: Vec<String> = vec![
         f.execution_id.to_string(),
@@ -1343,14 +1451,12 @@ fn reconcile_terminal_replay(
     f: &handle_codec::HandleFields,
     expected_outcome: &str,
 ) -> bool {
-    if let EngineError::Contention(
-        ff_core::engine_error::ContentionKind::ExecutionNotActive {
-            ref terminal_outcome,
-            ref lease_epoch,
-            ref attempt_id,
-            ..
-        },
-    ) = *err
+    if let EngineError::Contention(ff_core::engine_error::ContentionKind::ExecutionNotActive {
+        ref terminal_outcome,
+        ref lease_epoch,
+        ref attempt_id,
+        ..
+    }) = *err
     {
         terminal_outcome == expected_outcome
             && lease_epoch == &f.lease_epoch.to_string()
@@ -1422,10 +1528,7 @@ async fn read_retry_policy_json(
     ctx: &ExecKeyContext,
     execution_id: &ExecutionId,
 ) -> Result<String, EngineError> {
-    let policy_str: Option<String> = client
-        .get(&ctx.policy())
-        .await
-        .map_err(transport_fk)?;
+    let policy_str: Option<String> = client.get(&ctx.policy()).await.map_err(transport_fk)?;
     match policy_str {
         Some(json) => match serde_json::from_str::<serde_json::Value>(&json) {
             Ok(policy) => {
@@ -1489,11 +1592,7 @@ impl EngineBackend for ValkeyBackend {
         append_frame_impl(&self.client, &self.partition_config, &f, frame).await
     }
 
-    async fn complete(
-        &self,
-        handle: &Handle,
-        payload: Option<Vec<u8>>,
-    ) -> Result<(), EngineError> {
+    async fn complete(&self, handle: &Handle, payload: Option<Vec<u8>>) -> Result<(), EngineError> {
         let f = handle_codec::decode_handle(handle)?;
         complete_impl(&self.client, &self.partition_config, &f, payload).await
     }
@@ -1505,7 +1604,14 @@ impl EngineBackend for ValkeyBackend {
         classification: FailureClass,
     ) -> Result<FailOutcome, EngineError> {
         let f = handle_codec::decode_handle(handle)?;
-        fail_impl(&self.client, &self.partition_config, &f, reason, classification).await
+        fail_impl(
+            &self.client,
+            &self.partition_config,
+            &f,
+            reason,
+            classification,
+        )
+        .await
     }
 
     async fn cancel(&self, handle: &Handle, reason: &str) -> Result<(), EngineError> {
@@ -1556,11 +1662,7 @@ impl EngineBackend for ValkeyBackend {
         })
     }
 
-    async fn delay(
-        &self,
-        handle: &Handle,
-        delay_until: TimestampMs,
-    ) -> Result<(), EngineError> {
+    async fn delay(&self, handle: &Handle, delay_until: TimestampMs) -> Result<(), EngineError> {
         let f = handle_codec::decode_handle(handle)?;
         delay_impl(&self.client, &self.partition_config, &f, delay_until).await
     }
@@ -1579,13 +1681,18 @@ impl EngineBackend for ValkeyBackend {
         })
     }
 
-    async fn describe_flow(
-        &self,
-        _id: &FlowId,
-    ) -> Result<Option<FlowSnapshot>, EngineError> {
+    async fn describe_flow(&self, _id: &FlowId) -> Result<Option<FlowSnapshot>, EngineError> {
         Err(EngineError::Unavailable {
             op: "describe_flow",
         })
+    }
+
+    async fn list_edges(
+        &self,
+        flow_id: &FlowId,
+        direction: EdgeDirection,
+    ) -> Result<Vec<EdgeSnapshot>, EngineError> {
+        list_edges_impl(&self.client, &self.partition_config, flow_id, direction).await
     }
 
     async fn cancel_flow(
@@ -1614,7 +1721,10 @@ mod tests {
 
     #[test]
     fn cancel_policy_strings() {
-        assert_eq!(cancel_policy_to_str(CancelFlowPolicy::FlowOnly), "flow_only");
+        assert_eq!(
+            cancel_policy_to_str(CancelFlowPolicy::FlowOnly),
+            "flow_only"
+        );
         assert_eq!(
             cancel_policy_to_str(CancelFlowPolicy::CancelAll),
             "cancel_all"

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -251,7 +251,7 @@ impl ValkeyBackend {
 /// fall back to `ConnectionRetryStrategy::default()` per-field (0 /
 /// 0 / 0 / None); callers opting into any field should set all
 /// fields they care about.
-async fn build_client(config: &BackendConfig) -> Result<ferriskey::Client, EngineError> {
+pub async fn build_client(config: &BackendConfig) -> Result<ferriskey::Client, EngineError> {
     let BackendConnection::Valkey(v) = &config.connection else {
         return Err(EngineError::Unavailable {
             op: "ValkeyBackend::connect (non-Valkey BackendConnection)",

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -34,7 +34,9 @@ use ff_core::backend::{
     HandleKind, LeaseRenewal, PendingWaitpoint, ReclaimToken, ResumeSignal, UsageDimensions,
     WaitpointSpec,
 };
-use ff_core::contracts::decode::build_edge_snapshot;
+use ff_core::contracts::decode::{
+    build_edge_snapshot, build_execution_snapshot, build_flow_snapshot,
+};
 use ff_core::contracts::{
     CancelFlowArgs, CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
     ReportUsageResult,
@@ -361,6 +363,66 @@ async fn cancel_flow_fcall(
     ff_cancel_flow(client, &keys, &args)
         .await
         .map_err(EngineError::from)
+}
+
+/// Pipeline two `HGETALL`s (exec_core + tags) on the execution's
+/// partition and decode via [`build_execution_snapshot`]. `Ok(None)`
+/// when exec_core is absent. Decode failures surface as
+/// `EngineError::Validation { kind: Corruption, .. }`.
+///
+/// Mirrors the pre-T3 ff-sdk pipeline shape: the two keys share
+/// `{fp:N}` so cluster mode routes them to the same slot.
+async fn describe_execution_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    id: &ExecutionId,
+) -> Result<Option<ExecutionSnapshot>, EngineError> {
+    let partition = execution_partition(id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, id);
+    let core_key = ctx.core();
+    let tags_key = ctx.tags();
+
+    let mut pipe = client.pipeline();
+    let core_slot = pipe
+        .cmd::<HashMap<String, String>>("HGETALL")
+        .arg(&core_key)
+        .finish();
+    let tags_slot = pipe
+        .cmd::<HashMap<String, String>>("HGETALL")
+        .arg(&tags_key)
+        .finish();
+    pipe.execute().await.map_err(transport_fk)?;
+
+    let core = core_slot.value().map_err(transport_fk)?;
+    if core.is_empty() {
+        return Ok(None);
+    }
+    let tags_raw = tags_slot.value().map_err(transport_fk)?;
+    build_execution_snapshot(id.clone(), &core, tags_raw)
+}
+
+/// Single `HGETALL flow_core` + decode via [`build_flow_snapshot`].
+/// `Ok(None)` when flow_core is absent. Decode failures surface as
+/// `EngineError::Validation { kind: Corruption, .. }`.
+async fn describe_flow_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    id: &FlowId,
+) -> Result<Option<FlowSnapshot>, EngineError> {
+    let partition = flow_partition(id, partition_config);
+    let ctx = FlowKeyContext::new(&partition, id);
+    let core_key = ctx.core();
+
+    let raw: HashMap<String, String> = client
+        .cmd("HGETALL")
+        .arg(&core_key)
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    build_flow_snapshot(id.clone(), &raw).map(Some)
 }
 
 /// Read all edges adjacent to `subject_eid` on the requested side.
@@ -1674,17 +1736,13 @@ impl EngineBackend for ValkeyBackend {
 
     async fn describe_execution(
         &self,
-        _id: &ExecutionId,
+        id: &ExecutionId,
     ) -> Result<Option<ExecutionSnapshot>, EngineError> {
-        Err(EngineError::Unavailable {
-            op: "describe_execution",
-        })
+        describe_execution_impl(&self.client, &self.partition_config, id).await
     }
 
-    async fn describe_flow(&self, _id: &FlowId) -> Result<Option<FlowSnapshot>, EngineError> {
-        Err(EngineError::Unavailable {
-            op: "describe_flow",
-        })
+    async fn describe_flow(&self, id: &FlowId) -> Result<Option<FlowSnapshot>, EngineError> {
+        describe_flow_impl(&self.client, &self.partition_config, id).await
     }
 
     async fn list_edges(

--- a/crates/ff-core/Cargo.toml
+++ b/crates/ff-core/Cargo.toml
@@ -10,6 +10,28 @@ keywords.workspace = true
 categories.workspace = true
 description = "FlowFabric core types, partition math, key builders, error codes"
 
+[features]
+# RFC-012 Stage 1c tranche-1 scaffold: backend-implementer feature
+# surface. `default = [all]` means consumer crates (ff-sdk and
+# downstream) see the full trait with zero toggles. Backend crates may
+# opt into a strict subset; a `default-features = false` dependency
+# with, say, `features = ["core"]` will in later tranches see a
+# trait slice without streaming / suspension / budget methods.
+#
+# Tranche 1 only declares the feature names — the `EngineBackend`
+# trait does not yet carry `#[cfg(feature = "…")]` gates on any
+# method. Tranches 2-5 land the gates as each method migrates. All
+# feature bodies are intentionally empty here.
+#
+# Grouping rationale (per plan §Trait feature-gate strategy): names
+# track storage primitives, not consumer APIs — primitives change
+# slower than APIs, which keeps the cfg-gate topology stable.
+default = ["core", "streaming", "suspension", "budget"]
+core = []
+streaming = []
+suspension = []
+budget = []
+
 [dependencies]
 uuid = { workspace = true }
 serde = { workspace = true }

--- a/crates/ff-core/src/contracts/decode.rs
+++ b/crates/ff-core/src/contracts/decode.rs
@@ -18,18 +18,26 @@
 //! shape so public ff-sdk callers see no behavior change while the
 //! engine-side decoder moves.
 //!
-//! Only the edge decoder lives here today. Future tranches may
-//! migrate `build_execution_snapshot` / `build_flow_snapshot` to this
-//! module; they currently live in `ff-sdk::snapshot` because their
-//! pipelines are not yet trait-shaped.
+//! Stage 1c T3 adds [`build_execution_snapshot`] and
+//! [`build_flow_snapshot`] alongside the edge decoder: every
+//! engine-owned hash shape now parses through one canonical strict-parse
+//! surface, freeing `ff-backend-valkey` to implement
+//! `describe_execution` / `describe_flow` against the trait and letting
+//! ff-sdk collapse its snapshot module into thin trait forwarders.
 //!
 //! [`EngineError::Validation { kind: Corruption, .. }`]: crate::engine_error::EngineError::Validation
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
-use crate::contracts::EdgeSnapshot;
+use crate::contracts::{
+    AttemptSummary, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, LeaseSummary,
+};
 use crate::engine_error::{EngineError, ValidationKind};
-use crate::types::{EdgeId, ExecutionId, FlowId, TimestampMs};
+use crate::state::PublicState;
+use crate::types::{
+    AttemptId, AttemptIndex, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch, Namespace,
+    TimestampMs, WaitpointId, WorkerInstanceId,
+};
 
 /// FF-owned fields on the flow-scoped `edge:<edge_id>` hash.
 ///
@@ -204,6 +212,433 @@ fn parse_eid(raw: &HashMap<String, String>, field: &str) -> Result<ExecutionId, 
     })
 }
 
+// ═══════════════════════════════════════════════════════════════════════
+// execution decoder (describe_execution)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Assemble an [`ExecutionSnapshot`] from the raw HGETALL field maps.
+///
+/// `core` is the HGETALL of `exec_core`, `tags_raw` the HGETALL of the
+/// sibling tags hash (which may be empty for executions created without
+/// tags). Every parse failure surfaces as
+/// [`EngineError::Validation { kind: Corruption, .. }`] — fields that
+/// FCALLs write atomically are strict-required, while fields that clear
+/// on transition (`blocking_reason`, `current_attempt_id`, etc.) are
+/// treated as absent when empty.
+pub fn build_execution_snapshot(
+    execution_id: ExecutionId,
+    core: &HashMap<String, String>,
+    tags_raw: HashMap<String, String>,
+) -> Result<Option<ExecutionSnapshot>, EngineError> {
+    let ctx = "describe_execution: exec_core";
+
+    let public_state = parse_public_state(opt_str(core, "public_state").unwrap_or(""))?;
+
+    // `LaneId::try_new` validates non-empty + ASCII-printable + <= 64 bytes.
+    // Exec_core writes a LaneId that already passed these invariants at
+    // ingress; a read that fails validation here signals on-disk
+    // corruption — surface it rather than silently constructing an
+    // invalid LaneId that would mis-partition downstream.
+    let lane_id = LaneId::try_new(opt_str(core, "lane_id").unwrap_or("")).map_err(|e| {
+        corruption(
+            ctx,
+            Some("lane_id"),
+            &format!("fails LaneId validation (key corruption?): {e}"),
+        )
+    })?;
+
+    let namespace_str = opt_str(core, "namespace").unwrap_or("").to_owned();
+    let namespace = Namespace::new(namespace_str);
+
+    let flow_id = opt_str(core, "flow_id")
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            FlowId::parse(s).map_err(|e| {
+                corruption(
+                    ctx,
+                    Some("flow_id"),
+                    &format!("is not a valid UUID (key corruption?): {e}"),
+                )
+            })
+        })
+        .transpose()?;
+
+    let blocking_reason = opt_str(core, "blocking_reason")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    let blocking_detail = opt_str(core, "blocking_detail")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+
+    // created_at + last_mutation_at are engine-maintained invariants
+    // (lua/execution.lua writes both on create; every mutating FCALL
+    // updates last_mutation_at). Missing values indicate on-disk
+    // corruption, not a valid pre-create state — fail loudly.
+    let created_at = parse_ts(core, ctx, "created_at")?.ok_or_else(|| {
+        corruption(
+            ctx,
+            Some("created_at"),
+            "is missing or empty (key corruption?)",
+        )
+    })?;
+    let last_mutation_at = parse_ts(core, ctx, "last_mutation_at")?.ok_or_else(|| {
+        corruption(
+            ctx,
+            Some("last_mutation_at"),
+            "is missing or empty (key corruption?)",
+        )
+    })?;
+
+    let total_attempt_count: u32 =
+        parse_u32_strict(core, ctx, "total_attempt_count")?.unwrap_or(0);
+
+    let current_attempt = build_attempt_summary(core)?;
+    let current_lease = build_lease_summary(core)?;
+
+    let current_waitpoint = opt_str(core, "current_waitpoint_id")
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            WaitpointId::parse(s).map_err(|e| {
+                corruption(
+                    ctx,
+                    Some("current_waitpoint_id"),
+                    &format!("is not a valid UUID (key corruption?): {e}"),
+                )
+            })
+        })
+        .transpose()?;
+
+    let tags: BTreeMap<String, String> = tags_raw.into_iter().collect();
+
+    Ok(Some(ExecutionSnapshot::new(
+        execution_id,
+        flow_id,
+        lane_id,
+        namespace,
+        public_state,
+        blocking_reason,
+        blocking_detail,
+        current_attempt,
+        current_lease,
+        current_waitpoint,
+        created_at,
+        last_mutation_at,
+        total_attempt_count,
+        tags,
+    )))
+}
+
+fn opt_str<'a>(map: &'a HashMap<String, String>, field: &str) -> Option<&'a str> {
+    map.get(field).map(String::as_str)
+}
+
+/// Strictly parse a ms-timestamp field. `Ok(None)` when absent/empty,
+/// `Err` on unparseable content. `context` names both the calling
+/// FCALL and the hash (e.g. `"describe_execution: exec_core"`) so
+/// error messages point to the exact source of corruption.
+fn parse_ts(
+    map: &HashMap<String, String>,
+    context: &str,
+    field: &str,
+) -> Result<Option<TimestampMs>, EngineError> {
+    match opt_str(map, field).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some(raw) => {
+            let ms: i64 = raw.parse().map_err(|e| {
+                corruption(
+                    context,
+                    Some(field),
+                    &format!("is not a valid ms timestamp ('{raw}'): {e}"),
+                )
+            })?;
+            Ok(Some(TimestampMs::from_millis(ms)))
+        }
+    }
+}
+
+/// Strictly parse a `u32` field. Returns `Ok(None)` when the field is
+/// absent or empty (a valid pre-write state), `Err` when the value is
+/// present but unparseable (on-disk corruption).
+fn parse_u32_strict(
+    map: &HashMap<String, String>,
+    context: &str,
+    field: &str,
+) -> Result<Option<u32>, EngineError> {
+    match opt_str(map, field).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some(raw) => Ok(Some(raw.parse().map_err(|e| {
+            corruption(
+                context,
+                Some(field),
+                &format!("is not a valid u32 ('{raw}'): {e}"),
+            )
+        })?)),
+    }
+}
+
+/// Strictly parse a `u64` field. Semantics mirror [`parse_u32_strict`].
+fn parse_u64_strict(
+    map: &HashMap<String, String>,
+    context: &str,
+    field: &str,
+) -> Result<Option<u64>, EngineError> {
+    match opt_str(map, field).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some(raw) => Ok(Some(raw.parse().map_err(|e| {
+            corruption(
+                context,
+                Some(field),
+                &format!("is not a valid u64 ('{raw}'): {e}"),
+            )
+        })?)),
+    }
+}
+
+fn parse_public_state(raw: &str) -> Result<PublicState, EngineError> {
+    // exec_core stores the snake_case literal (e.g. "waiting"). PublicState's
+    // Deserialize accepts the JSON-quoted form, so wrap + delegate.
+    let quoted = format!("\"{raw}\"");
+    serde_json::from_str(&quoted).map_err(|e| {
+        corruption(
+            "describe_execution: exec_core",
+            Some("public_state"),
+            &format!("'{raw}' is not a known public state: {e}"),
+        )
+    })
+}
+
+fn build_attempt_summary(
+    core: &HashMap<String, String>,
+) -> Result<Option<AttemptSummary>, EngineError> {
+    let ctx = "describe_execution: exec_core";
+    let attempt_id_str = match opt_str(core, "current_attempt_id").filter(|s| !s.is_empty()) {
+        None => return Ok(None),
+        Some(s) => s,
+    };
+    let attempt_id = AttemptId::parse(attempt_id_str).map_err(|e| {
+        corruption(
+            ctx,
+            Some("current_attempt_id"),
+            &format!("is not a valid UUID: {e}"),
+        )
+    })?;
+    // When `current_attempt_id` is set, `current_attempt_index` MUST be
+    // set too — lua/execution.lua writes both atomically in
+    // `ff_claim_execution`. A missing index while the id is populated
+    // is corruption, not a valid intermediate state.
+    let attempt_index = parse_u32_strict(core, ctx, "current_attempt_index")?.ok_or_else(|| {
+        corruption(
+            ctx,
+            Some("current_attempt_index"),
+            "is missing while current_attempt_id is set (key corruption?)",
+        )
+    })?;
+    Ok(Some(AttemptSummary::new(
+        attempt_id,
+        AttemptIndex::new(attempt_index),
+    )))
+}
+
+fn build_lease_summary(
+    core: &HashMap<String, String>,
+) -> Result<Option<LeaseSummary>, EngineError> {
+    let ctx = "describe_execution: exec_core";
+    // A lease is "held" when the worker_instance_id field is populated
+    // AND lease_expires_at is set. Both clear together on revoke/expire
+    // (see clear_lease_and_indexes in lua/helpers.lua).
+    let wid_str = match opt_str(core, "current_worker_instance_id").filter(|s| !s.is_empty()) {
+        None => return Ok(None),
+        Some(s) => s,
+    };
+    let expires_at = match parse_ts(core, ctx, "lease_expires_at")? {
+        None => return Ok(None),
+        Some(ts) => ts,
+    };
+    // A lease is only "held" if the epoch is present too — lua/helpers.lua
+    // sets/clears epoch atomically with wid + expires_at. Parse strictly
+    // and require it: a missing epoch alongside a live wid is corruption.
+    let epoch = parse_u64_strict(core, ctx, "current_lease_epoch")?.ok_or_else(|| {
+        corruption(
+            ctx,
+            Some("current_lease_epoch"),
+            "is missing while current_worker_instance_id is set (key corruption?)",
+        )
+    })?;
+    Ok(Some(LeaseSummary::new(
+        LeaseEpoch::new(epoch),
+        WorkerInstanceId::new(wid_str.to_owned()),
+        expires_at,
+    )))
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// flow decoder (describe_flow)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// FF-owned snake_case fields on flow_core. Any HGETALL field NOT in
+/// this set AND matching the `^[a-z][a-z0-9_]*\.` namespaced-tag shape
+/// is surfaced on [`FlowSnapshot::tags`]. Fields that are neither FF-
+/// owned nor namespaced (unexpected shapes) are surfaced as a
+/// `Corruption` error so on-disk corruption or protocol drift fails loud.
+pub const FLOW_CORE_KNOWN_FIELDS: &[&str] = &[
+    "flow_id",
+    "flow_kind",
+    "namespace",
+    "public_flow_state",
+    "graph_revision",
+    "node_count",
+    "edge_count",
+    "created_at",
+    "last_mutation_at",
+    "cancelled_at",
+    "cancel_reason",
+    "cancellation_policy",
+];
+
+/// Assemble a [`FlowSnapshot`] from the raw HGETALL field map.
+///
+/// Cross-checks the stored `flow_id` against the caller's expected id.
+/// Unknown fields that match the `^[a-z][a-z0-9_]*\.` namespaced-tag
+/// shape are routed to `tags`; any other unknown field surfaces as
+/// `Corruption`.
+pub fn build_flow_snapshot(
+    flow_id: FlowId,
+    raw: &HashMap<String, String>,
+) -> Result<FlowSnapshot, EngineError> {
+    let ctx = "describe_flow: flow_core";
+
+    // flow_id cross-check — corruption or wrong-key read.
+    let stored_flow_id_str = opt_str(raw, "flow_id")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| corruption(ctx, Some("flow_id"), "is missing or empty (key corruption?)"))?;
+    if stored_flow_id_str != flow_id.to_string() {
+        return Err(corruption(
+            ctx,
+            Some("flow_id"),
+            &format!(
+                "'{stored_flow_id_str}' does not match requested flow_id \
+                 '{flow_id}' (key corruption or wrong-key read?)"
+            ),
+        ));
+    }
+
+    let namespace_str = opt_str(raw, "namespace")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            corruption(ctx, Some("namespace"), "is missing or empty (key corruption?)")
+        })?;
+    let namespace = Namespace::new(namespace_str.to_owned());
+
+    let flow_kind = opt_str(raw, "flow_kind")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            corruption(ctx, Some("flow_kind"), "is missing or empty (key corruption?)")
+        })?
+        .to_owned();
+
+    let public_flow_state = opt_str(raw, "public_flow_state")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            corruption(
+                ctx,
+                Some("public_flow_state"),
+                "is missing or empty (key corruption?)",
+            )
+        })?
+        .to_owned();
+
+    let graph_revision = parse_u64_strict(raw, ctx, "graph_revision")?
+        .ok_or_else(|| corruption(ctx, Some("graph_revision"), "is missing (key corruption?)"))?;
+    let node_count = parse_u32_strict(raw, ctx, "node_count")?
+        .ok_or_else(|| corruption(ctx, Some("node_count"), "is missing (key corruption?)"))?;
+    let edge_count = parse_u32_strict(raw, ctx, "edge_count")?
+        .ok_or_else(|| corruption(ctx, Some("edge_count"), "is missing (key corruption?)"))?;
+
+    let created_at = parse_ts(raw, ctx, "created_at")?.ok_or_else(|| {
+        corruption(
+            ctx,
+            Some("created_at"),
+            "is missing or empty (key corruption?)",
+        )
+    })?;
+    let last_mutation_at = parse_ts(raw, ctx, "last_mutation_at")?.ok_or_else(|| {
+        corruption(
+            ctx,
+            Some("last_mutation_at"),
+            "is missing or empty (key corruption?)",
+        )
+    })?;
+
+    let cancelled_at = parse_ts(raw, ctx, "cancelled_at")?;
+    let cancel_reason = opt_str(raw, "cancel_reason")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    let cancellation_policy = opt_str(raw, "cancellation_policy")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+
+    // Route unknown fields: namespaced-prefix (e.g. `cairn.task_id`) →
+    // tags; anything else → corruption.
+    let mut tags: BTreeMap<String, String> = BTreeMap::new();
+    for (k, v) in raw {
+        if FLOW_CORE_KNOWN_FIELDS.contains(&k.as_str()) {
+            continue;
+        }
+        if is_namespaced_tag_key(k) {
+            tags.insert(k.clone(), v.clone());
+        } else {
+            return Err(corruption(
+                ctx,
+                None,
+                &format!(
+                    "has unexpected field '{k}' — not an FF field and not a namespaced \
+                     tag (lowercase-alphanumeric-prefix + '.')"
+                ),
+            ));
+        }
+    }
+
+    Ok(FlowSnapshot::new(
+        flow_id,
+        flow_kind,
+        namespace,
+        public_flow_state,
+        graph_revision,
+        node_count,
+        edge_count,
+        created_at,
+        last_mutation_at,
+        cancelled_at,
+        cancel_reason,
+        cancellation_policy,
+        tags,
+    ))
+}
+
+/// Match the namespaced-tag shape `^[a-z][a-z0-9_]*\.` documented on
+/// [`ExecutionSnapshot::tags`] / [`FlowSnapshot::tags`]. Kept inline
+/// (no regex dependency) — the shape is tight enough to hand-check.
+pub(crate) fn is_namespaced_tag_key(k: &str) -> bool {
+    let mut chars = k.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    let mut saw_dot = false;
+    for c in chars {
+        if c == '.' {
+            saw_dot = true;
+            break;
+        }
+        if !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_') {
+            return false;
+        }
+    }
+    saw_dot
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -362,5 +797,286 @@ mod tests {
         raw.insert("upstream_execution_id".into(), "not-an-execution-id".into());
         let detail = expect_corruption(build_edge_snapshot(&f, &edge, &raw).unwrap_err());
         assert!(detail.contains("upstream_execution_id"), "{detail}");
+    }
+
+    // ─── ExecutionSnapshot (describe_execution) ───────────────────────
+
+    fn eid() -> ExecutionId {
+        let config = PartitionConfig::default();
+        ExecutionId::for_flow(&FlowId::new(), &config)
+    }
+
+    fn minimal_core(public_state: &str) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("public_state".to_owned(), public_state.to_owned());
+        m.insert("lane_id".to_owned(), "default".to_owned());
+        m.insert("namespace".to_owned(), "ns".to_owned());
+        m.insert("created_at".to_owned(), "1000".to_owned());
+        m.insert("last_mutation_at".to_owned(), "2000".to_owned());
+        m.insert("total_attempt_count".to_owned(), "0".to_owned());
+        m
+    }
+
+    fn expect_corruption_field<F>(err: EngineError, pred: F)
+    where
+        F: FnOnce(&str) -> bool,
+    {
+        let detail = expect_corruption(err);
+        assert!(pred(&detail), "detail did not match predicate: {detail}");
+    }
+
+    #[test]
+    fn waiting_exec_no_attempt_no_lease_no_tags() {
+        let snap = build_execution_snapshot(eid(), &minimal_core("waiting"), HashMap::new())
+            .unwrap()
+            .expect("should build");
+        assert_eq!(snap.public_state, PublicState::Waiting);
+        assert!(snap.current_attempt.is_none());
+        assert!(snap.current_lease.is_none());
+        assert!(snap.current_waitpoint.is_none());
+        assert_eq!(snap.tags.len(), 0);
+        assert_eq!(snap.created_at.0, 1000);
+        assert_eq!(snap.last_mutation_at.0, 2000);
+        assert!(snap.flow_id.is_none());
+        assert!(snap.blocking_reason.is_none());
+    }
+
+    #[test]
+    fn tags_flow_through_sorted() {
+        let mut tags = HashMap::new();
+        tags.insert("cairn.task_id".to_owned(), "t-1".to_owned());
+        tags.insert("cairn.project".to_owned(), "proj".to_owned());
+        let snap = build_execution_snapshot(eid(), &minimal_core("waiting"), tags)
+            .unwrap()
+            .unwrap();
+        let keys: Vec<_> = snap.tags.keys().cloned().collect();
+        assert_eq!(
+            keys,
+            vec!["cairn.project".to_owned(), "cairn.task_id".to_owned()]
+        );
+    }
+
+    #[test]
+    fn invalid_public_state_fails_loud() {
+        let err =
+            build_execution_snapshot(eid(), &minimal_core("bogus"), HashMap::new()).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("public_state"));
+    }
+
+    #[test]
+    fn invalid_lane_id_fails_loud() {
+        let mut core = minimal_core("waiting");
+        core.insert("lane_id".to_owned(), "lane\nbroken".to_owned());
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("lane_id"));
+    }
+
+    #[test]
+    fn missing_required_timestamps_fail_loud() {
+        for want in ["created_at", "last_mutation_at"] {
+            let mut core = minimal_core("waiting");
+            core.remove(want);
+            let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+            expect_corruption_field(err, |d| d.contains(want));
+        }
+    }
+
+    #[test]
+    fn malformed_total_attempt_count_fails_loud() {
+        let mut core = minimal_core("waiting");
+        core.insert("total_attempt_count".to_owned(), "not-a-number".to_owned());
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("total_attempt_count"));
+    }
+
+    #[test]
+    fn attempt_id_without_index_fails_loud() {
+        let mut core = minimal_core("active");
+        core.insert(
+            "current_attempt_id".to_owned(),
+            AttemptId::new().to_string(),
+        );
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("current_attempt_index"));
+    }
+
+    #[test]
+    fn lease_without_epoch_fails_loud() {
+        let mut core = minimal_core("active");
+        core.insert(
+            "current_worker_instance_id".to_owned(),
+            "w-inst-1".to_owned(),
+        );
+        core.insert("lease_expires_at".to_owned(), "9000".to_owned());
+        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("current_lease_epoch"));
+    }
+
+    #[test]
+    fn lease_summary_requires_both_wid_and_expires_at() {
+        let mut core = minimal_core("active");
+        core.insert(
+            "current_worker_instance_id".to_owned(),
+            "w-inst-1".to_owned(),
+        );
+        let snap = build_execution_snapshot(eid(), &core, HashMap::new())
+            .unwrap()
+            .unwrap();
+        assert!(snap.current_lease.is_none());
+
+        core.insert("lease_expires_at".to_owned(), "9000".to_owned());
+        core.insert("current_lease_epoch".to_owned(), "3".to_owned());
+        let snap = build_execution_snapshot(eid(), &core, HashMap::new())
+            .unwrap()
+            .unwrap();
+        let lease = snap.current_lease.expect("lease present");
+        assert_eq!(lease.lease_epoch, LeaseEpoch::new(3));
+        assert_eq!(lease.expires_at.0, 9000);
+        assert_eq!(lease.worker_instance_id.as_str(), "w-inst-1");
+    }
+
+    // ─── FlowSnapshot (describe_flow) ─────────────────────────────────
+
+    fn minimal_flow_core(id: &FlowId, state: &str) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("flow_id".to_owned(), id.to_string());
+        m.insert("flow_kind".to_owned(), "dag".to_owned());
+        m.insert("namespace".to_owned(), "ns".to_owned());
+        m.insert("public_flow_state".to_owned(), state.to_owned());
+        m.insert("graph_revision".to_owned(), "0".to_owned());
+        m.insert("node_count".to_owned(), "0".to_owned());
+        m.insert("edge_count".to_owned(), "0".to_owned());
+        m.insert("created_at".to_owned(), "1000".to_owned());
+        m.insert("last_mutation_at".to_owned(), "1000".to_owned());
+        m
+    }
+
+    #[test]
+    fn open_flow_round_trips() {
+        let f = fid();
+        let snap = build_flow_snapshot(f.clone(), &minimal_flow_core(&f, "open")).unwrap();
+        assert_eq!(snap.flow_id, f);
+        assert_eq!(snap.flow_kind, "dag");
+        assert_eq!(snap.namespace.as_str(), "ns");
+        assert_eq!(snap.public_flow_state, "open");
+        assert_eq!(snap.graph_revision, 0);
+        assert_eq!(snap.node_count, 0);
+        assert_eq!(snap.edge_count, 0);
+        assert_eq!(snap.created_at.0, 1000);
+        assert_eq!(snap.last_mutation_at.0, 1000);
+        assert!(snap.cancelled_at.is_none());
+        assert!(snap.cancel_reason.is_none());
+        assert!(snap.cancellation_policy.is_none());
+        assert!(snap.tags.is_empty());
+    }
+
+    #[test]
+    fn cancelled_flow_surfaces_cancel_fields() {
+        let f = fid();
+        let mut core = minimal_flow_core(&f, "cancelled");
+        core.insert("cancelled_at".to_owned(), "2000".to_owned());
+        core.insert("cancel_reason".to_owned(), "operator".to_owned());
+        core.insert("cancellation_policy".to_owned(), "cancel_all".to_owned());
+        let snap = build_flow_snapshot(f, &core).unwrap();
+        assert_eq!(snap.public_flow_state, "cancelled");
+        assert_eq!(snap.cancelled_at.unwrap().0, 2000);
+        assert_eq!(snap.cancel_reason.as_deref(), Some("operator"));
+        assert_eq!(snap.cancellation_policy.as_deref(), Some("cancel_all"));
+    }
+
+    #[test]
+    fn namespaced_tags_routed_to_tags_map() {
+        let f = fid();
+        let mut core = minimal_flow_core(&f, "open");
+        core.insert("cairn.task_id".to_owned(), "t-1".to_owned());
+        core.insert("cairn.project".to_owned(), "proj".to_owned());
+        core.insert("operator.label".to_owned(), "v".to_owned());
+        let snap = build_flow_snapshot(f, &core).unwrap();
+        assert_eq!(snap.tags.len(), 3);
+        let keys: Vec<_> = snap.tags.keys().cloned().collect();
+        assert_eq!(
+            keys,
+            vec![
+                "cairn.project".to_owned(),
+                "cairn.task_id".to_owned(),
+                "operator.label".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn unknown_flat_field_fails_loud() {
+        let f = fid();
+        let mut core = minimal_flow_core(&f, "open");
+        core.insert("bogus_future_field".to_owned(), "v".to_owned());
+        let err = build_flow_snapshot(f, &core).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("bogus_future_field"));
+    }
+
+    #[test]
+    fn missing_required_flow_fields_fail_loud() {
+        for want in [
+            "flow_id",
+            "namespace",
+            "flow_kind",
+            "public_flow_state",
+            "graph_revision",
+            "node_count",
+            "edge_count",
+            "created_at",
+            "last_mutation_at",
+        ] {
+            let f = fid();
+            let mut core = minimal_flow_core(&f, "open");
+            core.remove(want);
+            let err = build_flow_snapshot(f, &core).err().unwrap_or_else(|| {
+                panic!("field {want} should fail but build_flow_snapshot returned Ok")
+            });
+            expect_corruption_field(err, |d| d.contains(want));
+        }
+    }
+
+    #[test]
+    fn empty_required_strings_fail_loud() {
+        for want in ["flow_id", "namespace", "flow_kind", "public_flow_state"] {
+            let f = fid();
+            let mut core = minimal_flow_core(&f, "open");
+            core.insert(want.to_owned(), String::new());
+            let err = build_flow_snapshot(f, &core).err().unwrap_or_else(|| {
+                panic!("empty {want} should fail but build_flow_snapshot returned Ok")
+            });
+            expect_corruption_field(err, |d| d.contains(want));
+        }
+    }
+
+    #[test]
+    fn flow_snapshot_flow_id_mismatch_fails_loud() {
+        let requested = fid();
+        let other = fid();
+        let core = minimal_flow_core(&other, "open");
+        let err = build_flow_snapshot(requested, &core).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("flow_id") && d.contains("does not match"));
+    }
+
+    #[test]
+    fn malformed_counter_fails_loud() {
+        let f = fid();
+        let mut core = minimal_flow_core(&f, "open");
+        core.insert("graph_revision".to_owned(), "not-a-number".to_owned());
+        let err = build_flow_snapshot(f, &core).unwrap_err();
+        expect_corruption_field(err, |d| d.contains("graph_revision"));
+    }
+
+    #[test]
+    fn namespaced_tag_matcher_boundaries() {
+        assert!(is_namespaced_tag_key("cairn.task_id"));
+        assert!(is_namespaced_tag_key("a.b"));
+        assert!(is_namespaced_tag_key("ab_12.field"));
+        assert!(!is_namespaced_tag_key("cairn_task_id"));
+        assert!(!is_namespaced_tag_key("Cairn.task"));
+        assert!(!is_namespaced_tag_key("1cairn.task"));
+        assert!(!is_namespaced_tag_key(""));
+        assert!(!is_namespaced_tag_key(".x"));
+        assert!(!is_namespaced_tag_key("caIrn.task"));
     }
 }

--- a/crates/ff-core/src/contracts/decode.rs
+++ b/crates/ff-core/src/contracts/decode.rs
@@ -1,0 +1,366 @@
+// `EngineError` is ~200 bytes; the decoder and its helpers return
+// `Result<_, EngineError>` throughout to match the
+// [`crate::engine_backend::EngineBackend::list_edges`] contract. The
+// variant size is a cross-crate design point (see ff-backend-valkey's
+// crate-level allow for the same rationale); a future PR can box the
+// large `Conflict`/`Transport` variants. Module-local allow to
+// contain the exception to this one file.
+#![allow(clippy::result_large_err)]
+
+//! Canonical decoders for engine-owned hash shapes.
+//!
+//! RFC-012 Stage 1c (T2): the edge-hash decoder lives here so every
+//! `EngineBackend` implementation — not just `ff-backend-valkey` —
+//! shares one strict-parse posture and one error surface
+//! ([`EngineError::Validation { kind: Corruption, .. }`]). ff-sdk's
+//! snapshot module historically owned this code and surfaced
+//! `SdkError::Config`; the pre-migration wrapper still maps to that
+//! shape so public ff-sdk callers see no behavior change while the
+//! engine-side decoder moves.
+//!
+//! Only the edge decoder lives here today. Future tranches may
+//! migrate `build_execution_snapshot` / `build_flow_snapshot` to this
+//! module; they currently live in `ff-sdk::snapshot` because their
+//! pipelines are not yet trait-shaped.
+//!
+//! [`EngineError::Validation { kind: Corruption, .. }`]: crate::engine_error::EngineError::Validation
+
+use std::collections::HashMap;
+
+use crate::contracts::EdgeSnapshot;
+use crate::engine_error::{EngineError, ValidationKind};
+use crate::types::{EdgeId, ExecutionId, FlowId, TimestampMs};
+
+/// FF-owned fields on the flow-scoped `edge:<edge_id>` hash.
+///
+/// An HGETALL field outside this set signals on-disk corruption or
+/// protocol drift — see [`build_edge_snapshot`]'s unknown-field
+/// sweep. Kept `pub` so test fixtures / diagnostic tooling can share
+/// the canonical list instead of hard-coding duplicates.
+pub const EDGE_KNOWN_FIELDS: &[&str] = &[
+    "edge_id",
+    "flow_id",
+    "upstream_execution_id",
+    "downstream_execution_id",
+    "dependency_kind",
+    "satisfaction_condition",
+    "data_passing_ref",
+    "edge_state",
+    "created_at",
+    "created_by",
+];
+
+/// Assemble an [`EdgeSnapshot`] from the raw HGETALL field map.
+///
+/// Mirrors the pre-T2 ff-sdk free-fn: every validation gate (unknown
+/// fields, missing required fields, identity cross-check against the
+/// caller-supplied `flow_id`/`edge_id`) returns the same diagnostic
+/// shape, just routed through [`EngineError::Validation`] with
+/// [`ValidationKind::Corruption`] instead of `SdkError::Config`. The
+/// pre-migration ff-sdk wrapper re-maps to `SdkError::Config` for
+/// public-API parity; direct backend callers read the
+/// `EngineError::Validation` payload.
+///
+/// `flow_id` + `edge_id` are the caller's expected identities. The
+/// decoder verifies both are present and match the stored values; a
+/// mismatch or absence surfaces as `Corruption` because it indicates
+/// a wrong-key read or an on-disk drift.
+pub fn build_edge_snapshot(
+    flow_id: &FlowId,
+    edge_id: &EdgeId,
+    raw: &HashMap<String, String>,
+) -> Result<EdgeSnapshot, EngineError> {
+    // Unknown-field sweep — reject eagerly so a future FF rename that
+    // landed a new field surfaces as an explicit parse failure rather
+    // than silently dropping data.
+    for k in raw.keys() {
+        if !EDGE_KNOWN_FIELDS.contains(&k.as_str()) {
+            return Err(corruption(
+                "edge_snapshot: edge_hash",
+                None,
+                &format!("has unexpected field '{k}' (protocol drift or corruption?)"),
+            ));
+        }
+    }
+
+    // edge_id cross-check.
+    let stored_edge_id_str = required(raw, "edge_snapshot: edge_hash", "edge_id")?;
+    if stored_edge_id_str != edge_id.to_string() {
+        return Err(corruption(
+            "edge_snapshot: edge_hash",
+            Some("edge_id"),
+            &format!(
+                "'{stored_edge_id_str}' does not match requested edge_id \
+                 '{edge_id}' (key corruption or wrong-key read?)"
+            ),
+        ));
+    }
+
+    // flow_id cross-check.
+    let stored_flow_id_str = required(raw, "edge_snapshot: edge_hash", "flow_id")?;
+    if stored_flow_id_str != flow_id.to_string() {
+        return Err(corruption(
+            "edge_snapshot: edge_hash",
+            Some("flow_id"),
+            &format!(
+                "'{stored_flow_id_str}' does not match requested flow_id \
+                 '{flow_id}' (key corruption or wrong-key read?)"
+            ),
+        ));
+    }
+
+    let upstream_execution_id = parse_eid(raw, "upstream_execution_id")?;
+    let downstream_execution_id = parse_eid(raw, "downstream_execution_id")?;
+
+    let dependency_kind = required(raw, "edge_snapshot: edge_hash", "dependency_kind")?;
+    let satisfaction_condition =
+        required(raw, "edge_snapshot: edge_hash", "satisfaction_condition")?;
+
+    // data_passing_ref is stored as "" when the stager passed None.
+    // Treat empty as absent rather than surfacing an empty String.
+    let data_passing_ref = raw
+        .get("data_passing_ref")
+        .filter(|s| !s.is_empty())
+        .cloned();
+
+    let edge_state = required(raw, "edge_snapshot: edge_hash", "edge_state")?;
+
+    let created_at = parse_ts_required(raw, "edge_snapshot: edge_hash", "created_at")?;
+    let created_by = required(raw, "edge_snapshot: edge_hash", "created_by")?;
+
+    Ok(EdgeSnapshot::new(
+        edge_id.clone(),
+        flow_id.clone(),
+        upstream_execution_id,
+        downstream_execution_id,
+        dependency_kind,
+        satisfaction_condition,
+        data_passing_ref,
+        edge_state,
+        created_at,
+        created_by,
+    ))
+}
+
+/// Format a `Corruption` detail string in the
+/// `"<context>: <field?>: <message>"` shape documented on
+/// [`ValidationKind::Corruption`].
+fn corruption(context: &str, field: Option<&str>, message: &str) -> EngineError {
+    let detail = match field {
+        Some(f) => format!("{context}: {f}: {message}"),
+        None => format!("{context}: {message}"),
+    };
+    EngineError::Validation {
+        kind: ValidationKind::Corruption,
+        detail,
+    }
+}
+
+/// Fetch a required non-empty string field, emitting a `Corruption`
+/// error when the field is absent or empty.
+fn required(
+    raw: &HashMap<String, String>,
+    context: &str,
+    field: &str,
+) -> Result<String, EngineError> {
+    raw.get(field)
+        .filter(|s| !s.is_empty())
+        .cloned()
+        .ok_or_else(|| {
+            corruption(
+                context,
+                Some(field),
+                "is missing or empty (key corruption?)",
+            )
+        })
+}
+
+/// Parse a ms-timestamp field that must be present.
+fn parse_ts_required(
+    raw: &HashMap<String, String>,
+    context: &str,
+    field: &str,
+) -> Result<TimestampMs, EngineError> {
+    let s = required(raw, context, field)?;
+    let ms: i64 = s.parse().map_err(|e| {
+        corruption(
+            context,
+            Some(field),
+            &format!("is not a valid ms timestamp ('{s}'): {e}"),
+        )
+    })?;
+    Ok(TimestampMs::from_millis(ms))
+}
+
+/// Parse a required ExecutionId field.
+fn parse_eid(raw: &HashMap<String, String>, field: &str) -> Result<ExecutionId, EngineError> {
+    let s = required(raw, "edge_snapshot: edge_hash", field)?;
+    ExecutionId::parse(&s).map_err(|e| {
+        corruption(
+            "edge_snapshot: edge_hash",
+            Some(field),
+            &format!("'{s}' is not a valid ExecutionId (key corruption?): {e}"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::partition::PartitionConfig;
+
+    fn fid() -> FlowId {
+        FlowId::new()
+    }
+
+    fn eids_for_flow(f: &FlowId) -> (ExecutionId, ExecutionId) {
+        let cfg = PartitionConfig::default();
+        (
+            ExecutionId::for_flow(f, &cfg),
+            ExecutionId::for_flow(f, &cfg),
+        )
+    }
+
+    fn minimal_edge_hash(
+        flow: &FlowId,
+        edge: &EdgeId,
+        up: &ExecutionId,
+        down: &ExecutionId,
+    ) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("edge_id".into(), edge.to_string());
+        m.insert("flow_id".into(), flow.to_string());
+        m.insert("upstream_execution_id".into(), up.to_string());
+        m.insert("downstream_execution_id".into(), down.to_string());
+        m.insert("dependency_kind".into(), "success_only".into());
+        m.insert("satisfaction_condition".into(), "all_required".into());
+        m.insert("data_passing_ref".into(), String::new());
+        m.insert("edge_state".into(), "pending".into());
+        m.insert("created_at".into(), "1234".into());
+        m.insert("created_by".into(), "engine".into());
+        m
+    }
+
+    #[test]
+    fn round_trips_all_fields() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let raw = minimal_edge_hash(&f, &edge, &up, &down);
+        let snap = build_edge_snapshot(&f, &edge, &raw).unwrap();
+        assert_eq!(snap.edge_id, edge);
+        assert_eq!(snap.flow_id, f);
+        assert_eq!(snap.upstream_execution_id, up);
+        assert_eq!(snap.downstream_execution_id, down);
+        assert_eq!(snap.dependency_kind, "success_only");
+        assert_eq!(snap.satisfaction_condition, "all_required");
+        assert!(snap.data_passing_ref.is_none());
+        assert_eq!(snap.edge_state, "pending");
+        assert_eq!(snap.created_at.0, 1234);
+        assert_eq!(snap.created_by, "engine");
+    }
+
+    #[test]
+    fn data_passing_ref_round_trips_when_set() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("data_passing_ref".into(), "ref://blob-42".into());
+        let snap = build_edge_snapshot(&f, &edge, &raw).unwrap();
+        assert_eq!(snap.data_passing_ref.as_deref(), Some("ref://blob-42"));
+    }
+
+    fn expect_corruption(err: EngineError) -> String {
+        match err {
+            EngineError::Validation {
+                kind: ValidationKind::Corruption,
+                detail,
+            } => detail,
+            other => panic!("expected Validation::Corruption, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_field_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("bogus_future_field".into(), "v".into());
+        let detail = expect_corruption(build_edge_snapshot(&f, &edge, &raw).unwrap_err());
+        assert!(detail.contains("bogus_future_field"), "{detail}");
+    }
+
+    #[test]
+    fn flow_id_mismatch_fails_loud() {
+        let f = fid();
+        let other = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let raw = minimal_edge_hash(&other, &edge, &up, &down);
+        let detail = expect_corruption(build_edge_snapshot(&f, &edge, &raw).unwrap_err());
+        assert!(detail.contains("flow_id"), "{detail}");
+        assert!(detail.contains("does not match"), "{detail}");
+    }
+
+    #[test]
+    fn edge_id_mismatch_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let other_edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let raw = minimal_edge_hash(&f, &other_edge, &up, &down);
+        let detail = expect_corruption(build_edge_snapshot(&f, &edge, &raw).unwrap_err());
+        assert!(detail.contains("edge_id"), "{detail}");
+        assert!(detail.contains("does not match"), "{detail}");
+    }
+
+    #[test]
+    fn missing_required_fields_fail_loud() {
+        for want in [
+            "edge_id",
+            "flow_id",
+            "upstream_execution_id",
+            "downstream_execution_id",
+            "dependency_kind",
+            "satisfaction_condition",
+            "edge_state",
+            "created_at",
+            "created_by",
+        ] {
+            let f = fid();
+            let edge = EdgeId::new();
+            let (up, down) = eids_for_flow(&f);
+            let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+            raw.remove(want);
+            let err = build_edge_snapshot(&f, &edge, &raw)
+                .err()
+                .unwrap_or_else(|| panic!("missing {want} should fail"));
+            let detail = expect_corruption(err);
+            assert!(detail.contains(want), "detail for {want}: {detail}");
+        }
+    }
+
+    #[test]
+    fn malformed_created_at_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("created_at".into(), "not-a-number".into());
+        let detail = expect_corruption(build_edge_snapshot(&f, &edge, &raw).unwrap_err());
+        assert!(detail.contains("created_at"), "{detail}");
+    }
+
+    #[test]
+    fn malformed_upstream_eid_fails_loud() {
+        let f = fid();
+        let edge = EdgeId::new();
+        let (up, down) = eids_for_flow(&f);
+        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
+        raw.insert("upstream_execution_id".into(), "not-an-execution-id".into());
+        let detail = expect_corruption(build_edge_snapshot(&f, &edge, &raw).unwrap_err());
+        assert!(detail.contains("upstream_execution_id"), "{detail}");
+    }
+}

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -3,6 +3,8 @@
 //! Each Args struct defines the typed inputs to a Valkey Function.
 //! Each Result enum defines the possible outcomes (success variants + error codes).
 
+pub mod decode;
+
 use crate::policy::ExecutionPolicy;
 use crate::state::{AttemptType, PublicState, StateVector};
 use crate::types::{
@@ -1174,9 +1176,7 @@ impl std::str::FromStr for StreamCursor {
                 Err(StreamCursorParseError::BareMarkerRejected(s.to_owned()))
             }
             StreamCursorClass::Empty => Err(StreamCursorParseError::Empty),
-            StreamCursorClass::Malformed => {
-                Err(StreamCursorParseError::Malformed(s.to_owned()))
-            }
+            StreamCursorClass::Malformed => Err(StreamCursorParseError::Malformed(s.to_owned())),
         }
     }
 }
@@ -1194,9 +1194,7 @@ impl TryFrom<String> for StreamCursor {
             StreamCursorClass::Start => Ok(Self::Start),
             StreamCursorClass::End => Ok(Self::End),
             StreamCursorClass::Concrete => Ok(Self::At(s)),
-            StreamCursorClass::BareMarker => {
-                Err(StreamCursorParseError::BareMarkerRejected(s))
-            }
+            StreamCursorClass::BareMarker => Err(StreamCursorParseError::BareMarkerRejected(s)),
             StreamCursorClass::Empty => Err(StreamCursorParseError::Empty),
             StreamCursorClass::Malformed => Err(StreamCursorParseError::Malformed(s)),
         }
@@ -2088,6 +2086,50 @@ pub struct EdgeSnapshot {
     pub created_by: String,
 }
 
+/// Direction marker for [`crate::engine_backend::EngineBackend::list_edges`].
+///
+/// Carries the subject execution whose adjacency side the caller wants
+/// to list — mirrors the internal `AdjacencySide + subject_eid` pair
+/// the ff-sdk free-fn `list_edges_from_set` already uses. Keeping
+/// direction + subject fused in one enum means the trait method has a
+/// single `direction` parameter rather than a `(side, eid)` pair, and
+/// the backend impl can't forget one of the two.
+///
+/// * `Outgoing { from_node }` — the caller wants every edge whose
+///   `upstream_execution_id == from_node`. Corresponds to the
+///   `out:<execution_id>` adjacency SET under the execution's flow
+///   partition.
+/// * `Incoming { to_node }` — the caller wants every edge whose
+///   `downstream_execution_id == to_node`. Corresponds to the
+///   `in:<execution_id>` adjacency SET under the execution's flow
+///   partition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EdgeDirection {
+    /// Edges leaving `from_node` — `out:` adjacency SET.
+    Outgoing {
+        /// The subject execution whose outgoing edges to list.
+        from_node: ExecutionId,
+    },
+    /// Edges landing on `to_node` — `in:` adjacency SET.
+    Incoming {
+        /// The subject execution whose incoming edges to list.
+        to_node: ExecutionId,
+    },
+}
+
+impl EdgeDirection {
+    /// Return the subject execution id regardless of direction. Shared
+    /// helper for backend impls that need the execution id for the
+    /// initial `HGET exec_core.flow_id` lookup (flow routing) before
+    /// they know which adjacency SET to read.
+    pub fn subject(&self) -> &ExecutionId {
+        match self {
+            Self::Outgoing { from_node } => from_node,
+            Self::Incoming { to_node } => to_node,
+        }
+    }
+}
+
 impl EdgeSnapshot {
     /// Construct an [`EdgeSnapshot`]. Present so downstream crates
     /// (ff-sdk's `describe_edge` / `list_*_edges`) can assemble the
@@ -2195,7 +2237,10 @@ mod tests {
     #[test]
     fn stream_cursor_from_str_accepts_wire_tokens() {
         use std::str::FromStr;
-        assert_eq!(StreamCursor::from_str("start").unwrap(), StreamCursor::Start);
+        assert_eq!(
+            StreamCursor::from_str("start").unwrap(),
+            StreamCursor::Start
+        );
         assert_eq!(StreamCursor::from_str("end").unwrap(), StreamCursor::End);
         assert_eq!(
             StreamCursor::from_str("123").unwrap(),
@@ -2236,7 +2281,9 @@ mod tests {
     #[test]
     fn stream_cursor_from_str_rejects_malformed() {
         use std::str::FromStr;
-        for bad in ["abc", "-1", "1-", "-1-2", "1-2-3", "1.2", "1 2", "Start", "END"] {
+        for bad in [
+            "abc", "-1", "1-", "-1-2", "1-2-3", "1.2", "1 2", "Start", "END",
+        ] {
             assert!(
                 matches!(
                     StreamCursor::from_str(bad),
@@ -2272,8 +2319,14 @@ mod tests {
 
     #[test]
     fn stream_cursor_serializes_as_bare_string() {
-        assert_eq!(serde_json::to_string(&StreamCursor::Start).unwrap(), r#""start""#);
-        assert_eq!(serde_json::to_string(&StreamCursor::End).unwrap(), r#""end""#);
+        assert_eq!(
+            serde_json::to_string(&StreamCursor::Start).unwrap(),
+            r#""start""#
+        );
+        assert_eq!(
+            serde_json::to_string(&StreamCursor::End).unwrap(),
+            r#""end""#
+        );
         assert_eq!(
             serde_json::to_string(&StreamCursor::At("123-0".into())).unwrap(),
             r#""123-0""#
@@ -2307,10 +2360,7 @@ mod tests {
     fn stream_cursor_into_wire_string_moves_without_cloning() {
         assert_eq!(StreamCursor::Start.into_wire_string(), "-");
         assert_eq!(StreamCursor::End.into_wire_string(), "+");
-        assert_eq!(
-            StreamCursor::At("17-3".into()).into_wire_string(),
-            "17-3"
-        );
+        assert_eq!(StreamCursor::At("17-3".into()).into_wire_string(), "17-3");
     }
 }
 

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -53,6 +53,8 @@ use crate::backend::{
     ReclaimToken, ResumeSignal, WaitpointSpec,
 };
 use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult};
+#[cfg(feature = "core")]
+use crate::contracts::{EdgeDirection, EdgeSnapshot};
 use crate::engine_error::EngineError;
 use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 
@@ -112,11 +114,7 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// Terminal success. Borrows `handle` (round-4 M-D2) so callers
     /// can retry under `EngineError::Transport` without losing the
     /// cookie. Payload is `Option<Vec<u8>>` per the note above.
-    async fn complete(
-        &self,
-        handle: &Handle,
-        payload: Option<Vec<u8>>,
-    ) -> Result<(), EngineError>;
+    async fn complete(&self, handle: &Handle, payload: Option<Vec<u8>>) -> Result<(), EngineError>;
 
     /// Terminal failure with classification. Returns [`FailOutcome`]
     /// so the caller learns whether a retry was scheduled.
@@ -167,25 +165,17 @@ pub trait EngineBackend: Send + Sync + 'static {
 
     /// Non-mutating observation of signals that satisfied the handle's
     /// resume condition.
-    async fn observe_signals(&self, handle: &Handle)
-        -> Result<Vec<ResumeSignal>, EngineError>;
+    async fn observe_signals(&self, handle: &Handle) -> Result<Vec<ResumeSignal>, EngineError>;
 
     /// Consume a reclaim grant to mint a resumed-kind handle. Returns
     /// `Ok(None)` when the grant's target execution is no longer
     /// resumable (already reclaimed, terminal, etc.).
-    async fn claim_from_reclaim(
-        &self,
-        token: ReclaimToken,
-    ) -> Result<Option<Handle>, EngineError>;
+    async fn claim_from_reclaim(&self, token: ReclaimToken) -> Result<Option<Handle>, EngineError>;
 
     // Round-5 amendment: lease-releasing peers of `suspend`.
 
     /// Park the execution until `delay_until`, releasing the lease.
-    async fn delay(
-        &self,
-        handle: &Handle,
-        delay_until: TimestampMs,
-    ) -> Result<(), EngineError>;
+    async fn delay(&self, handle: &Handle, delay_until: TimestampMs) -> Result<(), EngineError>;
 
     /// Mark the execution as waiting for its child flow to complete,
     /// releasing the lease.
@@ -200,10 +190,36 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<Option<ExecutionSnapshot>, EngineError>;
 
     /// Snapshot a flow by id. `Ok(None)` ⇒ no such flow.
-    async fn describe_flow(
+    async fn describe_flow(&self, id: &FlowId) -> Result<Option<FlowSnapshot>, EngineError>;
+
+    /// List dependency edges adjacent to an execution. Read-only; the
+    /// backend resolves the subject execution's flow, reads the
+    /// direction-specific adjacency SET, and decodes each member's
+    /// flow-scoped `edge:<edge_id>` hash.
+    ///
+    /// Returns an empty `Vec` when the subject has no edges on the
+    /// requested side — including standalone executions (no owning
+    /// flow). Ordering is unspecified: the underlying adjacency SET
+    /// is an unordered SMEMBERS read. Callers that need deterministic
+    /// order should sort by [`EdgeSnapshot::edge_id`] /
+    /// [`EdgeSnapshot::created_at`] themselves.
+    ///
+    /// Parse failures on the edge hash surface as
+    /// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`]
+    /// — unknown fields, missing required fields, endpoint mismatches
+    /// against the adjacency SET all fail loud rather than silently
+    /// returning partial results.
+    ///
+    /// Gated on the `core` feature — edge reads are part of the
+    /// minimal engine surface a Postgres-style backend must honour.
+    ///
+    /// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`]: crate::engine_error::EngineError::Validation
+    #[cfg(feature = "core")]
+    async fn list_edges(
         &self,
-        id: &FlowId,
-    ) -> Result<Option<FlowSnapshot>, EngineError>;
+        flow_id: &FlowId,
+        direction: EdgeDirection,
+    ) -> Result<Vec<EdgeSnapshot>, EngineError>;
 
     /// Operator-initiated cancellation of a flow and (optionally) its
     /// member executions. See RFC-012 §3.1.1 for the policy /wait
@@ -237,4 +253,3 @@ pub trait EngineBackend: Send + Sync + 'static {
 /// EngineBackend>` use.
 #[allow(dead_code)]
 fn _assert_dyn_compatible(_: &dyn EngineBackend) {}
-

--- a/crates/ff-core/src/engine_error.rs
+++ b/crates/ff-core/src/engine_error.rs
@@ -162,6 +162,18 @@ pub enum ValidationKind {
     InvalidTagKey,
     /// Unrecognized stream frame type.
     InvalidFrameType,
+    /// On-disk corruption or protocol drift: an engine-owned hash /
+    /// key returned a field shape the decoder could not parse (missing
+    /// required field, malformed timestamp, unknown extra field,
+    /// cross-field identity mismatch, etc.). `detail` carries the
+    /// decoder's diagnostic string — the specific field name and/or
+    /// offending value — in the form
+    /// `"<context>: <field?>: <message>"` so operators can locate the
+    /// bad key without reparsing.
+    ///
+    /// Classified as `Terminal`: a consumer retrying the read will
+    /// see the same bytes. Surface to the operator; do not loop.
+    Corruption,
 }
 
 /// Contention sub-kinds (retryable per RFC-010 §10.7). Caller should
@@ -228,7 +240,9 @@ pub enum ConflictKind {
     /// to perform the follow-up read and promote the error.
     ///
     /// [`EdgeSnapshot`]: crate::contracts::EdgeSnapshot
-    DependencyAlreadyExists { existing: crate::contracts::EdgeSnapshot },
+    DependencyAlreadyExists {
+        existing: crate::contracts::EdgeSnapshot,
+    },
     /// Edge would create a cycle.
     CycleDetected,
     /// Self-referencing edge (upstream == downstream).

--- a/crates/ff-readiness-tests/src/valkey.rs
+++ b/crates/ff-readiness-tests/src/valkey.rs
@@ -3,7 +3,9 @@
 //! PR-D1 keeps this a passthrough — future PRs (D2+) may add
 //! version-probe + matrix-cell plumbing here.
 
-pub use ff_test::fixtures::{build_client_from_env, env_flag, TestCluster, TEST_PARTITION_CONFIG};
+pub use ff_test::fixtures::{
+    backend_config_from_env, build_client_from_env, env_flag, TestCluster, TEST_PARTITION_CONFIG,
+};
 
 /// Probe Valkey's server version. Prefers `valkey_version:` from INFO,
 /// falls back to `redis_version:` for older or Redis-OSS deployments.

--- a/crates/ff-readiness-tests/tests/common/mod.rs
+++ b/crates/ff-readiness-tests/tests/common/mod.rs
@@ -42,13 +42,7 @@ pub struct Dag {
 /// Spawn an SDK worker against the lane + namespace.
 pub async fn spawn_worker(lane: &str, ns: &str, suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_readiness_tests::valkey::env_flag("FF_TLS"),
-        cluster: ff_readiness_tests::valkey::env_flag("FF_CLUSTER"),
+        backend: ff_readiness_tests::valkey::backend_config_from_env(),
         worker_id: WorkerId::new(format!("readiness-fanout-worker-{suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("readiness-fanout-inst-{suffix}")),
         namespace: Namespace::new(ns),

--- a/crates/ff-readiness-tests/tests/inprocess_multi_test.rs
+++ b/crates/ff-readiness-tests/tests/inprocess_multi_test.rs
@@ -99,13 +99,7 @@ async fn drive_one_execution(tag: &str) {
         .expect("add_execution_to_flow");
 
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_readiness_tests::valkey::env_flag("FF_TLS"),
-        cluster: ff_readiness_tests::valkey::env_flag("FF_CLUSTER"),
+        backend: ff_readiness_tests::valkey::backend_config_from_env(),
         worker_id: WorkerId::new(format!("readiness-multi-worker-{tag}")),
         worker_instance_id: WorkerInstanceId::new(format!("readiness-multi-inst-{tag}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
+++ b/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
@@ -100,13 +100,7 @@ async fn lifecycle_happy_path() {
 
     // 6. Spawn in-process SDK worker using direct-valkey-claim.
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_readiness_tests::valkey::env_flag("FF_TLS"),
-        cluster: ff_readiness_tests::valkey::env_flag("FF_CLUSTER"),
+        backend: ff_readiness_tests::valkey::backend_config_from_env(),
         worker_id: WorkerId::new("readiness-happy-worker"),
         worker_instance_id: WorkerInstanceId::new("readiness-happy-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-readiness-tests/tests/lifecycle_retry_backoff.rs
+++ b/crates/ff-readiness-tests/tests/lifecycle_retry_backoff.rs
@@ -132,13 +132,7 @@ async fn lifecycle_retry_backoff() {
 
     // 6. Spawn in-process SDK worker.
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_readiness_tests::valkey::env_flag("FF_TLS"),
-        cluster: ff_readiness_tests::valkey::env_flag("FF_CLUSTER"),
+        backend: ff_readiness_tests::valkey::backend_config_from_env(),
         worker_id: WorkerId::new("readiness-retry-worker"),
         worker_instance_id: WorkerInstanceId::new("readiness-retry-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-readiness-tests/tests/waitpoint_hmac_roundtrip.rs
+++ b/crates/ff-readiness-tests/tests/waitpoint_hmac_roundtrip.rs
@@ -77,13 +77,7 @@ async fn waitpoint_hmac_roundtrip() {
 
     // 2. Spawn the SDK worker once — all four executions below share it.
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_readiness_tests::valkey::env_flag("FF_TLS"),
-        cluster: ff_readiness_tests::valkey::env_flag("FF_CLUSTER"),
+        backend: ff_readiness_tests::valkey::backend_config_from_env(),
         worker_id: WorkerId::new("readiness-hmac-worker"),
         worker_instance_id: WorkerInstanceId::new("readiness-hmac-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-sdk/src/config.rs
+++ b/crates/ff-sdk/src/config.rs
@@ -1,15 +1,27 @@
+use ff_core::backend::BackendConfig;
 use ff_core::types::{LaneId, Namespace, WorkerId, WorkerInstanceId};
 
 /// Configuration for a FlowFabric worker.
+///
+/// **RFC-012 Stage 1c tranche 1.** Valkey-specific connection
+/// parameters (`host`, `port`, `tls`, `cluster`) moved to the nested
+/// [`BackendConfig`] field, which also carries
+/// [`BackendTimeouts`](ff_core::backend::BackendTimeouts) and
+/// [`BackendRetry`](ff_core::backend::BackendRetry) policy. Build one
+/// with [`BackendConfig::valkey`] for the common standalone case; for
+/// TLS / cluster / tuned retry, construct the
+/// [`ValkeyConnection`](ff_core::backend::ValkeyConnection) and
+/// [`BackendConfig`] fields directly.
+///
+/// Worker-policy fields (`lease_ttl_ms`, `claim_poll_interval_ms`,
+/// capability set, lane list, identity) stay on `WorkerConfig` —
+/// those are orthogonal to the storage backend choice.
+///
+/// `WorkerConfig::new` was removed in this stage (pre-1.0 clean
+/// break); construct via struct literal.
 pub struct WorkerConfig {
-    /// Valkey hostname. Default: `"localhost"`.
-    pub host: String,
-    /// Valkey port. Default: `6379`.
-    pub port: u16,
-    /// Enable TLS for the Valkey connection.
-    pub tls: bool,
-    /// Enable Valkey cluster mode.
-    pub cluster: bool,
+    /// Backend connection + shared timeouts / retry policy.
+    pub backend: BackendConfig,
     /// Logical worker identity (e.g., "gpu-worker-pool-1").
     pub worker_id: WorkerId,
     /// Concrete worker process/runtime instance identity (e.g., container ID).
@@ -29,31 +41,6 @@ pub struct WorkerConfig {
 }
 
 impl WorkerConfig {
-    /// Create a minimal config for a single-lane worker.
-    pub fn new(
-        host: impl Into<String>,
-        port: u16,
-        worker_id: impl Into<String>,
-        worker_instance_id: impl Into<String>,
-        namespace: impl Into<String>,
-        lane: impl Into<String>,
-    ) -> Self {
-        Self {
-            host: host.into(),
-            port,
-            tls: false,
-            cluster: false,
-            worker_id: WorkerId::new(worker_id),
-            worker_instance_id: WorkerInstanceId::new(worker_instance_id),
-            namespace: Namespace::new(namespace),
-            lanes: vec![LaneId::new(lane)],
-            capabilities: Vec::new(),
-            lease_ttl_ms: 30_000,
-            claim_poll_interval_ms: 1_000,
-            max_concurrent_tasks: 1,
-        }
-    }
-
     /// Lease renewal interval: TTL / 3 (renew at 1/3 of TTL, leaving 2/3 margin).
     pub fn renewal_interval_ms(&self) -> u64 {
         self.lease_ttl_ms / 3

--- a/crates/ff-sdk/src/engine_error.rs
+++ b/crates/ff-sdk/src/engine_error.rs
@@ -82,7 +82,7 @@ pub async fn enrich_dependency_conflict(
     if raw.is_empty() {
         return Err(transport_script(ScriptError::DependencyAlreadyExists));
     }
-    match crate::snapshot::build_edge_snapshot_public(flow_id, edge_id, &raw) {
+    match ff_core::contracts::decode::build_edge_snapshot(flow_id, edge_id, &raw) {
         Ok(existing) => Ok(EngineError::Conflict(ConflictKind::DependencyAlreadyExists {
             existing,
         })),

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -18,18 +18,22 @@
 //!
 //! ```rust,ignore
 //! use ff_sdk::{FlowFabricWorker, WorkerConfig};
-//! use ff_core::types::LaneId;
+//! use ff_core::backend::BackendConfig;
+//! use ff_core::types::{LaneId, Namespace, WorkerId, WorkerInstanceId};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), ff_sdk::SdkError> {
-//!     let config = WorkerConfig::new(
-//!         "localhost",
-//!         6379,
-//!         "my-worker",
-//!         "my-worker-instance-1",
-//!         "default",
-//!         "main",
-//!     );
+//!     let config = WorkerConfig {
+//!         backend: BackendConfig::valkey("localhost", 6379),
+//!         worker_id: WorkerId::new("my-worker"),
+//!         worker_instance_id: WorkerInstanceId::new("my-worker-instance-1"),
+//!         namespace: Namespace::new("default"),
+//!         lanes: vec![LaneId::new("main")],
+//!         capabilities: Vec::new(),
+//!         lease_ttl_ms: 30_000,
+//!         claim_poll_interval_ms: 1_000,
+//!         max_concurrent_tasks: 1,
+//!     };
 //!
 //!     let worker = FlowFabricWorker::connect(config).await?;
 //!     let lane = LaneId::new("main");

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -1,624 +1,79 @@
 //! Typed read-models that decouple consumers from FF's storage engine.
 //!
-//! Today the only call here is [`FlowFabricWorker::describe_execution`],
-//! which replaces the HGETALL-on-exec_core pattern downstream consumers
-//! rely on with a typed snapshot. The engine remains free to rename
-//! hash fields or restructure keys under this surface — see issue #58
-//! for the strategic context (decoupling ahead of a Postgres backend
-//! port).
+//! **RFC-012 Stage 1c T3:** after T3 this module is thin forwarders.
+//! The decoders (`build_execution_snapshot`, `build_flow_snapshot`,
+//! `build_edge_snapshot`) live in `ff_core::contracts::decode` and
+//! the pipeline bodies that invoke them live on
+//! [`ff_backend_valkey::ValkeyBackend`] as `EngineBackend` trait
+//! methods. The three `describe_*` functions here are now 3-line
+//! delegations to `self.backend`; `list_incoming_edges` /
+//! `list_outgoing_edges` keep their `resolve_flow_id` step (the
+//! trait's `list_edges` requires a `FlowId` argument) and then call
+//! the trait method.
+//!
+//! See issue #58 for the strategic context (engine-surface sealing
+//! toward the Postgres backend port).
 //!
 //! Snapshot types (`ExecutionSnapshot`, `AttemptSummary`, `LeaseSummary`,
-//! `FlowSnapshot`) live in [`ff_core::contracts`] so non-SDK consumers
-//! (tests, REST server, future alternate backends) can share them
-//! without depending on ff-sdk.
+//! `FlowSnapshot`, `EdgeSnapshot`) live in [`ff_core::contracts`] so
+//! non-SDK consumers (tests, REST server, alternate backends) share
+//! them without depending on ff-sdk.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
-use ff_core::contracts::decode::build_edge_snapshot as build_edge_snapshot_core;
-use ff_core::contracts::{
-    AttemptSummary, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, LeaseSummary,
-};
-use ff_core::keys::{ExecKeyContext, FlowKeyContext};
+use ff_core::contracts::{EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot};
+use ff_core::keys::ExecKeyContext;
 use ff_core::partition::{execution_partition, flow_partition};
-use ff_core::state::PublicState;
-use ff_core::types::{
-    AttemptId, AttemptIndex, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch, Namespace,
-    TimestampMs, WaitpointId, WorkerInstanceId,
-};
+use ff_core::types::{EdgeId, ExecutionId, FlowId};
 
 use crate::SdkError;
 use crate::worker::FlowFabricWorker;
 
 impl FlowFabricWorker {
-    /// Read a typed snapshot of one execution.
+    /// Read a typed snapshot of one execution. See
+    /// [`ExecutionSnapshot`] for field semantics.
     ///
-    /// Returns `Ok(None)` when no execution exists at `id` (exec_core
-    /// hash absent). Returns `Ok(Some(snapshot))` on success. Errors
-    /// propagate Valkey transport faults and decode failures.
-    ///
-    /// # Consistency
-    ///
-    /// The snapshot is assembled from two pipelined `HGETALL`s — one
-    /// for `exec_core`, one for the sibling tags hash — issued in a
-    /// single round trip against the partition holding the execution.
-    /// The two reads share a hash-tag so they always land on the same
-    /// Valkey slot in cluster mode. They are NOT MULTI/EXEC-atomic:
-    /// a concurrent FCALL that HSETs both keys can interleave, and a
-    /// caller may observe exec_core fields from epoch `N+1` alongside
-    /// tags from epoch `N` (or vice versa). This matches the
-    /// last-write-wins-per-field semantics every existing HGETALL
-    /// consumer already assumes.
-    ///
-    /// # Field semantics
-    ///
-    /// * `public_state` is the engine-maintained derived label written
-    ///   atomically by every state-mutating FCALL. Parsed from the
-    ///   snake_case string stored on exec_core.
-    /// * `blocking_reason` / `blocking_detail` — `None` when the
-    ///   exec_core field is the empty string (cleared on transition).
-    /// * `current_attempt` — `None` before the first claim (exec_core
-    ///   `current_attempt_id` empty).
-    /// * `current_lease` — `None` when no lease is held (typical for
-    ///   terminal, suspended, or pre-claim executions).
-    /// * `current_waitpoint` — `None` unless an active suspension has
-    ///   pinned a waitpoint id.
-    /// * `tags` — empty map if the tags hash is absent (common for
-    ///   executions created without `tags_json`).
+    /// Post-T3 this is a thin forwarder onto the bundled
+    /// [`EngineBackend::describe_execution`](ff_core::engine_backend::EngineBackend::describe_execution)
+    /// impl; the HGETALL pipeline body and strict-parse decoder both
+    /// live in `ff-backend-valkey` / `ff-core` so alternate backends
+    /// can serve the same call shape. Parse failures surface as
+    /// `SdkError::Engine(EngineError::Validation { kind: Corruption, .. })`.
     pub async fn describe_execution(
         &self,
         id: &ExecutionId,
     ) -> Result<Option<ExecutionSnapshot>, SdkError> {
-        let partition = execution_partition(id, self.partition_config());
-        let ctx = ExecKeyContext::new(&partition, id);
-        let core_key = ctx.core();
-        let tags_key = ctx.tags();
-
-        // Pipeline the two HGETALLs in one round trip. The two keys
-        // share `{fp:N}` so cluster mode routes them to the same slot.
-        let mut pipe = self.client().pipeline();
-        let core_slot = pipe
-            .cmd::<HashMap<String, String>>("HGETALL")
-            .arg(&core_key)
-            .finish();
-        let tags_slot = pipe
-            .cmd::<HashMap<String, String>>("HGETALL")
-            .arg(&tags_key)
-            .finish();
-        pipe.execute().await.map_err(|e| crate::backend_context(e, "describe_execution: pipeline HGETALL exec_core + tags"))?;
-
-        let core = core_slot.value().map_err(|e| crate::backend_context(e, "describe_execution: decode HGETALL exec_core"))?;
-        if core.is_empty() {
-            return Ok(None);
-        }
-        let tags_raw = tags_slot.value().map_err(|e| crate::backend_context(e, "describe_execution: decode HGETALL tags"))?;
-
-        build_execution_snapshot(id.clone(), &core, tags_raw)
+        Ok(self.backend_ref().describe_execution(id).await?)
     }
-}
 
-/// Assemble an [`ExecutionSnapshot`] from the raw HGETALL field maps.
-///
-/// Kept as a free function so a future unit test can feed synthetic
-/// maps without a live Valkey.
-fn build_execution_snapshot(
-    execution_id: ExecutionId,
-    core: &HashMap<String, String>,
-    tags_raw: HashMap<String, String>,
-) -> Result<Option<ExecutionSnapshot>, SdkError> {
-    let public_state = parse_public_state(opt_str(core, "public_state").unwrap_or(""))?;
-
-    // `LaneId::try_new` validates non-empty + ASCII-printable + <= 64 bytes.
-    // Exec_core writes a LaneId that already passed these invariants at
-    // ingress; a read that fails validation here signals on-disk
-    // corruption — surface it rather than silently constructing an
-    // invalid LaneId that would mis-partition downstream.
-    let lane_id =
-        LaneId::try_new(opt_str(core, "lane_id").unwrap_or("")).map_err(|e| SdkError::Config {
-            context: "describe_execution: exec_core".into(),
-            field: Some("lane_id".into()),
-            message: format!("fails LaneId validation (key corruption?): {e}"),
-        })?;
-
-    let namespace_str = opt_str(core, "namespace").unwrap_or("").to_owned();
-    let namespace = Namespace::new(namespace_str);
-
-    let flow_id = opt_str(core, "flow_id")
-        .filter(|s| !s.is_empty())
-        .map(|s| {
-            FlowId::parse(s).map_err(|e| SdkError::Config {
-                context: "describe_execution: exec_core".into(),
-                field: Some("flow_id".into()),
-                message: format!("is not a valid UUID (key corruption?): {e}"),
-            })
-        })
-        .transpose()?;
-
-    let blocking_reason = opt_str(core, "blocking_reason")
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-    let blocking_detail = opt_str(core, "blocking_detail")
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-
-    // created_at + last_mutation_at are engine-maintained invariants
-    // (lua/execution.lua writes both on create; every mutating FCALL
-    // updates last_mutation_at). Missing values indicate on-disk
-    // corruption, not a valid pre-create state — fail loudly.
-    let created_at =
-        parse_ts(core, "describe_execution: exec_core", "created_at")?.ok_or_else(|| {
-            SdkError::Config {
-                context: "describe_execution: exec_core".into(),
-                field: Some("created_at".into()),
-                message: "is missing or empty (key corruption?)".into(),
-            }
-        })?;
-    let last_mutation_at = parse_ts(core, "describe_execution: exec_core", "last_mutation_at")?
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_execution: exec_core".into(),
-            field: Some("last_mutation_at".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?;
-
-    let total_attempt_count: u32 =
-        parse_u32_strict(core, "describe_execution: exec_core", "total_attempt_count")?
-            .unwrap_or(0);
-
-    let current_attempt = build_attempt_summary(core)?;
-    let current_lease = build_lease_summary(core)?;
-
-    let current_waitpoint = opt_str(core, "current_waitpoint_id")
-        .filter(|s| !s.is_empty())
-        .map(|s| {
-            WaitpointId::parse(s).map_err(|e| SdkError::Config {
-                context: "describe_execution: exec_core".into(),
-                field: Some("current_waitpoint_id".into()),
-                message: format!("is not a valid UUID (key corruption?): {e}"),
-            })
-        })
-        .transpose()?;
-
-    let tags: BTreeMap<String, String> = tags_raw.into_iter().collect();
-
-    Ok(Some(ExecutionSnapshot::new(
-        execution_id,
-        flow_id,
-        lane_id,
-        namespace,
-        public_state,
-        blocking_reason,
-        blocking_detail,
-        current_attempt,
-        current_lease,
-        current_waitpoint,
-        created_at,
-        last_mutation_at,
-        total_attempt_count,
-        tags,
-    )))
-}
-
-fn opt_str<'a>(map: &'a HashMap<String, String>, field: &str) -> Option<&'a str> {
-    map.get(field).map(String::as_str)
-}
-
-/// Strictly parse a ms-timestamp field. `Ok(None)` when absent/empty,
-/// `Err` on unparseable content. `context` names both the calling
-/// FCALL and the hash (e.g. `"describe_execution: exec_core"`) so
-/// error messages point to the exact source of corruption.
-fn parse_ts(
-    map: &HashMap<String, String>,
-    context: &str,
-    field: &str,
-) -> Result<Option<TimestampMs>, SdkError> {
-    match opt_str(map, field).filter(|s| !s.is_empty()) {
-        None => Ok(None),
-        Some(raw) => {
-            let ms: i64 = raw.parse().map_err(|e| SdkError::Config {
-                context: context.to_owned(),
-                field: Some(field.to_owned()),
-                message: format!("is not a valid ms timestamp ('{raw}'): {e}"),
-            })?;
-            Ok(Some(TimestampMs::from_millis(ms)))
-        }
-    }
-}
-
-/// Strictly parse a `u32` field. Returns `Ok(None)` when the field is
-/// absent or empty (a valid pre-write state), `Err` when the value is
-/// present but unparseable (on-disk corruption), `Ok(Some(v))` otherwise.
-/// `context` is the caller/hash prefix used in error messages.
-fn parse_u32_strict(
-    map: &HashMap<String, String>,
-    context: &str,
-    field: &str,
-) -> Result<Option<u32>, SdkError> {
-    match opt_str(map, field).filter(|s| !s.is_empty()) {
-        None => Ok(None),
-        Some(raw) => Ok(Some(raw.parse().map_err(|e| SdkError::Config {
-            context: context.to_owned(),
-            field: Some(field.to_owned()),
-            message: format!("is not a valid u32 ('{raw}'): {e}"),
-        })?)),
-    }
-}
-
-/// Strictly parse a `u64` field. Semantics mirror [`parse_u32_strict`].
-fn parse_u64_strict(
-    map: &HashMap<String, String>,
-    context: &str,
-    field: &str,
-) -> Result<Option<u64>, SdkError> {
-    match opt_str(map, field).filter(|s| !s.is_empty()) {
-        None => Ok(None),
-        Some(raw) => Ok(Some(raw.parse().map_err(|e| SdkError::Config {
-            context: context.to_owned(),
-            field: Some(field.to_owned()),
-            message: format!("is not a valid u64 ('{raw}'): {e}"),
-        })?)),
-    }
-}
-
-fn parse_public_state(raw: &str) -> Result<PublicState, SdkError> {
-    // exec_core stores the snake_case literal (e.g. "waiting"). PublicState's
-    // Deserialize accepts the JSON-quoted form, so wrap + delegate.
-    let quoted = format!("\"{raw}\"");
-    serde_json::from_str(&quoted).map_err(|e| SdkError::Config {
-        context: "describe_execution: exec_core".into(),
-        field: Some("public_state".into()),
-        message: format!("'{raw}' is not a known public state: {e}"),
-    })
-}
-
-fn build_attempt_summary(
-    core: &HashMap<String, String>,
-) -> Result<Option<AttemptSummary>, SdkError> {
-    let attempt_id_str = match opt_str(core, "current_attempt_id").filter(|s| !s.is_empty()) {
-        None => return Ok(None),
-        Some(s) => s,
-    };
-    let attempt_id = AttemptId::parse(attempt_id_str).map_err(|e| SdkError::Config {
-        context: "describe_execution: exec_core".into(),
-        field: Some("current_attempt_id".into()),
-        message: format!("is not a valid UUID: {e}"),
-    })?;
-    // When `current_attempt_id` is set, `current_attempt_index` MUST be
-    // set too — lua/execution.lua writes both atomically in
-    // `ff_claim_execution`. A missing index while the id is populated
-    // is corruption, not a valid intermediate state.
-    let attempt_index = parse_u32_strict(
-        core,
-        "describe_execution: exec_core",
-        "current_attempt_index",
-    )?
-    .ok_or_else(|| SdkError::Config {
-        context: "describe_execution: exec_core".into(),
-        field: Some("current_attempt_index".into()),
-        message: "is missing while current_attempt_id is set (key corruption?)".into(),
-    })?;
-    Ok(Some(AttemptSummary::new(
-        attempt_id,
-        AttemptIndex::new(attempt_index),
-    )))
-}
-
-fn build_lease_summary(core: &HashMap<String, String>) -> Result<Option<LeaseSummary>, SdkError> {
-    // A lease is "held" when the worker_instance_id field is populated
-    // AND lease_expires_at is set. Both clear together on revoke/expire
-    // (see clear_lease_and_indexes in lua/helpers.lua).
-    let wid_str = match opt_str(core, "current_worker_instance_id").filter(|s| !s.is_empty()) {
-        None => return Ok(None),
-        Some(s) => s,
-    };
-    let expires_at = match parse_ts(core, "describe_execution: exec_core", "lease_expires_at")? {
-        None => return Ok(None),
-        Some(ts) => ts,
-    };
-    // A lease is only "held" if the epoch is present too — lua/helpers.lua
-    // sets/clears epoch atomically with wid + expires_at. Parse strictly
-    // and require it: a missing epoch alongside a live wid is corruption.
-    let epoch = parse_u64_strict(core, "describe_execution: exec_core", "current_lease_epoch")?
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_execution: exec_core".into(),
-            field: Some("current_lease_epoch".into()),
-            message: "is missing while current_worker_instance_id is set (key corruption?)".into(),
-        })?;
-    Ok(Some(LeaseSummary::new(
-        LeaseEpoch::new(epoch),
-        WorkerInstanceId::new(wid_str.to_owned()),
-        expires_at,
-    )))
-}
-
-// ═══════════════════════════════════════════════════════════════════════
-// describe_flow (issue #58.2)
-// ═══════════════════════════════════════════════════════════════════════
-
-/// FF-owned snake_case fields on flow_core. Any HGETALL field NOT in
-/// this set AND matching the `^[a-z][a-z0-9_]*\.` namespaced-tag shape
-/// is surfaced on [`FlowSnapshot::tags`]. Fields that are neither FF-
-/// owned nor namespaced (unexpected shapes) are surfaced as a `Config`
-/// error so on-disk corruption or protocol drift fails loud.
-const FLOW_CORE_KNOWN_FIELDS: &[&str] = &[
-    // flow_id is consumed + validated up-front in build_flow_snapshot but
-    // must still be listed here so the unknown-field sweep downstream
-    // doesn't flag it as corruption.
-    "flow_id",
-    "flow_kind",
-    "namespace",
-    "public_flow_state",
-    "graph_revision",
-    "node_count",
-    "edge_count",
-    "created_at",
-    "last_mutation_at",
-    "cancelled_at",
-    "cancel_reason",
-    "cancellation_policy",
-];
-
-impl FlowFabricWorker {
-    /// Read a typed snapshot of one flow.
+    /// Read a typed snapshot of one flow. See [`FlowSnapshot`] for
+    /// field semantics.
     ///
-    /// Returns `Ok(None)` when no flow exists at `id` (flow_core hash
-    /// absent). Returns `Ok(Some(snapshot))` on success. Errors
-    /// propagate Valkey transport faults and decode failures.
-    ///
-    /// # Consistency
-    ///
-    /// The snapshot is assembled from a single `HGETALL flow_core`. No
-    /// second key is pipelined: unlike `describe_execution`, flow tags
-    /// live inline on `flow_core` under the namespaced-prefix
-    /// convention (see [`FlowSnapshot::tags`]). A single round trip is
-    /// sufficient and reflects last-write-wins-per-field semantics
-    /// under concurrent FCALLs — identical to every existing HGETALL
-    /// consumer.
-    ///
-    /// # Field semantics
-    ///
-    /// * `public_flow_state` — engine-written literal (`open`,
-    ///   `running`, `blocked`, `cancelled`, `completed`, `failed`).
-    ///   Surfaced as `String` because FF has no typed enum yet.
-    /// * `cancelled_at` / `cancel_reason` / `cancellation_policy` —
-    ///   populated only after `cancel_flow`. `None` for live flows
-    ///   and for pre-cancel_flow-persistence-era flows.
-    /// * `tags` — any flow_core field matching `^[a-z][a-z0-9_]*\.`
-    ///   (the namespaced-tag convention). FF's own fields stay in
-    ///   snake_case without dots, so there's no collision. Fields
-    ///   that match neither shape are treated as corruption and fail
-    ///   loud.
+    /// Post-T3 this is a thin forwarder onto the bundled
+    /// [`EngineBackend::describe_flow`](ff_core::engine_backend::EngineBackend::describe_flow)
+    /// impl.
     pub async fn describe_flow(&self, id: &FlowId) -> Result<Option<FlowSnapshot>, SdkError> {
-        let partition = flow_partition(id, self.partition_config());
-        let ctx = FlowKeyContext::new(&partition, id);
-        let core_key = ctx.core();
-
-        let raw: HashMap<String, String> = self
-            .client()
-            .cmd("HGETALL")
-            .arg(&core_key)
-            .execute()
-            .await
-            .map_err(|e| crate::backend_context(e, "describe_flow: HGETALL flow_core"))?;
-
-        if raw.is_empty() {
-            return Ok(None);
-        }
-
-        build_flow_snapshot(id.clone(), &raw).map(Some)
-    }
-}
-
-/// Assemble a [`FlowSnapshot`] from the raw HGETALL field map.
-///
-/// Kept as a free function so a future unit test can feed synthetic
-/// maps without a live Valkey.
-fn build_flow_snapshot(
-    flow_id: FlowId,
-    raw: &HashMap<String, String>,
-) -> Result<FlowSnapshot, SdkError> {
-    // flow_id is engine-written at create time (lua/flow.lua). Validate
-    // it matches the requested FlowId — a disagreement means either
-    // on-disk corruption or a caller accidentally reading the wrong key.
-    let stored_flow_id_str = opt_str(raw, "flow_id")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("flow_id".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?;
-    if stored_flow_id_str != flow_id.to_string() {
-        return Err(SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("flow_id".into()),
-            message: format!(
-                "'{stored_flow_id_str}' does not match requested flow_id \
-                 '{flow_id}' (key corruption or wrong-key read?)"
-            ),
-        });
+        Ok(self.backend_ref().describe_flow(id).await?)
     }
 
-    // namespace and flow_kind are engine-written at create time; absent
-    // or empty values indicate on-disk corruption.
-    let namespace_str = opt_str(raw, "namespace")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("namespace".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?;
-    let namespace = Namespace::new(namespace_str.to_owned());
-
-    let flow_kind = opt_str(raw, "flow_kind")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("flow_kind".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?
-        .to_owned();
-
-    let public_flow_state = opt_str(raw, "public_flow_state")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("public_flow_state".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?
-        .to_owned();
-
-    // graph_revision / node_count / edge_count are engine-maintained
-    // counters; missing values indicate corruption (ff_create_flow
-    // writes "0" to all three). Parse strictly.
-    let graph_revision = parse_u64_strict(raw, "describe_flow: flow_core", "graph_revision")?
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("graph_revision".into()),
-            message: "is missing (key corruption?)".into(),
-        })?;
-    let node_count =
-        parse_u32_strict(raw, "describe_flow: flow_core", "node_count")?.ok_or_else(|| {
-            SdkError::Config {
-                context: "describe_flow: flow_core".into(),
-                field: Some("node_count".into()),
-                message: "is missing (key corruption?)".into(),
-            }
-        })?;
-    let edge_count =
-        parse_u32_strict(raw, "describe_flow: flow_core", "edge_count")?.ok_or_else(|| {
-            SdkError::Config {
-                context: "describe_flow: flow_core".into(),
-                field: Some("edge_count".into()),
-                message: "is missing (key corruption?)".into(),
-            }
-        })?;
-
-    // created_at + last_mutation_at are engine-maintained; absent values
-    // indicate corruption (ff_create_flow writes both).
-    let created_at = parse_ts(raw, "describe_flow: flow_core", "created_at")?.ok_or_else(|| {
-        SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("created_at".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        }
-    })?;
-    let last_mutation_at = parse_ts(raw, "describe_flow: flow_core", "last_mutation_at")?
-        .ok_or_else(|| SdkError::Config {
-            context: "describe_flow: flow_core".into(),
-            field: Some("last_mutation_at".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?;
-
-    let cancelled_at = parse_ts(raw, "describe_flow: flow_core", "cancelled_at")?;
-    let cancel_reason = opt_str(raw, "cancel_reason")
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-    let cancellation_policy = opt_str(raw, "cancellation_policy")
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-
-    // Route unknown fields: namespaced-prefix (e.g. `cairn.task_id`) →
-    // tags; anything else → corruption. This keeps FF's snake_case
-    // field additions distinct from consumer metadata without a second
-    // HGETALL on a non-existent tags hash.
-    let mut tags: BTreeMap<String, String> = BTreeMap::new();
-    for (k, v) in raw {
-        if FLOW_CORE_KNOWN_FIELDS.contains(&k.as_str()) {
-            continue;
-        }
-        if is_namespaced_tag_key(k) {
-            tags.insert(k.clone(), v.clone());
-        } else {
-            return Err(SdkError::Config {
-                context: "describe_flow: flow_core".into(),
-                field: None,
-                message: format!(
-                    "has unexpected field '{k}' — not an FF field and not a namespaced \
-                     tag (lowercase-alphanumeric-prefix + '.')"
-                ),
-            });
-        }
-    }
-
-    Ok(FlowSnapshot::new(
-        flow_id,
-        flow_kind,
-        namespace,
-        public_flow_state,
-        graph_revision,
-        node_count,
-        edge_count,
-        created_at,
-        last_mutation_at,
-        cancelled_at,
-        cancel_reason,
-        cancellation_policy,
-        tags,
-    ))
-}
-
-/// Match the namespaced-tag shape `^[a-z][a-z0-9_]*\.` documented on
-/// [`ExecutionSnapshot::tags`] / [`FlowSnapshot::tags`]. Kept inline
-/// (no regex dependency) — the shape is tight enough to hand-check.
-fn is_namespaced_tag_key(k: &str) -> bool {
-    let mut chars = k.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !first.is_ascii_lowercase() {
-        return false;
-    }
-    let mut saw_dot = false;
-    for c in chars {
-        if c == '.' {
-            saw_dot = true;
-            break;
-        }
-        if !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_') {
-            return false;
-        }
-    }
-    saw_dot
-}
-
-// ═══════════════════════════════════════════════════════════════════════
-// describe_edge / list_*_edges (issue #58.3)
-// ═══════════════════════════════════════════════════════════════════════
-//
-// RFC-012 Stage 1c T2: the `EDGE_KNOWN_FIELDS` list and the
-// `build_edge_snapshot` decoder moved to
-// `ff_core::contracts::decode`. Parse failures now surface as
-// `EngineError::Validation { kind: Corruption, .. }` — callers that
-// match on `SdkError` see them wrapped as
-// `SdkError::Engine(EngineError::Validation(..))` via the crate-root
-// `From<EngineError> for SdkError` impl. The pipeline shape
-// (SMEMBERS + pipelined HGETALL) is unchanged; only the decoder
-// location moved so non-SDK backends can reuse it.
-
-impl FlowFabricWorker {
     /// Read a typed snapshot of one dependency edge.
     ///
-    /// Takes both `flow_id` and `edge_id`: the edge hash is stored under
-    /// the flow's partition (`ff:flow:{fp:N}:<flow_id>:edge:<edge_id>`)
-    /// and FF does not maintain a global `edge_id -> flow_id` index.
-    /// The caller already knows the flow from the staging call result
-    /// or the consumer's own metadata.
+    /// Takes both `flow_id` and `edge_id`: the edge hash is stored
+    /// under the flow's partition
+    /// (`ff:flow:{fp:N}:<flow_id>:edge:<edge_id>`) and FF does not
+    /// maintain a global `edge_id -> flow_id` index. The caller
+    /// already knows the flow from the staging call result or the
+    /// consumer's own metadata.
     ///
     /// Returns `Ok(None)` when the edge hash is absent (never staged,
-    /// or staged under a different flow). Returns `Ok(Some(snapshot))`
-    /// on success.
-    ///
-    /// # Consistency
-    ///
-    /// Single `HGETALL` — the flow-scoped edge hash is written once at
-    /// staging time and never mutated (per-execution resolution state
-    /// lives on a separate `dep:<edge_id>` hash), so a single round
-    /// trip is authoritative.
+    /// or staged under a different flow).
     pub async fn describe_edge(
         &self,
         flow_id: &FlowId,
         edge_id: &EdgeId,
     ) -> Result<Option<EdgeSnapshot>, SdkError> {
         let partition = flow_partition(flow_id, self.partition_config());
-        let ctx = FlowKeyContext::new(&partition, flow_id);
+        let ctx = ff_core::keys::FlowKeyContext::new(&partition, flow_id);
         let edge_key = ctx.edge(edge_id);
 
         let raw: HashMap<String, String> = self
@@ -633,7 +88,7 @@ impl FlowFabricWorker {
             return Ok(None);
         }
 
-        build_edge_snapshot_core(flow_id, edge_id, &raw)
+        ff_core::contracts::decode::build_edge_snapshot(flow_id, edge_id, &raw)
             .map(Some)
             .map_err(SdkError::from)
     }
@@ -641,20 +96,17 @@ impl FlowFabricWorker {
     /// List all outgoing dependency edges originating from an execution.
     ///
     /// Returns an empty `Vec` when the execution has no outgoing edges
-    /// (including the case where the execution is standalone, i.e. not
-    /// attached to any flow — such executions cannot participate in
-    /// dependency edges).
+    /// — including standalone executions not attached to any flow.
     ///
     /// # Reads
     ///
-    /// 1. `HGET exec_core flow_id` — resolve the flow owning the
-    ///    adjacency set. Missing or empty flow_id returns an empty Vec.
-    /// 2. `SMEMBERS` on the flow-scoped `out:<upstream_eid>` set.
-    /// 3. One pipelined round trip issuing one `HGETALL` per edge_id.
+    /// 1. `HGET exec_core flow_id` (via [`Self::resolve_flow_id`]).
+    /// 2. `EngineBackend::list_edges` on the resolved flow (SMEMBERS
+    ///    + pipelined HGETALL on the flow's partition).
     ///
-    /// Ordering is unspecified — the adjacency set is an unordered SET.
-    /// Callers that need deterministic order should sort by
-    /// [`EdgeSnapshot::edge_id`] (or `created_at`) themselves.
+    /// Ordering is unspecified — the adjacency set is an unordered
+    /// SET. Callers that need deterministic order should sort by
+    /// [`EdgeSnapshot::edge_id`] or `created_at`.
     pub async fn list_outgoing_edges(
         &self,
         upstream_eid: &ExecutionId,
@@ -662,15 +114,15 @@ impl FlowFabricWorker {
         let Some(flow_id) = self.resolve_flow_id(upstream_eid).await? else {
             return Ok(Vec::new());
         };
-        let partition = flow_partition(&flow_id, self.partition_config());
-        let ctx = FlowKeyContext::new(&partition, &flow_id);
-        self.list_edges_from_set(
-            &ctx.outgoing(upstream_eid),
-            &flow_id,
-            upstream_eid,
-            AdjacencySide::Outgoing,
-        )
-        .await
+        Ok(self
+            .backend_ref()
+            .list_edges(
+                &flow_id,
+                EdgeDirection::Outgoing {
+                    from_node: upstream_eid.clone(),
+                },
+            )
+            .await?)
     }
 
     /// List all incoming dependency edges landing on an execution.
@@ -682,15 +134,15 @@ impl FlowFabricWorker {
         let Some(flow_id) = self.resolve_flow_id(downstream_eid).await? else {
             return Ok(Vec::new());
         };
-        let partition = flow_partition(&flow_id, self.partition_config());
-        let ctx = FlowKeyContext::new(&partition, &flow_id);
-        self.list_edges_from_set(
-            &ctx.incoming(downstream_eid),
-            &flow_id,
-            downstream_eid,
-            AdjacencySide::Incoming,
-        )
-        .await
+        Ok(self
+            .backend_ref()
+            .list_edges(
+                &flow_id,
+                EdgeDirection::Incoming {
+                    to_node: downstream_eid.clone(),
+                },
+            )
+            .await?)
     }
 
     /// `HGET exec_core.flow_id` and parse to a [`FlowId`]. `None` when
@@ -701,7 +153,8 @@ impl FlowFabricWorker {
     /// (`execution_partition(eid) == flow_partition(flow_id)`) — a
     /// parsed-but-wrong flow_id would otherwise silently route the
     /// follow-up adjacency reads to the wrong partition and return
-    /// bogus empty results. A mismatch surfaces as `SdkError::Config`.
+    /// bogus empty results. A mismatch surfaces as
+    /// `SdkError::Engine(EngineError::Validation { kind: Corruption, .. })`.
     async fn resolve_flow_id(&self, eid: &ExecutionId) -> Result<Option<FlowId>, SdkError> {
         let exec_partition = execution_partition(eid, self.partition_config());
         let ctx = ExecKeyContext::new(&exec_partition, eid);
@@ -716,566 +169,29 @@ impl FlowFabricWorker {
         let Some(raw) = raw.filter(|s| !s.is_empty()) else {
             return Ok(None);
         };
-        let flow_id = FlowId::parse(&raw).map_err(|e| SdkError::Config {
-            context: "list_edges: exec_core".into(),
-            field: Some("flow_id".into()),
-            message: format!("'{raw}' is not a valid UUID (key corruption?): {e}"),
+        let flow_id = FlowId::parse(&raw).map_err(|e| {
+            SdkError::from(ff_core::engine_error::EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail: format!(
+                    "list_edges: exec_core: flow_id: '{raw}' is not a valid UUID \
+                     (key corruption?): {e}"
+                ),
+            })
         })?;
         let flow_partition_index = flow_partition(&flow_id, self.partition_config()).index;
         if exec_partition.index != flow_partition_index {
-            return Err(SdkError::Config {
-                context: "list_edges: exec_core".into(),
-                field: Some("flow_id".into()),
-                message: format!(
-                    "'{flow_id}' partition {flow_partition_index} does not match \
-                     execution partition {} (RFC-011 co-location violation; key corruption?)",
-                    exec_partition.index
-                ),
-            });
+            return Err(SdkError::from(
+                ff_core::engine_error::EngineError::Validation {
+                    kind: ff_core::engine_error::ValidationKind::Corruption,
+                    detail: format!(
+                        "list_edges: exec_core: flow_id: '{flow_id}' partition \
+                         {flow_partition_index} does not match execution partition {} \
+                         (RFC-011 co-location violation; key corruption?)",
+                        exec_partition.index
+                    ),
+                },
+            ));
         }
         Ok(Some(flow_id))
-    }
-
-    /// Shared body for `list_incoming_edges` / `list_outgoing_edges`:
-    /// SMEMBERS + pipelined HGETALL.
-    ///
-    /// `subject_eid` + `side` pin the expected endpoint on each
-    /// returned `EdgeSnapshot`: an adjacency SET entry whose edge
-    /// hash points at a different upstream (for `Outgoing` listings)
-    /// or downstream (for `Incoming`) is treated as corruption and
-    /// surfaced as `SdkError::Config`, matching the strict-parse
-    /// posture elsewhere in this module.
-    async fn list_edges_from_set(
-        &self,
-        adj_key: &str,
-        flow_id: &FlowId,
-        subject_eid: &ExecutionId,
-        side: AdjacencySide,
-    ) -> Result<Vec<EdgeSnapshot>, SdkError> {
-        let edge_id_strs: Vec<String> = self
-            .client()
-            .cmd("SMEMBERS")
-            .arg(adj_key)
-            .execute()
-            .await
-            .map_err(|e| crate::backend_context(e, "list_edges: SMEMBERS adj_set"))?;
-        if edge_id_strs.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Parse edge ids first so a corrupt adjacency entry fails loud
-        // before we spend a round trip on it.
-        let mut edge_ids: Vec<EdgeId> = Vec::with_capacity(edge_id_strs.len());
-        for raw in &edge_id_strs {
-            let parsed = EdgeId::parse(raw).map_err(|e| SdkError::Config {
-                context: "list_edges: adjacency_set".into(),
-                field: Some("edge_id".into()),
-                message: format!("'{raw}' is not a valid EdgeId (key corruption?): {e}"),
-            })?;
-            edge_ids.push(parsed);
-        }
-
-        let partition = flow_partition(flow_id, self.partition_config());
-        let ctx = FlowKeyContext::new(&partition, flow_id);
-
-        let mut pipe = self.client().pipeline();
-        let slots: Vec<_> = edge_ids
-            .iter()
-            .map(|eid| {
-                pipe.cmd::<HashMap<String, String>>("HGETALL")
-                    .arg(ctx.edge(eid))
-                    .finish()
-            })
-            .collect();
-        pipe.execute().await.map_err(|e| crate::backend_context(e, "list_edges: pipeline HGETALL edges"))?;
-
-        let mut out: Vec<EdgeSnapshot> = Vec::with_capacity(edge_ids.len());
-        for (edge_id, slot) in edge_ids.iter().zip(slots) {
-            let raw = slot.value().map_err(|e| crate::backend_context(e, "list_edges: decode HGETALL edge_hash"))?;
-            if raw.is_empty() {
-                // Adjacency SET referenced an edge_hash that no longer
-                // exists. FF does not delete edge hashes today (staging
-                // is write-once), so this is corruption — fail loud.
-                return Err(SdkError::Config {
-                    context: "list_edges: adjacency_set".into(),
-                    field: None,
-                    message: format!(
-                        "refers to edge_id '{edge_id}' but its edge_hash is absent \
-                         (key corruption?)"
-                    ),
-                });
-            }
-            let snap = build_edge_snapshot_core(flow_id, edge_id, &raw).map_err(SdkError::from)?;
-            // Cross-check: the edge hash's endpoint on the listed side
-            // must match the execution we're listing for. A mismatch
-            // means the adjacency SET and edge hash disagree (e.g. a
-            // stale or corrupted SET entry) — refuse to silently
-            // return an edge the caller did not ask about.
-            let endpoint = match side {
-                AdjacencySide::Outgoing => &snap.upstream_execution_id,
-                AdjacencySide::Incoming => &snap.downstream_execution_id,
-            };
-            if endpoint != subject_eid {
-                return Err(SdkError::Config {
-                    context: "list_edges: adjacency_set".into(),
-                    field: None,
-                    message: format!(
-                        "for execution '{subject_eid}' (side={side:?}) contains edge \
-                         '{edge_id}' whose stored endpoint is '{endpoint}' \
-                         (adjacency/edge-hash drift?)"
-                    ),
-                });
-            }
-            out.push(snap);
-        }
-        Ok(out)
-    }
-}
-
-/// Which side of an adjacency SET the subject execution lives on.
-/// Used by [`list_edges_from_set`] to cross-check the returned edge's
-/// stored endpoint against the listing's subject.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum AdjacencySide {
-    /// Outgoing: subject is the `upstream_execution_id` on each edge.
-    Outgoing,
-    /// Incoming: subject is the `downstream_execution_id` on each edge.
-    Incoming,
-}
-
-/// Crate-visible thin adapter over
-/// [`ff_core::contracts::decode::build_edge_snapshot`] for
-/// [`crate::engine_error::enrich_dependency_conflict`]. Returns the
-/// native [`ff_core::engine_error::EngineError`] so the caller can
-/// route parse failures into the same `EngineError`-shaped surface
-/// it already uses. Kept as a named indirection so the one non-SDK
-/// internal user (`enrich_dependency_conflict`) has a stable call
-/// site; new callers should invoke the ff-core module directly.
-#[allow(dead_code, clippy::result_large_err)]
-pub(crate) fn build_edge_snapshot_public(
-    flow_id: &FlowId,
-    edge_id: &EdgeId,
-    raw: &HashMap<String, String>,
-) -> Result<EdgeSnapshot, ff_core::engine_error::EngineError> {
-    build_edge_snapshot_core(flow_id, edge_id, raw)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ff_core::partition::PartitionConfig;
-    use ff_core::types::FlowId;
-
-    fn eid() -> ExecutionId {
-        let config = PartitionConfig::default();
-        ExecutionId::for_flow(&FlowId::new(), &config)
-    }
-
-    fn minimal_core(public_state: &str) -> HashMap<String, String> {
-        let mut m = HashMap::new();
-        m.insert("public_state".to_owned(), public_state.to_owned());
-        m.insert("lane_id".to_owned(), "default".to_owned());
-        m.insert("namespace".to_owned(), "ns".to_owned());
-        m.insert("created_at".to_owned(), "1000".to_owned());
-        m.insert("last_mutation_at".to_owned(), "2000".to_owned());
-        m.insert("total_attempt_count".to_owned(), "0".to_owned());
-        m
-    }
-
-    #[test]
-    fn waiting_exec_no_attempt_no_lease_no_tags() {
-        let snap = build_execution_snapshot(eid(), &minimal_core("waiting"), HashMap::new())
-            .unwrap()
-            .expect("should build");
-        assert_eq!(snap.public_state, PublicState::Waiting);
-        assert!(snap.current_attempt.is_none());
-        assert!(snap.current_lease.is_none());
-        assert!(snap.current_waitpoint.is_none());
-        assert_eq!(snap.tags.len(), 0);
-        assert_eq!(snap.created_at.0, 1000);
-        assert_eq!(snap.last_mutation_at.0, 2000);
-        assert!(snap.flow_id.is_none());
-        assert!(snap.blocking_reason.is_none());
-    }
-
-    #[test]
-    fn tags_flow_through_sorted() {
-        let mut tags = HashMap::new();
-        tags.insert("cairn.task_id".to_owned(), "t-1".to_owned());
-        tags.insert("cairn.project".to_owned(), "proj".to_owned());
-        let snap = build_execution_snapshot(eid(), &minimal_core("waiting"), tags)
-            .unwrap()
-            .unwrap();
-        let keys: Vec<_> = snap.tags.keys().cloned().collect();
-        assert_eq!(
-            keys,
-            vec!["cairn.project".to_owned(), "cairn.task_id".to_owned()]
-        );
-    }
-
-    #[test]
-    fn invalid_public_state_fails_loud() {
-        let err =
-            build_execution_snapshot(eid(), &minimal_core("bogus"), HashMap::new()).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert_eq!(field.as_deref(), Some("public_state"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn invalid_lane_id_fails_loud() {
-        // LaneId::try_new rejects non-printable bytes. Simulate on-disk
-        // corruption by stamping a lane_id with an embedded \n.
-        let mut core = minimal_core("waiting");
-        core.insert("lane_id".to_owned(), "lane\nbroken".to_owned());
-        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert_eq!(field.as_deref(), Some("lane_id"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn missing_required_timestamps_fail_loud() {
-        for want in ["created_at", "last_mutation_at"] {
-            let mut core = minimal_core("waiting");
-            core.remove(want);
-            let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
-            match err {
-                SdkError::Config {
-                    field,
-                    message: msg,
-                    ..
-                } => {
-                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
-                }
-                other => panic!("expected Config for {want}, got {other:?}"),
-            }
-        }
-    }
-
-    #[test]
-    fn malformed_total_attempt_count_fails_loud() {
-        let mut core = minimal_core("waiting");
-        core.insert("total_attempt_count".to_owned(), "not-a-number".to_owned());
-        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert_eq!(field.as_deref(), Some("total_attempt_count"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn attempt_id_without_index_fails_loud() {
-        // current_attempt_id set but current_attempt_index absent =>
-        // corruption, since lua/execution.lua writes both atomically.
-        let mut core = minimal_core("active");
-        core.insert(
-            "current_attempt_id".to_owned(),
-            AttemptId::new().to_string(),
-        );
-        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert_eq!(
-                    field.as_deref(),
-                    Some("current_attempt_index"),
-                    "msg: {msg}"
-                );
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn lease_without_epoch_fails_loud() {
-        // wid + expires_at present but epoch missing => corruption.
-        let mut core = minimal_core("active");
-        core.insert(
-            "current_worker_instance_id".to_owned(),
-            "w-inst-1".to_owned(),
-        );
-        core.insert("lease_expires_at".to_owned(), "9000".to_owned());
-        let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert_eq!(field.as_deref(), Some("current_lease_epoch"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn lease_summary_requires_both_wid_and_expires_at() {
-        // Only wid → no lease (lease expired + cleared lease_expires_at
-        // but wid not yet rewritten is not a real state; defensive).
-        let mut core = minimal_core("active");
-        core.insert(
-            "current_worker_instance_id".to_owned(),
-            "w-inst-1".to_owned(),
-        );
-        let snap = build_execution_snapshot(eid(), &core, HashMap::new())
-            .unwrap()
-            .unwrap();
-        assert!(snap.current_lease.is_none());
-
-        core.insert("lease_expires_at".to_owned(), "9000".to_owned());
-        core.insert("current_lease_epoch".to_owned(), "3".to_owned());
-        let snap = build_execution_snapshot(eid(), &core, HashMap::new())
-            .unwrap()
-            .unwrap();
-        let lease = snap.current_lease.expect("lease present");
-        assert_eq!(lease.lease_epoch, LeaseEpoch::new(3));
-        assert_eq!(lease.expires_at.0, 9000);
-        assert_eq!(lease.worker_instance_id.as_str(), "w-inst-1");
-    }
-
-    // ─── FlowSnapshot (describe_flow) ───
-
-    fn fid() -> FlowId {
-        FlowId::new()
-    }
-
-    fn minimal_flow_core(id: &FlowId, state: &str) -> HashMap<String, String> {
-        let mut m = HashMap::new();
-        m.insert("flow_id".to_owned(), id.to_string());
-        m.insert("flow_kind".to_owned(), "dag".to_owned());
-        m.insert("namespace".to_owned(), "ns".to_owned());
-        m.insert("public_flow_state".to_owned(), state.to_owned());
-        m.insert("graph_revision".to_owned(), "0".to_owned());
-        m.insert("node_count".to_owned(), "0".to_owned());
-        m.insert("edge_count".to_owned(), "0".to_owned());
-        m.insert("created_at".to_owned(), "1000".to_owned());
-        m.insert("last_mutation_at".to_owned(), "1000".to_owned());
-        m
-    }
-
-    #[test]
-    fn open_flow_round_trips() {
-        let f = fid();
-        let snap = build_flow_snapshot(f.clone(), &minimal_flow_core(&f, "open")).unwrap();
-        assert_eq!(snap.flow_id, f);
-        assert_eq!(snap.flow_kind, "dag");
-        assert_eq!(snap.namespace.as_str(), "ns");
-        assert_eq!(snap.public_flow_state, "open");
-        assert_eq!(snap.graph_revision, 0);
-        assert_eq!(snap.node_count, 0);
-        assert_eq!(snap.edge_count, 0);
-        assert_eq!(snap.created_at.0, 1000);
-        assert_eq!(snap.last_mutation_at.0, 1000);
-        assert!(snap.cancelled_at.is_none());
-        assert!(snap.cancel_reason.is_none());
-        assert!(snap.cancellation_policy.is_none());
-        assert!(snap.tags.is_empty());
-    }
-
-    #[test]
-    fn cancelled_flow_surfaces_cancel_fields() {
-        let f = fid();
-        let mut core = minimal_flow_core(&f, "cancelled");
-        core.insert("cancelled_at".to_owned(), "2000".to_owned());
-        core.insert("cancel_reason".to_owned(), "operator".to_owned());
-        core.insert("cancellation_policy".to_owned(), "cancel_all".to_owned());
-        let snap = build_flow_snapshot(f, &core).unwrap();
-        assert_eq!(snap.public_flow_state, "cancelled");
-        assert_eq!(snap.cancelled_at.unwrap().0, 2000);
-        assert_eq!(snap.cancel_reason.as_deref(), Some("operator"));
-        assert_eq!(snap.cancellation_policy.as_deref(), Some("cancel_all"));
-    }
-
-    #[test]
-    fn namespaced_tags_routed_to_tags_map() {
-        let f = fid();
-        let mut core = minimal_flow_core(&f, "open");
-        core.insert("cairn.task_id".to_owned(), "t-1".to_owned());
-        core.insert("cairn.project".to_owned(), "proj".to_owned());
-        core.insert("operator.label".to_owned(), "v".to_owned());
-        let snap = build_flow_snapshot(f, &core).unwrap();
-        assert_eq!(snap.tags.len(), 3);
-        let keys: Vec<_> = snap.tags.keys().cloned().collect();
-        // BTreeMap keeps them sorted.
-        assert_eq!(
-            keys,
-            vec![
-                "cairn.project".to_owned(),
-                "cairn.task_id".to_owned(),
-                "operator.label".to_owned()
-            ]
-        );
-    }
-
-    #[test]
-    fn unknown_flat_field_fails_loud() {
-        // A future FF field rename or on-disk drift lands a non-
-        // namespaced unknown key. Don't silently bucket it.
-        let f = fid();
-        let mut core = minimal_flow_core(&f, "open");
-        core.insert("bogus_future_field".to_owned(), "v".to_owned());
-        let err = build_flow_snapshot(f, &core).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert!(
-                    field.is_none(),
-                    "expected whole-object error, got field={field:?}"
-                );
-                assert!(msg.contains("bogus_future_field"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn missing_required_fields_fail_loud() {
-        for want in [
-            "flow_id",
-            "namespace",
-            "flow_kind",
-            "public_flow_state",
-            "graph_revision",
-            "node_count",
-            "edge_count",
-            "created_at",
-            "last_mutation_at",
-        ] {
-            let f = fid();
-            let mut core = minimal_flow_core(&f, "open");
-            core.remove(want);
-            let err = build_flow_snapshot(f, &core).err().unwrap_or_else(|| {
-                panic!("field {want} should fail but build_flow_snapshot returned Ok")
-            });
-            match err {
-                SdkError::Config {
-                    field,
-                    message: msg,
-                    ..
-                } => {
-                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
-                }
-                other => panic!("expected Config for {want}, got {other:?}"),
-            }
-        }
-    }
-
-    #[test]
-    fn empty_required_strings_fail_loud() {
-        // opt_str + .filter(|s| !s.is_empty()) must treat an empty
-        // value the same as a missing one for strict-parsed fields.
-        for want in ["flow_id", "namespace", "flow_kind", "public_flow_state"] {
-            let f = fid();
-            let mut core = minimal_flow_core(&f, "open");
-            core.insert(want.to_owned(), String::new());
-            let err = build_flow_snapshot(f, &core).err().unwrap_or_else(|| {
-                panic!("empty {want} should fail but build_flow_snapshot returned Ok")
-            });
-            match err {
-                SdkError::Config {
-                    field,
-                    message: msg,
-                    ..
-                } => {
-                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
-                }
-                other => panic!("expected Config for {want}, got {other:?}"),
-            }
-        }
-    }
-
-    #[test]
-    fn flow_id_mismatch_fails_loud() {
-        // flow_core.flow_id disagreeing with the requested FlowId is
-        // corruption or a wrong-key read — must surface as Config.
-        let requested = fid();
-        let other = fid();
-        let core = minimal_flow_core(&other, "open");
-        let err = build_flow_snapshot(requested, &core).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert_eq!(field.as_deref(), Some("flow_id"), "msg: {msg}");
-                assert!(msg.contains("does not match"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn malformed_counter_fails_loud() {
-        let f = fid();
-        let mut core = minimal_flow_core(&f, "open");
-        core.insert("graph_revision".to_owned(), "not-a-number".to_owned());
-        let err = build_flow_snapshot(f, &core).unwrap_err();
-        match err {
-            SdkError::Config {
-                field,
-                message: msg,
-                ..
-            } => {
-                assert_eq!(field.as_deref(), Some("graph_revision"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    // ─── EdgeSnapshot (describe_edge) ───
-    //
-    // RFC-012 Stage 1c T2: the edge-hash decoder moved to
-    // `ff_core::contracts::decode`. The unit-level coverage for
-    // unknown-field / missing-field / mismatch / malformed-number
-    // paths lives alongside the decoder at ff-core; the ff-sdk
-    // higher-level describe_edge + list_*_edges integration coverage
-    // lives in `crates/ff-test/tests/describe_edge_api.rs`.
-
-    #[test]
-    fn namespaced_tag_matcher_boundaries() {
-        // Positive
-        assert!(is_namespaced_tag_key("cairn.task_id"));
-        assert!(is_namespaced_tag_key("a.b"));
-        assert!(is_namespaced_tag_key("ab_12.field"));
-        // Negative: no dot
-        assert!(!is_namespaced_tag_key("cairn_task_id"));
-        // Negative: uppercase prefix
-        assert!(!is_namespaced_tag_key("Cairn.task"));
-        // Negative: leading digit
-        assert!(!is_namespaced_tag_key("1cairn.task"));
-        // Negative: empty
-        assert!(!is_namespaced_tag_key(""));
-        // Negative: dot at position 0
-        assert!(!is_namespaced_tag_key(".x"));
-        // Negative: uppercase in prefix
-        assert!(!is_namespaced_tag_key("caIrn.task"));
     }
 }

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
+use ff_core::contracts::decode::build_edge_snapshot as build_edge_snapshot_core;
 use ff_core::contracts::{
     AttemptSummary, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, LeaseSummary,
 };
@@ -111,13 +112,12 @@ fn build_execution_snapshot(
     // ingress; a read that fails validation here signals on-disk
     // corruption — surface it rather than silently constructing an
     // invalid LaneId that would mis-partition downstream.
-    let lane_id = LaneId::try_new(opt_str(core, "lane_id").unwrap_or("")).map_err(|e| {
-        SdkError::Config {
+    let lane_id =
+        LaneId::try_new(opt_str(core, "lane_id").unwrap_or("")).map_err(|e| SdkError::Config {
             context: "describe_execution: exec_core".into(),
             field: Some("lane_id".into()),
             message: format!("fails LaneId validation (key corruption?): {e}"),
-        }
-    })?;
+        })?;
 
     let namespace_str = opt_str(core, "namespace").unwrap_or("").to_owned();
     let namespace = Namespace::new(namespace_str);
@@ -582,23 +582,16 @@ fn is_namespaced_tag_key(k: &str) -> bool {
 // ═══════════════════════════════════════════════════════════════════════
 // describe_edge / list_*_edges (issue #58.3)
 // ═══════════════════════════════════════════════════════════════════════
-
-/// FF-owned fields on the flow-scoped `edge:<edge_id>` hash. An HGETALL
-/// field outside this set signals on-disk corruption or protocol drift
-/// and surfaces as `SdkError::Config` — matching the strict-parse
-/// posture on `describe_flow`.
-const EDGE_KNOWN_FIELDS: &[&str] = &[
-    "edge_id",
-    "flow_id",
-    "upstream_execution_id",
-    "downstream_execution_id",
-    "dependency_kind",
-    "satisfaction_condition",
-    "data_passing_ref",
-    "edge_state",
-    "created_at",
-    "created_by",
-];
+//
+// RFC-012 Stage 1c T2: the `EDGE_KNOWN_FIELDS` list and the
+// `build_edge_snapshot` decoder moved to
+// `ff_core::contracts::decode`. Parse failures now surface as
+// `EngineError::Validation { kind: Corruption, .. }` — callers that
+// match on `SdkError` see them wrapped as
+// `SdkError::Engine(EngineError::Validation(..))` via the crate-root
+// `From<EngineError> for SdkError` impl. The pipeline shape
+// (SMEMBERS + pipelined HGETALL) is unchanged; only the decoder
+// location moved so non-SDK backends can reuse it.
 
 impl FlowFabricWorker {
     /// Read a typed snapshot of one dependency edge.
@@ -640,7 +633,9 @@ impl FlowFabricWorker {
             return Ok(None);
         }
 
-        build_edge_snapshot(flow_id, edge_id, &raw).map(Some)
+        build_edge_snapshot_core(flow_id, edge_id, &raw)
+            .map(Some)
+            .map_err(SdkError::from)
     }
 
     /// List all outgoing dependency edges originating from an execution.
@@ -707,10 +702,7 @@ impl FlowFabricWorker {
     /// parsed-but-wrong flow_id would otherwise silently route the
     /// follow-up adjacency reads to the wrong partition and return
     /// bogus empty results. A mismatch surfaces as `SdkError::Config`.
-    async fn resolve_flow_id(
-        &self,
-        eid: &ExecutionId,
-    ) -> Result<Option<FlowId>, SdkError> {
+    async fn resolve_flow_id(&self, eid: &ExecutionId) -> Result<Option<FlowId>, SdkError> {
         let exec_partition = execution_partition(eid, self.partition_config());
         let ctx = ExecKeyContext::new(&exec_partition, eid);
         let raw: Option<String> = self
@@ -813,7 +805,7 @@ impl FlowFabricWorker {
                     ),
                 });
             }
-            let snap = build_edge_snapshot(flow_id, edge_id, &raw)?;
+            let snap = build_edge_snapshot_core(flow_id, edge_id, &raw).map_err(SdkError::from)?;
             // Cross-check: the edge hash's endpoint on the listed side
             // must match the execution we're listing for. A mismatch
             // means the adjacency SET and edge hash disagree (e.g. a
@@ -851,160 +843,21 @@ enum AdjacencySide {
     Incoming,
 }
 
-/// Crate-visible re-export of [`build_edge_snapshot`] for
-/// [`crate::engine_error::EngineError::enrich_dependency_conflict`].
-#[allow(dead_code)]
+/// Crate-visible thin adapter over
+/// [`ff_core::contracts::decode::build_edge_snapshot`] for
+/// [`crate::engine_error::enrich_dependency_conflict`]. Returns the
+/// native [`ff_core::engine_error::EngineError`] so the caller can
+/// route parse failures into the same `EngineError`-shaped surface
+/// it already uses. Kept as a named indirection so the one non-SDK
+/// internal user (`enrich_dependency_conflict`) has a stable call
+/// site; new callers should invoke the ff-core module directly.
+#[allow(dead_code, clippy::result_large_err)]
 pub(crate) fn build_edge_snapshot_public(
     flow_id: &FlowId,
     edge_id: &EdgeId,
     raw: &HashMap<String, String>,
-) -> Result<EdgeSnapshot, SdkError> {
-    build_edge_snapshot(flow_id, edge_id, raw)
-}
-
-/// Assemble an [`EdgeSnapshot`] from the raw HGETALL field map. Kept
-/// as a free function so unit tests can feed synthetic maps.
-///
-/// `flow_id` / `edge_id` are the caller's expected identities — both
-/// are cross-checked against the stored values to catch wrong-key
-/// reads and on-disk corruption.
-fn build_edge_snapshot(
-    flow_id: &FlowId,
-    edge_id: &EdgeId,
-    raw: &HashMap<String, String>,
-) -> Result<EdgeSnapshot, SdkError> {
-    // Sweep for unknown fields before parsing — a future FF rename
-    // that lands an unrecognised field must fail loud rather than
-    // silently drop data.
-    for k in raw.keys() {
-        if !EDGE_KNOWN_FIELDS.contains(&k.as_str()) {
-            return Err(SdkError::Config {
-                context: "edge_snapshot: edge_hash".into(),
-                field: None,
-                message: format!(
-                    "has unexpected field '{k}' (protocol drift or corruption?)"
-                ),
-            });
-        }
-    }
-
-    let stored_edge_id_str = opt_str(raw, "edge_id")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("edge_id".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?;
-    if stored_edge_id_str != edge_id.to_string() {
-        return Err(SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("edge_id".into()),
-            message: format!(
-                "'{stored_edge_id_str}' does not match requested edge_id \
-                 '{edge_id}' (key corruption or wrong-key read?)"
-            ),
-        });
-    }
-
-    let stored_flow_id_str = opt_str(raw, "flow_id")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("flow_id".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?;
-    if stored_flow_id_str != flow_id.to_string() {
-        return Err(SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("flow_id".into()),
-            message: format!(
-                "'{stored_flow_id_str}' does not match requested flow_id \
-                 '{flow_id}' (key corruption or wrong-key read?)"
-            ),
-        });
-    }
-
-    let upstream_execution_id = parse_eid(raw, "upstream_execution_id")?;
-    let downstream_execution_id = parse_eid(raw, "downstream_execution_id")?;
-
-    let dependency_kind = opt_str(raw, "dependency_kind")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("dependency_kind".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?
-        .to_owned();
-
-    let satisfaction_condition = opt_str(raw, "satisfaction_condition")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("satisfaction_condition".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?
-        .to_owned();
-
-    // data_passing_ref is stored as "" when the stager passed None.
-    // Treat empty as absent rather than surfacing an empty String.
-    let data_passing_ref = opt_str(raw, "data_passing_ref")
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-
-    let edge_state = opt_str(raw, "edge_state")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("edge_state".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?
-        .to_owned();
-
-    let created_at =
-        parse_ts(raw, "edge_snapshot: edge_hash", "created_at")?.ok_or_else(|| {
-            SdkError::Config {
-                context: "edge_snapshot: edge_hash".into(),
-                field: Some("created_at".into()),
-                message: "is missing or empty (key corruption?)".into(),
-            }
-        })?;
-
-    let created_by = opt_str(raw, "created_by")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some("created_by".into()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?
-        .to_owned();
-
-    Ok(EdgeSnapshot::new(
-        edge_id.clone(),
-        flow_id.clone(),
-        upstream_execution_id,
-        downstream_execution_id,
-        dependency_kind,
-        satisfaction_condition,
-        data_passing_ref,
-        edge_state,
-        created_at,
-        created_by,
-    ))
-}
-
-fn parse_eid(raw: &HashMap<String, String>, field: &str) -> Result<ExecutionId, SdkError> {
-    let s = opt_str(raw, field)
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| SdkError::Config {
-            context: "edge_snapshot: edge_hash".into(),
-            field: Some(field.to_owned()),
-            message: "is missing or empty (key corruption?)".into(),
-        })?;
-    ExecutionId::parse(s).map_err(|e| SdkError::Config {
-        context: "edge_snapshot: edge_hash".into(),
-        field: Some(field.to_owned()),
-        message: format!("'{s}' is not a valid ExecutionId (key corruption?): {e}"),
-    })
+) -> Result<EdgeSnapshot, ff_core::engine_error::EngineError> {
+    build_edge_snapshot_core(flow_id, edge_id, raw)
 }
 
 #[cfg(test)]
@@ -1065,7 +918,11 @@ mod tests {
         let err =
             build_execution_snapshot(eid(), &minimal_core("bogus"), HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
                 assert_eq!(field.as_deref(), Some("public_state"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
@@ -1080,7 +937,11 @@ mod tests {
         core.insert("lane_id".to_owned(), "lane\nbroken".to_owned());
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
                 assert_eq!(field.as_deref(), Some("lane_id"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
@@ -1094,7 +955,11 @@ mod tests {
             core.remove(want);
             let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
             match err {
-                SdkError::Config { field, message: msg, .. } => {
+                SdkError::Config {
+                    field,
+                    message: msg,
+                    ..
+                } => {
                     assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
                 }
                 other => panic!("expected Config for {want}, got {other:?}"),
@@ -1108,7 +973,11 @@ mod tests {
         core.insert("total_attempt_count".to_owned(), "not-a-number".to_owned());
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
                 assert_eq!(field.as_deref(), Some("total_attempt_count"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
@@ -1126,8 +995,16 @@ mod tests {
         );
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
-                assert_eq!(field.as_deref(), Some("current_attempt_index"), "msg: {msg}");
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
+                assert_eq!(
+                    field.as_deref(),
+                    Some("current_attempt_index"),
+                    "msg: {msg}"
+                );
             }
             other => panic!("expected Config, got {other:?}"),
         }
@@ -1144,7 +1021,11 @@ mod tests {
         core.insert("lease_expires_at".to_owned(), "9000".to_owned());
         let err = build_execution_snapshot(eid(), &core, HashMap::new()).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
                 assert_eq!(field.as_deref(), Some("current_lease_epoch"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
@@ -1259,8 +1140,15 @@ mod tests {
         core.insert("bogus_future_field".to_owned(), "v".to_owned());
         let err = build_flow_snapshot(f, &core).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
-                assert!(field.is_none(), "expected whole-object error, got field={field:?}");
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
+                assert!(
+                    field.is_none(),
+                    "expected whole-object error, got field={field:?}"
+                );
                 assert!(msg.contains("bogus_future_field"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
@@ -1287,7 +1175,11 @@ mod tests {
                 panic!("field {want} should fail but build_flow_snapshot returned Ok")
             });
             match err {
-                SdkError::Config { field, message: msg, .. } => {
+                SdkError::Config {
+                    field,
+                    message: msg,
+                    ..
+                } => {
                     assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
                 }
                 other => panic!("expected Config for {want}, got {other:?}"),
@@ -1307,7 +1199,11 @@ mod tests {
                 panic!("empty {want} should fail but build_flow_snapshot returned Ok")
             });
             match err {
-                SdkError::Config { field, message: msg, .. } => {
+                SdkError::Config {
+                    field,
+                    message: msg,
+                    ..
+                } => {
                     assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
                 }
                 other => panic!("expected Config for {want}, got {other:?}"),
@@ -1324,7 +1220,11 @@ mod tests {
         let core = minimal_flow_core(&other, "open");
         let err = build_flow_snapshot(requested, &core).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
                 assert_eq!(field.as_deref(), Some("flow_id"), "msg: {msg}");
                 assert!(msg.contains("does not match"), "msg: {msg}");
             }
@@ -1339,7 +1239,11 @@ mod tests {
         core.insert("graph_revision".to_owned(), "not-a-number".to_owned());
         let err = build_flow_snapshot(f, &core).unwrap_err();
         match err {
-            SdkError::Config { field, message: msg, .. } => {
+            SdkError::Config {
+                field,
+                message: msg,
+                ..
+            } => {
                 assert_eq!(field.as_deref(), Some("graph_revision"), "msg: {msg}");
             }
             other => panic!("expected Config, got {other:?}"),
@@ -1347,174 +1251,13 @@ mod tests {
     }
 
     // ─── EdgeSnapshot (describe_edge) ───
-
-    fn eids_for_flow(f: &FlowId) -> (ExecutionId, ExecutionId) {
-        let cfg = PartitionConfig::default();
-        (ExecutionId::for_flow(f, &cfg), ExecutionId::for_flow(f, &cfg))
-    }
-
-    fn minimal_edge_hash(
-        flow: &FlowId,
-        edge: &EdgeId,
-        up: &ExecutionId,
-        down: &ExecutionId,
-    ) -> HashMap<String, String> {
-        let mut m = HashMap::new();
-        m.insert("edge_id".into(), edge.to_string());
-        m.insert("flow_id".into(), flow.to_string());
-        m.insert("upstream_execution_id".into(), up.to_string());
-        m.insert("downstream_execution_id".into(), down.to_string());
-        m.insert("dependency_kind".into(), "success_only".into());
-        m.insert("satisfaction_condition".into(), "all_required".into());
-        m.insert("data_passing_ref".into(), String::new());
-        m.insert("edge_state".into(), "pending".into());
-        m.insert("created_at".into(), "1234".into());
-        m.insert("created_by".into(), "engine".into());
-        m
-    }
-
-    #[test]
-    fn edge_round_trips_all_fields() {
-        let f = fid();
-        let edge = EdgeId::new();
-        let (up, down) = eids_for_flow(&f);
-        let raw = minimal_edge_hash(&f, &edge, &up, &down);
-        let snap = build_edge_snapshot(&f, &edge, &raw).unwrap();
-        assert_eq!(snap.edge_id, edge);
-        assert_eq!(snap.flow_id, f);
-        assert_eq!(snap.upstream_execution_id, up);
-        assert_eq!(snap.downstream_execution_id, down);
-        assert_eq!(snap.dependency_kind, "success_only");
-        assert_eq!(snap.satisfaction_condition, "all_required");
-        assert!(snap.data_passing_ref.is_none());
-        assert_eq!(snap.edge_state, "pending");
-        assert_eq!(snap.created_at.0, 1234);
-        assert_eq!(snap.created_by, "engine");
-    }
-
-    #[test]
-    fn edge_data_passing_ref_round_trips_when_set() {
-        let f = fid();
-        let edge = EdgeId::new();
-        let (up, down) = eids_for_flow(&f);
-        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
-        raw.insert("data_passing_ref".into(), "ref://blob-42".into());
-        let snap = build_edge_snapshot(&f, &edge, &raw).unwrap();
-        assert_eq!(snap.data_passing_ref.as_deref(), Some("ref://blob-42"));
-    }
-
-    #[test]
-    fn edge_unknown_field_fails_loud() {
-        let f = fid();
-        let edge = EdgeId::new();
-        let (up, down) = eids_for_flow(&f);
-        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
-        raw.insert("bogus_future_field".into(), "v".into());
-        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
-        match err {
-            SdkError::Config { field, message: msg, .. } => {
-                assert!(field.is_none(), "expected whole-object error, got field={field:?}");
-                assert!(msg.contains("bogus_future_field"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn edge_flow_id_mismatch_fails_loud() {
-        let f = fid();
-        let other = fid();
-        let edge = EdgeId::new();
-        let (up, down) = eids_for_flow(&f);
-        let raw = minimal_edge_hash(&other, &edge, &up, &down);
-        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
-        match err {
-            SdkError::Config { field, message: msg, .. } => {
-                assert_eq!(field.as_deref(), Some("flow_id"), "msg: {msg}");
-                assert!(msg.contains("does not match"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn edge_edge_id_mismatch_fails_loud() {
-        let f = fid();
-        let edge = EdgeId::new();
-        let other_edge = EdgeId::new();
-        let (up, down) = eids_for_flow(&f);
-        let raw = minimal_edge_hash(&f, &other_edge, &up, &down);
-        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
-        match err {
-            SdkError::Config { field, message: msg, .. } => {
-                assert_eq!(field.as_deref(), Some("edge_id"), "msg: {msg}");
-                assert!(msg.contains("does not match"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn edge_missing_required_fields_fail_loud() {
-        for want in [
-            "edge_id",
-            "flow_id",
-            "upstream_execution_id",
-            "downstream_execution_id",
-            "dependency_kind",
-            "satisfaction_condition",
-            "edge_state",
-            "created_at",
-            "created_by",
-        ] {
-            let f = fid();
-            let edge = EdgeId::new();
-            let (up, down) = eids_for_flow(&f);
-            let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
-            raw.remove(want);
-            let err = build_edge_snapshot(&f, &edge, &raw)
-                .err()
-                .unwrap_or_else(|| panic!("missing {want} should fail"));
-            match err {
-                SdkError::Config { field, message: msg, .. } => {
-                    assert_eq!(field.as_deref(), Some(want), "msg for {want}: {msg}");
-                }
-                other => panic!("expected Config for {want}, got {other:?}"),
-            }
-        }
-    }
-
-    #[test]
-    fn edge_malformed_created_at_fails_loud() {
-        let f = fid();
-        let edge = EdgeId::new();
-        let (up, down) = eids_for_flow(&f);
-        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
-        raw.insert("created_at".into(), "not-a-number".into());
-        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
-        match err {
-            SdkError::Config { field, message: msg, .. } => {
-                assert_eq!(field.as_deref(), Some("created_at"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn edge_malformed_upstream_eid_fails_loud() {
-        let f = fid();
-        let edge = EdgeId::new();
-        let (up, down) = eids_for_flow(&f);
-        let mut raw = minimal_edge_hash(&f, &edge, &up, &down);
-        raw.insert("upstream_execution_id".into(), "not-an-execution-id".into());
-        let err = build_edge_snapshot(&f, &edge, &raw).unwrap_err();
-        match err {
-            SdkError::Config { field, message: msg, .. } => {
-                assert_eq!(field.as_deref(), Some("upstream_execution_id"), "msg: {msg}");
-            }
-            other => panic!("expected Config, got {other:?}"),
-        }
-    }
+    //
+    // RFC-012 Stage 1c T2: the edge-hash decoder moved to
+    // `ff_core::contracts::decode`. The unit-level coverage for
+    // unknown-field / missing-field / mismatch / malformed-number
+    // paths lives alongside the decoder at ff-core; the ff-sdk
+    // higher-level describe_edge + list_*_edges integration coverage
+    // lives in `crates/ff-test/tests/describe_edge_api.rs`.
 
     #[test]
     fn namespaced_tag_matcher_boundaries() {

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -591,6 +591,16 @@ impl FlowFabricWorker {
         Some(&self.backend)
     }
 
+    /// Crate-internal direct borrow of the backend. The public
+    /// [`Self::backend`] still returns `Option` for API stability
+    /// (Stage 1b holdover). Snapshot trait-forwarders in
+    /// [`crate::snapshot`] need an un-wrapped reference.
+    pub(crate) fn backend_ref(
+        &self,
+    ) -> &Arc<dyn ff_core::engine_backend::EngineBackend> {
+        &self.backend
+    }
+
     /// Handle to the completion-event subscription backend, for
     /// consumers that need to observe execution completions (DAG
     /// reconcilers, tenant-isolated subscribers).

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 #[cfg(feature = "direct-valkey-claim")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
 
-use ferriskey::{Client, ClientBuilder, Value};
+use ferriskey::{Client, Value};
 use ff_core::keys::{ExecKeyContext, IndexKeys};
 use ff_core::partition::PartitionConfig;
 use ff_core::types::*;
@@ -34,9 +33,21 @@ use crate::SdkError;
 /// # Usage
 ///
 /// ```rust,ignore
+/// use ff_core::backend::BackendConfig;
+/// use ff_core::types::{LaneId, Namespace, WorkerId, WorkerInstanceId};
 /// use ff_sdk::{FlowFabricWorker, WorkerConfig};
 ///
-/// let config = WorkerConfig::new("localhost", 6379, "w1", "w1-i1", "default", "main");
+/// let config = WorkerConfig {
+///     backend: BackendConfig::valkey("localhost", 6379),
+///     worker_id: WorkerId::new("w1"),
+///     worker_instance_id: WorkerInstanceId::new("w1-i1"),
+///     namespace: Namespace::new("default"),
+///     lanes: vec![LaneId::new("main")],
+///     capabilities: Vec::new(),
+///     lease_ttl_ms: 30_000,
+///     claim_poll_interval_ms: 1_000,
+///     max_concurrent_tasks: 1,
+/// };
 /// let worker = FlowFabricWorker::connect(config).await?;
 ///
 /// loop {
@@ -145,19 +156,14 @@ impl FlowFabricWorker {
             });
         }
 
-        let mut builder = ClientBuilder::new()
-            .host(&config.host, config.port)
-            .connect_timeout(Duration::from_secs(10))
-            .request_timeout(Duration::from_millis(5000));
-        if config.tls {
-            builder = builder.tls();
-        }
-        if config.cluster {
-            builder = builder.cluster();
-        }
-        let client = builder.build()
-            .await
-            .map_err(|e| crate::backend_context(e, "failed to connect"))?;
+        // Build the ferriskey client from the nested `BackendConfig`.
+        // Delegates to `ff_backend_valkey::build_client` so host/port +
+        // TLS + cluster + `BackendTimeouts::request` +
+        // `BackendRetry` wiring lives in exactly one place (pre-Stage
+        // 1c this path had its own `ClientBuilder` chain that diverged
+        // from the backend's shape; RFC-012 Stage 1c tranche 1
+        // consolidates).
+        let client = ff_backend_valkey::build_client(&config.backend).await?;
 
         // Verify connectivity
         let pong: String = client

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1395,6 +1395,9 @@ impl FlowFabricWorker {
         let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
+        // TODO(#150): migrate when EngineBackend trait grows a
+        // `claim_resumed_execution` method; for now this FCALL stays on
+        // ff-sdk's direct client path.
         let raw: Value = self
             .client
             .fcall("ff_claim_resumed_execution", &key_refs, &arg_refs)
@@ -1622,6 +1625,9 @@ impl FlowFabricWorker {
         let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
+        // TODO(#150): migrate when EngineBackend trait grows a
+        // `deliver_signal` method; for now this FCALL stays on
+        // ff-sdk's direct client path.
         let raw: Value = self
             .client
             .fcall("ff_deliver_signal", &key_refs, &arg_refs)

--- a/crates/ff-test/src/fixtures.rs
+++ b/crates/ff-test/src/fixtures.rs
@@ -355,6 +355,35 @@ pub async fn build_client_from_env() -> ferriskey::Result<Client> {
     builder.build().await
 }
 
+/// Build a [`BackendConfig`] (Valkey arm) from the same environment
+/// vars as [`build_client_from_env`]. Used by tests that construct a
+/// [`ff_sdk::WorkerConfig`] and need the nested `backend` field.
+///
+/// * `FF_HOST` (default: `localhost`)
+/// * `FF_PORT` (default: `6379`)
+/// * `FF_TLS` (default: `false`)
+/// * `FF_CLUSTER` (default: `false`)
+///
+/// [`BackendConfig`]: ff_core::backend::BackendConfig
+pub fn backend_config_from_env() -> ff_core::backend::BackendConfig {
+    use ff_core::backend::{BackendConfig, BackendConnection, ValkeyConnection};
+    let host = std::env::var("FF_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_owned());
+    let port: u16 = std::env::var("FF_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_PORT);
+    let mut conn = ValkeyConnection::new(host, port);
+    conn.tls = env_flag("FF_TLS");
+    conn.cluster = env_flag("FF_CLUSTER");
+    // `BackendConfig` is `#[non_exhaustive]` — build via the
+    // public `valkey` constructor then overwrite `connection` so
+    // TLS / cluster flags land. `timeouts` + `retry` stay at
+    // backend defaults.
+    let mut cfg = BackendConfig::valkey("", 0);
+    cfg.connection = BackendConnection::Valkey(conn);
+    cfg
+}
+
 /// Read an env var as a boolean flag (1, true, yes → true).
 pub fn env_flag(key: &str) -> bool {
     std::env::var(key)

--- a/crates/ff-test/tests/describe_edge_api.rs
+++ b/crates/ff-test/tests/describe_edge_api.rs
@@ -41,13 +41,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: WorkerId::new(format!("desc-edge-worker-{name_suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-edge-inst-{name_suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/describe_edge_api.rs
+++ b/crates/ff-test/tests/describe_edge_api.rs
@@ -418,14 +418,23 @@ async fn list_edges_detects_adjacency_endpoint_drift() {
         .await
         .expect_err("endpoint drift must surface");
     match err {
-        ff_sdk::SdkError::Config { message: msg, .. } => {
-            assert!(msg.contains("adjacency"), "msg: {msg}");
-            assert!(
-                msg.contains("stored endpoint"),
-                "msg should name drift: {msg}"
-            );
-        }
-        other => panic!("expected Config, got {other:?}"),
+        // RFC-012 Stage 1c T3: endpoint-drift detection lives in
+        // `ff_backend_valkey::list_edges_impl` and returns
+        // `EngineError::Validation { kind: Corruption, .. }`.
+        ff_sdk::SdkError::Engine(ref boxed) => match boxed.as_ref() {
+            ff_core::engine_error::EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail,
+            } => {
+                assert!(detail.contains("adjacency"), "detail: {detail}");
+                assert!(
+                    detail.contains("stored endpoint"),
+                    "detail should name drift: {detail}"
+                );
+            }
+            other => panic!("expected EngineError::Validation::Corruption, got {other:?}"),
+        },
+        other => panic!("expected SdkError::Engine(Validation::Corruption), got {other:?}"),
     }
 }
 
@@ -462,9 +471,18 @@ async fn describe_edge_corrupt_state_surfaces_error() {
         .await
         .expect_err("unknown edge_hash field must surface as error");
     match err {
-        ff_sdk::SdkError::Config { message: msg, .. } => {
-            assert!(msg.contains("bogus_future_field"), "msg: {msg}");
-        }
-        other => panic!("expected SdkError::Config, got {other:?}"),
+        // RFC-012 Stage 1c T3: `describe_edge` calls the ff-core
+        // decoder which returns `EngineError::Validation { kind:
+        // Corruption, detail }`.
+        ff_sdk::SdkError::Engine(ref boxed) => match boxed.as_ref() {
+            ff_core::engine_error::EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail,
+            } => {
+                assert!(detail.contains("bogus_future_field"), "detail: {detail}");
+            }
+            other => panic!("expected EngineError::Validation::Corruption, got {other:?}"),
+        },
+        other => panic!("expected SdkError::Engine(Validation::Corruption), got {other:?}"),
     }
 }

--- a/crates/ff-test/tests/describe_execution_api.rs
+++ b/crates/ff-test/tests/describe_execution_api.rs
@@ -41,13 +41,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: WorkerId::new(format!("desc-exec-worker-{name_suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-exec-inst-{name_suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/describe_execution_api.rs
+++ b/crates/ff-test/tests/describe_execution_api.rs
@@ -326,20 +326,24 @@ async fn describe_execution_corrupt_public_state_surfaces_error() {
         .await
         .expect_err("corrupt public_state must surface as error");
     match err {
-        ff_sdk::SdkError::Config {
-            field: ref f,
-            message: ref msg,
-            ..
-        } => {
-            // Post-#98 structured shape: the field name lives in
-            // `field`, not interpolated into `message`. Verify the
-            // error names public_state in either slot so the test
-            // survives future rephrasings of the human-readable part.
-            assert!(
-                f.as_deref() == Some("public_state") || msg.contains("public_state"),
-                "error must name the field (field={f:?}, msg={msg})"
-            );
-        }
-        other => panic!("expected SdkError::Config, got {other:?}"),
+        // RFC-012 Stage 1c T3: the strict-parse decoder moved into
+        // `ff_core::contracts::decode` and now surfaces via
+        // `EngineError::Validation { kind: Corruption, detail }`
+        // (wrapped by ff-sdk's `From<EngineError> for SdkError` into
+        // `SdkError::Engine`). The field name is embedded in `detail`
+        // with the shape `"<context>: <field>: <message>"`.
+        ff_sdk::SdkError::Engine(ref boxed) => match boxed.as_ref() {
+            ff_core::engine_error::EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail,
+            } => {
+                assert!(
+                    detail.contains("public_state"),
+                    "error must name the field (detail={detail})"
+                );
+            }
+            other => panic!("expected EngineError::Validation::Corruption, got {other:?}"),
+        },
+        other => panic!("expected SdkError::Engine(Validation::Corruption), got {other:?}"),
     }
 }

--- a/crates/ff-test/tests/describe_flow_api.rs
+++ b/crates/ff-test/tests/describe_flow_api.rs
@@ -272,12 +272,20 @@ async fn describe_flow_corrupt_state_surfaces_error() {
         .await
         .expect_err("unknown flat flow_core field must surface as error");
     match err {
-        ff_sdk::SdkError::Config { message: msg, .. } => {
-            assert!(
-                msg.contains("bogus_future_field"),
-                "error message must name the field: {msg}"
-            );
-        }
-        other => panic!("expected SdkError::Config, got {other:?}"),
+        // RFC-012 Stage 1c T3: decoder returns
+        // `EngineError::Validation { kind: Corruption, .. }` now.
+        ff_sdk::SdkError::Engine(ref boxed) => match boxed.as_ref() {
+            ff_core::engine_error::EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail,
+            } => {
+                assert!(
+                    detail.contains("bogus_future_field"),
+                    "error detail must name the field: {detail}"
+                );
+            }
+            other => panic!("expected EngineError::Validation::Corruption, got {other:?}"),
+        },
+        other => panic!("expected SdkError::Engine(Validation::Corruption), got {other:?}"),
     }
 }

--- a/crates/ff-test/tests/describe_flow_api.rs
+++ b/crates/ff-test/tests/describe_flow_api.rs
@@ -40,13 +40,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: WorkerId::new(format!("desc-flow-worker-{name_suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-flow-inst-{name_suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4270,10 +4270,7 @@ async fn test_max_concurrent_tasks_enforcement() {
 
     // Build a worker with max_concurrent_tasks = 2
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new("concurrency-test-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("concurrency-test-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -4858,10 +4855,7 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     // is guaranteed to saturate. Use the standard worker identity
     // so both grants are issued to this worker_id.
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new(WORKER),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(WORKER_INST),
         namespace: ff_core::types::Namespace::new(NS),
@@ -4943,10 +4937,7 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     // on the grant passes — we're modelling a retry from a fresh
     // worker process with free capacity, not a different identity.
     let second_worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new(WORKER),
         // Distinct instance id so the alive-key SET NX guard in
         // `FlowFabricWorker::connect` doesn't reject us as a
@@ -5442,10 +5433,7 @@ async fn test_sdk_suspend_signal_resume_reclaim() {
 
     // Build SDK worker
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new("suspend-test-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("suspend-test-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -5633,10 +5621,7 @@ async fn test_sdk_all_methods_smoke() {
         .unwrap();
 
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new("sdk-smoke-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("sdk-smoke-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -5725,10 +5710,7 @@ async fn test_sdk_claim_retry_attempt_index() {
         .unwrap();
 
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new("retry-idx-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("retry-idx-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -8794,10 +8776,7 @@ async fn build_reclaim_test_worker(
     worker_instance_id: &str,
 ) -> ff_sdk::FlowFabricWorker {
     let config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new(worker_id),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(worker_instance_id),
         namespace: ff_core::types::Namespace::new(NS),
@@ -9174,10 +9153,7 @@ async fn test_claim_from_reclaim_grant_rejects_at_capacity() {
     // Build a worker with max_concurrent_tasks=1 so the second
     // reclaim is guaranteed to saturate.
     let worker_config = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new(WORKER),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(WORKER_INST),
         namespace: ff_core::types::Namespace::new(NS),

--- a/crates/ff-test/tests/engine_backend_list_edges.rs
+++ b/crates/ff-test/tests/engine_backend_list_edges.rs
@@ -1,0 +1,275 @@
+//! RFC-012 Stage 1c T2: integration coverage for
+//! [`ff_core::engine_backend::EngineBackend::list_edges`] on the
+//! Valkey-backed impl.
+//!
+//! The ff-sdk free-fns `list_incoming_edges` / `list_outgoing_edges`
+//! retain their internal pipeline at Stage 1c-T2 (zero-behavior-change
+//! holdover); this test proves the new trait method returns the SAME
+//! edge set for the SAME flow, so the Stage 1c-T3 migration can
+//! point callers at the trait with confidence.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test engine_backend_list_edges \
+//!       -- --test-threads=1
+
+use std::sync::Arc;
+
+use ferriskey::Value;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::contracts::EdgeDirection;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
+use ff_core::partition::{PartitionConfig, execution_partition, flow_partition};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+const LANE: &str = "list-edges-lane";
+const NS: &str = "list-edges-ns";
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = test_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn build_worker(suffix: &str) -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        backend: ff_test::fixtures::backend_config_from_env(),
+        worker_id: WorkerId::new(format!("list-edges-worker-{suffix}")),
+        worker_instance_id: WorkerInstanceId::new(format!("list-edges-inst-{suffix}")),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+async fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    // Reuse the TestCluster's dialed client + test partition config so
+    // the backend and the SDK worker both hit the same keyspace under
+    // the same routing rules. `from_client_and_partitions` wraps the
+    // client into an `Arc<ValkeyBackend>`; upcast to
+    // `Arc<dyn EngineBackend>` via the trait-object coercion.
+    ValkeyBackend::from_client_and_partitions(tc.client().clone(), test_config())
+}
+
+async fn create_flow(tc: &TestCluster, fid: &FlowId) {
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let ctx = FlowKeyContext::new(&partition, fid);
+    let fidx = FlowIndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![ctx.core(), ctx.members(), fidx.flow_index()];
+    let now_ms = TimestampMs::now().0.to_string();
+    let args: Vec<String> = vec![fid.to_string(), "dag".to_owned(), NS.to_owned(), now_ms];
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_flow", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_create_flow");
+}
+
+async fn create_and_add_member(tc: &TestCluster, fid: &FlowId) -> ExecutionId {
+    let config = test_config();
+    let eid = ExecutionId::for_flow(fid, &config);
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "edge_test_kind".to_owned(),
+        "0".to_owned(),
+        "list-edges-test".to_owned(),
+        "{}".to_owned(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution");
+
+    let fpart = flow_partition(fid, &config);
+    let fctx = FlowKeyContext::new(&fpart, fid);
+    let fidx = FlowIndexKeys::new(&fpart);
+    let keys: Vec<String> = vec![fctx.core(), fctx.members(), ctx.core(), fidx.flow_index()];
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        eid.to_string(),
+        TimestampMs::now().0.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_add_execution_to_flow", &kr, &ar)
+        .await
+        .expect("FCALL ff_add_execution_to_flow");
+
+    eid
+}
+
+async fn stage_edge(
+    tc: &TestCluster,
+    fid: &FlowId,
+    up: &ExecutionId,
+    down: &ExecutionId,
+    expected_graph_revision: u64,
+) -> EdgeId {
+    let edge_id = EdgeId::new();
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let fctx = FlowKeyContext::new(&partition, fid);
+
+    let keys: Vec<String> = vec![
+        fctx.core(),
+        fctx.members(),
+        fctx.edge(&edge_id),
+        fctx.outgoing(up),
+        fctx.incoming(down),
+        fctx.grant(&edge_id.to_string()),
+    ];
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        edge_id.to_string(),
+        up.to_string(),
+        down.to_string(),
+        "success_only".to_owned(),
+        String::new(),
+        expected_graph_revision.to_string(),
+        TimestampMs::now().0.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_stage_dependency_edge", &kr, &ar)
+        .await
+        .expect("FCALL ff_stage_dependency_edge");
+    edge_id
+}
+
+/// Trait `list_edges` (Outgoing + Incoming) returns the same edge set
+/// as the ff-sdk free-fn pair for a fan-out flow with 2 outgoing +
+/// 1 incoming edge on the subject nodes.
+#[tokio::test]
+async fn list_edges_trait_matches_sdk_free_fn() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("parity").await;
+    let backend = build_backend(&tc).await;
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let up = create_and_add_member(&tc, &fid).await;
+    let mid = create_and_add_member(&tc, &fid).await;
+    let other = create_and_add_member(&tc, &fid).await;
+    // 3 adds → graph_revision 3, then +1 per staged edge.
+    let e1 = stage_edge(&tc, &fid, &up, &mid, 3).await;
+    let e2 = stage_edge(&tc, &fid, &up, &other, 4).await;
+
+    // Outgoing: `up` → {mid, other}.
+    let mut trait_out = backend
+        .list_edges(
+            &fid,
+            EdgeDirection::Outgoing {
+                from_node: up.clone(),
+            },
+        )
+        .await
+        .expect("trait list_edges Outgoing");
+    let mut sdk_out = worker
+        .list_outgoing_edges(&up)
+        .await
+        .expect("sdk list_outgoing_edges");
+    trait_out.sort_by(|a, b| a.edge_id.to_string().cmp(&b.edge_id.to_string()));
+    sdk_out.sort_by(|a, b| a.edge_id.to_string().cmp(&b.edge_id.to_string()));
+    assert_eq!(
+        trait_out, sdk_out,
+        "trait list_edges(Outgoing) must match ff-sdk list_outgoing_edges"
+    );
+    assert_eq!(trait_out.len(), 2, "expected 2 outgoing edges");
+    let ids: Vec<_> = trait_out.iter().map(|e| e.edge_id.clone()).collect();
+    assert!(ids.contains(&e1));
+    assert!(ids.contains(&e2));
+
+    // Incoming: `mid` ← {up}.
+    let trait_in = backend
+        .list_edges(
+            &fid,
+            EdgeDirection::Incoming {
+                to_node: mid.clone(),
+            },
+        )
+        .await
+        .expect("trait list_edges Incoming");
+    let sdk_in = worker
+        .list_incoming_edges(&mid)
+        .await
+        .expect("sdk list_incoming_edges");
+    assert_eq!(
+        trait_in, sdk_in,
+        "trait list_edges(Incoming) must match ff-sdk list_incoming_edges"
+    );
+    assert_eq!(trait_in.len(), 1, "expected 1 incoming edge on mid");
+    assert_eq!(trait_in[0].edge_id, e1);
+    assert_eq!(trait_in[0].upstream_execution_id, up);
+    assert_eq!(trait_in[0].downstream_execution_id, mid);
+
+    // Isolated node `other` has 0 incoming listed under `mid`'s flow.
+    let trait_iso = backend
+        .list_edges(
+            &fid,
+            EdgeDirection::Outgoing {
+                from_node: mid.clone(),
+            },
+        )
+        .await
+        .expect("trait list_edges Outgoing for leaf");
+    assert!(
+        trait_iso.is_empty(),
+        "leaf node has no outgoing edges; got {trait_iso:?}"
+    );
+}

--- a/crates/ff-test/tests/engine_backend_list_edges.rs
+++ b/crates/ff-test/tests/engine_backend_list_edges.rs
@@ -133,7 +133,9 @@ async fn create_and_add_member(tc: &TestCluster, fid: &FlowId) -> ExecutionId {
     let fpart = flow_partition(fid, &config);
     let fctx = FlowKeyContext::new(&fpart, fid);
     let fidx = FlowIndexKeys::new(&fpart);
-    let keys: Vec<String> = vec![fctx.core(), fctx.members(), ctx.core(), fidx.flow_index()];
+    // KEYS order per flowfabric.lua `ff_add_execution_to_flow`:
+    // (1) flow_core, (2) members_set, (3) flow_index, (4) exec_core.
+    let keys: Vec<String> = vec![fctx.core(), fctx.members(), fidx.flow_index(), ctx.core()];
     let args: Vec<String> = vec![
         fid.to_string(),
         eid.to_string(),

--- a/crates/ff-test/tests/resume_signals_integration.rs
+++ b/crates/ff-test/tests/resume_signals_integration.rs
@@ -23,10 +23,7 @@ const NS: &str = "resume-sig-ns";
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        host: std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("FF_PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(6379),
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        backend: ff_test::fixtures::backend_config_from_env(),
         worker_id: ff_core::types::WorkerId::new(format!("resume-sig-worker-{name_suffix}")),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "resume-sig-inst-{name_suffix}"

--- a/docs/cairn-migration-v0.4.0.md
+++ b/docs/cairn-migration-v0.4.0.md
@@ -124,7 +124,76 @@ from `completion_backend()` on this path because `Arc<dyn
 EngineBackend>` cannot be re-upcast to `Arc<dyn CompletionBackend>` in
 Rust's trait-object model. 0.3.4 makes the caller decide.
 
-## 6. Gotchas
+## 6. `SdkError` shape migration (post-RFC-012 Stage 1c T3)
+
+Stage 1c T3 moves the strict-parse decoders for `describe_execution`,
+`describe_flow`, and `describe_edge` (plus `list_*_edges`) out of
+ff-sdk and into `ff_core::contracts::decode`. Every `EngineBackend`
+implementation now shares one error surface:
+`EngineError::Validation { kind: ValidationKind::Corruption, detail }`.
+
+### Before (pre-0.4.0 ff-sdk)
+
+```rust
+match err {
+    ff_sdk::SdkError::Config { field, message, .. } => {
+        // field is Option<String>; message is the full context.
+        assert_eq!(field.as_deref(), Some("public_state"));
+    }
+    other => panic!("expected Config, got {other:?}"),
+}
+```
+
+### After (0.4.0+)
+
+```rust
+match err {
+    ff_sdk::SdkError::Engine(boxed) => match boxed.as_ref() {
+        ff_core::engine_error::EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::Corruption,
+            detail,
+        } => {
+            // detail is a "<context>: <field>: <message>" string;
+            // substring-match the field name.
+            assert!(detail.contains("public_state"));
+        }
+        other => panic!("expected Validation::Corruption, got {other:?}"),
+    },
+    other => panic!("expected SdkError::Engine, got {other:?}"),
+}
+```
+
+### Scope
+
+Only on-disk-corruption paths change shape. This includes:
+
+- `describe_execution` — exec_core / tags hash parse failures.
+- `describe_flow` — flow_core hash parse failures, unknown-field sweep.
+- `describe_edge`, `list_incoming_edges`, `list_outgoing_edges` — edge
+  hash parse failures, adjacency-set endpoint drift.
+
+`SdkError::Config` still exists and is still returned for SDK-side
+input validation (e.g. `WorkerConfig` with zero lanes). Only the
+subset of `SdkError::Config` emitted by the snapshot decoders
+collapses into `SdkError::Engine(EngineError::Validation { Corruption, .. })`.
+
+### Detail format
+
+`detail` is a human-readable string with the shape
+`"<context>: <field>: <message>"` (field omitted for whole-object
+errors). The `field` is embedded — not a typed slot — so consumers
+that want field-level routing should substring-match. FF's own tests
+use `assert!(detail.contains("<field>"))`; this is the recommended
+pattern.
+
+### Classification
+
+`EngineError::Validation` classifies as
+`ErrorClass::Terminal` (see `EngineError::class()`), so
+`SdkError::is_retryable()` returns `false` for these — same retry
+posture as the pre-migration `SdkError::Config`.
+
+## 7. Gotchas
 
 - **`#[non_exhaustive]` forces `..Default::default()`** on
   `BackendTimeouts`, `BackendRetry`, and most other `ff-core::backend`

--- a/examples/coding-agent/src/worker.rs
+++ b/examples/coding-agent/src/worker.rs
@@ -79,14 +79,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
 
-    let config = WorkerConfig::new(
-        &args.host,
-        args.port,
-        "coding-agent",
-        format!("coding-agent-{}", uuid::Uuid::new_v4()),
-        &args.namespace,
-        &args.lane,
-    );
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        worker_id: ff_core::types::WorkerId::new("coding-agent"),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
+            "coding-agent-{}",
+            uuid::Uuid::new_v4()
+        )),
+        namespace: ff_core::types::Namespace::new(&args.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&args.lane)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 1_000,
+        max_concurrent_tasks: 1,
+    };
 
     let worker = FlowFabricWorker::connect(config).await?;
     let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {

--- a/examples/media-pipeline/src/bin/embed.rs
+++ b/examples/media-pipeline/src/bin/embed.rs
@@ -80,15 +80,17 @@ async fn main() -> anyhow::Result<()> {
     let model = Arc::new(Mutex::new(model));
 
     let instance_id = format!("embed-{}", uuid::Uuid::new_v4());
-    let mut config = WorkerConfig::new(
-        &args.host,
-        args.port,
-        "embed",
-        &instance_id,
-        &args.namespace,
-        &args.lane,
-    );
-    config.capabilities = vec!["embed".into(), "minilm-l6".into()];
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        worker_id: ff_core::types::WorkerId::new("embed"),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
+        namespace: ff_core::types::Namespace::new(&args.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&args.lane)],
+        capabilities: vec!["embed".into(), "minilm-l6".into()],
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 1_000,
+        max_concurrent_tasks: 1,
+    };
 
     let worker = FlowFabricWorker::connect(config).await?;
     let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -113,15 +113,17 @@ async fn main() -> anyhow::Result<()> {
     let engine = Arc::new(Engine { backend, model });
 
     let instance_id = format!("summarize-{}", uuid::Uuid::new_v4());
-    let mut config = WorkerConfig::new(
-        &args.host,
-        args.port,
-        "summarize",
-        &instance_id,
-        &args.namespace,
-        &args.lane,
-    );
-    config.capabilities = vec!["llm".into(), "qwen-500m-q4".into()];
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        worker_id: ff_core::types::WorkerId::new("summarize"),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
+        namespace: ff_core::types::Namespace::new(&args.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&args.lane)],
+        capabilities: vec!["llm".into(), "qwen-500m-q4".into()],
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 1_000,
+        max_concurrent_tasks: 1,
+    };
 
     let worker = FlowFabricWorker::connect(config).await?;
     let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {

--- a/examples/media-pipeline/src/bin/transcribe.rs
+++ b/examples/media-pipeline/src/bin/transcribe.rs
@@ -82,15 +82,17 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let instance_id = format!("transcribe-{}", uuid::Uuid::new_v4());
-    let mut config = WorkerConfig::new(
-        &args.host,
-        args.port,
-        "transcribe",
-        &instance_id,
-        &args.namespace,
-        &args.lane,
-    );
-    config.capabilities = vec!["asr".into(), "whisper-tiny-en".into()];
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        worker_id: ff_core::types::WorkerId::new("transcribe"),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
+        namespace: ff_core::types::Namespace::new(&args.namespace),
+        lanes: vec![ff_core::types::LaneId::new(&args.lane)],
+        capabilities: vec!["asr".into(), "whisper-tiny-en".into()],
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 1_000,
+        max_concurrent_tasks: 1,
+    };
 
     let worker = FlowFabricWorker::connect(config).await?;
     let admin = match args.api_token.as_deref().map(str::trim).filter(|t| !t.is_empty()) {

--- a/examples/retry-and-cancel/src/main.rs
+++ b/examples/retry-and-cancel/src/main.rs
@@ -296,14 +296,20 @@ async fn run_worker(
     admin: Arc<FlowFabricAdminClient>,
     done: Arc<Notify>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let config = WorkerConfig::new(
-        host,
-        port,
-        WORKER_POOL,
-        format!("{WORKER_POOL}-{}", uuid::Uuid::new_v4()),
-        NAMESPACE,
-        LANE,
-    );
+    let config = WorkerConfig {
+        backend: ff_core::backend::BackendConfig::valkey(host, port),
+        worker_id: ff_core::types::WorkerId::new(WORKER_POOL),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
+            "{WORKER_POOL}-{}",
+            uuid::Uuid::new_v4()
+        )),
+        namespace: ff_core::types::Namespace::new(NAMESPACE),
+        lanes: vec![ff_core::types::LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 1_000,
+        max_concurrent_tasks: 1,
+    };
     let worker = FlowFabricWorker::connect(config).await?;
     let lane = LaneId::try_new(LANE)?;
 


### PR DESCRIPTION
## Summary

RFC-012 Stage 1c, tranche 1 of ~4. Subsequent tranches stack as additional commits on this branch; split into a stacked PR only if any tranche balloons >500 LOC.

- `WorkerConfig` split: `host`/`port`/`tls`/`cluster` move into nested `backend: BackendConfig`. Worker-policy fields stay put. `WorkerConfig::new` removed (pre-1.0 clean break, no deprecated shim).
- `FlowFabricWorker::connect` now routes through `ff_backend_valkey::build_client` (made `pub`) so host/port + TLS + cluster + request-timeout + retry wiring lives in one place shared with `ValkeyBackend::connect`.
- `ff-core` feature-flag scaffold: `default = ["core", "streaming", "suspension", "budget"]`. Bodies intentionally empty in tranche 1 — tranches 2-5 add `#[cfg(feature = …)]` gates on `EngineBackend` methods as they migrate.
- CI job added: `cargo check -p ff-core --no-default-features --features core` (feature-matrix floor per plan open-Q 6).
- `ff_test::fixtures::backend_config_from_env` helper + `ff_readiness_tests::valkey` re-export for tests that build `WorkerConfig` from env vars.
- 32 call sites migrated: 5 examples, 5 benches, 9 ff-test tests, 5 readiness tests. Breaking change; CHANGELOG [Unreleased] documents migration recipe.

## Tranche roadmap (from [rfcs/drafts/stage-1c-plan-draft.md](rfcs/drafts/stage-1c-plan-draft.md))

- **T1 (this PR):** `BackendConfig` carveout + feature scaffold + CI matrix entry. **Landed.**
- **T2:** `FullSnapshot` type + `describe_execution_full` trait method + Valkey impl + integration test. (Manager decision: full snapshot lives on the trait; no Valkey pipeline escape hatch.)
- **T3:** Migrate `FlowFabricWorker` hot-path (21 FCALL sites in `worker.rs` + 5 in `snapshot.rs`).
- **T4:** Seal `client()` + migrate `read_stream`/`tail_stream` (closes #87/#88 partial overlap).
- **T5:** Feature-matrix CI + end-to-end coverage.
- **T6:** CHANGELOG 0.4.0 bundle entries.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo check -p ff-core --no-default-features`
- [x] `cargo check -p ff-core --no-default-features --features core`
- [x] `cargo check -p ff-sdk --no-default-features` (agnosticism contract)
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings`
- [x] `cargo test -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server --features ff-sdk/direct-valkey-claim` (all 131+4+10+58+70+45 unit + doc tests pass)
- [ ] CI matrix (Valkey-integration tests) — kicked by this PR.
- [ ] `cargo semver-checks` — expected breaking per §Scope; local run failed on the aws-crate rustc-1.91 floor, unrelated to this change.

## Coordination

- Worker AAA (#117 Round-7 trait deltas, branch `worker-aaa/rfc-012-round-7-impl`) touches the same trait this PR will grow in later tranches. Sequencing is the manager's call if AAA's PR opens before T2 lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)