### PR TITLE
fix(ff-backend-valkey): downgrade hot-path tracing spans to level="debug" (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Hot-path tracing span level downgraded to `debug` (#173):**
+  Downgraded 5 hot-path `EngineBackend` impl spans (complete, renew,
+  progress, observe_signals, append_frame) from implicit `info` to
+  explicit `level = "debug"` to reduce span overhead at production
+  `RUST_LOG=info`. See #173 +
+  `rfcs/drafts/scenario-5-flame-capture.md` for investigation.
 - **v0.4.1 DX polish bundle (#176):** doc-only follow-up to v0.4.0
   consumer validation — six runtime-smoke frictions documented in
   place, no code changes. Rustdoc notes added on

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -776,6 +776,7 @@ fn parse_success_only(raw: &ferriskey::Value) -> Result<(), EngineError> {
 /// (Lua's `ff_renew_lease` does not bump epoch, so the handle's value
 /// is still authoritative).
 #[tracing::instrument(
+    level = "debug",
     name = "ff.renew",
     skip_all,
     fields(
@@ -845,6 +846,7 @@ async fn renew_impl(
 /// Stage 1b — `progress` FCALL body. Migrated from
 /// `ff_sdk::task::ClaimedTask::update_progress`. 1 KEY, 5 ARGV.
 #[tracing::instrument(
+    level = "debug",
     name = "ff.progress",
     skip_all,
     fields(
@@ -895,6 +897,7 @@ async fn progress_impl(
 /// `signal_id`s via `HMGET`, then pipelines per-signal
 /// `HGETALL signal_hash` + `GET signal_payload`.
 #[tracing::instrument(
+    level = "debug",
     name = "ff.observe_signals",
     skip_all,
     fields(
@@ -1090,6 +1093,7 @@ fn frame_kind_to_str(k: ff_core::backend::FrameKind) -> &'static str {
 /// for those constants is future work (RFC-012 §R7.5.6 shape
 /// commitment — not changing the wire under this refactor).
 #[tracing::instrument(
+    level = "debug",
     name = "ff.append_frame",
     skip_all,
     fields(
@@ -1499,6 +1503,7 @@ async fn wait_children_impl(
 /// Any other `ExecutionNotActive` combination surfaces the error
 /// so the caller learns what actually happened.
 #[tracing::instrument(
+    level = "debug",
     name = "ff.complete",
     skip_all,
     fields(


### PR DESCRIPTION
## Summary

Defensive mitigation from Worker SSSS's flame-capture investigation on issue #173 (see also `rfcs/drafts/scenario-5-flame-capture.md`). Downgrades 5 hot-path `EngineBackend` impl spans in `ff-backend-valkey` from implicit `info` to explicit `level = "debug"` so they compile out of the active path at the default production `RUST_LOG=info` filter.

### Why this is safe-and-cheap

SSSS's arithmetic: at `RUST_LOG=info`, a `debug`-level span is filtered at macro expansion time by `tracing`'s static max-level check — zero runtime cost, no allocation, no dispatcher hit. So even if Scenario 5's apparent regression turns out to be N=1 variance artifact (likely), this patch drops span overhead on the 5 per-attempt hot paths essentially to zero for operators running at info. Diagnostics remain a `RUST_LOG=ff_backend_valkey=debug` flip away.

### Functions downgraded (5)

- `complete_impl` → `ff.complete`
- `renew_impl` → `ff.renew`
- `progress_impl` → `ff.progress`
- `observe_signals_impl` → `ff.observe_signals`
- `append_frame_impl` → `ff.append_frame`

Non-hot impls (claim/suspend/delay/wait_children/describe_*/list_edges/cancel/fail/read_stream/tail_stream/create_waitpoint/report_usage/resolve_execution_flow_id/describe_edge/cancel_flow) deliberately remain at `info` — they fire rarely and the span is valuable when it does.

### Diff size

11 lines total (5 attr edits + CHANGELOG entry). Surgical.

## Test plan

- [x] `cargo check -p ff-backend-valkey --all-features` — clean
- [x] `cargo clippy -p ff-backend-valkey --all-targets -- -D warnings` — clean
- [x] `cargo test -p ff-backend-valkey --lib` — 13 passed, 0 failed
- [ ] Workspace CI (fmt/clippy/test matrix) green on PR

Refs: #173, `rfcs/drafts/scenario-5-flame-capture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)