### PR TITLE
feat(ff-core, ff-backend-valkey, ff-sdk): list_lanes trait method with cursor pagination (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   serves the same contract natively. `FlowFabricWorker::list_flows`
   wrapper on ff-sdk. Missing `flow_core` for an indexed id surfaces as
   `EngineError::Validation { kind: Corruption, .. }`.
+- **`EngineBackend::list_lanes` trait method + `FlowFabricWorker::list_lanes`
+  SDK wrapper (#184):** cursor-based pagination over the global lane
+  registry (`ff:idx:lanes`). The Valkey impl reads the SET via
+  `SMEMBERS`, sorts by `LaneId` name (lexicographic), and returns a
+  `limit`-sized page whose `next_cursor` is exclusive; callers loop
+  until `next_cursor == None` for the full registry. Gated on the
+  `core` feature. `LaneId` gained `PartialOrd` / `Ord` derives so the
+  page sort is stable across the trait + SDK surfaces. New
+  `ListLanesPage` (`#[non_exhaustive]`) in `ff_core::contracts`.
+  Lanes are global (not partition-scoped), so the trait method takes
+  no `Partition` argument. Prereq for ff-board's lane-overview panel
+  (issue #181 roll-up).
 - **Grafana dashboard JSON for operator observability** at
   `examples/grafana/flowfabric-ops.json`. Ten panels covering claim
   latency + rate, lease renewals, worker-at-capacity, admission

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -39,7 +39,7 @@ use ff_core::contracts::decode::{
 };
 use ff_core::contracts::{
     CancelFlowArgs, CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    FlowStatus, FlowSummary, ListFlowsPage, ReportUsageResult,
+    FlowStatus, FlowSummary, ListFlowsPage, ListLanesPage, ReportUsageResult,
 };
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
@@ -832,6 +832,72 @@ async fn resolve_execution_flow_id_impl(
         ),
     })?;
     Ok(Some(flow_id))
+}
+
+/// Read the global lane registry (`ff:idx:lanes`) as a sorted page.
+///
+/// `SMEMBERS ff:idx:lanes` + validate each entry via
+/// [`LaneId::try_new`] (corrupt entries surface as
+/// [`EngineError::Validation { kind: ValidationKind::Corruption, .. }`])
+/// + sort by lane name + slice on `(cursor, limit)`. The SET is
+/// bounded by the registry size, not the per-lane execution count, so
+/// a single-shot read is cheap enough for the registry sizes FF
+/// targets.
+///
+/// `ff:idx:lanes` has no hash tag — in cluster deployments it lives
+/// on its own slot, which is fine for a single-key SMEMBERS read.
+#[tracing::instrument(
+    name = "ff.list_lanes",
+    skip_all,
+    fields(backend = "valkey", limit)
+)]
+async fn list_lanes_impl(
+    client: &ferriskey::Client,
+    cursor: Option<LaneId>,
+    limit: usize,
+) -> Result<ListLanesPage, EngineError> {
+    if limit == 0 {
+        return Ok(ListLanesPage::new(Vec::new(), None));
+    }
+
+    let key = ff_core::keys::lanes_index_key();
+    let raw: Vec<String> = client
+        .cmd("SMEMBERS")
+        .arg(&key)
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+
+    // Validate + parse every member up front. A bad entry (e.g. an
+    // empty string or a lane name that violates `LaneId::try_new`
+    // bounds) indicates registry corruption and fails loud rather
+    // than silently dropping.
+    let mut lanes: Vec<LaneId> = Vec::with_capacity(raw.len());
+    for entry in raw {
+        let lane = LaneId::try_new(entry.clone()).map_err(|e| EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::Corruption,
+            detail: format!(
+                "list_lanes: ff:idx:lanes: member '{entry}' is not a valid LaneId \
+                 (key corruption?): {e:?}"
+            ),
+        })?;
+        lanes.push(lane);
+    }
+    lanes.sort();
+
+    // Slice `(cursor, cursor+limit]` — cursor is exclusive.
+    let start = match cursor {
+        Some(c) => lanes.partition_point(|l| l <= &c),
+        None => 0,
+    };
+    let end = start.saturating_add(limit).min(lanes.len());
+    let page: Vec<LaneId> = lanes[start..end].to_vec();
+    let next_cursor = if end < lanes.len() {
+        page.last().cloned()
+    } else {
+        None
+    };
+    Ok(ListLanesPage::new(page, next_cursor))
 }
 
 /// Read the deployment's partition config from
