### PR TITLE
feat(ff-core, ff-backend-valkey, ff-sdk): list_flows trait method with cursor pagination (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   per lane") on `examples/grafana/flowfabric-ops.json`. Public
   `ff_observability::AttemptOutcome` enum is feature-agnostic so call
   sites stay symmetric whether `observability` is on or off.
+- **`EngineBackend::list_flows` — cursor-paginated partition listing (#185).**
+  New trait method on `EngineBackend` (core-feature gated) that returns
+  a `ListFlowsPage` of `FlowSummary` rows ordered by `FlowId`
+  (UUID byte-lexicographic). Callers pass `cursor: None` on the first
+  call and forward the returned `next_cursor` to continue iteration;
+  `next_cursor: None` signals the partition is exhausted. New public
+  types in `ff_core::contracts`: `ListFlowsPage`, `FlowSummary`, and
+  `FlowStatus` (an `#[non_exhaustive]` enum mapping the free-form
+  `public_flow_state` literal — `open`/`running`/`blocked` collapse to
+  `Active`; `completed`/`failed`/`cancelled` project directly; unknown
+  literals surface as `Unknown` so callers fall back to
+  `describe_flow`). Valkey impl serves the SET-backed listing via
+  `SMEMBERS flow_index` + client-side UUID-byte sort + pipelined
+  `HGETALL flow_core` per page row; the trait rustdoc documents the
+  Postgres implementation pattern (`WHERE flow_id > $cursor
+  ORDER BY flow_id LIMIT $limit + 1`) so a future Postgres backend
+  serves the same contract natively. `FlowFabricWorker::list_flows`
+  wrapper on ff-sdk. Missing `flow_core` for an indexed id surfaces as
+  `EngineError::Validation { kind: Corruption, .. }`.
 - **Grafana dashboard JSON for operator observability** at
   `examples/grafana/flowfabric-ops.json`. Ten panels covering claim
   latency + rate, lease renewals, worker-at-capacity, admission

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -39,7 +39,7 @@ use ff_core::contracts::decode::{
 };
 use ff_core::contracts::{
     CancelFlowArgs, CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    ReportUsageResult,
+    FlowStatus, FlowSummary, ListFlowsPage, ReportUsageResult,
 };
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
@@ -521,6 +521,138 @@ async fn describe_flow_impl(
         return Ok(None);
     }
     build_flow_snapshot(id.clone(), &raw).map(Some)
+}
+
+/// Page the `flow_index` SET for a partition, ordered by `flow_id`
+/// (UUID byte-lexicographic), and pipeline `HGETALL flow_core` per row
+/// to build [`FlowSummary`] rows.
+///
+/// Cursor semantics: `cursor == None` starts from the smallest
+/// `flow_id`; `Some(fid)` starts strictly after `fid`. `next_cursor`
+/// is `Some(last_row_flow_id)` when the partition has more rows after
+/// the returned page, else `None`.
+///
+/// Missing `flow_core` for an indexed id is surfaced as
+/// `EngineError::Validation { kind: Corruption, .. }` — the same
+/// posture `list_edges_impl` takes for a drifted adjacency SET. FF's
+/// invariant is that a live `flow_index` entry has a present
+/// `flow_core`; the flow projector removes the index entry on
+/// terminal cleanup.
+#[tracing::instrument(
+    name = "ff.list_flows",
+    skip_all,
+    fields(backend = "valkey", partition = %partition)
+)]
+async fn list_flows_impl(
+    client: &ferriskey::Client,
+    partition: &ff_core::partition::PartitionKey,
+    cursor: Option<FlowId>,
+    limit: usize,
+) -> Result<ListFlowsPage, EngineError> {
+    if limit == 0 {
+        return Ok(ListFlowsPage::new(Vec::new(), None));
+    }
+
+    // Parse the opaque PartitionKey into a typed Partition so we can
+    // construct the {fp:N} flow-index key. Malformed keys surface as
+    // validation errors at the caller's boundary.
+    let part = partition.parse().map_err(|e| EngineError::Validation {
+        kind: ff_core::engine_error::ValidationKind::InvalidInput,
+        detail: format!("list_flows: partition: {e}"),
+    })?;
+    let fidx = FlowIndexKeys::new(&part);
+    let index_key = fidx.flow_index();
+
+    // SMEMBERS the full index and sort client-side. The flow projector
+    // keeps this SET bounded by pruning terminal flows, so partition-
+    // scoped listings stay tractable. A Postgres backend would serve
+    // `WHERE partition_key = $1 AND flow_id > $cursor ORDER BY
+    // flow_id LIMIT $limit + 1` directly; this impl is the SET
+    // equivalent.
+    let all_ids: Vec<String> = client
+        .cmd("SMEMBERS")
+        .arg(&index_key)
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+
+    // Parse + sort by UUID bytes. Corrupt entries (non-UUID strings)
+    // fail loud.
+    let mut parsed: Vec<FlowId> = Vec::with_capacity(all_ids.len());
+    for raw in &all_ids {
+        let fid = FlowId::parse(raw).map_err(|e| EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::Corruption,
+            detail: format!(
+                "list_flows: flow_index: '{raw}' is not a valid FlowId \
+                 (key corruption?): {e}"
+            ),
+        })?;
+        parsed.push(fid);
+    }
+    // UUID byte-lexicographic order — matches the Postgres `uuid`
+    // column's default ordering so the trait contract is backend-
+    // agnostic.
+    parsed.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+
+    // Slice after the cursor (exclusive). binary_search lets us skip
+    // past the entire prefix in O(log n) rather than a linear scan.
+    let start = match &cursor {
+        Some(c) => match parsed.binary_search_by(|probe| probe.as_bytes().cmp(c.as_bytes())) {
+            Ok(pos) => pos + 1,
+            Err(pos) => pos,
+        },
+        None => 0,
+    };
+
+    let page: Vec<FlowId> = parsed.iter().skip(start).take(limit).cloned().collect();
+    if page.is_empty() {
+        return Ok(ListFlowsPage::new(Vec::new(), None));
+    }
+    let has_more = start + page.len() < parsed.len();
+
+    // Pipeline one HGETALL flow_core per page row. All keys share the
+    // partition's {fp:N} tag so a single pipeline is cluster-safe.
+    let mut pipe = client.pipeline();
+    let slots: Vec<_> = page
+        .iter()
+        .map(|fid| {
+            let fctx = FlowKeyContext::new(&part, fid);
+            pipe.cmd::<HashMap<String, String>>("HGETALL")
+                .arg(fctx.core())
+                .finish()
+        })
+        .collect();
+    pipe.execute().await.map_err(transport_fk)?;
+
+    let mut flows: Vec<FlowSummary> = Vec::with_capacity(page.len());
+    for (fid, slot) in page.iter().zip(slots) {
+        let raw = slot.value().map_err(transport_fk)?;
+        if raw.is_empty() {
+            // flow_index drift — index entry without a flow_core. FF
+            // invariants say the projector removes the index entry
+            // before the flow_core disappears; treat as corruption.
+            return Err(EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::Corruption,
+                detail: format!(
+                    "list_flows: flow_index entry '{fid}' has no flow_core \
+                     (index/core drift — projector bug?)"
+                ),
+            });
+        }
+        let snap = build_flow_snapshot(fid.clone(), &raw)?;
+        flows.push(FlowSummary::new(
+            snap.flow_id,
+            snap.created_at,
+            FlowStatus::from_public_flow_state(&snap.public_flow_state),
+        ));
+    }
+
+    let next_cursor = if has_more {
+        flows.last().map(|f| f.flow_id.clone())
+    } else {
+        None
+    };
+    Ok(ListFlowsPage::new(flows, next_cursor))
 }
 
 /// Read all edges adjacent to `subject_eid` on the requested side.
