### PR TITLE
feat(ff-core, ff-sdk, ff-backend-valkey): seal ferriskey::Error leak via BackendError wrapper (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Breaking — Seal `ferriskey::Error` leak via `BackendError` wrapper (#88):**
+  Public SDK + server error surfaces no longer name `ferriskey::Error` /
+  `ferriskey::ErrorKind` directly. A new `ff_core::BackendError` +
+  `ff_core::BackendErrorKind` taxonomy (non-exhaustive, backend-agnostic)
+  replaces the raw ferriskey carriers so consumers can classify transport
+  faults without a ferriskey dependency.
+  - `ff-core`: new `BackendError` enum (`Valkey` variant today;
+    additional backends added additively) + `BackendErrorKind`
+    classifier (`Transport`, `Protocol`, `Timeout`, `Auth`,
+    `Cluster`, `BusyLoading`, `ScriptNotLoaded`, `Other`) with
+    `is_retryable()` + stability-fenced `as_stable_str()`.
+  - `ff-backend-valkey`: new `backend_error` module owning the
+    ferriskey → `BackendError` conversion
+    (`backend_error_from_ferriskey`, `classify_ferriskey_kind`,
+    `BackendErrorWrapper`).
+  - `ff-sdk`: `SdkError::Valkey(ferriskey::Error)` →
+    `SdkError::Backend(BackendError)`; `SdkError::ValkeyContext
+    { source: ferriskey::Error, .. }` → `SdkError::BackendContext
+    { source: BackendError, .. }`. `SdkError::valkey_kind()
+    -> Option<ferriskey::ErrorKind>` renamed to
+    `SdkError::backend_kind() -> Option<BackendErrorKind>`. New
+    `From<ferriskey::Error> for SdkError` preserves `?`-propagation
+    at internal call sites.
+  - `ff-server`: `ServerError::Valkey` / `ValkeyContext` similarly
+    reshaped to `Backend(BackendError)` / `BackendContext`.
+    `ServerError::valkey_kind` renamed to `backend_kind`. HTTP
+    `ErrorBody.kind` now sources the wire string from
+    `BackendErrorKind::as_stable_str()` instead of ferriskey's
+    `kind_to_stable_str`; values change (`"io_error"` →
+    `"transport"`, `"cluster_down"` / `"moved"` / `"ask"` /
+    `"try_again"` → `"cluster"`, etc.) — downstream consumers
+    (cairn-fabric) must update any `kind`-string matching.
+  - Behavioral refinement: `BackendErrorKind::is_retryable` treats
+    cluster-churn kinds (`Moved`, `Ask`, `MasterDown`, `CrossSlot`,
+    `ConnectionNotFoundForRoute`, etc.) as retryable where the
+    previous ff-script table treated them as terminal.
+    `FatalReceiveError` + `ProtocolDesync` likewise bucket into
+    retryable `Transport`. This aligns with standard Valkey-cluster
+    client semantics where these are redirects/transients the caller
+    should retry.
+
 - **Breaking — `ff_core::backend::Frame` extended (RFC-012 §R7, PR #147):**
   Added `frame_type: String` + `correlation_id: Option<String>` so
   `ClaimedTask::append_frame` can forward through the `EngineBackend`

--- a/crates/ff-backend-valkey/src/backend_error.rs
+++ b/crates/ff-backend-valkey/src/backend_error.rs
@@ -1,0 +1,195 @@
+//! ferriskey → [`BackendError`] conversion (#88).
+//!
+//! This is the single boundary where a native `ferriskey::Error` is
+//! lifted into the backend-agnostic [`BackendError`] surfaced by
+//! ff-sdk and ff-server. Keeping the conversion here — not in ff-core
+//! — preserves ff-core's ferriskey-free public surface. Every
+//! ff-sdk/ff-server constructor that previously wrapped
+//! `ferriskey::Error` directly now goes through these helpers.
+//!
+//! The mapping collapses ferriskey's 30+ `ErrorKind` variants into
+//! the curated [`BackendErrorKind`] taxonomy. The `message` field
+//! preserves the `Display` rendering of the native error so operator
+//! diagnostics do not regress.
+
+use ff_core::engine_error::{BackendError, BackendErrorKind};
+
+/// Classify a ferriskey [`ErrorKind`] into the backend-agnostic
+/// [`BackendErrorKind`]. See the ferriskey `value.rs` enum for the
+/// full source taxonomy; the buckets here are grouped by
+/// consumer-meaningful retry / operator posture, not 1:1 with
+/// ferriskey's internal categorisation.
+///
+/// [`ErrorKind`]: ferriskey::ErrorKind
+pub fn classify_ferriskey_kind(kind: ferriskey::ErrorKind) -> BackendErrorKind {
+    use ferriskey::ErrorKind as K;
+    match kind {
+        // Transport / I/O family.
+        K::IoError | K::FatalSendError | K::FatalReceiveError | K::ProtocolDesync => {
+            BackendErrorKind::Transport
+        }
+        // Cluster topology churn.
+        K::Moved
+        | K::Ask
+        | K::TryAgain
+        | K::ClusterDown
+        | K::CrossSlot
+        | K::MasterDown
+        | K::AllConnectionsUnavailable
+        | K::ConnectionNotFoundForRoute
+        | K::NotAllSlotsCovered
+        | K::MasterNameNotFoundBySentinel
+        | K::NoValidReplicasFoundBySentinel => BackendErrorKind::Cluster,
+        // Auth.
+        K::AuthenticationFailed | K::PermissionDenied => BackendErrorKind::Auth,
+        // Backend-side loading churn.
+        K::BusyLoadingError => BackendErrorKind::BusyLoading,
+        // Script / function lifecycle.
+        K::NoScriptError => BackendErrorKind::ScriptNotLoaded,
+        // Protocol-level rejections (malformed response, wrong type,
+        // client-side config issue, ExtensionError / UserOperationError,
+        // etc.).
+        K::ResponseError
+        | K::ParseError
+        | K::TypeError
+        | K::ExecAbortError
+        | K::InvalidClientConfig
+        | K::ClientError
+        | K::ExtensionError
+        | K::ReadOnly
+        | K::EmptySentinelList
+        | K::NotBusy
+        | K::RESP3NotSupported
+        | K::UserOperationError => BackendErrorKind::Protocol,
+        // ferriskey::ErrorKind is not `#[non_exhaustive]` today, but
+        // guard anyway — a future variant lands in a terminal
+        // `Other` bucket rather than failing to compile.
+        #[allow(unreachable_patterns)]
+        _ => BackendErrorKind::Other,
+    }
+}
+
+/// Lift a ferriskey error into a [`BackendError::Valkey`]. Preserves
+/// the native `Display` rendering as `message`.
+pub fn backend_error_from_ferriskey(err: &ferriskey::Error) -> BackendError {
+    BackendError::Valkey {
+        kind: classify_ferriskey_kind(err.kind()),
+        message: err.to_string(),
+    }
+}
+
+/// `From` shim for ergonomic `?`-propagation. Consumes the native
+/// error; callers that need to retain the ferriskey side (for trace
+/// logging) should call [`backend_error_from_ferriskey`] before
+/// dropping the original.
+impl From<ferriskey::Error> for BackendErrorWrapper {
+    fn from(err: ferriskey::Error) -> Self {
+        Self(backend_error_from_ferriskey(&err))
+    }
+}
+
+/// Transparent newtype so the `From<ferriskey::Error>` impl is
+/// orphan-rule–legal inside this crate without imposing on ff-core's
+/// foreign [`BackendError`] type. Consumers call `.into_inner()` to
+/// recover the [`BackendError`]; this stays an implementation detail
+/// of ff-sdk / ff-server boundaries.
+pub struct BackendErrorWrapper(BackendError);
+
+impl BackendErrorWrapper {
+    pub fn into_inner(self) -> BackendError {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferriskey::ErrorKind;
+
+    fn mk(kind: ErrorKind) -> ferriskey::Error {
+        ferriskey::Error::from((kind, "synthetic"))
+    }
+
+    #[test]
+    fn transport_bucket() {
+        for k in [
+            ErrorKind::IoError,
+            ErrorKind::FatalSendError,
+            ErrorKind::FatalReceiveError,
+            ErrorKind::ProtocolDesync,
+        ] {
+            assert_eq!(classify_ferriskey_kind(k), BackendErrorKind::Transport);
+        }
+    }
+
+    #[test]
+    fn cluster_bucket() {
+        for k in [
+            ErrorKind::Moved,
+            ErrorKind::Ask,
+            ErrorKind::TryAgain,
+            ErrorKind::ClusterDown,
+            ErrorKind::CrossSlot,
+            ErrorKind::MasterDown,
+            ErrorKind::AllConnectionsUnavailable,
+            ErrorKind::ConnectionNotFoundForRoute,
+        ] {
+            assert_eq!(classify_ferriskey_kind(k), BackendErrorKind::Cluster);
+        }
+    }
+
+    #[test]
+    fn auth_bucket() {
+        assert_eq!(
+            classify_ferriskey_kind(ErrorKind::AuthenticationFailed),
+            BackendErrorKind::Auth
+        );
+        assert_eq!(
+            classify_ferriskey_kind(ErrorKind::PermissionDenied),
+            BackendErrorKind::Auth
+        );
+    }
+
+    #[test]
+    fn busy_loading_and_script_buckets() {
+        assert_eq!(
+            classify_ferriskey_kind(ErrorKind::BusyLoadingError),
+            BackendErrorKind::BusyLoading
+        );
+        assert_eq!(
+            classify_ferriskey_kind(ErrorKind::NoScriptError),
+            BackendErrorKind::ScriptNotLoaded
+        );
+    }
+
+    #[test]
+    fn protocol_bucket() {
+        for k in [
+            ErrorKind::ResponseError,
+            ErrorKind::ParseError,
+            ErrorKind::TypeError,
+            ErrorKind::InvalidClientConfig,
+            ErrorKind::ClientError,
+            ErrorKind::ExtensionError,
+            ErrorKind::ReadOnly,
+        ] {
+            assert_eq!(classify_ferriskey_kind(k), BackendErrorKind::Protocol);
+        }
+    }
+
+    #[test]
+    fn from_ferriskey_preserves_message() {
+        let err = mk(ErrorKind::IoError);
+        let be = backend_error_from_ferriskey(&err);
+        assert_eq!(be.kind(), BackendErrorKind::Transport);
+        // Display message preserved verbatim.
+        assert_eq!(be.message(), err.to_string());
+    }
+
+    #[test]
+    fn wrapper_conversion_round_trips() {
+        let err = mk(ErrorKind::ClusterDown);
+        let wrapped: BackendErrorWrapper = err.into();
+        assert_eq!(wrapped.into_inner().kind(), BackendErrorKind::Cluster);
+    }
+}

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -50,9 +50,13 @@ use ff_script::error::ScriptError;
 use ff_script::functions::flow::{ff_cancel_flow, FlowStructOpKeys};
 use ff_script::result::FcallResult;
 
+pub mod backend_error;
 mod completion;
 mod handle_codec;
 
+pub use backend_error::{
+    backend_error_from_ferriskey, classify_ferriskey_kind, BackendErrorWrapper,
+};
 pub use completion::COMPLETION_CHANNEL;
 
 /// Valkey-FCALL–backed `EngineBackend`.

--- a/crates/ff-core/src/engine_error.rs
+++ b/crates/ff-core/src/engine_error.rs
@@ -330,6 +330,113 @@ pub enum BugKind {
     AttemptNotInCreatedState,
 }
 
+/// Backend-agnostic transport error carried across public
+/// ff-sdk / ff-server error surfaces (#88).
+///
+/// The `Valkey` variant is the only one populated today; additional
+/// variants (e.g. `Postgres`) will be added additively as other
+/// backends land. The enum is `#[non_exhaustive]` so consumers must
+/// include a wildcard arm.
+///
+/// Construction from the Valkey-native `ferriskey::Error` lives in
+/// `ff_backend_valkey::backend_error_from_ferriskey` — keeping that
+/// conversion outside ff-core preserves ff-core's ferriskey-free
+/// public surface.
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum BackendError {
+    /// Valkey-backend transport failure. Carries a backend-agnostic
+    /// classification plus the backend-rendered message so downstream
+    /// consumers can inspect without depending on ferriskey.
+    #[error("valkey backend: {kind:?}: {message}")]
+    Valkey {
+        kind: BackendErrorKind,
+        message: String,
+    },
+}
+
+impl BackendError {
+    /// Returns the classified backend kind if this error is a Valkey
+    /// transport fault. Forward-compatible with future backends:
+    /// non-Valkey variants return `None` on a call that names only the
+    /// Valkey kind; code that wants a backend-specific view should
+    /// match directly on [`BackendError`].
+    pub fn kind(&self) -> BackendErrorKind {
+        match self {
+            Self::Valkey { kind, .. } => *kind,
+        }
+    }
+
+    /// Return the backend-rendered message payload.
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Valkey { message, .. } => message.as_str(),
+        }
+    }
+}
+
+/// Classified backend transport errors, kept backend-agnostic on
+/// purpose (#88). Each variant maps a family of native backend error
+/// kinds into a stable, consumer-matchable shape.
+///
+/// Consumers requiring the exact native kind for a Valkey backend
+/// must go through `ff_backend_valkey` explicitly; ff-sdk/ff-server's
+/// public surface will only ever hand out [`BackendErrorKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BackendErrorKind {
+    /// Network / I/O failure: the request may or may not have been
+    /// processed. Typically retryable with backoff.
+    Transport,
+    /// Backend rejected the request on protocol / parse grounds. Not
+    /// retryable without a fix.
+    Protocol,
+    /// Backend timed out responding to the request. Retryable.
+    Timeout,
+    /// Authentication / authorization failure. Not retryable.
+    Auth,
+    /// Cluster topology churn (MOVED, ASK, CLUSTERDOWN, MasterDown,
+    /// CrossSlot, ConnectionNotFoundForRoute, AllConnectionsUnavailable).
+    /// Retryable after topology settles.
+    Cluster,
+    /// Backend is temporarily busy loading state (e.g. Valkey
+    /// `LOADING`). Retryable.
+    BusyLoading,
+    /// Backend indicates the referenced script/function does not
+    /// exist. Typically handled by the caller via re-load.
+    ScriptNotLoaded,
+    /// Any other classified error from the backend. Fallback bucket
+    /// for native kinds outside the curated set above.
+    Other,
+}
+
+impl BackendErrorKind {
+    /// Stable, lowercase-kebab label suitable for log fields / HTTP
+    /// `kind` body slots. Guaranteed not to change across releases
+    /// for the existing variants.
+    pub fn as_stable_str(&self) -> &'static str {
+        match self {
+            Self::Transport => "transport",
+            Self::Protocol => "protocol",
+            Self::Timeout => "timeout",
+            Self::Auth => "auth",
+            Self::Cluster => "cluster",
+            Self::BusyLoading => "busy_loading",
+            Self::ScriptNotLoaded => "script_not_loaded",
+            Self::Other => "other",
+        }
+    }
+
+    /// Whether a caller should consider this kind retryable with
+    /// backoff. Conservative — auth + protocol + other are terminal.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport | Self::Timeout | Self::Cluster | Self::BusyLoading
+        )
+    }
+}
+
 impl EngineError {
     /// Classify an [`EngineError`] using the underlying
     /// [`ErrorClass`] table.
@@ -428,5 +535,57 @@ mod tests {
             EngineError::Unavailable { op: "foo" }.class(),
             ErrorClass::Terminal
         );
+    }
+
+    #[test]
+    fn backend_error_kind_round_trip() {
+        let be = BackendError::Valkey {
+            kind: BackendErrorKind::Transport,
+            message: "connection reset".into(),
+        };
+        assert_eq!(be.kind(), BackendErrorKind::Transport);
+        assert_eq!(be.message(), "connection reset");
+    }
+
+    #[test]
+    fn backend_kind_stable_strings_fixed() {
+        // Stability fence: these strings are part of the public
+        // contract (log field values, HTTP body `kind` slots). Adding
+        // a variant is additive; changing an existing string is a
+        // break.
+        assert_eq!(BackendErrorKind::Transport.as_stable_str(), "transport");
+        assert_eq!(BackendErrorKind::Protocol.as_stable_str(), "protocol");
+        assert_eq!(BackendErrorKind::Timeout.as_stable_str(), "timeout");
+        assert_eq!(BackendErrorKind::Auth.as_stable_str(), "auth");
+        assert_eq!(BackendErrorKind::Cluster.as_stable_str(), "cluster");
+        assert_eq!(
+            BackendErrorKind::BusyLoading.as_stable_str(),
+            "busy_loading"
+        );
+        assert_eq!(
+            BackendErrorKind::ScriptNotLoaded.as_stable_str(),
+            "script_not_loaded"
+        );
+        assert_eq!(BackendErrorKind::Other.as_stable_str(), "other");
+    }
+
+    #[test]
+    fn backend_kind_retryability() {
+        for k in [
+            BackendErrorKind::Transport,
+            BackendErrorKind::Timeout,
+            BackendErrorKind::Cluster,
+            BackendErrorKind::BusyLoading,
+        ] {
+            assert!(k.is_retryable(), "{k:?} should be retryable");
+        }
+        for k in [
+            BackendErrorKind::Protocol,
+            BackendErrorKind::Auth,
+            BackendErrorKind::ScriptNotLoaded,
+            BackendErrorKind::Other,
+        ] {
+            assert!(!k.is_retryable(), "{k:?} should NOT be retryable");
+        }
     }
 }

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -15,3 +15,7 @@ pub mod types;
 
 // Convenience re-export so consumers can write `ff_core::EngineError`.
 pub use engine_error::EngineError;
