### PR TITLE
feat(ff-core, ff-backend-valkey, ff-sdk): list_suspended trait method with cursor pagination (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,36 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Lanes are global (not partition-scoped), so the trait method takes
   no `Partition` argument. Prereq for ff-board's lane-overview panel
   (issue #181 roll-up).
+- **`EngineBackend::list_suspended` — cursor-paginated suspended-
+  executions listing with reason populated (issue #183).** New
+  `core`-gated trait method on `EngineBackend` plus
+  `ff_core::contracts::{ListSuspendedPage, SuspendedExecutionEntry}`
+  (both `#[non_exhaustive]`). `SuspendedExecutionEntry` carries the
+  `reason_code` from `suspension:current` so `ff-board`-style panels
+  answer "what is this blocked on?" without a per-row round-trip.
+  `reason` is a `String` rather than a closed enum because the
+  suspending pipeline accepts free-form reason codes (typical values
+  `"signal"`, `"timer"`, `"children"`, `"join"` — but consumers
+  embed bespoke codes). Valkey backend impl on cluster routes
+  `cluster_scan` through the new hash-tag-aware single-shard path
+  (scans only the primary owning the partition tag); standalone
+  falls back to the cursor-based `SCAN MATCH` loop. Results merge by
+  ascending score with execution id as a lex tiebreak, slice past the
+  opaque cursor, and pipeline `HMGET suspension:current reason_code`
+  for the returned page. ff-sdk wrapper exposes the trait method
+  through `FlowFabricWorker::list_suspended`; the layer scaffolding
+  (`HookedBackend`, `PassthroughBackend`) forwards the new op for
+  hook observability.
+- **`ferriskey::cluster_scan` hash-tag-aware single-shard routing.**
+  When the `ClusterScanArgs.match_pattern` embeds a hash tag
+  (`{tag}`), the initial scan-state bitmap pre-marks every slot
+  scanned except the one owning the tag; the scan touches only that
+  primary and finishes once its cursor wraps. Pre-existing
+  no-tag behaviour is unchanged. Added `Client::is_cluster()` and a
+  typed `Client::cluster_scan()` wrapper that returns
+  `(ScanStateRC, Vec<Value>)` directly for Rust callers;
+  `ClusterScanArgs` / `ScanStateRC` / `ObjectType` re-exported at the
+  crate root.
 - **Grafana dashboard JSON for operator observability** at
   `examples/grafana/flowfabric-ops.json`. Ten panels covering claim
   latency + rate, lease renewals, worker-at-capacity, admission

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -535,17 +535,18 @@ async fn list_suspended_impl(
     let tag = parsed.hash_tag();
 
     // 1. Enumerate per-lane suspended ZSETs in this partition via
-    //    `KEYS`. Cluster routing for `KEYS`: ferriskey routes
-    //    `KEYS` as `AllPrimaries` + `CombineArrays` (see
-    //    `ferriskey/src/cluster/routing.rs`), so the returned array
-    //    is the union from every primary. Under RFC-011 hash-tag
-    //    co-location every lane:*:suspended key with this partition
-    //    tag lives on the same node; the broadcast is correct but
-    //    not minimal. Acceptable — `list_suspended` is operator-
-    //    tooling call shape, not hot path. `SCAN` was the earlier
-    //    choice; it does NOT work in cluster mode because its
-    //    per-node iteration lands on only one primary (see the CI
-    //    failure that drove this switch).
+    //    `SCAN MATCH ff:idx:{tag}:lane:*:suspended`. Two paths:
+    //
+    //    * Standalone: loop `SCAN` with a string cursor until the
+    //      sentinel "0" is returned.
+    //    * Cluster: `Client::cluster_scan` with the same match
+    //      pattern. ferriskey recognises the embedded hash tag
+    //      (`{tag}`) and pins the scan to the single primary that
+    //      owns the tag's slot, finishing as soon as that node's
+    //      cursor wraps — not a cluster-wide broadcast. Using
+    //      plain `cmd("SCAN")` in cluster mode would route to one
+    //      arbitrary primary via `RouteBy::Undefined` and miss the
+    //      partition if the owning primary differs.
     //
     //    Safety cap — refuse to enumerate pathologically large key
     //    spaces. 10k unique lane-suspended keys per partition is a
@@ -553,14 +554,56 @@ async fn list_suspended_impl(
     //    cost at query time.
     const MAX_LANE_KEYS: usize = 10_000;
     let match_pat = format!("ff:idx:{tag}:lane:*:suspended");
-    let mut lane_keys: Vec<String> = client
-        .cmd("KEYS")
-        .arg(match_pat.as_str())
-        .execute()
-        .await
-        .map_err(transport_fk)?;
-    if lane_keys.len() > MAX_LANE_KEYS {
-        lane_keys.truncate(MAX_LANE_KEYS);
+    let mut lane_keys: Vec<String> = Vec::new();
+    if client.is_cluster().await {
+        let args = ferriskey::ClusterScanArgs::builder()
+            .with_match_pattern(match_pat.as_str())
+            .with_count(100)
+            .build();
+        let mut cursor = ferriskey::ScanStateRC::new();
+        loop {
+            let (next_cursor, values) = client
+                .cluster_scan(&cursor, args.clone())
+                .await
+                .map_err(transport_fk)?;
+            for v in values {
+                if lane_keys.len() >= MAX_LANE_KEYS {
+                    break;
+                }
+                if let Ok(s) = ferriskey::from_owned_value::<String>(v) {
+                    lane_keys.push(s);
+                }
+            }
+            if next_cursor.is_finished() || lane_keys.len() >= MAX_LANE_KEYS {
+                break;
+            }
+            cursor = next_cursor;
+        }
+    } else {
+        let mut scan_cursor = "0".to_string();
+        loop {
+            let raw: ferriskey::Value = client
+                .cmd("SCAN")
+                .arg(scan_cursor.as_str())
+                .arg("MATCH")
+                .arg(match_pat.as_str())
+                .arg("COUNT")
+                .arg("100")
+                .execute()
+                .await
+                .map_err(transport_fk)?;
+            let (next_cursor, keys) = parse_scan_response(&raw);
+            for k in keys {
+                if lane_keys.len() >= MAX_LANE_KEYS {
+                    break;
+                }
+                lane_keys.push(k);
+            }
+            scan_cursor = next_cursor;
+            if scan_cursor == "0" || lane_keys.len() >= MAX_LANE_KEYS {
+                break;
+            }
+        }
     }
     if lane_keys.is_empty() {
         return Ok(ListSuspendedPage::new(Vec::new(), None));
@@ -671,6 +714,31 @@ async fn list_suspended_impl(
     }
 
     Ok(ListSuspendedPage::new(entries, next_cursor))
+}
+
+/// Parse a SCAN/SSCAN reply `[cursor, [key1, key2, ...]]`. Mirrors
+/// the pattern in `ff_engine::scanner::quota_reconciler`. Used on
+/// the standalone `list_suspended` path; the cluster path uses
+/// `Client::cluster_scan` which returns typed values directly.
+fn parse_scan_response(val: &ferriskey::Value) -> (String, Vec<String>) {
+    let arr = match val {
+        ferriskey::Value::Array(a) if a.len() >= 2 => a,
+        _ => return ("0".to_string(), vec![]),
+    };
+    let cursor = match &arr[0] {
+        Ok(ferriskey::Value::BulkString(b)) => String::from_utf8_lossy(b).into_owned(),
+        Ok(ferriskey::Value::SimpleString(s)) => s.clone(),
+        _ => return ("0".to_string(), vec![]),
+    };
+    let mut keys = Vec::new();
+    if let Ok(ferriskey::Value::Array(inner)) = &arr[1] {
+        for item in inner {
+            if let Ok(ferriskey::Value::BulkString(b)) = item {
+                keys.push(String::from_utf8_lossy(b).into_owned());
+            }
+        }
+    }
+    (cursor, keys)
 }
 
 /// Single `HGETALL flow_core` + decode via [`build_flow_snapshot`].

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -535,36 +535,32 @@ async fn list_suspended_impl(
     let tag = parsed.hash_tag();
 
     // 1. Enumerate per-lane suspended ZSETs in this partition via
-    //    SCAN MATCH. Same iteration shape as quota_reconciler.rs.
-    let match_pat = format!("ff:idx:{tag}:lane:*:suspended");
-    let mut lane_keys: Vec<String> = Vec::new();
-    let mut scan_cursor = "0".to_string();
-    // Safety cap — refuse to enumerate pathologically large key spaces.
-    // 10k unique lane-suspended keys per partition is a loud operational
-    // anomaly; the cap bounds the scan cost at query time.
+    //    `KEYS`. Cluster routing for `KEYS`: ferriskey routes
+    //    `KEYS` as `AllPrimaries` + `CombineArrays` (see
+    //    `ferriskey/src/cluster/routing.rs`), so the returned array
+    //    is the union from every primary. Under RFC-011 hash-tag
+    //    co-location every lane:*:suspended key with this partition
+    //    tag lives on the same node; the broadcast is correct but
+    //    not minimal. Acceptable — `list_suspended` is operator-
+    //    tooling call shape, not hot path. `SCAN` was the earlier
+    //    choice; it does NOT work in cluster mode because its
+    //    per-node iteration lands on only one primary (see the CI
+    //    failure that drove this switch).
+    //
+    //    Safety cap — refuse to enumerate pathologically large key
+    //    spaces. 10k unique lane-suspended keys per partition is a
+    //    loud operational anomaly; the cap bounds the enumeration
+    //    cost at query time.
     const MAX_LANE_KEYS: usize = 10_000;
-    loop {
-        let raw: ferriskey::Value = client
-            .cmd("SCAN")
-            .arg(scan_cursor.as_str())
-            .arg("MATCH")
-            .arg(match_pat.as_str())
-            .arg("COUNT")
-            .arg("100")
-            .execute()
-            .await
-            .map_err(transport_fk)?;
-        let (next_cursor, keys) = parse_scan_response(&raw);
-        for k in keys {
-            if lane_keys.len() >= MAX_LANE_KEYS {
-                break;
-            }
-            lane_keys.push(k);
-        }
-        scan_cursor = next_cursor;
-        if scan_cursor == "0" || lane_keys.len() >= MAX_LANE_KEYS {
-            break;
-        }
+    let match_pat = format!("ff:idx:{tag}:lane:*:suspended");
+    let mut lane_keys: Vec<String> = client
+        .cmd("KEYS")
+        .arg(match_pat.as_str())
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    if lane_keys.len() > MAX_LANE_KEYS {
+        lane_keys.truncate(MAX_LANE_KEYS);
     }
     if lane_keys.is_empty() {
         return Ok(ListSuspendedPage::new(Vec::new(), None));
@@ -675,29 +671,6 @@ async fn list_suspended_impl(
     }
 
     Ok(ListSuspendedPage::new(entries, next_cursor))
-}
-
-/// Parse a SCAN/SSCAN reply `[cursor, [key1, key2, ...]]`. Mirrors
-/// the pattern in `ff_engine::scanner::quota_reconciler`.
-fn parse_scan_response(val: &ferriskey::Value) -> (String, Vec<String>) {
-    let arr = match val {
-        ferriskey::Value::Array(a) if a.len() >= 2 => a,
-        _ => return ("0".to_string(), vec![]),
-    };
-    let cursor = match &arr[0] {
-        Ok(ferriskey::Value::BulkString(b)) => String::from_utf8_lossy(b).into_owned(),
-        Ok(ferriskey::Value::SimpleString(s)) => s.clone(),
-        _ => return ("0".to_string(), vec![]),
-    };
-    let mut keys = Vec::new();
-    if let Ok(ferriskey::Value::Array(inner)) = &arr[1] {
-        for item in inner {
-            if let Ok(ferriskey::Value::BulkString(b)) = item {
-                keys.push(String::from_utf8_lossy(b).into_owned());
-            }
-        }
-    }
-    (cursor, keys)
 }
 
 /// Single `HGETALL flow_core` + decode via [`build_flow_snapshot`].

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -613,18 +613,21 @@ async fn list_suspended_impl(
             .then_with(|| a.0.to_string().cmp(&b.0.to_string()))
     });
 
-    // 4. Advance past cursor (exclusive) if supplied.
+    // 4. Advance past cursor (exclusive) if supplied. Sort key is
+    //    (score asc, eid lex asc); locate the cursor's entry and
+    //    start at the next index. If the cursor's eid is no longer
+    //    present (resumed between pages), fall back to eid-lex
+    //    comparison.
     let start_idx = if let Some(c) = &cursor {
-        let c_str = c.to_string();
-        // Find first entry strictly greater than the cursor under the
-        // sort key. Since the cursor itself is an ExecutionId, treat
-        // any entry whose eid lex-compares > cursor as "after cursor"
-        // within the same score band; entries at a strictly greater
-        // score are also after.
-        merged
-            .iter()
-            .position(|(eid, _)| eid.to_string() > c_str)
-            .unwrap_or(merged.len())
+        if let Some(pos) = merged.iter().position(|(eid, _)| eid == c) {
+            pos + 1
+        } else {
+            let c_str = c.to_string();
+            merged
+                .iter()
+                .position(|(eid, _)| eid.to_string() > c_str)
+                .unwrap_or(merged.len())
+        }
     } else {
         0
     };

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -39,8 +39,10 @@ use ff_core::contracts::decode::{
 };
 use ff_core::contracts::{
     CancelFlowArgs, CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
-    FlowStatus, FlowSummary, ListFlowsPage, ListLanesPage, ReportUsageResult,
+    FlowStatus, FlowSummary, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
+    SuspendedExecutionEntry,
 };
+use ff_core::partition::PartitionKey;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
@@ -492,6 +494,207 @@ async fn describe_execution_impl(
     }
     let tags_raw = tags_slot.value().map_err(transport_fk)?;
     build_execution_snapshot(id.clone(), &core, tags_raw)
+}
+
+/// List suspended executions in one partition, cursor-paginated,
+/// with suspension `reason_code` populated per entry (issue #183).
+///
+/// The engine maintains per-lane suspended ZSETs
+/// (`ff:idx:<tag>:lane:<lane_id>:suspended`) rather than a single
+/// partition-wide ZSET, so this impl issues a bounded `SCAN` for the
+/// lane-suspended key set under the partition's hash tag (single-
+/// slot under RFC-011 co-location), `ZRANGE`s each, merges by score
+/// ascending (with execution id as lex tiebreak), skips past the
+/// supplied cursor, and pipelines `HMGET suspension:current reason_code`
+/// for the returned slice.
+///
+/// Cluster note: the SCAN is issued with a MATCH pattern pinned to
+/// the partition's hash tag. ferriskey's SCAN routing may broadcast
+/// across nodes; the MATCH filter still yields only keys whose slot
+/// maps to the tag, so the result set is correct but the scan cost
+/// is per-node. Operator-tooling call shape — not hot path.
+#[tracing::instrument(
+    name = "ff.list_suspended",
+    skip_all,
+    fields(backend = "valkey", partition = %partition)
+)]
+async fn list_suspended_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    partition: PartitionKey,
+    cursor: Option<ExecutionId>,
+    limit: usize,
+) -> Result<ListSuspendedPage, EngineError> {
+    if limit == 0 {
+        return Ok(ListSuspendedPage::new(Vec::new(), None));
+    }
+    let parsed = partition.parse().map_err(|e| EngineError::Validation {
+        kind: ff_core::engine_error::ValidationKind::InvalidInput,
+        detail: format!("list_suspended: partition: {e}"),
+    })?;
+    let tag = parsed.hash_tag();
+
+    // 1. Enumerate per-lane suspended ZSETs in this partition via
+    //    SCAN MATCH. Same iteration shape as quota_reconciler.rs.
+    let match_pat = format!("ff:idx:{tag}:lane:*:suspended");
+    let mut lane_keys: Vec<String> = Vec::new();
+    let mut scan_cursor = "0".to_string();
+    // Safety cap — refuse to enumerate pathologically large key spaces.
+    // 10k unique lane-suspended keys per partition is a loud operational
+    // anomaly; the cap bounds the scan cost at query time.
+    const MAX_LANE_KEYS: usize = 10_000;
+    loop {
+        let raw: ferriskey::Value = client
+            .cmd("SCAN")
+            .arg(scan_cursor.as_str())
+            .arg("MATCH")
+            .arg(match_pat.as_str())
+            .arg("COUNT")
+            .arg("100")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        let (next_cursor, keys) = parse_scan_response(&raw);
+        for k in keys {
+            if lane_keys.len() >= MAX_LANE_KEYS {
+                break;
+            }
+            lane_keys.push(k);
+        }
+        scan_cursor = next_cursor;
+        if scan_cursor == "0" || lane_keys.len() >= MAX_LANE_KEYS {
+            break;
+        }
+    }
+    if lane_keys.is_empty() {
+        return Ok(ListSuspendedPage::new(Vec::new(), None));
+    }
+
+    // 2. Pipelined ZRANGE WITHSCORES on every lane ZSET. Each ZSET
+    //    is small-to-medium (suspended executions on one lane);
+    //    pulling the full range lets us merge + skip-past-cursor on
+    //    the client side with correct (score, eid) ordering.
+    let mut pipe = client.pipeline();
+    let slots: Vec<_> = lane_keys
+        .iter()
+        .map(|k| {
+            pipe.cmd::<Vec<(String, f64)>>("ZRANGE")
+                .arg(k.as_str())
+                .arg("0")
+                .arg("-1")
+                .arg("WITHSCORES")
+                .finish()
+        })
+        .collect();
+    pipe.execute().await.map_err(transport_fk)?;
+
+    let mut merged: Vec<(ExecutionId, i64)> = Vec::new();
+    for (lane_key, slot) in lane_keys.iter().zip(slots) {
+        let pairs: Vec<(String, f64)> = slot.value().map_err(transport_fk)?;
+        for (eid_str, score) in pairs {
+            match ExecutionId::parse(&eid_str) {
+                Ok(eid) => merged.push((eid, score as i64)),
+                Err(e) => {
+                    tracing::warn!(
+                        raw_id = %eid_str,
+                        error = %e,
+                        zset = %lane_key,
+                        "list_suspended: ZSET member failed to parse as ExecutionId"
+                    );
+                }
+            }
+        }
+    }
+
+    // 3. Sort by (score asc, execution_id lex asc) for deterministic
+    //    cursor continuation.
+    merged.sort_by(|a, b| {
+        a.1.cmp(&b.1)
+            .then_with(|| a.0.to_string().cmp(&b.0.to_string()))
+    });
+
+    // 4. Advance past cursor (exclusive) if supplied.
+    let start_idx = if let Some(c) = &cursor {
+        let c_str = c.to_string();
+        // Find first entry strictly greater than the cursor under the
+        // sort key. Since the cursor itself is an ExecutionId, treat
+        // any entry whose eid lex-compares > cursor as "after cursor"
+        // within the same score band; entries at a strictly greater
+        // score are also after.
+        merged
+            .iter()
+            .position(|(eid, _)| eid.to_string() > c_str)
+            .unwrap_or(merged.len())
+    } else {
+        0
+    };
+
+    let end_idx = (start_idx + limit).min(merged.len());
+    let page: Vec<(ExecutionId, i64)> = merged[start_idx..end_idx].to_vec();
+    let next_cursor = if end_idx < merged.len() {
+        page.last().map(|(eid, _)| eid.clone())
+    } else {
+        None
+    };
+
+    if page.is_empty() {
+        return Ok(ListSuspendedPage::new(Vec::new(), next_cursor));
+    }
+
+    // 5. Pipelined `HMGET suspension:current reason_code` for each
+    //    returned execution. `suspension:current` lives under the
+    //    execution's partition (same partition as the caller's
+    //    `partition` under RFC-011 co-location, but we compute the
+    //    per-eid context so alternate routing remains correct).
+    let mut pipe = client.pipeline();
+    let slots: Vec<_> = page
+        .iter()
+        .map(|(eid, _)| {
+            let ep = execution_partition(eid, partition_config);
+            let ctx = ExecKeyContext::new(&ep, eid);
+            pipe.cmd::<Vec<Option<String>>>("HMGET")
+                .arg(ctx.suspension_current())
+                .arg("reason_code")
+                .finish()
+        })
+        .collect();
+    pipe.execute().await.map_err(transport_fk)?;
+
+    let mut entries = Vec::with_capacity(page.len());
+    for ((eid, score), slot) in page.into_iter().zip(slots) {
+        let fields: Vec<Option<String>> = slot.value().map_err(transport_fk)?;
+        let reason = fields
+            .into_iter()
+            .next()
+            .flatten()
+            .unwrap_or_default();
+        entries.push(SuspendedExecutionEntry::new(eid, score, reason));
+    }
+
+    Ok(ListSuspendedPage::new(entries, next_cursor))
+}
+
+/// Parse a SCAN/SSCAN reply `[cursor, [key1, key2, ...]]`. Mirrors
+/// the pattern in `ff_engine::scanner::quota_reconciler`.
+fn parse_scan_response(val: &ferriskey::Value) -> (String, Vec<String>) {
+    let arr = match val {
+        ferriskey::Value::Array(a) if a.len() >= 2 => a,
+        _ => return ("0".to_string(), vec![]),
+    };
+    let cursor = match &arr[0] {
+        Ok(ferriskey::Value::BulkString(b)) => String::from_utf8_lossy(b).into_owned(),
+        Ok(ferriskey::Value::SimpleString(s)) => s.clone(),
+        _ => return ("0".to_string(), vec![]),
+    };
+    let mut keys = Vec::new();
+    if let Ok(ferriskey::Value::Array(inner)) = &arr[1] {
+        for item in inner {
+            if let Ok(ferriskey::Value::BulkString(b)) = item {
+                keys.push(String::from_utf8_lossy(b).into_owned());
+            }
+        }
+    }
+    (cursor, keys)
 }
 
 /// Single `HGETALL flow_core` + decode via [`build_flow_snapshot`].
@@ -2389,6 +2592,22 @@ impl EngineBackend for ValkeyBackend {
             .await
             .map_err(|e| {
                 ff_core::engine_error::backend_context(e, "list_lanes: SMEMBERS ff:idx:lanes")
+            })
+    }
+
+    async fn list_suspended(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError> {
+        list_suspended_impl(&self.client, &self.partition_config, partition, cursor, limit)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "list_suspended: SCAN lane:*:suspended + ZRANGE + HMGET reason",
+                )
             })
     }
 

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2535,6 +2535,81 @@ impl ListLanesPage {
     }
 }
 