@@ -2162,6 +2294,22 @@ impl EngineBackend for ValkeyBackend {
                 ff_core::engine_error::backend_context(
                     e,
                     "resolve_execution_flow_id: HGET exec_core.flow_id",
+                )
+            })
+    }
+
+    async fn list_flows(
+        &self,
+        partition: ff_core::partition::PartitionKey,
+        cursor: Option<FlowId>,
+        limit: usize,
+    ) -> Result<ListFlowsPage, EngineError> {
+        list_flows_impl(&self.client, &partition, cursor, limit)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "list_flows: SMEMBERS flow_index + pipeline HGETALL flow_core",
                 )
             })
     }

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2162,6 +2162,121 @@ impl EdgeSnapshot {
     }
 }
 
+// ─── list_flows (issue #185) ───
+
+/// Typed flow-lifecycle status surfaced on [`FlowSummary`].
+///
+/// Mirrors the free-form `public_flow_state` literal that FF's flow
+/// lifecycle writes onto `flow_core` (known values: `open`, `running`,
+/// `blocked`, `cancelled`, `completed`, `failed` — see [`FlowSnapshot`]).
+/// The three "active" runtime states (`open`, `running`, `blocked`)
+/// collapse to [`FlowStatus::Active`] here — callers that need the
+/// exact runtime sub-state should use [`FlowSnapshot::public_flow_state`]
+/// via [`crate::engine_backend::EngineBackend::describe_flow`]. `failed`
+/// maps to [`FlowStatus::Failed`].
+///
+/// `#[non_exhaustive]` so future lifecycle states (if FF introduces
+/// any) can be added without a semver break.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FlowStatus {
+    /// `open` / `running` / `blocked` — flow is still live on the engine.
+    Active,
+    /// Terminal success: all members reached a successful terminal state
+    /// and the flow projector flipped `public_flow_state` to `completed`.
+    Completed,
+    /// Terminal failure: one or more members failed and the flow
+    /// projector flipped `public_flow_state` to `failed`.
+    Failed,
+    /// Cancelled by an operator via `cancel_flow`.
+    Cancelled,
+    /// The stored `public_flow_state` literal is present but not a
+    /// known value. The raw literal is preserved on
+    /// [`FlowSnapshot::public_flow_state`] — callers that need to act
+    /// on it should fall back to [`crate::engine_backend::EngineBackend::describe_flow`].
+    Unknown,
+}
+
+impl FlowStatus {
+    /// Map the raw `public_flow_state` literal stored on `flow_core`
+    /// to a typed [`FlowStatus`]. Unknown literals surface as
+    /// [`FlowStatus::Unknown`] so the list surface stays forwards-
+    /// compatible with future engine-side state additions.
+    pub fn from_public_flow_state(raw: &str) -> Self {
+        match raw {
+            "open" | "running" | "blocked" => Self::Active,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Lightweight per-flow projection returned by
+/// [`crate::engine_backend::EngineBackend::list_flows`].
+///
+/// Deliberately narrower than [`FlowSnapshot`] — listing pages serve
+/// dashboard-style enumerations where the caller does not want to pay
+/// for the full `flow_core` hash on every row. Consumers that need
+/// revision / node-count / tags / cancel metadata should fan out to
+/// [`crate::engine_backend::EngineBackend::describe_flow`] for the
+/// specific ids they care about.
+///
+/// `#[non_exhaustive]` — FF may add fields in minor releases without
+/// a semver break. Match with `..` or use [`FlowSummary::new`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct FlowSummary {
+    pub flow_id: FlowId,
+    /// Timestamp (ms since unix epoch) `flow_core.created_at` was
+    /// stamped. Mirrors [`FlowSnapshot::created_at`]; kept typed so
+    /// callers that want raw millis can read `.0`.
+    pub created_at: TimestampMs,
+    /// Typed projection of `flow_core.public_flow_state`. See
+    /// [`FlowStatus`] for the mapping.
+    pub status: FlowStatus,
+}
+
+impl FlowSummary {
+    /// Construct a [`FlowSummary`]. Present so downstream crates can
+    /// assemble the struct despite the `#[non_exhaustive]` marker.
+    pub fn new(flow_id: FlowId, created_at: TimestampMs, status: FlowStatus) -> Self {
+        Self {
+            flow_id,
+            created_at,
+            status,
+        }
+    }
+}
+
+/// One page of [`FlowSummary`] rows returned by
+/// [`crate::engine_backend::EngineBackend::list_flows`].
+///
+/// `next_cursor` is `Some(last_flow_id)` when at least one more row
+/// may exist on the partition — callers forward it verbatim as the
+/// next call's `cursor` argument to continue iteration. `None` means
+/// the listing is exhausted. Cursor semantics match the Postgres
+/// `WHERE flow_id > $cursor ORDER BY flow_id LIMIT $limit` pattern
+/// (see the trait method's rustdoc).
+///
+/// `#[non_exhaustive]` — FF may add summary-level fields (total count,
+/// partition hint) in future minor releases without a semver break.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ListFlowsPage {
+    pub flows: Vec<FlowSummary>,
+    pub next_cursor: Option<FlowId>,
+}
+
+impl ListFlowsPage {
+    /// Construct a [`ListFlowsPage`]. Present so downstream crates can
+    /// assemble the struct despite the `#[non_exhaustive]` marker.
+    pub fn new(flows: Vec<FlowSummary>, next_cursor: Option<FlowId>) -> Self {
+        Self { flows, next_cursor }
+    }
+}
+
 /// Summary of state after a mutation, returned by many functions.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateSummary {

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -54,7 +54,9 @@ use crate::backend::{
 };
 use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult};
 #[cfg(feature = "core")]