@@ -2311,6 +2377,18 @@ impl EngineBackend for ValkeyBackend {
                     e,
                     "list_flows: SMEMBERS flow_index + pipeline HGETALL flow_core",
                 )
+            })
+    }
+
+    async fn list_lanes(
+        &self,
+        cursor: Option<LaneId>,
+        limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        list_lanes_impl(&self.client, cursor, limit)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(e, "list_lanes: SMEMBERS ff:idx:lanes")
             })
     }
 

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2500,6 +2500,41 @@ pub struct ListExecutionsResult {
     pub total_returned: usize,
 }
 
+// ─── list_lanes (issue #184) ───
+
+/// One page of lane ids returned by
+/// [`crate::engine_backend::EngineBackend::list_lanes`].
+///
+/// Lanes are global (not partition-scoped) — the backend enumerates
+/// every registered lane, sorts by [`LaneId`] name, and returns a
+/// `limit`-sized slice starting after `cursor` (exclusive).
+///
+/// `next_cursor` is `Some(last_lane_in_page)` when more pages remain
+/// and `None` when the caller has read the final page. Callers that
+/// want the full list loop until `next_cursor` is `None`, threading
+/// the previous page's `next_cursor` into the next call's `cursor`
+/// argument.
+///
+/// `#[non_exhaustive]` — FF may add fields (e.g. a `total` hint) in
+/// minor releases without a semver break.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ListLanesPage {
+    /// The lanes in this page, sorted by [`LaneId`] name.
+    pub lanes: Vec<LaneId>,
+    /// Cursor for the next page (exclusive). `None` ⇒ final page.
+    pub next_cursor: Option<LaneId>,
+}
+
+impl ListLanesPage {
+    /// Construct a [`ListLanesPage`]. Present so downstream crates
+    /// (ff-backend-valkey's `list_lanes` impl) can assemble the
+    /// struct despite the `#[non_exhaustive]` marker.
+    pub fn new(lanes: Vec<LaneId>, next_cursor: Option<LaneId>) -> Self {
+        Self { lanes, next_cursor }
+    }
+}
+
 // ─── rotate_waitpoint_hmac_secret ───
 
 /// Args for `ff_rotate_waitpoint_hmac_secret`. Rotates the HMAC signing

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -54,7 +54,7 @@ use crate::backend::{
 };
 use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult};
 #[cfg(feature = "core")]
-use crate::contracts::{EdgeDirection, EdgeSnapshot, ListFlowsPage};
+use crate::contracts::{EdgeDirection, EdgeSnapshot, ListFlowsPage, ListLanesPage};
 #[cfg(feature = "core")]
 use crate::partition::PartitionKey;
 #[cfg(feature = "streaming")]
@@ -329,6 +329,36 @@ pub trait EngineBackend: Send + Sync + 'static {
         cursor: Option<FlowId>,
         limit: usize,
     ) -> Result<ListFlowsPage, EngineError>;
+
+    /// Enumerate registered lanes with cursor-based pagination.
+    ///
+    /// Lanes are global (not partition-scoped) — the backend serves
+    /// this from its lane registry and does NOT accept a
+    /// [`crate::partition::Partition`] argument. Results are sorted
+    /// by [`LaneId`] name so the ordering is stable across calls and
+    /// cursors address a deterministic position in the sort.
+    ///
+    /// * `cursor` — exclusive lower bound. `None` starts from the
+    ///   first lane. To continue a walk, pass the previous page's
+    ///   [`ListLanesPage::next_cursor`].
+    /// * `limit` — hard cap on the number of lanes returned in the
+    ///   page. Backends MAY round this down when the registry size
+    ///   is smaller; they MUST NOT return more than `limit`.
+    ///
+    /// [`ListLanesPage::next_cursor`] is `Some(last_lane_in_page)`
+    /// iff at least one more lane exists after the returned page,
+    /// and `None` on the final page. Callers loop until `next_cursor`
+    /// is `None` to read the full registry.
+    ///
+    /// Gated on the `core` feature — lane enumeration is part of the
+    /// minimal snapshot surface an alternate backend must honour
+    /// alongside [`Self::describe_flow`] / [`Self::list_edges`].
+    #[cfg(feature = "core")]
+    async fn list_lanes(
+        &self,
+        cursor: Option<LaneId>,
+        limit: usize,
+    ) -> Result<ListLanesPage, EngineError>;
 
     /// Operator-initiated cancellation of a flow and (optionally) its
     /// member executions. See RFC-012 §3.1.1 for the policy /wait

