### PR TITLE
feat(ff-core): UsageDimensions constructor + builders; docs: fix BackendError match pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,14 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`ff_backend_valkey::build_client`** is now `pub`. `FlowFabricWorker::connect`
   reuses it so the `BackendConfig` → `ferriskey::Client` mapping lives
   in exactly one place.
+- **`UsageDimensions` constructor + builder methods (ff-core):**
+  `UsageDimensions::new()` plus `with_input_tokens`, `with_output_tokens`,
+  `with_wall_ms`, `with_dedup_key` chaining setters. Mirrors the
+  `ScannerFilter::with_*` precedent — `UsageDimensions` is
+  `#[non_exhaustive]` so external crates cannot struct-literal
+  construct; `new()` + `with_*` is now the supported construction
+  path. Purely additive; existing `UsageDimensions::default()` call
+  sites continue to work.
 - **DX polish — re-exports + `ScannerFilter::with_namespace` ergonomics
   (HHH v0.3.4 re-smoke):** four additive papercut fixes for cairn's
   migration path.

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -442,6 +442,48 @@ pub struct UsageDimensions {
     pub dedup_key: Option<String>,
 }
 
+impl UsageDimensions {
+    /// Create an empty usage report (all dimensions zero / `None`).
+    ///
+    /// Provided for external-crate consumers: `UsageDimensions` is
+    /// `#[non_exhaustive]`, so struct-literal and functional-update
+    /// construction are unavailable across crate boundaries. Start
+    /// from `new()` and chain `with_*` setters to build a report.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the input-token count dimension. Consumes and returns
+    /// `self` for chaining.
+    pub fn with_input_tokens(mut self, tokens: u64) -> Self {
+        self.input_tokens = tokens;
+        self
+    }
+
+    /// Set the output-token count dimension. Consumes and returns
+    /// `self` for chaining.
+    pub fn with_output_tokens(mut self, tokens: u64) -> Self {
+        self.output_tokens = tokens;
+        self
+    }
+
+    /// Set the wall-clock duration dimension, in milliseconds.
+    /// Consumes and returns `self` for chaining.
+    pub fn with_wall_ms(mut self, ms: u64) -> Self {
+        self.wall_ms = Some(ms);
+        self
+    }
+
+    /// Set the optional caller-supplied idempotency key. When set,
+    /// the backend rejects a repeat application of the same key with
+    /// `ReportUsageResult::AlreadyApplied` rather than double-counting
+    /// (RFC-012 §R7.4). Consumes and returns `self` for chaining.
+    pub fn with_dedup_key(mut self, key: impl Into<String>) -> Self {
+        self.dedup_key = Some(key.into());
+        self
+    }
+}
+
 // ── §3.3.0 Reclaim / lease types ────────────────────────────────────────
 
 /// Opaque cookie returned by the reclaim scanner; consumed by
@@ -1039,6 +1081,22 @@ mod tests {
         assert_eq!(u.clone(), u);
         assert_eq!(UsageDimensions::default().input_tokens, 0);
         assert_eq!(UsageDimensions::default().dedup_key, None);
+    }
+
+    #[test]
+    fn usage_dimensions_builder_chain() {
+        let u = UsageDimensions::new()
+            .with_input_tokens(10)
+            .with_output_tokens(20)
+            .with_wall_ms(150)
+            .with_dedup_key("k1");
+        assert_eq!(u.input_tokens, 10);
+        assert_eq!(u.output_tokens, 20);
+        assert_eq!(u.wall_ms, Some(150));
+        assert_eq!(u.dedup_key.as_deref(), Some("k1"));
+        assert!(u.custom.is_empty());
+        // `new()` is equivalent to `default()`.
+        assert_eq!(UsageDimensions::new(), UsageDimensions::default());
     }
 
     #[test]

