### PR TITLE
bench(apalis): use apalis-workflow DAG for scenario 4 comparison (#51)

### DIFF
--- a/benches/comparisons/apalis/COMPARISON.md
+++ b/benches/comparisons/apalis/COMPARISON.md
@@ -25,7 +25,7 @@ we choose it explicitly; silent breakage during review is not.
 | 1 — submit → claim → complete | **Yes** — `apalis-scenario1` | Direct analog: `TaskSink::push` + `WorkerBuilder` with concurrency. |
 | 2 — suspend → signal → resume | **Skipped** | apalis has no first-class suspend/signal. Emulating it with external pub/sub would measure the emulator, not apalis. |
 | 3 — long-running steady-state | (owned by W2) | n/a here |
-| 4 — linear flow DAG           | **Yes, approximation** — `apalis-scenario4` | apalis has no DAG primitive. 10-stage chain wired by hand; each stage's handler pushes the next stage. Emits system label `apalis-approx`. |
+| 4 — linear flow DAG           | **Yes, native** — `apalis-scenario4` | Uses `apalis-workflow::Workflow` (sequential `and_then` combinator) over a single `RedisStorage`. Emits system label `apalis`. Prior to 2026-04-22 this harness was hand-rolled with 10 typed queues and labelled `apalis-approx`; see the update note further down. |
 | 5 — capability-routed claim   | **Skipped** | apalis queues are typed, not capability-routed. The closest mapping is "one queue per cap-set", which defeats the benchmark's point (routing arbitrates across a shared queue). |
 
 ## What's directly comparable
@@ -60,11 +60,65 @@ we choose it explicitly; silent breakage during review is not.
   strands the flow at stage i. FlowFabric engine retries/cancels per
   policy. Numbers assume no failures; with failures, apalis's numbers
   don't extrapolate.
-- **apalis-approx system label** — the JSON report for scenario 4
-  uses `system = "apalis-approx"` (not plain `apalis`) so an
-  aggregator doesn't accidentally graph these as a native DAG
-  benchmark. Tracked explicitly per
-  `ff_bench::comparison::SystemSupport::Approximation`.
+- **apalis system label (scenario 4)** — the JSON report for
+  scenario 4 now uses `system = "apalis"` because the harness uses
+  `apalis-workflow::Workflow` (apalis's first-class sequential
+  workflow primitive). Prior to 2026-04-22 this scenario emitted
+  `system = "apalis-approx"` because the harness was hand-rolled
+  across 10 typed queues — see the update note below.
+
+## Scenario 4 harness update (2026-04-22, issue #51)
+
+**Change**: Scenario 4's apalis harness switched from a hand-rolled
+10-stage chain (10 `WorkerBuilder` instances, each stage's handler
+pushing the next via a typed `RedisStorage<StageN>`) to a single
+`apalis-workflow::Workflow::new().and_then(…).and_then(…)` pipeline
+over ONE `RedisStorage` with one `WorkerBuilder`.
+
+**Why**: Issue #51. The apalis maintainer (geofmureithi) flagged the
+prior harness as under-representing apalis:
+
+> Ps in scenario 4, apalis offers apalis-workflow which has sequential
+> and dag primitives and would be better than the current approach (I
+> hope).
+
+See `rfcs/drafts/apalis-comparison.md` for Worker VV's full
+investigation. Adopting `apalis-workflow` is the hygienic fix — this
+bench should represent apalis's idiomatic shape.
+
+**Numerical effect (on the current bench host, Valkey 8.1.0)**:
+- At `flows=100` the scenario sits at the 50 ms driver-poll-jitter
+  floor (see the Polling-jitter-floor note in `src/scenario4.rs`):
+  both harnesses measure 9.3 flows/s (wall ≈ 10.70 s). No
+  measurable delta.
+- At `flows=500` the two diverge: prior harness 34.0 flows/s
+  (wall 14.69 s, N=3); `apalis-workflow` 9.8 flows/s (wall 50.93 s,
+  N=5). The linear-chain workload favours the prior hand-rolled
+  chain's cheap per-stage enqueue over `apalis-workflow`'s per-step
+  state persistence.
+
+The new harness is still correct to adopt even though this specific
+shape measures slower: COMPARISON is about apalis's idiomatic
+primitive, not "cheapest possible apalis harness". The FF-vs-apalis
+engine gap on this shape widens modestly as a result; that is the
+honest number.
+
+**Implementation note (Workflow bounds)**: apalis-workflow's
+`IntoWorkerService` impl requires `Backend::Args == BackendExt::Compact`.
+For `RedisStorage` that means the storage must be typed over the
+codec's compact form (`Vec<u8>`), not the user payload type.
+`src/scenario4.rs` does `RedisStorage::<Vec<u8>>::new(conn)`; the
+stage handlers still take typed `u64` (codec roundtrips at step
+boundaries). Payload is `u64` rather than a custom struct because
+`apalis-workflow::DagCodec` provides passthrough impls for primitives
+(String, integer types, bool, …) but not user types; the prior
+harness also only threaded a `flow_id` token (no data_passing) so
+this preserves the measurement contract.
+
+**Sample-teardown note**: `apalis-workflow` persists step-state keys
+in the backing Redis across runs. The harness runs `FLUSHALL` between
+N=5 samples to prevent sample-N state from leaking into sample-N+1
+(without this, sample 2+ deadline-fails with 0/100 completions).
 
 ## Running
 

--- a/benches/comparisons/apalis/Cargo.lock
+++ b/benches/comparisons/apalis/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -138,6 +138,22 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower",
+ "ulid",
+]
+
+[[package]]
+name = "apalis-workflow"
+version = "0.1.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d223e7ce6a21e22c4da5ff9a5b82e57578544a73dda04718f8a2801dd13847"
+dependencies = [
+ "apalis-core",
+ "futures",
+ "petgraph",
+ "serde",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
  "ulid",
 ]
 