--- a/crates/ff-core/src/types.rs
+++ b/crates/ff-core/src/types.rs
@@ -432,7 +432,12 @@ string_id! {
 // system boundary instead of silently hashing them via the SoloPartitioner.
 
 /// Submission lane (queue-compatible ingress).
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+///
+/// `PartialOrd` / `Ord` derive lexicographic order over the inner
+/// string — used by
+/// [`crate::engine_backend::EngineBackend::list_lanes`] to sort the
+/// `ff:idx:lanes` registry into a stable page order.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 #[serde(transparent)]
 pub struct LaneId(pub String);
 

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -4,7 +4,7 @@
 //! plugs into an `EngineBackend` impl via a small `LayerHooks`
 //! trait: one synchronous `before(method)` and one
 //! `after(method, duration, outcome)`. The generated
-//! `HookedBackend<H>` impl below handles the 17-method dispatch so
+//! `HookedBackend<H>` impl below handles the 18-method dispatch so
 //! layers don't re-implement it.
 //!
 //! Layers that need more than before/after (e.g. the circuit breaker
@@ -336,19 +336,6 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
             self,
             "report_usage",
             self.inner.report_usage(handle, budget, dimensions).await
-        )
-    }
-
-    #[cfg(feature = "core")]
-    async fn list_lanes(
-        &self,
-        cursor: Option<LaneId>,
-        limit: usize,
-    ) -> Result<ListLanesPage, EngineError> {
-        with_hooks!(
-            self,
-            "list_lanes",
-            self.inner.list_lanes(cursor, limit).await
         )
     }
 

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -22,8 +22,8 @@ use ff_core::backend::{
     ResumeSignal, WaitpointSpec,
 };
 use ff_core::contracts::{
-    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    ListFlowsPage, ReportUsageResult,
+    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
+    ListLanesPage, ReportUsageResult,
 };
 #[cfg(feature = "valkey-default")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
@@ -301,6 +301,18 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
         )
     }
 
+    async fn list_lanes(
+        &self,
+        cursor: Option<LaneId>,
+        limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        with_hooks!(
+            self,
+            "list_lanes",
+            self.inner.list_lanes(cursor, limit).await
+        )
+    }
+
     async fn cancel_flow(
         &self,
         id: &FlowId,
@@ -324,6 +336,19 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
             self,
             "report_usage",
             self.inner.report_usage(handle, budget, dimensions).await
+        )
+    }
+
+    #[cfg(feature = "core")]
+    async fn list_lanes(
+        &self,
+        cursor: Option<LaneId>,
+        limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        with_hooks!(
+            self,
+            "list_lanes",
+            self.inner.list_lanes(cursor, limit).await
         )
     }
 

--- a/crates/ff-sdk/src/layer/test_support.rs
+++ b/crates/ff-sdk/src/layer/test_support.rs
@@ -19,8 +19,8 @@ use ff_core::backend::{
     WaitpointSpec,
 };
 use ff_core::contracts::{
-    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    ListFlowsPage, ReportUsageResult,
+    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
+    ListLanesPage, ReportUsageResult,
 };
 #[cfg(feature = "valkey-default")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
@@ -216,6 +216,15 @@ impl EngineBackend for PassthroughBackend {
     ) -> Result<Option<FlowId>, EngineError> {
         self.record("resolve_execution_flow_id")?;
         Ok(None)
+    }
+
+    async fn list_lanes(
+        &self,
+        _cursor: Option<LaneId>,
+        _limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        self.record("list_lanes")?;
+        Ok(ListLanesPage::new(Vec::new(), None))
     }
 
     async fn cancel_flow(

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -24,10 +24,10 @@
 //! them without depending on ff-sdk.
 
 use ff_core::contracts::{
-    EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
+    EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage, ListLanesPage,
 };
 use ff_core::partition::{execution_partition, flow_partition, PartitionKey};
-use ff_core::types::{EdgeId, ExecutionId, FlowId};
+use ff_core::types::{EdgeId, ExecutionId, FlowId, LaneId};
 
 use crate::SdkError;
 use crate::worker::FlowFabricWorker;
@@ -158,6 +158,23 @@ impl FlowFabricWorker {
                 },
             )
             .await?)