--- a/docs/cairn-migration-v0.4.0.md
+++ b/docs/cairn-migration-v0.4.0.md
@@ -398,6 +398,30 @@ match err {
 `ServerError::Backend` / `ServerError::BackendContext` in the same
 shape (source `crates/ff-server/src/server.rs:224,302,318`).
 
+Note: `BackendError` is an **enum** (not a struct), with a `Valkey`
+variant today. Consumers who prefer pattern-matching over the
+`.kind()` method accessor must name the enum variant explicitly —
+there is no `BackendError { kind, .. }` struct-destructure form:
+
+```rust
+use ff_sdk::{BackendError, BackendErrorKind, SdkError};
+
+match err {
+    SdkError::Backend(BackendError::Valkey { kind, .. }) => match kind {
+        BackendErrorKind::Transport => { /* retry */ }
+        BackendErrorKind::Timeout   => { /* retry */ }
+        // …
+        _ => { /* non_exhaustive wildcard */ }
+    },
+    _ => { /* … */ }
+}
+```
+
+`BackendError` is `#[non_exhaustive]` at the enum level; additional
+backend variants (beyond `Valkey`) may be added additively in future
+releases, so any direct-match site should include a wildcard arm on
+the outer enum as well.
+
 ### 10.2 Classifier rename: `valkey_kind()` → `backend_kind()`
 
 ```rust


### PR DESCRIPTION
## Summary

Addresses XXX-2's v0.4.0 smoke findings with two additive polish items.

### 1. `UsageDimensions` constructor + builders (ff-core)

`UsageDimensions` is `#[non_exhaustive]` so external-crate consumers cannot struct-literal it. Adds the `new()` + `with_*` chainer style already established by `ScannerFilter` (#157) and `Frame` (#147).

**Before (0.4.0-prep main):**
```rust
// No way to construct without .default() + field-level mutation,
// and `#[non_exhaustive]` forbids functional-update from outside ff-core.
let mut u = UsageDimensions::default();
u.input_tokens = 10;
u.dedup_key = Some("k1".into());
// ... etc
```

**After:**
```rust
let u = UsageDimensions::new()
    .with_input_tokens(10)
    .with_output_tokens(20)
    .with_wall_ms(150)
    .with_dedup_key("k1");
```

Four `with_*` setters (`input_tokens`, `output_tokens`, `wall_ms`, `dedup_key`) cover every non-collection field. `custom: BTreeMap<String, u64>` intentionally stays on direct field access — callers typically batch-insert, so a `with_custom` didn't pay its weight.

Test `usage_dimensions_builder_chain` asserts chain shape + `new() == default()`.

### 2. Docs: `BackendError` match pattern (docs/cairn-migration-v0.4.0.md §9)

XXX-2 noted that the migration doc's §9 example uses `be.kind()` which is correct (the method accessor exists), but didn't show the direct-destructure form. The enum-variant nesting matters: `BackendError` is an **enum** with a `Valkey { kind, message }` variant, not a struct with a `kind` field.

**Before (doc showed only the `.kind()` accessor style):**
```rust
match err {
    SdkError::Backend(be) => match be.kind() { ... }
    _ => ...
}
```

**After (adds the direct-match form as a supplementary note):**
```rust
match err {
    SdkError::Backend(BackendError::Valkey { kind, .. }) => match kind { ... }
    _ => ...
}
```

Also flags that `BackendError` is `#[non_exhaustive]` at the enum level (future backends added additively), so direct-match sites need an outer wildcard too.

## Test plan

- [x] `cargo build -p ff-core` green
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings` (CI matrix gate) green
- [x] `cargo test -p ff-core --lib` — 161 pass including new `usage_dimensions_builder_chain`
- [x] `cargo check --workspace --all-features` green
- [x] CI gates on PR (matrix, CodeQL, security-and-quality)

## Scope + safety

- Additive only. No breaking changes. `UsageDimensions::default()` and direct-field access both preserved.
- CHANGELOG entry under `[Unreleased]` → `### Added`.
- Do not merge — owner review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)