### PR TITLE
docs(changelog): fill missing [Unreleased] entries since v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,26 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   through the relocated `ff-core` decoders. `ff-sdk`'s
   `FlowFabricWorker::describe_execution` / `describe_flow` /
   `list_*_edges` collapse to thin forwarders over the trait.
+- **`BackendTimeouts.request` now honored (#139).** `ValkeyBackend::connect`
+  previously dropped `config.timeouts` on the floor, dialing via URL-based
+  `Client::connect` / `connect_cluster`; the field had no observable effect.
+  Migrated to `ferriskey::ClientBuilder` so `BackendTimeouts.request` threads
+  through to `ClientBuilder::request_timeout` (cluster + TLS flags also move
+  to the builder; no behavior change for those). `None` preserves the
+  ferriskey default. Behavior-visible: consumers that set a custom
+  `request` timeout will now see it enforced.
+
+### Infrastructure
+
+- Scenario 4 bench methodology: switched to N=5 multi-sample runs with
+  reported mean + stdev for statistical honesty; single-sample numbers
+  previously hid run-to-run variance (#140).
+- Refreshed Scenario 4 baseline at v0.1.0 + HEAD under the N=5
+  methodology so regression tracking has a current reference point
+  (#144).
+- Scenario 4 `apalis` comparison now uses `apalis-workflow` DAG rather
+  than hand-rolled chaining, aligning the comparand with apalis's
+  intended DAG surface (#51, #148).
 
 ## [0.3.4] - 2026-04-22
 


### PR DESCRIPTION
## Summary

Audit commits `v0.3.4..main` against [Unreleased] entries (established
by NNN's grouping PR #153). Identified gaps where PRs merged without
CHANGELOG updates. All additions land under the existing grouped
structure.

## Per-PR audit

| PR    | Subject                                              | Entry? | Notes |
|-------|------------------------------------------------------|--------|-------|
| #136  | drop `BackendTimeouts.keepalive` field               | already in (Breaking) | |
| #137  | reshape `BackendRetry`                               | already in (Breaking) | |
| #139  | wire `BackendTimeouts.request`                       | **ADDED (Changed)** | Behavior-visible: custom request timeouts now enforced |
| #140  | Scenario 4 bench N=5 methodology                     | **ADDED (Infrastructure)** | |
| #141  | cairn-migration-v0.4.0.md doc                        | skipped | migration doc lives separately |
| #142  | wire `BackendRetry` to ClientBuilder                 | already in (Changed) | |
| #143  | v0.3.4 hotfix `Option<CompletionBackend>`            | skipped | captured under `[0.3.4]` |
| #144  | Scenario 4 baseline refresh (N=5)                    | **ADDED (Infrastructure)** | |
| #145  | RFC-012 Round-7 gap-fills                            | skipped | RFC-only; code lands via #147/#151 which are in [Unreleased] |
| #147  | `Frame` extension for `append_frame` parity          | already in (Breaking) | |
| #148  | apalis-workflow DAG scenario 4 swap                  | **ADDED (Infrastructure)** | |
| #149  | RFC-009 operator mitigation note                     | skipped | doc-only |
| #151  | `BackendError` wrapper (seal `ferriskey::Error`)     | already in (Breaking) | |
| #152  | cairn-migration doc fills                            | skipped | migration doc lives separately |
| #153  | CHANGELOG grouping (meta)                            | skipped | the grouping commit itself |

## Added entries

Under `### Changed`:
- `BackendTimeouts.request` now honored (#139)

New `### Infrastructure` section:
- Scenario 4 bench N=5 methodology (#140)
- Baseline refresh at v0.1.0 + HEAD under N=5 (#144)
- apalis-workflow DAG comparand for Scenario 4 (#51 / #148)

## Test plan

- [ ] Render-check `CHANGELOG.md` on GitHub — new entries sit under the
      correct grouped headers, `[0.3.4]` and below untouched.
- [ ] `[Unreleased]` entry count: 5 Breaking + 2 Changed + 3 Infrastructure = 10.

Generated with [Claude Code](https://claude.com/claude-code)