### PR TITLE
feat(ff-core, ff-backend-valkey, ff-sdk): seal FlowFabricWorker::client() + migrate stream fns through trait (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Breaking changes
 
+- **Seal `FlowFabricWorker::client()` + migrate stream fns through the
+  trait (#87, RFC-012 Stage 1c tranche-4):** the `FlowFabricWorker`
+  no longer leaks `ferriskey::Client` on its public surface, and the
+  free-fn `read_stream` / `tail_stream` helpers reshape from
+  `(&Client, &PartitionConfig, …)` to `(&dyn EngineBackend, …)`.
+  - `ff-core`: `EngineBackend` gains `read_stream` + `tail_stream`
+    methods, gated on the new `streaming` feature (default-on).
+    Backends that honour the `streaming` surface MUST implement
+    both.
+  - `ff-backend-valkey`: `ValkeyBackend` implements the new trait
+    methods behind a mirroring `streaming` feature (default-on).
+    The authoritative XRANGE / XREAD BLOCK bodies previously owned
+    by `ff-sdk::task::{read_stream,tail_stream}` now live here.
+  - `ff-sdk`: `FlowFabricWorker::client()` downgraded from `pub` to
+    `pub(crate)` — external consumers cannot obtain the ferriskey
+    client through the worker. New `ClaimedTask::read_stream` /
+    `ClaimedTask::tail_stream` methods forward through the task's
+    backend for task-holders. The free-fn `read_stream` /
+    `tail_stream` keep their public names but take `&dyn
+    EngineBackend` instead of `&Client` + `&PartitionConfig`;
+    validation (count_limit bounds, tail-cursor shape) still
+    executes at the SDK edge.
+  - `ff-test`: `TestCluster::backend()` accessor added so tests can
+    mint an `Arc<dyn EngineBackend>` without spinning a full
+    `FlowFabricWorker`.
+  - Migration: consumers holding a `ClaimedTask` should call
+    `task.read_stream(..)` / `task.tail_stream(..)`; non-task
+    callers should build an `EngineBackend` via
+    `ValkeyBackend::from_client_and_partitions(..)` and pass
+    `&*backend` to the free fns. The `examples/media-pipeline`
+    summarize worker exercises the task-method path.
+
 - **Seal `ferriskey::Error` leak via `BackendError` wrapper (#88):**
   Public SDK + server error surfaces no longer name `ferriskey::Error` /
   `ferriskey::ErrorKind` directly. A new `ff_core::BackendError` +

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -10,6 +10,14 @@ keywords.workspace = true
 categories.workspace = true
 description = "FlowFabric EngineBackend impl — Valkey FCALL backend"
 
+[features]
+# RFC-012 Stage 1c tranche-4 (#87) — mirror ff-core's `streaming`
+# feature so the backend's `read_stream` / `tail_stream` impls land
+# only when the trait surface declares them. Default-on tracks
+# ff-core's default.
+default = ["streaming"]
+streaming = ["ff-core/streaming"]
+
 [dependencies]
 ff-core = { workspace = true }
 ff-script = { workspace = true }

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -19,7 +19,7 @@ default = ["streaming"]
 streaming = ["ff-core/streaming"]
 
 [dependencies]
-ff-core = { workspace = true }
+ff-core = { version = "0.3.4", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 ff-script = { workspace = true }
 ferriskey = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -1776,6 +1776,122 @@ impl EngineBackend for ValkeyBackend {
         let f = handle_codec::decode_handle(handle)?;
         report_usage_impl(&self.client, &self.partition_config, &f, budget, dimensions).await
     }
+
+    #[cfg(feature = "streaming")]
+    async fn read_stream(
+        &self,
+        execution_id: &ExecutionId,
+        attempt_index: AttemptIndex,
+        from: ff_core::contracts::StreamCursor,
+        to: ff_core::contracts::StreamCursor,
+        count_limit: u64,
+    ) -> Result<ff_core::contracts::StreamFrames, EngineError> {
+        read_stream_impl(
+            &self.client,
+            &self.partition_config,
+            execution_id,
+            attempt_index,
+            from,
+            to,
+            count_limit,
+        )
+        .await
+    }
+
+    #[cfg(feature = "streaming")]
+    async fn tail_stream(
+        &self,
+        execution_id: &ExecutionId,
+        attempt_index: AttemptIndex,
+        after: ff_core::contracts::StreamCursor,
+        block_ms: u64,
+        count_limit: u64,
+    ) -> Result<ff_core::contracts::StreamFrames, EngineError> {
+        tail_stream_impl(
+            &self.client,
+            &self.partition_config,
+            execution_id,
+            attempt_index,
+            after,
+            block_ms,
+            count_limit,
+        )
+        .await
+    }
+}
+
+// ── Stream read implementations (RFC-012 Stage 1c tranche-4; #87) ──
+
+/// Valkey XRANGE-backed stream reader. Mirrors the free-function body
+/// that previously lived in `ff_sdk::task::read_stream` — moved here so
+/// the `ferriskey::Client` parameter no longer leaks through the SDK's
+/// public surface.
+#[cfg(feature = "streaming")]
+async fn read_stream_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    execution_id: &ExecutionId,
+    attempt_index: AttemptIndex,
+    from: ff_core::contracts::StreamCursor,
+    to: ff_core::contracts::StreamCursor,
+    count_limit: u64,
+) -> Result<ff_core::contracts::StreamFrames, EngineError> {
+    use ff_core::contracts::{ReadFramesArgs, ReadFramesResult};
+
+    let partition = execution_partition(execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, execution_id);
+    let keys = ff_script::functions::stream::StreamOpKeys { ctx: &ctx };
+
+    // Lower the opaque cursor to the Valkey XRANGE marker at the
+    // adapter edge. `ReadFramesArgs` is string-typed — the Lua ABI is
+    // untouched.
+    let args = ReadFramesArgs {
+        execution_id: execution_id.clone(),
+        attempt_index,
+        from_id: from.into_wire_string(),
+        to_id: to.into_wire_string(),
+        count_limit,
+    };
+
+    let ReadFramesResult::Frames(f) =
+        ff_script::functions::stream::ff_read_attempt_stream(client, &keys, &args)
+            .await
+            .map_err(transport_script)?;
+    Ok(f)
+}
+
+/// Valkey XREAD BLOCK-backed stream tailer. See
+/// [`read_stream_impl`] for the migration rationale.
+///
+/// Callers concerned with head-of-line blocking should build a
+/// dedicated `ValkeyBackend` backed by its own `ferriskey::Client` —
+/// the REST server's `tail_client` split in `ff-server` is the
+/// canonical pattern.
+#[cfg(feature = "streaming")]
+async fn tail_stream_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    execution_id: &ExecutionId,
+    attempt_index: AttemptIndex,
+    after: ff_core::contracts::StreamCursor,
+    block_ms: u64,
+    count_limit: u64,
+) -> Result<ff_core::contracts::StreamFrames, EngineError> {
+    let partition = execution_partition(execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, execution_id);
+    let stream_key = ctx.stream(attempt_index);
+    let stream_meta_key = ctx.stream_meta(attempt_index);
+
+    ff_script::stream_tail::xread_block(
+        client,
+        &stream_key,
+        &stream_meta_key,
+        after.to_wire(),
+        block_ms,
+        count_limit,
+    )
+    .await
+    .map_err(transport_script)
 }
 
 #[cfg(test)]

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -55,7 +55,11 @@ use crate::backend::{
 use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult};
 #[cfg(feature = "core")]
 use crate::contracts::{EdgeDirection, EdgeSnapshot};
+#[cfg(feature = "streaming")]
+use crate::contracts::{StreamCursor, StreamFrames};
 use crate::engine_error::EngineError;
+#[cfg(feature = "streaming")]
+use crate::types::AttemptIndex;
 use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 
 /// The engine write surface — a single trait a backend implementation
@@ -244,6 +248,55 @@ pub trait EngineBackend: Send + Sync + 'static {
         budget: &BudgetId,
         dimensions: crate::backend::UsageDimensions,
     ) -> Result<ReportUsageResult, EngineError>;
