### PR TITLE
feat(ff-sdk): SharedFfBackend factory for multi-worker shared-connection (closes #174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`ff_sdk::SharedFfBackend` factory (#174):** amortises a single
+  dialed `Arc<ValkeyBackend>` (and its completion-subscription
+  surface) across multiple logical `FlowFabricWorker` instances in
+  the same process. Direct answer to the apalis "shared connections"
+  hook tracked in #51 and cairn-fabric's multi-queue use case.
+  Usage: `let shared = SharedFfBackend::connect(cfg).await?;
+  let worker = shared.worker(worker_cfg).await?;` — every subsequent
+  `.worker(..)` clones the same `Arc` into
+  `FlowFabricWorker::connect_with` as both the `EngineBackend` and
+  `CompletionBackend` trait-object views. Scope today: the
+  `Arc<ValkeyBackend>` (and therefore the completion subscriber
+  allocation) is shared; the worker's embedded hot-path
+  `ferriskey::Client` is still redialed per worker until RFC-012
+  Stage 1d removes the embedded client. Gated behind `valkey-default`.
+  New concrete-typed `ValkeyBackend::connect_concrete` constructor on
+  `ff-backend-valkey` supports the factory (the pre-existing
+  `::connect` still returns `Arc<dyn EngineBackend>` unchanged).
 - **Observability wiring on `EngineBackend` trait methods (#154):** every
   non-stub `*_impl` in `ff-backend-valkey` now carries
   `#[tracing::instrument(name = "ff.<method>", skip_all, fields(backend,

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -118,7 +118,23 @@ impl ValkeyBackend {
     ///
     /// [`BackendRetry`]: ff_core::backend::BackendRetry
     pub async fn connect(config: BackendConfig) -> Result<Arc<dyn EngineBackend>, EngineError> {
-        Self::connect_inner(config, None, "connect").await
+        Self::connect_inner(config, None, "connect").await.map(|arc| arc as Arc<dyn EngineBackend>)
+    }
+
+    /// Dial a Valkey node and return the backend as the concrete
+    /// `Arc<ValkeyBackend>` (rather than the erased
+    /// `Arc<dyn EngineBackend>` that [`Self::connect`] returns).
+    ///
+    /// Motivating caller: `ff_sdk::SharedFfBackend` (issue #174) —
+    /// the factory needs to hand the same `Arc` in as both an
+    /// [`EngineBackend`] and a
+    /// [`CompletionBackend`](ff_core::completion_backend::CompletionBackend)
+    /// trait-object view, which requires starting from the concrete
+    /// type (coercing `Arc<dyn EngineBackend>` to
+    /// `Arc<dyn CompletionBackend>` loses trait-object identity and
+    /// would force a second allocation).
+    pub async fn connect_concrete(config: BackendConfig) -> Result<Arc<Self>, EngineError> {
+        Self::connect_inner(config, None, "connect_concrete").await
     }
 
     /// Shared dial + partition-config-load body for [`Self::connect`]
@@ -129,7 +145,7 @@ impl ValkeyBackend {
         config: BackendConfig,
         metrics: Option<Arc<ff_observability::Metrics>>,
         op_label: &'static str,
-    ) -> Result<Arc<dyn EngineBackend>, EngineError> {
+    ) -> Result<Arc<Self>, EngineError> {
         // `BackendConnection` is `#[non_exhaustive]` for future
         // backends; the compiler treats the pattern as refutable,
         // hence `let ... else`. Today only `Valkey` exists; a
@@ -143,6 +159,9 @@ impl ValkeyBackend {
                 op: match op_label {
                     "connect_with_metrics" => {
                         "ValkeyBackend::connect_with_metrics (non-Valkey BackendConnection)"
+                    }
+                    "connect_concrete" => {
+                        "ValkeyBackend::connect_concrete (non-Valkey BackendConnection)"
                     }
                     _ => "ValkeyBackend::connect (non-Valkey BackendConnection)",
                 },
@@ -256,7 +275,9 @@ impl ValkeyBackend {
         config: BackendConfig,
         metrics: Arc<ff_observability::Metrics>,
     ) -> Result<Arc<dyn EngineBackend>, EngineError> {
-        Self::connect_inner(config, Some(metrics), "connect_with_metrics").await
+        Self::connect_inner(config, Some(metrics), "connect_with_metrics")
+            .await
+            .map(|arc| arc as Arc<dyn EngineBackend>)
     }
 
     /// Encode the minimum set of attempt-cookie fields into a

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -75,6 +75,8 @@ pub mod admin;
 pub mod config;
 pub mod engine_error;
 #[cfg(feature = "valkey-default")]
+pub mod shared;
+#[cfg(feature = "valkey-default")]
 pub mod snapshot;
 #[cfg(feature = "valkey-default")]
 pub mod task;
@@ -107,6 +109,8 @@ pub use task::{
     SignalOutcome, StreamCursor, StreamFrames, SuspendOutcome, TimeoutBehavior,
     MAX_TAIL_BLOCK_MS, STREAM_READ_HARD_CAP,
 };
+#[cfg(feature = "valkey-default")]
+pub use shared::SharedFfBackend;
 #[cfg(feature = "valkey-default")]
 pub use worker::FlowFabricWorker;
 

--- a/crates/ff-sdk/src/shared.rs
+++ b/crates/ff-sdk/src/shared.rs
@@ -1,0 +1,124 @@
+//! `SharedFfBackend` — factory that amortises a single dialed
+//! [`ValkeyBackend`] (and its embedded multiplexed `ferriskey::Client`)
+//! across multiple logical [`FlowFabricWorker`] instances in the same
+//! process (issue #174).
+//!
+//! The motivating use case is apalis's "shared connections" hook from
+//! `MakeShared` (issue #51) and cairn-fabric multi-queue consumers
+//! that want one TCP socket serving N worker loops: without this
+//! factory, each [`FlowFabricWorker::connect`] call dials its own
+//! `ferriskey::Client`, so a process running 4 lane-specialised
+//! workers holds 4 sockets into Valkey for write-surface ops even
+//! though the backend is stateless.
+//!
+//! Today this factory collapses the `Arc<ValkeyBackend>` allocation
+//! (and therefore the `CompletionBackend` subscriber surface) into
+//! one. The worker's embedded hot-path `ferriskey::Client` is still
+//! redialed per worker by [`FlowFabricWorker::connect_with`] — Stage
+//! 1c / 1d of RFC-012 remove that embedded client entirely, at which
+//! point the `Arc<ValkeyBackend>` handed in here becomes the one and
+//! only client the worker talks through.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use ff_core::backend::BackendConfig;
+//! use ff_core::types::{LaneId, Namespace, WorkerId, WorkerInstanceId};
+//! use ff_sdk::{SharedFfBackend, WorkerConfig};
+//!
+//! # async fn run() -> Result<(), ff_sdk::SdkError> {
+//! let shared = SharedFfBackend::connect(
+//!     BackendConfig::valkey("127.0.0.1", 6379),
+//! ).await?;
+//!
+//! let cfg_a = WorkerConfig {
+//!     backend: BackendConfig::valkey("127.0.0.1", 6379),
+//!     worker_id: WorkerId::new("w-a"),
+//!     worker_instance_id: WorkerInstanceId::new("w-a-1"),
+//!     namespace: Namespace::new("default"),
+//!     lanes: vec![LaneId::new("lane-a")],
+//!     capabilities: Vec::new(),
+//!     lease_ttl_ms: 30_000,
+//!     claim_poll_interval_ms: 1_000,
+//!     max_concurrent_tasks: 1,
+//! };
+//! let cfg_b = WorkerConfig {
+//!     worker_id: WorkerId::new("w-b"),
+//!     worker_instance_id: WorkerInstanceId::new("w-b-1"),
+//!     lanes: vec![LaneId::new("lane-b")],
+//!     ..cfg_a.clone()
+//! };
+//!
+//! let worker_a = shared.worker(cfg_a).await?;
+//! let worker_b = shared.worker(cfg_b).await?;
+//! // `worker_a` and `worker_b` share the same `Arc<ValkeyBackend>` —
+//! // one allocation, one completion-subscription surface, one
+//! // backend trait-object for Stage 1c/1d hot-path migration.
+//! # Ok(()) }
+//! ```
+
+use std::sync::Arc;
+
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::BackendConfig;
+
+use crate::SdkError;
+use crate::config::WorkerConfig;
+use crate::worker::FlowFabricWorker;
+
+/// Factory that holds a single dialed [`ValkeyBackend`] and stamps
+/// out [`FlowFabricWorker`] instances that all share the same
+/// backend allocation.
+///
+/// Direct answer to apalis's `MakeShared` pattern from issue #51 and
+/// cairn-fabric's multi-queue "one socket, N worker loops" need.
+///
+/// See the module-level docs for the motivating example and the
+/// precise scope of sharing at the current RFC-012 stage.
+#[derive(Clone)]
+pub struct SharedFfBackend {
+    backend: Arc<ValkeyBackend>,
+}
+
+impl SharedFfBackend {
+    /// Dial a Valkey node and wrap the resulting [`ValkeyBackend`] in
+    /// a shareable factory.
+    ///
+    /// One call = one dialed `ferriskey::Client` + one
+    /// `Arc<ValkeyBackend>`. Each subsequent [`Self::worker`] call
+    /// clones the `Arc` — no additional dial.
+    pub async fn connect(config: BackendConfig) -> Result<Self, SdkError> {
+        let backend = ValkeyBackend::connect_concrete(config).await?;
+        Ok(Self { backend })
+    }
+
+    /// Build a [`FlowFabricWorker`] that forwards trait ops through
+    /// this factory's shared [`ValkeyBackend`]. The same `Arc` is
+    /// handed in as both the [`EngineBackend`] and
+    /// [`CompletionBackend`] trait-object views — one allocation,
+    /// two views.
+    ///
+    /// `config.backend` is still used by the underlying
+    /// [`FlowFabricWorker::connect_with`] to dial the worker's own
+    /// embedded `ferriskey::Client` today (RFC-012 Stage 1b holdover
+    /// — the shared `ValkeyBackend` only covers the migrated
+    /// per-task trait ops). Stage 1d removes the embedded client, at
+    /// which point the shared `Arc` becomes the sole transport.
+    ///
+    /// [`EngineBackend`]: ff_core::engine_backend::EngineBackend
+    /// [`CompletionBackend`]: ff_core::completion_backend::CompletionBackend
+    pub async fn worker(&self, config: WorkerConfig) -> Result<FlowFabricWorker, SdkError> {
+        let backend: Arc<dyn ff_core::engine_backend::EngineBackend> = self.backend.clone();
+        let completion: Arc<dyn ff_core::completion_backend::CompletionBackend> =
+            self.backend.clone();
+        FlowFabricWorker::connect_with(config, backend, Some(completion)).await
+    }
+
+    /// Borrow the shared [`ValkeyBackend`] as its concrete type.
+    /// Primarily for integration tests that assert sharing via
+    /// [`Arc::strong_count`]; consumers should prefer
+    /// [`Self::worker`] for the public path.
+    pub fn backend_arc(&self) -> &Arc<ValkeyBackend> {
+        &self.backend
+    }
+}

--- a/crates/ff-test/tests/shared_ff_backend.rs
+++ b/crates/ff-test/tests/shared_ff_backend.rs
@@ -1,0 +1,124 @@
+//! Integration test for [`ff_sdk::SharedFfBackend`] (issue #174).
+//!
+//! Spins two [`ff_sdk::FlowFabricWorker`] instances from a single
+//! `SharedFfBackend::connect(..)` factory and asserts that they share
+//! the same `Arc<ValkeyBackend>` allocation by inspecting
+//! [`Arc::strong_count`] on the concrete backend handle the factory
+//! hands out.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test shared_ff_backend -- --test-threads=1
+
+use std::sync::Arc;
+
+use ff_core::types::*;
+use ff_sdk::{SharedFfBackend, WorkerConfig};
+use ff_test::fixtures::TestCluster;
+
+const NS: &str = "shared-ff-ns";
+
+fn worker_config(suffix: &str, lane: &str) -> WorkerConfig {
+    WorkerConfig {
+        backend: ff_test::fixtures::backend_config_from_env(),
+        worker_id: WorkerId::new(format!("shared-ff-w-{suffix}")),
+        worker_instance_id: WorkerInstanceId::new(format!("shared-ff-inst-{suffix}")),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(lane)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    }
+}
+
+/// The factory mints two workers that both hold the same
+/// `Arc<ValkeyBackend>` — `strong_count` climbs with each
+/// `.worker(..)` call and the workers' backend trait-objects are
+/// pointer-equal to the factory's concrete handle.
+#[tokio::test]
+async fn shared_backend_is_reused_across_workers() {
+    // Pre-seed the partition config so `ValkeyBackend::connect_concrete`
+    // does not fall back to `PartitionConfig::default()` with a warn log.
+    // Uses the same HSET seed the other engine-backend-* tests rely on.
+    let _tc = TestCluster::connect().await;
+    let cfg = ff_test::fixtures::TEST_PARTITION_CONFIG;
+    let _: () = _tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+
+    let shared = SharedFfBackend::connect(ff_test::fixtures::backend_config_from_env())
+        .await
+        .expect("SharedFfBackend::connect");
+
+    // Baseline: factory holds one strong reference.
+    assert_eq!(
+        Arc::strong_count(shared.backend_arc()),
+        1,
+        "freshly-connected factory should own the only strong ref"
+    );
+
+    let w1 = shared
+        .worker(worker_config("a", "lane-a"))
+        .await
+        .expect("shared.worker(a)");
+    // After one worker: factory + engine-view + completion-view = 3.
+    // (FlowFabricWorker stores two Arc<dyn ..> trait-object views
+    // onto the same underlying ValkeyBackend allocation.)
+    assert_eq!(
+        Arc::strong_count(shared.backend_arc()),
+        3,
+        "one worker adds two trait-object views onto the shared Arc"
+    );
+
+    let w2 = shared
+        .worker(worker_config("b", "lane-b"))
+        .await
+        .expect("shared.worker(b)");
+    // Two workers: factory + 2 × (engine-view + completion-view) = 5.
+    assert_eq!(
+        Arc::strong_count(shared.backend_arc()),
+        5,
+        "second worker adds two more trait-object views onto the same Arc"
+    );
+
+    // Sanity: both workers see a backend trait-object and they both
+    // exist (we never `.take()` them away). The strong-count check
+    // above is the load-bearing assertion; the following lines just
+    // exercise the accessors so a future refactor that silently drops
+    // backend storage on one path surfaces here.
+    assert!(w1.backend().is_some(), "worker-a exposes a backend");
+    assert!(w2.backend().is_some(), "worker-b exposes a backend");
+    assert!(
+        w1.completion_backend().is_some(),
+        "worker-a exposes a completion backend"
+    );
+    assert!(
+        w2.completion_backend().is_some(),
+        "worker-b exposes a completion backend"
+    );
+
+    // Drop one worker; strong_count falls by 2 (engine + completion).
+    drop(w1);
+    assert_eq!(
+        Arc::strong_count(shared.backend_arc()),
+        3,
+        "dropping one worker releases its two trait-object views"
+    );
+
+    drop(w2);
+    assert_eq!(
+        Arc::strong_count(shared.backend_arc()),
+        1,
+        "dropping all workers returns us to the factory-only baseline"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `ff_sdk::SharedFfBackend` — a factory type that amortises a single
dialed `Arc<ValkeyBackend>` (and its completion-subscription surface)
across multiple logical `FlowFabricWorker` instances in the same
process. Direct answer to the apalis "shared connections" hook tracked
in #51 and cairn-fabric's multi-queue / multi-lane consumer shape.

## Motivation

apalis's `MakeShared` pattern (issue #51) and cairn-fabric's
multi-queue setup both want one process running N lane-specialised
workers over a single pool of Valkey connections. Until today each
`FlowFabricWorker::connect(..)` call dialed its own client *and* its
own `Arc<ValkeyBackend>`, so the process held N sockets and N
completion-subscription handles for workers that are stateless at the
backend layer.

## Before / after

Before (N workers → N sockets + N `Arc<ValkeyBackend>`):

```rust
let w1 = FlowFabricWorker::connect(cfg_a).await?;  // dial #1
let w2 = FlowFabricWorker::connect(cfg_b).await?;  // dial #2
// Two independent Arc<ValkeyBackend>s, two completion subscribers.
```

After (N workers → 1 shared `Arc<ValkeyBackend>`):

```rust
let shared  = SharedFfBackend::connect(BackendConfig::valkey("127.0.0.1", 6379)).await?;
let worker1 = shared.worker(cfg_a).await?;
let worker2 = shared.worker(cfg_b).await?;
// Same Arc<ValkeyBackend>, same completion surface,
// two logical FlowFabricWorker.
```

## Scope at this RFC-012 stage (called out in the CHANGELOG)

The `Arc<ValkeyBackend>` itself (and therefore the completion-subscriber
allocation) is shared. The worker's embedded hot-path `ferriskey::Client`
is still redialed per worker by `FlowFabricWorker::connect_with`; Stage
1d removes the embedded client, at which point the shared `Arc`
becomes the sole transport. This PR does not attempt that migration —
it builds on top of `connect_with` exactly as #174 prescribed.

## Supporting changes

- `ValkeyBackend::connect_concrete` returns `Arc<Self>` directly so
  the factory can hand the same allocation in as both the
  `EngineBackend` and `CompletionBackend` trait-object views.
- `ValkeyBackend::connect` is unchanged on the surface (still returns
  `Arc<dyn EngineBackend>`); internal `connect_inner` now yields
  `Arc<Self>` and the public constructors upcast at the boundary.
- Gated behind `ff-sdk`'s `valkey-default` feature (uses concrete
  `ValkeyBackend`). `--no-default-features` build of ff-sdk stays clean.

## Test plan

- [x] `cargo build --workspace --all-features` — clean.
- [x] `cargo build -p ff-sdk --no-default-features` — clean
      (agnosticism contract preserved).
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler
      -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey
      --all-targets -- -D warnings` — clean.
- [x] `cargo test -p ff-sdk --lib` — 40 tests pass (no regressions).
- [x] `cargo test -p ff-test --test shared_ff_backend
      -- --test-threads=1` — new integration test passes.
      Asserts `Arc::strong_count` on the factory's concrete backend
      climbs `1 → 3 → 5` as workers are minted and falls back to `1`
      on drops, proving the `Arc<ValkeyBackend>` is genuinely shared
      (not independently allocated).

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)