### PR TITLE
feat(ff-observability-http): new crate for consumer-side /metrics endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@
 #     `publish-new` + `publish-update`.
 #   - GITHUB_TOKEN is auto-provided by GHA; `gh release create` uses it.
 #
-# Publish set (9 crates, topologically ordered):
+# Publish set (10 crates, topologically ordered):
 #   ferriskey -> ff-core -> ff-script -> ff-observability
+#     -> ff-observability-http
 #     -> ff-backend-valkey -> ff-engine -> ff-scheduler
 #     -> ff-sdk -> ff-server
 # ff-test is dev-only (publish = false) and not in the set.
@@ -136,7 +137,10 @@ jobs:
       # the Tier 1 envelope collapse (PR #18) inlined the former
       # telemetrylib sub-crate. ff-core is a leaf. ff-script depends on
       # ff-core. ff-observability is a leaf (added in v0.3.1 after v0.3.0
-      # partial-published). ff-backend-valkey depends on ff-core + ff-script
+      # partial-published). ff-observability-http depends on
+      # ff-observability (+ axum) — consumer-side /metrics endpoint for
+      # library-mode consumers that don't pull ff-server.
+      # ff-backend-valkey depends on ff-core + ff-script
       # (added in v0.3.2 after v0.3.1 partial-published). ff-engine depends
       # on ff-core + ff-observability. ff-scheduler depends on ff-core +
       # ff-script + ff-observability. ff-sdk depends on ff-core + ff-script
@@ -191,6 +195,20 @@ jobs:
             exit 1
           }
       - run: sleep 30
+      - name: publish ff-observability-http
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          VER="${TAG_VERSION#v}"
+          cargo publish -p ff-observability-http --no-verify || {
+            echo "::error::cargo publish ff-observability-http failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
+            echo "::error::  cargo yank --version ${VER} ff-observability"
+            exit 1
+          }
+      - run: sleep 30
       - name: publish ff-backend-valkey
         env:
           TAG_VERSION: ${{ github.ref_name }}
@@ -202,6 +220,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-observability-http"
             exit 1
           }
       - run: sleep 30
@@ -216,6 +235,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             exit 1
           }
@@ -231,6 +251,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             exit 1
@@ -247,6 +268,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
@@ -264,6 +286,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-core"
             echo "::error::  cargo yank --version ${VER} ff-script"
             echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-scheduler"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (post #170). Importable via Grafana UI or the `/api/dashboards/db`
   endpoint; see `examples/grafana/README.md`. Positioned as the
   0.5.x operator-visibility alternative while `ff-board` builds out.