-use crate::contracts::{EdgeDirection, EdgeSnapshot};
+use crate::contracts::{EdgeDirection, EdgeSnapshot, ListFlowsPage};
+#[cfg(feature = "core")]
+use crate::partition::PartitionKey;
 #[cfg(feature = "streaming")]
 use crate::contracts::{StreamCursor, StreamFrames};
 use crate::engine_error::EngineError;
@@ -280,6 +282,53 @@ pub trait EngineBackend: Send + Sync + 'static {
         &self,
         eid: &ExecutionId,
     ) -> Result<Option<FlowId>, EngineError>;
+
+    /// List flows on a partition with cursor-based pagination (issue
+    /// #185).
+    ///
+    /// Returns a [`ListFlowsPage`] of [`FlowSummary`](crate::contracts::FlowSummary)
+    /// rows ordered by `flow_id` (UUID byte-lexicographic). `cursor`
+    /// is `None` for the first page; callers forward the returned
+    /// `next_cursor` verbatim to continue iteration, and the listing
+    /// is exhausted when `next_cursor` is `None`. `limit` is the
+    /// maximum number of rows to return on this page — implementations
+    /// MAY return fewer (end of partition) but MUST NOT exceed it.
+    ///
+    /// Ordering rationale: flow ids are UUIDs, and both Valkey
+    /// (sort after-the-fact) and Postgres (`ORDER BY flow_id`) can
+    /// agree on byte-lexicographic order — the same order
+    /// `FlowId::to_string()` produces for canonical hyphenated UUIDs.
+    /// Mapping to `cursor > flow_id` keeps the contract backend-
+    /// independent.
+    ///
+    /// # Postgres implementation pattern
+    ///
+    /// A Postgres-backed implementation serves this directly with
+    ///
+    /// ```sql
+    /// SELECT flow_id, created_at_ms, public_flow_state
+    ///   FROM ff_flow
+    ///  WHERE partition_key = $1
+    ///    AND ($2::uuid IS NULL OR flow_id > $2)
+    ///  ORDER BY flow_id
+    ///  LIMIT $3 + 1;
+    /// ```
+    ///
+    /// — reading one extra row to decide whether `next_cursor` should
+    /// be set to the last row's `flow_id`. The Valkey implementation
+    /// maintains the `ff:idx:{fp:N}:flow_index` SET and performs the
+    /// sort + slice client-side (SMEMBERS then sort-by-UUID-bytes),
+    /// pipelining `HGETALL flow_core` for each row on the page.
+    ///
+    /// Gated on the `core` feature — flow listing is part of the
+    /// minimal engine surface a Postgres-style backend must honour.
+    #[cfg(feature = "core")]
+    async fn list_flows(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<FlowId>,
+        limit: usize,
+    ) -> Result<ListFlowsPage, EngineError>;
 
     /// Operator-initiated cancellation of a flow and (optionally) its
     /// member executions. See RFC-012 §3.1.1 for the policy /wait

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -23,7 +23,7 @@ use ff_core::backend::{
 };
 use ff_core::contracts::{
     CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    ReportUsageResult,
+    ListFlowsPage, ReportUsageResult,
 };
 #[cfg(feature = "valkey-default")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
