### PR TITLE
feat(ff-core, ff-backend-valkey, ff-sdk, ff-server): list_executions trait + cursor pagination (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `(ScanStateRC, Vec<Value>)` directly for Rust callers;
   `ClusterScanArgs` / `ScanStateRC` / `ObjectType` re-exported at the
   crate root.
+- **`EngineBackend::list_executions` trait method + `ListExecutionsPage`
+  contract (issue #182).** Partition-scoped forward-only cursor
+  pagination over the `ff:idx:{p:N}:all_executions` set. Signature is
+  `list_executions(partition: PartitionKey, cursor: Option<ExecutionId>,
+  limit: usize) -> ListExecutionsPage` gated on the `core` feature so
+  Postgres-style backends must honour it. Response carries
+  `executions: Vec<ExecutionId>` + `next_cursor: Option<ExecutionId>`
+  (exclusive; `None` ⇒ end of stream). Valkey impl reads SMEMBERS,
+  lex-sorts on wire form, filters strictly greater than the caller's
+  cursor, and trims to `limit` (capped at 1000). `FlowFabricWorker::
+  list_executions` thin-forwards onto the trait.
 - **Grafana dashboard JSON for operator observability** at
   `examples/grafana/flowfabric-ops.json`. Ten panels covering claim
   latency + rate, lease renewals, worker-at-capacity, admission
@@ -139,6 +150,19 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **BREAKING (unreleased HTTP surface): `GET /v1/executions` reshaped
+  to forward-only cursor pagination (issue #182).** Query parameters
+  now `partition` (`u16`, required) + optional `cursor`
+  (`ExecutionId`, exclusive start) + optional `limit` (capped at
+  1000). Response shape swapped from
+  `{ executions: [ExecutionSummary], total_returned }` to
+  `{ executions: [ExecutionId], next_cursor: ExecutionId | null }`.
+  The previous `lane` + `state` filters were dropped; per-execution
+  metadata is now fetched via `GET /v1/executions/{id}` or the
+  `describe_execution` trait method. The old offset-based endpoint
+  was never published on crates.io, so this is unreleased-surface
+  churn only. Server::list_executions replaced by
+  Server::list_executions_page which mirrors the trait's shape.
 - **Hot-path tracing span level downgraded to `debug` (#173):**
   Downgraded 5 hot-path `EngineBackend` impl spans (complete, renew,
   progress, observe_signals, append_frame) from implicit `info` to

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -39,8 +39,8 @@ use ff_core::contracts::decode::{
 };
 use ff_core::contracts::{
     CancelFlowArgs, CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    FlowStatus, FlowSummary, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
-    SuspendedExecutionEntry,
+    FlowStatus, FlowSummary, ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage,
+    ReportUsageResult, SuspendedExecutionEntry,
 };
 use ff_core::partition::PartitionKey;
 use ff_core::engine_backend::EngineBackend;
@@ -1145,6 +1145,98 @@ async fn list_lanes_impl(
         None
     };
     Ok(ListLanesPage::new(page, next_cursor))
+}
+
+/// Partition-scoped forward-only cursor listing of executions.
+///
+/// Reads `SMEMBERS ff:idx:{p:N}:all_executions`, parses every member
+/// as [`ExecutionId`] (failing loud on corruption), sorts lexicographic
+/// (stable across calls — ExecutionId prefix is the partition hash tag
+/// so intra-partition order is UUID-suffix order), filters to members
+/// strictly greater than `cursor`, and truncates to `limit`.
+/// `next_cursor` is the last emitted id iff at least one more member
+/// remains past the page boundary.
+///
+/// v1 note: a full `SMEMBERS` scan per page is acceptable for
+/// partitions holding O(10k) executions (retention trims terminal ids
+/// out; live-set cardinality stays bounded by worker concurrency). A
+/// future optimisation may introduce a parallel ZSET keyed by
+/// `created_at` so paging becomes a constant-time `ZRANGEBYSCORE` —
+/// that is out of scope for the list-executions trait landing.
+#[tracing::instrument(
+    name = "ff.list_executions",
+    skip_all,
+    fields(backend = "valkey", partition = %partition_key)
+)]
+async fn list_executions_impl(
+    client: &ferriskey::Client,
+    partition_key: &PartitionKey,
+    cursor: Option<&ExecutionId>,
+    limit: usize,
+) -> Result<ListExecutionsPage, EngineError> {
+    // `limit == 0` is a legitimate caller request (e.g. probing for
+    // cursor validity); short-circuit before touching Valkey.
+    if limit == 0 {
+        return Ok(ListExecutionsPage::new(Vec::new(), None));
+    }
+
+    let partition = partition_key
+        .parse()
+        .map_err(|e| EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::InvalidInput,
+            detail: format!(
+                "list_executions: partition: '{partition_key}' is not a valid PartitionKey: {e}"
+            ),
+        })?;
+    let idx = IndexKeys::new(&partition);
+    let all_key = idx.all_executions();
+
+    let raw_members: Vec<String> = client
+        .cmd("SMEMBERS")
+        .arg(&all_key)
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+
+    if raw_members.is_empty() {
+        return Ok(ListExecutionsPage::new(Vec::new(), None));
+    }
+
+    // Parse every member up-front; a corrupt SET entry surfaces as
+    // Validation { Corruption } rather than being silently skipped.
+    let mut parsed: Vec<ExecutionId> = Vec::with_capacity(raw_members.len());
+    for raw in &raw_members {
+        let eid = ExecutionId::parse(raw).map_err(|e| EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::Corruption,
+            detail: format!(
+                "list_executions: {all_key}: member: '{raw}' is not a valid ExecutionId \
+                 (key corruption?): {e}"
+            ),
+        })?;
+        parsed.push(eid);
+    }
+
+    // Lex sort on the wire string so the ordering is stable across
+    // concurrent inserts (ExecutionId has no Ord impl).
+    parsed.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+    // Forward-only cursor: take members strictly greater than cursor.
+    let filtered: Vec<ExecutionId> = if let Some(c) = cursor {
+        let cs = c.as_str();
+        parsed
+            .into_iter()
+            .filter(|e| e.as_str() > cs)
+            .collect()
+    } else {
+        parsed
+    };
+
+    // Cap limit at 1000 per RFC-012 read-surface defaults.
+    let effective_limit = limit.min(1000);
+    let has_more = filtered.len() > effective_limit;
+    let page: Vec<ExecutionId> = filtered.into_iter().take(effective_limit).collect();
+    let next_cursor = if has_more { page.last().cloned() } else { None };
+    Ok(ListExecutionsPage::new(page, next_cursor))
 }
 
 /// Read the deployment's partition config from