@@ -463,7 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -495,7 +511,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.1.0"
+version = "0.3.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -523,7 +539,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1_smol",
- "socket2 0.6.3",
+ "socket2",
  "strum",
  "strum_macros",
  "tokio",
@@ -534,6 +550,21 @@ dependencies = [
  "url",
  "versions",
  "zstd",
+]
+
+[[package]]
+name = "ff-backend-valkey"
+version = "0.3.4"
+dependencies = [
+ "async-trait",
+ "ferriskey",
+ "ff-core",
+ "ff-script",
+ "futures-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -562,6 +593,7 @@ dependencies = [
  "anyhow",
  "apalis",
  "apalis-redis",
+ "apalis-workflow",
  "clap",
  "ff-bench",
  "futures",
@@ -575,17 +607,20 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.1.0"
+version = "0.3.4"
 dependencies = [
+ "async-trait",
  "crc16",
+ "futures-core",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
 [[package]]
 name = "ff-script"
-version = "0.1.0"
+version = "0.3.4"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -597,11 +632,14 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.1.0"
+version = "0.3.4"
 dependencies = [
  "ferriskey",
+ "ff-backend-valkey",
  "ff-core",
  "ff-script",
+ "reqwest",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -613,6 +651,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "foldhash"
@@ -899,7 +943,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1286,7 +1330,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1371,6 +1415,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,7 +1509,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1489,7 +1546,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1594,7 +1651,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
@@ -1741,7 +1798,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1927,22 +1984,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2097,7 +2144,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2518,7 +2565,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/benches/comparisons/apalis/Cargo.toml
+++ b/benches/comparisons/apalis/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/scenario4.rs"
 ff-bench = { path = "../../harness" }
 apalis = { version = "=1.0.0-rc.7", features = ["tracing", "limit"] }
 apalis-redis = { version = "=1.0.0-rc.7", features = ["tokio-comp"] }
+apalis-workflow = { version = "=0.1.0-rc.7" }
 redis = { version = "1", default-features = false, features = ["tokio-comp", "aio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal", "sync"] }
 futures = "0.3"

--- a/benches/comparisons/apalis/src/scenario4.rs
+++ b/benches/comparisons/apalis/src/scenario4.rs
@@ -1,71 +1,55 @@
-//! apalis comparison — scenario 4 (linear DAG as chained jobs).
+#![recursion_limit = "512"]
+#![type_length_limit = "16777216"]
+//! apalis comparison — scenario 4 (linear 10-stage workflow).
 //!
-//! apalis has no flow/DAG primitive. A consumer who wants a 10-node
-//! linear chain in apalis wires it by hand: each stage's handler
-//! schedules the next stage via the shared storage. That's the
-//! comparison target, not a hypothetical "apalis DAG".
+//! Uses `apalis-workflow::Workflow` — apalis's first-class sequential
+//! workflow primitive (`and_then` combinator). The prior harness
+//! hand-rolled the chain by wiring 10 `WorkerBuilder` instances with
+//! per-stage inter-queue pushes, which issue #51's maintainer
+//! (geofmureithi) flagged as under-representing apalis. See Worker VV's
+//! investigation at `rfcs/drafts/apalis-comparison.md`.
 //!
 //! # Shape
 //!
-//! 10 distinct job types `Stage0..Stage9`. Each stage's handler does
-//! the stage work, then:
-//!   * `Stage9`: INCR `bench:apalis:flow_completed` (terminal; no
-//!     further scheduling). A driver on the main task polls this
-//!     counter and stops when it equals `--flows`.
-//!   * `Stage_{i < 9}`: push the next stage's job via the shared
-//!     storage.
+//! A single `Workflow::new("…").and_then(stage0)…and_then(stage9)`
+//! composed over ONE `RedisStorage` backend and ONE `WorkerBuilder`
+//! (concurrency 16). Each stage is a trivial async fn forwarding the
+//! `u64` flow_id; `stage_terminal` INCRs the
+//! `bench:apalis:flow_completed` counter. The driver seeds `--flows`
+//! via `WorkflowSink::push_start` and drains by polling the counter
+//! — same drain protocol as the prior harness so the only moving part
+//! is the engine-side primitive.
 //!
-//! The measurement: submit `--flows` Stage0 jobs at t=0; drain ends
-//! when `bench:apalis:flow_completed == flows`.
+//! Note: `u64` is used as the inter-stage payload rather than a custom
+//! struct because `apalis-workflow`'s `DagCodec`/workflow plumbing
+//! requires primitive types (or user types with a `DagCodec` impl).
+//! The prior harness also only threaded a `flow_id` token (no
+//! data_passing), so this preserves the measurement contract.
 //!
 //! # What this measures
 //!
-//! * Wall time per flow = (end of flow_completed increment) -
-//!   (Stage0 submit). Per-flow latencies aren't tracked — apalis
-//!   doesn't expose "this specific job's completion time" without
-//!   middleware wiring that changes the comparison. We report
-//!   aggregate wall only.
-//! * Throughput = flows / wall.
+//! Throughput = flows / drain_wall for a 10-stage linear chain using
+//! apalis's idiomatic workflow primitive. State persists per-step in
+//! the same Redis storage rather than round-tripping across 10 typed
+//! queues.
 //!
 //! # NOT comparable
 //!
-//! * No data_passing. Stages carry a dummy `flow_id` token; real
-//!   users who want data flow wire JSON blobs into each stage's
-//!   payload (and pay the round-trip serialization cost).
-//! * No failure semantics. A Stage_i failure strands the flow at
-//!   that stage; ff-bench's scenario 4 (when it lands in W3's
-//!   flow_dag.rs) has FlowFabric's engine retry/cancel semantics.
-//!
-//! These deltas are why apalis's numbers on this scenario are a
-//! "what it feels like today", not "what a fair DAG engine would
-//! give you".
-//!
-//! # Polling-jitter floor
-//!
-//! The driver observes completion by polling `GET COMPLETED_KEY`
-//! every 50 ms (see the drain loop further down). Up to 50 ms of
-//! slack can sit between the Stage9 handler's INCR and the driver's
-//! next GET — wall is inflated by that slack. At `flows=10` the
-//! bias is ~5%; at `flows ≥ 100` it drops into noise. A tighter
-//! measurement would use Redis pub/sub (SUBSCRIBE on a completion
-//! channel the Stage9 handler PUBLISHes to) so the driver wakes
-//! exactly when the last completion lands. Tracked as a Batch C
-//! follow-up rather than fixed here — the current number is honest
-//! for the apalis-canonical "poll a counter" shape and consistent
-//! with how an apalis user would actually observe drain.
+//! Same caveats as before (no data_passing payload, no per-flow
+//! latency, poll-jitter floor of 50 ms). Documented in COMPARISON.md.
 
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use apalis::prelude::*;
 use apalis_redis::RedisStorage;
+use apalis_workflow::{Workflow, WorkflowSink};
 use clap::Parser;
 use redis::AsyncCommands;
-use serde::{Deserialize, Serialize};
+use redis::aio::MultiplexedConnection;
 
 const SCENARIO: &str = "flow_dag";
-const SYSTEM: &str = "apalis-approx";
+const SYSTEM: &str = "apalis";
 const STAGES: usize = 10;
 const CONCURRENCY: usize = 16;
 const COMPLETED_KEY: &str = "bench:apalis:flow_completed";
@@ -77,54 +61,35 @@ struct Args {
     #[arg(long, env = "FF_BENCH_VALKEY_PORT", default_value_t = 6379)]
     valkey_port: u16,
     /// Number of parallel flows to seed. Each flow is one linear
-    /// 10-stage chain.
+    /// 10-stage workflow instance.
     #[arg(long, default_value_t = 100)]
     flows: usize,
     #[arg(long, default_value = "benches/results")]
     results_dir: String,
-    /// Abort if drain takes longer than this. Even a conservative
-    /// apalis run shouldn't need more than a minute for 100 flows;
-    /// the deadline catches a stuck worker instead of hanging CI.
+    /// Abort if drain takes longer than this.
     #[arg(long, default_value_t = 120)]
     deadline_secs: u64,
+    /// N=5 methodology per PR #140. Number of independent samples.
+    #[arg(long, default_value_t = 5)]
+    samples: usize,
 }
 
-/// Macro-rolled stage jobs. Each variant carries the flow id so a
-/// flow's trajectory can be traced across the chain. The next-stage
-/// storage handles are threaded through a shared Arc so each handler
-/// can schedule the successor.
-macro_rules! stage_job {
-    ($name:ident) => {
-        #[derive(Debug, Clone, Serialize, Deserialize)]
-        struct $name {
-            flow_id: u64,
-        }
-    };
+async fn stage_pass(
+    s: u64,
+    _conn: Data<MultiplexedConnection>,
+) -> Result<u64, BoxDynError> {
+    Ok(s)
 }
 
-stage_job!(Stage0);
-stage_job!(Stage1);
-stage_job!(Stage2);
-stage_job!(Stage3);
-stage_job!(Stage4);
-stage_job!(Stage5);
-stage_job!(Stage6);
-stage_job!(Stage7);
-stage_job!(Stage8);
-stage_job!(Stage9);
-
-/// Storage handles shared across every stage's handler. Arc'd so the
-/// handler closures can cheaply clone per invocation.
-struct Storages {
-    s1: tokio::sync::Mutex<RedisStorage<Stage1>>,
-    s2: tokio::sync::Mutex<RedisStorage<Stage2>>,
-    s3: tokio::sync::Mutex<RedisStorage<Stage3>>,
-    s4: tokio::sync::Mutex<RedisStorage<Stage4>>,
-    s5: tokio::sync::Mutex<RedisStorage<Stage5>>,
-    s6: tokio::sync::Mutex<RedisStorage<Stage6>>,
-    s7: tokio::sync::Mutex<RedisStorage<Stage7>>,
-    s8: tokio::sync::Mutex<RedisStorage<Stage8>>,
-    s9: tokio::sync::Mutex<RedisStorage<Stage9>>,
+/// Terminal stage. INCRs the completion counter via the injected
+/// `Data<MultiplexedConnection>`.
+async fn stage_terminal(
+    _flow_id: u64,
+    conn: Data<MultiplexedConnection>,
+) -> Result<(), BoxDynError> {
+    let mut c: MultiplexedConnection = (*conn).clone();
+    let _: () = c.incr(COMPLETED_KEY, 1).await?;
+    Ok(())
 }
 
 #[tokio::main]
@@ -132,207 +97,126 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let url = format!("redis://{}:{}/", args.valkey_host, args.valkey_port);
 
-    // Clean slate on the completion counter so repeated runs don't
-    // carry over.
     let raw_client = redis::Client::open(url.clone())?;
-    let mut raw = raw_client.get_multiplexed_async_connection().await?;
-    let _: () = raw.del(COMPLETED_KEY).await?;
 
-    // Create one RedisStorage per stage — each stage is a distinct
-    // typed queue in apalis's model.
-    async fn new_storage<T>(url: &str) -> Result<RedisStorage<T>>
-    where
-        T: 'static + Send + Serialize + for<'de> Deserialize<'de>,
-    {
-        let conn = apalis_redis::connect(url)
-            .await
-            .map_err(|e| anyhow::anyhow!("connect: {e}"))?;
-        Ok(RedisStorage::new(conn))
+    let mut sample_walls: Vec<Duration> = Vec::with_capacity(args.samples);
+    for sample_idx in 0..args.samples {
+        let wall = run_sample(&args, &url, &raw_client).await?;
+        eprintln!(
+            "[apalis-s4] sample {}/{}: {:.2}s",
+            sample_idx + 1,
+            args.samples,
+            wall.as_secs_f64()
+        );
+        sample_walls.push(wall);
     }
 
-    let mut storage_0: RedisStorage<Stage0> = new_storage(&url).await?;
-    let storage_1: RedisStorage<Stage1> = new_storage(&url).await?;
-    let storage_2: RedisStorage<Stage2> = new_storage(&url).await?;
-    let storage_3: RedisStorage<Stage3> = new_storage(&url).await?;
-    let storage_4: RedisStorage<Stage4> = new_storage(&url).await?;
-    let storage_5: RedisStorage<Stage5> = new_storage(&url).await?;
-    let storage_6: RedisStorage<Stage6> = new_storage(&url).await?;
-    let storage_7: RedisStorage<Stage7> = new_storage(&url).await?;
-    let storage_8: RedisStorage<Stage8> = new_storage(&url).await?;
-    let storage_9: RedisStorage<Stage9> = new_storage(&url).await?;
+    let mean_wall = sample_walls.iter().sum::<Duration>() / (args.samples as u32);
+    let throughput = args.flows as f64 / mean_wall.as_secs_f64();
+    let walls_secs: Vec<f64> = sample_walls.iter().map(|d| d.as_secs_f64()).collect();
 
-    let storages = Arc::new(Storages {
-        s1: tokio::sync::Mutex::new(storage_1.clone()),
-        s2: tokio::sync::Mutex::new(storage_2.clone()),
-        s3: tokio::sync::Mutex::new(storage_3.clone()),
-        s4: tokio::sync::Mutex::new(storage_4.clone()),
-        s5: tokio::sync::Mutex::new(storage_5.clone()),
-        s6: tokio::sync::Mutex::new(storage_6.clone()),
-        s7: tokio::sync::Mutex::new(storage_7.clone()),
-        s8: tokio::sync::Mutex::new(storage_8.clone()),
-        s9: tokio::sync::Mutex::new(storage_9.clone()),
+    let report = serde_json::json!({
+        "scenario": SCENARIO,
+        "system": SYSTEM,
+        "git_sha": ff_bench::git_sha(),
+        "valkey_version": ff_bench::valkey_version(),
+        "host": ff_bench::host_info(),
+        "cluster": false,
+        "timestamp_utc": ff_bench::iso8601_utc(),
+        "config": {
+            "flows": args.flows,
+            "nodes_per_flow": STAGES,
+            "concurrency": CONCURRENCY,
+            "samples": args.samples,
+            "apalis_version": "1.0.0-rc.7",
+            "apalis_workflow_version": "0.1.0-rc.7",
+            "primitive": "apalis_workflow::Workflow (and_then combinator)",
+        },
+        "throughput_ops_per_sec": throughput,
+        "per_sample_wall_secs": walls_secs,
+        "mean_wall_secs": mean_wall.as_secs_f64(),
+        "latency_ms": { "p50": 0.0, "p95": 0.0, "p99": 0.0 },
+        "notes": "Scenario 4 harness uses apalis-workflow::Workflow (sequential and_then) per issue #51. Prior harness hand-rolled the 10-stage chain across 10 typed queues; maintainer flagged as under-representing apalis. N=5 per PR #140 methodology. latency_ms not reported — apalis doesn't surface per-flow completion without middleware we'd have to write ourselves.",
     });
 
-    // One WorkerBuilder per stage. Each handler pushes the next stage.
-    // apalis has no "chain" combinator so we wire it by hand — the
-    // honest shape a consumer would ship.
-    let s0_storages = storages.clone();
-    let w0 = WorkerBuilder::new("s0")
-        .backend(storage_0.clone())
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage0| {
-            let st = s0_storages.clone();
-            async move {
-                st.s1.lock().await.push(Stage1 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s0->s1: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s1_storages = storages.clone();
-    let w1 = WorkerBuilder::new("s1")
-        .backend(storage_1)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage1| {
-            let st = s1_storages.clone();
-            async move {
-                st.s2.lock().await.push(Stage2 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s1->s2: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s2_storages = storages.clone();
-    let w2 = WorkerBuilder::new("s2")
-        .backend(storage_2)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage2| {
-            let st = s2_storages.clone();
-            async move {
-                st.s3.lock().await.push(Stage3 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s2->s3: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s3_storages = storages.clone();
-    let w3 = WorkerBuilder::new("s3")
-        .backend(storage_3)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage3| {
-            let st = s3_storages.clone();
-            async move {
-                st.s4.lock().await.push(Stage4 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s3->s4: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s4_storages = storages.clone();
-    let w4 = WorkerBuilder::new("s4")
-        .backend(storage_4)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage4| {
-            let st = s4_storages.clone();
-            async move {
-                st.s5.lock().await.push(Stage5 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s4->s5: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s5_storages = storages.clone();
-    let w5 = WorkerBuilder::new("s5")
-        .backend(storage_5)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage5| {
-            let st = s5_storages.clone();
-            async move {
-                st.s6.lock().await.push(Stage6 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s5->s6: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s6_storages = storages.clone();
-    let w6 = WorkerBuilder::new("s6")
-        .backend(storage_6)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage6| {
-            let st = s6_storages.clone();
-            async move {
-                st.s7.lock().await.push(Stage7 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s6->s7: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s7_storages = storages.clone();
-    let w7 = WorkerBuilder::new("s7")
-        .backend(storage_7)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage7| {
-            let st = s7_storages.clone();
-            async move {
-                st.s8.lock().await.push(Stage8 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s7->s8: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
-    let s8_storages = storages.clone();
-    let w8 = WorkerBuilder::new("s8")
-        .backend(storage_8)
-        .concurrency(CONCURRENCY)
-        .build(move |j: Stage8| {
-            let st = s8_storages.clone();
-            async move {
-                st.s9.lock().await.push(Stage9 { flow_id: j.flow_id }).await
-                    .map_err(|e| anyhow::anyhow!("s8->s9: {e}"))?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
+    let results_dir = std::path::Path::new(&args.results_dir);
+    std::fs::create_dir_all(results_dir)?;
+    let path = results_dir.join(format!(
+        "{}-{}-{}.json",
+        SCENARIO,
+        SYSTEM,
+        report["git_sha"].as_str().unwrap_or("unknown")
+    ));
+    std::fs::write(&path, serde_json::to_vec_pretty(&report)?)?;
+    eprintln!(
+        "[apalis-s4] wrote {} — {:.1} flows/sec mean_wall={:.2}s N={}",
+        path.display(),
+        throughput,
+        mean_wall.as_secs_f64(),
+        args.samples
+    );
+    Ok(())
+}
 
-    // Stage9 handler: INCR the completion counter. MultiplexedConnection
-    // is cloneable and shares the underlying TCP socket across calls —
-    // clone it once out here, not per-invocation.
+/// One independent sample: clean counter, build a fresh storage +
+/// worker, seed `--flows`, drain via counter poll.
+async fn run_sample(
+    args: &Args,
+    url: &str,
+    raw_client: &redis::Client,
+) -> Result<Duration> {
+    // FLUSHALL between samples — apalis-workflow persists step-state
+    // keys in the backing Redis and reuses the default namespace
+    // across runs, so a second sample would see sample 1's leftovers
+    // unless the DB is cleared. Matches the N=5 methodology note in
+    // `benches/results/baseline.md` for scenario-4 harnesses.
+    let mut raw = raw_client.get_multiplexed_async_connection().await?;
+    let _: () = redis::cmd("FLUSHALL").query_async(&mut raw).await?;
+    let _: () = raw.del(COMPLETED_KEY).await?;
+
+    let conn = apalis_redis::connect(url)
+        .await
+        .map_err(|e| anyhow::anyhow!("apalis_redis::connect: {e}"))?;
+    // Workflow requires `Backend::Args == BackendExt::Compact`; for
+    // RedisStorage `Compact = Vec<u8>`, so the storage must be typed
+    // over `Vec<u8>` (raw codec-encoded bytes). Stage handlers still
+    // take the typed `u64` — the codec roundtrips between compact and
+    // typed at step boundaries.
+    let mut storage = RedisStorage::<Vec<u8>>::new(conn);
+
     let counter_conn = raw_client.get_multiplexed_async_connection().await?;
-    let w9 = WorkerBuilder::new("s9")
-        .backend(storage_9)
-        .concurrency(CONCURRENCY)
-        .build(move |_j: Stage9| {
-            let mut c = counter_conn.clone();
-            async move {
-                let _: () = c.incr(COMPLETED_KEY, 1).await?;
-                Ok::<(), BoxDynError>(())
-            }
-        });
 
-    // Each stage's `run_until` future is polled inline via
-    // `futures::future::join_all`, sharing a broadcast shutdown.
-    // Wrapping in tokio::spawn would require the worker's Future to
-    // be 'static + Send — apalis 1.0-rc.7 workers have an HRTB on
-    // their error type that blocks spawn; polling inline sidesteps
-    // that. 10 concurrent stages across one task aren't parallel on
-    // the runtime worker threads, but each stage's own
-    // `.concurrency(16)` tower layer parallelises inside the stage,
-    // so the stage-count-vs-cores ratio still covers the hot path.
+    // 10-stage sequential workflow via apalis-workflow::Workflow.
+    // Each `and_then` persists a step transition in the backing
+    // RedisStorage rather than enqueueing across typed queues.
+    let workflow = Workflow::new("ff-bench-s4-linear")
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_pass)
+        .and_then(stage_terminal);
+
     use apalis::prelude::WorkerError;
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
 
-    let mk_signal = || {
-        let mut rx = shutdown_tx.subscribe();
-        async move {
-            let _ = rx.recv().await;
-            Ok::<(), WorkerError>(())
-        }
+    let mut rx = shutdown_tx.subscribe();
+    let shutdown_fut = async move {
+        let _ = rx.recv().await;
+        Ok::<(), WorkerError>(())
     };
-    let s0_fut = w0.run_until(mk_signal());
-    let s1_fut = w1.run_until(mk_signal());
-    let s2_fut = w2.run_until(mk_signal());
-    let s3_fut = w3.run_until(mk_signal());
-    let s4_fut = w4.run_until(mk_signal());
-    let s5_fut = w5.run_until(mk_signal());
-    let s6_fut = w6.run_until(mk_signal());
-    let s7_fut = w7.run_until(mk_signal());
-    let s8_fut = w8.run_until(mk_signal());
-    let s9_fut = w9.run_until(mk_signal());
 
-    // Driver side: warm, seed, poll the terminal counter, then fire
-    // the shutdown broadcast that releases every run_until future.
-    // Ran concurrently with the worker futures via tokio::join!.
+    let worker = WorkerBuilder::new("s4-workflow")
+        .backend(storage.clone())
+        .data(counter_conn)
+        .concurrency(CONCURRENCY)
+        .build(workflow);
+    let worker_fut = worker.run_until(shutdown_fut);
+
     let driver_raw_client = raw_client.clone();
     let flows = args.flows;
     let deadline_secs = args.deadline_secs;
@@ -340,12 +224,10 @@ async fn main() -> Result<()> {
         tokio::time::sleep(Duration::from_millis(250)).await;
         let submit_start = Instant::now();
         for flow_id in 0..flows {
-            storage_0
-                .push(Stage0 {
-                    flow_id: flow_id as u64,
-                })
+            storage
+                .push_start(flow_id as u64)
                 .await
-                .map_err(|e| anyhow::anyhow!("seed Stage0 {flow_id}: {e}"))?;
+                .map_err(|e| anyhow::anyhow!("push_start {flow_id}: {e}"))?;
         }
         let submit_wall = submit_start.elapsed();
         eprintln!(
@@ -380,46 +262,6 @@ async fn main() -> Result<()> {
         Ok::<Duration, anyhow::Error>(wall)
     };
 
-    let (driver_res, _, _, _, _, _, _, _, _, _, _) = tokio::join!(
-        driver, s0_fut, s1_fut, s2_fut, s3_fut, s4_fut, s5_fut, s6_fut, s7_fut, s8_fut, s9_fut
-    );
-    let wall = driver_res?;
-
-    let throughput = args.flows as f64 / wall.as_secs_f64();
-
-    let report = serde_json::json!({
-        "scenario": SCENARIO,
-        "system": SYSTEM,
-        "git_sha": ff_bench::git_sha(),
-        "valkey_version": ff_bench::valkey_version(),
-        "host": ff_bench::host_info(),
-        "cluster": false,
-        "timestamp_utc": ff_bench::iso8601_utc(),
-        "config": {
-            "flows": args.flows,
-            "nodes_per_flow": STAGES,
-            "concurrency_per_stage": CONCURRENCY,
-            "apalis_version": "1.0.0-rc.7",
-        },
-        "throughput_ops_per_sec": throughput,
-        "latency_ms": { "p50": 0.0, "p95": 0.0, "p99": 0.0 },
-        "notes": "Approximation: apalis has no DAG primitive. 10-stage chain wired by hand; each stage's handler schedules the next. No data_passing, no flow-level retry, no cancellation propagation. System label is 'apalis-approx' so aggregators don't alias with a hypothetical native apalis DAG. latency_ms not reported — apalis doesn't surface per-flow completion without middleware we'd have to write ourselves, which would change the comparison.",
-    });
-
-    let results_dir = std::path::Path::new(&args.results_dir);
-    std::fs::create_dir_all(results_dir)?;
-    let path = results_dir.join(format!(
-        "{}-{}-{}.json",
-        SCENARIO,
-        SYSTEM,
-        report["git_sha"].as_str().unwrap_or("unknown")
-    ));
-    std::fs::write(&path, serde_json::to_vec_pretty(&report)?)?;
-    eprintln!(
-        "[apalis-s4] wrote {} — {:.1} flows/sec wall={:.2}s",
-        path.display(),
-        throughput,
-        wall.as_secs_f64()
-    );
-    Ok(())
+    let (driver_res, _worker_res) = tokio::join!(driver, worker_fut);
+    driver_res
 }

--- a/benches/results/baseline.md
+++ b/benches/results/baseline.md
@@ -64,16 +64,40 @@ improvement (175906 → 117197 ms) falls in the same band.
 
 ## Scenario 3 — flow_dag_linear (100 flows × 10 nodes, 16 workers)
 
-| system         | git_sha | flows/s | p50 ms  | p95 ms  | p99 ms   |
-|----------------|---------|---------|---------|---------|----------|
-| ff-server      | da89fa9 |   8.16  |  352.95 | (n/a)   | 11948.56 |
-| ff-server (v0.1.0) | 01f6327 |   8.18 | 347.63  | (n/a)   | 12055.19 |
-| ff-server (pre-BatchC) | b4ec2c2 |   5.96 | 7348.79 | 8555.88 | 9350.30 |
-| apalis-approx  | 1b2cce5 |   1.02  | n/a     | n/a     | n/a      |
+| system                    | git_sha | flows/s | p50 ms  | p95 ms  | p99 ms   |
+|---------------------------|---------|---------|---------|---------|----------|
+| ff-server                 | da89fa9 |   8.16  |  352.95 | (n/a)   | 11948.56 |
+| ff-server (v0.1.0)        | 01f6327 |   8.18  | 347.63  | (n/a)   | 12055.19 |
+| ff-server (pre-BatchC)    | b4ec2c2 |   5.96  | 7348.79 | 8555.88 | 9350.30  |
+| apalis (apalis-workflow, N=5)   | a4057c7 |   9.3   | n/a     | n/a     | n/a      |
+| apalis-approx (prior harness)   | 1b2cce5 |   1.02  | n/a     | n/a     | n/a      |
 
 Flat vs v0.1.0 across all percentiles — the push-based promotion
 speedup (21× at p50 over pre-BatchC) holds. p99 tail growth still
 present; no follow-up investigation filed in this cycle.
+
+**apalis harness update (2026-04-22, issue #51):** Scenario-4 apalis
+harness switched from a hand-rolled 10-stage inter-queue chain to
+`apalis-workflow::Workflow` (sequential `and_then` primitive) after
+the apalis maintainer (geofmureithi) flagged the prior harness as
+under-representing apalis. The `apalis-approx` row above is from a
+single-sample run at commit `1b2cce5` (different hardware / Valkey
+config) and should NOT be compared directly to either the
+`apalis` row (N=5, `a4057c7`, same host as current ff-server row) or
+the v0.3.2 numbers. When re-run on the current host with the
+**prior** harness at flows=100 N=5, apalis also measures 9.3 flows/s
+— the flows=100 workload sits at the 50 ms driver-poll-jitter floor
+(wall ≈ 10.70 s for both harnesses). At flows=500 the two harnesses
+diverge measurably: prior harness 34.0 flows/s (wall 14.69 s, N=3),
+`apalis-workflow` 9.8 flows/s (wall 50.93 s, N=5). The linear-chain
+shape favours the prior hand-rolled chain's cheap per-stage enqueue
+over `apalis-workflow`'s per-step state persistence. The harness is
+still correct to adopt — see COMPARISON.md — because this represents
+apalis's idiomatic shape, even if it measures slower on this
+specific scenario. Per-sample walls (new harness, flows=500, N=5):
+50.89, 50.88, 50.88, 50.97, 51.01 s. System label relabelled
+`apalis` (not `apalis-approx`) for the new harness row since the
+harness is no longer hand-rolled.
 
 ## Scenario 4 — long_running_steady_state (300s, refill 20 tasks / 10s, **N=5 samples**)
 


### PR DESCRIPTION
## Summary

- apalis maintainer (geofmureithi) flagged our hand-rolled 10-stage inter-queue chain on issue #51 as under-representing apalis; this PR swaps in `apalis-workflow::Workflow` (sequential `and_then`) so the apalis side of scenario 4 measures apalis's idiomatic primitive.
- Adds `apalis-workflow =0.1.0-rc.7` as a bench-workspace dep. Runs N=5 per PR #140 methodology, builds + clippy clean.
- Relabels scenario 4's `system` from `apalis-approx` to `apalis` (no longer hand-rolled). Retains the prior `apalis-approx` baseline.md row for historical reference with an explanatory note.

## Why

Issue #51, verbatim from the maintainer:

> Ps in scenario 4, apalis offers apalis-workflow which has sequential and dag primitives and would be better than the current approach (I hope).

Cites Worker VV's full investigation in `rfcs/drafts/apalis-comparison.md` (conclusion: "scenario-4 bench fix (the actual #51 ask). Adopt apalis-workflow in benches/comparisons/apalis/apalis-scenario4. This is hygiene.").

## Harness before/after

**Before** (`src/scenario4.rs`, ~425 lines): 10 `WorkerBuilder` instances, 10 typed `RedisStorage<StageN>` queues, each stage's handler `.push()`es the next stage via an `Arc<Mutex<Storages>>`; `broadcast::channel` shutdown fanned across 10 `run_until` futures.

**After** (~277 lines): ONE `Workflow::new("…").and_then(stage_pass)…and_then(stage_terminal)` over ONE `RedisStorage<Vec<u8>>` with ONE `WorkerBuilder(concurrency=16)`. N=5 sampling is built into the binary (`--samples N`) with FLUSHALL between samples.

## Numbers (Valkey 8.1.0, AMD EPYC 9R14 16c, 30 GB)

| workload        | prior harness (flows=100 N=5, flows=500 N=3) | apalis-workflow (N=5) |
|-----------------|-----------------------------------------------|-----------------------|
| flows=100, 10 stages | 9.3 flows/s, wall 10.70 s                  | 9.3 flows/s, wall 10.70 s |
| flows=500, 10 stages | 34.0 flows/s, wall 14.69 s                 | 9.8 flows/s, wall 50.93 s |

Per-sample (apalis-workflow, flows=500, N=5): 50.89, 50.88, 50.88, 50.97, 51.01 s.

**Gap direction**: flows=100 sits at the 50 ms driver-poll-jitter floor so neither harness moves. At flows=500 the FF/apalis gap on the linear-chain shape **widens** in FF's favour — `apalis-workflow`'s per-step state persistence is heavier than the prior cheap per-stage enqueue, so the idiomatic primitive is slower here. The harness is still correct to adopt: the bench should represent apalis's idiomatic shape per #51, not the cheapest possible harness.

## Implementation notes (full detail in COMPARISON.md)

- `Workflow`'s `IntoWorkerService` impl requires `Backend::Args == BackendExt::Compact`; for `RedisStorage` that's `Vec<u8>`. Stage handlers still take typed `u64` (codec roundtrips at step boundaries).
- Payload is `u64` rather than a custom struct because `apalis-workflow::DagCodec` provides passthrough impls for primitives only; prior harness also only threaded a `flow_id` token (no data_passing), so the measurement contract is preserved.
- FLUSHALL between samples is mandatory — `apalis-workflow` persists step-state keys across runs; without the flush, sample 2+ deadline-fail with 0/100 completions.

## Follow-up

Issue #51 should get a close-the-loop comment citing this PR and linking `rfcs/drafts/apalis-comparison.md` for the broader architectural framing.

## References

- Issue: https://github.com/avifenesh/FlowFabric/issues/51
- Worker VV investigation: `rfcs/drafts/apalis-comparison.md`
- apalis-workflow README: https://github.com/apalis-dev/apalis/blob/main/apalis-workflow/README.md

## Test plan

- [x] `cargo build --release --bin apalis-scenario4` — passes
- [x] `cargo clippy --bins -- -D warnings` — clean
- [x] `cargo check --bins` — clean
- [x] Runs N=5 at flows=100 and flows=500 without deadline failures (with FLUSHALL between samples)
- [x] JSON report emits `system = "apalis"`, `per_sample_wall_secs` array, `primitive` config field
- [ ] Reviewer: spot-check baseline.md table + COMPARISON.md note for numerical consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)