@@ -285,6 +285,19 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
             self,
             "resolve_execution_flow_id",
             self.inner.resolve_execution_flow_id(eid).await
+        )
+    }
+
+    async fn list_flows(
+        &self,
+        partition: ff_core::partition::PartitionKey,
+        cursor: Option<FlowId>,
+        limit: usize,
+    ) -> Result<ListFlowsPage, EngineError> {
+        with_hooks!(
+            self,
+            "list_flows",
+            self.inner.list_flows(partition, cursor, limit).await
         )
     }
 

--- a/crates/ff-sdk/src/layer/test_support.rs
+++ b/crates/ff-sdk/src/layer/test_support.rs
@@ -20,7 +20,7 @@ use ff_core::backend::{
 };
 use ff_core::contracts::{
     CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    ReportUsageResult,
+    ListFlowsPage, ReportUsageResult,
 };
 #[cfg(feature = "valkey-default")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
@@ -226,6 +226,16 @@ impl EngineBackend for PassthroughBackend {
     ) -> Result<CancelFlowResult, EngineError> {
         self.record("cancel_flow")?;
         Err(EngineError::Unavailable { op: "cancel_flow" })
+    }
+
+    async fn list_flows(
+        &self,
+        _partition: ff_core::partition::PartitionKey,
+        _cursor: Option<FlowId>,
+        _limit: usize,
+    ) -> Result<ListFlowsPage, EngineError> {
+        self.record("list_flows")?;
+        Ok(ListFlowsPage::new(Vec::new(), None))
     }
 
     async fn report_usage(

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -23,8 +23,10 @@
 //! non-SDK consumers (tests, REST server, alternate backends) share
 //! them without depending on ff-sdk.
 
-use ff_core::contracts::{EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot};
-use ff_core::partition::{execution_partition, flow_partition};
+use ff_core::contracts::{
+    EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
+};
+use ff_core::partition::{execution_partition, flow_partition, PartitionKey};
 use ff_core::types::{EdgeId, ExecutionId, FlowId};
 
 use crate::SdkError;
@@ -55,6 +57,31 @@ impl FlowFabricWorker {
     /// impl.
     pub async fn describe_flow(&self, id: &FlowId) -> Result<Option<FlowSnapshot>, SdkError> {
         Ok(self.backend_ref().describe_flow(id).await?)
+    }
+
+    /// List flows on a partition with cursor-based pagination
+    /// (issue #185).
+    ///
+    /// `partition` is an opaque [`PartitionKey`] — typically obtained
+    /// from a [`crate::ClaimGrant`] or from
+    /// [`ff_core::partition::flow_partition`] when the caller already
+    /// knows a `FlowId` on the partition it wants to enumerate.
+    /// `cursor` is `None` on the first call and the previous page's
+    /// `next_cursor` on subsequent calls; iteration terminates when
+    /// the returned `next_cursor` is `None`.
+    ///
+    /// Thin forwarder onto
+    /// [`EngineBackend::list_flows`](ff_core::engine_backend::EngineBackend::list_flows).
+    pub async fn list_flows(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<FlowId>,
+        limit: usize,
+    ) -> Result<ListFlowsPage, SdkError> {
+        Ok(self
+            .backend_ref()
+            .list_flows(partition, cursor, limit)
+            .await?)
     }
 
     /// Read a typed snapshot of one dependency edge.

--- a/crates/ff-test/tests/engine_backend_list_flows.rs
+++ b/crates/ff-test/tests/engine_backend_list_flows.rs
@@ -1,0 +1,309 @@
+//! Integration coverage for
+//! [`ff_core::engine_backend::EngineBackend::list_flows`] (issue #185)
+//! on the Valkey-backed impl.
+//!
+//! Creates a pile of flows, bins them by partition, picks a partition
+//! that lands at least five flows, and exercises the cursor-based
+//! pagination contract: first page, second page, terminal cursor.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test engine_backend_list_flows \
+//!       -- --test-threads=1
+
+use std::collections::HashMap;
+
+use ferriskey::Value;
+use ff_core::contracts::{FlowStatus, FlowSummary};
+use ff_core::keys::{FlowIndexKeys, FlowKeyContext};
+use ff_core::partition::{flow_partition, PartitionConfig, PartitionKey};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+const LANE: &str = "list-flows-lane";
+const NS: &str = "list-flows-ns";
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = test_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn build_worker(suffix: &str) -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        backend: ff_test::fixtures::backend_config_from_env(),
+        worker_id: WorkerId::new(format!("list-flows-worker-{suffix}")),
+        worker_instance_id: WorkerInstanceId::new(format!("list-flows-inst-{suffix}")),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 1,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+async fn create_flow(tc: &TestCluster, fid: &FlowId, flow_kind: &str) {
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let ctx = FlowKeyContext::new(&partition, fid);
+    let fidx = FlowIndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![ctx.core(), ctx.members(), fidx.flow_index()];
+    let now_ms = TimestampMs::now().0.to_string();
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        flow_kind.to_owned(),
+        NS.to_owned(),
+        now_ms,
+    ];
+    let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_flow", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_create_flow failed");
+}
+
+async fn cancel_flow_raw(tc: &TestCluster, fid: &FlowId) {
+    let config = test_config();
+    let partition = flow_partition(fid, &config);
+    let ctx = FlowKeyContext::new(&partition, fid);
+    let fidx = FlowIndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.members(),
+        fidx.flow_index(),
+        ctx.pending_cancels(),
+        fidx.cancel_backlog(),
+    ];
+    let now_ms = TimestampMs::now().0.to_string();
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        "operator_requested".to_owned(),
+        "cancel_all".to_owned(),
+        now_ms,
+        String::new(),
+    ];
+    let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_cancel_flow", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_cancel_flow failed");
+}
+
+/// Create flows until at least `want` of them land on a single
+/// partition; return `(partition_key, flow_ids_on_that_partition)`.
+async fn seed_crowded_partition(
+    tc: &TestCluster,
+    want: usize,
+) -> (PartitionKey, Vec<FlowId>) {
+    let cfg = test_config();
+    let mut by_partition: HashMap<u16, Vec<FlowId>> = HashMap::new();
+    // With num_flow_partitions=4 and uniform UUID hashing, ~25% of
+    // flows land on each partition. Seeding 48 flows gives us ~12 per
+    // partition in expectation — comfortably past `want = 5`.
+    for _ in 0..48 {
+        let fid = FlowId::new();
+        let part = flow_partition(&fid, &cfg);
+        create_flow(tc, &fid, "dag").await;
+        by_partition.entry(part.index).or_default().push(fid);
+    }
+    let (index, fids) = by_partition
+        .into_iter()
+        .filter(|(_, v)| v.len() >= want)
+        .max_by_key(|(_, v)| v.len())
+        .expect("at least one partition should have enough flows");
+    let part = ff_core::partition::Partition {
+        family: ff_core::partition::PartitionFamily::Flow,
+        index,
+    };
+    (PartitionKey::from(&part), fids)
+}
+
+/// Drain the full partition listing via `list_flows`, following the
+/// cursor to completion. Returns the concatenated rows.
+async fn drain(
+    worker: &ff_sdk::FlowFabricWorker,
+    partition: &PartitionKey,
+    limit: usize,
+) -> Vec<FlowSummary> {
+    let mut out: Vec<FlowSummary> = Vec::new();
+    let mut cursor: Option<FlowId> = None;
+    loop {
+        let page = worker
+            .list_flows(partition.clone(), cursor.clone(), limit)
+            .await
+            .expect("list_flows ok");
+        out.extend(page.flows.into_iter());
+        match page.next_cursor {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+        // Safety belt: detect a broken cursor that fails to advance.
+        assert!(out.len() < 1000, "list_flows paging failed to terminate");
+    }
+    out
+}
+
+// ─── Tests ───
+
+#[tokio::test]
+async fn list_flows_pages_all_seeded_rows() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("drain").await;
+
+    let (partition, seeded) = seed_crowded_partition(&tc, 5).await;
+
+    // Drain with a small page so at least two iterations happen.
+    let drained = drain(&worker, &partition, 3).await;
+    assert_eq!(
+        drained.len(),
+        seeded.len(),
+        "drained count must match seeded count on the partition"
+    );
+
+    // Every seeded flow must appear exactly once.
+    let drained_set: std::collections::HashSet<FlowId> =
+        drained.iter().map(|f| f.flow_id.clone()).collect();
+    let seeded_set: std::collections::HashSet<FlowId> = seeded.into_iter().collect();
+    assert_eq!(drained_set, seeded_set);
+
+    // Byte-lexicographic sort must hold across the full listing.
+    let ids: Vec<&FlowId> = drained.iter().map(|f| &f.flow_id).collect();
+    for pair in ids.windows(2) {
+        assert!(
+            pair[0].as_bytes() < pair[1].as_bytes(),
+            "list_flows must return rows in UUID byte-lexicographic order"
+        );
+    }
+
+    // Summary shape: created_at is populated, status is Active for
+    // freshly-created flows.
+    for row in &drained {
+        assert!(row.created_at.0 > 0, "created_at must be populated");
+        assert_eq!(
+            row.status,
+            FlowStatus::Active,
+            "fresh flows project to FlowStatus::Active"
+        );
+    }
+}
+
+#[tokio::test]
+async fn list_flows_cursor_is_exclusive_and_advances() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("cursor").await;
+
+    let (partition, _seeded) = seed_crowded_partition(&tc, 5).await;
+
+    let page1 = worker
+        .list_flows(partition.clone(), None, 3)
+        .await
+        .expect("list_flows page 1");
+    assert_eq!(page1.flows.len(), 3);
+    assert!(
+        page1.next_cursor.is_some(),
+        "page 1 must surface a cursor when more rows exist"
+    );
+    let cursor = page1.next_cursor.clone().unwrap();
+    // Cursor is the last row on the page.
+    assert_eq!(
+        &cursor,
+        &page1.flows.last().unwrap().flow_id,
+        "next_cursor is the last returned flow_id"
+    );
+
+    let page2 = worker
+        .list_flows(partition.clone(), Some(cursor.clone()), 3)
+        .await
+        .expect("list_flows page 2");
+    // No overlap with page 1 (cursor is exclusive).
+    let page1_ids: Vec<FlowId> = page1.flows.iter().map(|f| f.flow_id.clone()).collect();
+    for row in &page2.flows {
+        assert!(
+            !page1_ids.contains(&row.flow_id),
+            "page 2 row {} must not appear in page 1",
+            row.flow_id
+        );
+        assert!(
+            row.flow_id.as_bytes() > cursor.as_bytes(),
+            "page 2 rows must be strictly greater than the cursor"
+        );
+    }
+}
+
+#[tokio::test]
+async fn list_flows_surfaces_cancelled_status() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("cancelled").await;
+
+    // Create a single flow and cancel it. Use its own partition so we
+    // don't need to seed a crowded one.
+    let fid = FlowId::new();
+    create_flow(&tc, &fid, "dag").await;
+    cancel_flow_raw(&tc, &fid).await;
+
+    let cfg = test_config();
+    let part = flow_partition(&fid, &cfg);
+    let pk: PartitionKey = (&part).into();
+
+    let page = worker
+        .list_flows(pk, None, 100)
+        .await
+        .expect("list_flows ok");
+    let row = page
+        .flows
+        .iter()
+        .find(|f| f.flow_id == fid)
+        .expect("cancelled flow must appear in listing");
+    assert_eq!(row.status, FlowStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn list_flows_empty_partition_returns_empty() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+    let worker = build_worker("empty").await;
+
+    // A partition we haven't written anything to. Pick partition 0 —
+    // cleanup guarantees it's empty.
+    let part = ff_core::partition::Partition {
+        family: ff_core::partition::PartitionFamily::Flow,
+        index: 0,
+    };
+    let pk: PartitionKey = (&part).into();
+
+    let page = worker
+        .list_flows(pk, None, 10)
+        .await
+        .expect("list_flows ok");
+    assert!(page.flows.is_empty());
+    assert!(page.next_cursor.is_none());
+}