@@ -2651,6 +2743,22 @@ impl EngineBackend for ValkeyBackend {
                 ff_core::engine_error::backend_context(
                     e,
                     "list_suspended: SCAN lane:*:suspended + ZRANGE + HMGET reason",
+                )
+            })
+    }
+
+    async fn list_executions(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError> {
+        list_executions_impl(&self.client, &partition, cursor.as_ref(), limit)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "list_executions: SMEMBERS all_executions + sort/filter",
                 )
             })
     }

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2610,6 +2610,38 @@ impl ListSuspendedPage {
     }
 }
 
+// ─── list_executions ───
+
+/// One page of partition-scoped execution ids returned by
+/// [`EngineBackend::list_executions`](crate::engine_backend::EngineBackend::list_executions).
+///
+/// Pagination is forward-only and cursor-based. `next_cursor` carries
+/// the last `ExecutionId` emitted in `executions` iff another page is
+/// available; callers pass that id back as the next call's `cursor`
+/// (exclusive start). `next_cursor = None` signals end-of-stream.
+///
+/// `#[non_exhaustive]` — FF may add fields (e.g. `approximate_total`)
+/// in minor releases without a semver break. Use
+/// [`ListExecutionsPage::new`] for cross-crate construction.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ListExecutionsPage {
+    /// Execution ids on this page, in ascending lexicographic order.
+    pub executions: Vec<ExecutionId>,
+    /// Exclusive cursor to request the next page. `None` ⇒ no more
+    /// results.
+    pub next_cursor: Option<ExecutionId>,
+}
+
+impl ListExecutionsPage {
+    /// Construct a [`ListExecutionsPage`]. Present so downstream
+    /// crates can assemble the struct despite the `#[non_exhaustive]`
+    /// marker.
+    pub fn new(executions: Vec<ExecutionId>, next_cursor: Option<ExecutionId>) -> Self {
+        Self { executions, next_cursor }
+    }
+}
+
 // ─── rotate_waitpoint_hmac_secret ───
 
 /// Args for `ff_rotate_waitpoint_hmac_secret`. Rotates the HMAC signing

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -55,7 +55,8 @@ use crate::backend::{
 use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult};
 #[cfg(feature = "core")]
 use crate::contracts::{
-    EdgeDirection, EdgeSnapshot, ListFlowsPage, ListLanesPage, ListSuspendedPage,
+    EdgeDirection, EdgeSnapshot, ListExecutionsPage, ListFlowsPage, ListLanesPage,
+    ListSuspendedPage,
 };
 #[cfg(feature = "core")]
 use crate::partition::PartitionKey;
@@ -395,6 +396,39 @@ pub trait EngineBackend: Send + Sync + 'static {
         cursor: Option<ExecutionId>,
         limit: usize,
     ) -> Result<ListSuspendedPage, EngineError>;
