### PR TITLE
feat(ff-observability, ff-server): Sentry integration via FF_SENTRY_* env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   crate is for the consumer-in-library-mode use case. Release workflow,
   `docs/RELEASING.md`, and `release.toml` updated for the new
   publish-list entry (guarded by the drift check added in PR #132).
+- **Sentry error reporting (`ff-observability/sentry`, `ff-server/sentry`):**
+  opt-in Sentry integration for engine-side (`ff-server`, `ff-engine`) and
+  consumer-side binaries. New `ff_observability::init_sentry()` reads
+  `FF_SENTRY_DSN` / `FF_SENTRY_ENVIRONMENT` / `FF_SENTRY_RELEASE`;
+  `ff_observability::sentry_tracing_layer()` composes a `sentry-tracing`
+  layer into any `tracing_subscriber::registry()`. Both features are off
+  by default and compile out entirely (no `sentry` / `sentry-tracing`
+  crates in the dep tree) — orthogonal to `observability` (OTEL metrics).
+  `ff-server` calls `init_sentry()` early in `main()` when built with
+  `--features sentry`; `FF_SENTRY_DSN` unset is a graceful no-op. See
+  `docs/DEPLOYMENT.md` for the env-var table.
 - **Observability wiring on `EngineBackend` trait methods (#154):** every
   non-stub `*_impl` in `ff-backend-valkey` now carries
   `#[tracing::instrument(name = "ff.<method>", skip_all, fields(backend,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -463,6 +481,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -673,6 +715,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +742,16 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -880,6 +942,10 @@ dependencies = [
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "prometheus",
+ "sentry",
+ "sentry-tracing",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -903,7 +969,7 @@ dependencies = [
  "ff-server",
  "ff-test",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde_json",
  "serial_test",
  "tokio",
@@ -942,7 +1008,7 @@ dependencies = [
  "ff-backend-valkey",
  "ff-core",
  "ff-script",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -988,7 +1054,7 @@ dependencies = [
  "ff-sdk",
  "ff-server",
  "futures",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serial_test",
@@ -1197,6 +1263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -1789,6 +1872,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +1956,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +2169,22 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2094,6 +2373,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2292,6 +2572,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,6 +2653,12 @@ dependencies = [
  "syn",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -2518,6 +2844,103 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "sentry"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.2",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
+dependencies = [
+ "bitflags",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -2811,6 +3234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3073,6 +3497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3524,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3561,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3107,6 +3569,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/ff-observability/Cargo.toml
+++ b/crates/ff-observability/Cargo.toml
@@ -22,6 +22,13 @@ enabled = [
     "dep:opentelemetry-prometheus",
     "dep:prometheus",
 ]
+# OFF by default. When ON, exposes `init_sentry()` which installs a
+# Sentry client + `sentry-tracing` layer when `FF_SENTRY_DSN` is set.
+# When OFF, neither sentry nor sentry-tracing appears in the dep tree.
+# Enabled transitively through `ff-server/sentry`. Orthogonal to
+# `enabled` (OTEL metrics) — the two features do not depend on each
+# other.
+sentry = ["dep:sentry", "dep:sentry-tracing", "dep:tracing", "dep:tracing-subscriber"]
 
 [dependencies]
 # Exact-patch pins. Plan §3 locked OTEL 0.27.x, but `opentelemetry-
@@ -41,3 +48,15 @@ opentelemetry = { version = "=0.31.0", default-features = false, features = ["me
 opentelemetry_sdk = { version = "=0.31.0", default-features = false, features = ["metrics"], optional = true }
 opentelemetry-prometheus = { version = "=0.31.0", optional = true }
 prometheus = { version = "=0.14.0", default-features = false, optional = true }
+
+# Sentry error reporting. Gated behind the `sentry` feature (orthogonal
+# to `enabled`). Caret-ranged on the current stable minor — the sentry
+# Rust SDK follows semver on the 0.x line and we want security patches
+# without a manual bump. Re-pin deliberately if a breaking minor lands.
+sentry = { version = "0.47", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"], optional = true }
+sentry-tracing = { version = "0.47", optional = true }
+# Only pulled when `sentry` is on — the layer returned from
+# `sentry_tracing_layer()` is generic over a `tracing::Subscriber`
+# registry, so the trait bounds need both crates in scope.
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"], optional = true }

--- a/crates/ff-observability/src/lib.rs
+++ b/crates/ff-observability/src/lib.rs
@@ -30,3 +30,13 @@ mod shim;
 pub use real::Metrics;
 #[cfg(not(feature = "enabled"))]
 pub use shim::Metrics;
+
+// Sentry error-reporting module. Gated behind the `sentry` feature,
+// orthogonal to `enabled` (OTEL metrics) — consumers can turn either
+// on without pulling the other. See [`sentry`] module docs for the
+// env-var contract and usage.
+#[cfg(feature = "sentry")]
+pub mod sentry;
+
+#[cfg(feature = "sentry")]
+pub use sentry::{init_sentry, tracing_layer as sentry_tracing_layer};

--- a/crates/ff-observability/src/sentry.rs
+++ b/crates/ff-observability/src/sentry.rs
@@ -1,0 +1,101 @@
+//! Sentry error-reporting integration (feature `sentry`).
+//!
+//! Opt-in error reporting for both engine-side (`ff-server`, `ff-engine`)
+//! and consumer-side processes. Compiled out entirely when the `sentry`
+//! feature is off; when on, exposes a single [`init_sentry`] entry point
+//! that wires the Sentry client + a `sentry-tracing` layer into the
+//! tracing subscriber installed by the caller.
+//!
+//! # Env-var contract
+//!
+//! All configuration is via `FF_SENTRY_*` env vars. No other code path
+//! sets Sentry state, so a consumer that does not set `FF_SENTRY_DSN`
+//! gets a zero-runtime-cost no-op — no network, no background thread.
+//!
+//! | Variable               | Required | Default           | Purpose                                                                   |
+//! | ---------------------- | -------- | ----------------- | ------------------------------------------------------------------------- |
+//! | `FF_SENTRY_DSN`        | yes      | —                 | Sentry project DSN. If unset, [`init_sentry`] returns `None` (no-op).     |
+//! | `FF_SENTRY_ENVIRONMENT`| no       | `"production"`    | Sentry `environment` tag. Set to `staging`, `dev`, etc.                   |
+//! | `FF_SENTRY_RELEASE`    | no       | crate `CARGO_PKG_VERSION` | Sentry `release` tag. Override to wire in a git SHA or build ID. |
+//!
+//! # Usage
+//!
+//! Call [`init_sentry`] **before** installing the tracing subscriber,
+//! then compose [`tracing_layer`] into the subscriber so
+//! `tracing::error!` events become Sentry events:
+//!
+//! ```ignore
+//! use tracing_subscriber::prelude::*;
+//!
+//! let _sentry_guard = ff_observability::init_sentry();
+//! tracing_subscriber::registry()
+//!     .with(tracing_subscriber::fmt::layer())
+//!     .with(tracing_subscriber::EnvFilter::from_default_env())
+//!     .with(ff_observability::sentry_tracing_layer())
+//!     .init();
+//! // `_sentry_guard` must live until shutdown; dropping it flushes
+//! // buffered events.
+//! ```
+//!
+//! The returned [`sentry::ClientInitGuard`] must be held for the process
+//! lifetime — dropping it early flushes and disables reporting.
+
+/// Initialize Sentry from `FF_SENTRY_*` env vars.
+///
+/// Returns `Some(guard)` when `FF_SENTRY_DSN` is set and non-empty;
+/// returns `None` when the DSN is unset or empty (graceful no-op).
+/// Callers should hold the `Option` for the process lifetime regardless
+/// — dropping `Some(guard)` early flushes and disables reporting.
+///
+/// This function only installs the Sentry **client**; it does NOT touch
+/// the tracing subscriber. To bridge `tracing::error!` events into
+/// Sentry, compose [`tracing_layer`] into your subscriber (see module
+/// docs).
+///
+/// # Env vars honored
+///
+/// - `FF_SENTRY_DSN` — required; absence disables.
+/// - `FF_SENTRY_ENVIRONMENT` — optional, default `"production"`.
+/// - `FF_SENTRY_RELEASE` — optional, default this crate's version.
+#[must_use = "drop the guard at shutdown to flush buffered events"]
+pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
+    let dsn = std::env::var("FF_SENTRY_DSN")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+
+    let environment = std::env::var("FF_SENTRY_ENVIRONMENT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "production".to_string());
+
+    let release = std::env::var("FF_SENTRY_RELEASE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    let guard = sentry::init((
+        dsn,
+        sentry::ClientOptions {
+            release: Some(release.into()),
+            environment: Some(environment.into()),
+            ..Default::default()
+        },
+    ));
+
+    Some(guard)
+}
+
+/// Returns a `sentry-tracing` layer for composing into a
+/// `tracing_subscriber` registry. Compose this *after* calling
+/// [`init_sentry`]; events recorded before the client is initialized
+/// are dropped.
+///
+/// The layer is cheap to construct even when no DSN is set — Sentry's
+/// hub short-circuits when the client is a no-op.
+pub fn tracing_layer<S>() -> sentry_tracing::SentryLayer<S>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    sentry_tracing::layer()
+}
+

--- a/crates/ff-server/Cargo.toml
+++ b/crates/ff-server/Cargo.toml
@@ -25,6 +25,12 @@ observability = [
     "ff-engine/observability",
     "ff-scheduler/observability",
 ]
+# OFF by default. When ON, links `sentry` + `sentry-tracing` and calls
+# `ff_observability::init_sentry()` early in `main()` so `FF_SENTRY_DSN`
+# wires process-wide error reporting. When OFF, neither crate is in the
+# dep tree and the init call compiles out entirely. Orthogonal to
+# `observability` — metrics and error reporting are independent axes.
+sentry = ["ff-observability/sentry"]
 
 [dependencies]
 ff-core = { workspace = true }

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -17,20 +17,38 @@ async fn main() {
         return;
     }
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| {
-                    // `audit=info` is non-negotiable: rotation, security-kid
-                    // changes, and other compliance events use
-                    // `tracing::*!(target: "audit", ...)`. Without this
-                    // directive the default subscriber silently drops every
-                    // audit event (module-path directives like `ff_server=info`
-                    // do not match custom targets).
-                    "ff_server=info,ff_engine=info,ff_script=info,tower_http=debug,audit=info".into()
-                }),
-        )
-        .init();
+    // Initialize Sentry before tracing so the client is live when the
+    // `sentry-tracing` bridge starts forwarding events. No-op when
+    // `FF_SENTRY_DSN` is unset; compiles out when the `sentry` feature
+    // is off. Guard must live until the process exits to flush buffered
+    // events on drop.
+    #[cfg(feature = "sentry")]
+    let _sentry_guard = ff_observability::init_sentry();
+
+    // `audit=info` is non-negotiable: rotation, security-kid changes,
+    // and other compliance events use `tracing::*!(target: "audit",
+    // ...)`. Without this directive the default subscriber silently
+    // drops every audit event (module-path directives like
+    // `ff_server=info` do not match custom targets).
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| {
+            tracing_subscriber::EnvFilter::new(
+                "ff_server=info,ff_engine=info,ff_script=info,tower_http=debug,audit=info",
+            )
+        });
+
+    // Registry-based composition so the Sentry layer can attach
+    // alongside `fmt` when the `sentry` feature is on. Without the
+    // feature, only `fmt` + `env_filter` are installed — identical
+    // to the previous `fmt().with_env_filter().init()` shape.
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    let subscriber = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer());
+    #[cfg(feature = "sentry")]
+    let subscriber = subscriber.with(ff_observability::sentry_tracing_layer());
+    subscriber.init();
 
     let config = match ServerConfig::from_env() {
         Ok(c) => c,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -137,6 +137,21 @@ they drive timeouts, promotions, reconciliation, and retention.
 | `FF_API_TOKEN`    | Random 32+ byte secret, base64.        | Without it, every route except `GET /healthz` is unauthenticated.           |
 | `FF_CORS_ORIGINS` | Comma-separated allowlist, or `*`      | Default is permissive (`*`). Tighten before exposing the API to browsers.   |
 
+### Optional: Sentry error reporting
+
+Enable the `sentry` feature on `ff-server` (or a consumer binary that
+depends on `ff-observability`) to ship `tracing::error!` events and
+panics to a Sentry project. All configuration is via `FF_SENTRY_*` env
+vars; leaving `FF_SENTRY_DSN` unset is a graceful no-op (no network, no
+background thread). See `ff-observability::sentry` rustdoc for the full
+contract.
+
+| Variable                | Default                  | Purpose                                                          |
+| ----------------------- | ------------------------ | ---------------------------------------------------------------- |
+| `FF_SENTRY_DSN`         | unset (disables)         | Sentry project DSN. Required to activate.                        |
+| `FF_SENTRY_ENVIRONMENT` | `production`             | Sentry `environment` tag (`staging`, `dev`, …).                  |
+| `FF_SENTRY_RELEASE`     | crate `CARGO_PKG_VERSION`| Sentry `release` tag — wire in a git SHA or build ID here.       |
+
 The complete list of variables (all the scanner intervals, partition
 counts, etc.) is in the rustdoc for
 [`ServerConfig::from_env`](../crates/ff-server/src/config.rs) and mirrored


### PR DESCRIPTION
## Summary

Opt-in Sentry error reporting for engine-side (`ff-server`, `ff-engine`) and consumer-side binaries, per Observability RFC adjudications.

## Feature-flag shape

- **`ff-observability`** gains a flat `sentry` feature (orthogonal to `enabled` — OTEL metrics and error reporting are independent axes). When off, no `sentry` / `sentry-tracing` crates in the dep tree.
- **`ff-server`** gains a flat `sentry` feature that activates `ff-observability/sentry` and wires `init_sentry()` into `main()`.
- Both features OFF by default. Default builds are byte-identical to `main`.

## Env vars honored (3)

| Variable                | Default                   | Purpose                                            |
| ----------------------- | ------------------------- | -------------------------------------------------- |
| `FF_SENTRY_DSN`         | unset (no-op)             | Sentry project DSN. Required to activate.          |
| `FF_SENTRY_ENVIRONMENT` | `production`              | Sentry `environment` tag.                          |
| `FF_SENTRY_RELEASE`     | crate `CARGO_PKG_VERSION` | Sentry `release` tag — override with git SHA/build ID. |

`FF_SENTRY_DSN` unset (or empty) returns `None` from `init_sentry()` and is a graceful no-op — no network, no background thread.

## Integration points

- `ff-server/src/main.rs`: calls `ff_observability::init_sentry()` before tracing init (so the `sentry-tracing` bridge is live from the first event). Tracing subscriber refactored from `fmt().init()` to registry composition so the Sentry layer attaches alongside `fmt` + `env_filter` when the feature is on; behavior unchanged when off.
- Consumers (binaries depending on `ff-observability`) can enable `ff-observability/sentry` directly and follow the same pattern — module rustdoc shows the registry-composition snippet.

## Crate version

- `sentry = "0.47"` (caret-ranged on the current stable minor; project policy is no forced version pin).
- `sentry-tracing = "0.47"`.
- Enabled features: `backtrace`, `contexts`, `panic`, `reqwest`, `rustls` (no default `native-tls`).

## Doc location

- `ff-observability/src/sentry.rs` — module rustdoc with env-var table + usage snippet.
- `docs/DEPLOYMENT.md` — new "Optional: Sentry error reporting" subsection under the env-var tables.
- `CHANGELOG.md` — `### Added` entry under `[Unreleased]`.

## Tests

- `cargo check -p ff-observability` (default + `--features sentry`): clean.
- `cargo check -p ff-server` (default + `--features sentry`): clean.
- `cargo clippy -p ff-observability -p ff-server --all-targets` (default + `--features ff-server/sentry`) with `-D warnings`: clean.
- `cargo test -p ff-observability --features sentry`: clean (doc-test marked `ignore` because it needs real tracing init).

## Test plan

- [x] Default build (no features) compiles without sentry deps
- [x] `--features sentry` compiles on both crates
- [x] Clippy `-D warnings` clean in both modes
- [x] `FF_SENTRY_DSN` unset returns `None` from `init_sentry()` (code-reviewed; no test because env-var mutation is `unsafe` under 2024 edition + `#![forbid(unsafe_code)]`)
- [ ] Manual smoke: run `ff-server` with `FF_SENTRY_DSN=<real-dsn>` and verify events land in the Sentry project

## Hard-rule compliance

- Additive only — `ff-server` main refactor is behavior-preserving (same filter, same init order).
- Both sentry features OFF by default.
- No `--no-verify`.
- Isolated worktree (`/home/ubuntu/ff-worker-bbbbb-sentry`).

Co-authored per project policy.