+// ─── list_suspended ───
+
+/// One entry in a [`ListSuspendedPage`] — a suspended execution and
+/// the reason it is blocked, answering an operator's "what's this
+/// waiting on?" without a follow-up round-trip.
+///
+/// `reason` carries the free-form `reason_code` recorded by the
+/// suspending worker at `lua/suspension.lua` (HSET `suspension:current
+/// reason_code`). It is a `String`, not a closed enum: the suspension
+/// pipeline accepts arbitrary caller-supplied codes (typical values
+/// are `"signal"`, `"timer"`, `"children"`, `"join"`, but consumers
+/// embed bespoke codes). A future enum projection can classify
+/// known codes once the set is frozen; until then, callers that want
+/// structured routing MUST match on the string explicitly.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SuspendedExecutionEntry {
+    /// Execution currently in `lifecycle_phase=suspended`.
+    pub execution_id: ExecutionId,
+    /// Score stored on the per-lane suspended ZSET — the scheduled
+    /// `timeout_at` in milliseconds, or the `9999999999999` sentinel
+    /// when no timeout was set (see `lua/suspension.lua`).
+    pub suspended_at_ms: i64,
+    /// Free-form reason code from `suspension:current.reason_code`.
+    /// Empty string when the suspension hash is absent or does not
+    /// carry a `reason_code` field (older records). See the struct
+    /// rustdoc for the deliberate-String rationale.
+    pub reason: String,
+}
+
+impl SuspendedExecutionEntry {
+    /// Construct a new entry. Preferred over direct field init for
+    /// `#[non_exhaustive]` forward-compat.
+    pub fn new(execution_id: ExecutionId, suspended_at_ms: i64, reason: String) -> Self {
+        Self {
+            execution_id,
+            suspended_at_ms,
+            reason,
+        }
+    }
+}
+
+/// One cursor-paginated page of suspended executions.
+///
+/// Pagination is cursor-based (not offset/limit) so a Valkey backend
+/// can resume a partition scan from the last seen execution id and a
+/// future Postgres backend can do keyset pagination on
+/// `executions WHERE state='suspended'`. The cursor is opaque to
+/// callers: pass `next_cursor` back as the `cursor` argument to the
+/// next [`EngineBackend::list_suspended`] call to fetch the next
+/// page. `None` means the stream is exhausted.
+///
+/// [`EngineBackend::list_suspended`]: crate::engine_backend::EngineBackend::list_suspended
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ListSuspendedPage {
+    /// Entries on this page, ordered by ascending `suspended_at_ms`
+    /// (timeout order) with `execution_id` as a lex tiebreak.
+    pub entries: Vec<SuspendedExecutionEntry>,
+    /// Resume-point for the next page. `None` when no further
+    /// entries remain in the partition.
+    pub next_cursor: Option<ExecutionId>,
+}
+
+impl ListSuspendedPage {
+    /// Construct a new page. Preferred over direct field init for
+    /// `#[non_exhaustive]` forward-compat.
+    pub fn new(entries: Vec<SuspendedExecutionEntry>, next_cursor: Option<ExecutionId>) -> Self {
+        Self {
+            entries,
+            next_cursor,
+        }
+    }
+}
+
 // ─── rotate_waitpoint_hmac_secret ───
 
 /// Args for `ff_rotate_waitpoint_hmac_secret`. Rotates the HMAC signing

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -54,7 +54,9 @@ use crate::backend::{
 };
 use crate::contracts::{CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult};
 #[cfg(feature = "core")]
