### PR TITLE
docs(examples): Grafana dashboard JSON for 0.5.x operator observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Grafana dashboard JSON for operator observability** at
+  `examples/grafana/flowfabric-ops.json`. Ten panels covering claim
+  latency + rate, lease renewals, worker-at-capacity, admission
+  control (quota + budget), scanner cadence + latency, cancel backlog,
+  and HTTP request rate + latency. Built against the metrics
+  `ff-observability` emits through its OTEL → Prometheus pipeline
+  (post #170). Importable via Grafana UI or the `/api/dashboards/db`
+  endpoint; see `examples/grafana/README.md`. Positioned as the
+  0.5.x operator-visibility alternative while `ff-board` builds out.
 - **Observability wiring on `EngineBackend` trait methods (#154):** every
   non-stub `*_impl` in `ff-backend-valkey` now carries
   `#[tracing::instrument(name = "ff.<method>", skip_all, fields(backend,

--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -1,0 +1,150 @@
+# FlowFabric — Grafana Operator Dashboard
+
+A curated Grafana dashboard (`flowfabric-ops.json`) for FlowFabric
+operators. This is the 0.5.x alternative to the forthcoming Web UI
+(`ff-board`) and targets the "80% of operator visibility use cases"
+that the Web UI will later subsume.
+
+## What it shows
+
+Ten panels covering the metrics currently emitted by `ff-observability`
+through its OTEL → Prometheus exposition pipeline (as of PR #170):
+
+1. **Claim-from-grant latency (per lane)** — P50/P95/P99 over
+   `ff_claim_from_grant_duration_seconds`.
+2. **Claim-from-grant rate (per lane)** — observation rate of the same
+   histogram (`_count` series) by lane.
+3. **Lease renewals (by outcome)** — `ff_lease_renewal_total` split by
+   `outcome=ok|err`.
+4. **Worker-at-capacity rejections** — `ff_worker_at_capacity_total`.
+5. **Admission control — quota blocks & budget breaches** —
+   `ff_quota_hit_total` (reason=rate|concurrency) and
+   `ff_budget_hit_total` (dimension=...).
+6. **Scanner cycle duration P95** —
+   `ff_scanner_cycle_duration_seconds` by `scanner` label.
+7. **Scanner cycle cadence** — `ff_scanner_cycle_total` rate by
+   `scanner` label.
+8. **Cancel-reconciler backlog depth** — `ff_cancel_backlog_depth`
+   (observable gauge).
+9. **HTTP request rate (by status class)** — `ff_http_requests_total`
+   aggregated to 2xx / 3xx / 4xx / 5xx via `label_replace`.
+10. **HTTP P95 latency (by path)** — `ff_http_request_duration_seconds`
+    P95 by matched-route `path` label.
+
+## Importing
+
+### Grafana UI
+
+1. Open Grafana → **Dashboards** → **New** → **Import**.
+2. Upload `flowfabric-ops.json` (or paste its contents).
+3. On the import screen, pick the Prometheus datasource that scrapes
+   your ff-server's `/metrics` endpoint when prompted for the
+   `datasource` variable.
+4. Click **Import**.
+
+### HTTP API
+
+Grafana's dashboard API accepts the raw JSON wrapped in a
+`{"dashboard": ..., "overwrite": true}` envelope. Example using
+`curl`, a service-account token, and `jq`:
+
+```bash
+GRAFANA_URL="https://grafana.example.com"
+GRAFANA_TOKEN="glsa_..."   # service-account token with dashboard-write scope
+
+jq -n --slurpfile dash examples/grafana/flowfabric-ops.json \
+  '{dashboard: $dash[0], overwrite: true, message: "import FlowFabric ops dashboard"}' \
+  | curl -sS -X POST "$GRAFANA_URL/api/dashboards/db" \
+      -H "Authorization: Bearer $GRAFANA_TOKEN" \
+      -H "Content-Type: application/json" \
+      --data-binary @-
+```
+
+The dashboard is marked `editable: true`, so operators can customise
+panels, thresholds, and layout after import without forking this file.
+
+## Datasource configuration
+
+The dashboard uses a single templated datasource variable named
+`datasource` (type `prometheus`). It defaults to the name `prometheus`,
+which matches the name most Helm charts and `grafana.ini` examples use
+for the first Prometheus datasource.
+
+If your datasource has a different name — e.g. `Prometheus` (capital P),
+`prom-ha`, `mimir` — pick it from the datasource dropdown at the top of
+the dashboard after import; the selection is saved per-user.
+
+Your Prometheus must be configured to scrape ff-server's `/metrics`
+endpoint. A minimal scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: flowfabric
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["ff-server.default.svc.cluster.local:8080"]
+```
+
+The `/metrics` route is only mounted when ff-server is built with the
+`observability` feature and a `Metrics` registry is passed to
+`api::router_with_metrics(..)` (see `crates/ff-server/src/main.rs` and
+`crates/ff-server/src/api.rs`). Without that, `/metrics` returns 404
+and every panel on this dashboard stays empty.
+
+## Metric reference
+
+All names below are the **Prometheus-exposition** names (with the
+`_total` / `_seconds` suffixes that `opentelemetry_prometheus` appends
+automatically). They match `crates/ff-observability/src/real.rs`
+one-for-one.
+
+| Metric | Type | Labels | Emitted from |
+|---|---|---|---|
+| `ff_http_requests_total` | counter | `method`, `path`, `status` | ff-server HTTP middleware (`ff-server/src/metrics.rs`) |
+| `ff_http_request_duration_seconds` | histogram | `method`, `path`, `status` | ff-server HTTP middleware |
+| `ff_scanner_cycle_total` | counter | `scanner` | `ff-engine/src/scanner/mod.rs` — every cycle, regardless of work done |
+| `ff_scanner_cycle_duration_seconds` | histogram | `scanner` | same |
+| `ff_cancel_backlog_depth` | observable gauge | — | cancel-reconciler scanner, sampled per cycle |
+| `ff_claim_from_grant_duration_seconds` | histogram | `lane` | `ff-scheduler/src/claim.rs` |
+| `ff_lease_renewal_total` | counter | `outcome` (ok\|err) | `ff-backend-valkey` `renew_impl` (post PR #170) |
+| `ff_worker_at_capacity_total` | counter | — | `ff-scheduler` claim path |
+| `ff_budget_hit_total` | counter | `dimension` | `ff-scheduler` claim path, on `HardBreach` |
+| `ff_quota_hit_total` | counter | `reason` (rate\|concurrency) | `ff-scheduler` claim path |
+
+### Label-value reference
+
+* `scanner` — static name string provided by each scanner registration
+  (e.g. `cancel_reconciler`, `lease_reclaim`, etc., depending on which
+  scanners your deployment enables). The dashboard auto-discovers them
+  via `sum by (scanner)` — no config needed.
+* `lane` — lane label from ff-scheduler's claim-from-grant path (per
+  RFC-012 lane partitioning).
+* `outcome` — `ok` on successful lease renewal, `err` otherwise.
+* `dimension` — budget dimension string from the flow's `budgets`
+  config (e.g. `tokens`, `usd`, or user-defined).
+* `reason` — `rate` for rate-quota denials, `concurrency` for
+  concurrency-quota denials.
+* `path` — matched Axum route template, not raw URL (keeps cardinality
+  bounded per the RFC cardinality envelope of ~1 000 label-sets).
+
+## Known scope gaps (0.5.x)
+
+This dashboard is scoped strictly to what `ff-observability` emits
+today. A few operator-relevant signals the Web UI will eventually cover
+are **not** available here because no metric exists for them yet:
+
+* **Completion outcome split** (success / failed / cancelled / expired
+  rates). Completions are tracked in spans but not exported as a
+  counter.
+* **End-to-end claim-to-complete latency.**
+  `ff_claim_from_grant_duration_seconds` covers only the claim step.
+* **Queue depth per partition.** Not currently exported.
+* **Active / suspended execution counts.** Not currently exported.
+* **Error rate by `BackendErrorKind`.** Errors surface in logs and
+  spans; no counter is emitted.
+* **Worker instance count.** Not currently exported (use your service
+  discovery or `up{job="flowfabric"}` instead).
+
+Rather than invent metric names for these gaps, we defer them to
+ff-observability work. When those counters land, this dashboard will
+grow panels in a follow-up PR.

--- a/examples/grafana/flowfabric-ops.json
+++ b/examples/grafana/flowfabric-ops.json
@@ -1,0 +1,363 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "FlowFabric operator dashboard — the 0.5.x alternative to the forthcoming Web UI (ff-board). Panels are built against metrics emitted by the ff-observability OTEL pipeline exposed on ff-server's /metrics endpoint (post PR #170). Metric names are authoritative: they match ff-observability/src/real.rs exactly and include the Prometheus-exporter suffixes (_total, _seconds) automatically appended by opentelemetry_prometheus.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Claim-from-grant latency (per lane)",
+      "description": "Histogram quantiles over ff_claim_from_grant_duration_seconds. One series per quantile × lane. Rising P99 with flat P50 typically means tail contention on a specific lane; rising P50 means broad backend pressure.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum by (le, lane) (rate(ff_claim_from_grant_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 {{lane}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, lane) (rate(ff_claim_from_grant_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 {{lane}}"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, sum by (le, lane) (rate(ff_claim_from_grant_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 {{lane}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Claim-from-grant rate (per lane)",
+      "description": "Successful claim_from_grant operations per second, per lane. Histogram _count series gives the observation rate. Useful as the denominator when reasoning about latency spikes.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "stacking": { "mode": "normal", "group": "A" } }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (lane) (rate(ff_claim_from_grant_duration_seconds_count[$__rate_interval]))",
+          "legendFormat": "{{lane}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Lease renewals (by outcome)",
+      "description": "ff_lease_renewal_total split by outcome label (ok|err). A sustained err rate or a sharp drop in ok indicates lease-renewal failure — workers will lose their lease and the attempt will be reclaimed.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "err" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ok" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (outcome) (rate(ff_lease_renewal_total[$__rate_interval]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Worker-at-capacity rejections",
+      "description": "ff_worker_at_capacity_total — claim attempts rejected because every worker slot was busy. Sustained non-zero rate means you are under-provisioned on workers for the offered load.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(ff_worker_at_capacity_total[$__rate_interval]))",
+          "legendFormat": "rejections/s"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Admission control — quota blocks & budget breaches",
+      "description": "ff_quota_hit_total (reason=rate|concurrency) and ff_budget_hit_total (dimension=...) side-by-side. Quota hits are soft admission denials; budget hits are hard-breach events surfaced by ff-scheduler's claim path.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(ff_quota_hit_total[$__rate_interval]))",
+          "legendFormat": "quota:{{reason}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (dimension) (rate(ff_budget_hit_total[$__rate_interval]))",
+          "legendFormat": "budget:{{dimension}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Scanner cycle duration P95 (per scanner)",
+      "description": "P95 over ff_scanner_cycle_duration_seconds, grouped by scanner label. A scanner whose P95 climbs toward its sleep interval is about to fall behind — investigate partition count or Valkey latency.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, scanner) (rate(ff_scanner_cycle_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{scanner}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Scanner cycle cadence (per scanner)",
+      "description": "ff_scanner_cycle_total rate — cycles per second, one series per scanner. A stuck scanner stops producing data points here; a flatline at 0 (or the series disappearing) is the actionable signal. Reference values are scanner-specific sleep intervals.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (scanner) (rate(ff_scanner_cycle_total[$__rate_interval]))",
+          "legendFormat": "{{scanner}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Cancel-reconciler backlog depth",
+      "description": "ff_cancel_backlog_depth — observable gauge sampled by the cancel-reconciler scanner each cycle. Steady growth means the reconciler is not draining as fast as cancels are being requested; investigate cancel-processing throughput.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 32 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "ff_cancel_backlog_depth",
+          "legendFormat": "depth"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "HTTP request rate (by status class)",
+      "description": "ff_http_requests_total aggregated to status class (2xx/3xx/4xx/5xx). 5xx trend is the primary ff-server health signal; 4xx trend typically reflects client misuse (bad handles, missing tokens).",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "stacking": { "mode": "normal", "group": "A" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "5xx" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "4xx" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "2xx" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (class) (label_replace(rate(ff_http_requests_total[$__rate_interval]), \"class\", \"${1}xx\", \"status\", \"([0-9])[0-9][0-9]\"))",
+          "legendFormat": "{{class}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "HTTP request P95 latency (by path)",
+      "description": "P95 over ff_http_request_duration_seconds, grouped by path label. The path label is the matched route template (not the raw URL), so cardinality stays bounded per RFC cardinality envelope.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, path) (rate(ff_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{path}}"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["flowfabric", "operations", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "prometheus", "value": "prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "FlowFabric — Operator Observability",
+  "uid": "flowfabric-ops",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

In-tree Grafana dashboard JSON + operator README at `examples/grafana/`,
positioned as the 0.5.x alternative to the forthcoming `ff-board` Web UI
for the "80% of operator observability use cases."

Scope is strict: panels are built **only** against metrics
`ff-observability` actually emits through its OTEL → Prometheus pipeline
(post #170). Known-missing signals (completion outcome split, queue
depth per partition, active/suspended counts, error rate by
`BackendErrorKind`, worker count) are documented in the README as
deferred to follow-ups — rather than invented here.

## Panels (10)

1. Claim-from-grant latency P50/P95/P99 (per lane) —
   `ff_claim_from_grant_duration_seconds`
2. Claim-from-grant rate (per lane) — `_count` series of the same
3. Lease renewals by outcome — `ff_lease_renewal_total{outcome=ok|err}`
4. Worker-at-capacity rejections — `ff_worker_at_capacity_total`
5. Admission control (quota + budget) — `ff_quota_hit_total{reason}`
   and `ff_budget_hit_total{dimension}`
6. Scanner cycle P95 (per scanner) —
   `ff_scanner_cycle_duration_seconds`
7. Scanner cycle cadence (per scanner) — `ff_scanner_cycle_total`
8. Cancel-reconciler backlog depth — `ff_cancel_backlog_depth`
9. HTTP request rate by status class — `ff_http_requests_total` with
   `label_replace` into 2xx/3xx/4xx/5xx
10. HTTP P95 latency by path — `ff_http_request_duration_seconds`

## Metric source

Names + labels sourced one-for-one from
`crates/ff-observability/src/real.rs` with the `_total` / `_seconds`
suffixes that `opentelemetry_prometheus` appends at exposition.
Cross-checked against the call sites in `ff-server`, `ff-engine`, and
`ff-scheduler`, and against
`rfcs/drafts/observability-coverage-audit.md`.

## Import instructions

**Grafana UI:** Dashboards → New → Import → upload
`examples/grafana/flowfabric-ops.json`, pick your Prometheus
datasource when prompted for the `datasource` variable, Import.

**HTTP API:**

```bash
jq -n --slurpfile dash examples/grafana/flowfabric-ops.json \
  '{dashboard: $dash[0], overwrite: true, message: "import FlowFabric ops dashboard"}' \
  | curl -sS -X POST "$GRAFANA_URL/api/dashboards/db" \
      -H "Authorization: Bearer $GRAFANA_TOKEN" \
      -H "Content-Type: application/json" --data-binary @-
```

Dashboard is `editable: true` so operators can customise after import.
Single templated `datasource` variable (type `prometheus`, default
name `prometheus`).

## Test plan

- [x] `python3 -m json.tool` validates `flowfabric-ops.json`
- [ ] Manual: import into a Grafana 10+ instance pointed at a
      Prometheus that scrapes an ff-server `/metrics` endpoint; verify
      every panel resolves (even if empty before traffic)
- [ ] CI: pure docs + data; no Rust code touched — expect CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)