+- **`ff-observability-http` crate — consumer-side Prometheus `/metrics`
+  HTTP endpoint.** New publishable workspace member that bridges
+  `ff-observability`'s OTEL + Prometheus registry to an `axum::Router`
+  so consumers embedding `ff-sdk` in library mode can expose a scrape
+  endpoint without also pulling `ff-server`. Two entry points:
+  `router(Arc<Metrics>) -> axum::Router` for merging into an existing
+  app, and `serve(addr, Arc<Metrics>)` for a standalone listener. Feature
+  model mirrors `ff-observability`: `enabled` off by default, ON
+  transitively enables `ff-observability/enabled`. Per the Observability
+  RFC adjudication, this ships as a separate crate (not a feature on
+  `ff-sdk`) so axum is only pulled into consumers that opt in.
+  `ff-server` keeps its own built-in `/metrics` route (PR #94) — this
+  crate is for the consumer-in-library-mode use case. Release workflow,
+  `docs/RELEASING.md`, and `release.toml` updated for the new
+  publish-list entry (guarded by the drift check added in PR #132).
 - **Observability wiring on `EngineBackend` trait methods (#154):** every
   non-stub `*_impl` in `ff-backend-valkey` now carries
   `#[tracing::instrument(name = "ff.<method>", skip_all, fields(backend,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff-observability-http"
+version = "0.4.0"
+dependencies = [
+ "axum",
+ "ff-observability",
+ "tokio",
+]
+
+[[package]]
 name = "ff-readiness-tests"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/ff-readiness-tests",
     "crates/ff-backend-valkey",
     "crates/ff-observability",
+    "crates/ff-observability-http",
 ]
 
 [workspace.package]
@@ -42,6 +43,7 @@ ff-server = { version = "0.4.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
 ff-backend-valkey = { version = "0.4.0", path = "crates/ff-backend-valkey" }
 ff-observability = { version = "0.4.0", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.4.0", path = "crates/ff-observability-http" }
 ferriskey = { version = "0.4.0", path = "ferriskey" }
 
 # Shared external deps

--- a/crates/ff-observability-http/Cargo.toml
+++ b/crates/ff-observability-http/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ff-observability-http"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "FlowFabric consumer-side Prometheus /metrics HTTP endpoint — bridges ff-observability's registry to an axum Router for consumers embedding ff-sdk without ff-server"
+
+[features]
+# OFF by default — the router mounts and `render()` returns empty text
+# until the consumer enables the real OTEL backend on `ff-observability`.
+# Turning `enabled` ON here transitively enables
+# `ff-observability/enabled`, matching the pattern used by the other
+# consumer-feature gates (`ff-server/observability`,
+# `ff-engine/observability`). Keep call shape identical under both
+# configurations so consumers don't branch on the feature.
+default = []
+enabled = ["ff-observability/enabled"]
+
+[dependencies]
+# ff-observability is the single owner of the OTEL/Prometheus deps —
+# this crate only wires its `render()` output into an axum Router so
+# consumers get `/metrics` without pulling ff-server.
+ff-observability = { workspace = true }
+axum = { workspace = true }
+tokio = { workspace = true, features = ["net"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util"] }

--- a/crates/ff-observability-http/src/lib.rs
+++ b/crates/ff-observability-http/src/lib.rs
@@ -1,0 +1,94 @@
+//! FlowFabric consumer-side Prometheus `/metrics` HTTP endpoint.
+//!
+//! This crate bridges the [`ff_observability::Metrics`] registry (the
+//! single owner of the OTEL + Prometheus dep surface) to an axum
+//! [`Router`] so consumers embedding `ff-sdk` in library mode can expose
+//! a scrape endpoint without also pulling `ff-server`.
+//!
+//! `ff-server` has its own `/metrics` wiring (see `ff-server::metrics`
+//! PR #94); this crate is for the consumer-in-library-mode use case
+//! where no ff-server process exists.
+//!
+//! ## Shape
+//!
+//! Two entry points, both thin:
+//!
+//! * [`router`] — returns an `axum::Router` the consumer merges into
+//!   their own axum app. Mounts `GET /metrics`.
+//! * [`serve`] — convenience: binds the address and runs the router
+//!   on the current tokio runtime. Use only when you don't already
+//!   have an axum app.
+//!
+//! ## Feature model
+//!
+//! Matches `ff-observability`. The `enabled` feature on this crate
+//! transitively enables `ff-observability/enabled`, so a consumer
+//! only needs one feature flag in their own `Cargo.toml`:
+//!
+//! ```toml
+//! ff-observability-http = { version = "0.4", features = ["enabled"] }
+//! ```
+//!
+//! With the feature OFF, [`Metrics::render`](ff_observability::Metrics::render)
+//! returns an empty string and `/metrics` responds 200 with an empty
+//! body — the consumer can still wire the route unconditionally.
+//!
+//! ## Authentication
+//!
+//! The endpoint is intentionally unauthenticated, matching Prometheus
+//! operational convention: network-layer (ingress ACL, service-mesh
+//! policy, or interface-bind) gates scrape access. If you need auth,
+//! mount [`router`] behind your own middleware stack.
+
+#![forbid(unsafe_code)]
+
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    extract::State,
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use ff_observability::Metrics;
+
+/// Build an axum [`Router`] with `GET /metrics` mounted.
+///
+/// The returned router owns an `Arc<Metrics>` so it is cheap to clone
+/// and safe to `merge` into a larger app. The handler responds with
+/// Prometheus text exposition format (`text/plain; version=0.0.4`).
+pub fn router(metrics: Arc<Metrics>) -> Router {
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .with_state(metrics)
+}
+
+/// Bind `addr` and serve the metrics router until the task is cancelled.
+///
+/// Convenience wrapper for consumers that don't already have an axum
+/// app. Uses [`tokio::net::TcpListener`] + [`axum::serve`] directly so
+/// there is no extra runtime configuration to think about.
+///
+/// Returns an [`io::Error`] if the bind fails. Runtime errors from
+/// `axum::serve` surface through the same error type.
+pub async fn serve(addr: SocketAddr, metrics: Arc<Metrics>) -> io::Result<()> {
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router(metrics)).await
+}
+
+/// GET /metrics handler. Returns Prometheus text exposition.
+async fn metrics_handler(State(metrics): State<Arc<Metrics>>) -> Response {
+    let body = metrics.render();
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+        )],
+        body,
+    )
+        .into_response()
+}