### PR DESCRIPTION
## Summary

Closes #185. Adds `EngineBackend::list_flows(partition, cursor, limit)` so operator dashboards / admin tooling can page through flows on a partition without reaching into `ff:idx:{fp:N}:flow_index` directly.

- New core-feature-gated trait method returning `ListFlowsPage { flows: Vec<FlowSummary>, next_cursor: Option<FlowId> }`.
- New public contracts: `ListFlowsPage`, `FlowSummary { flow_id, created_at, status }`, and a typed `FlowStatus` enum (`Active` / `Completed` / `Failed` / `Cancelled` / `Unknown`) that projects the free-form `public_flow_state` literal.
- Cursor-pagination convention: `cursor > flow_id` in UUID byte-lexicographic order — the same order a Postgres backend serves via `WHERE flow_id > $cursor ORDER BY flow_id LIMIT $limit + 1`. The trait rustdoc documents the Postgres implementation pattern so a future backend serves the same contract.
- Valkey impl: `SMEMBERS flow_index` + client-side UUID-byte sort + binary-search slice past the cursor + pipelined `HGETALL flow_core` per page row. `flow_index` entry without a `flow_core` surfaces as `EngineError::Validation { Corruption }` (index/core drift).
- ff-sdk `FlowFabricWorker::list_flows` wrapper delegates through the trait; `HookedBackend` + the layer test-support `PassthroughBackend` gain the method.