+
+    /// Forward-only paginated listing of the executions indexed under
+    /// one partition.
+    ///
+    /// Reads the partition-wide `ff:idx:{p:N}:all_executions` set,
+    /// sorts lexicographically on `ExecutionId`, and returns the page
+    /// of ids strictly greater than `cursor` (or starting from the
+    /// smallest id when `cursor = None`). The returned
+    /// [`ListExecutionsPage::next_cursor`] is the last id on the page
+    /// iff at least one more id exists past it; `None` signals
+    /// end-of-stream.
+    ///
+    /// `limit` is the maximum number of ids returned on this page. A
+    /// `limit` of `0` returns an empty page with `next_cursor = None`.
+    /// Backends MAY cap `limit` internally (Valkey: 1000) and return
+    /// fewer ids than requested; callers continue paginating until
+    /// `next_cursor == None`.
+    ///
+    /// Ordering is stable under concurrent inserts for already-emitted
+    /// ids (an id less-than-or-equal-to the caller's cursor is never
+    /// re-emitted in later pages) but new inserts past the cursor WILL
+    /// appear in subsequent pages — consistent with forward-only
+    /// cursor semantics.
+    ///
+    /// Gated on the `core` feature — partition-scoped listing is part
+    /// of the minimal engine surface every backend must honour.
+    #[cfg(feature = "core")]
+    async fn list_executions(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError>;
 
     /// Operator-initiated cancellation of a flow and (optionally) its
     /// member executions. See RFC-012 §3.1.1 for the policy /wait

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -353,7 +353,6 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
         )
     }
 
