### PR TITLE
feat(ff-sdk): migrate snapshot raw-HGET helpers through trait; delete FlowFabricWorker::client (closes #160)

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -538,6 +538,62 @@ async fn list_edges_impl(
     Ok(out)
 }
 
+/// Single `HGETALL edge_hash` + decode via [`build_edge_snapshot`].
+/// `Ok(None)` when the edge hash is absent. Decode failures surface
+/// as `EngineError::Validation { kind: Corruption, .. }`.
+async fn describe_edge_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    flow_id: &FlowId,
+    edge_id: &EdgeId,
+) -> Result<Option<EdgeSnapshot>, EngineError> {
+    let partition = flow_partition(flow_id, partition_config);
+    let fctx = FlowKeyContext::new(&partition, flow_id);
+    let edge_key = fctx.edge(edge_id);
+
+    let raw: HashMap<String, String> = client
+        .cmd("HGETALL")
+        .arg(&edge_key)
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    build_edge_snapshot(flow_id, edge_id, &raw).map(Some)
+}
+
+/// Single `HGET exec_core flow_id` + parse. `Ok(None)` when the
+/// exec_core hash is absent OR the `flow_id` field is empty
+/// (standalone execution). A present-but-malformed value surfaces as
+/// `EngineError::Validation { kind: Corruption, .. }`.
+async fn resolve_execution_flow_id_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    eid: &ExecutionId,
+) -> Result<Option<FlowId>, EngineError> {
+    let partition = execution_partition(eid, partition_config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let raw: Option<String> = client
+        .cmd("HGET")
+        .arg(ctx.core())
+        .arg("flow_id")
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    let Some(raw) = raw.filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let flow_id = FlowId::parse(&raw).map_err(|e| EngineError::Validation {
+        kind: ff_core::engine_error::ValidationKind::Corruption,
+        detail: format!(
+            "resolve_execution_flow_id: exec_core: flow_id: '{raw}' is not a valid UUID \
+             (key corruption?): {e}"
+        ),
+    })?;
+    Ok(Some(flow_id))
+}
+
 /// Read the deployment's partition config from
 /// `ff:config:partitions`. Keeps `ValkeyBackend` aligned with
 /// ff-server's published `num_flow_partitions` / budget / quota
@@ -1756,6 +1812,21 @@ impl EngineBackend for ValkeyBackend {
         direction: EdgeDirection,
     ) -> Result<Vec<EdgeSnapshot>, EngineError> {
         list_edges_impl(&self.client, &self.partition_config, flow_id, direction).await
+    }
+
+    async fn describe_edge(
+        &self,
+        flow_id: &FlowId,
+        edge_id: &EdgeId,
+    ) -> Result<Option<EdgeSnapshot>, EngineError> {
+        describe_edge_impl(&self.client, &self.partition_config, flow_id, edge_id).await
+    }
+
+    async fn resolve_execution_flow_id(
+        &self,
+        eid: &ExecutionId,
+    ) -> Result<Option<FlowId>, EngineError> {
+        resolve_execution_flow_id_impl(&self.client, &self.partition_config, eid).await
     }
 
     async fn cancel_flow(

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -60,6 +60,8 @@ use crate::contracts::{StreamCursor, StreamFrames};
 use crate::engine_error::EngineError;
 #[cfg(feature = "streaming")]
 use crate::types::AttemptIndex;
+#[cfg(feature = "core")]
+use crate::types::EdgeId;
 use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 
 /// The engine write surface — a single trait a backend implementation
@@ -224,6 +226,50 @@ pub trait EngineBackend: Send + Sync + 'static {
         flow_id: &FlowId,
         direction: EdgeDirection,
     ) -> Result<Vec<EdgeSnapshot>, EngineError>;
+
+    /// Snapshot a single dependency edge by its owning flow + edge id.
+    ///
+    /// `Ok(None)` when the edge hash is absent (never staged, or
+    /// staged under a different flow than `flow_id`). Parse failures
+    /// on a present edge hash surface as
+    /// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`]
+    /// — the stored `flow_id` field is cross-checked against the
+    /// caller's expected `flow_id` so a wrong-key read fails loud
+    /// rather than returning an unrelated edge.
+    ///
+    /// Gated on the `core` feature — single-edge reads are part of
+    /// the minimal snapshot surface an alternate backend must honour
+    /// alongside [`Self::describe_execution`] / [`Self::describe_flow`]
+    /// / [`Self::list_edges`].
+    ///
+    /// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`]: crate::engine_error::EngineError::Validation
+    #[cfg(feature = "core")]
+    async fn describe_edge(
+        &self,
+        flow_id: &FlowId,
+        edge_id: &EdgeId,
+    ) -> Result<Option<EdgeSnapshot>, EngineError>;
+
+    /// Resolve an execution's owning flow id, if any.
+    ///
+    /// `Ok(None)` when the execution's core record is absent or has
+    /// no associated flow (standalone execution). A present-but-
+    /// malformed `flow_id` field surfaces as
+    /// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`].
+    ///
+    /// Gated on the `core` feature. Used by ff-sdk's
+    /// `list_outgoing_edges` / `list_incoming_edges` to pivot from a
+    /// consumer-supplied `ExecutionId` to the `FlowId` required by
+    /// [`Self::list_edges`]. A Valkey backend serves this with a
+    /// single `HGET exec_core flow_id`; a Postgres backend serves it
+    /// with the equivalent single-column row lookup.
+    ///
+    /// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`]: crate::engine_error::EngineError::Validation
+    #[cfg(feature = "core")]
+    async fn resolve_execution_flow_id(
+        &self,
+        eid: &ExecutionId,
+    ) -> Result<Option<FlowId>, EngineError>;
 
     /// Operator-initiated cancellation of a flow and (optionally) its
     /// member executions. See RFC-012 §3.1.1 for the policy /wait

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -1,28 +1,29 @@
 //! Typed read-models that decouple consumers from FF's storage engine.
 //!
-//! **RFC-012 Stage 1c T3:** after T3 this module is thin forwarders.
-//! The decoders (`build_execution_snapshot`, `build_flow_snapshot`,
+//! **RFC-012 Stage 1c T3 + issue #160:** this module is a pure thin
+//! forwarder onto the `EngineBackend` trait. The decoders
+//! (`build_execution_snapshot`, `build_flow_snapshot`,
 //! `build_edge_snapshot`) live in `ff_core::contracts::decode` and
 //! the pipeline bodies that invoke them live on
 //! [`ff_backend_valkey::ValkeyBackend`] as `EngineBackend` trait
-//! methods. The three `describe_*` functions here are now 3-line
-//! delegations to `self.backend`; `list_incoming_edges` /
+//! methods. The five `describe_*` / `list_*_edges` functions here are
+//! 3-line delegations to `self.backend`; `list_incoming_edges` /
 //! `list_outgoing_edges` keep their `resolve_flow_id` step (the
-//! trait's `list_edges` requires a `FlowId` argument) and then call
-//! the trait method.
+//! trait's `list_edges` requires a `FlowId` argument) but route it
+//! through [`EngineBackend::resolve_execution_flow_id`] plus a local
+//! RFC-011 co-location cross-check.
 //!
 //! See issue #58 for the strategic context (engine-surface sealing
-//! toward the Postgres backend port).
+//! toward the Postgres backend port); issue #160 closed out the last
+//! raw-client call sites so `FlowFabricWorker::client()` could be
+//! deleted.
 //!
 //! Snapshot types (`ExecutionSnapshot`, `AttemptSummary`, `LeaseSummary`,
 //! `FlowSnapshot`, `EdgeSnapshot`) live in [`ff_core::contracts`] so
 //! non-SDK consumers (tests, REST server, alternate backends) share
 //! them without depending on ff-sdk.
 
-use std::collections::HashMap;
-
 use ff_core::contracts::{EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot};
-use ff_core::keys::ExecKeyContext;
 use ff_core::partition::{execution_partition, flow_partition};
 use ff_core::types::{EdgeId, ExecutionId, FlowId};
 
@@ -67,30 +68,16 @@ impl FlowFabricWorker {
     ///
     /// Returns `Ok(None)` when the edge hash is absent (never staged,
     /// or staged under a different flow).
+    ///
+    /// Post-#160 this is a thin forwarder onto the bundled
+    /// [`EngineBackend::describe_edge`](ff_core::engine_backend::EngineBackend::describe_edge)
+    /// impl.
     pub async fn describe_edge(
         &self,
         flow_id: &FlowId,
         edge_id: &EdgeId,
     ) -> Result<Option<EdgeSnapshot>, SdkError> {
-        let partition = flow_partition(flow_id, self.partition_config());
-        let ctx = ff_core::keys::FlowKeyContext::new(&partition, flow_id);
-        let edge_key = ctx.edge(edge_id);
-
-        let raw: HashMap<String, String> = self
-            .client()
-            .cmd("HGETALL")
-            .arg(&edge_key)
-            .execute()
-            .await
-            .map_err(|e| crate::backend_context(e, "describe_edge: HGETALL edge_hash"))?;
-
-        if raw.is_empty() {
-            return Ok(None);
-        }
-
-        ff_core::contracts::decode::build_edge_snapshot(flow_id, edge_id, &raw)
-            .map(Some)
-            .map_err(SdkError::from)
+        Ok(self.backend_ref().describe_edge(flow_id, edge_id).await?)
     }
 
     /// List all outgoing dependency edges originating from an execution.
@@ -100,7 +87,8 @@ impl FlowFabricWorker {
     ///
     /// # Reads
     ///
-    /// 1. `HGET exec_core flow_id` (via [`Self::resolve_flow_id`]).
+    /// 1. `EngineBackend::resolve_execution_flow_id` (single HGET on
+    ///    `exec_core.flow_id` for the Valkey backend).
     /// 2. `EngineBackend::list_edges` on the resolved flow (SMEMBERS
     ///    + pipelined HGETALL on the flow's partition).
     ///
@@ -145,49 +133,31 @@ impl FlowFabricWorker {
             .await?)
     }
 
-    /// `HGET exec_core.flow_id` and parse to a [`FlowId`]. `None` when
-    /// the exec_core hash is absent OR the flow_id field is empty
-    /// (standalone execution).
-    ///
-    /// Also pins the RFC-011 co-location invariant
-    /// (`execution_partition(eid) == flow_partition(flow_id)`) — a
+    /// Resolve `exec_core.flow_id` via the trait and pin the RFC-011
+    /// co-location invariant
+    /// (`execution_partition(eid) == flow_partition(flow_id)`). A
     /// parsed-but-wrong flow_id would otherwise silently route the
     /// follow-up adjacency reads to the wrong partition and return
     /// bogus empty results. A mismatch surfaces as
     /// `SdkError::Engine(EngineError::Validation { kind: Corruption, .. })`.
+    ///
+    /// Returns `None` when the execution has no owning flow
+    /// (standalone) or when exec_core is absent.
     async fn resolve_flow_id(&self, eid: &ExecutionId) -> Result<Option<FlowId>, SdkError> {
-        let exec_partition = execution_partition(eid, self.partition_config());
-        let ctx = ExecKeyContext::new(&exec_partition, eid);
-        let raw: Option<String> = self
-            .client()
-            .cmd("HGET")
-            .arg(ctx.core())
-            .arg("flow_id")
-            .execute()
-            .await
-            .map_err(|e| crate::backend_context(e, "list_edges: HGET exec_core.flow_id"))?;
-        let Some(raw) = raw.filter(|s| !s.is_empty()) else {
+        let Some(flow_id) = self.backend_ref().resolve_execution_flow_id(eid).await? else {
             return Ok(None);
         };
-        let flow_id = FlowId::parse(&raw).map_err(|e| {
-            SdkError::from(ff_core::engine_error::EngineError::Validation {
-                kind: ff_core::engine_error::ValidationKind::Corruption,
-                detail: format!(
-                    "list_edges: exec_core: flow_id: '{raw}' is not a valid UUID \
-                     (key corruption?): {e}"
-                ),
-            })
-        })?;
+        let exec_partition_index = execution_partition(eid, self.partition_config()).index;
         let flow_partition_index = flow_partition(&flow_id, self.partition_config()).index;
-        if exec_partition.index != flow_partition_index {
+        if exec_partition_index != flow_partition_index {
             return Err(SdkError::from(
                 ff_core::engine_error::EngineError::Validation {
                     kind: ff_core::engine_error::ValidationKind::Corruption,
                     detail: format!(
                         "list_edges: exec_core: flow_id: '{flow_id}' partition \
-                         {flow_partition_index} does not match execution partition {} \
-                         (RFC-011 co-location violation; key corruption?)",
-                        exec_partition.index
+                         {flow_partition_index} does not match execution partition \
+                         {exec_partition_index} (RFC-011 co-location violation; \
+                         key corruption?)"
                     ),
                 },
             ));

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -627,25 +627,6 @@ impl FlowFabricWorker {
         self.completion_backend_handle.clone()
     }
 
-    /// Crate-internal borrow of the underlying `ferriskey::Client`.
-    ///
-    /// **RFC-012 Stage 1c tranche-4 (#87):** downgraded from `pub` to
-    /// `pub(crate)`. The public `FlowFabricWorker` surface no longer
-    /// exposes the ferriskey type — consumers that previously reached
-    /// in for `read_stream` / `tail_stream` should now use
-    /// [`ClaimedTask::read_stream`](crate::ClaimedTask::read_stream) /
-    /// [`ClaimedTask::tail_stream`](crate::ClaimedTask::tail_stream)
-    /// (task-holders) or [`read_stream`](crate::read_stream) /
-    /// [`tail_stream`](crate::tail_stream) through a `&dyn
-    /// EngineBackend` (non-task callers).
-    ///
-    /// Retained for in-crate use by
-    /// [`crate::worker::FlowFabricWorker`]'s raw HGET helpers, which
-    /// are not yet migrated to the trait (separate tracking issue).
-    pub(crate) fn client(&self) -> &Client {
-        &self.client
-    }
-
     /// Get the worker config.
     pub fn config(&self) -> &WorkerConfig {
         &self.config

--- a/crates/ff-test/tests/engine_backend_describe_edge_resolve.rs
+++ b/crates/ff-test/tests/engine_backend_describe_edge_resolve.rs
@@ -1,0 +1,270 @@
+//! Issue #160: integration coverage for the two `EngineBackend` trait
+//! methods introduced to let `ff-sdk::snapshot` retire its raw-HGET
+//! helpers:
+//!
+//! - [`ff_core::engine_backend::EngineBackend::describe_edge`]
+//! - [`ff_core::engine_backend::EngineBackend::resolve_execution_flow_id`]
+//!
+//! Mirrors the precedent set by `engine_backend_describe.rs` and
+//! `engine_backend_list_edges.rs`: stage a flow + execution + edge
+//! via FCALL, read both through the trait object and through the
+//! ff-sdk wrapper, assert the two agree.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test engine_backend_describe_edge_resolve \
+//!       -- --test-threads=1
+
+use std::sync::Arc;
+
+use ferriskey::Value;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
+use ff_core::partition::{PartitionConfig, execution_partition, flow_partition};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+const LANE: &str = "desc-edge-lane";
+const NS: &str = "desc-edge-ns";
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = test_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn build_worker(suffix: &str) -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        backend: ff_test::fixtures::backend_config_from_env(),
+        worker_id: WorkerId::new(format!("desc-edge-worker-{suffix}")),
+        worker_instance_id: WorkerInstanceId::new(format!("desc-edge-inst-{suffix}")),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    ValkeyBackend::from_client_and_partitions(tc.client().clone(), test_config())
+}
+
+async fn create_flow(tc: &TestCluster, fid: &FlowId) {
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let ctx = FlowKeyContext::new(&partition, fid);
+    let fidx = FlowIndexKeys::new(&partition);
+    let keys: Vec<String> = vec![ctx.core(), ctx.members(), fidx.flow_index()];
+    let now_ms = TimestampMs::now().0.to_string();
+    let args: Vec<String> = vec![fid.to_string(), "dag".to_owned(), NS.to_owned(), now_ms];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_flow", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_flow");
+}
+
+async fn create_and_add_member(tc: &TestCluster, fid: &FlowId) -> ExecutionId {
+    let config = test_config();
+    let eid = ExecutionId::for_flow(fid, &config);
+    let partition = execution_partition(&eid, &config);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "edge_test_kind".to_owned(),
+        "0".to_owned(),
+        "desc-edge-test".to_owned(),
+        "{}".to_owned(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution");
+
+    let fpart = flow_partition(fid, &config);
+    let fctx = FlowKeyContext::new(&fpart, fid);
+    let fidx = FlowIndexKeys::new(&fpart);
+    let keys: Vec<String> = vec![fctx.core(), fctx.members(), fidx.flow_index(), ctx.core()];
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        eid.to_string(),
+        TimestampMs::now().0.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_add_execution_to_flow", &kr, &ar)
+        .await
+        .expect("FCALL ff_add_execution_to_flow");
+
+    eid
+}
+
+async fn stage_edge(
+    tc: &TestCluster,
+    fid: &FlowId,
+    up: &ExecutionId,
+    down: &ExecutionId,
+    expected_graph_revision: u64,
+) -> EdgeId {
+    let edge_id = EdgeId::new();
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let fctx = FlowKeyContext::new(&partition, fid);
+
+    let keys: Vec<String> = vec![
+        fctx.core(),
+        fctx.members(),
+        fctx.edge(&edge_id),
+        fctx.outgoing(up),
+        fctx.incoming(down),
+        fctx.grant(&edge_id.to_string()),
+    ];
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        edge_id.to_string(),
+        up.to_string(),
+        down.to_string(),
+        "success_only".to_owned(),
+        String::new(),
+        expected_graph_revision.to_string(),
+        TimestampMs::now().0.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_stage_dependency_edge", &kr, &ar)
+        .await
+        .expect("FCALL ff_stage_dependency_edge");
+    edge_id
+}
+
+/// Trait `describe_edge` returns the same snapshot as the ff-sdk
+/// wrapper. Also covers the `Ok(None)` branch (unstaged edge).
+#[tokio::test]
+async fn describe_edge_trait_matches_sdk() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("desc").await;
+    let backend = build_backend(&tc);
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let up = create_and_add_member(&tc, &fid).await;
+    let down = create_and_add_member(&tc, &fid).await;
+    let e1 = stage_edge(&tc, &fid, &up, &down, 2).await;
+
+    let trait_snap = backend
+        .describe_edge(&fid, &e1)
+        .await
+        .expect("trait describe_edge")
+        .expect("edge hash should be present");
+    let sdk_snap = worker
+        .describe_edge(&fid, &e1)
+        .await
+        .expect("sdk describe_edge")
+        .expect("edge hash should be present");
+    assert_eq!(trait_snap, sdk_snap, "trait must match SDK wrapper");
+    assert_eq!(trait_snap.edge_id, e1);
+    assert_eq!(trait_snap.upstream_execution_id, up);
+    assert_eq!(trait_snap.downstream_execution_id, down);
+
+    // Ok(None) path — unstaged edge id under the same flow.
+    let absent = EdgeId::new();
+    let trait_missing = backend
+        .describe_edge(&fid, &absent)
+        .await
+        .expect("trait describe_edge on absent");
+    let sdk_missing = worker
+        .describe_edge(&fid, &absent)
+        .await
+        .expect("sdk describe_edge on absent");
+    assert!(trait_missing.is_none());
+    assert!(sdk_missing.is_none());
+}
+
+/// Trait `resolve_execution_flow_id` returns the member's owning flow
+/// and `None` for a standalone execution id that was never created.
+#[tokio::test]
+async fn resolve_execution_flow_id_trait_roundtrip() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let _worker = build_worker("resolve").await;
+    let backend = build_backend(&tc);
+
+    let fid = FlowId::new();
+    create_flow(&tc, &fid).await;
+    let eid = create_and_add_member(&tc, &fid).await;
+
+    let resolved = backend
+        .resolve_execution_flow_id(&eid)
+        .await
+        .expect("trait resolve_execution_flow_id");
+    assert_eq!(
+        resolved,
+        Some(fid.clone()),
+        "member's flow_id must round-trip through the trait"
+    );
+
+    // Absent exec_core ⇒ Ok(None). Mint a fresh ExecutionId that we
+    // deliberately never create, keeping it co-located under the same
+    // flow partition so the routing touches a real key slot.
+    let config = test_config();
+    let unseen = ExecutionId::for_flow(&fid, &config);
+    let absent = backend
+        .resolve_execution_flow_id(&unseen)
+        .await
+        .expect("trait resolve on absent exec_core");
+    assert!(
+        absent.is_none(),
+        "absent exec_core must surface as Ok(None), got {absent:?}"
+    );
+}


### PR DESCRIPTION
## Summary

RFC-012 Stage 1c cleanup: ff-sdk::snapshot had two residual raw-client call sites that bypassed the `EngineBackend` trait. Stage 1c T4 (#158) sealed `FlowFabricWorker::client()` as `pub(crate)` but couldn't delete it because `snapshot.rs` still used it for `describe_edge` (HGETALL edge_hash) and `resolve_flow_id` (HGET exec_core.flow_id). This PR closes that gap.

## Grep sweep

**Before** (2 sites in `crates/ff-sdk/src/`):
```
snapshot.rs:80:   .client()   // HGETALL edge_hash for describe_edge
snapshot.rs:162:  .client()   // HGET exec_core.flow_id for resolve_flow_id
```

**After**: 0 sites.
```
$ grep -rn '\.client()' crates/ff-sdk/src/
(no matches)
$ grep -rn 'fn client\b' crates/ff-sdk/src/
(no matches)
```

## Per-site migration

| Site | Decision |
| --- | --- |
| `describe_edge` HGETALL edge_hash | New trait method `EngineBackend::describe_edge(flow_id, edge_id)`. Single HGETALL + `build_edge_snapshot` decode. Sits alongside `describe_execution` / `describe_flow` / `list_edges` as the minimal snapshot surface a Postgres backend must serve. Gated on `core`. |
| `resolve_flow_id` HGET exec_core.flow_id | New trait method `EngineBackend::resolve_execution_flow_id(eid)`. Single-column lookup any backend can implement. Cheaper than re-using `describe_execution` (which would spend 2 HGETALLs to read back one field). The RFC-011 co-location cross-check stays in ff-sdk since it is partition-arithmetic validation, not a backend concern. Gated on `core`. |

Both trait methods implemented on `ValkeyBackend` via new `describe_edge_impl` / `resolve_execution_flow_id_impl` free-fns mirroring the existing `_impl` family's shape.

## `FlowFabricWorker::client()` deletion

Deleted. Post-migration grep confirms no in-crate caller remained, so there is no need for a `backend_raw()` crack-keeper. The `Client` field on `FlowFabricWorker` is untouched — it is still used by `read_partition_config` and the two `ClaimedTask::new` / `self.client.clone()` sites inside `worker.rs`, which are unrelated to the snapshot path.

## New trait methods

- `EngineBackend::describe_edge` (core-gated) — semver-breaking addition to the trait.
- `EngineBackend::resolve_execution_flow_id` (core-gated) — semver-breaking addition to the trait.

Both are documented with `Ok(None)` semantics, error surface, and Postgres implementability.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo check -p ff-core --no-default-features` and `--features core` both clean
- [x] `cargo clippy --workspace --all-features --all-targets` clean (modulo pre-existing vendored-ferriskey warnings)
- [x] `FF_PORT=6389 cargo test -p ff-test --test engine_backend_describe_edge_resolve` — 2/2 pass
- [x] `FF_PORT=6389 cargo test -p ff-test --test describe_edge_api --test describe_execution_api --test describe_flow_api --test engine_backend_describe --test engine_backend_list_edges --test engine_backend_list_edges_faults` — all pass, zero behavior changes
- [x] `cargo test -p ff-core -p ff-sdk -p ff-backend-valkey --lib` — all pass

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)