+
+    // ── Stream reads (RFC-012 Stage 1c tranche-4; issue #87) ──
+
+    /// Read frames from a completed or in-flight attempt's stream.
+    ///
+    /// `from` / `to` are [`StreamCursor`] values — `StreamCursor::Start`
+    /// / `StreamCursor::End` are equivalent to XRANGE `-` / `+`, and
+    /// `StreamCursor::At("<id>")` reads from a concrete entry id.
+    ///
+    /// Input validation (count_limit bounds, cursor shape) is the
+    /// caller's responsibility — SDK-side wrappers in
+    /// [`ff-sdk`](https://docs.rs/ff-sdk) enforce bounds before
+    /// forwarding. Backends MAY additionally reject out-of-range
+    /// input via [`EngineError::Validation`].
+    ///
+    /// Gated on the `streaming` feature — stream reads are part of
+    /// the stream-subset surface a backend without XREAD-like
+    /// primitives may omit.
+    #[cfg(feature = "streaming")]
+    async fn read_stream(
+        &self,
+        execution_id: &ExecutionId,
+        attempt_index: AttemptIndex,
+        from: StreamCursor,
+        to: StreamCursor,
+        count_limit: u64,
+    ) -> Result<StreamFrames, EngineError>;
+
+    /// Tail a live attempt's stream.
+    ///
+    /// `after` is an exclusive [`StreamCursor`] — entries with id
+    /// strictly greater than `after` are returned. `StreamCursor::Start`
+    /// / `StreamCursor::End` are NOT accepted here; callers MUST pass
+    /// a concrete id (or `StreamCursor::from_beginning()`). The SDK
+    /// wrapper rejects the open markers before reaching the backend.
+    ///
+    /// `block_ms == 0` → non-blocking peek. `block_ms > 0` → blocks up
+    /// to that many ms for a new entry.
+    ///
+    /// Gated on the `streaming` feature — see [`read_stream`](Self::read_stream).
+    #[cfg(feature = "streaming")]
+    async fn tail_stream(
+        &self,
+        execution_id: &ExecutionId,
+        attempt_index: AttemptIndex,
+        after: StreamCursor,
+        block_ms: u64,
+        count_limit: u64,
+    ) -> Result<StreamFrames, EngineError>;
 }
 
 /// Object-safety assertion: `dyn EngineBackend` compiles iff every

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -390,6 +390,62 @@ impl ClaimedTask {
         &self.lane_id
     }
 
