### PR TITLE
docs: v0.4.1 DX polish bundle (closes #176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,28 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `valkey_kind`) transparently descend through the wrapper so
   retry/terminal semantics are preserved.
 
+### Changed
+
+- **v0.4.1 DX polish bundle (#176):** doc-only follow-up to v0.4.0
+  consumer validation — six runtime-smoke frictions documented in
+  place, no code changes. Rustdoc notes added on
+  `CompletionBackend::subscribe_completions_filtered` (completion
+  PUBLISH gated on `flow_id` — solo executions never emit),
+  `ClaimedTask::update_progress` + `::append_frame` + the same pair
+  on the `EngineBackend` trait (cross-reference: `update_progress`
+  writes scalar fields on `exec_core`, stream-frame producers must
+  use `append_frame`), `ValkeyBackend::connect` (capability erasure
+  when returning `Arc<dyn EngineBackend>`; use
+  `from_client_partitions_and_connection` to retain
+  `CompletionBackend`), `FlowFabricWorker::connect` (rotate
+  `WorkerInstanceId` per smoke-script run to avoid the 2×
+  lease-TTL SET-NX liveness trap), and `Scheduler::claim_for_worker`
+  (lane-FIFO drains prior-run leftovers before fresh submissions —
+  recommend a fresh lane per smoke run). `docs/cairn-migration-v0.4.0.md`
+  §15 captures the three cross-cutting items (flow_id gating,
+  `connect` capability erasure, `Server::start` hard-fail on
+  `PartitionConfig` mismatch).
+
 ### Fixed
 
 - **ff-script + ff-sdk default-features leak on `ff-core` (#164):**

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -117,6 +117,26 @@ impl ValkeyBackend {
     /// `.retry_strategy(..)` call).
     ///
     /// [`BackendRetry`]: ff_core::backend::BackendRetry
+    ///
+    /// # Capability erasure
+    ///
+    /// The return type is `Arc<dyn EngineBackend>`, which cannot be
+    /// re-upcast to `Arc<dyn ff_core::completion_backend::CompletionBackend>`
+    /// (Rust's trait-object model does not support cross-trait
+    /// upcasts). Consumers that want BOTH the write surface and the
+    /// completion-subscription surface from a single dial must either:
+    ///
+    /// 1. Build the client + `ValkeyConnection` directly and call
+    ///    [`Self::from_client_partitions_and_connection`], holding
+    ///    the concrete `Arc<ValkeyBackend>` and cloning it into each
+    ///    trait-object position; or
+    /// 2. Construct via ff-server's own wiring (which keeps the
+    ///    concrete `Arc<ValkeyBackend>` for both positions).
+    ///
+    /// [`ValkeyBackend::connect`] is the simplest entry point for
+    /// write-only consumers; completion subscribers need one of the
+    /// patterns above. See `docs/cairn-migration-v0.4.0.md` §5 +
+    /// §15.
     pub async fn connect(config: BackendConfig) -> Result<Arc<dyn EngineBackend>, EngineError> {
         Self::connect_inner(config, None, "connect").await
     }

--- a/crates/ff-core/src/completion_backend.rs
+++ b/crates/ff-core/src/completion_backend.rs
@@ -114,6 +114,22 @@ pub trait CompletionBackend: Send + Sync + 'static {
     /// `filter.instance_tag` is set (2 HGETs total when both are
     /// set). The backend short-circuits on the cheaper namespace
     /// check first.
+    ///
+    /// # Gotcha: completions are only published for executions that
+    /// belong to a flow
+    ///
+    /// The Lua terminal emits `PUBLISH ff:dag:completions <payload>`
+    /// only when `core.flow_id` is set on the execution (see
+    /// `crates/ff-script/src/flowfabric.lua` — the PUBLISH is gated
+    /// on `is_set(core.flow_id)`). Solo / standalone executions
+    /// submitted without a flow never hit the channel, so a
+    /// completion subscriber will observe **nothing** for them —
+    /// the terminal state lands in `exec_core` as usual and the
+    /// `dependency_reconciler` interval scan picks it up, but the
+    /// push stream stays silent. Smoke tests that submit a single
+    /// execution and wait on a completion subscription will hang
+    /// indefinitely; either submit under a flow or poll
+    /// `describe_execution` instead.
     async fn subscribe_completions_filtered(
         &self,
         filter: &ScannerFilter,

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -101,6 +101,11 @@ pub trait EngineBackend: Send + Sync + 'static {
     async fn renew(&self, handle: &Handle) -> Result<LeaseRenewal, EngineError>;
 
     /// Numeric-progress heartbeat.
+    ///
+    /// Writes scalar `progress_percent` / `progress_message` fields on
+    /// `exec_core`; each call overwrites the previous value. This does
+    /// NOT append to the output stream — stream-frame producers must use
+    /// [`append_frame`](Self::append_frame) instead.
     async fn progress(
         &self,
         handle: &Handle,
@@ -111,6 +116,11 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// Append one stream frame. Distinct from [`progress`](Self::progress)
     /// per RFC-012 §3.1.1 K#6. Returns the backend-assigned stream entry
     /// id and post-append frame count (RFC-012 §R7.2.1).
+    ///
+    /// Stream-frame producers (arbitrary `frame_type` + payload, consumed
+    /// via the read/tail surfaces) MUST use this method rather than
+    /// [`progress`](Self::progress); the latter updates scalar fields on
+    /// `exec_core` and is invisible to stream consumers.
     async fn append_frame(
         &self,
         handle: &Handle,

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -411,6 +411,18 @@ impl Scheduler {
     /// Returns `Ok(None)` if no eligible executions exist anywhere.
     /// Returns `Ok(Some(grant))` on success.
     /// Returns `Err` on Valkey errors.
+    ///
+    /// # Lane-FIFO: prior-run leftovers drain first
+    ///
+    /// Claim grants are issued in per-lane FIFO order over the lane's
+    /// eligible queue. A smoke / dev script that reuses a lane across
+    /// runs will observe the lane's leftover executions from earlier
+    /// runs — failed, orphaned, or still-eligible — drain *before*
+    /// the fresh submission is claimed. This surfaces as a confusing
+    /// "wrong execution picked up" during iterative development.
+    /// Smoke tests should either (a) use a fresh lane name per run
+    /// (e.g. suffixing with a UUID or timestamp), or (b) call
+    /// `cancel_flow` / `FLUSHDB` between runs to drain the lane.
     pub async fn claim_for_worker(
         &self,
         lane: &LaneId,

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -668,6 +668,17 @@ impl ClaimedTask {
     ///
     /// **RFC-012 Stage 1b.** Forwards through the `EngineBackend`
     /// trait (`backend.progress(&handle, Some(pct), Some(msg))`).
+    ///
+    /// # Not for stream frames
+    ///
+    /// `update_progress` writes the `progress_percent` / `progress_message`
+    /// fields on `exec_core` (the execution's state hash). It is a
+    /// scalar heartbeat — each call overwrites the previous value and
+    /// nothing is appended to the output stream. Producers emitting
+    /// stream frames (arbitrary `frame_type` + payload, consumed via
+    /// `ClaimedTask::read_stream` / `tail_stream` or the HTTP
+    /// stream-tail routes) MUST use [`Self::append_frame`] instead;
+    /// `update_progress` is invisible to stream consumers.
     pub async fn update_progress(&self, pct: u8, message: &str) -> Result<(), SdkError> {
         let handle = self.synth_handle();
         self.backend
@@ -758,6 +769,15 @@ impl ClaimedTask {
     /// extended [`ff_core::backend::Frame`] shape (`frame_type:
     /// String`, `correlation_id: Option<String>`), giving byte-for-byte
     /// wire parity with the pre-migration direct-FCALL path.
+    ///
+    /// # `append_frame` vs [`Self::update_progress`]
+    ///
+    /// Stream-frame producers (arbitrary `frame_type` + payload
+    /// consumed via `ClaimedTask::read_stream` / `tail_stream` or the
+    /// HTTP stream-tail routes) MUST use `append_frame`.
+    /// `update_progress` writes scalar `progress_percent` /
+    /// `progress_message` fields to `exec_core` and is invisible to
+    /// stream consumers.
     pub async fn append_frame(
         &self,
         frame_type: &str,

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -147,6 +147,19 @@ impl FlowFabricWorker {
     /// library — that is the server's responsibility (ff-server calls
     /// `ff_script::loader::ensure_library()` on startup). The SDK assumes
     /// the library is already loaded.
+    ///
+    /// # Smoke / dev scripts: rotate `WorkerInstanceId`
+    ///
+    /// The SDK writes a SET-NX liveness sentinel keyed on the worker's
+    /// `WorkerInstanceId`. When a smoke / dev script reuses the same
+    /// `WorkerInstanceId` across restarts, subsequent runs trap behind
+    /// the prior run's SET-NX until the liveness key's TTL (≈ 2× the
+    /// configured lease TTL) expires — the worker appears stuck and
+    /// claims nothing. Iterative scripts should synthesise a fresh
+    /// `WorkerInstanceId` per process (e.g. `WorkerInstanceId::new()`
+    /// or embed a UUID/timestamp) rather than hard-coding a stable
+    /// value. Production workers that cleanly shut down release the
+    /// key; only crashed / kill -9'd processes hit this trap.
     pub async fn connect(config: WorkerConfig) -> Result<Self, SdkError> {
         if config.lanes.is_empty() {
             return Err(SdkError::Config {

--- a/docs/cairn-migration-v0.4.0.md
+++ b/docs/cairn-migration-v0.4.0.md
@@ -640,6 +640,95 @@ are infallible — no `TryInto` plumbing required. Existing
 
 Source: PR #157.
 
+## 15. v0.4.1 DX polish bundle (#176)
+
+Six runtime-smoke frictions surfaced during v0.4.0 consumer validation.
+All doc-only — no code changes required. Three of them have
+cross-cutting migration implications worth calling out here; the
+other three are localised rustdoc notes (see the linked sites).
+
+### 15.1 Completion PUBLISH is gated on `flow_id`
+
+The Lua terminal (`crates/ff-script/src/flowfabric.lua`) emits
+`PUBLISH ff:dag:completions …` **only** when `core.flow_id` is set.
+Standalone executions (submitted without a flow) never hit the
+channel. Consumers subscribing via
+[`CompletionBackend::subscribe_completions`](../crates/ff-core/src/completion_backend.rs)
+or `subscribe_completions_filtered` observe nothing for them — the
+terminal state lands in `exec_core` and the `dependency_reconciler`
+interval scan picks it up, but the push stream stays silent.
+
+Smoke tests that submit a single execution and `.next().await` on a
+completion stream will hang. Either submit under a flow, or poll
+`describe_execution` instead.
+
+### 15.2 `ValkeyBackend::connect` erases `CompletionBackend`
+
+`ValkeyBackend::connect(config) -> Arc<dyn EngineBackend>` loses the
+`CompletionBackend` capability: Rust's trait-object model cannot
+re-upcast `Arc<dyn EngineBackend>` to `Arc<dyn CompletionBackend>`.
+
+Consumers that need both trait views from one dial should build the
+client + `ValkeyConnection` directly and call
+[`ValkeyBackend::from_client_partitions_and_connection`](../crates/ff-backend-valkey/src/lib.rs),
+holding the concrete `Arc<ValkeyBackend>` and cloning it into each
+trait-object position:
+
+```rust
+use std::sync::Arc;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::ValkeyConnection;
+use ff_core::completion_backend::CompletionBackend;
+use ff_core::engine_backend::EngineBackend;
+
+let client = /* build ferriskey::Client */;
+let partition_config = /* load from ff:config:partitions */;
+let conn: ValkeyConnection = /* … */;
+let backend: Arc<ValkeyBackend> =
+    ValkeyBackend::from_client_partitions_and_connection(
+        client, partition_config, conn);
+
+let engine: Arc<dyn EngineBackend> = backend.clone();
+let completion: Arc<dyn CompletionBackend> = backend;
+```
+
+See also §5 (`connect_with` + `completion_backend()` on the worker).
+
+### 15.3 `Server::start` hard-fails on `PartitionConfig` mismatch
+
+`ff-server`'s boot sequence validates the `ff:config:partitions` hash
+against the configured `PartitionConfig` (see
+`crates/ff-server/src/server.rs` — step 2). A mismatch aborts start
+rather than silently re-tagging keys on a mis-sized deployment.
+
+Dev / smoke workflows that change `PartitionConfig` must either:
+
+- `FLUSHDB` / `FLUSHALL` the target Valkey before starting, so the
+  server creates the config fresh; or
+- Match the host's persisted `PartitionConfig` (inspect with
+  `GET ff:config:partitions`).
+
+This is intentional — silent divergence would route keys to
+different slots on different processes. Production deployments
+should treat `PartitionConfig` as a cluster-lifetime constant.
+
+### 15.4 Other items (rustdoc-only)
+
+- `update_progress` vs `append_frame` — cross-referenced in both
+  methods' rustdoc (`ff-sdk::task::ClaimedTask`,
+  `ff-core::engine_backend::EngineBackend`). `update_progress` is a
+  scalar heartbeat on `exec_core`; stream-frame producers must use
+  `append_frame`.
+- SET-NX liveness key traps repeat runs for ≈ 2× lease TTL —
+  rustdoc note on `FlowFabricWorker::connect` recommends rotating
+  `WorkerInstanceId` per smoke-script run.
+- `claim_for_worker` lane-FIFO surprise — rustdoc note on
+  `Scheduler::claim_for_worker` explains that leftover eligible execs
+  from prior runs drain before the current submission is observed;
+  recommend a fresh lane name for smoke tests.
+
+Source: issue #176.
+
 ## References
 
 - RFC-012 Stage 1a: type introduction (landed).


### PR DESCRIPTION
## Summary

Doc-only follow-up to v0.4.0 consumer validation (Worker QQQQ's six runtime-smoke frictions, issue #176). Bundles into 0.5.0 — NOT tagging v0.4.1.

All six items addressed as rustdoc + migration-doc + CHANGELOG `[Unreleased]`; no code changes.

1. **Completion PUBLISH gated on `flow_id`** — rustdoc note on `CompletionBackend::subscribe_completions_filtered` + `docs/cairn-migration-v0.4.0.md` §15.1. Solo executions never emit to `ff:dag:completions`.
2. **`update_progress` vs `append_frame`** — cross-reference on both `ClaimedTask` methods and on the `EngineBackend` trait methods. `update_progress` writes scalar `exec_core` fields; stream producers must use `append_frame`.
3. **`ValkeyBackend::connect` erases `CompletionBackend`** — rustdoc on `connect` explains the `Arc<dyn EngineBackend>` upcast limitation + `docs/cairn-migration-v0.4.0.md` §15.2 shows the `from_client_partitions_and_connection` + concrete-`Arc` pattern.
4. **SET-NX liveness key traps repeat runs for ~2× lease TTL** — rustdoc note on `FlowFabricWorker::connect` recommending fresh `WorkerInstanceId` per smoke-script run.
5. **`Server::start` hard-fail on `PartitionConfig` mismatch** — `docs/cairn-migration-v0.4.0.md` §15.3 documents the FLUSHDB / matching-host dev workflow. No code change (intentional fail-fast).
6. **`claim_for_worker` lane-FIFO surprise** — rustdoc note on `Scheduler::claim_for_worker` explaining that prior-run leftovers drain before fresh submissions; recommend fresh lane for smoke tests.

## Test plan

- [x] `cargo check -p ff-core -p ff-sdk -p ff-backend-valkey -p ff-scheduler` clean (pre-existing warning only)
- [x] `cargo doc --no-deps` for all touched crates: link-warning count unchanged (16 → 16; no new warnings introduced)
- [x] All 6 items doc-only — none required code
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)