## Test plan

- [x] `cargo build --workspace --all-targets` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p ff-core --lib` — 162 passed.
- [x] `cargo test -p ff-sdk --lib` — 40 passed.
- [x] `cargo test -p ff-test --test engine_backend_list_flows -- --test-threads=1` — 4 passed (drain-to-completion, exclusive cursor advance, cancelled-status projection, empty partition).
- [ ] CI gates green.

FlowStatus shape: new enum (no pre-existing `FlowState` type — `public_flow_state` was surfaced as `String` on `FlowSnapshot`). The new enum is `#[non_exhaustive]` with a dedicated `Unknown` variant so callers can fall back to `describe_flow` for the exact literal if a future lifecycle state is added engine-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `EngineBackend` trait method and wires it through Valkey and the SDK, which can break downstream implementors and changes how flow listings are retrieved/paginated. Valkey implementation does full `SMEMBERS` + client-side sort, so performance/memory depends on `flow_index` size and correctness of index/core invariants.
> 
> **Overview**
> Adds a new core-gated `EngineBackend::list_flows(partition, cursor, limit)` API for cursor-paginated flow enumeration, returning a `ListFlowsPage` of lightweight `FlowSummary` rows plus `next_cursor`.
> 
> Introduces new public contracts `FlowStatus` (typed projection of `public_flow_state`), `FlowSummary`, and `ListFlowsPage`; implements the method in `ff-backend-valkey` via `SMEMBERS flow index` + UUID-byte sorting + pipelined `HGETALL flow_core`, surfacing index/core drift as `Validation::Corruption`. Exposes the capability via `ff-sdk::FlowFabricWorker::list_flows`, updates hooked/test backends, and adds Valkey integration tests covering paging order, cursor exclusivity, cancelled-state projection, and empty partitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14dfce1446161a9fbfd1efe8cf437049733484f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->