### PR TITLE
docs, feat(ff-core, ff-backend-valkey): DX polish — re-exports + ScannerFilter::with_namespace ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,24 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`ff_backend_valkey::build_client`** is now `pub`. `FlowFabricWorker::connect`
   reuses it so the `BackendConfig` → `ferriskey::Client` mapping lives
   in exactly one place.
+- **DX polish — re-exports + `ScannerFilter::with_namespace` ergonomics
+  (HHH v0.3.4 re-smoke):** four additive papercut fixes for cairn's
+  migration path.
+  - `ff_core::ScannerFilter` re-exported at the crate root (was only
+    reachable via `ff_core::backend::ScannerFilter`).
+  - `ff_core::backend::Namespace` re-exported from `ff_core::types`
+    so consumers already scoped to `ff_core::backend::*` don't need
+    a second `use` crossing into `ff_core::types`. `Namespace`
+    remains canonically exported at `ff_core::types::Namespace`; this
+    is purely additive.
+  - `ff_backend_valkey::BackendConfig` re-exported from
+    `ff_core::backend::BackendConfig` so single-crate consumers of
+    `ff_backend_valkey` don't need to also name `ff_core::backend`.
+  - `ScannerFilter::with_namespace` now accepts
+    `impl Into<Namespace>` (was typed `Namespace`). Non-breaking:
+    existing `Namespace::new("t")`-style call sites still compile
+    via the identity `From<Namespace> for Namespace` impl, and `&str`
+    / `String` now work directly via `string_id!`'s `From` impls.
 
 ### Changed
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use ff_core::backend::{
-    AppendFrameOutcome, BackendConfig, BackendConnection, CancelFlowPolicy, CancelFlowWait,
+    AppendFrameOutcome, BackendConnection, CancelFlowPolicy, CancelFlowWait,
     CapabilitySet, ClaimPolicy, FailOutcome, FailureClass, FailureReason, Frame, Handle,
     HandleKind, LeaseRenewal, PendingWaitpoint, ReclaimToken, ResumeSignal, UsageDimensions,
     WaitpointSpec,
@@ -62,6 +62,11 @@ pub use backend_error::{
     backend_error_from_ferriskey, classify_ferriskey_kind, BackendErrorWrapper,
 };
 pub use completion::COMPLETION_CHANNEL;
+// DX (HHH v0.3.4 re-smoke): consumers that have already imported
+// `ff_backend_valkey` shouldn't need to also dip into
+// `ff_core::backend` just to name `BackendConfig`. Re-export it here
+// so `ff_backend_valkey::BackendConfig` works as a single-crate path.
+pub use ff_core::backend::BackendConfig;
 
 /// Valkey-FCALL–backed `EngineBackend`.
 ///

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -21,7 +21,15 @@
 //! type inventory and §4.1-§4.2 for the `Handle` / `EngineError` shapes.
 
 use crate::contracts::ReclaimGrant;
-use crate::types::{Namespace, TimestampMs, WaitpointToken};
+use crate::types::{TimestampMs, WaitpointToken};
+
+// DX (HHH v0.3.4 re-smoke): `Namespace` lives in `ff_core::types` but
+// is used on `BackendConfig` + `ScannerFilter` (both defined in this
+// module). Re-export here so consumers already scoped to
+// `ff_core::backend::*` can grab it without a second `use` line
+// crossing into `ff_core::types`. Also brings `Namespace` into local
+// scope for the definitions below.
+pub use crate::types::Namespace;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -838,8 +846,14 @@ impl ScannerFilter {
 
     /// Set the tenant-scope namespace filter dimension. Consumes
     /// and returns `self` for chaining.
-    pub fn with_namespace(mut self, ns: Namespace) -> Self {
-        self.namespace = Some(ns);
+    ///
+    /// Accepts anything that converts into [`Namespace`] so callers
+    /// can pass `&str` / `String` directly without the
+    /// `Namespace::new(...)` ceremony (the conversion is infallible;
+    /// [`Namespace`] has `From<&str>` and `From<String>` via the
+    /// crate's `string_id!` macro).
+    pub fn with_namespace(mut self, ns: impl Into<Namespace>) -> Self {
+        self.namespace = Some(ns.into());
         self
     }
 

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -19,3 +19,7 @@ pub use engine_error::EngineError;
 // ff-sdk / ff-server surfaces. Kept alongside `EngineError` so
 // consumers can `use ff_core::{BackendError, BackendErrorKind}`.
 pub use engine_error::{BackendError, BackendErrorKind};
+// DX (HHH v0.3.4 re-smoke): re-export `ScannerFilter` at crate root
+// so consumers can write `ff_core::ScannerFilter` instead of the
+// longer `ff_core::backend::ScannerFilter` path.
+pub use backend::ScannerFilter;


### PR DESCRIPTION
## Summary

Four additive DX papercut fixes that Worker HHH surfaced during the
v0.3.4 re-smoke of the cairn-fabric migration path. None are ship-
blockers but each is a 1-3 line change that trims a papercut from
cairn's `use` story.

- **`ff_core::ScannerFilter`** re-exported at the crate root (was only
  reachable via `ff_core::backend::ScannerFilter`).
- **`ff_backend_valkey::BackendConfig`** re-exported from
  `ff_core::backend::BackendConfig` so single-crate consumers of
  `ff_backend_valkey` don't also need to name `ff_core::backend`.
- **`ff_core::backend::Namespace`** re-exported from `ff_core::types`.
  `Namespace` is used on `BackendConfig` + `ScannerFilter`, so the
  module-location mismatch confused consumers. Chose option (b) from
  the worker brief — additive re-export; the canonical path
  `ff_core::types::Namespace` is unchanged, so no existing imports
  break.
- **`ScannerFilter::with_namespace`** now accepts `impl Into<Namespace>`
  (was typed `Namespace`). Non-breaking: existing `Namespace::new(s)`
  call sites still compile via the identity `From<Namespace>` impl,
  and `&str` / `String` now work directly via `string_id!`'s `From`
  impls. `Namespace` is a `string_id!`-generated newtype so the
  conversion is infallible — `impl Into` is the right shape, no
  `TryInto`/`Result` plumbing needed.

No semver break. All four changes are additive to the public API
surface.

## Motivation

Cited from HHH's v0.3.4 re-smoke findings — papercuts 1-4 on the
migration-path checklist. These are the remaining "shouldn't have to
look this up" friction points consumers hit with the accepted RFC-012
/ #88 surface.

## Local gates

- `cargo build --workspace --all-features` — clean
- `cargo build --workspace --no-default-features` — clean
- `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey --features ff-sdk/direct-valkey-claim -- -D warnings` — clean (CI-shaped)
- `cargo test -p ff-core` — 134 passed / 0 failed
- `cargo semver-checks -p ff-core -p ff-backend-valkey` — flags the
  same three pre-existing Unreleased breakers (`AdmissionDecision`
  removed, `ReportUsageResult` non_exhaustive,
  `EngineBackend::create_waitpoint` added); nothing attributable to
  this PR.

## Test plan

- [ ] CI: full-features build green
- [ ] CI: no-default-features build green
- [ ] CI: clippy -D warnings green
- [ ] CI: machete clean
- [ ] CI: semver-checks — only the pre-existing Unreleased breakers
      appear (no new failures from this PR's re-exports or the
      `with_namespace` signature change)
- [ ] Confirm cairn's v0.3.4 → 0.4.0 migration code can drop the
      `ff_core::backend::` prefix on `ScannerFilter` and the
      `ff_core::backend::` prefix on `BackendConfig` when already
      importing `ff_backend_valkey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)