--- a/crates/ff-observability-http/tests/metrics.rs
+++ b/crates/ff-observability-http/tests/metrics.rs
@@ -1,0 +1,58 @@
+//! Integration test: spin the `/metrics` endpoint and hit it.
+//!
+//! Runs only when the `enabled` feature is on — that's the only
+//! configuration where `Metrics::render()` produces non-empty output,
+//! which is what the assertion checks for. Under the default (disabled)
+//! build the test is compiled out so the crate's own CI-default matrix
+//! stays clean.
+
+#![cfg(feature = "enabled")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ff_observability::Metrics;
+use ff_observability_http::router;
+
+#[tokio::test]
+async fn metrics_endpoint_serves_prometheus_text() {
+    let metrics = Arc::new(Metrics::new());
+    // Emit at least one sample so the exposition body is non-empty.
+    metrics.inc_lease_renewal("ok");
+
+    // Bind to an ephemeral port, capture the actual addr, then serve.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = router(Arc::clone(&metrics));
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Minimal HTTP/1.1 GET — avoids adding `reqwest` / `hyper-util`
+    // just for this one probe. We only need status + body substring.
+    let resp = raw_get(addr, "/metrics").await;
+    assert!(resp.starts_with("HTTP/1.1 200"), "status line: {resp:?}");
+    assert!(
+        resp.contains("ff_lease_renewal_total")
+            || resp.contains("ff_lease_renewal"),
+        "expected a metric line in body, got: {resp}"
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+async fn raw_get(addr: std::net::SocketAddr, path: &str) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let req = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes()).await.unwrap();
+    let mut buf = Vec::with_capacity(8192);
+    let read = tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut buf))
+        .await
+        .expect("response within 5s")
+        .unwrap();
+    assert!(read > 0, "empty response");
+    String::from_utf8_lossy(&buf).into_owned()
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,7 @@ This doc covers the operator workflow for cutting a release. Tooling lives in
 
 ## What gets published
 