+    /// Read frames from this task's attempt stream.
+    ///
+    /// Forwards through the task's `Arc<dyn EngineBackend>` — consumers
+    /// no longer need the `ferriskey::Client` leak (#87). See
+    /// [`EngineBackend::read_stream`](ff_core::engine_backend::EngineBackend::read_stream)
+    /// for the backend-level contract.
+    ///
+    /// Validation (count_limit bounds) runs at this boundary — out-of-range
+    /// input surfaces as [`SdkError::Config`] before reaching the backend.
+    pub async fn read_stream(
+        &self,
+        from: StreamCursor,
+        to: StreamCursor,
+        count_limit: u64,
+    ) -> Result<StreamFrames, SdkError> {
+        validate_stream_read_count(count_limit)?;
+        Ok(self
+            .backend
+            .read_stream(&self.execution_id, self.attempt_index, from, to, count_limit)
+            .await?)
+    }
+
+    /// Tail this task's attempt stream for new frames.
+    ///
+    /// See [`EngineBackend::tail_stream`](ff_core::engine_backend::EngineBackend::tail_stream)
+    /// for the head-of-line warning — the task's backend is shared
+    /// with claim/complete/fail hot paths. Consumers that need
+    /// isolation should build a dedicated `EngineBackend` for tail
+    /// reads.
+    pub async fn tail_stream(
+        &self,
+        after: StreamCursor,
+        block_ms: u64,
+        count_limit: u64,
+    ) -> Result<StreamFrames, SdkError> {
+        if block_ms > MAX_TAIL_BLOCK_MS {
+            return Err(SdkError::Config {
+                context: "tail_stream".into(),
+                field: Some("block_ms".into()),
+                message: format!("exceeds {MAX_TAIL_BLOCK_MS}ms ceiling"),
+            });
+        }
+        validate_stream_read_count(count_limit)?;
+        validate_tail_cursor(&after)?;
+        Ok(self
+            .backend
+            .tail_stream(
+                &self.execution_id,
+                self.attempt_index,
+                after,
+                block_ms,
+                count_limit,
+            )
+            .await?)
+    }
+
     /// Synthesise a Valkey-backend `Handle` encoding this task's
     /// attempt-cookie fields. Private to the SDK — the trait
     /// forwarders call this per op to produce the `&Handle` argument