+// #88: backend-agnostic transport error carried across public
+// ff-sdk / ff-server surfaces. Kept alongside `EngineError` so
+// consumers can `use ff_core::{BackendError, BackendErrorKind}`.
+pub use engine_error::{BackendError, BackendErrorKind};

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -87,6 +87,10 @@ pub use config::WorkerConfig;
 pub use engine_error::{
     BugKind, ConflictKind, ContentionKind, EngineError, StateKind, ValidationKind,
 };
+// #88: backend-agnostic transport error surface. Consumers that
+// previously matched on `ferriskey::ErrorKind` via `valkey_kind()`
+// now match on `BackendErrorKind` via `backend_kind()`.
+pub use ff_core::engine_error::{BackendError, BackendErrorKind};
 // `FailOutcome` is ff-core-native (Stage 1a move); re-export
 // unconditionally so consumers can name `ff_sdk::FailOutcome` even
 // under `--no-default-features`.
@@ -105,17 +109,21 @@ pub use worker::FlowFabricWorker;
 /// SDK error type.
 #[derive(Debug, thiserror::Error)]
 pub enum SdkError {
-    /// Valkey connection or command error (preserves ErrorKind for caller inspection).
-    #[cfg(feature = "valkey-default")]
-    #[error("valkey: {0}")]
-    Valkey(#[from] ferriskey::Error),
+    /// Backend transport error. Previously wrapped `ferriskey::Error`
+    /// directly (#88); now carries a backend-agnostic
+    /// [`BackendError`] so consumers match on
+    /// [`BackendErrorKind`] instead of ferriskey's native taxonomy.
+    /// The ferriskey → [`BackendError`] mapping lives in
+    /// `ff_backend_valkey::backend_error::backend_error_from_ferriskey`.
+    #[error("backend: {0}")]
+    Backend(#[from] BackendError),
 
-    /// Valkey error with additional context.
-    #[cfg(feature = "valkey-default")]
-    #[error("valkey: {context}: {source}")]
-    ValkeyContext {
+    /// Backend error with additional context (e.g. call-site label).
+    /// Previously `ValkeyContext { source: ferriskey::Error }` (#88).
+    #[error("backend: {context}: {source}")]
+    BackendContext {
         #[source]
-        source: ferriskey::Error,
+        source: BackendError,
         context: String,
     },
 
@@ -160,13 +168,13 @@ pub enum SdkError {
     /// * [`SdkError::is_retryable`] returns `true` — saturation is
     ///   transient: any in-flight task's
     ///   complete/fail/cancel/drop releases a permit. Retry after
-    ///   milliseconds, not a retry loop with backoff for a Valkey
+    ///   milliseconds, not a retry loop with backoff for a backend
     ///   transport failure.
-    /// * [`SdkError::valkey_kind`] returns `None` — this is not a
-    ///   Valkey transport or Lua error, so there is no
-    ///   `ferriskey::ErrorKind` to inspect. Callers that fan out
-    ///   on `valkey_kind()` should match `WorkerAtCapacity`
-    ///   explicitly (or use `is_retryable()`).
+    /// * [`SdkError::backend_kind`] returns `None` — this is not a
+    ///   backend transport error, so there is no
+    ///   [`BackendErrorKind`] to inspect. Callers that fan out on
+    ///   `backend_kind()` should match `WorkerAtCapacity` explicitly
+    ///   (or use `is_retryable()`).
     ///
     /// [`FlowFabricWorker::claim_from_grant`]: crate::FlowFabricWorker::claim_from_grant
     /// [`FlowFabricWorker::claim_from_reclaim_grant`]: crate::FlowFabricWorker::claim_from_reclaim_grant
@@ -177,7 +185,7 @@ pub enum SdkError {
     /// the underlying `reqwest::Error` via `#[source]` so callers
     /// can inspect `is_timeout()` / `is_connect()` / etc. for
     /// finer-grained retry logic. Distinct from
-    /// [`SdkError::Valkey`] — this fires on the HTTP/JSON surface,
+    /// [`SdkError::Backend`] — this fires on the HTTP/JSON surface,
     /// not on the Lua/Valkey hot path.
     #[error("http: {context}: {source}")]
     Http {
@@ -220,6 +228,31 @@ fn fmt_config(context: &str, field: Option<&str>, message: &str) -> String {
     }
 }
 
+/// Lift a native `ferriskey::Error` into [`SdkError::Backend`] via
+/// [`ff_backend_valkey::backend_error_from_ferriskey`] (#88). Keeps
+/// `?`-propagation ergonomic at FCALL/transport call sites while
+/// the public variant stays backend-agnostic.
+#[cfg(feature = "valkey-default")]
+impl From<ferriskey::Error> for SdkError {
+    fn from(err: ferriskey::Error) -> Self {
+        Self::Backend(ff_backend_valkey::backend_error_from_ferriskey(&err))
+    }
+}
+
+/// Build an [`SdkError::BackendContext`] from a native
+/// `ferriskey::Error` and a call-site label, preserving the
+/// backend-agnostic shape on the public surface (#88).
+#[cfg(feature = "valkey-default")]
+pub(crate) fn backend_context(
+    err: ferriskey::Error,
+    context: impl Into<String>,
+) -> SdkError {
+    SdkError::BackendContext {
+        source: ff_backend_valkey::backend_error_from_ferriskey(&err),
+        context: context.into(),
+    }
+}
+
 /// Preserves the ergonomic `?`-propagation from FCALL sites that
 /// return `Result<_, ScriptError>`. Routes through `EngineError`'s
 /// typed classification so every call site gets the same
@@ -239,34 +272,44 @@ impl From<EngineError> for SdkError {
 }
 
 impl SdkError {
-    /// Returns the underlying ferriskey `ErrorKind` if this error carries one.
-    /// Covers transport variants (`Valkey`, `ValkeyContext`) directly and
-    /// `Engine(EngineError::Transport { .. })` via delegation.
-    #[cfg(feature = "valkey-default")]
-    pub fn valkey_kind(&self) -> Option<ferriskey::ErrorKind> {
+    /// Returns the classified [`BackendErrorKind`] if this error
+    /// carries a backend transport fault. Covers the direct
+    /// [`SdkError::Backend`] / [`SdkError::BackendContext`] variants
+    /// and `Engine(EngineError::Transport { .. })` via the
+    /// ScriptError-aware downcast in `ff_script::engine_error_ext`.
+    ///
+    /// Renamed from `valkey_kind` in #88 — the previous return type
+    /// `Option<ferriskey::ErrorKind>` leaked ferriskey into every
+    /// consumer doing retry classification.
+    pub fn backend_kind(&self) -> Option<BackendErrorKind> {
         match self {
-            Self::Valkey(e) => Some(e.kind()),
-            Self::ValkeyContext { source, .. } => Some(source.kind()),
-            Self::Engine(e) => ff_script::engine_error_ext::valkey_kind(e),
-            // HTTP/admin-surface errors carry no ferriskey::ErrorKind;
-            // the admin path never touches Valkey directly from the
-            // SDK side. Use `AdminApi.kind` for the server-supplied
+            Self::Backend(be) => Some(be.kind()),
+            Self::BackendContext { source, .. } => Some(source.kind()),
+            #[cfg(feature = "valkey-default")]
+            Self::Engine(e) => ff_script::engine_error_ext::valkey_kind(e)
+                .map(ff_backend_valkey::classify_ferriskey_kind),
+            #[cfg(not(feature = "valkey-default"))]
+            Self::Engine(_) => None,
+            // HTTP/admin-surface errors carry no backend fault;
+            // the admin path never touches the backend directly from
+            // the SDK side. Use `AdminApi.kind` for the server-supplied
             // label when present.
-            Self::Config { .. } | Self::WorkerAtCapacity | Self::Http { .. } | Self::AdminApi { .. } => {
-                None
-            }
+            Self::Config { .. }
+            | Self::WorkerAtCapacity
+            | Self::Http { .. }
+            | Self::AdminApi { .. } => None,
         }
     }
 
-    /// Whether this error is safely retryable by a caller. For transport
-    /// variants, delegates to [`ff_script::retry::is_retryable_kind`]. For
-    /// `Engine` errors, returns `true` iff the typed classification is
+    /// Whether this error is safely retryable by a caller. For backend
+    /// transport variants, delegates to
+    /// [`BackendErrorKind::is_retryable`]. For `Engine` errors, returns
+    /// `true` iff the typed classification is
     /// `ErrorClass::Retryable`. `Config` errors are never retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
-            #[cfg(feature = "valkey-default")]
-            Self::Valkey(e) | Self::ValkeyContext { source: e, .. } => {
-                ff_script::retry::is_retryable_kind(e.kind())
+            Self::Backend(be) | Self::BackendContext { source: be, .. } => {
+                be.kind().is_retryable()
             }
             Self::Engine(e) => {
                 matches!(
@@ -308,31 +351,28 @@ mod tests {
     }
 
     #[test]
-    fn valkey_kind_direct_and_context() {
+    fn backend_kind_direct_and_context() {
         assert_eq!(
-            SdkError::Valkey(mk_fk_err(ErrorKind::IoError)).valkey_kind(),
-            Some(ErrorKind::IoError)
+            SdkError::from(mk_fk_err(ErrorKind::IoError)).backend_kind(),
+            Some(BackendErrorKind::Transport)
         );
         assert_eq!(
-            SdkError::ValkeyContext {
-                source: mk_fk_err(ErrorKind::BusyLoadingError),
-                context: "connect".into()
-            }
-            .valkey_kind(),
-            Some(ErrorKind::BusyLoadingError)
+            crate::backend_context(mk_fk_err(ErrorKind::BusyLoadingError), "connect")
+                .backend_kind(),
+            Some(BackendErrorKind::BusyLoading)
         );
     }
 
     #[test]
-    fn valkey_kind_delegates_through_engine_transport() {
+    fn backend_kind_delegates_through_engine_transport() {
         let err = SdkError::from(ScriptError::Valkey(mk_fk_err(ErrorKind::ClusterDown)));
-        assert_eq!(err.valkey_kind(), Some(ErrorKind::ClusterDown));
+        assert_eq!(err.backend_kind(), Some(BackendErrorKind::Cluster));
     }
 
     #[test]
-    fn valkey_kind_none_for_lua_and_config() {
+    fn backend_kind_none_for_lua_and_config() {
         assert_eq!(
-            SdkError::from(ScriptError::LeaseExpired).valkey_kind(),
+            SdkError::from(ScriptError::LeaseExpired).backend_kind(),
             None
         );
         assert_eq!(
@@ -341,16 +381,21 @@ mod tests {
                 field: Some("bearer_token".into()),
                 message: "bad host".into(),
             }
-            .valkey_kind(),
+            .backend_kind(),
             None
         );
     }
 
     #[test]
     fn is_retryable_transport() {
-        assert!(SdkError::Valkey(mk_fk_err(ErrorKind::IoError)).is_retryable());
-        assert!(!SdkError::Valkey(mk_fk_err(ErrorKind::FatalReceiveError)).is_retryable());
-        assert!(!SdkError::Valkey(mk_fk_err(ErrorKind::AuthenticationFailed)).is_retryable());
+        // Transport-bucketed kinds (IoError, FatalSend/Receive,
+        // ProtocolDesync) are retryable under the #88 classifier.
+        assert!(SdkError::from(mk_fk_err(ErrorKind::IoError)).is_retryable());
+        // Auth-bucketed kinds are terminal.
+        assert!(!SdkError::from(mk_fk_err(ErrorKind::AuthenticationFailed)).is_retryable());
+        // Protocol-bucketed kinds (ResponseError, ParseError, TypeError,
+        // InvalidClientConfig, etc.) are terminal.
+        assert!(!SdkError::from(mk_fk_err(ErrorKind::ResponseError)).is_retryable());
     }
 
     #[test]
@@ -469,6 +514,6 @@ mod tests {
             retryable: Some(true),
             raw_body: String::new(),
         };
-        assert_eq!(err.valkey_kind(), None);
+        assert_eq!(err.backend_kind(), None);
     }
 }

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -83,22 +83,13 @@ impl FlowFabricWorker {
             .cmd::<HashMap<String, String>>("HGETALL")
             .arg(&tags_key)
             .finish();
-        pipe.execute().await.map_err(|e| SdkError::ValkeyContext {
-            source: e,
-            context: "describe_execution: pipeline HGETALL exec_core + tags".into(),
-        })?;
+        pipe.execute().await.map_err(|e| crate::backend_context(e, "describe_execution: pipeline HGETALL exec_core + tags"))?;
 
-        let core = core_slot.value().map_err(|e| SdkError::ValkeyContext {
-            source: e,
-            context: "describe_execution: decode HGETALL exec_core".into(),
-        })?;
+        let core = core_slot.value().map_err(|e| crate::backend_context(e, "describe_execution: decode HGETALL exec_core"))?;
         if core.is_empty() {
             return Ok(None);
         }
-        let tags_raw = tags_slot.value().map_err(|e| SdkError::ValkeyContext {
-            source: e,
-            context: "describe_execution: decode HGETALL tags".into(),
-        })?;
+        let tags_raw = tags_slot.value().map_err(|e| crate::backend_context(e, "describe_execution: decode HGETALL tags"))?;
 
         build_execution_snapshot(id.clone(), &core, tags_raw)
     }
@@ -406,10 +397,7 @@ impl FlowFabricWorker {
             .arg(&core_key)
             .execute()
             .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "describe_flow: HGETALL flow_core".into(),
-            })?;
+            .map_err(|e| crate::backend_context(e, "describe_flow: HGETALL flow_core"))?;
 
         if raw.is_empty() {
             return Ok(None);
@@ -646,10 +634,7 @@ impl FlowFabricWorker {
             .arg(&edge_key)
             .execute()
             .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "describe_edge: HGETALL edge_hash".into(),
-            })?;
+            .map_err(|e| crate::backend_context(e, "describe_edge: HGETALL edge_hash"))?;
 
         if raw.is_empty() {
             return Ok(None);
@@ -735,10 +720,7 @@ impl FlowFabricWorker {
             .arg("flow_id")
             .execute()
             .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "list_edges: HGET exec_core.flow_id".into(),
-            })?;
+            .map_err(|e| crate::backend_context(e, "list_edges: HGET exec_core.flow_id"))?;
         let Some(raw) = raw.filter(|s| !s.is_empty()) else {
             return Ok(None);
         };
@@ -784,10 +766,7 @@ impl FlowFabricWorker {
             .arg(adj_key)
             .execute()
             .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "list_edges: SMEMBERS adj_set".into(),
-            })?;
+            .map_err(|e| crate::backend_context(e, "list_edges: SMEMBERS adj_set"))?;
         if edge_id_strs.is_empty() {
             return Ok(Vec::new());
         }
@@ -816,17 +795,11 @@ impl FlowFabricWorker {
                     .finish()
             })
             .collect();
-        pipe.execute().await.map_err(|e| SdkError::ValkeyContext {
-            source: e,
-            context: "list_edges: pipeline HGETALL edges".into(),
-        })?;
+        pipe.execute().await.map_err(|e| crate::backend_context(e, "list_edges: pipeline HGETALL edges"))?;
 
         let mut out: Vec<EdgeSnapshot> = Vec::with_capacity(edge_ids.len());
         for (edge_id, slot) in edge_ids.iter().zip(slots) {
-            let raw = slot.value().map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "list_edges: decode HGETALL edge_hash".into(),
-            })?;
+            let raw = slot.value().map_err(|e| crate::backend_context(e, "list_edges: decode HGETALL edge_hash"))?;
             if raw.is_empty() {
                 // Adjacency SET referenced an edge_hash that no longer
                 // exists. FF does not delete edge hashes today (staging

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -836,7 +836,7 @@ impl ClaimedTask {
             .client
             .fcall("ff_suspend_execution", &key_refs, &arg_refs)
             .await
-            .map_err(SdkError::Valkey)?;
+            .map_err(SdkError::from)?;
 
         self.stop_renewal();
         parse_suspend_result(&raw, suspension_id, waitpoint_id, waitpoint_key)
@@ -892,7 +892,7 @@ impl ClaimedTask {
 /// server either committed or rejected with a typed response. Only
 /// raw `Transport` errors (connection drops, request timeouts, parse
 /// failures) count as "did not land", which matches the pre-Stage-1b
-/// SDK's `fcall(...).await.map_err(SdkError::Valkey)?` short-circuit
+/// SDK's `fcall(...).await.map_err(SdkError::from)?` short-circuit
 /// — those errors returned before `stop_renewal()` ran, preserving
 /// the `Drop` warning for genuine "lease will leak" cases.
 ///

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -157,14 +157,14 @@ impl FlowFabricWorker {
         }
         let client = builder.build()
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "failed to connect".into() })?;
+            .map_err(|e| crate::backend_context(e, "failed to connect"))?;
 
         // Verify connectivity
         let pong: String = client
             .cmd("PING")
             .execute()
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "PING failed".into() })?;
+            .map_err(|e| crate::backend_context(e, "PING failed"))?;
         if pong != "PONG" {
             return Err(SdkError::Config {
                 context: "worker_connect".into(),
@@ -221,10 +221,7 @@ impl FlowFabricWorker {
             .arg(alive_ttl_ms.to_string().as_str())
             .execute()
             .await
-            .map_err(|e| SdkError::ValkeyContext {
-                source: e,
-                context: "SET NX worker alive key".into(),
-            })?;
+            .map_err(|e| crate::backend_context(e, "SET NX worker alive key"))?;
         if set_result.is_none() {
             return Err(SdkError::Config {
                 context: "worker_connect".into(),
@@ -716,7 +713,7 @@ impl FlowFabricWorker {
                 .arg("1")
                 .execute()
                 .await
-                .map_err(|e| SdkError::ValkeyContext { source: e, context: "ZRANGEBYSCORE failed".into() })?;
+                .map_err(|e| crate::backend_context(e, "ZRANGEBYSCORE failed"))?;
 
             let execution_id_str = match extract_first_array_string(&result) {
                 Some(s) => s,
@@ -881,7 +878,7 @@ impl FlowFabricWorker {
             .client
             .fcall("ff_issue_claim_grant", &key_refs, &arg_refs)
             .await
-            .map_err(SdkError::Valkey)?;
+            .map_err(SdkError::from)?;
 
         crate::task::parse_success_result(&raw, "ff_issue_claim_grant")
     }
@@ -1031,7 +1028,7 @@ impl FlowFabricWorker {
             .client
             .fcall("ff_claim_execution", &key_refs, &arg_refs)
             .await
-            .map_err(SdkError::Valkey)?;
+            .map_err(SdkError::from)?;
 
         // Parse claim result: {1, "OK", lease_id, lease_epoch, attempt_index,
         //                      attempt_id, attempt_type, lease_expires_at}
@@ -1168,7 +1165,7 @@ impl FlowFabricWorker {
     ///   between grant issuance and caps change allows it.
     /// * `ScriptError::Parse` — `ff_claim_execution` returned an
     ///   unexpected shape (wrapped in [`SdkError::Engine`]).
-    /// * [`SdkError::Valkey`] / [`SdkError::ValkeyContext`] —
+    /// * [`SdkError::Backend`] / [`SdkError::BackendContext`] —
     ///   transport error during the FCALL or the
     ///   `read_execution_context` follow-up.
     ///
@@ -1280,7 +1277,7 @@ impl FlowFabricWorker {
     /// * `ScriptError::ExecutionNotLeaseable` — `lifecycle_phase` is
     ///   not `runnable`.
     /// * `ScriptError::ExecutionNotFound` — core key missing.
-    /// * [`SdkError::Valkey`] / [`SdkError::ValkeyContext`] —
+    /// * [`SdkError::Backend`] / [`SdkError::BackendContext`] —
     ///   transport.
     ///
     /// [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
@@ -1345,7 +1342,7 @@ impl FlowFabricWorker {
             .arg("current_attempt_index")
             .execute()
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "read attempt_index".into() })?;
+            .map_err(|e| crate::backend_context(e, "read attempt_index"))?;
         let att_idx = AttemptIndex::new(
             att_idx_str.as_deref().and_then(|s| s.parse().ok()).unwrap_or(0),
         );
@@ -1386,7 +1383,7 @@ impl FlowFabricWorker {
             .client
             .fcall("ff_claim_resumed_execution", &key_refs, &arg_refs)
             .await
-            .map_err(SdkError::Valkey)?;
+            .map_err(SdkError::from)?;
 
         // Parse result — same format as ff_claim_execution:
         // {1, "OK", lease_id, lease_epoch, expires_at, attempt_id, attempt_index, attempt_type}
@@ -1494,7 +1491,7 @@ impl FlowFabricWorker {
             .client
             .get(&ctx.payload())
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "GET payload failed".into() })?;
+            .map_err(|e| crate::backend_context(e, "GET payload failed"))?;
         let input_payload = payload.unwrap_or_default().into_bytes();
 
         // Read execution_kind from core
@@ -1502,7 +1499,7 @@ impl FlowFabricWorker {
             .client
             .hget(&ctx.core(), "execution_kind")
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "HGET execution_kind failed".into() })?;
+            .map_err(|e| crate::backend_context(e, "HGET execution_kind failed"))?;
         let execution_kind = kind.unwrap_or_default();
 
         // Read tags
@@ -1510,7 +1507,7 @@ impl FlowFabricWorker {
             .client
             .hgetall(&ctx.tags())
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "HGETALL tags".into() })?;
+            .map_err(|e| crate::backend_context(e, "HGETALL tags"))?;
 
         Ok((input_payload, execution_kind, tags))
     }
@@ -1540,7 +1537,7 @@ impl FlowFabricWorker {
             .client
             .hget(&ctx.core(), "lane_id")
             .await
-            .map_err(|e| SdkError::ValkeyContext { source: e, context: "HGET lane_id".into() })?;
+            .map_err(|e| crate::backend_context(e, "HGET lane_id"))?;
         let lane_id = LaneId::new(lane_str.unwrap_or_else(|| "default".to_owned()));
 
         // KEYS (14): exec_core, wp_condition, wp_signals_stream,
@@ -1613,7 +1610,7 @@ impl FlowFabricWorker {
             .client
             .fcall("ff_deliver_signal", &key_refs, &arg_refs)
             .await
-            .map_err(SdkError::Valkey)?;
+            .map_err(SdkError::from)?;
 
         crate::task::parse_signal_result(&raw)
     }
@@ -1665,7 +1662,7 @@ async fn read_partition_config(client: &Client) -> Result<PartitionConfig, SdkEr
     let fields: HashMap<String, String> = client
         .hgetall(&key)
         .await
-        .map_err(|e| SdkError::ValkeyContext { source: e, context: format!("HGETALL {key}") })?;
+        .map_err(|e| crate::backend_context(e, format!("HGETALL {key}")))?;
 
     if fields.is_empty() {
         return Err(SdkError::Config {

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -207,9 +207,10 @@ impl From<ServerError> for ApiError {
     }
 }
 
-/// HTTP error body. `kind`/`retryable` are populated for 500s backed by a
-/// `ferriskey::Error` so HTTP clients (e.g. cairn-fabric) can make retry
-/// decisions without parsing the `error` string.
+/// HTTP error body. `kind`/`retryable` are populated for 500s backed by
+/// a backend transport fault (see `ff_core::BackendErrorKind`) so HTTP
+/// clients (e.g. cairn-fabric) can make retry decisions without parsing
+/// the `error` string.
 #[derive(Serialize)]
 struct ErrorBody {
     error: String,
@@ -227,8 +228,6 @@ impl ErrorBody {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        use ff_script::retry::kind_to_stable_str;
-
         let (status, body) = match &self.0 {
             ServerError::NotFound(msg) => {
                 (StatusCode::NOT_FOUND, ErrorBody::plain(msg.clone()))
@@ -249,13 +248,12 @@ impl IntoResponse for ApiError {
                     retryable: Some(true),
                 },
             ),
-            ServerError::Valkey(e) => {
-                let kind_str = kind_to_stable_str(e.kind());
+            ServerError::Backend(be) => {
+                let kind_str = be.kind().as_stable_str();
                 tracing::error!(
                     kind = kind_str,
-                    code = e.code().unwrap_or(""),
-                    detail = e.detail().unwrap_or(""),
-                    "valkey error"
+                    message = be.message(),
+                    "backend error"
                 );
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -266,14 +264,13 @@ impl IntoResponse for ApiError {
                     },
                 )
             }
-            ServerError::ValkeyContext { source, context } => {
-                let kind_str = kind_to_stable_str(source.kind());
+            ServerError::BackendContext { source, context } => {
+                let kind_str = source.kind().as_stable_str();
                 tracing::error!(
                     kind = kind_str,
-                    code = source.code().unwrap_or(""),
-                    detail = source.detail().unwrap_or(""),
+                    message = source.message(),
                     context = %context,
-                    "valkey error"
+                    "backend error"
                 );
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -285,7 +282,10 @@ impl IntoResponse for ApiError {
                 )
             }
             ServerError::LibraryLoad(load_err) => {
-                let kind_str = load_err.valkey_kind().map(kind_to_stable_str);
+                let kind_str = load_err
+                    .valkey_kind()
+                    .map(ff_backend_valkey::classify_ferriskey_kind)
+                    .map(|k| k.as_stable_str());
                 tracing::error!(
                     kind = kind_str.unwrap_or(""),
                     error = %load_err,
@@ -1280,7 +1280,7 @@ async fn healthz(
         .cmd("PING")
         .execute()
         .await
-        .map_err(|e| ApiError(ServerError::ValkeyContext { source: e, context: "healthz PING".into() }))?;
+        .map_err(|e| ApiError(crate::server::backend_context(e, "healthz PING")))?;
     Ok(Json(HealthResponse { status: "ok" }))
 }
 

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -214,14 +214,20 @@ pub struct Server {
 /// Server error type.
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
-    /// Valkey connection or command error (preserves ErrorKind for caller inspection).
-    #[error("valkey: {0}")]
-    Valkey(#[from] ferriskey::Error),
-    /// Valkey error with additional context (preserves ErrorKind via #[source]).
-    #[error("valkey ({context}): {source}")]
-    ValkeyContext {
+    /// Backend transport error. Previously wrapped `ferriskey::Error`
+    /// directly (#88); now carries a backend-agnostic
+    /// [`ff_core::BackendError`] so consumers match on
+    /// [`ff_core::BackendErrorKind`] instead of ferriskey's native
+    /// taxonomy. The ferriskey → [`ff_core::BackendError`] mapping
+    /// lives in `ff_backend_valkey::backend_error_from_ferriskey`.
+    #[error("backend: {0}")]
+    Backend(#[from] ff_core::BackendError),
+    /// Backend error with additional context. Previously
+    /// `ValkeyContext { source: ferriskey::Error }` (#88).
+    #[error("backend ({context}): {source}")]
+    BackendContext {
         #[source]
-        source: ferriskey::Error,
+        source: ff_core::BackendError,
         context: String,
     },
     #[error("config: {0}")]
@@ -261,27 +267,56 @@ pub enum ServerError {
     },
 }
 
+/// Lift a native `ferriskey::Error` into [`ServerError::Backend`] via
+/// [`ff_backend_valkey::backend_error_from_ferriskey`] (#88). Keeps
+/// `?`-propagation ergonomic at ferriskey call sites while the
+/// public variant stays backend-agnostic.
+impl From<ferriskey::Error> for ServerError {
+    fn from(err: ferriskey::Error) -> Self {
+        Self::Backend(ff_backend_valkey::backend_error_from_ferriskey(&err))
+    }
+}
+
+/// Build a [`ServerError::BackendContext`] from a native
+/// `ferriskey::Error` and a call-site label (#88).
+pub(crate) fn backend_context(
+    err: ferriskey::Error,
+    context: impl Into<String>,
+) -> ServerError {
+    ServerError::BackendContext {
+        source: ff_backend_valkey::backend_error_from_ferriskey(&err),
+        context: context.into(),
+    }
+}
+
 impl ServerError {
-    /// Returns the underlying ferriskey ErrorKind, if this error carries one.
-    /// Covers direct Valkey variants and library-load failures that bubble a
-    /// `ferriskey::Error` through `LoadError::Valkey`.
-    pub fn valkey_kind(&self) -> Option<ferriskey::ErrorKind> {
+    /// Returns the classified [`ff_core::BackendErrorKind`] if this
+    /// error carries a backend transport fault. Covers direct
+    /// Backend variants and library-load failures.
+    ///
+    /// Renamed from `valkey_kind` in #88 — the previous return type
+    /// `Option<ferriskey::ErrorKind>` leaked ferriskey into every
+    /// consumer doing retry/error classification.
+    pub fn backend_kind(&self) -> Option<ff_core::BackendErrorKind> {
         match self {
-            Self::Valkey(e) | Self::ValkeyContext { source: e, .. } => Some(e.kind()),
-            Self::LibraryLoad(e) => e.valkey_kind(),
+            Self::Backend(be) | Self::BackendContext { source: be, .. } => Some(be.kind()),
+            Self::LibraryLoad(e) => e
+                .valkey_kind()
+                .map(ff_backend_valkey::classify_ferriskey_kind),
             _ => None,
         }
     }
 
-    /// Whether this error is safely retryable by a caller. Semantics match
-    /// `ScriptError::class() == Retryable` for Lua errors plus a kind-aware
-    /// check for transport/library-load failures. Business-logic rejections
-    /// (NotFound, InvalidInput, OperationFailed, Script, Config, PartitionMismatch)
-    /// return false — those won't change on retry.
+    /// Whether this error is safely retryable by a caller. For
+    /// backend transport variants, delegates to
+    /// [`ff_core::BackendErrorKind::is_retryable`]. Business-logic
+    /// rejections (NotFound, InvalidInput, OperationFailed, Script,
+    /// Config, PartitionMismatch) return false — those won't change
+    /// on retry.
     pub fn is_retryable(&self) -> bool {
         match self {
-            Self::Valkey(e) | Self::ValkeyContext { source: e, .. } => {
-                is_retryable_kind(e.kind())
+            Self::Backend(be) | Self::BackendContext { source: be, .. } => {
+                be.kind().is_retryable()
             }
             Self::LibraryLoad(load_err) => load_err
                 .valkey_kind()
@@ -347,14 +382,14 @@ impl Server {
         let client = builder
             .build()
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "connect".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "connect"))?;
 
         // Verify connectivity
         let pong: String = client
             .cmd("PING")
             .execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "PING".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "PING"))?;
         if pong != "PONG" {
             return Err(ServerError::OperationFailed(format!(
                 "unexpected PING response: {pong}"
@@ -470,18 +505,12 @@ impl Server {
         let tail_client = tail_builder
             .build()
             .await
-            .map_err(|e| ServerError::ValkeyContext {
-                source: e,
-                context: "connect (tail)".into(),
-            })?;
+            .map_err(|e| crate::server::backend_context(e, "connect (tail)"))?;
         let tail_pong: String = tail_client
             .cmd("PING")
             .execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext {
-                source: e,
-                context: "PING (tail)".into(),
-            })?;
+            .map_err(|e| crate::server::backend_context(e, "PING (tail)"))?;
         if tail_pong != "PONG" {
             return Err(ServerError::OperationFailed(format!(
                 "tail client unexpected PING response: {tail_pong}"
@@ -735,7 +764,7 @@ impl Server {
             .client
             .hget(&ctx.core(), "public_state")
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGET public_state".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGET public_state"))?;
 
         match state_str {
             Some(s) => {
@@ -800,10 +829,7 @@ impl Server {
             .arg(ctx.result())
             .execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext {
-                source: e,
-                context: "GET exec result".into(),
-            })?;
+            .map_err(|e| crate::server::backend_context(e, "GET exec result"))?;
         Ok(payload)
     }
 
@@ -865,10 +891,7 @@ impl Server {
             .arg(ctx.core())
             .execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext {
-                source: e,
-                context: "EXISTS exec_core (pending waitpoints)".into(),
-            })?;
+            .map_err(|e| crate::server::backend_context(e, "EXISTS exec_core (pending waitpoints)"))?;
         if !core_exists {
             return Err(ServerError::NotFound(format!(
                 "execution not found: {execution_id}"
@@ -896,10 +919,7 @@ impl Server {
                 .arg(WAITPOINTS_SSCAN_COUNT.to_string().as_str())
                 .execute()
                 .await
-                .map_err(|e| ServerError::ValkeyContext {
-                    source: e,
-                    context: "SSCAN waitpoints".into(),
-                })?;
+                .map_err(|e| crate::server::backend_context(e, "SSCAN waitpoints"))?;
             cursor = reply.0;
             wp_ids_raw.extend(reply.1);
             if cursor == "0" {
@@ -978,10 +998,7 @@ impl Server {
         pass1
             .execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext {
-                source: e,
-                context: "pipeline HMGET waitpoints + HGET total_matchers".into(),
-            })?;
+            .map_err(|e| crate::server::backend_context(e, "pipeline HMGET waitpoints + HGET total_matchers"))?;
 
         // Collect pass-1 results + queue pass-2 HMGETs for condition
         // matcher names on waitpoints that are actionable (state in
@@ -1000,10 +1017,7 @@ impl Server {
             .zip(cond_slots)
         {
             let wp_fields: Vec<Option<String>> =
-                wp_slot.value().map_err(|e| ServerError::ValkeyContext {
-                    source: e,
-                    context: format!("pipeline slot HMGET waitpoint {wp_id}"),
-                })?;
+                wp_slot.value().map_err(|e| crate::server::backend_context(e, format!("pipeline slot HMGET waitpoint {wp_id}")))?;
 
             // Waitpoint hash may have been GC'd between the SSCAN and
             // this HMGET (rotation / cleanup race). Skip silently.
@@ -1041,10 +1055,7 @@ impl Server {
 
             let total_matchers = cond_slot
                 .value()
-                .map_err(|e| ServerError::ValkeyContext {
-                    source: e,
-                    context: format!("pipeline slot HGET total_matchers {wp_id}"),
-                })?
+                .map_err(|e| crate::server::backend_context(e, format!("pipeline slot HGET total_matchers {wp_id}")))?
                 .and_then(|s| s.parse::<usize>().ok())
                 .unwrap_or(0);
 
@@ -1080,10 +1091,7 @@ impl Server {
             matcher_slots.push(Some(cmd.finish()));
         }
         if pass2_needed {
-            pass2.execute().await.map_err(|e| ServerError::ValkeyContext {
-                source: e,
-                context: "pipeline HMGET wp_condition matchers".into(),
-            })?;
+            pass2.execute().await.map_err(|e| crate::server::backend_context(e, "pipeline HMGET wp_condition matchers"))?;
         }
 
         let parse_ts = |raw: &str| -> Option<TimestampMs> {
@@ -1106,13 +1114,10 @@ impl Server {
                 None => Vec::new(),
                 Some(s) => {
                     let vals: Vec<Option<String>> =
-                        s.value().map_err(|e| ServerError::ValkeyContext {
-                            source: e,
-                            context: format!(
+                        s.value().map_err(|e| crate::server::backend_context(e, format!(
                                 "pipeline slot HMGET wp_condition matchers {}",
                                 k.wp_id
-                            ),
-                        })?;
+                            )))?;
                     vals.into_iter()
                         .flatten()
                         .filter(|name| !name.is_empty())
@@ -1248,7 +1253,7 @@ impl Server {
             .client
             .hgetall(&bctx.definition())
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGETALL budget_def".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGETALL budget_def"))?;
 
         if def.is_empty() {
             return Err(ServerError::NotFound(format!(
@@ -1261,7 +1266,7 @@ impl Server {
             .client
             .hgetall(&bctx.usage())
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGETALL budget_usage".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGETALL budget_usage"))?;
         let usage: HashMap<String, u64> = usage_raw
             .into_iter()
             .filter(|(k, _)| k != "_init")
@@ -1273,7 +1278,7 @@ impl Server {
             .client
             .hgetall(&bctx.limits())
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGETALL budget_limits".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGETALL budget_limits"))?;
         let mut hard_limits = HashMap::new();
         let mut soft_limits = HashMap::new();
         for (k, v) in &limits_raw {
@@ -1623,10 +1628,7 @@ impl Server {
                     .arg("cancel_reason")
                     .execute()
                     .await
-                    .map_err(|e| ServerError::ValkeyContext {
-                        source: e,
-                        context: "HMGET flow_core cancellation_policy,cancel_reason".into(),
-                    })?;
+                    .map_err(|e| crate::server::backend_context(e, "HMGET flow_core cancellation_policy,cancel_reason"))?;
                 let stored_policy = flow_meta
                     .first()
                     .and_then(|v| v.as_ref())
@@ -1643,10 +1645,7 @@ impl Server {
                     .arg(fctx.members())
                     .execute()
                     .await
-                    .map_err(|e| ServerError::ValkeyContext {
-                        source: e,
-                        context: "SMEMBERS flow members (already terminal)".into(),
-                    })?;
+                    .map_err(|e| crate::server::backend_context(e, "SMEMBERS flow members (already terminal)"))?;
                 // Cap the returned list to avoid pathological bandwidth on
                 // idempotent retries for flows with 10k+ members. Clients
                 // already received the authoritative member list on the
@@ -1941,7 +1940,7 @@ impl Server {
             .client
             .hget(&ctx.core(), "lane_id")
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGET lane_id".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGET lane_id"))?;
         let lane = LaneId::new(lane_str.unwrap_or_else(|| "default".to_owned()));
 
         // KEYS (7): exec_core, deps_meta, unresolved_set, dep_hash,
@@ -1997,7 +1996,7 @@ impl Server {
             .client
             .hget(&ctx.core(), "lane_id")
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGET lane_id".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGET lane_id"))?;
         let lane = LaneId::new(lane_str.unwrap_or_else(|| "default".to_owned()));
 
         let wp_id = &args.waitpoint_id;
@@ -2099,7 +2098,7 @@ impl Server {
             .client
             .hget(&ctx.core(), "lane_id")
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGET lane_id".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGET lane_id"))?;
         let lane = LaneId::new(lane_str.unwrap_or_else(|| "default".to_owned()));
 
         // KEYS (2): exec_core, eligible_zset
@@ -2152,15 +2151,11 @@ impl Server {
             )
             .await
             .map_err(|e| match e {
-                ff_scheduler::SchedulerError::Valkey(inner) => {
-                    ServerError::Valkey(inner)
-                }
+                ff_scheduler::SchedulerError::Valkey(inner) => ServerError::from(inner),
                 ff_scheduler::SchedulerError::ValkeyContext { source, context } => {
-                    ServerError::ValkeyContext { source, context }
+                    crate::server::backend_context(source, context)
                 }
-                ff_scheduler::SchedulerError::Config(msg) => {
-                    ServerError::InvalidInput(msg)
-                }
+                ff_scheduler::SchedulerError::Config(msg) => ServerError::InvalidInput(msg),
             })
     }
 
@@ -2178,7 +2173,7 @@ impl Server {
             .client
             .hget(&ctx.core(), "current_worker_instance_id")
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGET worker_instance_id".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGET worker_instance_id"))?;
         let wiid = match wiid_str {
             Some(ref s) if !s.is_empty() => WorkerInstanceId::new(s),
             _ => {
@@ -2226,7 +2221,7 @@ impl Server {
             .client
             .hgetall(&ctx.core())
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGETALL exec_core".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HGETALL exec_core"))?;
 
         if fields.is_empty() {
             return Err(ServerError::NotFound(format!(
@@ -2351,7 +2346,7 @@ impl Server {
             .arg(limit)
             .execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: format!("ZRANGE {zset_key}") })?;
+            .map_err(|e| crate::server::backend_context(e, format!("ZRANGE {zset_key}")))?;
 
         if eids.is_empty() {
             return Ok(ListExecutionsResult {
@@ -2404,12 +2399,12 @@ impl Server {
 
         pipe.execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "pipeline HMGET".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "pipeline HMGET"))?;
 
         let mut summaries = Vec::with_capacity(parsed.len());
         for (eid, slot) in parsed.into_iter().zip(slots) {
             let fields: Vec<Option<String>> = slot.value()
-                .map_err(|e| ServerError::ValkeyContext { source: e, context: "pipeline slot".into() })?;
+                .map_err(|e| crate::server::backend_context(e, "pipeline slot"))?;
 
             let field = |i: usize| -> String {
                 fields
@@ -2469,7 +2464,7 @@ impl Server {
             .arg("terminal_outcome")
             .execute()
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HMGET replay pre-read".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HMGET replay pre-read"))?;
         let lane = LaneId::new(
             dyn_fields
                 .first()
@@ -2517,7 +2512,7 @@ impl Server {
                 .arg(flow_ctx.incoming(execution_id))
                 .execute()
                 .await
-                .map_err(|e| ServerError::ValkeyContext { source: e, context: "SMEMBERS replay edges".into() })?;
+                .map_err(|e| crate::server::backend_context(e, "SMEMBERS replay edges"))?;
 
             // Extended KEYS: blocked_deps_zset, deps_meta, deps_unresolved, dep_edge_0..N
             fcall_keys.push(idx.lane_blocked_dependencies(&lane)); // 5
@@ -2841,9 +2836,9 @@ async fn verify_valkey_version(client: &Client) -> Result<(), ServerError> {
                     // fail so operators see the true root cause immediately,
                     // not a 60s hang followed by a generic "transient" error.
                     let retryable = e
-                        .valkey_kind()
-                        .map(ff_script::retry::is_retryable_kind)
-                        // Non-Valkey errors (parse, missing field, operation
+                        .backend_kind()
+                        .map(|k| k.is_retryable())
+                        // Non-backend errors (parse, missing field, operation
                         // failures) are treated as transient — a fresh-boot
                         // Valkey may not have redis_version populated yet.
                         .unwrap_or(true);
@@ -2886,10 +2881,7 @@ async fn query_valkey_version(client: &Client) -> Result<(u32, u32), ServerError
         .arg("server")
         .execute()
         .await
-        .map_err(|e| ServerError::ValkeyContext {
-            source: e,
-            context: "INFO server".into(),
-        })?;
+        .map_err(|e| crate::server::backend_context(e, "INFO server"))?;
     let bodies = extract_info_bodies(&raw)?;
     // Cluster: return the minimum (major, minor) across all nodes so a stale
     // pre-upgrade replica cannot hide behind an already-upgraded primary.
@@ -3036,7 +3028,7 @@ async fn validate_or_create_partition_config(
     let existing: HashMap<String, String> = client
         .hgetall(&key)
         .await
-        .map_err(|e| ServerError::ValkeyContext { source: e, context: format!("HGETALL {key}") })?;
+        .map_err(|e| crate::server::backend_context(e, format!("HGETALL {key}")))?;
 
     if existing.is_empty() {
         // First boot — create the config
@@ -3044,15 +3036,15 @@ async fn validate_or_create_partition_config(
         client
             .hset(&key, "num_flow_partitions", &config.num_flow_partitions.to_string())
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HSET num_flow_partitions".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HSET num_flow_partitions"))?;
         client
             .hset(&key, "num_budget_partitions", &config.num_budget_partitions.to_string())
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HSET num_budget_partitions".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HSET num_budget_partitions"))?;
         client
             .hset(&key, "num_quota_partitions", &config.num_quota_partitions.to_string())
             .await
-            .map_err(|e| ServerError::ValkeyContext { source: e, context: "HSET num_quota_partitions".into() })?;
+            .map_err(|e| crate::server::backend_context(e, "HSET num_quota_partitions"))?;
         return Ok(());
     }
 
@@ -3126,10 +3118,7 @@ async fn init_one_partition(
         .arg("current_kid")
         .execute()
         .await
-        .map_err(|e| ServerError::ValkeyContext {
-            source: e,
-            context: format!("HGET {key} current_kid (init probe)"),
-        })?;
+        .map_err(|e| crate::server::backend_context(e, format!("HGET {key} current_kid (init probe)")))?;
 
     if let Some(stored_kid) = stored_kid {
         // We didn't know the stored kid up front, so now HGET the real
@@ -3139,10 +3128,7 @@ async fn init_one_partition(
         let stored_secret: Option<String> = client
             .hget(&key, &field)
             .await
-            .map_err(|e| ServerError::ValkeyContext {
-                source: e,
-                context: format!("HGET {key} secret:<kid> (init check)"),
-            })?;
+            .map_err(|e| crate::server::backend_context(e, format!("HGET {key} secret:<kid> (init check)")))?;
         if stored_secret.is_none() {
             // Torn write from a previous boot: current_kid present but
             // secret:<kid> missing. Without repair, mint returns
@@ -3152,10 +3138,7 @@ async fn init_one_partition(
             client
                 .hset(&key, &field, secret_hex)
                 .await
-                .map_err(|e| ServerError::ValkeyContext {
-                    source: e,
-                    context: format!("HSET {key} secret:<kid> (repair torn write)"),
-                })?;
+                .map_err(|e| crate::server::backend_context(e, format!("HSET {key} secret:<kid> (repair torn write)")))?;
             return Ok(PartitionBootOutcome::Repaired);
         }
         if stored_secret.as_deref() != Some(secret_hex) {
@@ -3177,10 +3160,7 @@ async fn init_one_partition(
         .arg(secret_hex)
         .execute()
         .await
-        .map_err(|e| ServerError::ValkeyContext {
-            source: e,
-            context: format!("HSET {key} (init waitpoint HMAC atomic)"),
-        })?;
+        .map_err(|e| crate::server::backend_context(e, format!("HSET {key} (init waitpoint HMAC atomic)")))?;
     Ok(PartitionBootOutcome::Installed)
 }
 
@@ -3460,10 +3440,10 @@ impl Server {
                      original secret for this kid before retrying."
                 ))
             }
-            ff_script::ScriptError::Valkey(v) => ServerError::ValkeyContext {
-                source: v,
-                context: format!("FCALL ff_rotate_waitpoint_hmac_secret partition={partition}"),
-            },
+            ff_script::ScriptError::Valkey(v) => crate::server::backend_context(
+                v,
+                format!("FCALL ff_rotate_waitpoint_hmac_secret partition={partition}"),
+            ),
             other => ServerError::OperationFailed(format!(
                 "rotation failed on partition {partition}: {other}"
             )),
@@ -3941,10 +3921,9 @@ fn parse_replay_result(raw: &Value) -> Result<ReplayExecutionResult, ServerError
 /// transient error like `IoError`.
 fn script_error_to_server(e: ff_script::error::ScriptError) -> ServerError {
     match e {
-        ff_script::error::ScriptError::Valkey(valkey_err) => ServerError::ValkeyContext {
-            source: valkey_err,
-            context: "stream FCALL transport".into(),
-        },
+        ff_script::error::ScriptError::Valkey(valkey_err) => {
+            crate::server::backend_context(valkey_err, "stream FCALL transport")
+        }
         other => ServerError::Script(other.to_string()),
     }
 }
@@ -4073,9 +4052,9 @@ async fn fcall_with_reload_on_client(
             client
                 .fcall(function, keys, args)
                 .await
-                .map_err(ServerError::Valkey)
+                .map_err(ServerError::from)
         }
-        Err(e) => Err(ServerError::Valkey(e)),
+        Err(e) => Err(ServerError::from(e)),
     }
 }
 
@@ -4094,7 +4073,7 @@ async fn build_cancel_execution_fcall(
     let lane_str: Option<String> = client
         .hget(&ctx.core(), "lane_id")
         .await
-        .map_err(|e| ServerError::ValkeyContext { source: e, context: "HGET lane_id".into() })?;
+        .map_err(|e| crate::server::backend_context(e, "HGET lane_id"))?;
     let lane = LaneId::new(lane_str.unwrap_or_else(|| "default".to_owned()));
 
     let dyn_fields: Vec<Option<String>> = client
@@ -4105,7 +4084,7 @@ async fn build_cancel_execution_fcall(
         .arg("current_worker_instance_id")
         .execute()
         .await
-        .map_err(|e| ServerError::ValkeyContext { source: e, context: "HMGET cancel pre-read".into() })?;
+        .map_err(|e| crate::server::backend_context(e, "HMGET cancel pre-read"))?;
 
     let att_idx_val = dyn_fields.first()
         .and_then(|v| v.as_ref())
@@ -4159,18 +4138,18 @@ async fn build_cancel_execution_fcall(
 /// The last entry is not slept on because it's the final attempt.
 const CANCEL_MEMBER_RETRY_DELAYS_MS: [u64; 3] = [100, 500, 2_000];
 
-/// Reach into a `ServerError` for a `ferriskey::ErrorKind` when one is
-/// available. Matches the variants that can carry a transport-layer kind:
-/// direct `Valkey`, `ValkeyContext`, and `LibraryLoad` (which itself wraps
-/// a `ferriskey::Error`).
-fn extract_valkey_kind(e: &ServerError) -> Option<ferriskey::ErrorKind> {
-    match e {
-        ServerError::Valkey(err) | ServerError::ValkeyContext { source: err, .. } => {
-            Some(err.kind())
-        }
-        ServerError::LibraryLoad(load_err) => load_err.valkey_kind(),
-        _ => None,
-    }
+/// Reach into a `ServerError` for a transport-layer retryability hint.
+/// Matches the variants that can carry a backend transport fault:
+/// direct `Backend`, `BackendContext`, and `LibraryLoad` (which
+/// wraps a ferriskey error internally).
+///
+/// Renamed from `extract_valkey_kind` in #88 — the previous return
+/// type `Option<ferriskey::ErrorKind>` leaked ferriskey into the
+/// server's internal retry logic. Callers now get a backend-agnostic
+/// [`BackendErrorKind`] and dispatch via
+/// [`BackendErrorKind::is_retryable`].
+fn extract_backend_kind(e: &ServerError) -> Option<ff_core::BackendErrorKind> {
+    e.backend_kind()
 }
 
 /// Cancel a single member execution from a cancel_flow dispatch context.
@@ -4255,8 +4234,8 @@ async fn cancel_member_execution(
                 // Only retry transport-layer transients; business-logic
                 // errors (Script / OperationFailed / NotFound / InvalidInput)
                 // won't change on retry.
-                let retryable = extract_valkey_kind(&e)
-                    .map(ff_script::retry::is_retryable_kind)
+                let retryable = extract_backend_kind(&e)
+                    .map(|k| k.is_retryable())
                     .unwrap_or(false);
                 if !retryable || is_last {
                     return Err(e);
@@ -4432,33 +4411,35 @@ mod tests {
     }
 
     #[test]
-    fn is_retryable_valkey_variant_uses_kind_table() {
-        assert!(ServerError::Valkey(mk_fk_err(ErrorKind::IoError)).is_retryable());
-        assert!(ServerError::Valkey(mk_fk_err(ErrorKind::FatalSendError)).is_retryable());
-        assert!(ServerError::Valkey(mk_fk_err(ErrorKind::TryAgain)).is_retryable());
-        assert!(ServerError::Valkey(mk_fk_err(ErrorKind::BusyLoadingError)).is_retryable());
-        assert!(ServerError::Valkey(mk_fk_err(ErrorKind::ClusterDown)).is_retryable());
+    fn is_retryable_backend_variant_uses_kind_table() {
+        // Transport-bucketed: retryable.
+        assert!(ServerError::from(mk_fk_err(ErrorKind::IoError)).is_retryable());
+        assert!(ServerError::from(mk_fk_err(ErrorKind::FatalSendError)).is_retryable());
+        assert!(ServerError::from(mk_fk_err(ErrorKind::FatalReceiveError)).is_retryable());
+        // Cluster-bucketed (Moved / Ask / TryAgain / ClusterDown): retryable
+        // after topology settles — the #88 BackendErrorKind classifier
+        // treats these as transient cluster-churn, a semantic refinement
+        // over the previous ff-script retry table.
+        assert!(ServerError::from(mk_fk_err(ErrorKind::TryAgain)).is_retryable());
+        assert!(ServerError::from(mk_fk_err(ErrorKind::ClusterDown)).is_retryable());
+        assert!(ServerError::from(mk_fk_err(ErrorKind::Moved)).is_retryable());
+        assert!(ServerError::from(mk_fk_err(ErrorKind::Ask)).is_retryable());
+        // BusyLoading: retryable.
+        assert!(ServerError::from(mk_fk_err(ErrorKind::BusyLoadingError)).is_retryable());
 
-        assert!(!ServerError::Valkey(mk_fk_err(ErrorKind::FatalReceiveError)).is_retryable());
-        assert!(!ServerError::Valkey(mk_fk_err(ErrorKind::AuthenticationFailed)).is_retryable());
-        assert!(!ServerError::Valkey(mk_fk_err(ErrorKind::NoScriptError)).is_retryable());
-        assert!(!ServerError::Valkey(mk_fk_err(ErrorKind::Moved)).is_retryable());
-        assert!(!ServerError::Valkey(mk_fk_err(ErrorKind::Ask)).is_retryable());
-        assert!(!ServerError::Valkey(mk_fk_err(ErrorKind::ReadOnly)).is_retryable());
+        // Auth / Protocol / ScriptNotLoaded: terminal.
+        assert!(!ServerError::from(mk_fk_err(ErrorKind::AuthenticationFailed)).is_retryable());
+        assert!(!ServerError::from(mk_fk_err(ErrorKind::NoScriptError)).is_retryable());
+        assert!(!ServerError::from(mk_fk_err(ErrorKind::ReadOnly)).is_retryable());
     }
 
     #[test]
-    fn is_retryable_valkey_context_uses_kind_table() {
-        let err = ServerError::ValkeyContext {
-            source: mk_fk_err(ErrorKind::IoError),
-            context: "HGET test".into(),
-        };
+    fn is_retryable_backend_context_uses_kind_table() {
+        let err = crate::server::backend_context(mk_fk_err(ErrorKind::IoError), "HGET test");
         assert!(err.is_retryable());
 
-        let err = ServerError::ValkeyContext {
-            source: mk_fk_err(ErrorKind::AuthenticationFailed),
-            context: "auth".into(),
-        };
+        let err =
+            crate::server::backend_context(mk_fk_err(ErrorKind::AuthenticationFailed), "auth");
         assert!(!err.is_retryable());
     }
 
@@ -4491,17 +4472,17 @@ mod tests {
     }
 
     #[test]
-    fn valkey_kind_delegates_through_library_load() {
+    fn backend_kind_delegates_through_library_load() {
         let err = ServerError::LibraryLoad(ff_script::loader::LoadError::Valkey(
             mk_fk_err(ErrorKind::ClusterDown),
         ));
-        assert_eq!(err.valkey_kind(), Some(ErrorKind::ClusterDown));
+        assert_eq!(err.backend_kind(), Some(ff_core::BackendErrorKind::Cluster));
 
         let err = ServerError::LibraryLoad(ff_script::loader::LoadError::VersionMismatch {
             expected: "1".into(),
             got: "2".into(),
         });
-        assert_eq!(err.valkey_kind(), None);
+        assert_eq!(err.backend_kind(), None);
     }
 
     // ── Valkey version check (RFC-011 §13) ──
@@ -4757,7 +4738,7 @@ os:Linux\r\n";
             required: "7.2".into(),
         };
         assert!(!err.is_retryable());
-        assert_eq!(err.valkey_kind(), None);
+        assert_eq!(err.backend_kind(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #88. Seals the `ferriskey::Error` / `ferriskey::ErrorKind` leak on ff-sdk and ff-server public error surfaces so consumers (cairn-fabric) can classify backend transport faults without a ferriskey dependency.

- **ff-core**: new `BackendError` + `BackendErrorKind` taxonomy (non-exhaustive, backend-agnostic): `Transport / Protocol / Timeout / Auth / Cluster / BusyLoading / ScriptNotLoaded / Other`, with `is_retryable()` and stability-fenced `as_stable_str()`.
- **ff-backend-valkey**: new `backend_error` module owning the ferriskey -> `BackendError` conversion boundary (`backend_error_from_ferriskey`, `classify_ferriskey_kind`, `BackendErrorWrapper`).
- **ff-sdk** (breaking): `SdkError::{Valkey, ValkeyContext}` -> `{Backend, BackendContext}`, `valkey_kind()` -> `backend_kind()`. `From<ferriskey::Error>` + `backend_context` helper keep call sites ergonomic.
- **ff-server** (breaking): parallel reshape of `ServerError`. HTTP `ErrorBody.kind` wire string now comes from `BackendErrorKind::as_stable_str()` (value changes: `"io_error"` -> `"transport"`, `"cluster_down"` / `"moved"` / `"ask"` -> `"cluster"`, etc.). Consumer-affecting for cairn-fabric.
- **Behavioral refinement**: `BackendErrorKind::is_retryable` treats cluster-churn kinds (MOVED/ASK/CLUSTERDOWN/MasterDown/CrossSlot) as retryable where the previous ff-script retry-table treated them as terminal.

Ferriskey is still used internally (the conversion layer lives in `ff-backend-valkey`) but is no longer nameable on any ff-sdk / ff-server public variant or method signature.

Resumed DDD's stalled work: partial `BackendError` type + early SDK reshape were on disk; finished by migrating 24 ff-sdk call sites, 50+ ff-server call sites, updating tests, plus the ff-server HTTP handler + extract_valkey_kind internals.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo build --workspace --no-default-features` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` all green (ff-core 259, ff-script 134, ff-server 45, ff-sdk 58, ff-engine 70, ff-backend-valkey 7, ff-scheduler 13, + others)
- [x] `cargo machete` clean for changed crates (remaining findings are pre-existing in `benches/`)
- [x] `cargo semver-checks` confirms breaking on ff-server as expected (ff-sdk also breaking on variant rename + method rename)
- [ ] Integration tests (`cargo test --workspace`) require live Valkey; not run locally