-Nine crates, all pinned to the same version, published in topological order:
+Ten crates, all pinned to the same version, published in topological order:
 
 1. `ferriskey`       — Valkey client (reparented fork of glide-core;
    the former `telemetrylib` sub-crate was inlined during the Tier 1
@@ -17,20 +17,26 @@ Nine crates, all pinned to the same version, published in topological order:
    shim. Added to the publish set in v0.3.1 after v0.3.0
    partial-published (ff-engine depends on it as a workspace dep
    and its publish step fails without it being on crates.io).
-5. `ff-backend-valkey` — RFC-012 EngineBackend trait Valkey impl,
+5. `ff-observability-http` — consumer-side Prometheus `/metrics` HTTP
+   endpoint (axum Router + `serve()` convenience). Bridges
+   `ff-observability`'s registry to a scrape endpoint for consumers
+   embedding `ff-sdk` in library mode without `ff-server`. Added to
+   the publish set alongside its introduction; `ff-server` still
+   ships its own built-in `/metrics` route (PR #94).
+6. `ff-backend-valkey` — RFC-012 EngineBackend trait Valkey impl,
    separated from ff-sdk in RFC-012 Stage 1a. Added to the publish
    set in v0.3.2 after v0.3.1 partial-published (ff-sdk depends on
    it as a workspace dep and its publish step fails without it
    being on crates.io).
-6. `ff-engine`       — cross-partition dispatch + scanners
+7. `ff-engine`       — cross-partition dispatch + scanners
    (includes the `completion_listener` module for push-based DAG
    promotion; see [`rfc011-operator-runbook.md`](rfc011-operator-runbook.md)
    §"DAG promotion: push listener + safety-net reconciler")
-7. `ff-scheduler`    — claim-grant scheduler
-8. `ff-sdk`          — worker SDK. `direct-valkey-claim` feature is
+8. `ff-scheduler`    — claim-grant scheduler
+9. `ff-sdk`          — worker SDK. `direct-valkey-claim` feature is
    off by default; production deployments use the scheduler-routed
    HTTP path via `FlowFabricWorker::claim_via_server`
-9. `ff-server`       — HTTP server library + binary
+10. `ff-server`      — HTTP server library + binary
 
 Excluded from publish:
 
@@ -57,7 +63,7 @@ Before cutting a release, verify:
 - [ ] `CARGO_REGISTRY_TOKEN` is configured in repo settings (Settings →
       Secrets and variables → Actions). Generate at
       <https://crates.io/me> → API Tokens with scope `publish-new` +
-      `publish-update`. The token must have upload rights to all nine
+      `publish-update`. The token must have upload rights to all ten
       crate names — claim them on crates.io first if they are new.
 - [ ] Working on a release branch (`main` or `release/*`).
 - [ ] Working tree is clean.

--- a/release.toml
+++ b/release.toml
@@ -2,13 +2,18 @@
 #
 # This config drives `cargo release <level>` to perform a consolidated,
 # workspace-wide version bump across the publishable crates:
-#   ferriskey, ff-core, ff-script, ff-observability, ff-backend-valkey,
+#   ferriskey, ff-core, ff-script, ff-observability,
+#   ff-observability-http, ff-backend-valkey,
 #   ff-engine, ff-scheduler, ff-sdk, ff-server
 # The former telemetrylib sub-crate was inlined into ferriskey in
 # PR #18; it is no longer a separate publish target. ff-observability
 # was added to the publish set in v0.3.1 after v0.3.0
 # partial-published. ff-backend-valkey was added to the publish set
 # in v0.3.2 after v0.3.1 partial-published (ff-sdk depends on it).
+# ff-observability-http was added alongside its introduction as a
+# consumer-side /metrics endpoint (axum bridge on top of
+# ff-observability); ff-server keeps its own built-in /metrics route
+# per PR #94.
 #
 # Intentionally excluded from the bump (via [package.metadata.release]
 # release = false in each crate's Cargo.toml):


### PR DESCRIPTION
## Summary

New publishable workspace crate `ff-observability-http` exposing a Prometheus `/metrics` HTTP endpoint for consumers embedding `ff-sdk` in library mode without `ff-server`. Per the Observability RFC adjudication, this ships as a **separate crate** (not a feature on `ff-sdk`) so axum only lands in consumers that opt in. `ff-server`'s own `/metrics` route (PR #94) is untouched.

## Rationale

The Observability RFC owner-lock called out the consumer-in-library-mode gap: consumers wiring `ff-sdk` directly into their own process (no ff-server) had no way to expose a scrape endpoint without re-implementing the exposition handler. Putting it behind a feature on `ff-sdk` would contaminate the ff-sdk dep tree with axum for every consumer; a separate crate keeps the axum pull opt-in via one dep line.

## Shape

- `router(Arc<Metrics>) -> axum::Router` — merges into an existing axum app.
- `serve(addr, Arc<Metrics>) -> io::Result<()>` — standalone listener, uses `tokio::net::TcpListener` + `axum::serve` directly.
- `enabled` feature transitively enables `ff-observability/enabled`; default-off so the endpoint responds 200 with empty text until the consumer opts into the real OTEL backend. Mirrors the existing `ff-server/observability` + `ff-engine/observability` feature pattern.

## Verification

- `cargo build --workspace` green.
- `cargo package -p ff-observability-http --allow-dirty` green.
- `cargo test -p ff-observability-http --features enabled` — 1 integration test passes (binds ephemeral port, emits one sample, hits GET /metrics over raw TCP, asserts 200 + `ff_lease_renewal` body line).
- `cargo clippy -p ff-observability-http --all-targets --features enabled -- -D warnings` clean.
- Local run of the publish-list drift check (PR #132 gate) passes.

## Publish-list drift update (mandatory)

Triggered the PR #132 drift guard by adding a new publishable crate. Updated in the same PR to avoid the v0.3.0 class of failure:

- `.github/workflows/release.yml` — `cargo publish -p ff-observability-http` step inserted topologically between ff-observability and ff-backend-valkey; downstream yank-error lists (ff-engine, ff-scheduler, ff-sdk, ff-server) updated to include the new crate.
- `docs/RELEASING.md` — 10-crate list with rationale for the new entry.
- `release.toml` — crate-list comment refreshed.
- `CHANGELOG.md` — Unreleased `### Added` entry.

## Test plan

- [ ] CI: `build --workspace` green
- [ ] CI: `publish-list drift check` green (will catch any missed release-surface update)
- [ ] CI: `cargo test -p ff-observability-http --features enabled` green
- [ ] CI: clippy + machete + semver-checks green
- [ ] Manual: consumer can mount `router(metrics)` into their own axum app and `GET /metrics` returns text-exposition body

🤖 Generated with [Claude Code](https://claude.com/claude-code)