@@ -1757,37 +1813,17 @@ fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
 /// `tail_client`; direct SDK callers should either use a dedicated
 /// client OR paginate through smaller `count_limit` slices.
 pub async fn read_stream(
-    client: &Client,
-    partition_config: &PartitionConfig,
+    backend: &dyn EngineBackend,
     execution_id: &ExecutionId,
     attempt_index: AttemptIndex,
     from: StreamCursor,
     to: StreamCursor,
     count_limit: u64,
 ) -> Result<StreamFrames, SdkError> {
-    use ff_core::contracts::{ReadFramesArgs, ReadFramesResult};
     validate_stream_read_count(count_limit)?;
-
-    let partition = execution_partition(execution_id, partition_config);
-    let ctx = ExecKeyContext::new(&partition, execution_id);
-    let keys = ff_script::functions::stream::StreamOpKeys { ctx: &ctx };
-
-    // Lower the opaque cursor to the Valkey XRANGE marker at the
-    // adapter edge. `ReadFramesArgs` is string-typed — the Lua ABI is
-    // untouched.
-    let args = ReadFramesArgs {
-        execution_id: execution_id.clone(),
-        attempt_index,
-        from_id: from.into_wire_string(),
-        to_id: to.into_wire_string(),
-        count_limit,
-    };
-
-    let ReadFramesResult::Frames(f) =
-        ff_script::functions::stream::ff_read_attempt_stream(client, &keys, &args)
-            .await
-            .map_err(SdkError::from)?;
-    Ok(f)
+    Ok(backend
+        .read_stream(execution_id, attempt_index, from, to, count_limit)
+        .await?)
 }
 
 /// Tail a live attempt's stream.
