### PR TITLE
feat(ff-core, ff-sdk, ff-backend-valkey): extend Frame for append_frame SDK-forwarder parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Breaking — `ff_core::backend::Frame` extended (RFC-012 §R7, PR #146):**
+  Added `frame_type: String` + `correlation_id: Option<String>` so
+  `ClaimedTask::append_frame` can forward through the `EngineBackend`
+  trait without wire-parity regression. Closes the Round-7
+  append_frame SDK-forwarder gap flagged in PR #145. `Frame` remains
+  `#[non_exhaustive]`; new `Frame::with_frame_type` /
+  `Frame::with_correlation_id` builder setters. The Valkey impl
+  uses `frame.frame_type` as the free-form `frame_type` ARGV when
+  non-empty, falling back to the `FrameKind` encoding when callers
+  populate only the typed `kind`.
+
 - **Breaking — `EngineBackend` trait (RFC-012 §R7, #117):**
   - `append_frame` now returns `AppendFrameOutcome { stream_id,
     frame_count }` (was `()`). The type moves from `ff_sdk::task`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **Breaking — `ff_core::backend::Frame` extended (RFC-012 §R7, PR #146):**
+- **Breaking — `ff_core::backend::Frame` extended (RFC-012 §R7, PR #147):**
   Added `frame_type: String` + `correlation_id: Option<String>` so
   `ClaimedTask::append_frame` can forward through the `EngineBackend`
   trait without wire-parity regression. Closes the Round-7

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -727,7 +727,15 @@ async fn append_frame_impl(
 
     let now = now_ms_timestamp();
     let payload_str = String::from_utf8_lossy(&frame.bytes).into_owned();
-    let frame_type = frame_kind_to_str(frame.kind);
+    // Free-form `frame_type` wins when populated (SDK forwarder path
+    // sets it to "delta" / "agent_step" / etc.); otherwise fall back
+    // to the stable `FrameKind` encoding for typed-only callers.
+    let frame_type: String = if frame.frame_type.is_empty() {
+        frame_kind_to_str(frame.kind).to_owned()
+    } else {
+        frame.frame_type.clone()
+    };
+    let correlation_id = frame.correlation_id.clone().unwrap_or_default();
 
     let keys: Vec<String> = vec![
         ctx.core(),
@@ -743,11 +751,11 @@ async fn append_frame_impl(
         f.attempt_index.to_string(),
         f.lease_id.to_string(),
         f.lease_epoch.to_string(),
-        frame_type.to_owned(),
+        frame_type,
         now.to_string(),
         payload_str,
         "utf8".to_owned(),
-        String::new(), // correlation_id — trait `Frame` has no slot today
+        correlation_id,
         "worker".to_owned(),
         "10000".to_owned(),
         f.attempt_id.to_string(),

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -186,6 +186,22 @@ pub enum FrameKind {
 /// Today's FCALL takes the byte payload + frame_type + optional seq as
 /// discrete ARGV; Stage 0 collects them into a named type for trait
 /// signatures.
+///
+/// **Round-7 follow-up (PR #145 → #146):** extended with
+/// `frame_type: String` (the SDK-public free-form classifier — values
+/// like `"delta"`, `"log"`, `"agent_step"`, `"summary_token"`,
+/// `"transcribe_line"`, `"progress"` — distinct from the coarse
+/// [`FrameKind`] enum) and `correlation_id: Option<String>` (the
+/// wire-level `correlation_id` ARGV, surfaced at the SDK as
+/// `metadata: Option<&str>`). Adding these lets
+/// `ClaimedTask::append_frame` forward through the trait without
+/// wire-parity regression.
+///
+/// `frame_type` is free-form and is what the backend writes into the
+/// Lua-side `frame_type` ARGV. [`FrameKind`] remains for typed
+/// classification at the trait surface; when callers populate only
+/// `kind`, the backend falls back to a stable encoding of the enum
+/// variant (see `frame_kind_to_str` in `ff-backend-valkey`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Frame {
@@ -194,17 +210,30 @@ pub struct Frame {
     /// Optional monotonic sequence. Set by the caller when the stream
     /// protocol is sequence-bound; `None` lets the backend assign.
     pub seq: Option<u64>,
+    /// Free-form classifier written to the Lua-side `frame_type` ARGV.
+    /// Empty string means "defer to [`FrameKind`]" — the backend
+    /// substitutes the enum-variant encoding.
+    pub frame_type: String,
+    /// Optional correlation id (wire `correlation_id` ARGV). `None`
+    /// encodes as the empty string on the wire.
+    pub correlation_id: Option<String>,
 }
 
 impl Frame {
     /// Construct a frame. `seq` defaults to `None` (backend-assigned);
-    /// callers that need an explicit sequence use
-    /// [`Frame::with_seq`].
+    /// `frame_type` defaults to empty (backend falls back to
+    /// `FrameKind` encoding); `correlation_id` defaults to `None`.
+    /// Callers that need an explicit sequence use [`Frame::with_seq`];
+    /// callers on the SDK forwarder path populate `frame_type` +
+    /// `correlation_id` via [`Frame::with_frame_type`] /
+    /// [`Frame::with_correlation_id`].
     pub fn new(bytes: Vec<u8>, kind: FrameKind) -> Self {
         Self {
             bytes,
             kind,
             seq: None,
+            frame_type: String::new(),
+            correlation_id: None,
         }
     }
 
@@ -214,7 +243,21 @@ impl Frame {
             bytes,
             kind,
             seq: Some(seq),
+            frame_type: String::new(),
+            correlation_id: None,
         }
+    }
+
+    /// Builder-style setter for the free-form `frame_type` classifier.
+    pub fn with_frame_type(mut self, frame_type: impl Into<String>) -> Self {
+        self.frame_type = frame_type.into();
+        self
+    }
+
+    /// Builder-style setter for the optional `correlation_id`.
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<String>) -> Self {
+        self.correlation_id = Some(correlation_id.into());
+        self
     }
 }
 
@@ -919,11 +962,29 @@ mod tests {
             bytes: b"hello".to_vec(),
             kind: FrameKind::Stdout,
             seq: Some(3),
+            frame_type: "delta".to_owned(),
+            correlation_id: Some("req-42".to_owned()),
         };
         assert_eq!(f.clone(), f);
         assert_eq!(f.kind, FrameKind::Stdout);
+        assert_eq!(f.frame_type, "delta");
+        assert_eq!(f.correlation_id.as_deref(), Some("req-42"));
         assert_ne!(FrameKind::Stderr, FrameKind::Event);
         let _ = format!("{f:?}");
+    }
+
+    #[test]
+    fn frame_builders_populate_extended_fields() {
+        let f = Frame::new(b"payload".to_vec(), FrameKind::Event)
+            .with_frame_type("agent_step")
+            .with_correlation_id("corr-1");
+        assert_eq!(f.frame_type, "agent_step");
+        assert_eq!(f.correlation_id.as_deref(), Some("corr-1"));
+        assert_eq!(f.seq, None);
+
+        let bare = Frame::new(b"p".to_vec(), FrameKind::Event);
+        assert_eq!(bare.frame_type, "");
+        assert_eq!(bare.correlation_id, None);
     }
 
     #[test]

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -690,72 +690,32 @@ impl ClaimedTask {
     ///
     /// Non-consuming — the worker can append many frames during execution.
     /// The stream is created lazily on the first append.
-    //
-    // RFC-012 §R7.2.1 widened `EngineBackend::append_frame`'s return
-    // to `AppendFrameOutcome` — that half of the trait alignment is
-    // done. The SDK-side migration remains direct-FCALL for now
-    // because the trait's `Frame { kind: FrameKind, bytes, seq }`
-    // input shape does not carry the SDK-public `frame_type: &str`
-    // (free-form) or `metadata: Option<&str>` (wire `correlation_id`)
-    // arguments — 5 in-tree example callers pass frame_type strings
-    // ("delta", "log", "agent_step", "summary_token", etc.) that
-    // don't map onto `FrameKind::{Stdout,Stderr,Event,Blob}` without
-    // a silent wire regression. Closing this gap needs a `Frame`-
-    // shape extension (adds `frame_type: String` + `correlation_id:
-    // Option<String>`) — tracked for Stage 1d alongside the `suspend`
-    // input-shape rework. Until then the SDK keeps byte-for-byte
-    // wire parity by issuing `ff_append_frame` directly; the trait's
-    // `append_frame_impl` in ff-backend-valkey covers the
-    // FrameKind-based call sites.
+    ///
+    /// **RFC-012 §R7.2.1 / PR #146:** forwards through the
+    /// `EngineBackend` trait. The free-form `frame_type` tag and
+    /// optional `metadata` (wire `correlation_id`) travel on the
+    /// extended [`ff_core::backend::Frame`] shape (`frame_type:
+    /// String`, `correlation_id: Option<String>`), giving byte-for-byte
+    /// wire parity with the pre-migration direct-FCALL path.
     pub async fn append_frame(
         &self,
         frame_type: &str,
         payload: &[u8],
         metadata: Option<&str>,
     ) -> Result<AppendFrameOutcome, SdkError> {
-        let partition = execution_partition(&self.execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, &self.execution_id);
-
-        let now = TimestampMs::now();
-
-        // KEYS (3): exec_core, stream_key, stream_meta
-        let keys: Vec<String> = vec![
-            ctx.core(),
-            ctx.stream(self.attempt_index),
-            ctx.stream_meta(self.attempt_index),
-        ];
-
-        let payload_str = String::from_utf8_lossy(payload);
-
-        // ARGV (13): execution_id, attempt_index, lease_id, lease_epoch,
-        //            frame_type, ts, payload, encoding, correlation_id,
-        //            source, retention_maxlen, attempt_id, max_payload_bytes
-        let args: Vec<String> = vec![
-            self.execution_id.to_string(),     // 1
-            self.attempt_index.to_string(),    // 2
-            self.lease_id.to_string(),         // 3
-            self.lease_epoch.to_string(),      // 4
-            frame_type.to_owned(),             // 5
-            now.to_string(),                   // 6 ts
-            payload_str.into_owned(),          // 7
-            "utf8".to_owned(),                 // 8 encoding
-            metadata.unwrap_or("").to_owned(), // 9 correlation_id
-            "worker".to_owned(),               // 10 source
-            "10000".to_owned(),                // 11 retention_maxlen
-            self.attempt_id.to_string(),       // 12
-            "65536".to_owned(),                // 13 max_payload_bytes
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .client
-            .fcall("ff_append_frame", &key_refs, &arg_refs)
+        let handle = self.synth_handle();
+        let mut frame = ff_core::backend::Frame::new(
+            payload.to_vec(),
+            ff_core::backend::FrameKind::Event,
+        )
+        .with_frame_type(frame_type);
+        if let Some(cid) = metadata {
+            frame = frame.with_correlation_id(cid);
+        }
+        self.backend
+            .append_frame(&handle, frame)
             .await
-            .map_err(SdkError::Valkey)?;
-
-        parse_append_frame_result(&raw)
+            .map_err(SdkError::from)
     }
 
     // ── Phase 3: Suspend ──
@@ -1614,82 +1574,6 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
     } else {
         Ok(SignalOutcome::Accepted { signal_id, effect })
     }
-}
-
-/// Parse ff_append_frame result: ok(entry_id, frame_count)
-fn parse_append_frame_result(raw: &Value) -> Result<AppendFrameOutcome, SdkError> {
-    let arr = match raw {
-        Value::Array(arr) => arr,
-        _ => {
-            return Err(SdkError::from(ScriptError::Parse {
-                fcall: "parse_append_frame_result".into(),
-                execution_id: None,
-                message: "ff_append_frame: expected Array".into(),
-            }));
-        }
-    };
-
-    let status_code = match arr.first() {
-        Some(Ok(Value::Int(n))) => *n,
-        _ => {
-            return Err(SdkError::from(ScriptError::Parse {
-                fcall: "parse_append_frame_result".into(),
-                execution_id: None,
-                message: "ff_append_frame: bad status code".into(),
-            }));
-        }
-    };
-
-    if status_code != 1 {
-        let err_field_str = |idx: usize| -> String {
-            arr.get(idx)
-                .and_then(|v| match v {
-                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                    Ok(Value::SimpleString(s)) => Some(s.clone()),
-                    _ => None,
-                })
-                .unwrap_or_default()
-        };
-        let error_code = {
-            let s = err_field_str(1);
-            if s.is_empty() { "unknown".to_owned() } else { s }
-        };
-        let detail = err_field_str(2);
-        return Err(SdkError::from(
-            ScriptError::from_code_with_detail(&error_code, &detail).unwrap_or_else(|| {
-                ScriptError::Parse {
-                    fcall: "parse_append_frame_result".into(),
-                    execution_id: None,
-                    message: format!("ff_append_frame: {error_code}"),
-                }
-            }),
-        ));
-    }
-
-    // ok(entry_id, frame_count)  → arr[2] = entry_id, arr[3] = frame_count
-    let stream_id = arr
-        .get(2)
-        .and_then(|v| match v {
-            Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-            Ok(Value::SimpleString(s)) => Some(s.clone()),
-            _ => None,
-        })
-        .unwrap_or_default();
-
-    let frame_count = arr
-        .get(3)
-        .and_then(|v| match v {
-            Ok(Value::BulkString(b)) => String::from_utf8_lossy(b).parse::<u64>().ok(),
-            Ok(Value::SimpleString(s)) => s.parse::<u64>().ok(),
-            Ok(Value::Int(n)) => Some(*n as u64),
-            _ => None,
-        })
-        .unwrap_or(0);
-
-    Ok(AppendFrameOutcome {
-        stream_id,
-        frame_count,
-    })
 }
 
 /// Parse ff_fail_execution result:


### PR DESCRIPTION
## Why

AAA-2 flagged in PR #145 that the trait `Frame` shape cannot represent the SDK's wire contract — it carries `{ bytes, kind: FrameKind, seq }`, but `ff_append_frame` takes a free-form `frame_type` string (SDK-public) plus an optional `correlation_id` (wire-level, surfaced as `metadata` at the SDK). As a result, `ClaimedTask::append_frame` stayed on a direct-FCALL path with a TODO — forwarding through the trait would silently regress wire parity for the 5 in-tree callers that pass non-FrameKind frame_type strings.

This PR closes the gap by extending `Frame` with the two missing slots, wiring them through the backend, and migrating the SDK forwarder.

## 5-caller grep (all unchanged — flow through the updated forwarder)

| frame_type | caller |
|---|---|
| `"delta"` | `crates/ff-test/tests/e2e_lifecycle.rs:5666` |
| `"progress"` | `crates/ff-readiness-tests/tests/lifecycle_{happy_path,retry_backoff}.rs` (3 sites) |
| `"agent_step"` | `examples/coding-agent/src/worker.rs:333` |
| `FRAME_SUMMARY_FINAL` / `"summary_token"` | `examples/media-pipeline/src/bin/summarize.rs:382,515,536` |
| `"transcribe_line"` | `examples/media-pipeline/src/bin/transcribe.rs:195` |

The only in-tree `Frame { ... }` struct-literal lives in `ff-core/src/backend.rs` (a derive-smoke test); updated mechanically with the 2 new fields. A second test covers the new builder setters.

## Before / after — `ff_core::backend::Frame`

```rust
// before
#[derive(Clone, Debug, PartialEq, Eq)]
#[non_exhaustive]
pub struct Frame {
    pub bytes: Vec<u8>,
    pub kind: FrameKind,
    pub seq: Option<u64>,
}

// after
#[derive(Clone, Debug, PartialEq, Eq)]
#[non_exhaustive]
pub struct Frame {
    pub bytes: Vec<u8>,
    pub kind: FrameKind,
    pub seq: Option<u64>,
    pub frame_type: String,              // free-form classifier — wire ARGV-5
    pub correlation_id: Option<String>,  // wire ARGV-9
}

impl Frame {
    pub fn with_frame_type(mut self, frame_type: impl Into<String>) -> Self { ... }
    pub fn with_correlation_id(mut self, correlation_id: impl Into<String>) -> Self { ... }
}
```

## SDK forwarder collapse

`ClaimedTask::append_frame` drops the 40-line direct-FCALL block (hand-rolled KEYS/ARGV, `parse_append_frame_result` helper, TODO comment) in favour of:

```rust
pub async fn append_frame(
    &self,
    frame_type: &str,
    payload: &[u8],
    metadata: Option<&str>,
) -> Result<AppendFrameOutcome, SdkError> {
    let handle = self.synth_handle();
    let mut frame = Frame::new(payload.to_vec(), FrameKind::Event)
        .with_frame_type(frame_type);
    if let Some(cid) = metadata {
        frame = frame.with_correlation_id(cid);
    }
    self.backend.append_frame(&handle, frame).await.map_err(SdkError::from)
}
```

The `parse_append_frame_result` helper in `ff-sdk` is removed (orphaned by this change — the trait path parses via `FcallResult` in `ff-backend-valkey`).

## Backend wiring

`append_frame_impl` in `ff-backend-valkey`:
- ARGV-5 `frame_type`: uses `frame.frame_type` when non-empty; falls back to `frame_kind_to_str(frame.kind)` (preserves FrameKind-only callers).
- ARGV-9 `correlation_id`: `frame.correlation_id.clone().unwrap_or_default()` (was always empty string before).

All other ARGV positions unchanged — byte-for-byte parity with the SDK's pre-migration direct-FCALL (`retention_maxlen = "10000"`, `source = "worker"`, `max_payload_bytes = "65536"`, `encoding = "utf8"`).

## Test plan

- [x] `cargo test -p ff-core --lib` (131 pass, incl. 2 new Frame cases)
- [x] `cargo test -p ff-sdk --lib` (66 pass)
- [x] `cargo test -p ff-backend-valkey --lib` (6 pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --no-default-features`
- [x] `cargo machete`
- [x] `cargo semver-checks -p ff-core` — no new Frame-related findings; 3 pre-existing PR #145 breakages unchanged (expected for this release)
- [ ] Integration tests requiring a Valkey server (readiness-tests, e2e_lifecycle) — exercised in CI

## Notes

- Frame remains `#[non_exhaustive]`, so adding fields is a non-breaking change at the field level; semver-checks confirms no new public-surface breakage.
- No test-shape edits beyond the mechanical 2-field extension of the Frame derive-smoke test. The 7-line new `frame_builders_populate_extended_fields` test covers the new setters per RFC hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)