### PR TITLE
feat(ff-observability, ff-backend-valkey): ff_attempt_outcome_total counter metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`ff_attempt_outcome_total` counter metric** (`ff-observability` +
+  `ff-backend-valkey`). Labelled by `lane` + `outcome`
+  (`ok`|`error`|`timeout`|`cancelled`|`retry`), fired at the
+  `EngineBackend` trait boundary after `complete` / `fail` / `cancel`
+  succeed on the backend FCALL (including reconciled terminal replays).
+  Cardinality bounded at 5 × N lanes (accepted at 5×16=80 per
+  Observability RFC prereq #4). Surfaces as panel 11 ("Attempt outcomes
+  per lane") on `examples/grafana/flowfabric-ops.json`. Public
+  `ff_observability::AttemptOutcome` enum is feature-agnostic so call
+  sites stay symmetric whether `observability` is on or off.
 - **Grafana dashboard JSON for operator observability** at
   `examples/grafana/flowfabric-ops.json`. Ten panels covering claim
   latency + rate, lease renewals, worker-at-capacity, admission

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -1962,11 +1962,18 @@ impl EngineBackend for ValkeyBackend {
 
     async fn complete(&self, handle: &Handle, payload: Option<Vec<u8>>) -> Result<(), EngineError> {
         let f = handle_codec::decode_handle(handle)?;
-        complete_impl(&self.client, &self.partition_config, &f, payload)
+        let result = complete_impl(&self.client, &self.partition_config, &f, payload)
             .await
             .map_err(|e| {
                 ff_core::engine_error::backend_context(e, "complete: FCALL ff_complete_execution")
-            })
+            });
+        // Fire `ff_attempt_outcome_total` only after the FCALL-side
+        // terminal is confirmed (Ok, including reconciled replays).
+        // Errors pre-terminal do NOT count as an outcome.
+        if let (Ok(()), Some(metrics)) = (&result, &self.metrics) {
+            metrics.inc_attempt_outcome(f.lane_id.as_str(), ff_observability::AttemptOutcome::Ok);
+        }
+        result
     }
 
     async fn fail(
@@ -1976,7 +1983,8 @@ impl EngineBackend for ValkeyBackend {
         classification: FailureClass,
     ) -> Result<FailOutcome, EngineError> {
         let f = handle_codec::decode_handle(handle)?;
-        fail_impl(
+        let is_timeout = classification == FailureClass::Timeout;
+        let result = fail_impl(
             &self.client,
             &self.partition_config,
             &f,
@@ -1984,16 +1992,38 @@ impl EngineBackend for ValkeyBackend {
             classification,
         )
         .await
-        .map_err(|e| ff_core::engine_error::backend_context(e, "fail: FCALL ff_fail_execution"))
+        .map_err(|e| ff_core::engine_error::backend_context(e, "fail: FCALL ff_fail_execution"));
+        // Map FailOutcome + classification to the metric label:
+        //   RetryScheduled          → "retry"
+        //   TerminalFailed(Timeout) → "timeout"
+        //   TerminalFailed(other)   → "error"
+        if let (Ok(outcome), Some(metrics)) = (&result, &self.metrics) {
+            let label = match outcome {
+                FailOutcome::RetryScheduled { .. } => ff_observability::AttemptOutcome::Retry,
+                FailOutcome::TerminalFailed if is_timeout => {
+                    ff_observability::AttemptOutcome::Timeout
+                }
+                FailOutcome::TerminalFailed => ff_observability::AttemptOutcome::Error,
+            };
+            metrics.inc_attempt_outcome(f.lane_id.as_str(), label);
+        }
+        result
     }
 
     async fn cancel(&self, handle: &Handle, reason: &str) -> Result<(), EngineError> {
         let f = handle_codec::decode_handle(handle)?;
-        cancel_impl(&self.client, &self.partition_config, &f, reason)
+        let result = cancel_impl(&self.client, &self.partition_config, &f, reason)
             .await
             .map_err(|e| {
                 ff_core::engine_error::backend_context(e, "cancel: FCALL ff_cancel_execution")
-            })
+            });
+        if let (Ok(()), Some(metrics)) = (&result, &self.metrics) {
+            metrics.inc_attempt_outcome(
+                f.lane_id.as_str(),
+                ff_observability::AttemptOutcome::Cancelled,
+            );
+        }
+        result
     }
 
     async fn suspend(

--- a/crates/ff-observability-http/tests/metrics.rs
+++ b/crates/ff-observability-http/tests/metrics.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use ff_observability::Metrics;
+use ff_observability::{AttemptOutcome, Metrics};
 use ff_observability_http::router;
 
 #[tokio::test]
@@ -36,6 +36,58 @@ async fn metrics_endpoint_serves_prometheus_text() {
         resp.contains("ff_lease_renewal_total")
             || resp.contains("ff_lease_renewal"),
         "expected a metric line in body, got: {resp}"
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+/// Scrape `/metrics` after firing a mix of attempt outcomes across
+/// two lanes and assert the counter surfaces with both labels.
+#[tokio::test]
+async fn attempt_outcome_counter_scrapes_with_lane_and_outcome() {
+    let metrics = Arc::new(Metrics::new());
+    metrics.inc_attempt_outcome("default", AttemptOutcome::Ok);
+    metrics.inc_attempt_outcome("default", AttemptOutcome::Ok);
+    metrics.inc_attempt_outcome("default", AttemptOutcome::Error);
+    metrics.inc_attempt_outcome("priority", AttemptOutcome::Timeout);
+    metrics.inc_attempt_outcome("priority", AttemptOutcome::Cancelled);
+    metrics.inc_attempt_outcome("priority", AttemptOutcome::Retry);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = router(Arc::clone(&metrics));
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let resp = raw_get(addr, "/metrics").await;
+    assert!(resp.starts_with("HTTP/1.1 200"), "status line: {resp:?}");
+    assert!(
+        resp.contains("ff_attempt_outcome_total"),
+        "counter name missing: {resp}"
+    );
+    // Each of the 5 outcome labels must appear at least once, and
+    // both lane labels must be present.
+    for outcome in ["ok", "error", "timeout", "cancelled", "retry"] {
+        let needle = format!("outcome=\"{outcome}\"");
+        assert!(resp.contains(&needle), "missing {needle} in: {resp}");
+    }
+    assert!(resp.contains("lane=\"default\""), "missing lane=default");
+    assert!(resp.contains("lane=\"priority\""), "missing lane=priority");
+    // Double-count check: the (default, ok) series fired twice and must
+    // be exposed as value 2 (line ends with ` 2`).
+    let ok_line = resp
+        .lines()
+        .find(|l| {
+            l.starts_with("ff_attempt_outcome_total{")
+                && l.contains("lane=\"default\"")
+                && l.contains("outcome=\"ok\"")
+        })
+        .unwrap_or_else(|| panic!("no (default, ok) series line in: {resp}"));
+    assert!(
+        ok_line.trim_end().ends_with(" 2"),
+        "expected value=2 on {ok_line}"
     );
 
     server.abort();

--- a/crates/ff-observability/src/lib.rs
+++ b/crates/ff-observability/src/lib.rs
@@ -31,6 +31,40 @@ pub use real::Metrics;
 #[cfg(not(feature = "enabled"))]
 pub use shim::Metrics;
 
+/// Terminal attempt outcome label for `ff_attempt_outcome_total`.
+///
+/// The variant set is fixed at 5 by the Observability RFC prereq #4
+/// adjudication so cardinality stays bounded at `5 × N lanes`. Kept
+/// feature-agnostic (defined here, not in `real`/`shim`) so call sites
+/// can construct the value identically whether metrics are compiled in
+/// or not.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AttemptOutcome {
+    /// Attempt completed successfully (terminal-ok / `complete` FCALL).
+    Ok,
+    /// Attempt failed terminally — no retries left.
+    Error,
+    /// Attempt failed with classification = `Timeout`.
+    Timeout,
+    /// Attempt was cancelled (worker or flow-level cancel).
+    Cancelled,
+    /// Attempt failed but a retry was scheduled.
+    Retry,
+}
+
+impl AttemptOutcome {
+    /// Stable `&'static str` label — matches the Prometheus exposition.
+    pub fn as_stable_str(&self) -> &'static str {
+        match self {
+            AttemptOutcome::Ok => "ok",
+            AttemptOutcome::Error => "error",
+            AttemptOutcome::Timeout => "timeout",
+            AttemptOutcome::Cancelled => "cancelled",
+            AttemptOutcome::Retry => "retry",
+        }
+    }
+}
+
 // Sentry error-reporting module. Gated behind the `sentry` feature,
 // orthogonal to `enabled` (OTEL metrics) — consumers can turn either
 // on without pulling the other. See [`sentry`] module docs for the

--- a/crates/ff-observability/src/real.rs
+++ b/crates/ff-observability/src/real.rs
@@ -32,6 +32,7 @@ use prometheus::{Encoder, TextEncoder};
 /// * `ff_cancel_backlog_depth` — 1 (no labels)
 /// * `ff_claim_from_grant_duration_seconds` — ≤ 16 lanes
 /// * `ff_lease_renewal_total` — 2 outcomes (ok, err) = 2
+/// * `ff_attempt_outcome_total` — 5 outcomes × ≤ 16 lanes = 80 (prereq #4)
 /// * `ff_worker_at_capacity_total` — 1 (no labels)
 /// * `ff_budget_hit_total` — per-dimension, typically ≤ 8
 /// * `ff_quota_hit_total` — 2 reasons (rate, concurrency) = 2
@@ -60,6 +61,7 @@ mod name {
     pub const CANCEL_BACKLOG_DEPTH: &str = "ff_cancel_backlog_depth";
     pub const CLAIM_FROM_GRANT_DURATION: &str = "ff_claim_from_grant_duration";
     pub const LEASE_RENEWAL: &str = "ff_lease_renewal";
+    pub const ATTEMPT_OUTCOME: &str = "ff_attempt_outcome";
     pub const WORKER_AT_CAPACITY: &str = "ff_worker_at_capacity";
     pub const BUDGET_HIT: &str = "ff_budget_hit";
     pub const QUOTA_HIT: &str = "ff_quota_hit";
@@ -84,6 +86,7 @@ struct Inner {
     _cancel_backlog_gauge: ObservableGauge<u64>,
     claim_duration: Histogram<f64>,
     lease_renewal: Counter<u64>,
+    attempt_outcome: Counter<u64>,
     worker_at_capacity: Counter<u64>,
     budget_hit: Counter<u64>,
     quota_hit: Counter<u64>,
@@ -137,6 +140,13 @@ impl Metrics {
             .u64_counter(name::LEASE_RENEWAL)
             .with_description("Lease renewal attempts, labelled by outcome (ok|err).")
             .build();
+        let attempt_outcome = meter
+            .u64_counter(name::ATTEMPT_OUTCOME)
+            .with_description(
+                "Terminal attempt outcomes, labelled by lane + outcome \
+                 (ok|error|timeout|cancelled|retry).",
+            )
+            .build();
         let worker_at_capacity = meter
             .u64_counter(name::WORKER_AT_CAPACITY)
             .with_description("Count of claim attempts rejected with WorkerAtCapacity.")
@@ -174,6 +184,7 @@ impl Metrics {
             _cancel_backlog_gauge: cancel_backlog_gauge,
             claim_duration,
             lease_renewal,
+            attempt_outcome,
             worker_at_capacity,
             budget_hit,
             quota_hit,
@@ -187,19 +198,15 @@ impl Metrics {
         let mut buf = Vec::with_capacity(4096);
         // TextEncoder writes valid UTF-8; unwrap on encode is the
         // documented contract (see prometheus::TextEncoder docs).
-        encoder.encode(&metric_families, &mut buf).expect("prometheus text encode");
+        encoder
+            .encode(&metric_families, &mut buf)
+            .expect("prometheus text encode");
         String::from_utf8(buf).expect("prometheus text is utf-8")
     }
 
     // ── HTTP ──
 
-    pub fn record_http_request(
-        &self,
-        method: &str,
-        path: &str,
-        status: u16,
-        elapsed: Duration,
-    ) {
+    pub fn record_http_request(&self, method: &str, path: &str, status: u16, elapsed: Duration) {
         let attrs = [
             KeyValue::new("method", method.to_owned()),
             KeyValue::new("path", path.to_owned()),
@@ -214,7 +221,9 @@ impl Metrics {
     pub fn record_scanner_cycle(&self, scanner: &'static str, elapsed: Duration) {
         let attrs = [KeyValue::new("scanner", scanner)];
         self.0.scanner_total.add(1, &attrs);
-        self.0.scanner_duration.record(elapsed.as_secs_f64(), &attrs);
+        self.0
+            .scanner_duration
+            .record(elapsed.as_secs_f64(), &attrs);
     }
 
     // ── Cancel backlog ──
@@ -233,7 +242,25 @@ impl Metrics {
     // ── Lease ──
 
     pub fn inc_lease_renewal(&self, outcome: &'static str) {
-        self.0.lease_renewal.add(1, &[KeyValue::new("outcome", outcome)]);
+        self.0
+            .lease_renewal
+            .add(1, &[KeyValue::new("outcome", outcome)]);
+    }
+
+    // ── Attempt terminal outcome ──
+
+    /// Increment `ff_attempt_outcome_total` — fired at the trait
+    /// boundary when `complete` / `fail` / `cancel` succeed on the
+    /// backend. Cardinality is bounded at 5 outcomes × N lanes
+    /// (accepted at 5×16=80 per Observability RFC prereq #4).
+    pub fn inc_attempt_outcome(&self, lane: &str, outcome: super::AttemptOutcome) {
+        self.0.attempt_outcome.add(
+            1,
+            &[
+                KeyValue::new("lane", lane.to_owned()),
+                KeyValue::new("outcome", outcome.as_stable_str()),
+            ],
+        );
     }
 
     // ── Worker-at-capacity ──

--- a/crates/ff-observability/src/shim.rs
+++ b/crates/ff-observability/src/shim.rs
@@ -55,6 +55,10 @@ impl Metrics {
 
     pub fn inc_lease_renewal(&self, _outcome: &'static str) {}
 
+    // ── Attempt terminal outcome ──
+
+    pub fn inc_attempt_outcome(&self, _lane: &str, _outcome: super::AttemptOutcome) {}
+
     // ── Worker-at-capacity ──
 
     pub fn inc_worker_at_capacity(&self) {}

--- a/examples/grafana/flowfabric-ops.json
+++ b/examples/grafana/flowfabric-ops.json
@@ -329,6 +329,46 @@
           "legendFormat": "{{path}}"
         }
       ]
+    },
+    {
+      "id": 11,
+      "title": "Attempt outcomes (per lane)",
+      "description": "ff_attempt_outcome_total split by lane + outcome (ok|error|timeout|cancelled|retry). Fires once per terminal attempt transition in ff-backend-valkey's complete/fail/cancel trait impl. Cardinality is bounded at 5 × N lanes (accepted at 5×16=80 per Observability RFC prereq #4).",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 48 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*error.*" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*timeout.*" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*ok.*" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (lane, outcome) (rate(ff_attempt_outcome_total[$__rate_interval]))",
+          "legendFormat": "{{lane}} / {{outcome}}"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## Summary

Adds `ff_attempt_outcome_total` — a terminal-attempt outcome counter labelled by `lane` + `outcome`, per Observability RFC prereq #4 (accepted at 5×16=80 series cardinality).

- `ff-observability`: public `AttemptOutcome` enum (5 variants: `Ok|Error|Timeout|Cancelled|Retry`), defined feature-agnostic in `lib.rs` so call-site shape stays symmetric across `enabled` on/off. `real` adds the `ff_attempt_outcome` counter instrument + `inc_attempt_outcome(lane, outcome)` method mirroring `inc_lease_renewal`; `shim` adds the matching no-op.
- `ff-backend-valkey`: wires the counter into the `EngineBackend` trait impl's `complete` / `fail` / `cancel` methods. Emits after the underlying FCALL returns `Ok`, including reconciled terminal replays — matches the `inc_lease_renewal` pattern at the same boundary.
- Dashboard: panel 11 "Attempt outcomes (per lane)" on `examples/grafana/flowfabric-ops.json`, querying `sum by (lane, outcome) (rate(ff_attempt_outcome_total[$__rate_interval]))`.
- Integration test in `ff-observability-http/tests/metrics.rs` scrapes `/metrics`, asserts all 5 outcome labels + 2 lane labels present, and verifies double-count value.
- CHANGELOG Unreleased `### Added` entry.

## Emission sites

Three trait methods on `ValkeyBackend` fire exactly once per successful terminal:

| Trait method | FailOutcome / FailureClass           | Metric `outcome` label |
| ------------ | ------------------------------------ | ---------------------- |
| `complete`   | —                                    | `ok`                   |
| `fail`       | `RetryScheduled`                     | `retry`                |
| `fail`       | `TerminalFailed` + `FailureClass::Timeout` | `timeout`        |
| `fail`       | `TerminalFailed` + other             | `error`                |
| `cancel`     | —                                    | `cancelled`            |

Pre-terminal FCALL failures do NOT count (preserves the exactly-once-per-terminal invariant the RFC prereq requires).

## Cardinality rationale

5 outcomes × N lanes. N is the deployment's lane set (caller-controlled, historically small; 16 is the RFC's typical envelope). The `lane` label arrives pre-validated via the decoded `HandleFields::lane_id` — a runtime enum of caller-configured IDs, not a per-request string. No unbounded label source.

## Test plan

- [x] `cargo test -p ff-observability-http --features enabled` — integration test green (2/2)
- [x] `cargo test -p ff-server --features observability --test metrics` — existing metrics tests still green
- [x] `cargo build --workspace --all-features` — clean
- [x] `cargo clippy -p ff-observability -p ff-observability-http -p ff-backend-valkey --all-features --tests -- -D warnings` — clean
- [ ] CI matrix: confirm default (`enabled` off) shim compiles and test runs as before

Co-author: Claude Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)