-use crate::contracts::{EdgeDirection, EdgeSnapshot, ListFlowsPage, ListLanesPage};
+use crate::contracts::{
+    EdgeDirection, EdgeSnapshot, ListFlowsPage, ListLanesPage, ListSuspendedPage,
+};
 #[cfg(feature = "core")]
 use crate::partition::PartitionKey;
 #[cfg(feature = "streaming")]
@@ -359,6 +361,40 @@ pub trait EngineBackend: Send + Sync + 'static {
         cursor: Option<LaneId>,
         limit: usize,
     ) -> Result<ListLanesPage, EngineError>;
+
+    /// List suspended executions in one partition, cursor-paginated,
+    /// with each entry's suspension `reason_code` populated (issue
+    /// #183).
+    ///
+    /// Consumer-facing "what's blocked on what?" panels (ff-board's
+    /// suspended-executions view, operator CLIs) need the reason in
+    /// the list response so the UI does not round-trip per row to
+    /// `describe_execution` for a field it knows it needs. `reason`
+    /// on [`SuspendedExecutionEntry`] carries the free-form
+    /// `suspension:current.reason_code` field — see the type rustdoc
+    /// for the String-not-enum rationale.
+    ///
+    /// `cursor` is opaque to callers; pass `None` to start a fresh
+    /// scan and feed the returned [`ListSuspendedPage::next_cursor`]
+    /// back in on subsequent pages until it comes back `None`.
+    /// `limit` bounds the `entries` count; backends MAY return fewer
+    /// when the partition is exhausted.
+    ///
+    /// Ordering is by ascending `suspended_at_ms` (the per-lane
+    /// suspended ZSET score == `timeout_at` or the no-timeout
+    /// sentinel) with execution id as a lex tiebreak, so cursor
+    /// continuation is deterministic across calls.
+    ///
+    /// Gated on the `core` feature — suspended-list enumeration is
+    /// part of the minimal engine surface a Postgres-style backend
+    /// must honour.
+    #[cfg(feature = "core")]
+    async fn list_suspended(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError>;
 
     /// Operator-initiated cancellation of a flow and (optionally) its
     /// member executions. See RFC-012 §3.1.1 for the policy /wait

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -23,8 +23,9 @@ use ff_core::backend::{
 };
 use ff_core::contracts::{
     CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
-    ListLanesPage, ReportUsageResult,
+    ListLanesPage, ListSuspendedPage, ReportUsageResult,
 };
+use ff_core::partition::PartitionKey;
 #[cfg(feature = "valkey-default")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
 use ff_core::engine_backend::EngineBackend;
@@ -310,6 +311,19 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
             self,
             "list_lanes",
             self.inner.list_lanes(cursor, limit).await
+        )
+    }
+
+    async fn list_suspended(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError> {
+        with_hooks!(
+            self,
+            "list_suspended",
+            self.inner.list_suspended(partition, cursor, limit).await
         )
     }
 

--- a/crates/ff-sdk/src/layer/test_support.rs
+++ b/crates/ff-sdk/src/layer/test_support.rs
@@ -20,8 +20,9 @@ use ff_core::backend::{
 };
 use ff_core::contracts::{
     CancelFlowResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage,
-    ListLanesPage, ReportUsageResult,
+    ListLanesPage, ListSuspendedPage, ReportUsageResult,
 };
+use ff_core::partition::PartitionKey;
 #[cfg(feature = "valkey-default")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
 use ff_core::engine_backend::EngineBackend;
@@ -225,6 +226,16 @@ impl EngineBackend for PassthroughBackend {
     ) -> Result<ListLanesPage, EngineError> {
         self.record("list_lanes")?;
         Ok(ListLanesPage::new(Vec::new(), None))
+    }
+
+    async fn list_suspended(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError> {
+        self.record("list_suspended")?;
+        Ok(ListSuspendedPage::new(Vec::new(), None))
     }
 
     async fn cancel_flow(

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -25,6 +25,7 @@
 
 use ff_core::contracts::{
     EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListFlowsPage, ListLanesPage,
+    ListSuspendedPage,
 };
 use ff_core::partition::{execution_partition, flow_partition, PartitionKey};
 use ff_core::types::{EdgeId, ExecutionId, FlowId, LaneId};
@@ -175,6 +176,29 @@ impl FlowFabricWorker {
         limit: usize,
     ) -> Result<ListLanesPage, SdkError> {
         Ok(self.backend_ref().list_lanes(cursor, limit).await?)
+    }
+
+    /// List suspended executions in one partition, cursor-paginated,
+    /// with each entry's suspension `reason_code` populated (issue
+    /// #183).
+    ///
+    /// Thin forwarder onto the bundled
+    /// [`EngineBackend::list_suspended`](ff_core::engine_backend::EngineBackend::list_suspended)
+    /// impl. `cursor = None` starts a fresh scan; feed the returned
+    /// [`ListSuspendedPage::next_cursor`] back in to page forward until
+    /// it returns `None`. See
+    /// [`ff_core::contracts::SuspendedExecutionEntry`] for the per-row
+    /// fields (including the free-form `reason` code).
+    pub async fn list_suspended(
+        &self,
+        partition: PartitionKey,
+        cursor: Option<ExecutionId>,
+        limit: usize,
+    ) -> Result<ListSuspendedPage, SdkError> {
+        Ok(self
+            .backend_ref()
+            .list_suspended(partition, cursor, limit)
+            .await?)
     }
 
     /// Resolve `exec_core.flow_id` via the trait and pin the RFC-011

--- a/crates/ff-test/tests/engine_backend_list_suspended.rs
+++ b/crates/ff-test/tests/engine_backend_list_suspended.rs
@@ -1,0 +1,160 @@
+//! Integration coverage for
+//! [`ff_core::engine_backend::EngineBackend::list_suspended`] on the
+//! Valkey-backed impl (issue #183).
+//!
+//! Seeds three suspended executions across two lanes in one
+//! partition, then pages through via the trait method with
+//! `limit=2` + cursor and asserts:
+//!   - entries are ordered by ascending `suspended_at_ms` (score)
+//!   - `reason` is populated from `suspension:current.reason_code`
+//!   - `next_cursor` returns the remaining entry on a second call
+//!   - a third call with the exhausted cursor returns an empty page
+//!
+//! The seeding path is direct `HSET` + `ZADD` rather than a full
+//! `ff_suspend_execution` FCALL — list_suspended only reads
+//! `lane:*:suspended` ZSETs + `suspension:current.reason_code`, so
+//! the full suspend scaffold is out of scope.
+//!
+//! Run with: cargo test -p ff-test --test engine_backend_list_suspended -- --test-threads=1
+
+use std::sync::Arc;
+
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, PartitionKey};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> ff_core::partition::PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+async fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    ValkeyBackend::from_client_and_partitions(tc.client().clone(), test_config())
+}
+
+/// Seed one suspended execution in `(partition, lane)` with the
+/// given `suspended_at_ms` score on the lane-suspended ZSET and
+/// `reason_code` on `suspension:current`.
+async fn seed_suspended(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    lane: &LaneId,
+    suspended_at_ms: i64,
+    reason_code: &str,
+) {
+    let partition = execution_partition(eid, &test_config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+
+    // Seed exec_core minimally (not strictly required by list_suspended,
+    // but keeps the fixture close to the real suspended state shape).
+    let _: i64 = tc
+        .client()
+        .cmd("HSET")
+        .arg(ctx.core().as_str())
+        .arg("execution_id")
+        .arg(eid.to_string().as_str())
+        .arg("lifecycle_phase")
+        .arg("suspended")
+        .arg("public_state")
+        .arg("suspended")
+        .execute()
+        .await
+        .unwrap();
+
+    // Seed suspension:current with the reason_code the impl HMGETs.
+    let _: i64 = tc
+        .client()
+        .cmd("HSET")
+        .arg(ctx.suspension_current().as_str())
+        .arg("suspension_id")
+        .arg(uuid::Uuid::new_v4().to_string().as_str())
+        .arg("reason_code")
+        .arg(reason_code)
+        .execute()
+        .await
+        .unwrap();
+
+    // Add to the per-lane suspended ZSET with the given score.
+    let _: i64 = tc
+        .client()
+        .cmd("ZADD")
+        .arg(idx.lane_suspended(lane).as_str())
+        .arg(suspended_at_ms.to_string().as_str())
+        .arg(eid.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn list_suspended_paginates_and_populates_reason() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let fid = FlowId::new();
+    let cfg = test_config();
+
+    // Three executions in the same flow (=> same partition under
+    // RFC-011 co-location), two lanes to exercise the cross-lane
+    // SCAN + merge path.
+    let eid_a = ExecutionId::for_flow(&fid, &cfg);
+    let eid_b = ExecutionId::for_flow(&fid, &cfg);
+    let eid_c = ExecutionId::for_flow(&fid, &cfg);
+
+    let lane_1 = LaneId::new("list-susp-lane-1");
+    let lane_2 = LaneId::new("list-susp-lane-2");
+
+    // Score ordering: a (1000) < b (2000) < c (3000), so pagination
+    // by limit=2 returns [a, b] then [c].
+    seed_suspended(&tc, &eid_a, &lane_1, 1000, "signal").await;
+    seed_suspended(&tc, &eid_b, &lane_2, 2000, "timer").await;
+    seed_suspended(&tc, &eid_c, &lane_1, 3000, "children").await;
+
+    let backend = build_backend(&tc).await;
+    let partition = execution_partition(&eid_a, &cfg);
+    let pkey = PartitionKey::from(&partition);
+
+    // Page 1: first two entries ordered by score.
+    let page1 = backend
+        .list_suspended(pkey.clone(), None, 2)
+        .await
+        .expect("list_suspended page 1");
+    assert_eq!(page1.entries.len(), 2, "page 1 should hold 2 entries");
+    assert_eq!(page1.entries[0].execution_id, eid_a);
+    assert_eq!(page1.entries[0].suspended_at_ms, 1000);
+    assert_eq!(page1.entries[0].reason, "signal");
+    assert_eq!(page1.entries[1].execution_id, eid_b);
+    assert_eq!(page1.entries[1].suspended_at_ms, 2000);
+    assert_eq!(page1.entries[1].reason, "timer");
+    let cursor = page1
+        .next_cursor
+        .clone()
+        .expect("page 1 should yield a next cursor");
+
+    // Page 2: remaining entry.
+    let page2 = backend
+        .list_suspended(pkey.clone(), Some(cursor.clone()), 2)
+        .await
+        .expect("list_suspended page 2");
+    assert_eq!(page2.entries.len(), 1, "page 2 should hold 1 entry");
+    assert_eq!(page2.entries[0].execution_id, eid_c);
+    assert_eq!(page2.entries[0].suspended_at_ms, 3000);
+    assert_eq!(page2.entries[0].reason, "children");
+    assert!(
+        page2.next_cursor.is_none(),
+        "page 2 should exhaust the partition, got cursor={:?}",
+        page2.next_cursor
+    );
+
+    // Page 3: resuming past the last-seen execution returns empty.
+    let page3 = backend
+        .list_suspended(pkey, Some(page2.entries[0].execution_id.clone()), 2)
+        .await
+        .expect("list_suspended page 3");
+    assert!(page3.entries.is_empty(), "exhausted scan should be empty");
+    assert!(page3.next_cursor.is_none());
+}

--- a/ferriskey/src/client/mod.rs
+++ b/ferriskey/src/client/mod.rs
@@ -878,6 +878,40 @@ impl Client {
     //
     // The wrapper create an object contain the cursor-id with a drop function that will remove the cursor from the container.
     // When the ref is removed from the hash-map, there's no more references to the ScanState, and the GC will clean it.
+    /// Returns `true` when the underlying connection is in
+    /// cluster mode. Cheap: acquires the read-lock on the
+    /// already-initialized [`ClientWrapper`] and matches the
+    /// variant.
+    pub async fn is_cluster(&self) -> bool {
+        let guard = self.internal_client.read().await;
+        matches!(&*guard, ClientWrapper::Cluster { .. })
+    }
+
+    /// Typed-tuple variant of [`Self::cluster_scan`] for Rust
+    /// callers that want direct access to the next scan state and
+    /// key list without the language-binding cursor-id container
+    /// shim. Errors on standalone.
+    pub async fn cluster_scan_typed<'a>(
+        &'a mut self,
+        scan_state_cursor: &'a ScanStateRC,
+        cluster_scan_args: ClusterScanArgs,
+    ) -> Result<(ScanStateRC, Vec<Value>)> {
+        let scan_state_cursor_clone = scan_state_cursor.clone();
+        let cluster_scan_args_clone = cluster_scan_args.clone();
+        let client = self.get_or_initialize_client().await?;
+        match client {
+            ClientWrapper::Standalone(_) => Err(Error::from((
+                ErrorKind::InvalidClientConfig,
+                "Cluster scan is not supported in standalone mode",
+            ))),
+            ClientWrapper::Cluster { mut client } => {
+                client
+                    .cluster_scan(scan_state_cursor_clone, cluster_scan_args_clone)
+                    .await
+            }
+        }
+    }
+
     pub async fn cluster_scan<'a>(
         &'a mut self,
         scan_state_cursor: &'a ScanStateRC,

--- a/ferriskey/src/cluster/mod.rs
+++ b/ferriskey/src/cluster/mod.rs
@@ -28,7 +28,7 @@ pub mod connections;
 pub mod container;
 pub(crate) mod pipeline;
 pub mod routing;
-pub(crate) mod scan;
+pub mod scan;
 pub mod slotmap;
 pub mod topology;
 /// Exposed only for testing.

--- a/ferriskey/src/cluster/scan.rs
+++ b/ferriskey/src/cluster/scan.rs
@@ -41,7 +41,7 @@
 //! - Invalid routing scenarios
 
 use crate::cluster::routing::SlotAddr;
-use crate::cluster::topology::SLOT_SIZE;
+use crate::cluster::topology::{SLOT_SIZE, get_slot};
 use crate::cluster::{ClusterConnInner, Connect, InnerCore, RefreshPolicy};
 use crate::cmd::cmd;
 use crate::connection::ConnectionLike;
@@ -395,15 +395,34 @@ impl ScanState {
     async fn initiate_scan<C>(
         core: &InnerCore<C>,
         allow_non_covered_slots: bool,
+        match_pattern: Option<&[u8]>,
     ) -> Result<ScanState>
     where
         C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
     {
-        let mut new_scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE as usize];
+        // Hash-tag-scoped scan: if the match pattern embeds a
+        // Valkey hash tag (`{tag}`), every matching key hashes
+        // into the single slot owned by that tag. Pre-mark every
+        // other slot as scanned so the scan only traverses the
+        // one primary that owns the tag's slot and finishes
+        // after that node's cursor wraps. Without this, ferriskey
+        // iterates every primary serially — correct, but wasteful
+        // when the caller has already pinned a hash tag.
+        let (mut new_scanned_slots_map, start_slot) = match match_pattern
+            .and_then(hashtag_from_pattern)
+        {
+            Some(tag) => {
+                let pinned = get_slot(tag);
+                let mut map: SlotsBitsArray = [u64::MAX; BITS_ARRAY_SIZE as usize];
+                unmark_slot_as_scanned(&mut map, pinned);
+                (map, pinned)
+            }
+            None => ([0; BITS_ARRAY_SIZE as usize], 0),
+        };
         let new_cursor = 0;
         let address = next_address_to_scan(
             core,
-            0,
+            start_slot,
             &mut new_scanned_slots_map,
             allow_non_covered_slots,
         )
@@ -510,6 +529,28 @@ fn mark_slot_as_scanned(scanned_slots_map: &mut SlotsBitsArray, slot: u16) {
     let slot_index = (slot as u64 / BITS_PER_U64 as u64) as usize;
     let slot_bit = slot as u64 % (BITS_PER_U64 as u64);
     scanned_slots_map[slot_index] |= 1 << slot_bit;
+}
+
+/// Clear the bit for `slot` in the bitmap, marking it as NOT
+/// scanned. Used by hash-tag-scoped initiation, where the bitmap
+/// starts with every slot marked scanned except the pinned slot
+/// so `next_address_to_scan` locates only the primary that owns
+/// the hash tag.
+fn unmark_slot_as_scanned(scanned_slots_map: &mut SlotsBitsArray, slot: u16) {
+    let slot_index = (slot as u64 / BITS_PER_U64 as u64) as usize;
+    let slot_bit = slot as u64 % (BITS_PER_U64 as u64);
+    scanned_slots_map[slot_index] &= !(1 << slot_bit);
+}
+
+/// Extract the bytes of the first Valkey hash tag (`{...}`) in a
+/// MATCH pattern, or `None` if absent or empty. Matches the
+/// tag-extraction logic in [`crate::cluster::topology`] used for
+/// slot routing so scan pinning and key routing agree.
+fn hashtag_from_pattern(pattern: &[u8]) -> Option<&[u8]> {
+    let open = pattern.iter().position(|b| *b == b'{')?;
+    let close_rel = pattern[open + 1..].iter().position(|b| *b == b'}')?;
+    let tag = &pattern[open + 1..open + 1 + close_rel];
+    (!tag.is_empty()).then_some(tag)
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -641,7 +682,13 @@ where
     // - Otherwise, initiate a new scan.
     let scan_state = match scan_state_cursor.state_from_wrapper() {
         Some(state) => state,
-        None => match ScanState::initiate_scan(&core, allow_non_covered_slots).await {
+        None => match ScanState::initiate_scan(
+            &core,
+            allow_non_covered_slots,
+            cluster_scan_args.match_pattern.as_deref(),
+        )
+        .await
+        {
             Ok(state) => state,
             Err(err) => {
                 // Early return if initiating the scan fails
@@ -887,6 +934,45 @@ mod tests {
         mark_slot_as_scanned(&mut scanned_slots_map, 5);
 
         assert_eq!(scanned_slots_map[0], 1 << 5);
+    }
+
+    #[test]
+    fn test_hashtag_from_pattern() {
+        assert_eq!(hashtag_from_pattern(b"ff:idx:{abc}:lane:*"), Some(&b"abc"[..]));
+        assert_eq!(hashtag_from_pattern(b"no-tag-here:*"), None);
+        assert_eq!(hashtag_from_pattern(b"{}empty"), None);
+        assert_eq!(hashtag_from_pattern(b"{only-open"), None);
+        // Only first occurrence considered.
+        assert_eq!(hashtag_from_pattern(b"{first}and{second}"), Some(&b"first"[..]));
+    }
+
+    #[test]
+    fn test_unmark_slot_as_scanned() {
+        let mut map: SlotsBitsArray = [u64::MAX; BITS_ARRAY_SIZE as usize];
+        unmark_slot_as_scanned(&mut map, 5);
+        // Slot 5 cleared, everything else set.
+        assert_eq!(map[0], u64::MAX & !(1u64 << 5));
+        for word in &map[1..] {
+            assert_eq!(*word, u64::MAX);
+        }
+        // next_slot should now return exactly 5.
+        assert_eq!(next_slot(&map), Some(5));
+    }
+
+    #[test]
+    fn test_hashtag_scoped_bitmap_finishes_after_pinned_slot() {
+        // Simulate the hash-tag-scoped initial bitmap: every slot
+        // marked scanned except the pinned one. Once the pinned
+        // node's slots (a super-set including the pinned slot)
+        // get marked scanned by the completed-address path,
+        // next_slot returns END_OF_SCAN so the scan finishes on
+        // a single node rather than iterating every primary.
+        let pinned = get_slot(b"abc");
+        let mut map: SlotsBitsArray = [u64::MAX; BITS_ARRAY_SIZE as usize];
+        unmark_slot_as_scanned(&mut map, pinned);
+        assert_eq!(next_slot(&map), Some(pinned));
+        mark_slot_as_scanned(&mut map, pinned);
+        assert_eq!(next_slot(&map), Some(END_OF_SCAN));
     }
 
     #[tokio::test]

--- a/ferriskey/src/cluster/scan.rs
+++ b/ferriskey/src/cluster/scan.rs
@@ -951,7 +951,7 @@ mod tests {
         let mut map: SlotsBitsArray = [u64::MAX; BITS_ARRAY_SIZE as usize];
         unmark_slot_as_scanned(&mut map, 5);
         // Slot 5 cleared, everything else set.
-        assert_eq!(map[0], u64::MAX & !(1u64 << 5));
+        assert_eq!(map[0], !(1u64 << 5));
         for word in &map[1..] {
             assert_eq!(*word, u64::MAX);
         }

--- a/ferriskey/src/ferriskey_client.rs
+++ b/ferriskey/src/ferriskey_client.rs
@@ -331,6 +331,41 @@ impl Client {
         self.execute(c).await
     }
 
+    /// Returns `true` when the underlying connection is in
+    /// cluster mode, `false` for standalone. Lets callers that
+    /// need mode-specific behaviour (e.g. `cluster_scan` vs
+    /// plain `SCAN`) dispatch without introspecting the builder
+    /// that produced this client.
+    pub async fn is_cluster(&self) -> bool {
+        self.0.is_cluster().await
+    }
+
+    /// Cluster-wide `SCAN` driven by ferriskey's internal slot
+    /// bitmap. Returns the next [`ScanStateRC`] (call
+    /// [`ScanStateRC::is_finished`] to detect completion) plus the
+    /// batch of keys found on the node visited in this step.
+    ///
+    /// When [`ClusterScanArgs::match_pattern`] embeds a Valkey
+    /// hash tag (`{tag}`), the scan is pinned to the single
+    /// primary that owns the tag's slot and finishes after that
+    /// node's cursor wraps — an O(one-primary) operation, not
+    /// O(cluster-wide).
+    ///
+    /// Errors with [`crate::value::ErrorKind::InvalidClientConfig`]
+    /// when called on a standalone client. Callers should dispatch
+    /// on [`Client::is_cluster`].
+    pub async fn cluster_scan(
+        &self,
+        scan_state: &crate::ScanStateRC,
+        args: crate::ClusterScanArgs,
+    ) -> Result<(crate::ScanStateRC, Vec<crate::value::Value>)> {
+        // Clone mirrors the pattern used by `execute`: ClientInner
+        // needs `&mut self` for IAM token rotation; the clone is
+        // cheap (Arc fields + atomics).
+        let mut inner = (*self.0).clone();
+        inner.cluster_scan_typed(scan_state, args).await
+    }
+
     /// Start building an arbitrary command by name.
     pub fn cmd(&self, name: &str) -> CommandBuilder {
         CommandBuilder {

--- a/ferriskey/src/lib.rs
+++ b/ferriskey/src/lib.rs
@@ -68,6 +68,7 @@ pub use ferriskey_client::{
     Client, ClientBuilder, CommandBuilder, LazyClient, PipeCmdBuilder, PipeSlot, ReadFrom,
     TypedPipeline,
 };
+pub use cluster::scan::{ClusterScanArgs, ClusterScanArgsBuilder, ObjectType, ScanStateRC};
 
 /// Connect to a standalone Valkey server.
 ///


### PR DESCRIPTION
Closes #183.

## Summary

- New `core`-gated `EngineBackend::list_suspended(partition, cursor, limit)` async trait method; Valkey-backed impl + ff-sdk `FlowFabricWorker::list_suspended` wrapper; layer scaffolding (`HookedBackend`, `PassthroughBackend`) forwards the op.
- New `#[non_exhaustive]` types `ff_core::contracts::{ListSuspendedPage, SuspendedExecutionEntry}` with `new(..)` constructors for forward-compat. Per-entry `reason` is populated from `suspension:current.reason_code` so consumers don't round-trip per row.

## Trait + type shapes

```rust
// ff-core::engine_backend (gated on `core`)
async fn list_suspended(
    &self,
    partition: PartitionKey,
    cursor: Option<ExecutionId>,
    limit: usize,
) -> Result<ListSuspendedPage, EngineError>;

// ff-core::contracts
#[non_exhaustive]
pub struct ListSuspendedPage {
    pub entries: Vec<SuspendedExecutionEntry>,
    pub next_cursor: Option<ExecutionId>,
}

#[non_exhaustive]
pub struct SuspendedExecutionEntry {
    pub execution_id: ExecutionId,
    pub suspended_at_ms: i64,
    pub reason: String,
}
```

### SuspendReason shape: `String`, not enum

`lua/suspension.lua` writes `reason_code` as a free-form caller-supplied string (typical values `"signal"`, `"timer"`, `"children"`, `"join"`, but consumers embed bespoke codes). A closed enum would silently drop unknown codes; `String` keeps the wire contract honest. A future enum projection can classify known codes once the set is frozen — documented inline on `SuspendedExecutionEntry`.

## Pagination mechanics

Cursor-based (not offset/limit) so a Valkey backend can do ZRANGE continuation and a Postgres backend (per #58) can do keyset pagination. Ordering: `suspended_at_ms` ascending with `execution_id` as a lex tiebreak — deterministic so cursor continuation is stable across calls. Pass `None` to start a fresh scan; feed `next_cursor` back in until it returns `None`.

## Valkey impl

The engine maintains per-lane suspended ZSETs (`ff:idx:<tag>:lane:<lane_id>:suspended`) rather than a partition-wide one. The impl SCANs for those keys under the partition's hash tag (single-slot under RFC-011 co-location), pipelines `ZRANGE 0 -1 WITHSCORES` on each, merges client-side, slices past the opaque cursor, and pipelines `HMGET suspension:current reason_code` for the returned page. Cluster fan-out caveat is documented in the impl rustdoc — operator-tooling call shape, not hot path.

## Test coverage

New `crates/ff-test/tests/engine_backend_list_suspended.rs`:

- seeds 3 suspended executions across 2 lanes in one partition (direct `HSET` + `ZADD` fixture — `list_suspended` only reads ZSETs + `suspension:current.reason_code`);
- page 1 (`limit=2, cursor=None`) returns the 2 lowest-score entries with `reason` populated;
- page 2 (`limit=2, cursor=Some(next_cursor)`) returns the remaining entry and `next_cursor=None`;
- page 3 (resuming past exhaustion) returns an empty page.

## Test plan

- [x] `cargo check --workspace --all-features` green
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey --features ff-sdk/direct-valkey-claim -- -D warnings` clean
- [x] `cargo clippy -p ff-test --tests --features ff-sdk/direct-valkey-claim -- -D warnings` clean
- [x] `cargo check -p ff-core --no-default-features` green (confirms `core`-gated method doesn't leak through disabled features)
- [x] Integration test `engine_backend_list_suspended::list_suspended_paginates_and_populates_reason` passes against local Valkey

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `EngineBackend` API and a non-trivial Valkey/cluster scan implementation (SCAN/ZRANGE merge + cursor logic), which could impact correctness/perf for large partitions or cluster routing edge cases.
> 
> **Overview**
> Adds **`EngineBackend::list_suspended`** (core-gated) plus new `ff_core::contracts` types `ListSuspendedPage` and `SuspendedExecutionEntry` to return cursor-paginated suspended executions **including `suspension:current.reason_code`**.
> 
> Implements the method in the Valkey backend by scanning per-lane `lane:*:suspended` ZSETs, merging/sorting results deterministically, paging via an opaque cursor, and pipelining `HMGET` to populate reasons; the ff-sdk forwards this via `FlowFabricWorker::list_suspended` and hook/test backends are updated accordingly. Also extends `ferriskey` with cluster-mode detection and a hash-tag-scoped `cluster_scan` optimization, and adds an integration test covering ordering, pagination, and reason population.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7579c4290f34f3960b45219f689a247abbc887a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->