+    }
+
+    /// Enumerate registered lanes with cursor-based pagination.
+    ///
+    /// Thin forwarder onto
+    /// [`EngineBackend::list_lanes`](ff_core::engine_backend::EngineBackend::list_lanes).
+    /// Lanes are global (not partition-scoped); the Valkey backend
+    /// serves this from the `ff:idx:lanes` SET, sorts by lane name,
+    /// and returns a `limit`-sized page starting after `cursor`
+    /// (exclusive). Loop until [`ListLanesPage::next_cursor`] is
+    /// `None` to read the full registry.
+    pub async fn list_lanes(
+        &self,
+        cursor: Option<LaneId>,
+        limit: usize,
+    ) -> Result<ListLanesPage, SdkError> {
+        Ok(self.backend_ref().list_lanes(cursor, limit).await?)
     }
 
     /// Resolve `exec_core.flow_id` via the trait and pin the RFC-011

--- a/crates/ff-test/tests/engine_backend_list_lanes.rs
+++ b/crates/ff-test/tests/engine_backend_list_lanes.rs
@@ -1,0 +1,152 @@
+//! Integration coverage for
+//! [`ff_core::engine_backend::EngineBackend::list_lanes`] on the
+//! Valkey-backed impl (issue #184).
+//!
+//! Lanes are a global SET (`ff:idx:lanes`) rather than a
+//! partition-scoped index. The test seeds the SET directly via
+//! `SADD`, exercises the trait + SDK wrapper, and verifies:
+//!   * sort order (lexicographic by lane name),
+//!   * cursor-based pagination (exclusive lower bound),
+//!   * final-page `next_cursor == None`,
+//!   * `limit == 0` short-circuit,
+//!   * empty registry → empty page.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test engine_backend_list_lanes \
+//!       -- --test-threads=1
+
+use std::sync::Arc;
+
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::LaneId;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    ValkeyBackend::from_client_and_partitions(tc.client().clone(), test_config())
+}
+
+async fn seed_lanes(tc: &TestCluster, lanes: &[&str]) {
+    if lanes.is_empty() {
+        return;
+    }
+    let members: Vec<String> = lanes.iter().map(|s| (*s).to_owned()).collect();
+    let _: i64 = tc
+        .client()
+        .cmd("SADD")
+        .arg("ff:idx:lanes")
+        .arg(members)
+        .execute()
+        .await
+        .expect("SADD ff:idx:lanes");
+}
+
+async fn build_sdk_worker() -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        backend: ff_test::fixtures::backend_config_from_env(),
+        worker_id: ff_core::types::WorkerId::new("list-lanes-worker"),
+        worker_instance_id: ff_core::types::WorkerInstanceId::new("list-lanes-inst"),
+        namespace: ff_core::types::Namespace::new("list-lanes-ns"),
+        lanes: vec![LaneId::new("default")],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_lanes_paginates_sorted_registry() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    // Seed 5 lanes in non-sorted order. Expected sort:
+    //   ["alpha", "bravo", "charlie", "delta", "echo"]
+    seed_lanes(&tc, &["charlie", "alpha", "echo", "bravo", "delta"]).await;
+
+    let backend = build_backend(&tc);
+
+    // Page 1 — limit 2, no cursor ⇒ ["alpha", "bravo"], next=Some("bravo").
+    let p1 = backend.list_lanes(None, 2).await.expect("list_lanes p1");
+    assert_eq!(
+        p1.lanes,
+        vec![LaneId::new("alpha"), LaneId::new("bravo")],
+        "page 1 sort order wrong"
+    );
+    assert_eq!(p1.next_cursor, Some(LaneId::new("bravo")));
+
+    // Page 2 — continue from "bravo" ⇒ ["charlie", "delta"], next=Some("delta").
+    let p2 = backend
+        .list_lanes(p1.next_cursor.clone(), 2)
+        .await
+        .expect("list_lanes p2");
+    assert_eq!(
+        p2.lanes,
+        vec![LaneId::new("charlie"), LaneId::new("delta")]
+    );
+    assert_eq!(p2.next_cursor, Some(LaneId::new("delta")));
+
+    // Page 3 — continue from "delta" ⇒ ["echo"], final page.
+    let p3 = backend
+        .list_lanes(p2.next_cursor.clone(), 2)
+        .await
+        .expect("list_lanes p3");
+    assert_eq!(p3.lanes, vec![LaneId::new("echo")]);
+    assert_eq!(p3.next_cursor, None, "last page must have no next_cursor");
+
+    // Over-limit returns full set in one page with no next_cursor.
+    let full = backend.list_lanes(None, 100).await.expect("list_lanes full");
+    assert_eq!(full.lanes.len(), 5);
+    assert_eq!(full.next_cursor, None);
+    // Still sorted.
+    let mut expected = full.lanes.clone();
+    expected.sort();
+    assert_eq!(full.lanes, expected);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_lanes_empty_registry_returns_empty_page() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let backend = build_backend(&tc);
+    let page = backend
+        .list_lanes(None, 10)
+        .await
+        .expect("list_lanes empty");
+    assert!(page.lanes.is_empty());
+    assert_eq!(page.next_cursor, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_lanes_limit_zero_short_circuits() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_lanes(&tc, &["alpha", "bravo"]).await;
+
+    let backend = build_backend(&tc);
+    let page = backend.list_lanes(None, 0).await.expect("list_lanes zero");
+    assert!(page.lanes.is_empty());
+    assert_eq!(page.next_cursor, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_lanes_sdk_wrapper_matches_trait() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_lanes(&tc, &["a", "b", "c"]).await;
+
+    let worker = build_sdk_worker().await;
+    let page = worker.list_lanes(None, 10).await.expect("sdk list_lanes");
+    assert_eq!(
+        page.lanes,
+        vec![LaneId::new("a"), LaneId::new("b"), LaneId::new("c")]
+    );
+    assert_eq!(page.next_cursor, None);
+}


### PR DESCRIPTION
## Summary

- Adds `EngineBackend::list_lanes(cursor, limit) -> ListLanesPage` — global (non-partition-scoped) enumeration of the `ff:idx:lanes` lane registry, gated on the `core` feature.
- Valkey impl: `SMEMBERS ff:idx:lanes` → validate each entry via `LaneId::try_new` (corruption-loud) → sort lexicographically → slice on `(cursor, limit]` (cursor exclusive).
- New `ListLanesPage` (`#[non_exhaustive]`) in `ff_core::contracts` carries `lanes: Vec<LaneId>` + `next_cursor: Option<LaneId>`.
- `FlowFabricWorker::list_lanes` thin forwarder on `ff-sdk`.
- `LaneId` gains `PartialOrd` / `Ord` derives so page sort is stable across the trait + SDK surfaces.

Closes #184. Prereq for ff-board's lane-overview panel (issue #181 roll-up).

## Design notes

- **Lanes are global, not partition-scoped** — per the task scope the trait method takes no `Partition` arg. The richer `LaneSummary` shape proposed in #184's original body (depth / active-count / oldest-eligible-age) is deliberately out of scope here; ff-board gets those via `/metrics` per sibling decisions X2/X3.
- **Cursor is exclusive lower bound** — matches the #182/#183 convention the owner locked for this family. `next_cursor == Some(last_lane_in_page)` while more pages remain, `None` on the final page.
- **Population of `ff:idx:lanes`** is out of scope for this PR. The helper `ff_core::keys::lanes_index_key()` already existed but had no writers — tests SADD directly. A follow-up can wire population into `ff_create_execution` (option (a) in the #184 body) without touching this trait method.

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p ff-core` — 162 passed
- [x] `cargo test -p ff-backend-valkey -p ff-sdk --lib` — 40 passed
- [x] `FF_PORT=6389 cargo test -p ff-test --test engine_backend_list_lanes -- --test-threads=1` — 4 passed (pagination, empty registry, limit==0, SDK↔trait parity)
- [x] `FF_PORT=6389 cargo test -p ff-test --test engine_backend_describe --test engine_backend_list_edges -- --test-threads=1` — adjacent trait tests still pass
- [ ] CI matrix (valkey 7.2 / 8 × standalone / cluster × linux / macos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `EngineBackend` API surface that all backends must implement when `core` is enabled, plus a Valkey implementation that reads and validates shared registry data; bugs here could break admin/observability tooling that enumerates lanes.
> 
> **Overview**
> Adds cursor-paginated lane enumeration to the engine surface via `EngineBackend::list_lanes(cursor, limit) -> ListLanesPage`, along with the new `ListLanesPage` contract type.
> 
> Implements `list_lanes` for the Valkey backend by reading `ff:idx:lanes`, validating entries as `LaneId`, sorting lexicographically, and slicing pages with an *exclusive* cursor; also exposes a `FlowFabricWorker::list_lanes` SDK forwarder and derives `Ord` on `LaneId` to guarantee stable ordering. Includes new integration tests covering sort order, pagination behavior, empty/limit=0 cases, and SDK/trait parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848da2e14b6cb62394235084a807ea68f6e849a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->