@@ -1860,8 +1896,7 @@ pub async fn read_stream(
 /// configuration is required for timeout reasons — only for head-of-line
 /// isolation above.
 pub async fn tail_stream(
-    client: &Client,
-    partition_config: &PartitionConfig,
+    backend: &dyn EngineBackend,
     execution_id: &ExecutionId,
     attempt_index: AttemptIndex,
     after: StreamCursor,
@@ -1878,25 +1913,13 @@ pub async fn tail_stream(
     validate_stream_read_count(count_limit)?;
     // XREAD does not accept `-` / `+` markers as cursors — reject at
     // the SDK boundary with `SdkError::Config` rather than forwarding
-    // an invalid `-`/`+` into ferriskey (which would surface as an
-    // opaque server error).
+    // an invalid `-`/`+` into the backend (which would surface as an
+    // opaque `EngineError::Transport`).
     validate_tail_cursor(&after)?;
 
-    let partition = execution_partition(execution_id, partition_config);
-    let ctx = ExecKeyContext::new(&partition, execution_id);
-    let stream_key = ctx.stream(attempt_index);
-    let stream_meta_key = ctx.stream_meta(attempt_index);
-
-    ff_script::stream_tail::xread_block(
-        client,
-        &stream_key,
-        &stream_meta_key,
-        after.to_wire(),
-        block_ms,
-        count_limit,
-    )
-    .await
-    .map_err(SdkError::from)
+    Ok(backend
+        .tail_stream(execution_id, attempt_index, after, block_ms, count_limit)
+        .await?)
 }
 
 #[cfg(test)]

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -638,7 +638,7 @@ impl FlowFabricWorker {
     /// EngineBackend` (non-task callers).
     ///
     /// Retained for in-crate use by
-    /// [`crate::snapshot::FlowFabricWorker`]'s raw HGET helpers, which
+    /// [`crate::worker::FlowFabricWorker`]'s raw HGET helpers, which
     /// are not yet migrated to the trait (separate tracking issue).
     pub(crate) fn client(&self) -> &Client {
         &self.client

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -625,8 +625,22 @@ impl FlowFabricWorker {
         self.completion_backend_handle.clone()
     }
 
-    /// Get a reference to the underlying ferriskey client.
-    pub fn client(&self) -> &Client {
+    /// Crate-internal borrow of the underlying `ferriskey::Client`.
+    ///
+    /// **RFC-012 Stage 1c tranche-4 (#87):** downgraded from `pub` to
+    /// `pub(crate)`. The public `FlowFabricWorker` surface no longer
+    /// exposes the ferriskey type — consumers that previously reached
+    /// in for `read_stream` / `tail_stream` should now use
+    /// [`ClaimedTask::read_stream`](crate::ClaimedTask::read_stream) /
+    /// [`ClaimedTask::tail_stream`](crate::ClaimedTask::tail_stream)
+    /// (task-holders) or [`read_stream`](crate::read_stream) /
+    /// [`tail_stream`](crate::tail_stream) through a `&dyn
+    /// EngineBackend` (non-task callers).
+    ///
+    /// Retained for in-crate use by
+    /// [`crate::snapshot::FlowFabricWorker`]'s raw HGET helpers, which
+    /// are not yet migrated to the trait (separate tracking issue).
+    pub(crate) fn client(&self) -> &Client {
         &self.client
     }
 
@@ -636,11 +650,12 @@ impl FlowFabricWorker {
     }
 
     /// Get the server-published partition config this worker bound to at
-    /// `connect()`. Callers need this when computing partition hash-tags
-    /// for direct-client reads (e.g. ff-sdk::read_stream) to stay aligned
-    /// with the server's `num_flow_partitions` — using
-    /// `PartitionConfig::default()` assumes 256 partitions and silently
-    /// misses data on deployments with any other value.
+    /// `connect()`. Exposed so consumers that mint custom
+    /// [`ExecutionId`]s (e.g. for `describe_execution` lookups on ids
+    /// produced outside this worker) stay aligned with the server's
+    /// `num_flow_partitions` — using `PartitionConfig::default()`
+    /// assumes 256 partitions and silently misses data on deployments
+    /// with any other value.
     pub fn partition_config(&self) -> &ff_core::partition::PartitionConfig {
         &self.partition_config
     }

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -21,6 +21,10 @@ ff-engine = { workspace = true }
 ff-scheduler = { workspace = true }
 ff-script = { workspace = true }
 ff-sdk = { workspace = true, features = ["direct-valkey-claim"] }
+# Promoted from dev-dependencies in #87 closure (Stage 1c tranche-4):
+# `TestCluster::backend()` minting lives in the fixtures library so
+# tests can exercise the trait-forwarded read_stream/tail_stream.
+ff-backend-valkey = { workspace = true }
 ferriskey = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
@@ -30,7 +34,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 ff-server = { workspace = true }
-ff-backend-valkey = { workspace = true }
 serial_test = "3"
 axum = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/ff-test/src/fixtures.rs
+++ b/crates/ff-test/src/fixtures.rs
@@ -88,6 +88,19 @@ impl TestCluster {
         &self.client
     }
 
+    /// Build an `Arc<dyn EngineBackend>` wrapping this cluster's
+    /// client + partition config. Used by tests that exercise the
+    /// trait-forwarded surface (e.g. `read_stream`/`tail_stream`
+    /// post-#87) without spinning up a full `FlowFabricWorker`.
+    pub fn backend(
+        &self,
+    ) -> std::sync::Arc<dyn ff_core::engine_backend::EngineBackend> {
+        ff_backend_valkey::ValkeyBackend::from_client_and_partitions(
+            self.client.clone(),
+            self.config,
+        )
+    }
+
     /// Get the test partition config (small, suitable for testing).
     pub fn partition_config(&self) -> &PartitionConfig {
         &self.config

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -7763,7 +7763,6 @@ async fn test_read_stream_round_trips_append_frame_fields() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     fcall_create_execution(&tc, &eid, NS, LANE, "stream_read_rt", 0).await;
     fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
@@ -7780,8 +7779,7 @@ async fn test_read_stream_round_trips_append_frame_fields() {
     ).await;
 
     let result = ff_sdk::read_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(att_idx.parse().unwrap()),
         ff_sdk::StreamCursor::Start,
@@ -7815,11 +7813,9 @@ async fn test_read_stream_empty_returns_empty() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     let result = ff_sdk::read_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(0),
         ff_sdk::StreamCursor::Start,
@@ -7840,7 +7836,6 @@ async fn test_read_stream_slice_and_resume() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     fcall_create_execution(&tc, &eid, NS, LANE, "stream_slice", 0).await;
     fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
@@ -7858,8 +7853,7 @@ async fn test_read_stream_slice_and_resume() {
     let att = AttemptIndex::new(att_idx.parse().unwrap());
 
     let page1 = ff_sdk::read_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         att,
         ff_sdk::StreamCursor::Start,
@@ -7877,8 +7871,7 @@ async fn test_read_stream_slice_and_resume() {
     let resume_from = format!("{ms}-{next_seq}");
 
     let page2 = ff_sdk::read_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         att,
         ff_sdk::StreamCursor::At(resume_from),
@@ -7899,12 +7892,10 @@ async fn test_tail_stream_timeout_returns_empty() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     let started = std::time::Instant::now();
     let result = ff_sdk::tail_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(0),
         ff_sdk::StreamCursor::from_beginning(),
@@ -7931,7 +7922,6 @@ async fn test_tail_stream_unblocks_on_write() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     fcall_create_execution(&tc, &eid, NS, LANE, "stream_tail", 0).await;
     fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
@@ -7953,8 +7943,7 @@ async fn test_tail_stream_unblocks_on_write() {
     });
 
     let result = ff_sdk::tail_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(att_idx.parse().unwrap()),
         ff_sdk::StreamCursor::from_beginning(),
@@ -7984,12 +7973,10 @@ async fn test_tail_stream_long_block_respects_ferriskey_timeout_extension() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     let started = std::time::Instant::now();
     let result = ff_sdk::tail_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(0),
         ff_sdk::StreamCursor::from_beginning(),
@@ -8023,7 +8010,6 @@ async fn test_stream_closed_signal_propagates_to_read_and_tail() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     fcall_create_execution(&tc, &eid, NS, LANE, "stream_closed", 0).await;
     fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
@@ -8042,8 +8028,7 @@ async fn test_stream_closed_signal_propagates_to_read_and_tail() {
 
     // read_stream sees the frame AND the terminal markers.
     let read = ff_sdk::read_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         att,
         ff_sdk::StreamCursor::Start,
@@ -8061,8 +8046,7 @@ async fn test_stream_closed_signal_propagates_to_read_and_tail() {
     // still reports closed — this is the signal consumers poll on.
     let tip = read.frames.last().unwrap().id.clone();
     let tail = ff_sdk::tail_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         att,
         ff_sdk::StreamCursor::At(tip),
@@ -8087,7 +8071,6 @@ async fn test_lease_expired_closes_stream_meta() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     fcall_create_execution(&tc, &eid, NS, LANE, "stream_lease_expire", 0).await;
     fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
@@ -8109,8 +8092,7 @@ async fn test_lease_expired_closes_stream_meta() {
 
     let att = AttemptIndex::new(att_idx.parse().unwrap());
     let result = ff_sdk::read_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         att,
         ff_sdk::StreamCursor::Start,
@@ -8137,7 +8119,6 @@ async fn test_tail_stream_no_block_returns_available() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     fcall_create_execution(&tc, &eid, NS, LANE, "stream_peek", 0).await;
     fcall_issue_claim_grant(&tc, &eid, LANE, WORKER, WORKER_INST).await;
@@ -8151,8 +8132,7 @@ async fn test_tail_stream_no_block_returns_available() {
 
     let started = std::time::Instant::now();
     let result = ff_sdk::tail_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(att_idx.parse().unwrap()),
         ff_sdk::StreamCursor::from_beginning(),
@@ -8183,11 +8163,9 @@ async fn test_read_stream_rejects_zero_count_limit() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     let err = ff_sdk::read_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(0),
         ff_sdk::StreamCursor::Start,
@@ -8211,11 +8189,9 @@ async fn test_tail_stream_rejects_zero_count_limit() {
     tc.cleanup().await;
 
     let eid = tc.new_execution_id();
-    let config = test_config();
 
     let err = ff_sdk::tail_stream(
-        tc.client(),
-        &config,
+        &*tc.backend(),
         &eid,
         AttemptIndex::new(0),
         ff_sdk::StreamCursor::from_beginning(),

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -29,8 +29,8 @@ use std::time::Duration;
 use anyhow::Context;
 use clap::Parser;
 use ff_sdk::{
-    read_stream, ClaimedTask, ConditionMatcher, FlowFabricAdminClient, FlowFabricWorker,
-    StreamCursor, SuspendOutcome, TimeoutBehavior, WorkerConfig, STREAM_READ_HARD_CAP,
+    ClaimedTask, ConditionMatcher, FlowFabricAdminClient, FlowFabricWorker, StreamCursor,
+    SuspendOutcome, TimeoutBehavior, WorkerConfig, STREAM_READ_HARD_CAP,
 };
 use llama_cpp_2::{
     context::params::LlamaContextParams,
@@ -155,8 +155,6 @@ async fn main() -> anyhow::Result<()> {
                             engine.clone(),
                             args.max_new_tokens,
                             args.skip_approval,
-                            worker.client(),
-                            worker.partition_config(),
                         ).await {
                             tracing::error!(execution_id = %eid, error = %e, "task failed");
                         }
@@ -185,10 +183,8 @@ async fn handle(
     engine: Arc<Engine>,
     max_new_tokens: usize,
     skip_approval: bool,
-    client: &ferriskey::Client,
-    partition_config: &ff_core::partition::PartitionConfig,
 ) -> anyhow::Result<()> {
-    let persisted = load_persisted_result(&task, client, partition_config).await?;
+    let persisted = load_persisted_result(&task).await?;
 
     if persisted.is_some() {
         // Summary already generated in a prior attempt. Inspect the resume
@@ -279,20 +275,15 @@ async fn handle(
 /// O(tokens_generated_since_last_summary_final) for typical cases.
 async fn load_persisted_result(
     task: &ClaimedTask,
-    client: &ferriskey::Client,
-    partition_config: &ff_core::partition::PartitionConfig,
 ) -> anyhow::Result<Option<SummarizeResult>> {
-    let frames = read_stream(
-        client,
-        partition_config,
-        task.execution_id(),
-        task.attempt_index(),
-        StreamCursor::Start,
-        StreamCursor::End,
-        STREAM_READ_HARD_CAP,
-    )
-    .await
-    .context("read_stream for resume check")?;
+    let frames = task
+        .read_stream(
+            StreamCursor::Start,
+            StreamCursor::End,
+            STREAM_READ_HARD_CAP,
+        )
+        .await
+        .context("read_stream for resume check")?;
 
     let adapted: Vec<AdaptedFrame<'_>> = frames
         .frames


### PR DESCRIPTION
## Summary

RFC-012 Stage 1c tranche-4 (final). Seals `FlowFabricWorker::client()`
to `pub(crate)` and reshapes the free-fn `read_stream` / `tail_stream`
to route through a `&dyn EngineBackend` instead of `&ferriskey::Client`
+ `&PartitionConfig`. Task-holders get ergonomic `ClaimedTask::read_stream`
/ `ClaimedTask::tail_stream` methods.

Closes #87.

## Grep sweep

- `FlowFabricWorker::client()` external callers: 1 (example/media-pipeline summarize) — migrated to `task.read_stream(..)`; zero external callers post-change. Internal: 2 sites in `ff-sdk::snapshot` (direct field access via `pub(crate)`).
- Free-fn `read_stream` / `tail_stream` callers: 13 test sites in `ff-test::e2e_lifecycle` + 1 example — migrated. Example uses the new task-method; tests use `TestCluster::backend()` → `&*tc.backend()`.
- `ferriskey::Client` no longer appears on any public `ff-sdk` worker-facing accessor.

## Migration matrix

| Site                                       | Before                 | After                     |
| ------------------------------------------ | ---------------------- | ------------------------- |
| `ff-core::EngineBackend`                   | no stream methods      | `+ read_stream` / `+ tail_stream` gated on the new `streaming` feature (default-on) |
| `ff-backend-valkey::ValkeyBackend`         | no stream impl         | impls mirroring the previous SDK bodies; `streaming` feature passthrough to `ff-core/streaming` |
| `ff-sdk::task::{read_stream,tail_stream}`  | `(&Client, &PartitionConfig, …)` | `(&dyn EngineBackend, …)` |
| `ff-sdk::ClaimedTask`                      | no stream accessor     | `+ read_stream(..)` / `+ tail_stream(..)` forwarding through `self.backend` |
| `ff-sdk::FlowFabricWorker::client()`       | `pub`                  | `pub(crate)` (still used by in-crate `snapshot.rs`) |
| `ff-test::TestCluster`                     | `client()` only        | `+ backend() -> Arc<dyn EngineBackend>` for trait-forwarded tests |
| `examples/media-pipeline/summarize`        | `worker.client()` + free-fn `read_stream` | `task.read_stream(..)` |
| 13 sites in `ff-test::e2e_lifecycle`       | `tc.client(), &config` | `&*tc.backend()` |

How `client()` resolved: **downgraded to `pub(crate)`** — still used by
`ff-sdk::snapshot`'s raw `HGETALL` / `HGET` helpers that haven't been
trait-migrated yet (separate tracking issue). Public surface no longer
exposes it.

Read/tail free-fn migration choice: **option (b)** (method on
`ClaimedTask`) is the canonical task-holder path. The free fns are
preserved with reshaped signatures for non-task callers (tests,
external consumers that have an `EngineBackend` but no `ClaimedTask`).
Validation (count_limit bounds, tail-cursor shape) stays at the SDK
edge so `SdkError::Config` semantics are preserved.

## CHANGELOG

Added under `## [Unreleased]` → `### Breaking changes`, summarising
the five per-crate shifts above + migration guidance for consumers.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib --bins` — 45+259+160+58+44+45+7 pass
- [x] `cargo test -p ff-test --test e2e_lifecycle` — 108 pass (10 stream-specific + 98 unrelated, all green)
- [ ] CI to confirm the same under workspace-wide conditions

## Hard-rules checklist

- [x] Isolated worktree (`/home/ubuntu/ff-worker-zz10-t4`)
- [x] Plan-before-fix (grep sweep + migration matrix above)
- [x] Zero behavior change on tests that didn't migrate (0 tests edited outside the 13 stream-specific sites)
- [x] Co-author trailer
- [x] No `--no-verify`
- [x] Breaking documented in CHANGELOG
- [x] Don't merge, don't tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)