-    #[cfg(feature = "core")]
     async fn list_executions(
         &self,
         partition: PartitionKey,

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -22,8 +22,8 @@ use ff_core::backend::{
     ResumeSignal, WaitpointSpec,
 };
 use ff_core::contracts::{
-    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
-    ListLanesPage, ListSuspendedPage, ReportUsageResult,
+    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
+    ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
 };
 use ff_core::partition::PartitionKey;
 #[cfg(feature = "valkey-default")]
@@ -350,6 +350,20 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
             self,
             "report_usage",
             self.inner.report_usage(handle, budget, dimensions).await
+        )
+    }
+
+    #[cfg(feature = "core")]
+    async fn list_executions(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError> {
+        with_hooks!(
+            self,
+            "list_executions",
+            self.inner.list_executions(partition, cursor, limit).await
         )
     }
 

--- a/crates/ff-sdk/src/layer/test_support.rs
+++ b/crates/ff-sdk/src/layer/test_support.rs
@@ -19,8 +19,8 @@ use ff_core::backend::{
     WaitpointSpec,
 };
 use ff_core::contracts::{
-    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
-    ListLanesPage, ListSuspendedPage, ReportUsageResult,
+    CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
+    ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
 };
 use ff_core::partition::PartitionKey;
 #[cfg(feature = "valkey-default")]
@@ -266,6 +266,16 @@ impl EngineBackend for PassthroughBackend {
     ) -> Result<ReportUsageResult, EngineError> {
         self.record("report_usage")?;
         Err(EngineError::Unavailable { op: "report_usage" })
+    }
+
+    async fn list_executions(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError> {
+        self.record("list_executions")?;
+        Ok(ListExecutionsPage::new(Vec::new(), None))
     }
 
     #[cfg(feature = "valkey-default")]

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -24,8 +24,8 @@
 //! them without depending on ff-sdk.
 
 use ff_core::contracts::{
-    EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage, ListLanesPage,
-    ListSuspendedPage,
+    EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListExecutionsPage,
+    ListFlowsPage, ListLanesPage, ListSuspendedPage,
 };
 use ff_core::partition::{execution_partition, flow_partition, PartitionKey};
 use ff_core::types::{EdgeId, ExecutionId, FlowId, LaneId};
@@ -198,6 +198,26 @@ impl FlowFabricWorker {
         Ok(self
             .backend_ref()
             .list_suspended(partition, cursor, limit)
+            .await?)
+    }
+
+    /// Forward-only paginated listing of executions in a partition.
+    ///
+    /// Thin forwarder onto
+    /// [`EngineBackend::list_executions`](ff_core::engine_backend::EngineBackend::list_executions).
+    /// Pagination is cursor-based: pass `cursor = None` for the first
+    /// page and feed the returned
+    /// [`ListExecutionsPage::next_cursor`] back as `cursor` until it
+    /// returns `None`. See the trait rustdoc for the full contract.
+    pub async fn list_executions(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListExecutionsPage, SdkError> {
+        Ok(self
+            .backend_ref()
+            .list_executions(partition, cursor, limit)
             .await?)
     }
 

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -601,30 +601,48 @@ fn build_cors_layer(origins: &[String], auth_enabled: bool) -> Result<CorsLayer,
 
 #[derive(Deserialize)]
 struct ListExecutionsParams {
+    /// Partition index (`u16`) to enumerate. Serves as the partition
+    /// key for the forward-only cursor listing.
     partition: u16,
-    #[serde(default = "default_lane")]
-    lane: String,
-    #[serde(default = "default_state_filter")]
-    state: String,
+    /// Exclusive cursor: start listing strictly after this execution
+    /// id. Omit for the first page.
+    #[serde(default)]
+    cursor: Option<String>,
     #[serde(default = "default_limit")]
     limit: u64,
-    #[serde(default)]
-    offset: u64,
 }
 
-fn default_lane() -> String { "default".to_owned() }
-fn default_state_filter() -> String { "eligible".to_owned() }
 fn default_limit() -> u64 { 50 }
 
+/// List executions in one partition with forward-only cursor
+/// pagination.
+///
+/// **Breaking change (unreleased HTTP surface, not on crates.io):** as
+/// of issue #182 this endpoint is a thin forwarder onto
+/// [`ff_core::engine_backend::EngineBackend::list_executions`]. The
+/// previous offset + lane + state filter query parameters were
+/// dropped; the endpoint now returns partition-scoped execution ids
+/// with an opaque `next_cursor`.
+///
+/// Request: `GET /v1/executions?partition=<u16>&cursor=<eid>&limit=<usize>`.
+/// Response: `{ "executions": ["<eid>", ...], "next_cursor": "<eid>" | null }`.
 async fn list_executions(
     State(server): State<Arc<Server>>,
     Query(params): Query<ListExecutionsParams>,
-) -> Result<Json<ListExecutionsResult>, ApiError> {
-    let lane = ff_core::types::LaneId::try_new(params.lane.clone())
-        .map_err(|e| ApiError::from(ServerError::InvalidInput(format!("invalid lane: {e}"))))?;
-    let limit = params.limit.min(1000);
+) -> Result<Json<ListExecutionsPage>, ApiError> {
+    let limit = params.limit.min(1000) as usize;
+    let cursor = match params.cursor {
+        Some(raw) if !raw.is_empty() => Some(
+            ff_core::types::ExecutionId::parse(&raw).map_err(|e| {
+                ApiError::from(ServerError::InvalidInput(format!(
+                    "invalid cursor: {e}"
+                )))
+            })?,
+        ),
+        _ => None,
+    };
     let result = server
-        .list_executions(params.partition, &lane, &params.state, params.offset, limit)
+        .list_executions_page(params.partition, cursor, limit)
         .await?;
     Ok(Json(result))
 }

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -11,8 +11,8 @@ use ff_core::contracts::{
     CreateBudgetArgs, CreateBudgetResult, CreateExecutionArgs, CreateExecutionResult,
     CreateFlowArgs, CreateFlowResult, CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
     ApplyDependencyToChildArgs, ApplyDependencyToChildResult,
-    DeliverSignalArgs, DeliverSignalResult, ExecutionInfo, ExecutionSummary,
-    ListExecutionsResult, PendingWaitpointInfo, ReplayExecutionResult,
+    DeliverSignalArgs, DeliverSignalResult, ExecutionInfo,
+    ListExecutionsPage, PendingWaitpointInfo, ReplayExecutionResult,
     ReportUsageArgs, ReportUsageResult, ResetBudgetResult,
     RevokeLeaseResult,
     RotateWaitpointHmacSecretArgs,
@@ -2303,133 +2303,72 @@ impl Server {
         })
     }
 
-    /// List executions from a partition's index ZSET.
+    /// Partition-scoped forward-only cursor listing of executions.
     ///
-    /// No FCALL — direct ZRANGE + pipelined HMGET reads.
-    pub async fn list_executions(
+    /// Parity-wrapper around the Valkey body of
+    /// [`ff_core::engine_backend::EngineBackend::list_executions`].
+    /// Issue #182 replaced the previous offset + lane + state-filter
+    /// shape with this cursor-based API (per owner adjudication:
+    /// cursor-everywhere, HTTP surface unreleased). Reads
+    /// `ff:idx:{p:N}:all_executions`, sorts lexicographically on
+    /// `ExecutionId`, filters `> cursor`, and trims to `limit`.
+    pub async fn list_executions_page(
         &self,
         partition_id: u16,
-        lane: &LaneId,
-        state_filter: &str,
-        offset: u64,
-        limit: u64,
-    ) -> Result<ListExecutionsResult, ServerError> {
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListExecutionsPage, ServerError> {
+        if limit == 0 {
+            return Ok(ListExecutionsPage::new(Vec::new(), None));
+        }
         let partition = ff_core::partition::Partition {
             family: ff_core::partition::PartitionFamily::Execution,
             index: partition_id,
         };
         let idx = IndexKeys::new(&partition);
+        let all_key = idx.all_executions();
 
-        let zset_key = match state_filter {
-            "eligible" => idx.lane_eligible(lane),
-            "delayed" => idx.lane_delayed(lane),
-            "terminal" => idx.lane_terminal(lane),
-            "suspended" => idx.lane_suspended(lane),
-            "active" => idx.lane_active(lane),
-            other => {
-                return Err(ServerError::InvalidInput(format!(
-                    "invalid state_filter: {other}. Use: eligible, delayed, terminal, suspended, active"
-                )));
-            }
-        };
-
-        // ZRANGE key -inf +inf BYSCORE LIMIT offset count
-        let eids: Vec<String> = self
+        let raw_members: Vec<String> = self
             .client
-            .cmd("ZRANGE")
-            .arg(&zset_key)
-            .arg("-inf")
-            .arg("+inf")
-            .arg("BYSCORE")
-            .arg("LIMIT")
-            .arg(offset)
-            .arg(limit)
+            .cmd("SMEMBERS")
+            .arg(&all_key)
             .execute()
             .await
-            .map_err(|e| crate::server::backend_context(e, format!("ZRANGE {zset_key}")))?;
+            .map_err(|e| crate::server::backend_context(e, format!("SMEMBERS {all_key}")))?;
 
-        if eids.is_empty() {
-            return Ok(ListExecutionsResult {
-                executions: vec![],
-                total_returned: 0,
-            });
+        if raw_members.is_empty() {
+            return Ok(ListExecutionsPage::new(Vec::new(), None));
         }
 
-        // Parse execution IDs, warning on corrupt ZSET members
-        let mut parsed = Vec::with_capacity(eids.len());
-        for eid_str in &eids {
-            match ExecutionId::parse(eid_str) {
+        let mut parsed: Vec<ExecutionId> = Vec::with_capacity(raw_members.len());
+        for raw in &raw_members {
+            match ExecutionId::parse(raw) {
                 Ok(id) => parsed.push(id),
                 Err(e) => {
                     tracing::warn!(
-                        raw_id = %eid_str,
+                        raw_id = %raw,
                         error = %e,
-                        zset = %zset_key,
-                        "list_executions: ZSET member failed to parse as ExecutionId (data corruption?)"
+                        set = %all_key,
+                        "list_executions_page: SMEMBERS member failed to parse as ExecutionId \
+                         (data corruption?)"
                     );
                 }
             }
         }
+        parsed.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 
-        if parsed.is_empty() {
-            return Ok(ListExecutionsResult {
-                executions: vec![],
-                total_returned: 0,
-            });
-        }
+        let filtered: Vec<ExecutionId> = if let Some(c) = cursor.as_ref() {
+            let cs = c.as_str();
+            parsed.into_iter().filter(|e| e.as_str() > cs).collect()
+        } else {
+            parsed
+        };
 
-        // Pipeline all HMGETs into a single round-trip
-        let mut pipe = self.client.pipeline();
-        let mut slots = Vec::with_capacity(parsed.len());
-        for eid in &parsed {
-            let ep = execution_partition(eid, &self.config.partition_config);
-            let ctx = ExecKeyContext::new(&ep, eid);
-            let slot = pipe
-                .cmd::<Vec<Option<String>>>("HMGET")
-                .arg(ctx.core())
-                .arg("namespace")
-                .arg("lane_id")
-                .arg("execution_kind")
-                .arg("public_state")
-                .arg("priority")
-                .arg("created_at")
-                .finish();
-            slots.push(slot);
-        }
-
-        pipe.execute()
-            .await
-            .map_err(|e| crate::server::backend_context(e, "pipeline HMGET"))?;
-
-        let mut summaries = Vec::with_capacity(parsed.len());
-        for (eid, slot) in parsed.into_iter().zip(slots) {
-            let fields: Vec<Option<String>> = slot.value()
-                .map_err(|e| crate::server::backend_context(e, "pipeline slot"))?;
-
-            let field = |i: usize| -> String {
-                fields
-                    .get(i)
-                    .and_then(|v| v.as_ref())
-                    .cloned()
-                    .unwrap_or_default()
-            };
-
-            summaries.push(ExecutionSummary {
-                execution_id: eid,
-                namespace: field(0),
-                lane_id: field(1),
-                execution_kind: field(2),
-                public_state: field(3),
-                priority: field(4).parse().unwrap_or(0),
-                created_at: field(5),
-            });
-        }
-
-        let total = summaries.len();
-        Ok(ListExecutionsResult {
-            executions: summaries,
-            total_returned: total,
-        })
+        let effective_limit = limit.min(1000);
+        let has_more = filtered.len() > effective_limit;
+        let page: Vec<ExecutionId> = filtered.into_iter().take(effective_limit).collect();
+        let next_cursor = if has_more { page.last().cloned() } else { None };
+        Ok(ListExecutionsPage::new(page, next_cursor))
     }
 
     /// Replay a terminal execution.

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -7,7 +7,6 @@
 //!
 //! TODO: Untested API endpoints (tested at Server/FCALL layer but not HTTP):
 //! - POST /v1/executions/{id}/revoke-lease
-//! - GET  /v1/executions?partition=N (list_executions)
 //! - POST /v1/budgets/{id}/usage (report_usage)
 //! - POST /v1/budgets/{id}/reset (reset_budget)
 //! - POST /v1/flows/{id}/edges (stage_dependency_edge)
@@ -19,7 +18,6 @@
 //! TODO: Untested Server methods (tested via FCALL but not typed Server API):
 //! - Server::revoke_lease()
 //! - Server::reset_budget()
-//! - Server::list_executions()
 
 use std::sync::Arc;
 

--- a/crates/ff-test/tests/engine_backend_list_executions.rs
+++ b/crates/ff-test/tests/engine_backend_list_executions.rs
@@ -1,0 +1,376 @@
+//! Trait-boundary + HTTP integration tests for
+//! [`ff_core::engine_backend::EngineBackend::list_executions`] on the
+//! Valkey-backed impl, plus the reshaped `GET /v1/executions` cursor
+//! endpoint introduced by issue #182.
+//!
+//! Covers:
+//!
+//! 1. Page threading across 3 pages at `limit=5` over 15 executions —
+//!    the forward-only cursor returns `next_cursor=Some` twice, then
+//!    `None` on the tail page.
+//! 2. `next_cursor == None` when the partition holds fewer than
+//!    `limit` members.
+//! 3. HTTP endpoint (`GET /v1/executions?partition=N&cursor=...&limit=N`)
+//!    returns the same page shape as the trait.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test engine_backend_list_executions \
+//!       -- --test-threads=1
+
+use std::sync::Arc;
+
+use ferriskey::Value;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::contracts::ListExecutionsPage;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{PartitionConfig, PartitionKey, execution_partition};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use tokio::task::AbortHandle;
+
+const LANE: &str = "list-execs-lane";
+const NS: &str = "list-execs-ns";
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = test_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    ValkeyBackend::from_client_and_partitions(tc.client().clone(), test_config())
+}
+
+/// Seed `n` executions all colocated to the same flow partition so
+/// they land on a single `all_executions` SET. Returns the sorted
+/// (lex-ascending) `ExecutionId` list so tests can assert page
+/// contents.
+async fn seed_executions(tc: &TestCluster, flow_id: &FlowId, n: usize) -> Vec<ExecutionId> {
+    let config = test_config();
+    let mut ids: Vec<ExecutionId> = Vec::with_capacity(n);
+    for _ in 0..n {
+        let eid = ExecutionId::for_flow(flow_id, &config);
+        create_execution(tc, &eid).await;
+        ids.push(eid);
+    }
+    ids.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    ids
+}
+
+async fn create_execution(tc: &TestCluster, eid: &ExecutionId) {
+    let config = test_config();
+    let partition = execution_partition(eid, &config);
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "list_execs_kind".to_owned(),
+        "0".to_owned(),
+        "list-execs-test".to_owned(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution");
+}
+
+fn partition_key_for(flow_id: &FlowId) -> PartitionKey {
+    let partition = ff_core::partition::flow_partition(flow_id, &test_config());
+    PartitionKey::from(&partition)
+}
+
+fn partition_index_for(flow_id: &FlowId) -> u16 {
+    ff_core::partition::flow_partition(flow_id, &test_config()).index
+}
+
+// ─── Trait-boundary tests ───
+
+/// Paginating 15 executions at limit=5 yields 3 pages with
+/// `next_cursor` threaded correctly. Final page has `next_cursor=None`.
+#[tokio::test]
+#[serial_test::serial]
+async fn list_executions_paginates_15_at_limit_5() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let backend = build_backend(&tc);
+
+    let fid = FlowId::new();
+    let seeded = seed_executions(&tc, &fid, 15).await;
+    let partition_key = partition_key_for(&fid);
+
+    // Page 1: cursor=None, limit=5.
+    let page1 = backend
+        .list_executions(partition_key.clone(), None, 5)
+        .await
+        .expect("page1");
+    assert_eq!(page1.executions.len(), 5, "page1 has 5 members");
+    assert_eq!(&page1.executions, &seeded[0..5]);
+    assert_eq!(
+        page1.next_cursor.as_ref(),
+        Some(&seeded[4]),
+        "page1 next_cursor is last returned id"
+    );
+
+    // Page 2: cursor = page1.next_cursor.
+    let page2 = backend
+        .list_executions(partition_key.clone(), page1.next_cursor.clone(), 5)
+        .await
+        .expect("page2");
+    assert_eq!(page2.executions.len(), 5, "page2 has 5 members");
+    assert_eq!(&page2.executions, &seeded[5..10]);
+    assert_eq!(page2.next_cursor.as_ref(), Some(&seeded[9]));
+
+    // Page 3: cursor = page2.next_cursor.
+    let page3 = backend
+        .list_executions(partition_key.clone(), page2.next_cursor.clone(), 5)
+        .await
+        .expect("page3");
+    assert_eq!(page3.executions.len(), 5, "page3 has 5 members");
+    assert_eq!(&page3.executions, &seeded[10..15]);
+    assert_eq!(
+        page3.next_cursor, None,
+        "page3 is final — next_cursor must be None"
+    );
+
+    // Page 4: cursor past end yields empty page + None.
+    let page4 = backend
+        .list_executions(partition_key, Some(seeded[14].clone()), 5)
+        .await
+        .expect("page4");
+    assert!(page4.executions.is_empty());
+    assert_eq!(page4.next_cursor, None);
+}
+
+/// Empty partition returns an empty page with `next_cursor = None`.
+#[tokio::test]
+#[serial_test::serial]
+async fn list_executions_empty_partition_returns_empty_page() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let backend = build_backend(&tc);
+
+    // Synthesise a partition key for an empty partition.
+    let partition_key = PartitionKey::from(&ff_core::partition::Partition {
+        family: ff_core::partition::PartitionFamily::Flow,
+        index: 0,
+    });
+    let page = backend
+        .list_executions(partition_key, None, 10)
+        .await
+        .expect("empty partition list");
+    assert!(page.executions.is_empty());
+    assert_eq!(page.next_cursor, None);
+}
+
+/// `limit == 0` is a legitimate no-op probe; returns empty page +
+/// `next_cursor=None` without hitting Valkey's all_executions set.
+#[tokio::test]
+#[serial_test::serial]
+async fn list_executions_limit_zero_returns_empty_page() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let backend = build_backend(&tc);
+
+    let fid = FlowId::new();
+    seed_executions(&tc, &fid, 3).await;
+    let partition_key = partition_key_for(&fid);
+
+    let page = backend
+        .list_executions(partition_key, None, 0)
+        .await
+        .expect("limit=0");
+    assert!(page.executions.is_empty());
+    assert_eq!(page.next_cursor, None);
+}
+
+// ─── HTTP integration ───
+
+struct TestApi {
+    client: reqwest::Client,
+    base_url: String,
+    abort_handle: AbortHandle,
+}
+
+impl Drop for TestApi {
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
+fn test_server_config() -> ff_server::config::ServerConfig {
+    let config = ff_test::fixtures::TEST_PARTITION_CONFIG;
+    let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
+    let port: u16 = std::env::var("FF_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6379);
+    let tls = ff_test::fixtures::env_flag("FF_TLS");
+    let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
+    ff_server::config::ServerConfig {
+        host,
+        port,
+        tls,
+        cluster,
+        partition_config: config,
+        lanes: vec![LaneId::new(LANE)],
+        listen_addr: "127.0.0.1:0".into(),
+        engine_config: ff_engine::EngineConfig {
+            partition_config: config,
+            lanes: vec![LaneId::new(LANE)],
+            ..Default::default()
+        },
+        skip_library_load: true,
+        cors_origins: vec!["*".to_owned()],
+        api_token: None,
+        waitpoint_hmac_secret:
+            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+        waitpoint_hmac_grace_ms: 86_400_000,
+        max_concurrent_stream_ops: 64,
+    }
+}
+
+async fn setup_api() -> TestApi {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+
+    let server = ff_server::server::Server::start(test_server_config())
+        .await
+        .expect("Server::start");
+    let server = Arc::new(server);
+    let app = ff_server::api::router(server.clone(), &["*".to_owned()], None)
+        .expect("router builds");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    TestApi {
+        client: reqwest::Client::new(),
+        base_url,
+        abort_handle: handle.abort_handle(),
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct HttpPage {
+    executions: Vec<ExecutionId>,
+    next_cursor: Option<ExecutionId>,
+}
+
+/// HTTP endpoint paginates the same way as the trait.
+#[tokio::test]
+#[serial_test::serial]
+async fn list_executions_http_paginates_15_at_limit_5() {
+    let api = setup_api().await;
+    let tc = TestCluster::connect().await;
+
+    let fid = FlowId::new();
+    let seeded = seed_executions(&tc, &fid, 15).await;
+    let partition = partition_index_for(&fid);
+
+    // Page 1.
+    let url = format!("{}/v1/executions?partition={}&limit=5", api.base_url, partition);
+    let resp = api.client.get(&url).send().await.expect("GET page1");
+    assert_eq!(resp.status(), StatusCode::OK, "page1 status");
+    let page1: HttpPage = resp.json().await.expect("json page1");
+    assert_eq!(page1.executions.len(), 5);
+    assert_eq!(&page1.executions, &seeded[0..5]);
+    let cursor = page1
+        .next_cursor
+        .as_ref()
+        .expect("page1 has next_cursor")
+        .clone();
+
+    // Page 2.
+    let url = format!(
+        "{}/v1/executions?partition={}&limit=5&cursor={}",
+        api.base_url, partition, cursor
+    );
+    let resp = api.client.get(&url).send().await.expect("GET page2");
+    let page2: HttpPage = resp.json().await.expect("json page2");
+    assert_eq!(page2.executions.len(), 5);
+    assert_eq!(&page2.executions, &seeded[5..10]);
+    let cursor = page2.next_cursor.expect("page2 has next_cursor");
+
+    // Page 3.
+    let url = format!(
+        "{}/v1/executions?partition={}&limit=5&cursor={}",
+        api.base_url, partition, cursor
+    );
+    let resp = api.client.get(&url).send().await.expect("GET page3");
+    let page3: HttpPage = resp.json().await.expect("json page3");
+    assert_eq!(page3.executions.len(), 5);
+    assert_eq!(&page3.executions, &seeded[10..15]);
+    assert!(
+        page3.next_cursor.is_none(),
+        "final page's next_cursor must be null"
+    );
+}
+
+/// Invalid cursor string surfaces as HTTP 400.
+#[tokio::test]
+#[serial_test::serial]
+async fn list_executions_http_rejects_malformed_cursor() {
+    let api = setup_api().await;
+    let url = format!(
+        "{}/v1/executions?partition=0&limit=5&cursor=not-an-execution-id",
+        api.base_url
+    );
+    let resp = api.client.get(&url).send().await.expect("GET malformed");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// Keep an unused-import guard explicit so a future refactor that
+// accidentally drops `ListExecutionsPage` from the public API surface
+// fails this compile-time witness rather than only the runtime tests.
+#[allow(dead_code)]
+fn _witness_shape(_p: ListExecutionsPage) {}


### PR DESCRIPTION
## Summary

Closes #182. Lands `EngineBackend::list_executions` as the Postgres-portable
partition-scoped read surface and migrates `GET /v1/executions` from offset
to forward-only cursor pagination per the owner adjudication
(cursor-based pagination everywhere, HTTP is pre-0.5.0 unreleased surface).

## Trait signature (ff-core, gated on `core`)

```rust
async fn list_executions(
    &self,
    partition: PartitionKey,
    cursor: Option<ExecutionId>,  // exclusive; None = start from smallest
    limit: usize,
) -> Result<ListExecutionsPage, EngineError>;
```

`ListExecutionsPage { executions: Vec<ExecutionId>, next_cursor: Option<ExecutionId> }`
is `#[non_exhaustive]`. `next_cursor == None` signals end-of-stream.

## Valkey impl

SMEMBERS `ff:idx:{p:N}:all_executions` -> parse every member to
`ExecutionId` (corrupt entries fail loud as `Validation { Corruption }`) ->
lex-sort on wire string (ExecutionId shares a partition prefix, so
intra-partition lex order is UUID-suffix order) -> filter strictly `>` the
caller's cursor -> trim to `limit` (capped at 1000). `next_cursor` is the
last emitted id iff more members remain past the page boundary.

v1 scan-per-page note documented on the impl: acceptable for partitions
holding O(10k) executions since retention trims terminal ids; a parallel
created-at ZSET is noted as a future optimisation.

## HTTP endpoint — before / after

**Before (unreleased):**

```
GET /v1/executions?partition=0&lane=default&state=eligible&offset=0&limit=50
-> { executions: [ExecutionSummary...], total_returned: N }
```

**After:**

```
GET /v1/executions?partition=0&cursor=<eid>&limit=50
-> { executions: [<eid>, ...], next_cursor: "<eid>" | null }
```

Dropped lane + state filters; per-execution metadata now flows through
`GET /v1/executions/{id}` or the `describe_execution` trait. Breaking only
to unreleased HTTP surface (not on crates.io).

## Cursor mechanics

Forward-only: feed `next_cursor` back as `cursor` on the next call, stop
when it returns `null`. An id already less-than-or-equal-to a caller's
cursor is never re-emitted; concurrent inserts past the cursor DO show up
in subsequent pages (standard forward-only semantics).

## Test plan

- [x] `cargo test -p ff-test --test engine_backend_list_executions` — 5
  tests pass against real Valkey (3-page threading at 15/limit=5, empty
  partition, `limit=0` probe, HTTP pagination parity, malformed-cursor
  400).
- [x] `cargo check --workspace --all-targets` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p ff-test -- --test-threads=1` full suite green.
- [x] `cargo test -p ff-core -p ff-backend-valkey -p ff-sdk -p ff-server --lib`
  green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new required (feature-gated) `EngineBackend` method and reshapes the (unreleased) `GET /v1/executions` API to cursor pagination, which can break consumers and backend implementations. The Valkey implementation does full-set scans (`SMEMBERS` + sort/filter) per page, which may impact performance on large partitions if assumptions about cardinality are violated.
> 
> **Overview**
> Adds a new `EngineBackend::list_executions(partition, cursor, limit) -> ListExecutionsPage` read surface (gated on `core`) plus the `ListExecutionsPage { executions: Vec<ExecutionId>, next_cursor }` contract, and wires it through `ff-backend-valkey` and `FlowFabricWorker`/SDK hook layers.
> 
> Reshapes the (unreleased) HTTP `GET /v1/executions` endpoint to **partition-scoped, forward-only cursor pagination**, dropping the previous `lane`/`state` filters and offset-based response; `ff-server` replaces `Server::list_executions` with `Server::list_executions_page` and returns only `ExecutionId`s with `next_cursor`.
> 
> Adds end-to-end tests covering trait paging behavior, HTTP parity, and malformed cursor handling, and updates the changelog to document the new trait and breaking HTTP change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ed390168e8cc9d2c83a4e83c5c83bda0e1dbb2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->