### PR TITLE
chore: bump workspace to 0.4.0 + CHANGELOG section flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-23
+
 ### Breaking changes
 
 - **Seal `FlowFabricWorker::client()` + migrate stream fns through the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "axum",
  "ferriskey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -33,16 +33,16 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.3.4", path = "crates/ff-core" }
-ff-script = { version = "0.3.4", path = "crates/ff-script" }
-ff-engine = { version = "0.3.4", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.3.4", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.3.4", path = "crates/ff-sdk" }
-ff-server = { version = "0.3.4", path = "crates/ff-server" }
+ff-core = { version = "0.4.0", path = "crates/ff-core" }
+ff-script = { version = "0.4.0", path = "crates/ff-script" }
+ff-engine = { version = "0.4.0", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.4.0", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.4.0", path = "crates/ff-sdk" }
+ff-server = { version = "0.4.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.3.4", path = "crates/ff-backend-valkey" }
-ff-observability = { version = "0.3.4", path = "crates/ff-observability" }
-ferriskey = { version = "0.3.4", path = "ferriskey" }
+ff-backend-valkey = { version = "0.4.0", path = "crates/ff-backend-valkey" }
+ff-observability = { version = "0.4.0", path = "crates/ff-observability" }
+ferriskey = { version = "0.4.0", path = "ferriskey" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -19,7 +19,7 @@ default = ["streaming"]
 streaming = ["ff-core/streaming"]
 
 [dependencies]
-ff-core = { version = "0.3.4", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.4.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 ff-script = { workspace = true }
 ferriskey = { workspace = true }
 async-trait = { workspace = true }

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## What

- `workspace.package.version` 0.3.4 -> 0.4.0
- 9 inter-crate path-version pins under `[workspace.dependencies]` -> 0.4.0
- `ferriskey/Cargo.toml` explicit `version` -> 0.4.0
- `crates/ff-backend-valkey/Cargo.toml` stray explicit `ff-core` pin -> 0.4.0
- `CHANGELOG.md`: `## [Unreleased]` flipped to `## [0.4.0] - 2026-04-23`; fresh empty `## [Unreleased]` added above per Keep-a-Changelog.
- `Cargo.lock` refreshed via `cargo package`.

## Why

The v0.4.0 tag was pushed and the publish job failed because the workspace version was still 0.3.4. The tag has since been deleted. This PR is the missing bump so the next tag push can publish.

## Verification

- `cargo package --workspace --allow-dirty --exclude ff-readiness-tests --exclude ff-test` succeeds for all 9 publishable crates at 0.4.0 (ff-core, ff-script, ff-observability, ff-engine, ff-backend-valkey, ferriskey, ff-scheduler, ff-sdk, ff-server).

## CI notes

- `cargo-semver-checks` **will fail** on this PR — expected. 0.4.0 carries intentional breaking changes (FlowFabricWorker::client sealing, BackendError wrapper, grant_api reshape, etc. — see CHANGELOG [0.4.0] `### Breaking changes`). The major/minor bump is precisely to accommodate them.
- `cargo-machete` pre-existing bench findings — ignore.

## Operator checklist (post-merge)

- [ ] Re-tag `v0.4.0` on the merge commit.
- [ ] Push tag; publish workflow picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)