### PR TITLE
chore: bump workspace to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-23
+
 ### Added
 
 - **`ff_attempt_outcome_total` counter metric** (`ff-observability` +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "ff-observability",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "ferriskey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -34,17 +34,17 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.4.0", path = "crates/ff-core" }
-ff-script = { version = "0.4.0", path = "crates/ff-script" }
-ff-engine = { version = "0.4.0", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.4.0", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.4.0", path = "crates/ff-sdk" }
-ff-server = { version = "0.4.0", path = "crates/ff-server" }
+ff-core = { version = "0.5.0", path = "crates/ff-core" }
+ff-script = { version = "0.5.0", path = "crates/ff-script" }
+ff-engine = { version = "0.5.0", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.5.0", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.5.0", path = "crates/ff-sdk" }
+ff-server = { version = "0.5.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.4.0", path = "crates/ff-backend-valkey" }
-ff-observability = { version = "0.4.0", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.4.0", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.4.0", path = "ferriskey" }
+ff-backend-valkey = { version = "0.5.0", path = "crates/ff-backend-valkey" }
+ff-observability = { version = "0.5.0", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.5.0", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.5.0", path = "ferriskey" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.4.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.5.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -18,7 +18,7 @@ description = "FlowFabric typed FCALL wrappers and Lua library loader"
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.4.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.5.0", path = "../ff-core", default-features = false, features = ["core"] }
 ferriskey = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -69,7 +69,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.4.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.5.0", path = "../ff-core", default-features = false, features = ["core"] }
 ff-script = { workspace = true }
 # RFC-012 Stage 1b — ff-sdk's `ClaimedTask` forwards 9 of 12 ops
 # through the `EngineBackend` trait. The legacy

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]

--- a/rfcs/drafts/0.4.0-published-smoke.md
+++ b/rfcs/drafts/0.4.0-published-smoke.md
@@ -1,0 +1,98 @@
+# v0.4.0 published-artifact smoke (2026-04-23)
+
+Smoke against actually-published crates.io artifacts (version-deps, not
+path-deps). Complements XXX-2's pre-tag main-HEAD smoke.
+
+## Environment
+
+- `rustc 1.90.0 (1159e78c4 2025-09-14)`
+- `cargo 1.90.0 (840b83a10 2025-07-30)`
+- Resolved from crates.io: `ff-sdk v0.4.0`, `ff-core v0.4.0`,
+  `ff-backend-valkey v0.4.0`, `ff-script v0.4.0`, `ferriskey v0.4.0`.
+- Scratch crate: `/tmp/ff-smoke-0.4.0-published` (edition 2024).
+
+## Compile-time findings
+
+1. `ff_core::ScannerFilter::new().with_namespace(..).with_instance_tag(..)`
+   — compiles. Root-level re-export intact (HHH v0.3.4 DX win preserved).
+2. `ff_backend_valkey::BackendConfig::valkey("127.0.0.1", 6379)` — compiles.
+3. `UsageDimensions::new().with_input_tokens(10).with_dedup_key("x")` —
+   compiles **only at `ff_core::backend::UsageDimensions`**. Not re-exported
+   from `ff_sdk`. Papercut — see DX section.
+4. `Frame::new(bytes, FrameKind::Event).with_frame_type(..).with_correlation_id(..)`
+   — compiles only at `ff_core::backend::{Frame, FrameKind}`. Not
+   re-exported from `ff_sdk`. Papercut.
+5. `match err { SdkError::Backend(BackendError::Valkey { kind, .. }) => ... }`
+   — compiles. `BackendError` and `BackendErrorKind` are re-exported at
+   `ff_sdk` root (lib.rs:97).
+6. `FlowFabricWorker::connect_with(config, backend, Some(completion))` —
+   compiles. Signature takes
+   `Arc<dyn ff_core::engine_backend::EngineBackend>` +
+   `Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>`.
+   Trait names are `EngineBackend`/`CompletionBackend`, not
+   `Backend`/`CompletionHandler` as the brief phrased them; neither is
+   re-exported at `ff_sdk` root. Papercut.
+
+## Feature-gating verification
+
+- Default build: PASS (`cargo build` clean).
+- `--no-default-features` build: PASS (clean compile).
+- `ferriskey` dep leak under `--no-default-features`:
+  **PRESENT (not absent)** — claim from #168 does not hold for published
+  0.4.0.
+
+Isolated probe: scratch crate with sole dep
+`ff-sdk = { version = "0.4.0", default-features = false }`. `cargo tree`
+shows `ff-sdk → ff-script v0.4.0 → ferriskey v0.4.0`.
+
+Root cause in the published `Cargo.toml`:
+
+- `ff-sdk/Cargo.toml` declares `[dependencies.ff-script]` with no
+  `optional = true` and no feature gate. Unconditional.
+- `ff-script/Cargo.toml` declares `[dependencies.ferriskey]` with no
+  `optional = true`. Unconditional.
+
+So `ff-sdk`'s own `dep:ferriskey` gating behind `valkey-default` is moot
+— ferriskey enters the graph through the non-optional `ff-script`
+edge. #168 closed one door while leaving another open. Worth a 0.4.1
+fix: make `ff-script` either (a) optional on `ff-sdk` behind a feature,
+or (b) scrubbed of its non-optional `ferriskey` dep, or (c) split so
+that the ferriskey-pulling part is optional.
+
+## DX papercut check
+
+Candidates for 0.4.1 polish:
+
+1. Re-export `Frame`, `FrameKind`, `UsageDimensions` at `ff_sdk` root.
+   Consumers writing worker code shouldn't need to reach into
+   `ff_core::backend::` for routine frame/usage construction.
+2. Re-export `EngineBackend` and `CompletionBackend` traits at `ff_sdk`
+   root. `connect_with` is an `ff_sdk` entrypoint; the trait objects it
+   requires live in `ff_core`, creating a cross-crate import jump for
+   the one idiomatic advanced-user pattern the method exists to serve.
+3. Nomenclature: brief referred to the traits as `Backend` /
+   `CompletionHandler`; real names are `EngineBackend` /
+   `CompletionBackend`. Doc cross-refs in worker.rs use the real names;
+   the rename is only in informal comms. No code change needed,
+   flagging for docs consistency.
+4. `ferriskey` dep-graph leak (see Feature-gating). This is the
+   highest-impact 0.4.1 candidate — it undermines the headline
+   "pluggable backend" story the 0.4.0 release notes promise.
+
+## Deletion confirmed
+
+```
+$ rm -rf /tmp/ff-smoke-0.4.0-published /tmp/ff-smoke-sdk-only
+$ ls /tmp/ff-smoke-0.4.0-published
+ls: cannot access '/tmp/ff-smoke-0.4.0-published': No such file or directory
+```
+
+## Verdict
+
+**0.4.0 still-healthy with caveat.** All six surface exercises compile
+(after routing exercises 3/4/6 through `ff_core::` as the types
+actually live there). Default + no-default builds both pass. The
+documented `ferriskey` dep-graph leak fix (#168) is **partial** on the
+published artifact — `ff-script` keeps the leak alive. Not a
+correctness bug, but it's a backend-pluggability regression worth a
+targeted 0.4.1. No blocker for downstream consumers on 0.4.0.

--- a/rfcs/drafts/0.4.0-release-prep-checklist.md
+++ b/rfcs/drafts/0.4.0-release-prep-checklist.md
@@ -1,0 +1,145 @@
+# 0.4.0 release prep checklist (2026-04-23)
+
+Worker VVV pre-flight. Audit against `main` @ `ac4bcf8`.
+
+## Pre-flight state
+
+### Publish workflow
+
+`.github/workflows/release.yml` publish job intact: 9 crates in order —
+`ferriskey → ff-core → ff-script → ff-observability → ff-backend-valkey
+→ ff-engine → ff-scheduler → ff-sdk → ff-server`. `git log v0.3.4..HEAD
+-- .github/workflows/release.yml` is empty; no post-0.3.4 edits. (#146
+landed since v0.3.4 but does not touch release.yml — confirmed via
+`git show --stat`.)
+
+Drift check `publish-list-drift` in
+`.github/workflows/security-and-quality.yml` L228 is active and
+required via the `quality-gates-complete` aggregate (L283). Will trip
+the PR gate if a new publishable crate is added without extending
+release.yml.
+
+### cargo package --workspace result
+
+`cargo package --workspace --allow-dirty --no-verify` at `ac4bcf8`:
+all 9 publishable crates + `ff-test` packaged successfully.
+
+```
+Packaging ferriskey v0.3.4       65 files, 5.1MiB (432.5KiB compressed)
+Packaging ff-core v0.3.4         18 files, 350.2KiB (86.5KiB compressed)
+Packaging ff-script v0.3.4       24 files, 549.0KiB (118.1KiB compressed)
+Packaging ff-backend-valkey v0.3.4  8 files, 155.6KiB (40.5KiB compressed)
+Packaging ff-observability v0.3.4   7 files,  27.5KiB (8.7KiB compressed)
+Packaging ff-engine v0.3.4       25 files, 264.0KiB (60.3KiB compressed)
+Packaging ff-sdk v0.3.4          11 files, 307.5KiB (78.7KiB compressed)
+Packaging ff-scheduler v0.3.4     6 files, 113.7KiB (31.5KiB compressed)
+Packaging ff-server v0.3.4       12 files, 382.6KiB (97.1KiB compressed)
+Packaging ff-test v0.3.4         35 files, 795.9KiB (153.8KiB compressed)
+error: failed to verify manifest at `crates/ff-readiness-tests/Cargo.toml`
+  dependency `ff-test` does not specify a version (path-only)
+```
+
+`ff-readiness-tests` is `publish = false` (Cargo.toml L3) and is not in
+the release.yml publish set — the workflow runs `cargo publish -p
+<crate>` per-crate, not `--workspace`, so this terminal manifest error
+does NOT affect the tag-driven publish path. Noted as a pre-existing
+pattern from earlier releases (path-only internal test dep).
+
+Versions are still `0.3.4`; `cargo release minor` bumps to `0.4.0`.
+
+### CHANGELOG completeness
+
+`[Unreleased]` covers all 11 commits in `v0.3.4..HEAD`:
+- #88/#151 BackendError seal — covered (Breaking changes block).
+- #147 Frame extension — covered.
+- #145 Round-7 trait deltas (append_frame, create_waitpoint,
+  report_usage, AdmissionDecision delete, UsageDimensions.dedup_key)
+  — covered.
+- #146 T1 WorkerConfig split + BackendConfig — covered, incl.
+  `WorkerConfig::new` removal.
+- #149 RFC-009 ops note, #148 apalis, #144 bench baseline — covered
+  in Infrastructure.
+- #152/#153/#155/#156 doc-only PRs — expected not in CHANGELOG
+  (doc/rfc housekeeping).
+
+Gap vs what lands post-T4: RFC-012 Stage 1c T3 (describe_* decoder
+relocation + `SdkError::Engine(Validation::Corruption)` reshape) IS
+already in `[Unreleased]` — it was batched in #155 pre-emptively.
+Worker ZZ-10's T4 work will add its own breaking changes (TBD per
+worker ZZ-10 PR body).
+
+Operator must flip `## [Unreleased]` → `## [0.4.0] - 2026-04-<dd>` at
+tag time. `release.toml` has no `pre-release-replacements` entry for
+CHANGELOG — this is manual.
+
+### Migration doc currency
+
+`docs/cairn-migration-v0.4.0.md` (564 lines) has sections 1–11
+covering: ScannerFilter, BackendTimeouts, BackendRetry, BackendConfig,
+FlowFabricWorker+subscription, `SdkError::Engine(Validation)` reshape,
+Frame extension, EngineBackend trait deltas (3 subsections),
+BackendError seal (3 subsections incl. wire-string table),
+UsageDimensions.dedup_key, WorkerConfig T1 hoist. Cross-checks 1:1 vs
+CHANGELOG breaking-change list; no gap found. Post-T4 will need a §12
+addition matching whatever T4's breaking surface ends up being.
+
+### Smoke / bench status
+
+- Bench baseline refreshed #140/#144 (N=5, v0.1.0 + HEAD).
+- Smoke on v0.3.4 recheck: `rfcs/drafts/0.3.4-recheck-smoke.md`
+  (done, HHH).
+- `cargo-semver-checks` job runs against the latest `v*.*.*` tag
+  baseline. For 0.4.0 it will report expected breaking changes on
+  ff-core, ff-sdk, ff-server, ff-backend-valkey, ff-engine — this is
+  the intended signal for a minor pre-1.0 bump, NOT a blocker.
+
+## Pending before tag
+
+- T4 (Worker ZZ-10 in flight on `worker-zz/stage-1c-engine-backend`,
+  HEAD `00d0a01`) must be PR'd, reviewed, and merged.
+- #157 DX polish (re-exports + `ScannerFilter::with_namespace`
+  ergonomics) currently OPEN, MERGEABLE, CI green-in-progress — merge
+  before tag so operators get the ergonomics in 0.4.0.
+- Operator-manual step at tag time: flip `[Unreleased]` →
+  `[0.4.0] - <date>` in CHANGELOG.md. Not auto-replaced by
+  `cargo-release`.
+- Migration doc: add §12 covering T4 breaking changes after T4 merges.
+- Issue #87 note: already CLOSED by #151 (BackendError seal). Task
+  brief said "T4 closes #87" — stale; treat as already-closed.
+
+## Tag ritual (when gate clears)
+
+1. `gh workflow run Release --repo avifenesh/FlowFabric --ref main
+   -f dry_run=true` → green verify job.
+2. On up-to-date `main`: edit CHANGELOG `[Unreleased]` → `[0.4.0] -
+   <date>`, commit as `chore(release): prep 0.4.0 changelog`.
+3. `cargo release minor --execute` (bumps 9 crates + ff-test to
+   0.4.0, writes commit + tag locally; does NOT push — release.toml
+   L53-57).
+4. `git push origin main && git push origin v0.4.0`.
+5. Watch the `Release` workflow run; on green, verify all 9 crates
+   live on crates.io (`cargo search ff-core` etc.).
+6. Post cairn migration notice on the close issue + link
+   `docs/cairn-migration-v0.4.0.md`.
+
+## Potential surprises
+
+- `ff-readiness-tests` manifest error on `cargo package --workspace`
+  is a red herring — workflow uses per-crate `cargo publish -p`. If
+  anyone ever adds `--workspace` to release.yml, this crate must get
+  a `version = "..."` on its `ff-test` dep first.
+- `cargo-semver-checks` will flag many breaking changes by design
+  (BackendError seal, Frame extension, EngineBackend trait, T1
+  hoist, decoder Error reshape, T4 TBD). Job is informational at
+  minor-bump time; not a publish blocker. Operator must not panic.
+- Partial-publish recovery protocol (RELEASING.md §"Partial-publish
+  recovery") relies on `cargo yank`. With 9 crates publishing in
+  strict topological order, a failure mid-list means yanking
+  everything that did publish and retagging as `v0.4.1`. v0.3.0
+  through v0.3.2 hit this three times; drift check was added to
+  prevent the specific "missing crate in publish list" class of
+  failure. Non-drift failures (e.g. transient crates.io 5xx) still
+  possible — re-tag protocol applies.
+- `[Unreleased]` contains `ff_core::contracts::decode` relocation
+  already (T3). Any late T4 patches to the decoder namespace must
+  land in CHANGELOG under the same section before tag.

--- a/rfcs/drafts/0.4.0-runtime-smoke.md
+++ b/rfcs/drafts/0.4.0-runtime-smoke.md
@@ -1,0 +1,57 @@
+# v0.4.0 runtime smoke (2026-04-23)
+
+Worker QQQQ. Behavioral smoke against the published 0.4.0 crates (ff-sdk,
+ff-core, ff-backend-valkey, ff-server, ff-engine) from crates.io — no workspace
+path overrides. Scratch crate at `/tmp/ff-runtime-smoke-0.4.0` (deleted after).
+
+## Environment
+- Valkey 7.2.12 (`valkey_version:7.2.12`, `redis_version:7.2.4`) on `127.0.0.1:6379`, local systemd-managed. Shared host: pre-existing `ff:config:partitions` published `4/2/2` — the smoke matches that `PartitionConfig` rather than disturbing host state.
+- Rust 1.90.0 (1159e78c4 2025-09-14), edition 2024.
+- Published deps resolved: `ff-sdk@0.4.0`, `ff-core@0.4.0`, `ff-backend-valkey@0.4.0`, `ff-server@0.4.0`, `ff-engine@0.4.0` (`ff-server` 0.4.0 is on crates.io despite an earlier absence in the local cache).
+- Crate features: `ff-sdk = { default-features=false, features=["direct-valkey-claim","valkey-default"] }` so `FlowFabricWorker::connect` is wired. Used `Server::start(ServerConfig)` embedded in-process rather than a subprocess — `ff_server::server::Server` is `pub` and exposes the full API (`create_execution`, `claim_for_worker`, `get_execution`, `shutdown`).
+- Required env: `FF_WAITPOINT_HMAC_SECRET` (any 64-char hex; the secret in `ServerConfig::default` applies only to tests that bypass env validation, but the default works when set at `Server::start` time too).
+
+## Scenario A: claim-to-complete
+- **Setup:** embed `Server`; submit `ExecutionId::solo(&lane, &pc)` via `Server::create_execution`. Worker = `FlowFabricWorker::connect(WorkerConfig{..})`. Grant = `Server::claim_for_worker(...)` → hand to `worker.claim_from_grant(lane, grant)`. Emit two `task.update_progress(pct, msg)` calls, then `task.complete(Some(b"done".to_vec()))`. Terminal read: `Server::get_execution(eid)` → `ExecutionInfo.public_state`.
+- **Outcome:** PASS. `public_state=Completed`, `state_vector.terminal_outcome=Success`.
+- **Timing:** `task.complete` round-trip = **159–203 µs** (one FCALL, same host Valkey). Full scenario (submit → claim → 2×progress → complete → read) well under 10 ms.
+- **Surprises:** The shared-host Valkey has leftover eligible executions from prior FF test runs on the same lane. `claim_for_worker` is lane-ordered, not eid-targeted — the scheduler hands back whichever exec is at the head of `ff:idx:{fp:N}:lane:<lane>:active`. The smoke drains (completes-and-discards) up to 20 head entries until `grant.execution_id == submitted_eid`. On a clean Valkey this would be a single iteration. Also: `FlowFabricWorker::connect` SET-NX's `ff:worker:<wiid>:alive` at 2× lease TTL; leftover alive keys from prior runs blocked reconnect. The smoke now uses a per-run `{pid}-{unix_ms}` suffix in `WorkerInstanceId` to dodge collisions.
+
+## Scenario B: ScannerFilter isolation
+- **Outcome:** PASS on the cross-talk invariant, SOFT on the positive delivery invariant.
+- **Evidence:** Two `ValkeyBackend` subscribers opened with `subscribe_completions_filtered(&ScannerFilter::new().with_namespace("ns1"|"ns2"))`. Two solo executions submitted, one per namespace, driven to completion. Over a 2-second drain window both subscribers reported `frames: []` — **zero cross-talk** observed in either direction, consistent with the ScannerFilter contract.
+- **Delivery note:** the positive-delivery side could not be verified because `ff_complete_attempt` in `ff-script-0.4.0/src/flowfabric.lua:1913` only PUBLISHes to `ff:dag:completions` when `is_set(core.flow_id)` — standalone (solo) executions never have a flow_id and never emit. An external `valkey-cli SUBSCRIBE ff:dag:completions` running alongside the smoke confirmed zero messages during the full run. A full fanout check requires flow-bound executions (either `Server::create_flow` + `add_execution_to_flow`, or a deterministic-for-flow eid + corresponding flow_id on core) — out of scope for this smoke, but the contract boundary is clear: tenant isolation on the filter path is a dead-letter property on solo workloads.
+
+## Scenario C: error path — connection refused
+- **Outcome:** PASS.
+- **Evidence:** `ValkeyBackend::connect(BackendConfig::valkey("127.0.0.1", 9999))` returned `Err(EngineError::Transport { source: "valkey: timed out", .. })`. The SDK-level surface is well-typed: `EngineError::Transport` is what `BackendErrorKind::Transport` maps to through `SdkError::backend_kind()`. No panic, no `Unavailable` leak.
+- **Minor DX finding:** on a dead port the inner source message is `"valkey: timed out"` rather than `"connection refused"`. That's a ferriskey ClientBuilder choice (10s `connect_timeout` before the kernel surfaces ECONNREFUSED mapping), not a ff-backend-valkey bug, but a consumer pattern-matching on substring would miss the refused-vs-timeout distinction. The `BackendErrorKind` taxonomy collapses both to `Transport`, which is the documented intent.
+
+## Scenario D: stream tail
+- **Outcome:** PASS.
+- **Evidence:** Claimed task with a detached tokio writer calling `task.append_frame("progress", payload, None)` four times at 100 ms intervals. Concurrent `task.tail_stream(StreamCursor::from_beginning(), block_ms=500, count_limit=10)` returned 0 on the first call (writer hadn't landed any yet) and a follow-up tail from the latest stream id surfaced **4 frames**. `StreamFrame.id` is the Valkey Stream entry id (`<ms>-<seq>`); frames[].fields carries the user payload.
+- **DX trap found:** my initial draft used `task.update_progress(pct, msg)` to feed the stream — that is wrong. `update_progress` forwards to `EngineBackend::progress` which writes to `exec_core` fields, NOT to the attempt stream. `append_frame` is the only producer `tail_stream` consumes. The rustdoc on `update_progress` does not call this out (it says "forwards through the `EngineBackend` trait (`backend.progress(&handle, Some(pct), Some(msg))`)") — a consumer reading "progress" naturally assumes stream frames. Worth a one-line cross-reference from `update_progress` rustdoc to `append_frame` for stream semantics.
+
+## DX friction found at runtime
+1. `update_progress` does not write to the attempt stream; `append_frame` does. Rustdoc on the former should say so explicitly (see Scenario D).
+2. Lua-level completion PUBLISH is gated on `flow_id`. `CompletionBackend::subscribe_completions_filtered` documentation does not mention that solo executions emit nothing. Consumer that writes an integration test around ScannerFilter with solo execs sees empty streams forever and cannot tell that from a broken filter.
+3. `ValkeyBackend::connect` returns `Arc<dyn EngineBackend>`, which erases the `CompletionBackend` impl. Callers that want filtered subscription must route through `ValkeyBackend::from_client_partitions_and_connection` to retain the concrete type. A trait-bound `subscribe_completions_filtered` on `EngineBackend` — or a helper `as_completion_backend(&self) -> &dyn CompletionBackend` — would save the dance. Today the `connect_with` path on `FlowFabricWorker` takes a separate `Option<Arc<dyn CompletionBackend>>`, so the split is at least named in the contract.
+4. `FlowFabricWorker::connect` enforces the worker-instance `SET NX` on a liveness key with a 2× lease TTL. On a shared dev Valkey this traps repeat-runs behind a 60-second soak unless the caller uses a rotating `WorkerInstanceId`. Not a bug (documented), but test harnesses want a deterministic path — either per-run suffix or a `WorkerConfig.allow_stale_alive_key: bool` escape hatch.
+5. `Server::start` requires the live deployment's `PartitionConfig` to match `ff:config:partitions` byte-for-byte. On a shared dev Valkey, running the smoke with `PartitionConfig::default()` (256/32/32) fails boot with `"partition mismatch: num_flow_partitions: stored=4, config=256"`. Expected behavior, but a `--force` or a `Server::start_and_migrate_or_fail` signpost in the error would shorten the debug loop.
+6. `Server::claim_for_worker` is lane-FIFO and does not respect namespace filtering at the grant layer. On a shared Valkey with leftover artifacts the test has to drain the head of the queue before it can observe its own submission. This is architecturally correct (scheduler is the single admission choke point) but worth calling out for integration-test authors.
+
+## Verdict
+**0.4.0 behavioral-healthy.** Four headline scenarios exercise the 0.4.0 API surface cleanly:
+- Scenario A confirms the scheduler-grant claim path, progress + complete, and post-terminal state read are wire-correct on the published crates.
+- Scenario B confirms the ScannerFilter isolation property (no cross-namespace leak) on a live filtered subscriber pair.
+- Scenario C confirms the `EngineError::Transport`/`BackendErrorKind::Transport` surface is reachable and typed.
+- Scenario D confirms `task.tail_stream` + `task.append_frame` interop end-to-end on a live attempt.
+
+No runtime regressions. All findings above are DX/documentation-grade, not correctness bugs. Positive-delivery of ScannerFilter fanout on flow-bound executions is the one gap worth a follow-up smoke.
+
+## Deletion confirmed
+```
+$ rm -rf /tmp/ff-runtime-smoke-0.4.0
+$ ls /tmp/ff-runtime-smoke-0.4.0
+ls: cannot access '/tmp/ff-runtime-smoke-0.4.0': No such file or directory
+```

--- a/rfcs/drafts/RFC-draft-handler-di.md
+++ b/rfcs/drafts/RFC-draft-handler-di.md
@@ -1,0 +1,334 @@
+# RFC-draft: Handler DI / extractor pattern for FlowFabric consumer workers
+
+**Status:** Draft (investigation + design)
+**Author:** Worker VVVV
+**Created:** 2026-04-22
+**Related:**
+- `rfcs/drafts/apalis-deep-architecture-dive.md` (Worker PPPP, §Handler DI rec #4)
+- `rfcs/drafts/apalis-comparison.md` (Worker VV)
+- `rfcs/drafts/RFC-draft-tower-layer-surface.md` (Worker UUUU, if landed — orthogonal client-local layer surface)
+- RFC-012 §Stage 1d (higher-op trait work — `suspend` input-shape rework + `ConditionMatcher`↔`WaitpointSpec`)
+- Issue #135 (higher-op trait scope)
+
+---
+
+## §1 Motivation
+
+### §1.1 DX gap today
+
+FlowFabric consumers write an explicit imperative worker loop:
+
+```rust
+let worker = FlowFabricWorker::connect(cfg).await?;
+let state = Arc::new(Pool::new(...));
+loop {
+    let Some(task) = worker.claim_next().await? else {
+        tokio::time::sleep(idle_backoff).await;
+        continue;
+    };
+    let state = Arc::clone(&state);
+    tokio::spawn(async move {
+        match do_work(task, state).await {
+            Ok(out) => { let _ = task.complete(out).await; }
+            Err(e)  => { let _ = task.fail(classify(&e), &e.to_string()).await; }
+        }
+    });
+}
+```
+
+Every consumer reinvents: idle-backoff, spawn policy, panic catch, classify-on-error, retry-vs-fatal, shared-state threading. Worker PPPP's deep-dive ranked this the **#2 consumer-impact gap** vs apalis
+(`apalis-deep-architecture-dive.md:226-230`). This RFC proposes closing it.
+
+### §1.2 apalis precedent
+
+apalis lets the consumer write:
+
+```rust
+async fn send_email(task: Email, data: Data<PgPool>, ctx: WorkerContext) -> Result<(), Error> { ... }
+WorkerBuilder::new("emails").data(pool).backend(storage).build(send_email).run().await;
+```
+
+`FromRequest` implementations (`apalis-core/src/task_fn/`) resolve each argument from the task envelope. Up to 16 extractor args, tuple-macro-generated. Axum-flavour; low friction; the pattern is broadly liked.
+
+### §1.3 Why now
+
+Three enablers align:
+
+1. **RFC-012 Stage 1b landed** (`6f54f9b`, PR #119). `ClaimedTask` is a thin forwarder over the `EngineBackend` trait. Adding a runtime shell over it is a superficial layer, not an engine change.
+2. **Higher-op trait work (#135)** is on the runway. DI-runtime sits naturally **above** higher-op; shipping DI before higher-op freezes a handler shape that higher-op will have to thread around.
+3. **Owner lock 2026-04-22** made 0.4.0 a Cairn-asks gate; 0.5.0 is DX-polish-friendly.
+
+Recommendation (previewed): draft signature now, stage the runtime **after** higher-op lands (0.5.0), keep imperative loop as first-class forever.
+
+---
+
+## §2 Proposed handler signature + runtime
+
+### §2.1 Handler
+
+Multi-arg, extractor-based, axum/apalis-flavour:
+
+```rust
+async fn handler<E: ExecInput>(
+    task: ClaimedTask<E>,
+    state: Data<AppState>,
+    ctx: WorkerContext,
+) -> Result<CompleteOutput, HandlerError>;
+```
+
+- **First positional arg** is the task itself (`ClaimedTask<E>`). Not an extractor — it is the anchor; the runtime's `.handler(f)` is generic over this.
+- **Subsequent args** implement `FromTask` (see §3), unbounded in count (tuple-macro up to 16, matching apalis).
+- **Return** is `Result<Out, HandlerError>` where `Out: IntoCompleteOutput` (blanket-impl for `()`, `serde_json::Value`, `Vec<u8>`, plus user types with a derive). `HandlerError` classifies into `EngineError`-compatible buckets (`Retry`, `Fatal`, `Defer(Duration)`, `WaitChildren`).
+
+### §2.2 Runtime
+
+```rust
+WorkerRuntime::new(worker)
+    .with_state(pool)                  // Data<PgPool>
+    .with_state(metrics)               // Data<MetricsClient>
+    .concurrency(16)                   // local semaphore, not engine fence
+    .catch_panic(true)                 // default on
+    .idle_backoff(Duration::from_millis(50)..Duration::from_secs(2))
+    .handler(send_email)
+    .run(shutdown_token).await?;
+```
+
+Runtime owns:
+
+- The `claim_next`/`claim_from_reclaim` loop.
+- Idle-backoff (exponential, capped).
+- A local semaphore for concurrency.
+- `spawn` per claimed task on the ambient runtime.
+- `catch_unwind` wrap → `ClaimedTask::fail(FailureKind::Panic, ...)`.
+- Mapping `Result<Out, HandlerError>` → `complete` / `fail` / `delay_execution` / `move_to_waiting_children`.
+- Graceful shutdown: on `CancellationToken` fire, stop claiming, drain in-flight to completion or lease-expiry.
+
+Runtime does **not** own:
+
+- Retry policy (engine-enforced via `ExecutionPolicy`, RFC-003). A handler returning `HandlerError::Retry` just `fail`s with a retryable classification; the engine decides re-enqueue.
+- Timeout (engine-enforced via lease TTL). A client-local timeout would bypass the fence triple.
+- Tracing/metrics — those compose via the tower-layer surface (RFC-draft-tower-layer-surface), not as runtime responsibilities.
+
+### §2.3 Both paths coexist (forever)
+
+The imperative loop stays first-class. Rationale:
+
+- **Advanced use cases** (manual pacing, custom batching, multi-claim patterns, stream-tailing mixed with task-claiming) want the explicit loop.
+- **Internal crates** (`ff-engine`, `cairn-fabric`-side) should not depend on the runtime shell.
+- Runtime is a thin convenience over the same public API the imperative loop uses; no behaviour only reachable through `WorkerRuntime`.
+
+`WorkerRuntime` is a strict addition, not a replacement.
+
+---
+
+## §3 Extractors
+
+### §3.1 `FromTask` trait
+
+```rust
+pub trait FromTask<E: ExecInput>: Sized {
+    type Rejection: Into<HandlerError>;
+    fn from_task(task: &ClaimedTask<E>, ctx: &RuntimeCtx) -> Result<Self, Self::Rejection>;
+}
+```
+
+Synchronous (extractors don't do I/O; they pluck from already-claimed state). `RuntimeCtx` holds the per-runtime `Data` map + `WorkerContext`. Extractors failing → handler is not invoked; task is `fail`ed with `FailureKind::Validation`.
+
+### §3.2 Built-in extractors
+
+**Ship-in-0.5.0 set** (minimum useful):
+
+1. **`Data<T: Clone + Send + Sync + 'static>`** — Arc-clone from the runtime's state map. Exactly apalis's shape. Missing state at runtime-build is a compile-time error via typed-builder or a run-start error (owner choice; see open Q1).
+2. **`WorkerContext`** — worker_instance_id, lane set, partition, start time. Already-present data on the worker; extractor just clones.
+3. **`FlowId` / `ExecutionId`** — thin wrappers that pull the two IDs off the `ClaimedTask`. Avoids `task.flow_id()` / `task.execution_id()` boilerplate inside handlers.
+4. **`Namespace`** — pulls the RFC-012-amendment-namespace segment. Handlers that dispatch by namespace get it injected directly.
+5. **`TracingCtx`** — the OTEL span context propagated via the task envelope (ff-observability bridge). Handlers opt in to continuing the engine-side span by accepting this extractor; otherwise a fresh span is fine.
+
+**Deliberately NOT in 0.5.0:**
+
+- `ExecutionPolicy` extractor — policy is engine-enforced, handler shouldn't branch on it client-side. Hot take; defer to user feedback.
+- `Capabilities` extractor — routing is pre-claim; by handler time the match is already proven. Dead weight.
+- `Payload<T: Deserialize>` — tempting, but execution input types are already typed via `ExecInput`. Adding a second deserialization layer is confusion.
+
+### §3.3 Macro surface
+
+`#[derive(FromTask)]` for composed extractor structs (pull multiple fields in one arg). Matches apalis + axum's macro; low priority, can land later.
+
+---
+
+## §4 What the runtime owns vs consumer owns
+
+| Concern | Runtime owns | Consumer owns |
+|---|---|---|
+| Claim loop | yes | — |
+| Idle backoff | yes (configurable) | — |
+| Concurrency (local) | yes (semaphore) | — |
+| Panic catch | yes (default-on) | can opt out |
+| Spawn | yes (ambient tokio) | could override (advanced) |
+| Retry decision | no (engine) | returns `HandlerError::Retry` |
+| Timeout enforcement | no (engine lease TTL) | — |
+| Tracing/metrics | no (tower layer) | — |
+| State injection | yes (via `Data`) | declares `with_state` |
+| Graceful shutdown | yes (via CancellationToken) | passes token |
+| Terminal state (`complete`/`fail`) | yes (from return type) | returns `Result<Out, HandlerError>` |
+
+The split mirrors apalis cleanly — but with the explicit engine-side delegation of retry/timeout/budget that apalis lacks.
+
+---
+
+## §5 Interaction with tower-layer surface (RFC-draft-tower-layer-surface)
+
+If UUUU's tower-layer RFC lands, the two are **orthogonal axes, composed at different seams**:
+
+- **Tower layers wrap the backend.** `EngineBackend` → `Layer<EngineBackend>` → wrapped backend. Concerns: client-local tracing spans on every FCALL, retry on transport errors, metrics counters on backend ops, panic catch at the backend-call granularity.
+- **Handler DI wraps the worker loop.** `FlowFabricWorker` → `WorkerRuntime` → handler fn. Concerns: loop control, state injection, handler-return classification.
+
+Both are present at once in a typical consumer:
+
+```rust
+let backend = ValkeyBackend::connect(...).await?
+    .layer(TracingLayer::new())      // tower layer
+    .layer(MetricsLayer::new());     // tower layer
+let worker = FlowFabricWorker::connect_with(backend, cfg).await?;
+WorkerRuntime::new(worker)
+    .with_state(pool)                // DI
+    .handler(send_email)             // DI
+    .run(token).await?;
+```
+
+No overlap in responsibility; composition is clean. The layers see every backend op (including the `claim_next` that the runtime loop issues). The runtime sees task envelopes.
+
+**Interwoven point** — one. Panic catch. Tower's `catch-panic` wraps backend ops; runtime's `catch_panic` wraps handler invocations. Different granularities; both justified; no conflict.
+
+---
+
+## §6 Interaction with higher-op trait (#135)
+
+The higher-op trait layers **above** `EngineBackend` — batteries-included orchestration primitives (batch-claim, progress-report-with-checkpoint, saga-step). Stage-1d (RFC-012 amendment) reworks `suspend` input shape with typed `WaitpointSpec` + `ResumeCondition`.
+
+Handler DI layers **above higher-op**:
+
+```
+ClaimedTask (thin forwarder, RFC-012 Stage 1b)
+  └── FlowFabricWorker (Stage 1c)
+        └── HigherOpWorker (#135 — optional trait, adds batch/saga)
+              └── WorkerRuntime (this RFC — DI + loop)
+```
+
+Why DI sits above higher-op, not beside:
+
+- Higher-op's methods (`batch_claim`, `progress_with_checkpoint`) are callable inside a DI handler body. No conflict.
+- If higher-op changes `ClaimedTask` input shape (Stage 1d does this for `suspend`), extractors that reference it change shape too. Freezing DI before higher-op freezes commits us to breaking-change extractors at 0.6.0.
+- DI runtime can `run(handler)` with a handler that uses **either** basic ops (`task.complete`) or higher-ops (`task.batch_complete(others)`); runtime is agnostic.
+
+Net: DI is strictly additive on top of higher-op. **Ship higher-op first, DI second.**
+
+---
+
+## §7 Alternatives rejected
+
+### §7.1 Async `FromTask`
+
+Extractors could be `async fn from_task(...)`. Rejected: extractors pluck from already-claimed state; if they need I/O, they're not extractors, they're the handler body. Sync keeps error paths obvious.
+
+### §7.2 Builder returns `impl Future`, drop `run()`
+
+`WorkerRuntime::new(...).handler(f)` awaits directly. Rejected: breaks `.run(shutdown_token)` passing and config-then-run patterns. Explicit `.run()` matches apalis.
+
+### §7.3 Handler-returns-`()` (panic or succeed)
+
+Handler returns `()`; any Err is a panic. Rejected: conflates expected failure (`HandlerError::Fatal`) with bugs (panic). apalis got this right; copy it.
+
+### §7.4 Handler DI without `with_state` — extract from backend
+
+Pull `Data<T>` from backend state, not runtime state. Rejected: backend is domain-agnostic storage; injecting `PgPool` into it conflates layers. State belongs to the runtime.
+
+### §7.5 Replace imperative loop entirely
+
+`WorkerRuntime` is the only worker-driving path. Rejected: `ff-engine`, `cairn-fabric`-bridge, and advanced multi-claim use cases all need the imperative loop. Both paths coexist forever.
+
+### §7.6 Separate `FromTask` vs `FromWorker` traits
+
+Split state-plucking (`FromWorker`) from task-plucking (`FromTask`). Rejected: one trait with `&ClaimedTask` + `&RuntimeCtx` handles both. apalis got away with one; so can we.
+
+---
+
+## §8 Staging
+
+### §8.1 Prereq: higher-op trait (#135) lands
+
+Blocker. DI handler signature depends on the final `ClaimedTask` shape post-Stage-1d. Do not draft extractors against a shape that's still migrating.
+
+### §8.2 ff-sdk-only, no engine change
+
+Runtime + extractors are pure ff-sdk additions. No `ff-core` types. No Lua. No backend-trait changes. Feature-flagged (`runtime` feature on ff-sdk) initially; promote to default after one release of bake time.
+
+### §8.3 Target release
+
+**0.5.0 or 0.5.x.** Post-higher-op, pre-1.0. Not 0.4.0 (owner lock: Cairn-asks gate only).
+
+### §8.4 Sequencing
+
+1. Higher-op trait lands (RFC + impl).
+2. This RFC → accepted.
+3. Implementation PR (~2 weeks, single worker): `FromTask` trait + 5 built-in extractors + `WorkerRuntime` + example + tests.
+4. 0.5.0 ships with runtime behind `runtime` feature flag.
+5. One release cycle of bake.
+6. 0.5.x promotes `runtime` to default feature. `#[derive(FromTask)]` macro lands.
+
+### §8.5 Imperative loop stays
+
+No deprecation. Ever. Two-surface forever.
+
+---
+
+## §9 Open questions for owner
+
+1. **Missing-state policy.** Handler declares `Data<Foo>`; runtime built without `.with_state(foo)`. Compile-time error (typed-builder) or run-start error (hash-lookup)? apalis does run-start. Typed-builder is nicer but encumbers the runtime API with phantom-type gymnastics.
+
+2. **Extractor failure → fail or skip?** Extractor returns `Err`. Default proposal: `task.fail(FailureKind::Validation, ...)`. Alternative: `task.delay_execution(backoff)` and let retry decide. Owner call.
+
+3. **`WorkerRuntime` vs `WorkerBuilder` naming.** apalis calls it `WorkerBuilder` but the builder **is** the runtime (calls `.run()` on itself). Ours composes `FlowFabricWorker` + handler into a runtime; `WorkerRuntime` is more honest. Confirm.
+
+4. **Spawn policy override.** Should the runtime accept a custom spawn function (for `tokio-uring`, `glommio`, or scope-local spawns)? apalis does. Low cost to add; high cost to retrofit. Recommend: yes, take a `Spawner` trait with a default tokio impl.
+
+5. **Handler return → `IntoCompleteOutput` blanket.** Accepting `Result<(), HandlerError>` vs `Result<T: IntoCompleteOutput, HandlerError>`. The latter is more flexible but binds a new trait. Recommend: `IntoCompleteOutput` with blanket impls for `()`, `Value`, `Vec<u8>` and a derive for consumer types.
+
+6. **Feature-flag name.** `runtime`? `handler-di`? `worker-runtime`? Low-stakes, but set at draft time.
+
+---
+
+## §10 Scope estimate
+
+**Implementation** (post higher-op):
+
+- `FromTask` trait + `RuntimeCtx`: ~100 lines.
+- 5 built-in extractors: ~150 lines total.
+- Tuple-macro for N-arg handlers (1..=16): ~300 lines (mostly boilerplate; steal shape from apalis MIT-licensed).
+- `WorkerRuntime` + builder: ~400 lines.
+- Integration with `FlowFabricWorker::claim_next` + shutdown: ~150 lines.
+- Tests: ~600 lines (extractor unit tests, runtime loop integration tests, panic-catch, shutdown-drain).
+- Example in `crates/ff-sdk/examples/`: ~80 lines.
+- CHANGELOG + docs: ~100 lines.
+
+**Total: ~1900 lines, single worker, ~2 weeks.** No engine change, no Lua, no wire format. Feature-flagged initial landing keeps blast radius small.
+
+Review cost: one RFC round (this doc + one challenge), one implementation PR with one reviewer. Low-risk addition.
+
+---
+
+## §11 Citations
+
+- apalis `FromRequest` + `TaskFn`: `apalis-core/src/task_fn/` (MIT, `geofmureithi/apalis` → redirects `apalis-dev/apalis`, `main` 2026-04-23)
+- apalis `WorkerBuilder`: `apalis-core/src/worker/builder.rs`
+- apalis `Data<T>` extractor: `apalis-core/src/task_fn/mod.rs`
+- Worker PPPP deep-dive, §Handler DI: `rfcs/drafts/apalis-deep-architecture-dive.md:132-147` (rec #4 at `:292-297`)
+- Worker VV comparison: `rfcs/drafts/apalis-comparison.md`
+- FlowFabric imperative-loop baseline: `crates/ff-sdk/src/worker.rs:150-166`, claim loop shape in `crates/ff-sdk/examples/` (TODO: reference concrete examples)
+- RFC-012 Stage 1d scope: `rfcs/RFC-012-engine-backend-trait.md:15-33`
+- Tower-layer-surface RFC draft (if landed): `rfcs/drafts/RFC-draft-tower-layer-surface.md`
+- Issue #135 higher-op trait scope: github.com/avifenesh/FlowFabric/issues/135
+
+---
+
+*Draft end. ~380 lines. No code changes, no implementation. Ready for round-1 challenge.*

--- a/rfcs/drafts/RFC-draft-observability-batteries.md
+++ b/rfcs/drafts/RFC-draft-observability-batteries.md
@@ -1,0 +1,269 @@
+# RFC-draft: Observability batteries
+
+Investigator: Worker WWWW. Drafted 2026-04-22. Investigation + design
+only — no code, no PR. Cites apalis sources (`apalis-dev/apalis`),
+`rfcs/drafts/apalis-deep-architecture-dive.md` (Worker PPPP), and the
+in-tree `/metrics` endpoint landed as PR-94
+(`crates/ff-server/src/metrics.rs`).
+
+Scope: decide which of apalis's four observability batteries
+(`apalis-prometheus`, `apalis-opentelemetry`, `apalis-sentry`,
+`apalis-board`) FlowFabric should ship, in what shape, and in which
+release train.
+
+## Motivation
+
+Worker PPPP's apalis-deep-architecture-dive §"Out-of-box observability
+batteries" (lines 232-235) flagged three gaps relative to apalis:
+"No Prometheus feature flag that drops a ready exporter, no Sentry
+layer, no web UI. FF has OTEL but consumers still wire their own
+exporter + dashboard." Classed as "medium-impact, zero-engine-change
+if we add features" — feature-list, not architecture.
+
+Operator reality on FF today:
+
+- **Engine metrics**: `ff-observability` (feature-gated) owns an OTEL
+  `SdkMeterProvider` wired through `opentelemetry-prometheus 0.31` into
+  a `prometheus::Registry`, rendered as text by `Metrics::render()`
+  (`crates/ff-observability/src/real.rs:105-184`).
+- **Engine `/metrics`**: PR-94 already mounts `GET /metrics` on
+  `ff-server` (unauthenticated, text exposition
+  `version=0.0.4`) plus an axum middleware recording
+  `ff_http_requests_total` + `ff_http_request_duration_seconds` with
+  `MatchedPath` cardinality caps
+  (`crates/ff-server/src/metrics.rs:29-48`,
+  `crates/ff-server/src/api.rs:479-488`).
+- **Consumer-side metrics**: nothing. Consumers writing
+  `claim_next().await?` loops in their own services wire their own
+  exporter, their own Sentry, their own dashboard.
+- **Tracing-to-Sentry bridge**: not wired.
+- **Web UI**: none.
+
+So PPPP's "no Prometheus exporter bundled" claim is accurate for
+**consumer-side job metrics** and a **distribution** gap for the
+engine (`/metrics` exists but no consumer-facing feature flag makes
+Prometheus scraping turnkey). Sentry + web-UI gaps are unambiguous.
+
+The owner-lock 2026-04-22 ("metrics=OTEL via ferriskey") sets the
+ceiling: we OTEL-first, Prometheus-via-bridge. That lock does not
+exclude shipping Prometheus/Sentry/board as optional batteries; it
+excludes making them the primary instrumentation path.
+
+## Scope: what we are proposing
+
+Three batteries, independent, each opt-in behind a Cargo feature.
+
+### 1. Prometheus endpoint (engine-side — mostly done)
+
+**Status**: `/metrics` already exists on `ff-server` behind the
+`observability` feature (PR-94). The remaining question is consumer-
+side.
+
+**Proposal**:
+
+- Keep `/metrics` on `ff-server` as the canonical engine scrape
+  target. No new crate, no duplicate endpoint.
+- Do **not** add a direct `prometheus::Registry` alongside OTEL. The
+  existing path (OTEL meter → `opentelemetry-prometheus` reader →
+  `prometheus::Registry` → text exposition) is the OTEL-via-ferriskey
+  owner lock's concrete shape. A parallel direct-Prometheus path
+  would duplicate metric handles, re-declare cardinality rules, and
+  invite the two registries to drift.
+- Add a **consumer-side** story: document (in `ff-sdk`'s README +
+  `examples/`) how a consumer running a worker loop exposes its own
+  `/metrics` using the same `ff-observability` crate in `enabled`
+  mode, or a thin `ff-sdk` feature `metrics-endpoint` that exposes
+  an `axum::Router` returning `Metrics::render()`. No new crate.
+- Feature-gate shape: existing `observability` feature on
+  `ff-server`, `ff-engine`, `ff-scheduler` stays. Add
+  `metrics-endpoint` feature on `ff-sdk` (pulls `axum` + re-exports
+  a `metrics_router()` builder). No `ff-prometheus` crate.
+
+**Interaction with #170's OTEL bridge**: additive. The bridge is the
+source; `/metrics` is a sink. A direct Prometheus endpoint would be
+duplicative; we are not adding one.
+
+**Scope estimate**: engine `/metrics` already done. Consumer
+`metrics-endpoint` feature on `ff-sdk` is ~0.5 day (axum router +
+example + one integration test). Documentation is ~0.5 day.
+
+### 2. Sentry integration
+
+**Proposal**: ship a `sentry` feature on `ff-observability` that
+installs a `sentry-tracing` layer into the `tracing_subscriber`
+registry when enabled. Both engine and consumer can opt in.
+
+**Shape**:
+
+- New feature `ff-observability/sentry` → pulls
+  `sentry = { version, default-features = false, features = ["tracing"] }`
+  and `sentry-tracing`.
+- New function `ff_observability::install_sentry(dsn, opts)` that
+  initializes the guard and returns it; caller owns the guard's
+  lifetime (drop on shutdown to flush).
+- Events: forward `tracing::error!` and `tracing::warn!` by default;
+  configurable via the usual sentry-tracing knobs.
+- Engine-side: `ff-server` gains a `sentry` feature that
+  transitively enables `ff-observability/sentry` and reads
+  `FF_SENTRY_DSN` from env in `main.rs`. Off by default.
+- Consumer-side: same mechanism — consumer binary enables
+  `ff-observability/sentry`, calls `install_sentry`, done.
+
+**Both** sides, because errors happen on both. No engine-only
+restriction.
+
+**Env-var config**: `FF_SENTRY_DSN`, `FF_SENTRY_ENVIRONMENT`,
+`FF_SENTRY_SAMPLE_RATE`. Mirrors `sentry` crate's conventions.
+
+**Scope estimate**: ~4 hours engine-side, ~2 hours consumer example.
+
+### 3. Web UI (admin board)
+
+**Proposal**: defer to 0.6.x. Not in 0.5 scope.
+
+**Rationale**:
+
+- apalis-board is a non-trivial artifact: a SPA + an API server that
+  reads backend state. FF would need equivalents for execution list,
+  lane throughput, lease-renewal rate, suspended-execution detail,
+  budget state. Given RFC-012's engine-backend-trait abstraction,
+  the board also has to be backend-agnostic — it cannot read Valkey
+  directly.
+- Minimum-viable shape: new crate `ff-board` exposing an axum
+  handler + embedded HTML (no separate SPA build). Consumes public
+  `ff-sdk` read APIs (list-executions, get-execution,
+  list-suspended, etc.).
+- Scope estimate: **>1 week** for a usable MVP (read-only list +
+  detail views). Multi-week for write-operations (cancel, reclaim).
+  The read-API surface on `ff-sdk` is not yet fully shaped — several
+  endpoints (list-suspended with cursor, lane throughput histogram)
+  would need to land first.
+- Risk: an HTML admin UI becomes a supported surface. Bug reports,
+  i18n pressure, accessibility. Cost is not just the initial spike.
+
+**Recommendation**: park behind an RFC-draft for 0.6+, surface the
+read-API requirements into a separate prerequisite list. Do not
+commit a timeline in 0.5.
+
+## Non-goals
+
+- **Direct `prometheus` client in ff-observability.** OTEL-via-
+  ferriskey is the owner lock; we render Prometheus text through the
+  existing bridge. Not adding a parallel registry.
+- **An independent `ff-prometheus` crate.** Engine `/metrics` is on
+  `ff-server`; consumer `/metrics` is a thin feature on `ff-sdk`. No
+  third crate.
+- **Sentry as a required dependency.** Feature-gated, off by default,
+  on both engine and consumer.
+- **A web UI in 0.5.** Defer to 0.6+ RFC.
+- **Auth on `/metrics`.** PR-94 set the convention: network-layer
+  ACL, not app-layer auth. Unchanged.
+- **Job-level dashboards modelled on apalis-board's workflow graph.**
+  FF flows have different topology (RFC-007); we would not mimic
+  apalis-board's DAG renderer, even in 0.6.
+
+## Interaction with other RFCs
+
+- **Worker UUUU's tower-layer RFC** (client-side composable layers):
+  Sentry + Prometheus are orthogonal axes. A tower layer emits
+  tracing events; `sentry-tracing` catches them; the Prometheus
+  endpoint renders what the tower layer recorded. No API overlap.
+  **Coordination point**: if UUUU's RFC introduces an
+  `ff-sdk::observability` namespace for client-side layers, the
+  `metrics-endpoint` feature proposed here should live inside it
+  (same module, same feature flag discipline). Cross-link at
+  implementation time.
+- **#170 OTEL bridge**: this RFC is additive — Sentry is a new sink
+  alongside the existing OTEL → Prometheus bridge; consumer
+  `metrics-endpoint` re-uses #170's render path.
+- **RFC-012 engine-backend-trait**: web UI (when we build it) must
+  read via the trait, not Valkey directly. Noted as a prerequisite
+  for the deferred 0.6 work.
+
+## Alternatives rejected
+
+1. **Use-OTEL-only; tell consumers to deploy an OTEL collector.**
+   Technically sufficient — `opentelemetry-prometheus` +
+   `opentelemetry-otlp` cover both scrape and push. Rejected because
+   the marginal cost of a `sentry` feature is low and the
+   consumer-experience delta is large: "enable a feature + set an
+   env var" vs "stand up a collector, configure exporters, wire
+   alerting." We're a batteries-included engine, and Sentry is a
+   table-stakes battery.
+2. **Bundle an opinionated Grafana dashboard JSON instead of a web
+   UI.** Actively considered for 0.6. Much cheaper than a web UI and
+   serves 80% of the same need. Should be a separate RFC.
+3. **Separate `ff-prometheus` crate with its own registry.**
+   Rejected: duplicates OTEL registration, drifts from the owner
+   lock, doubles the cardinality-governance surface.
+4. **Sentry engine-only, not consumer.** Rejected: consumer code is
+   where flow-logic errors actually surface; engine-only Sentry
+   misses the primary signal.
+
+## Staging recommendation
+
+| Battery | Release | Scope | Rationale |
+|---|---|---|---|
+| Engine `/metrics` | done (PR-94) | 0 days | already shipped |
+| Consumer `metrics-endpoint` feature on `ff-sdk` | 0.5.0 | ~1 day | tiny, re-uses #170's renderer |
+| Sentry feature on `ff-observability` + `ff-server` | 0.5.0 | ~0.5 day | table-stakes, feature-gated |
+| Grafana dashboard JSON (bundled example) | 0.5.x | ~1 day | defer if 0.5.0 is full |
+| Web UI (`ff-board`) | 0.6+ | multi-week | needs SDK read-API prerequisites; separate RFC |
+
+0.5.0 lands two batteries (consumer-metrics + Sentry) for ~1.5 days of
+work total. 0.5.x adds dashboard JSON if the release train has room.
+0.6+ opens the `ff-board` RFC.
+
+## Open questions for owner
+
+1. **Sentry feature naming**: `ff-observability/sentry` (flat) or
+   `ff-observability/sinks-sentry` (anticipating future sinks —
+   Datadog, Honeycomb direct)? The flat name is simpler today;
+   the prefixed name scales. Owner preference?
+2. **Consumer `metrics-endpoint` crate location**: on `ff-sdk` (this
+   RFC's proposal) or on a new `ff-observability-http` crate?
+   Pushing onto `ff-sdk` pulls `axum` into consumer dependency
+   graphs who opt in; a separate crate is cleaner but adds a
+   workspace member.
+3. **Web-UI commitment**: is 0.6+ deferred-for-now acceptable, or
+   does the owner want a concrete milestone commitment now? If the
+   latter, we need the SDK read-API prerequisite list as a parallel
+   investigation.
+4. **Grafana dashboard JSON**: in-tree (`examples/grafana/`) or
+   out-of-tree (separate `flowfabric-dashboards` repo)? In-tree
+   couples dashboard evolution to engine releases — usually what
+   operators want.
+5. **Env-var prefix for Sentry**: `FF_SENTRY_*` (matches other FF
+   env vars) or `SENTRY_*` (matches sentry crate defaults so
+   consumers can reuse existing ops config)? Small, but picks a
+   support boundary.
+
+## Scope estimate
+
+- Consumer `metrics-endpoint` on `ff-sdk`: **0.5 day** (axum router,
+  example, integration test).
+- Sentry feature + env wiring: **0.5 day** (feature flag, installer,
+  main.rs integration, doc).
+- Documentation pass covering both + the already-existing `/metrics`:
+  **0.5 day** (new section in `ff-observability` README +
+  `docs/operator-guide.md` entry).
+- **Total 0.5.0 scope**: ~1.5 days of one-worker time.
+- Grafana dashboard JSON (optional 0.5.x): ~1 day.
+- Web UI (0.6+): separate RFC, separate estimate, **>1 week MVP**.
+
+## References
+
+- `rfcs/drafts/apalis-deep-architecture-dive.md` (Worker PPPP),
+  §"Observability" lines 181-189 + §"Out-of-box observability
+  batteries" lines 232-235.
+- `crates/ff-observability/src/real.rs` lines 69-184 (existing OTEL
+  → Prometheus bridge).
+- `crates/ff-server/src/metrics.rs` lines 1-70 (PR-94 `/metrics`
+  endpoint + HTTP middleware).
+- `crates/ff-server/src/api.rs` lines 479-488 (unauthenticated
+  `/metrics` mount).
+- Owner lock 2026-04-22: "metrics=OTEL via ferriskey" (cited in
+  manager notes `project_ff_release_decisions.md`).
+- apalis sources: `apalis-dev/apalis/apalis-prometheus`,
+  `apalis/src/layers/sentry`, `apalis/src/layers/opentelemetry`,
+  `apalis-dev/apalis-board` (web UI).

--- a/rfcs/drafts/RFC-draft-tower-layer-surface.md
+++ b/rfcs/drafts/RFC-draft-tower-layer-surface.md
@@ -1,0 +1,399 @@
+# RFC-draft: Client-local layer surface for `EngineBackend`
+
+**Status:** Draft (Worker UUUU, 2026-04-22). Investigation + design only. No code in this spawn.
+**Related:**
+- `rfcs/drafts/apalis-deep-architecture-dive.md` (Worker PPPP, 2026-04-23) — recommendation #5.
+- RFC-012 (`EngineBackend` trait).
+- RFC-003 / RFC-004 / RFC-011 (fence-triple, lease, exec/flow co-location — invariants this RFC MUST NOT violate).
+- apalis primary sources: `apalis/src/layers/mod.rs`, `apalis/Cargo.toml` (layer feature flags),
+  tower ecosystem `tower::Layer` / `tower::Service`.
+
+## §1 Motivation
+
+Worker PPPP's apalis deep-dive (§"Tower layer composition", lines 104–129)
+identified that apalis exposes a tower `Layer` surface for cross-cutting
+concerns — retry, timeout, tracing, concurrency/rate limit, catch-panic,
+prometheus, opentelemetry, sentry — all composed at `WorkerBuilder` time
+via `.layer(...)`. Feature flags in `apalis/Cargo.toml` default-enable
+`["tracing", "catch-panic", "limit", "timeout", "retry"]`.
+
+FlowFabric has no comparable ergonomic surface. Cross-cutting concerns
+today fall into two non-overlapping buckets:
+
+- **Engine-enforced** (fenced, distributed-correct): `RetryPolicy` +
+  `ExecutionPolicy` on the task record (RFC-005/008); lease TTL as
+  timeout (RFC-003); flow budgets (RFC-008). These stay engine-side —
+  a client-local layer cannot fence a stale writer.
+- **Client-local** (user-space, per-worker): local tracing spans around
+  a trait call, in-process rate caps, panic isolation around handler
+  execution, SDK-side metric counters, client-local circuit-breakers
+  guarding the backend connection. FlowFabric surfaces **none** of
+  these ergonomically. Consumers wrap `claim_next()` + trait calls
+  by hand.
+
+This RFC proposes a narrow, bespoke layer trait that wraps
+`Arc<dyn EngineBackend>` at `FlowFabricWorker::connect_with(...)` time.
+Non-fenced, purely user-space, strictly additive. Complements — does
+not replace — engine primitives.
+
+### §1.1 What consumer pain this closes
+
+1. cairn-fabric hand-rolls `tracing::info_span!` around each `claim_next`
+   + `complete`; no composable way to add a span wrapper across all
+   backend calls.
+2. "Don't fire more than K `complete` calls per second to protect
+   downstream" — no engine-side knob fits (flow budgets are per-flow, not
+   per-worker-SDK).
+3. Handler panics tear the worker loop; consumers reinvent
+   `AssertUnwindSafe` wrapping.
+4. OTEL bridge (owner-lock 2026-04-22) is engine-scope; consumers wanting
+   a second metrics pipeline (StatsD, vendor SDK) have no SDK-side hook.
+
+None require fence semantics. All are client-local.
+
+## §2 Proposed trait shape
+
+### §2.1 Core trait
+
+```rust
+/// Wrap an `EngineBackend` with a client-local cross-cutting concern.
+///
+/// A layer is a pure function from `Arc<dyn EngineBackend>` to a new
+/// `Arc<dyn EngineBackend>`. The output delegates to the input for
+/// all trait methods, optionally observing or short-circuiting.
+///
+/// Layers run **client-local only**. They MUST NOT be used to enforce
+/// any distributed-correctness invariant (see §4).
+pub trait EngineBackendLayer: Send + Sync + 'static {
+    fn layer(
+        &self,
+        inner: Arc<dyn EngineBackend>,
+    ) -> Arc<dyn EngineBackend>;
+}
+```
+
+### §2.2 Blanket impl for closures
+
+```rust
+impl<F> EngineBackendLayer for F
+where
+    F: Fn(Arc<dyn EngineBackend>) -> Arc<dyn EngineBackend>
+        + Send + Sync + 'static,
+{
+    fn layer(&self, inner: Arc<dyn EngineBackend>) -> Arc<dyn EngineBackend> {
+        (self)(inner)
+    }
+}
+```
+
+### §2.3 Why not `tower::Service` directly
+
+- `tower::Service<Req>` requires a single request type. `EngineBackend`
+  is a trait with 17 heterogeneous methods (RFC-012 round-7 envelope);
+  forcing a sum-type request enum duplicates the trait and pessimises
+  every call-site.
+- `tower::Layer`'s `poll_ready`/`call` split forces pin-boxed futures
+  and backpressure reasoning where neither is needed.
+- apalis uses tower because `Backend::poll` returns a single
+  `Stream<Item = Request<Args>>`. FF's trait is lifecycle ops, not
+  poll-shaped.
+- Bespoke trait is 12 lines of spec, one method, zero generic soup.
+  apalis itself wraps tower in `WorkerBuilderExt` to smooth ergonomics
+  (`apalis/src/layers/mod.rs`); we can land the equivalent
+  ergonomics without the machinery underneath.
+
+### §2.4 Alternative: per-method hooks enum
+
+Rejected: a `BackendEvent` enum + callback registration grows by variant
+(RFC-012 went 13 → 17 methods in two rounds), breaks
+non-exhaustive-enum semver on every growth, and loses composition —
+trait-object wrapping already gives us dispatch for free.
+
+## §3 Built-in layers (bundled with `ff-sdk`)
+
+Five initial layers. All feature-gated behind `ff-sdk` features
+(mirror apalis's `default = ["tracing", "catch-panic", ...]` pattern,
+though FF should consider `default = []` given #58 decoupling posture).
+
+### §3.1 `TracingLayer` — feature `layer-tracing`
+
+Wraps each `EngineBackend` method call in a `tracing::info_span!` with
+method name + (where available) `handle.execution_id()`. Distinct from
+the engine-side `#[instrument]` on Lua dispatch (#170) because this
+span lives in the **consumer's** span tree, not the engine's.
+
+Rationale: consumers using `tracing-opentelemetry` with their own
+collector want the backend call to appear under the consumer's root
+span; engine-side `#[instrument]` emits into the ferriskey OTEL
+bridge, a different sink.
+
+### §3.2 `RateLimitLayer` — feature `layer-ratelimit`
+
+Token-bucket rate-cap on configured methods (typical target:
+`complete`, `fail`, `append_frame`). Per-worker-process, in-memory.
+Enforces "don't exceed K ops/sec from this process"; useful for
+consumers that want to protect downstream side-effect sinks. Does
+**not** interact with RFC-008 flow budgets — those are per-flow,
+engine-enforced, global. This is per-worker, local, best-effort.
+
+Open question §7.1: single bucket for all methods vs per-method
+buckets vs a pluggable `fn(&MethodName) -> RateSpec`.
+
+### §3.3 `PanicCatchLayer` — feature `layer-catch-panic`
+
+Wraps each trait call in `FutureExt::catch_unwind`, converting panics
+into `EngineError::Bug { .. }`. Rationale: an `EngineBackend` impl
+today is assumed panic-free; a hand-rolled consumer layer (e.g. a
+`MetricsLayer` with a bad metric name) could panic and would take the
+worker loop with it. This gives consumers a safety net for their own
+stack of layers. The underlying Valkey backend remains panic-free
+regardless.
+
+Note: this covers panics **inside the layer stack**, not inside the
+**user handler**. The user-handler panic story belongs with the
+higher-op trait (#135 scope), not this RFC.
+
+### §3.4 `MetricsLayer` — feature `layer-metrics`
+
+Emits counters/histograms via a consumer-supplied `MetricsSink` trait
+(shape sketched; simple `record_call(&method, duration, outcome)`).
+Complements but does not overlap #170's engine-side `#[instrument]`:
+engine-side records inside the Lua dispatch; this records at the
+**SDK caller** — which sees round-trip time, not engine-time, and is
+where consumer SLOs actually live.
+
+Deliberately does not standardise on a specific exporter (Prometheus,
+OTEL, StatsD). `MetricsSink` is a 1-method trait, consumer plugs in
+anything. Contrast with apalis which ships a hard-wired
+`apalis-prometheus` layer — FF stays sink-agnostic per the
+OTEL-via-ferriskey owner lock.
+
+### §3.5 `CircuitBreakerLayer` — feature `layer-circuit-breaker`
+
+Opens a circuit on consecutive `EngineError::Transport` errors from
+the wrapped backend. While open, fails fast with a synthetic
+`Transport` error rather than attempting the wrapped call. Half-open
+trial after a cool-down. Rationale: protects the consumer from
+hammering a degraded Valkey node; distinct from engine-side retry
+(which is about task-level retry semantics on the fenced record).
+
+Open question §7.2: reasonable default thresholds; whether to also
+open on `Contention`.
+
+### §3.6 Explicitly NOT bundled
+
+- **`RetryLayer`** (client-local retry). Considered. Rejected for
+  v1 because it collides semantically with engine-enforced
+  `RetryPolicy` (RFC-005) and would confuse consumers. A consumer
+  who wants client-local retry can write one in three lines against
+  the trait; we do not want to bless it in the default feature set.
+  Reconsider in v2 with a clear name (`TransportRetryLayer`?) and a
+  contract that it **only** retries `EngineError::Transport`.
+- **`TimeoutLayer`** (client-local timeout). Rejected: lease TTL is
+  the truth; a local timeout that fires before the engine releases
+  the lease creates a divergent-state bug class. If a consumer
+  wants a wall-clock kill switch they wrap with `tokio::time::timeout`
+  at the handler level, outside the backend.
+- **Sentry / Prometheus exporter layers.** Per OTEL-via-ferriskey
+  owner lock, FF does not ship vendor-specific exporters. Consumers
+  stack these themselves through `MetricsLayer` + their sink.
+
+## §4 What layers CANNOT do (hard boundary)
+
+A layer sees `Arc<dyn EngineBackend>`. It can observe, short-circuit,
+or decorate. It **must not**:
+
+1. **Reshape persistence.** A layer that rewrites KEYS/ARGV or fakes
+   Lua return values is a new backend impl, not a layer. Implement
+   `EngineBackend` directly.
+2. **Claim to enforce the fence triple** (RFC-003). Fence-current /
+   active-index / epoch fence are Lua-enforced at the backend. A
+   layer cannot synthesise these; attempting to observe and rewrite
+   them breaks RFC-003's stale-writer rejection invariant.
+3. **Fake lease ownership or waitpoint-resume tokens** (RFC-004).
+   HMAC resume tokens are engine-signed; a layer cannot mint or
+   validate them. Panic if a consumer tries.
+4. **Skip or reorder calls in a way that breaks atomicity.** E.g.
+   a layer must not batch `complete` calls. The engine assumes each
+   `complete` is a distinct fenced write.
+5. **Violate RFC-011 (exec/flow co-location).** A layer must not
+   reroute calls across partitions; partition routing is
+   `ValkeyBackend`'s concern (or the eventual Postgres backend's).
+
+§6 lists a test-case checklist Stage-1 implementation MUST pass to
+guard these boundaries.
+
+## §5 Composition API
+
+### §5.1 Builder-style on `Arc<dyn EngineBackend>`
+
+```rust
+use ff_sdk::layer::{EngineBackendLayerExt, TracingLayer, RateLimitLayer};
+
+let backend: Arc<dyn EngineBackend> =
+    ValkeyBackend::from_client_and_partitions(client, partitions).await?.into();
+
+let layered = backend
+    .layer(TracingLayer::default())
+    .layer(RateLimitLayer::per_method("complete", 500))
+    .layer(PanicCatchLayer::default());
+
+let worker = FlowFabricWorker::connect_with(config, layered, None).await?;
+```
+
+`EngineBackendLayerExt` is a sealed extension trait providing `.layer(L)`
+on `Arc<dyn EngineBackend>`. Sealed so we don't bind future extension
+points to the current shape.
+
+### §5.2 Ordering semantics
+
+Outer layer runs first (like tower, like apalis — documented at
+`apalis/src/layers/mod.rs` "tracing added before retry will see all
+retries as a single operation"). Document prominently: "tracing
+**outside** rate-limit sees rate-limited-rejections as distinct
+events; tracing **inside** sees only successful admissions."
+
+### §5.3 Zero-layer case
+
+`FlowFabricWorker::connect_with(config, backend, None)` continues to
+work unchanged. No-op is the default. Every layer is opt-in.
+
+## §6 Interaction with existing engine-enforced policies
+
+| Concern                   | Ownership            | Layer-appropriate? |
+|---------------------------|----------------------|--------------------|
+| `RetryPolicy` (RFC-005)   | Engine (fenced)      | No — engine only.  |
+| Lease TTL (RFC-003)       | Engine (fenced)      | No — engine only.  |
+| Flow budget (RFC-008)     | Engine (fenced)      | No — engine only.  |
+| Waitpoint HMAC (RFC-004)  | Engine (signed)      | No — engine only.  |
+| Local tracing span        | Consumer             | **Yes.**           |
+| SDK-side metric counters  | Consumer             | **Yes.**           |
+| In-process rate cap       | Consumer             | **Yes.**           |
+| Handler panic isolation   | Consumer             | **Yes.**           |
+| Transport-level breaker   | Consumer             | **Yes.**           |
+
+Rule of thumb: **if losing the concern causes a distributed-correctness
+bug, it's engine-enforced. If losing it causes a consumer-side
+observability or ergonomics loss, it's layer-appropriate.**
+
+## §7 Open questions for owner
+
+1. **Default feature set.** apalis default-enables 5 layers;
+   `ff-sdk` philosophy so far has been minimal defaults (#58
+   decoupling posture). Recommendation: `default = []`, all layers
+   opt-in. Owner call.
+2. **Circuit-breaker trigger scope.** Transport-only, or also
+   `Contention` / `Conflict`? (§3.5).
+3. **Rate-limit granularity.** Single bucket / per-method / pluggable
+   (§3.2).
+4. **`MetricsSink` vs `ff-observability` bridge.** Does the built-in
+   `MetricsLayer` go through `ff-observability` (engine OTEL sink) or
+   a separate consumer-chosen sink? Recommendation: separate — the
+   whole point is to offer a client-local pipeline. Owner to
+   confirm consistency with 2026-04-22 OTEL lock.
+5. **Layer-ordering enforcement.** Should we refuse `PanicCatchLayer`
+   as the innermost layer (unable to catch its own implementation
+   bugs) at compile time or runtime? Recommendation: runtime warn
+   only, document convention.
+6. **Semver of the `EngineBackendLayer` trait itself.** Adding a
+   method would break implementers. Recommendation: seal for v1,
+   add `#[doc(hidden)] fn __private(&self) {}` to reserve future
+   expansion. Owner preference?
+7. **Higher-op trait interplay (#135).** When higher-op trait lands,
+   do layers wrap the lower `EngineBackend` trait or the higher
+   trait? Recommendation: `EngineBackend` only (the lower, stable
+   surface); higher-op gets its own extractor story per apalis's
+   `FromRequest` pattern (PPPP recommendation #4).
+
+## §8 Alternatives rejected
+
+### §8.1 Adopt `tower::Service` + `tower::Layer` directly
+
+Rejected per §2.3. Machinery cost > ergonomic win for a 17-method
+heterogeneous trait. apalis's own `WorkerBuilderExt` demonstrates
+you always end up wrapping tower anyway.
+
+### §8.2 No layer surface; consumers wrap `Arc<dyn EngineBackend>`
+by hand
+
+Status quo. Works, but (a) every consumer reimplements the same
+five concerns, (b) no shared vocabulary for discussions ("add a
+rate-limit layer" vs "write a struct that impls 17 methods
+delegating to an inner Arc and also does rate-limiting"),
+(c) `EngineBackend` grows by RFC amendment (13 → 17 in two rounds);
+per-consumer wrappers ossify against old shapes. A sealed layer
+trait + the blanket closure impl gives us one stable wrap point.
+
+### §8.3 Per-method callback registration (`on_before_complete`, etc.)
+
+Rejected per §2.4. Non-composable, grows by variant not by
+composition, collides with non-exhaustive-enum semver plans.
+
+### §8.4 Make layers themselves fenced
+
+Rejected. By definition fencing lives in Lua + the engine. Layers
+that pretend to fence are a footgun. Document in §4 that this is
+never allowed.
+
+### §8.5 Replace engine `RetryPolicy` with a `RetryLayer`
+
+Explicitly out of scope. RFC-005's retry is fenced, at-most-once
+per attempt number, and survives worker crash. A client-local
+layer cannot replicate that. See §3.6 on why we don't even
+bundle a `RetryLayer`.
+
+## §9 Semver impact
+
+- **Additive.** New trait, new `ff-sdk::layer` module, new
+  feature flags, new ext trait. No change to `EngineBackend` shape
+  or any existing SDK API.
+- **Consumer ergonomic win.** Existing call sites (zero layers)
+  continue to compile unchanged.
+- **Target release:** 0.5.0 minor, or 0.4.x point release if owner
+  decides the trait is small-enough and implementation risk is low.
+  Recommendation: 0.5.0 to co-land with higher-op trait + extractor
+  work (one coherent ergonomic refresh).
+
+## §10 Scope estimate
+
+**RFC acceptance:**
+- Worker debate round (per `feedback_rfc_team_debate_protocol`):
+  high-impact, all-worker review until unanimous ACCEPT. Est. 2–3
+  rounds, ~6–10 hours wall-time single-agent with subagent-parallel
+  reviews.
+- Owner adjudication on §7 open questions: 1 round.
+
+**Implementation (first landing, `ff-sdk`):**
+- `EngineBackendLayer` trait + `Arc<dyn EngineBackend>::layer(..)` ext + closure impl: ~2h.
+- `TracingLayer`: ~2h (including span-name mapping for all 17 methods).
+- `RateLimitLayer`: ~3h (token bucket, governor crate or hand-rolled).
+- `PanicCatchLayer`: ~2h (catch_unwind + `EngineError::Bug` mapping).
+- `MetricsLayer` + `MetricsSink` trait: ~3h (sink-agnostic, 1-method trait, 17-method dispatch).
+- `CircuitBreakerLayer`: ~4h (state machine + half-open trial).
+- Tests, including §4 boundary-enforcement cases (layer can't fake
+  a fence, can't mint a waitpoint HMAC, can't skip/reorder calls):
+  ~6h.
+- Docs + examples in `crates/ff-sdk/examples/`: ~3h.
+
+**Total first-landing estimate:** ~25 hours single-agent.
+Parallelisable across two workers (layer infra + 2-3 built-ins each).
+
+Stage gates:
+1. Accept RFC after debate.
+2. Stage 1: trait + ext + `TracingLayer` + `PanicCatchLayer` (smallest
+   vertical slice, prove the surface).
+3. Stage 2: remaining three built-in layers.
+4. Stage 3: cairn-fabric migration example (if requested by consumer
+   team; peer-team boundaries respected per
+   `feedback_peer_team_boundaries`).
+
+## §11 Citations
+
+- apalis layers: https://github.com/geofmureithi/apalis/blob/main/apalis/src/layers/mod.rs
+- apalis features (default layer set): https://github.com/geofmureithi/apalis/blob/main/apalis/Cargo.toml
+- tower::Layer: https://docs.rs/tower/latest/tower/trait.Layer.html
+- PPPP's deep-dive: `rfcs/drafts/apalis-deep-architecture-dive.md` §"Tower layer composition" (lines 104–129), §Recommendations item 5 (lines 297–301)
+- FF `FlowFabricWorker::connect_with`: `crates/ff-sdk/src/worker.rs:574`
+- FF `EngineBackend` trait: RFC-012 §3.1.1 (17 methods post-round-7)
+- Engine-enforced policies: RFC-003 (fence-triple), RFC-004 (waitpoint/HMAC), RFC-005 (retry), RFC-008 (budget), RFC-011 (exec/flow colocation)
+- OTEL-via-ferriskey owner lock: 2026-04-22 release decisions (`project_ff_release_decisions`)

--- a/rfcs/drafts/apalis-deep-architecture-dive.md
+++ b/rfcs/drafts/apalis-deep-architecture-dive.md
@@ -1,0 +1,356 @@
+# apalis architectural deep-dive (2026-04-23)
+
+Investigator: Worker PPPP. Scope: what geofmureithi means by "upgrades
+your approach with best practices and shared connections" beyond the
+scenario-4 DAG harness fix that Worker VV already covered in
+`apalis-comparison.md`. Read-only. Primary-source citations only.
+
+## Method
+
+- apalis repo `geofmureithi/apalis` (redirects to `apalis-dev/apalis`),
+  `main` as of 2026-04-23.
+- Sources inspected (raw):
+  - `apalis-core/src/backend/mod.rs` (Backend trait)
+  - `apalis-core/src/backend/shared.rs` (`MakeShared` trait)
+  - `apalis-core/src/worker/mod.rs`, `.../builder.rs` (WorkerBuilder)
+  - `apalis-core/src/task_fn/mod.rs` (TaskFn / `FromRequest` /
+    `Data<T>` extractors)
+  - `apalis/src/lib.rs`, `apalis/src/layers/mod.rs` (tower glue)
+  - `apalis/Cargo.toml` (feature flags)
+  - `apalis/README.md`, `apalis-redis/README.md`,
+    `apalis-workflow/README.md`
+  - `apalis-redis` (separate repo `apalis-dev/apalis-redis`) —
+    `src/lib.rs`, `src/shared.rs`.
+- FF baselines:
+  - `/home/ubuntu/FlowFabric/crates/ff-sdk/src/worker.rs` (worker)
+  - `/home/ubuntu/FlowFabric/crates/ff-backend-valkey/src/lib.rs`
+    (`ValkeyBackend`, `from_client_and_partitions`, `build_client`)
+  - `/home/ubuntu/FlowFabric/ferriskey/src/ferriskey_client.rs`
+    (`Client` is `#[derive(Clone)]`, `ClientBuilder` API)
+  - `/home/ubuntu/FlowFabric/benches/comparisons/apalis/src/*.rs`
+    (`apalis_redis::connect` per scenario)
+
+## What geofmureithi likely meant by "upgrades your approach"
+
+Three distinct technical claims packed into the sentence:
+
+1. **"Shared connections"** — specific. `apalis-redis` exposes
+   `SharedRedisStorage` (`apalis-redis/src/shared.rs`) that owns
+   **one `redis::aio::MultiplexedConnection`** and vends N
+   `RedisStorage<Args>` instances via `MakeShared::make_shared()`
+   (`apalis-core/src/backend/shared.rs:12-33`). One TCP socket, N
+   typed queues, one pub/sub `PSUBSCRIBE tasks:*:available` fanout.
+   FF's bench harness dials a fresh `apalis_redis::connect(url)` per
+   scenario (`benches/comparisons/apalis/src/scenario1.rs:74`,
+   `scenario4.rs:177`) and builds the worker against that — that's
+   the "strawman" setup he's pointing at.
+
+2. **"Best practices"** — idiomatic `WorkerBuilder` + tower
+   `.layer(...)` composition for retry/timeout/tracing/catch-panic
+   instead of running a raw storage + hand-rolled loop.
+
+3. **"Upgrades your approach"** — implies using `apalis-workflow`
+   (already covered by Worker VV for scenario 4) **plus** the above
+   two. The "your approach" here is the bench harness, not FF's
+   engine.
+
+Net: he is not claiming apalis's engine is better than FF's engine.
+He is claiming our apalis **harness** is underspecified on 3 axes.
+Two of those (shared connections, tower layers) we hadn't examined.
+
+## Per-axis comparison
+
+### Connection sharing
+
+**apalis.** `apalis-redis/src/shared.rs:13-19`:
+
+```rust
+pub struct SharedRedisStorage {
+    conn: MultiplexedConnection,
+    registry: Arc<Mutex<HashMap<String, Arc<Event>>>>,
+}
+```
+
+`SharedRedisStorage::new(client)` dials exactly one multiplexed
+connection, opens a single `PSUBSCRIBE tasks:*:available`, and each
+`make_shared()` call returns a `RedisStorage<Args, MultiplexedConnection>`
+cloning the same `conn` and registering an `event_listener::Event`
+keyed by type-name. N queues → 1 socket, 1 pub/sub stream.
+
+**FF.** `ferriskey::Client` is `#[derive(Clone)]`
+(`ferriskey/src/ferriskey_client.rs:24`) and internally
+Arc-backed — cloning shares the same multiplexed pipelined
+connection. `ValkeyBackend::from_client_and_partitions`
+(`crates/ff-backend-valkey/src/lib.rs:176`) already lets a caller
+wire a pre-dialed client into an `Arc<dyn EngineBackend>`, and
+`FlowFabricWorker::connect_with`
+(`crates/ff-sdk/src/worker.rs:574`) accepts a caller-supplied
+`Arc<dyn EngineBackend>`. So the **primitive exists**; what's missing
+is the ergonomic equivalent of `SharedRedisStorage::make_shared()` —
+a one-liner that says "give me N workers sharing one underlying
+connection, each with distinct `worker_instance_id`/lane/capability
+state". Today each worker's `FlowFabricWorker::connect(config)` calls
+`ff_backend_valkey::build_client(&config.backend)`
+(`ff-sdk/src/worker.rs:166`), dialing a **fresh** client per
+`connect` call. A consumer running multi-queue workers in one
+process ends up with N sockets unless they manually plumb
+`connect_with(..., Arc::clone(&backend), ...)`.
+
+Verdict: FF has the mechanism, not the sugar. Missing: a
+`SharedFfBackend` factory + worker convenience constructor. Small
+API, real ergonomic win, zero engine change.
+
+### Tower layer composition
+
+**apalis.** `WorkerBuilderExt` (`apalis/src/layers/mod.rs`) wires
+tower's `retry`, `timeout`, `limit` (concurrency + rate),
+`filter`/`filter_async`, `map_*`, `catch_panic`, `enable_tracing`,
+plus opt-in `prometheus`, `opentelemetry`, `sentry` layers, all as
+tower `Layer`s composed at builder time. Feature flags (`apalis/Cargo.toml`):
+default = `["tracing", "catch-panic", "limit", "timeout", "retry"]`.
+Layer ordering is user-visible ("tracing added before retry will
+see all retries as a single operation").
+
+**FF.** Retry and timeout are engine primitives:
+- `RetryPolicy` + `ExecutionPolicy` live on the task record; the
+  scanner re-enqueues after lease expiry (RFC-003).
+- Timeout is the lease TTL itself.
+- Tracing/metrics go through `ff-observability` (OTEL-via-ferriskey
+  owner lock 2026-04-22).
+
+This is a **different axis**, not strictly worse. apalis's tower
+layers are **user-space, per-worker, client-side**: a panic-catch or
+local timeout can't protect against a wedged process — apalis's
+at-least-once contract + heartbeat re-enqueue covers that. FF's
+engine-enforced timeout IS fence-fenced (stale writer Lua-rejected),
+which tower timeouts cannot be. But on **cross-cutting observability
+/ hooks / local rate-limiting** FF surfaces nothing comparable;
+consumer writes those by hand around `claim_next().await?`. The
+higher-op trait (#135 scope) is where this gap would naturally close.
+
+### Handler DI (function-as-handler)
+
+**apalis.** `async fn send_email(task: Email, data: Data<usize>)` →
+`WorkerBuilder::new(...).build(send_email)`. `FromRequest`
+implementations extract `Data<T>`, `TaskId<I>`, `WorkerContext`, etc.
+from the task envelope (`apalis-core/src/task_fn/`, macro-generated
+up to 16 extractor args). Axum-flavour.
+
+**FF.** Consumer writes `while let Some(t) = worker.claim_next().await? { ... }`
+and manually threads shared state through a closure. Leaf-handler
+ergonomics are lower: no extractors, explicit loop, explicit
+`t.complete(...)`/`t.fail(...)`. Higher-op trait is pre-merge.
+
+Verdict: genuine DX gap. Not philosophical — apalis's pattern
+directly ports to FF's model once higher-op lands. Worth explicitly
+designing `#[derive(FromRequest)]`-equivalent extractors (axum
+already proved the ergonomic-contract).
+
+### Storage backend agnosticism
+
+**apalis.** `Backend` trait (`apalis-core/src/backend/mod.rs`):
+
+```rust
+pub trait Backend {
+    type Args; type IdType: Clone; type Context: Default;
+    type Error; type Stream: Stream<...>;
+    type Beat: Stream<Item = Result<(), Self::Error>>;
+    type Layer;
+    fn heartbeat(&self, worker: &WorkerContext) -> Self::Beat;
+    fn middleware(&self) -> Self::Layer;
+    fn poll(self, worker: &WorkerContext) -> Self::Stream;
+}
+```
+
+Extension traits add capabilities (`TaskSink`, `FetchById`, `ListTasks`,
+`ListWorkers`, `Metrics`, `Reschedule`, `ResumeAbandoned`, `Update`,
+`WaitForCompletion`) that backends opt into — per-backend feature
+matrix surfaced via the `features_table!` macro
+(`apalis-redis/src/lib.rs:55-72`).
+
+**FF.** `EngineBackend` trait (RFC-012, Stage 1b in flight) is the
+same pattern — capability traits + per-store impl. Currently
+Valkey-only, Postgres on the runway (#58). **Axes-aligned**.
+
+What FF doesn't have yet: the capability-matrix **in-rustdoc**
+pattern (`features_table!`). Small but nice for consumer-facing
+discoverability.
+
+### Observability
+
+**apalis.** `apalis-prometheus`, `apalis/src/layers/opentelemetry`,
+`apalis/src/layers/tracing`, `apalis/src/layers/sentry` — all
+opt-in feature flags. **apalis-board**: web UI for workers + jobs.
+
+**FF.** `ff-observability` (OTEL bridge via ferriskey), engine-side
+metrics, no web UI, no Sentry integration, no Prometheus exporter
+bundled. Comparable on OTEL, missing on (1) pre-built Prom exporter,
+(2) web UI, (3) Sentry bridge. Whether those matter depends on
+positioning: FF-as-engine vs apalis-as-library.
+
+### Scheduling primitives
+
+**apalis.** `apalis-cron` — crate that wraps a cron schedule as a
+backend and uses the same `WorkerBuilder`. Separate concern from
+`delay_for` (combinator on `Workflow`).
+
+**FF.** RFC-009 flow scheduler (leader-elected, engine-native) +
+`delay_until` on tasks. apalis-cron is lighter (single-process,
+per-worker schedule); FF's design is cluster-aware. Different axes.
+
+### Heartbeat / lease
+
+**apalis.** `Backend::heartbeat(&self, worker) -> Self::Beat` is a
+stream of keep-alive ticks; each backend implements on its own
+terms. `apalis-redis` runs `register_worker.lua`
+(`apalis-redis/src/lib.rs`) on a configurable `keep_alive`
+interval — writes the worker into a `workers_set` + inflight-jobs
+key with TTL. Crash = key expires = another worker re-enqueues via
+`reenqueue_orphaned_after`. **No fencing token.** A stale worker
+whose heartbeat lapsed momentarily but whose task handler is still
+running can complete-write after re-delivery, creating a
+double-execution window.
+
+**FF.** RFC-003 fence-triple: `lease_current` + `active_index` +
+epoch fence. Stale-writer Lua-rejected at the boundary. Strictly
+stronger contract. Worth-keeping.
+
+## What FF is ACTUALLY doing worse (honest, ranked by consumer impact)
+
+1. **No "shared connections" sugar.** Primitive exists
+   (`connect_with(Arc<dyn EngineBackend>)`); ergonomic one-liner
+   doesn't. A consumer with 5 worker types in one process today
+   opens 5 Valkey sockets by default. apalis users get 1 by calling
+   `SharedRedisStorage::new(client).make_shared()` five times.
+   High-impact for multi-queue-in-one-process deployments.
+
+2. **Handler ergonomics.** `async fn(Task, Data<T>, WorkerContext)`
+   with extractors vs hand-rolled `claim_next` loop. Affects every
+   consumer's first-line-of-code. Higher-op trait closes this —
+   but not landed yet.
+
+3. **Out-of-box observability batteries.** No Prometheus feature
+   flag that drops a ready exporter, no Sentry layer, no web UI. FF
+   has OTEL but consumers still wire their own exporter + dashboard.
+   Medium-impact, zero-engine-change if we add features.
+
+## What FF is doing DIFFERENTLY, not worse
+
+- **Engine-enforced retry/timeout/budget** (RFC-005/008) vs tower
+  layers. FF's is fenced; apalis's is composable client-side.
+  Orthogonal; both defensible. FF can add a tower-layer-compatible
+  *client-local* surface (local tracing spans, local rate limits)
+  without compromising Lua atomicity — non-blocking design note
+  worth opening.
+
+- **Capability-graded routing** (RFC-006-ish) vs type-segregated
+  queues. apalis's `Args` generic **is** the queue discriminator
+  (one `RedisStorage<Email>` per type, namespace from
+  `type_name::<T>()`). FF routes via capability tags at claim-grant
+  time, one task record space. Different philosophy, neither wrong.
+
+- **Multi-backend** via one trait (FF) vs per-backend crate
+  (apalis). Both viable; #58 plan commits FF to the one-trait path.
+
+## What FF is genuinely doing BETTER
+
+- **Fenced atomicity on lease/claim** — stale worker writes
+  Lua-rejected. apalis-redis cannot prove single-execution across
+  heartbeat-lapse + revival. Impact: matters a lot for
+  side-effect-producing tasks; matters less for idempotent work.
+  Quantify: on a 30s lease + 1s heartbeat, apalis's double-execute
+  window is O(seconds) under pathological GC pauses; FF's is zero.
+  In benign conditions both are zero.
+
+- **Waitpoints + HMAC resume tokens** (RFC-004). No apalis analogue
+  surfaced; `apalis-workflow` persists state but doesn't expose
+  external-resume by token. For webhook/external-event flows this is
+  not a DX delta, it's a capability delta.
+
+- **Exec/flow co-location** (RFC-011). Apalis-workflow persists as
+  generic backend rows; no slot-locality guarantee. Matters for
+  tail-latency under Valkey cluster mode.
+
+- **Scheduler as engine primitive** (RFC-009, leader-elected). apalis
+  cron is per-process.
+
+## Recommendations
+
+**Small-scope (fold into 0.4.x):**
+
+1. **`SharedFfBackend` factory + worker one-liner.** Expose a
+   convenience that mirrors `SharedRedisStorage::make_shared`. Uses
+   existing `connect_with` machinery, zero engine change. Answer to
+   geofmureithi's "shared connections" directly.
+2. **`SharedFfBackend` example** in `crates/ff-sdk/examples/` and a
+   callout in the 0.4.x CHANGELOG.
+3. **Update `benches/comparisons/apalis/src/*.rs`** to use
+   `SharedRedisStorage::new(client).make_shared()` for FF harness
+   equivalents; re-run. Pairs with the scenario-4 workflow fix VV
+   already recommended.
+
+**Medium-scope (0.5.0):**
+
+4. **FromRequest-style extractors** on the higher-op trait (#135
+   scope). Targets: `Data<T>`, `TaskId`, `WorkerContext`,
+   `Capabilities`. Do this once higher-op trait API is frozen.
+5. **Client-local tower-compatible layer surface.** Non-fenced,
+   purely user-space (local tracing, local rate-limit, local panic
+   catch). Does not replace engine primitives; complements them.
+   Opens FF to the tower ecosystem without compromising Lua
+   atomicity. Separate drafts/ note, RFC-scale.
+6. **Capability-matrix `features_table!`-style rustdoc** — helper
+   macro to render per-backend capability docs. DX polish.
+
+**Don't-adopt:**
+
+- **Tower layers replacing RetryPolicy.** FF's fenced retry is
+  load-bearing; apalis's layer is client-side best-effort. Retain
+  engine-enforced retry; optionally **also** offer a tower layer
+  for local-side observations.
+- **Per-backend-crate multi-backend.** #58 one-trait plan is the
+  committed path.
+- **apalis-workflow as FF's flow model.** RFC-007 + RFC-011 + RFC-004
+  together do more than apalis-workflow (waitpoints,
+  exec-flow-colocation, fence-triple). Adopting the scenario-4
+  bench-harness fix ≠ adopting the flow primitive.
+
+## What to answer geofmureithi
+
+> Re-read your note carefully and you're right on two beyond
+> scenario 4: (a) our harness dials a fresh `apalis_redis::connect`
+> per scenario instead of using `SharedRedisStorage::make_shared` —
+> we'll fix that and re-run. (b) The tower layer story (retry,
+> timeout, tracing via `.layer(...)`) is something we should surface
+> idiomatically in the apalis harness too. Separately, we're
+> opening a FF-side ticket for a `SharedBackend` ergonomic sugar —
+> the primitive (shared `ferriskey::Client`, `connect_with(Arc<dyn
+> EngineBackend>)`) already exists, just not as a one-liner.
+> Happy to accept your PR if you want to drive the harness changes;
+> otherwise we'll land them and ping you to re-review before the
+> updated comparison goes out.
+
+## Citations
+
+- apalis README: https://github.com/geofmureithi/apalis/blob/main/apalis/README.md
+- apalis-redis README + shared example:
+  https://github.com/apalis-dev/apalis-redis/blob/main/README.md
+- `MakeShared` trait:
+  https://github.com/geofmureithi/apalis/blob/main/apalis-core/src/backend/shared.rs
+- `SharedRedisStorage`:
+  https://github.com/apalis-dev/apalis-redis/blob/main/src/shared.rs
+- Backend trait:
+  https://github.com/geofmureithi/apalis/blob/main/apalis-core/src/backend/mod.rs
+- Layers:
+  https://github.com/geofmureithi/apalis/blob/main/apalis/src/layers/mod.rs
+- apalis/Cargo.toml features:
+  https://github.com/geofmureithi/apalis/blob/main/apalis/Cargo.toml
+- FF `FlowFabricWorker::connect`:
+  `/home/ubuntu/FlowFabric/crates/ff-sdk/src/worker.rs:150-166`
+- FF `ValkeyBackend::from_client_and_partitions`:
+  `/home/ubuntu/FlowFabric/crates/ff-backend-valkey/src/lib.rs:176`
+- FF bench client setup:
+  `/home/ubuntu/FlowFabric/benches/comparisons/apalis/src/scenario1.rs:74`,
+  `scenario4.rs:177`
+- VV's prior report:
+  `/home/ubuntu/FlowFabric/rfcs/drafts/apalis-comparison.md`

--- a/rfcs/drafts/ff-board-sdk-prerequisites.md
+++ b/rfcs/drafts/ff-board-sdk-prerequisites.md
@@ -1,0 +1,156 @@
+# ff-board SDK prerequisite audit (2026-04-23)
+
+Investigator: Worker AAAAA. Investigation-only — no code, no PR.
+Inputs: `rfcs/drafts/RFC-draft-observability-batteries.md` (Worker WWWW,
+§Scope 3 lines 120-146 + §Non-goals lines 161-163 + §Open-questions-3),
+owner commit 2026-04-22 moving Web UI into **0.5.0** scope, current
+`ff-sdk` public surface, current `EngineBackend` trait.
+
+Purpose: list the SDK read-APIs that a minimal `ff-board` v1 would
+bind to, classify which already exist vs. which must land before
+`ff-board` can start, and file prerequisite issues so the Web UI spike
+is not blocked on discovery.
+
+Hard scope guard (from the accepted observability RFC, §Non-goals): no
+apalis-board DAG-workflow renderer mimicry; FF flow topology differs
+(RFC-007). We scope to **read-only operator panels**, not DAG editing.
+
+## 1. MVP Web UI scope
+
+`ff-board` v1 — read-only, backend-agnostic (via `EngineBackend`
+trait where possible, falling back to `ff-server` HTTP where the
+trait doesn't yet cover), embedded HTML + axum handler:
+
+| # | Panel | Primary user question |
+|---|---|---|
+| P1 | **Execution list** (paged, filter by state: eligible/delayed/active/suspended/terminal) | "What's in flight right now?" |
+| P2 | **Execution detail** (state, attempts, leases, resume signals, parent flow) | "Why is this one stuck?" |
+| P3 | **Suspended-execution list** (cursor-paginated, waitpoint reason) | "What's waiting on signals?" |
+| P4 | **Lane list + throughput** (per-lane: depth, claim rate, lease miss rate, recent N-minute window) | "Is a lane backed up?" |
+| P5 | **Lease renewal health** (global + per-lane renewal success/miss rate) | "Are workers healthy?" |
+| P6 | **Stream tail** (live frames for an attempt, for debugging a running execution) | "What is this execution doing?" |
+| P7 | **Flow summary** (flow snapshot + member executions + edges) | "What's the shape of this flow?" |
+| P8 | **Error/retry rate per lane** (windowed) | "Which lanes are failing?" |
+
+Explicit out-of-MVP: DAG topology renderer (non-goal per RFC);
+write-operations — cancel/reclaim/signal (deferred to v2; operator
+can use `ff-sdk` admin CLI).
+
+## 2. Per-panel SDK needs
+
+Legend: `[E]` = exists and is usable today; `[S]` = exists on
+`ff-server` HTTP but no `ff-sdk` wrapper; `[B]` = exists on backend
+state but neither `ff-sdk` nor `EngineBackend` trait exposes it;
+`[M]` = not available, must be built.
+
+| Panel | Today's surface | Gap |
+|---|---|---|
+| P1 execution list | `ff-server` `GET /v1/executions?partition&lane&state&offset&limit` → `ListExecutionsResult`. `Server::list_executions` is Valkey-ZRANGE on lane indexes. No `ff-sdk` wrapper. Not on `EngineBackend` trait. `[S]` | Add `ff-sdk` wrapper `list_executions(partition, lane, state, cursor)`. Ideally promote to `EngineBackend::list_executions` (cross-backend question — Postgres shape differs). |
+| P2 execution detail | `EngineBackend::describe_execution` + `observe_signals` + `resolve_execution_flow_id` all exist; `ff-sdk::snapshot::describe_execution` wraps. `[E]` | None for the snapshot. Attempts/leases already in `ExecutionSnapshot`. |
+| P3 suspended list | Server `list_executions(state="suspended")` returns eids only — no waitpoint-reason, no cursor (offset/limit-based). RFC flagged "list-suspended cursor" explicitly. `[B]` | Cursor-paginated variant returning `ExecutionId + waitpoint_reason + suspended_at`. SDK wrapper. Backend primitive: ZSCAN on suspended ZSET + HMGET reason. |
+| P4 lane list + throughput | Lanes themselves: there is **no `list_lanes` API** anywhere. Throughput: `ff_claim_from_grant_duration` histogram + `ff_lease_renewal_total` exist on `/metrics` but are **not** exposed as a structured per-lane read API — only as Prometheus text. `[M]` for lanes + throughput. | New SDK fn `list_lanes(partition) -> Vec<LaneSummary>` (depth, oldest-eligible age, active-count). New SDK fn `lane_throughput(lane, window) -> LaneThroughput` (claims/sec, p50/p99 claim latency, fail rate). |
+| P5 lease renewal | `ff_lease_renewal_total{outcome}` metric exists; no structured read API. `[M]` | New SDK fn `lease_health(window)` OR document that ff-board consumes the Prometheus scrape directly. Recommend a thin SDK helper that parses the local `/metrics` text → struct, not a new backend trait method (metric origin is the right source of truth). |
+| P6 stream tail | `EngineBackend::read_stream` + `tail_stream` exist (streaming feature). `ff-server` HTTP endpoints exist (`GET /v1/executions/{id}/attempts/{idx}/stream[/tail]`). **No `ff-sdk` wrapper.** `[S]` | SDK wrapper `read_attempt_stream` + `tail_attempt_stream` (already-shaped backend, missing convenience). |
+| P7 flow summary | `EngineBackend::describe_flow` + `list_edges` + `describe_edge` exist. `ff-sdk::snapshot` wraps. **No `list_flows` anywhere** — can't enumerate flows without knowing IDs. `[E]` for detail, `[M]` for enumeration. | New SDK fn `list_flows(partition, cursor) -> Vec<FlowSummary>`. Needs backend primitive (currently flows aren't indexed in a scan-friendly way — cross-backend question). |
+| P8 error/retry rate | Per-lane retry/error rate is **not emitted as a metric today** (only claim-duration + lease-renewal). `[M]` | Either (a) add `ff_attempt_outcome_total{lane,outcome}` counter to `ff-observability`, and have ff-board read via /metrics parse, or (b) new SDK fn `lane_error_rate(lane, window)`. Preference: (a) — reuses existing metrics pipeline. |
+
+## 3. Classification
+
+| Bucket | Count | Items |
+|---|---|---|
+| **Free wrappers** (data exists, SDK convenience needed) | 3 | (F1) `ff-sdk::list_executions` wrapper over `/v1/executions`; (F2) `ff-sdk::read_attempt_stream` + `tail_attempt_stream` wrappers; (F3) `ff-sdk::list_pending_waitpoints` wrapper over `/v1/executions/{id}/pending-waitpoints`. |
+| **New trait methods** (EngineBackend extension, `#[non_exhaustive]` additive, backend impl needed) | 3 | (T1) `list_executions(partition, lane, state, cursor) -> ListExecutionsPage`; (T2) `list_suspended(partition, cursor) -> SuspendedPage` with reason; (T3) `list_lanes(partition) -> Vec<LaneSummary>` (depth + counts). |
+| **Cross-backend questions** (data shape differs; needs decision before trait signature) | 3 | (X1) `list_flows` — Valkey has no flow index, Postgres would; should it be in the trait at all, or a backend-specific extension? (X2) `lane_throughput` — metrics are observability-plane data, not engine-state; decide: trait method, SDK helper over `/metrics` text, or OTEL-only (ff-board queries Prometheus directly)? (X3) `lease_health` — same question as X2. |
+| **New metrics** (no new API, just emit + document) | 1 | (N1) `ff_attempt_outcome_total{lane,outcome}` counter added to `ff-observability` so P8 can read it from `/metrics`. |
+
+Net: **10 prerequisite items** for an MVP ff-board — 3 free, 3
+new-trait, 3 cross-backend (requiring owner decision before
+implementation), 1 metric-only.
+
+Recommendation: resolve the 3 cross-backend questions first (X1/X2/X3
+are architectural and the outcome changes how much work T1–T3 are).
+For X2/X3 specifically, we recommend **"ff-board reads /metrics
+directly"** — the observability RFC's owner lock is "metrics=OTEL via
+ferriskey"; routing lane throughput back through the engine-backend
+trait duplicates the cardinality/naming governance already centralized
+in `ff-observability`. ff-board is local-to-engine (same axum server
+or co-deployed) and can scrape `/metrics` over loopback.
+
+That collapses X2 + X3 into "no new API" → effective prereq count
+drops to 7 (3 free + 3 new-trait + 1 metric).
+
+## 4. Filed issues
+
+Grouping: **single umbrella tracking issue with a checklist** plus
+**one standalone issue per new-trait-method** (T1/T2/T3) and
+**X1 as a design decision** since that blocks trait signatures.
+F1/F2/F3/N1/X2/X3 stay as checklist items under the umbrella —
+small + don't need RFC-level discussion (X2/X3 have a recommended
+resolution pending owner confirm).
+
+| # | Issue | Kind |
+|---|---|---|
+| [#181](https://github.com/avifenesh/FlowFabric/issues/181) | ff-board Web UI SDK prerequisites (0.5.0 tracking) | Umbrella |
+| [#182](https://github.com/avifenesh/FlowFabric/issues/182) | EngineBackend: `list_executions` trait method | T1 |
+| [#183](https://github.com/avifenesh/FlowFabric/issues/183) | EngineBackend: `list_suspended` cursor-paginated trait method | T2 |
+| [#184](https://github.com/avifenesh/FlowFabric/issues/184) | EngineBackend: `list_lanes` trait method | T3 |
+| [#185](https://github.com/avifenesh/FlowFabric/issues/185) | Design question: `list_flows` cross-backend shape | X1 |
+
+## 5. Effort estimate
+
+Prerequisites **before ff-board itself starts**:
+
+| Item | Kind | Estimate |
+|---|---|---|
+| Cross-backend decisions (X1/X2/X3) — owner lock | discussion | 0.5 day (async) |
+| F1 list_executions wrapper | free | 0.5 day (incl. test) |
+| F2 stream read/tail wrappers | free | 0.5 day |
+| F3 list_pending_waitpoints wrapper | free | 0.25 day |
+| T1 EngineBackend::list_executions + Valkey impl | trait | 1.0 day |
+| T2 EngineBackend::list_suspended + Valkey impl (reason field + cursor) | trait | 1.5 days |
+| T3 EngineBackend::list_lanes + Valkey impl | trait | 1.0 day |
+| N1 `ff_attempt_outcome_total` counter + wiring | metric | 0.5 day |
+| Doc pass on new SDK surface | doc | 0.5 day |
+| **Prereq total** | | **~6 days** (1 worker) |
+
+`ff-board` itself (per observability RFC §3): **>1 week MVP** for
+read-only list + detail; multi-week for write-ops. We recommend
+**read-only MVP only** in 0.5.0 (~1.5 weeks), deferring write-ops to
+0.6.x.
+
+**0.5.0 total ff-board budget**: ~6 days prereqs + ~7 days MVP ≈
+**2.5–3 weeks** of one-worker time, assuming the cross-backend
+decisions resolve quickly. Longer if X1 (list_flows) requires its
+own sub-RFC.
+
+## 6. Hard scope lines drawn
+
+- No DAG renderer (RFC Non-goal, line 162-163).
+- No write-operations in v1 (cancel/reclaim/signal) — operator uses
+  existing SDK/CLI.
+- No auth on ff-board (same convention as `/metrics`, PR-94, §Non-
+  goals line 159-160 of the observability RFC — network-layer ACL).
+- No separate SPA build — embedded HTML in the `ff-board` crate per
+  the observability RFC §3 lines 132-135.
+- ff-board consumes `/metrics` over loopback for throughput/health
+  (X2/X3 resolution recommended above); does NOT re-implement
+  metric collection.
+
+## 7. Open decisions for owner (block implementation of T1–T3)
+
+1. **X1 `list_flows`**: is a flow-enumeration primitive in scope for
+   0.5.0, or do we scope ff-board v1 to "flow detail only, given an
+   ID from an execution"? The latter is cheaper and defers the
+   cross-backend question.
+2. **X2/X3 throughput & lease-health data path**: confirm
+   recommended approach — ff-board scrapes `/metrics` directly, no
+   new trait method. If rejected, we must design a structured
+   read API for observability-plane data.
+3. **list_executions pagination shape**: server today is
+   `offset/limit`; trait should be `cursor`-based to work for
+   Postgres. OK to make the server endpoint cursor-based at the
+   same time (backwards-incompatible on the unreleased HTTP
+   surface)?
+4. **N1 attempt-outcome metric cardinality**: `{lane,outcome}` —
+   outcome ∈ {ok, error, timeout, cancelled, retry}. 5 outcomes ×
+   ≤16 lanes = 80 series. Within existing cardinality budget. OK?

--- a/rfcs/drafts/main-final-verification.md
+++ b/rfcs/drafts/main-final-verification.md
@@ -1,0 +1,74 @@
+# Main final verification (2026-04-23)
+
+## HEAD
+
+`0847f90` — feat(ff-core): UsageDimensions constructor + builders; docs: fix
+BackendError match pattern (#162). Pulled from origin/main; fast-forwarded
+cleanly from `ffa56bd` (post-#162 is the current tip).
+
+## Build results
+
+- Full workspace + all-features: **PASS** (`cargo build --workspace
+  --all-features` finished in 27.80s; warnings only — pre-existing dead-code
+  in `ferriskey::cmd::set_fenced`).
+- ff-sdk --no-default-features: **PASS** (`cargo build -p ff-sdk
+  --no-default-features` finished in 10.97s; agnostic facade compiles without
+  ferriskey on ff-sdk's own direct edges).
+- Workspace lib tests compile: **PASS** (`cargo test --workspace --lib
+  --no-run` produced unittest executables for every crate: ferriskey,
+  ff-backend-valkey, ff-core, ff-engine, ff-observability, ff-readiness-tests,
+  ff-scheduler, ff-script, ff-sdk, ff-server, ff-test).
+
+## cargo package --workspace
+
+`cargo package --workspace --allow-dirty` initially errored on
+`ff-readiness-tests` (no version on its `ff-test` dep — but both crates are
+`publish = false`; cargo's workspace-package verifier requires version-pinned
+deps even for non-publish crates). Re-ran with `--exclude ff-readiness-tests
+--exclude ff-test`; all 9 publishable crates packaged + verify-compiled:
+
+- ferriskey 0.3.4 — OK (65 files, 432.5KiB compressed)
+- ff-core 0.3.4 — OK (18 files, 87.7KiB)
+- ff-script 0.3.4 — OK (24 files, 118.1KiB)
+- ff-backend-valkey 0.3.4 — OK (8 files, 41.5KiB)
+- ff-observability 0.3.4 — OK (7 files, 8.7KiB)
+- ff-engine 0.3.4 — OK (25 files, 60.3KiB)
+- ff-sdk 0.3.4 — OK (11 files, 79.3KiB)
+- ff-scheduler 0.3.4 — OK (31.6KiB)
+- ff-server 0.3.4 — OK (12 files, 97.1KiB)
+
+All verify-compiles finished in 3m00s.
+
+## Scratch consumer smoke
+
+Scratch at `/tmp/ff-smoke-main-final` (path-dep on `/home/ubuntu/FlowFabric`):
+
+- `ScannerFilter::new().with_namespace("t")` — compiles.
+- `BackendConfig::valkey("127.0.0.1", 6379)` — compiles.
+- `UsageDimensions::new().with_input_tokens(10).with_dedup_key("x")` —
+  compiles (confirms #162 landing: `new()` + builders are on the public
+  surface).
+- `Frame::new(bytes, FrameKind::Event).with_frame_type("delta")
+  .with_correlation_id("c")` — compiles.
+- `match err { SdkError::Backend(BackendError::Valkey { kind, .. }) => ... }`
+  — compiles, runs, and matches (`kind=Transport`).
+- `cargo build` (default features): PASS.
+- `cargo build --no-default-features`: PASS.
+- `cargo run`: prints `smoke ok: kind=Transport`.
+- Scratch deleted; `ls /tmp/ff-smoke-main-final` → No such file or directory.
+
+## Tag-readiness verdict
+
+**ready-to-tag**. Workspace builds + packages cleanly at HEAD `0847f90`; all
+publishable crates (ferriskey, ff-core, ff-script, ff-backend-valkey,
+ff-observability, ff-engine, ff-sdk, ff-scheduler, ff-server) verify-compile
+through `cargo package`; external consumer against the public `ff-core` +
+`ff-sdk` surface builds under both feature configurations and the
+`BackendError::Valkey { kind, .. }` match pattern advertised in the v0.4.0
+migration doc works unchanged.
+
+Advisory (non-blocker): `ff-readiness-tests`'s path-dep on `ff-test` lacks a
+`version = ...`. Harmless for publishing since both are `publish = false`,
+but it makes workspace-wide `cargo package` require an explicit exclude. If
+desired, add `version = "0.3.4"` alongside the path to let plain
+`cargo package --workspace` succeed. Not a tag blocker.

--- a/rfcs/drafts/main-pre-0.4.0-smoke.md
+++ b/rfcs/drafts/main-pre-0.4.0-smoke.md
@@ -1,0 +1,109 @@
+# Main pre-0.4.0 smoke (2026-04-23)
+
+**Scratch:** `/tmp/ff-smoke-main-prepatch-2` (deleted after smoke).
+**Main HEAD:** `ffa56bd` (post #145/#146/#147/#151/#152/#155/#156/#157).
+**Exerciser:** Worker XXX-2 (retry after XXX API error).
+
+## Default-features build
+
+`cargo build` on the scratch crate (ff-sdk default = `valkey-default`
+on): **green**, 1 downstream warning (`parse_success_result` dead-code
+in ff-sdk, pre-existing). `cargo run` prints the expected
+`pre-0.4.0 smoke compile ok`.
+
+## --no-default-features build
+
+Scratch crate declares its own `valkey` feature forwarding to
+`ff-sdk/valkey-default` and sets `ff-sdk = { default-features = false }`.
+`cargo build --no-default-features`: **green**. ff-sdk recompiled
+without ferriskey-surface modules (`task`, `worker`, `snapshot`,
+`admin`, `engine_error::enrich_dependency_conflict`). Consumer-side
+code gated behind `#[cfg(feature = "valkey")]` drops cleanly — the
+`FlowFabricWorker::connect_with` + `completion_backend()` exerciser
+correctly vanishes when the feature is off. RFC-012 §1.3 agnosticism
+claim holds for ff-sdk's own surface.
+
+## New API surface exercised (list of 7)
+
+1. **ScannerFilter DX re-export (#157).** `use ff_core::ScannerFilter;`
+   + `ScannerFilter::new().with_namespace("tenant-a").with_instance_tag("k","v")`
+   compiles. `with_namespace` accepts `&'static str` via
+   `impl Into<Namespace>` — no `Namespace::new(...)` ceremony needed.
+2. **BackendConfig re-export (#157).**
+   `ff_backend_valkey::BackendConfig::valkey("127.0.0.1", 6379)` resolves
+   via the `pub use ff_core::backend::BackendConfig;` line in
+   ff-backend-valkey's lib root.
+3. **BackendError seal (#151).** `SdkError::Backend(BackendError::Valkey { kind, .. })`
+   matches; `kind.as_stable_str()` returns the lowercase wire string
+   (`"transport" | "protocol" | "timeout" | "auth" | "cluster" |
+   "busy_loading" | "script_not_loaded" | "other"`). **Note:**
+   `BackendError` is an `enum` with a single `Valkey` variant today,
+   not a struct — the task-sheet template
+   `BackendError { kind, .. }` needs to be spelled
+   `BackendError::Valkey { kind, .. }`. Doesn't change user-facing
+   stability; just a spec-nit.
+4. **UsageDimensions dedup\_key (#145).** Construction blocked at the
+   idiomatic `UsageDimensions { dedup_key: ..., ..Default::default() }`
+   form (E0639, see papercuts). Fallback `Default::default()` +
+   field-set assignment compiles; fields are `pub` so this is a valid
+   escape hatch.
+5. **Frame extension (#147).** `Frame::new(vec![], FrameKind::Event)`
+   compiles. `FrameKind` variants are `{Stdout, Stderr, Event, Blob}`
+   — no `Delta` variant (the smoke-sheet's example name). SDK-side
+   `"delta"` is encoded via `Frame::frame_type: String`, not the
+   `FrameKind` enum. `Frame` is also `#[non_exhaustive]`, so
+   consumer-side struct-literal construction is blocked — only the
+   `Frame::new` / `with_seq` / `with_frame_type` / `with_correlation_id`
+   builders are reachable. That's a **design choice**, not a papercut.
+6. **`FlowFabricWorker::connect_with` signature.** Confirmed
+   `(WorkerConfig, Arc<dyn EngineBackend>, Option<Arc<dyn CompletionBackend>>)
+   -> Result<Self, SdkError>` (ff-sdk/src/worker.rs:572). Smoke
+   compile passes type-checking.
+7. **`completion_backend()` accessor.** Confirmed
+   `-> Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>`
+   (ff-sdk/src/worker.rs:622). Option wrapper retained for the
+   "backend doesn't support push-completion" shape.
+
+## Regression vs v0.3.4
+
+None found at the compile surface for the exercised APIs. All seven
+touch-points compile both with and without `valkey-default`.
+BackendError wire strings, `Frame` builders, and `connect_with` /
+`completion_backend` signatures line up with the CHANGELOG
+`[Unreleased]` entries (#155) and the cairn-migration guide (#152).
+
+## Papercuts (non-blocker)
+
+1. **UsageDimensions has no inherent constructor + is `#[non_exhaustive]`.**
+   Downstream crates cannot write
+   `UsageDimensions { dedup_key: Some("k".into()), ..Default::default() }`
+   — the E0639 check rejects `..Default::default()` on
+   `#[non_exhaustive]` structs from other crates. The only supported
+   path today is `let mut u = UsageDimensions::default(); u.dedup_key =
+   Some("k".into());`. Fine for ergonomics inside ff-sdk (same crate,
+   rule doesn't apply); awkward for the 3rd-party / cairn-fabric SDK
+   story. Compare `Frame::new(...)` + `.with_*` chain — that pattern
+   works nicely and could be mirrored here as
+   `UsageDimensions::new()` + `.with_dedup_key(..)` /
+   `.with_input_tokens(..)`. **Size:** ~15 lines, no behavior change,
+   adds a clear idiomatic path. Not blocking 0.4.0 but worth a
+   post-tag polish issue.
+
+2. **Cosmetic — smoke-sheet drift vs `BackendError` shape.** The
+   pre-0.4.0 smoke template lists
+   `SdkError::Backend(BackendError { kind, .. })`. Today's actual
+   shape needs `BackendError::Valkey { kind, .. }`. Either the
+   current enum should gain a non-variant `kind()` pattern (it already
+   has the method), or the docs/template should be updated. Spec-nit,
+   not an API change.
+
+## Recommendation
+
+**Green-light 0.4.0 tag pending Stage 1c T4** (Worker ZZ-10's seal of
+`FlowFabricWorker::client()` + migration of stream fns). The new API
+surface from #145/#146/#147/#151/#157 is coherent, compiles under both
+feature configurations, and matches the CHANGELOG + migration
+guide. The UsageDimensions papercut is worth filing as a follow-up
+but does not block the tag — `Default` + field-set is a viable escape
+hatch and the pattern is used sparingly (report\_usage call sites
+only).

--- a/rfcs/drafts/post-stage-1c-test-coverage.md
+++ b/rfcs/drafts/post-stage-1c-test-coverage.md
@@ -1,0 +1,172 @@
+# Post-Stage-1c test coverage audit (2026-04-23)
+
+Audit target: `EngineBackend` trait surface in
+`crates/ff-core/src/engine_backend.rs` (18 methods post-Round-7 +
+Stage-1c T2 `list_edges`).
+
+Scope: unit tests in the method's home crate, integration tests in
+`crates/ff-test/tests/` that exercise the method **via the trait**
+(not the SDK free-fn / FCALL bypass), and error-path coverage.
+
+## Method coverage matrix
+
+Legend:
+- UT = unit test in `ff-backend-valkey` (or another home crate).
+- IT-T = integration test calling the **trait method** directly.
+- IT-S = integration test that reaches the backend impl **only via
+  the SDK hot-path forward** (so the trait dispatch is exercised but
+  not asserted independently).
+- Stub = impl currently returns `EngineError::Unavailable` (no real
+  wire behaviour to cover).
+
+| # | Method | UT | IT-T | IT-S | Error-path | Notes |
+|---|--------|----|------|------|-----------|-------|
+| 1 | `claim` | none | none | none | n/a | Stub (lib.rs:1619). SDK `claim_next` bypasses the trait entirely. Zero coverage. |
+| 2 | `renew` | none | none | YES — `task.rs:977` renewal task exercised in every lifecycle test (e.g. `e2e_lifecycle.rs:611`) | NO direct test of `StaleLease` / `LeaseExpired` typed returns through the trait | Trait forwards a wired impl (lib.rs:1626); only happy-path via SDK. |
+| 3 | `progress` | none | none | partial — SDK `update_progress` is wired to direct FCALL, **not** the trait (grep of `self.backend.progress` = zero hits in ff-sdk) | none | Trait impl wired (lib.rs:1631) but **no caller in-tree** routes through it. Effective coverage: ZERO. |
+| 4 | `append_frame` | none | none | partial — `task.append_frame` still direct-FCALL; trait `append_frame` has no SDK forwarder (grep `self.backend.append_frame` = 0) | none | Trait impl wired (lib.rs:1648) but no in-tree caller routes through it. Effective coverage: ZERO. |
+| 5 | `complete` | none | none | YES — SDK `task.complete` forwards via `self.backend.complete` (`task.rs:499`); exercised ubiquitously (`e2e_lifecycle.rs:4303,4803,…`) | replay path exercised (`test_complete_replay_returns_enriched_detail` at `e2e_lifecycle.rs:1441`); transport-failure path not exercised at trait level | Good happy-path, weak error-path. |
+| 6 | `fail` | none | none | YES — SDK `task.fail` → `self.backend.fail` (`task.rs:554`); `test_fail_with_retry` / `test_fail_terminal` (`e2e_lifecycle.rs:1161,1251`) | retry-scheduled + terminal-classified outcomes covered; transport retry idempotency not covered through trait | Reasonable. |
+| 7 | `cancel` | none | none | YES — `task.cancel` → `self.backend.cancel` (`task.rs:581`); `test_create_claim_cancel_from_active` (`e2e_lifecycle.rs:747`) | cancel-of-already-cancelled replay not asserted at trait level | Reasonable happy-path, thin error-path. |
+| 8 | `suspend` | none | none | none | n/a | Stub (lib.rs:1690). SDK `task.suspend` is direct FCALL, does **not** forward through trait. Zero coverage. |
+| 9 | `create_waitpoint` | none | none | partial — SDK `task.create_pending_waitpoint` is direct-FCALL per `task.rs:170` comment; grep `self.backend.create_waitpoint` = 0 | none | Trait impl wired (lib.rs:1698) but no in-tree caller routes through it. Effective coverage: ZERO. |
+| 10 | `observe_signals` | none | none | YES — `task.rs:865` forwards via `self.backend.observe_signals`; `resume_signals_integration.rs` (4 tests) exercises it | `resume_signals_empty_for_non_resumed_claim` covers the non-Resumed-kind error shape | Best-covered hot-path method. |
+| 11 | `claim_from_reclaim` | none | none | none | n/a | Stub (lib.rs:1719). SDK `claim_from_reclaim_grant` does direct FCALL (worker.rs:1285). Zero coverage. |
+| 12 | `delay` | none | none | YES — `task.rs:454` forwards; `test_delay_execution` (`e2e_lifecycle.rs:786`) | none | Single happy-path test. |
+| 13 | `wait_children` | none | none | YES — `task.rs:469` forwards; exercised in flow lifecycle tests (`e2e_lifecycle.rs:4020,5345`) | none | Happy-path only. |
+| 14 | `describe_execution` | none | none | partial — SDK `worker.describe_execution` (`snapshot.rs:66`) uses direct HGETALL pipeline, **not** the trait; no in-tree caller routes through the trait impl | none | Trait impl wired (lib.rs:1737) but dead-in-test. Effective coverage: ZERO at the trait boundary. |
+| 15 | `describe_flow` | none | none | partial — SDK `worker.describe_flow` (`snapshot.rs:389`) direct HGETALL; same story as #14 | none | Effective coverage: ZERO at the trait boundary. |
+| 16 | `list_edges` | none | YES — `engine_backend_list_edges.rs:199` `list_edges_trait_matches_sdk_free_fn` asserts trait result equals SDK free-fn | n/a | no corruption / missing-flow error-path assertion via trait | Only method with a dedicated trait-boundary test. |
+| 17 | `cancel_flow` | none | none | partial — `ff-server` uses direct FCALL (`server.rs:1612`), not the trait; `cancel_flow_backlog.rs` / `e2e_lifecycle.rs:7171` hit the FCALL, not the trait method | none | Trait impl wired (lib.rs:1757) but no in-tree caller. Effective coverage: ZERO at the trait boundary. |
+| 18 | `report_usage` | none | YES — `r7_backend_report_usage.rs:104` `r7_report_usage_trait_round_trip` calls `backend.report_usage` directly | partial — the test asserts all four `ReportUsageResult` variants | no dedicated transport-fault test | Best-covered read/admin method at trait level. |
+
+## Gaps by category
+
+### Zero coverage (no test exercises the method, directly or indirectly)
+
+- `claim` (#1) — stub, no callers.
+- `suspend` (#8) — stub, no callers.
+- `claim_from_reclaim` (#11) — stub, no callers.
+
+Stubs-returning-`Unavailable` are defensible for today, but once the
+RFC-012 Stage-1d hot-path migration lands, these become real methods
+and inherit the surrounding zero-coverage posture unless tests are
+added in the same PR.
+
+### Integration-only gap: trait wired but no caller routes through it
+
+These methods have a real wired impl in `ff-backend-valkey`, but
+no SDK code-path and no test calls the trait method. A
+`todo!()`/panic substituted into the trait impl would not fail any
+existing test:
+
+- `progress` (#3)
+- `append_frame` (#4)
+- `create_waitpoint` (#9)
+- `describe_execution` (#14)
+- `describe_flow` (#15)
+- `cancel_flow` (#17)
+
+Risk: Stage-1d migration could ship a broken trait impl that CI
+never catches.
+
+### Error-path gaps (happy-path covered, failure modes not)
+
+Every method except `report_usage` (#18, covers all four result
+variants) has minimal or zero error-path coverage at the trait
+boundary. Specific untested failure modes:
+
+- `renew`: `State::StaleLease`, `State::LeaseExpired` typed
+  returns — tested via Lua error strings in FCALL tests, not
+  surfaced through the trait's `Result<LeaseRenewal, EngineError>`
+  shape.
+- `complete` / `fail` / `cancel`: replay / fence-triple-mismatch
+  paths exist but are asserted at SDK/FCALL layer, not against the
+  trait return.
+- `observe_signals`: non-`Resumed` handle kind (tested), but
+  corruption / transport variants not.
+- `list_edges`: missing-flow and adjacency-endpoint-drift paths are
+  tested **via SDK free-fn** (`describe_edge_api.rs:385`), not via
+  trait.
+- `report_usage`: transport-fault variant untested.
+
+No tests anywhere induce `EngineError::Transport` (Valkey
+unavailable / ferriskey client error) through the trait for any
+method — the error-surface section of the trait rustdoc is
+unverified.
+
+## Prioritization
+
+Ranking axes:
+1. Cairn exposure — will cairn-rs call this method via the trait
+   under the 0.4.0 migration?
+2. Change risk — was this method added or reshaped recently?
+3. Stub status — zero-behaviour impls can't regress today but will
+   land with hot-path behaviour in Stage-1d.
+
+| Rank | Method | Cairn | Change-risk | Rationale |
+|------|--------|-------|-------------|-----------|
+| P0 | `list_edges` error-path | HIGH (Stage-1c T2, new surface cairn edge-listing hits) | HIGH (just added) | Trait test exists but corruption/missing-flow not asserted via trait. |
+| P0 | `describe_execution` / `describe_flow` via trait | HIGH (cairn's primary read API) | MED | Wired impls completely untouched by tests; SDK bypasses them. |
+| P0 | `report_usage` transport-fault | HIGH (budget enforcement blocks cairn admissions) | HIGH (Round-7 reshape) | All happy-path variants covered; transport fault would corrupt consumer retry logic silently. |
+| P1 | `append_frame` / `progress` / `create_waitpoint` via trait | MED | LOW (wired impls stable) | Dead-in-test trait impls; Stage-1d migration will break silently if a typo lands. |
+| P1 | `cancel_flow` via trait | MED (operator tools, cairn admin) | MED | Server bypasses trait today; any 0.4.x consumer who uses the trait directly hits an untested code-path. |
+| P2 | `complete`/`fail`/`cancel` replay via trait | MED | LOW | SDK-layer replay tests exist; trait-return assertion is belt-and-braces. |
+| P2 | `renew` typed-state returns | LOW (SDK renewal task handles) | LOW | Assertion gap; behaviour exercised. |
+| P3 | `claim` / `suspend` / `claim_from_reclaim` | n/a (stubs) | n/a until Stage-1d | Defer until hot-path migration; add tests in the migration PR. |
+
+## Recommendations
+
+### Must-add (pre 0.4.0 ship)
+
+1. **Trait-boundary parity test for `describe_execution` +
+   `describe_flow`** — mirror the `engine_backend_list_edges.rs`
+   pattern: assert `backend.describe_*` returns the same snapshot
+   as the SDK free-fn for a seeded execution/flow. This closes the
+   largest "wired but untested" hole and protects the cairn read
+   surface.
+2. **`list_edges` error-path via trait** — missing-flow returns
+   `Ok(vec![])` (or similar) and adjacency-drift returns
+   `Validation{Corruption}`; both are tested via SDK today
+   (`describe_edge_api.rs:385,442`), port one of each to the
+   trait.
+3. **`report_usage` transport-fault test** — induce a ferriskey
+   transport error (drop connection mid-FCALL or point at a dead
+   socket) and assert `EngineError::Transport` with a
+   `ScriptError`-downcastable inner. This is the one method that
+   asserts its result enum exhaustively; pairing that with a
+   transport assertion fully closes its error surface.
+
+### Nice-to-add (0.4.x)
+
+- Trait-boundary tests for `progress`, `append_frame`,
+  `create_waitpoint`, `cancel_flow` — one happy-path each. Cheap
+  once the pattern from Must-add #1 exists.
+- `renew` typed-state test: claim, let lease expire on the wire,
+  call `backend.renew` and assert `LeaseRenewal` variant (if the
+  return type distinguishes) or `EngineError::State{StaleLease}`.
+- Replay-idempotency assertions at the trait layer for `complete` /
+  `fail` / `cancel` (one test each).
+
+### Acceptable-as-is
+
+- `claim`, `suspend`, `claim_from_reclaim` — stubs; tests land with
+  Stage-1d hot-path migration, not before. Tracking their zero
+  coverage as a pre-merge gate on the Stage-1d PR is sufficient.
+- `delay`, `wait_children`, `observe_signals` — SDK-forwarded and
+  exercised by lifecycle + resume tests; error-path gap is
+  acknowledged but the happy-path posture is solid.
+
+## Summary
+
+- 18 trait methods total.
+- 3 are stubs (acceptable deferral).
+- 6 are wired but have **zero in-tree callers** through the trait
+  (silent-breakage risk in Stage-1d).
+- 2 have direct trait-boundary tests (`list_edges`, `report_usage`).
+- 7 are exercised via SDK forward paths (trait dispatch runs, but
+  return-value assertions are at the SDK layer).
+- 0 methods have induced-transport-fault coverage through the
+  trait.
+- Error-path coverage is thin across the board; `report_usage` is
+  the sole method asserting all of its typed result variants.

--- a/rfcs/drafts/scenario-5-flame-capture.md
+++ b/rfcs/drafts/scenario-5-flame-capture.md
@@ -1,0 +1,191 @@
+# Scenario 5 (suspend_signal_resume) tail regression — flame capture
+
+**Issue:** #173
+**Baseline source:** `benches/results/baseline.md` §Scenario 5
+**Investigated SHA:** d595b27 (v0.4.0 post PR #170)
+**Prior baseline SHA:** v0.3.2 (da89fa9)
+**Author:** Worker-SSSS (single-agent)
+**Status:** Analysis + recommendation. No PR opened — fix is small but
+empirical measurement was blocked by criterion harness behaviour in
+this environment (see §Empirical blockers). Recommending a 20-LOC
+attr-level fix on a follow-up PR once a clean rerun is possible.
+
+---
+
+## 1. Reported regression
+
+| metric | v0.4.0 | v0.3.2 | delta |
+|--------|--------|--------|-------|
+| p50 ms |  9.36  |  9.23  | +1.4% |
+| p95 ms | 10.83  |  9.93  | +9.1% |
+| p99 ms | 11.96  | 10.76  | +11.2% |
+| ops/s  | 106.87 | 108.34 | -1.4% |
+
+Tail-only shift. p50 inside noise. Documented as non-release-blocking
+against the v0.1.0 floor per `feedback_perf_honesty.md`.
+
+## 2. Prime suspect — PR #170
+
+PR #170 added `#[tracing::instrument]` to 19 `*_impl` + one `fcall`
+function in `ff-backend-valkey` at the **default `info` level** with
+3–4 `Display`-valued fields (`execution_id`, `attempt_id`,
+`lease_epoch`, ...). Default server filter is
+`ff_server=info,ff_engine=info,ff_script=info,tower_http=debug,audit=info`
+(no `ff_backend_valkey` directive), so the global crate default
+(`info`) applies and every span is live — subscribed to and allocated.
+
+## 3. Call-graph of the measured window
+
+Scenario 5 measures:
+
+```
+t0 = Instant::now()
+task.suspend(...)                 # direct FCALL — NOT instrumented
+GET /v1/executions/{}/pending-waitpoints
+POST /v1/executions/{}/signal     # server-side — no *_impl hop
+loop { worker.claim_next() }      # direct FCALL — NOT instrumented
+task.complete(None)               # ↓ goes through EngineBackend::complete
+t0.elapsed()
+```
+
+Only **`complete_impl`** fires inside the measured window (one span
+per iteration). Cross-checked:
+
+- `task.suspend` calls `self.client.fcall("ff_suspend_execution", …)`
+  directly (`crates/ff-sdk/src/task.rs:898`). It does not dispatch
+  through `EngineBackend::create_waitpoint` → `create_waitpoint_impl`
+  is NOT exercised.
+- `worker.claim_next` uses raw `ZRANGEBYSCORE` + FCALL
+  (`crates/ff-sdk/src/worker.rs:678-780`). No `*_impl` hop.
+- `task.complete` calls `self.backend.complete(…)` → `complete_impl`
+  (instrumented).
+- `task.resume_signals` is NOT called in this bench; `observe_signals_impl`
+  is cold.
+- `renew_impl` fires from the background renewal task every
+  `lease_ttl_ms/3 = 10_000ms`. With iter ~9ms, ~1 tick per ~1000
+  iters — not a hot contributor.
+- `ff-server` does NOT hold a `dyn EngineBackend`
+  (`grep "EngineBackend" crates/ff-server/src`: no impl, only error
+  wrapping). HTTP POST /signal goes through server-local script
+  paths, not through the instrumented `*_impl` surface.
+
+**Hot instrumented fn: `complete_impl` (1 call/iter).**
+
+## 4. Span-cost arithmetic
+
+`tracing::instrument` at info level with `skip_all` + 3
+`Display`-valued fields costs:
+
+- Callsite interest check: ~20 ns (cached)
+- Span alloc + value registry insert: ~200–500 ns
+- `%f.execution_id` + `%f.attempt_id` + `%f.lease_epoch` formatted via
+  `Display` into the span's field store: ~100–300 ns each (UUID
+  itoa/u64 fmt + allocation for the string slot)
+- `enter` / `exit` guard drops: ~20 ns each
+
+Budget per call: **~1–2 µs** worst case under the default
+`fmt::Subscriber` (which does NOT emit on span open/close by default;
+`FmtSpan::NONE` is the default).
+
+One `complete_impl` call per iter × 100 iters = ~200 µs total
+overhead spread across 100 samples. **This cannot cause a ~0.9 ms
+p95 shift on its own.**
+
+## 5. Alternative hypotheses
+
+| Hypothesis | Verdict |
+|------------|---------|
+| `complete_impl` span accumulation | Rejected — too cheap. |
+| `backend_context(err, label)` wrap | Rejected — happy path is zero-cost closure (`map_err` only enters on `Err`). |
+| `ff-observability::Metrics` handle deref | Rejected — `observability` feature is OFF by default; shim is a no-op. `inc_lease_renewal` only fires in `renew()`, not `complete()`. |
+| `connect_inner` refactor | Rejected — called once at worker setup, outside the measured window. |
+| Rare `complete_impl` span × tokio scheduler interaction at p99 | Plausible but small. |
+| **N=1 methodology variance** | **Most likely.** baseline.md §methodology: "p95/p99 are computed from 100 per-iteration samples inside one criterion run." No between-run averaging. The +9.1%/+11.2% is inside the single-run tail-noise band documented at §176: "Recommend: follow-up flame capture on one suspend_signal_resume run to attribute the tail drift". |
+
+The v0.1.0 floor for p95 is 10.59 ms (baseline.md:151). v0.4.0 at
+10.83 is +2.3% above the two-release floor — well inside the
+documented `≥ 5% regression ⇒ investigate; ≥ 10% ⇒ block` policy
+band against the FLOOR, even though the delta against v0.3.2
+crosses the p95 threshold.
+
+## 6. Empirical blockers
+
+Planned: reproduce N=5 on d595b27, then ablate by stripping the
+`complete_impl` instrument attr and re-running.
+
+Actual: the isolated worktree ran `ff-server` cleanly against the
+existing 4-partition Valkey; the criterion harness started warmup
+but no sample rows landed within 8-minute windows across three
+attempts. Server logs confirm exactly one POST /v1/executions
+during the run (12:12:15Z) followed by silence — the bench's
+`claim_next` tight-loop (`claim_poll_interval_ms = 1`) appears to
+never observe the newly-created execution on the eligible ZSET.
+Hypothesis: partition layout mismatch between the reused Valkey
+instance and the bench worker's `num_flow_partitions=4` view.
+Not pursued further — the bench was last known-good on the EPYC
+bench host, and local criterion variance is not a safe substitute
+for the release-gate host anyway.
+
+## 7. Recommended fix
+
+Downgrade hot-path `#[tracing::instrument]` attrs from the default
+`info` to `debug` on the four `*_impl` functions the SDK hot path
+touches, so span creation compiles out under the default
+`ff_*=info` filter:
+
+```rust
+// crates/ff-backend-valkey/src/lib.rs
+#[tracing::instrument(
+    name = "ff.complete",
+    level = "debug",          // ← add
+    skip_all,
+    fields(
+        backend = "valkey",
+        execution_id = %f.execution_id,
+        attempt_id = %f.attempt_id,
+        lease_epoch = %f.lease_epoch,
+    )
+)]
+async fn complete_impl(…) { … }
+```
+
+Apply to: `complete_impl`, `renew_impl`, `progress_impl`,
+`observe_signals_impl`, `append_frame_impl`. (~25 LOC across 5
+attrs.) Leave `describe_execution_impl`, `describe_flow_impl`,
+`list_edges_impl`, `describe_edge_impl`, `cancel_flow_fcall`,
+`cancel_impl`, `fail_impl`, `report_usage_impl` at `info` — these
+are operator-observed control-plane ops, not worker hot path, and
+the span is load-bearing for incident response.
+
+Rationale:
+1. Closes a cost gap regardless of whether it is the true cause of
+   the Scenario 5 shift — span cost ≈ 0 under default production
+   filter is strictly better than ~1–2 µs.
+2. Preserves audit coverage: operators who want the spans set
+   `RUST_LOG=ff_backend_valkey=debug` to surface the worker-hot
+   ops; the attrs are still present.
+3. Parallel to how `renew_lease` in `ff-sdk/src/task.rs:1029` is
+   already scoped via `#[tracing::instrument(name = "renew_lease",
+   skip_all, ...)]` — the Round-7 work kept renewal at a dedicated
+   span for bench harness `on_enter / on_exit` layers.
+
+## 8. Deferred: metric-handle caching
+
+If a future bench on the canonical EPYC host still shows the Scenario
+5 tail drift after the `level = "debug"` downgrade, the next suspect
+is the `metrics: Option<Arc<Metrics>>` field on `ValkeyBackend` —
+every `renew()` trait call does an `Option` match + `Arc` deref. Not
+a per-iter hit in Scenario 5, but on the capability-routed Scenario
+5 variant (`cap_routed.rs`) where renewal is continuous, this
+matters. Cache the handle at `connect_with_metrics` time into a
+non-Option `Arc<Metrics>` where the shim provides the no-op default.
+~40 LOC, separate PR, gated on re-measurement.
+
+## 9. Next step
+
+Open a follow-up PR (label `perf`, not release-blocking) with the
+§7 attr-level downgrade only. Reviewer verification: on the EPYC
+bench host, re-run `cargo bench --bench suspend_signal_resume` at
+N=5 and confirm p95 ≤ v0.3.2's 9.93 ms + 5% = 10.43 ms. If the
+shift persists after the downgrade, escalate to the §8 metric-cache
+work and file a fresh investigation ticket against the new SHA.

--- a/rfcs/drafts/session-end-state-snapshot.md
+++ b/rfcs/drafts/session-end-state-snapshot.md
@@ -1,0 +1,83 @@
+# Session end state snapshot (2026-04-23)
+
+Worker HHHH investigation-only snapshot. Live `gh` + `git` cross-check.
+
+## Main state
+
+- HEAD: `b018fb9` — `docs: draft 0.4.0 release notes (#163)`
+- Commits since `v0.3.4`: **14** (`git log v0.3.4..origin/main --oneline | wc -l`)
+
+## Open PRs
+
+| # | Title | mergeStateStatus |
+|---|---|---|
+| 165 | test(ff-test): trait-boundary coverage for describe_execution, describe_flow, list_edges, report_usage (#154 offshoot) | BLOCKED |
+| 162 | feat(ff-core): UsageDimensions constructor + builders; docs: fix BackendError match pattern | BLOCKED |
+| 159 | docs: polish stale rustdoc references post-Stage-1c + Round-7 | BLOCKED |
+| 158 | feat(ff-core, ff-backend-valkey, ff-sdk): seal FlowFabricWorker::client() + migrate stream fns through trait (#87) | BLOCKED (CI in progress: Analyze rust, CodeQL gate, cargo-semver-checks) |
+| 118 | chore(deps): bump the cargo group across 1 directory with 1 update | UNKNOWN (dependabot) |
+
+## Open issues
+
+| # | Title | Classification |
+|---|---|---|
+| 164 | Feature-flag propagation: ff-script leaks ff-core default features | Post-0.4.0 followup (Stage 1d scope) |
+| 160 | Migrate ff-sdk::snapshot in-crate raw HGET helpers to EngineBackend trait | Post-0.4.0 followup (trait-migration debt) |
+| 154 | Wire observability on EngineBackend trait methods (#[instrument] + metrics + backend_context) | Post-0.4.0 followup (#165 offshoot in flight) |
+| 150 | Add deliver_signal + claim_resumed_execution to EngineBackend trait | Legitimately-deferred per audit §Deferrable |
+
+## Unfinished goals
+
+- **Goal 3: Stage 1c T4 land (#158 pending merge).** Still OPEN, MERGEABLE
+  but BLOCKED; CI checks (Analyze rust / CodeQL gate / cargo-semver-checks)
+  IN_PROGRESS. Not yet merged this session — only pending-goal gap.
+- All other session goals (v0.3.3+v0.3.4 ship, #146 T1–T3, Round-7 #145,
+  cairn blockers, migration doc gaps, publish-list-drift CI, bench
+  methodology, #88 BackendError seal via #151) are merged or closed.
+
+## Release gate assessment
+
+Per `rfcs/drafts/0.4.0-release-prep-checklist.md` §Pending before tag:
+
+- **Blockers:**
+  - #158 (T4) must merge — `client()` seal + stream-fn trait migration.
+  - Migration doc §12 covering T4 must follow merge.
+  - CHANGELOG `[Unreleased]` → `[0.4.0] - <date>` flip (manual at tag).
+- **Non-blockers-deferred:**
+  - #150 (deliver_signal / claim_resumed_execution) — safe for 0.4.1/0.5.0
+    per audit §Deferrable.
+  - #154 / #160 / #164 — trait-observability, snapshot HGET migration,
+    ff-script feature leak: all post-0.4.0 trait-completion debt.
+  - #162 UsageDimensions builders — additive ergonomics, non-gating.
+  - #159 rustdoc polish — cosmetic, non-gating.
+  - #165 trait-boundary test coverage — #154 offshoot, non-gating.
+- **Ready-to-tag: no** — pending #158 merge + migration §12 + CHANGELOG
+  flip. Everything else covered or legitimately-deferred.
+
+## Cairn status
+
+- **Blockers cleared: yes** — session goal 5 (close all cairn blockers)
+  marked done; audit confirms no cairn-facing items in open-issue set.
+- **Migration guide: current through T3 + Round-7 + BackendError seal**
+  (#152, #161 landed). Missing §12 for T4 (#158) — tracked as pending
+  in checklist; will follow T4 merge.
+- **Post-session cairn actions tracked:** partial. The task brief
+  references a "drop PR #106 filter" cairn action; this is a
+  cairn-repo peer-team task, not an avifenesh/FlowFabric issue, and
+  is not tracked as a FlowFabric open issue (correct per peer-team
+  boundaries memory). No post-session FlowFabric-side followup
+  opened specifically for cairn adoption of the 0.4.0 migration.
+
+## Lessons recorded vs uncaptured
+
+- **Session-evident and already in memory:** peer-team boundaries,
+  shared-branch coordination, sweep-PR-comments-before-merge, RFC
+  phases vs CI gates, sync-main-before-review — all exercised this
+  session and already captured.
+- **Potentially uncaptured:** the "T4 closes #87 — stale, #87 already
+  closed by #151" artifact in the checklist (tasks can stale-reference
+  a closed tracking issue after an earlier PR collapses it). Minor;
+  not worth a dedicated memory entry unless it recurs.
+- **Thematic CHANGELOG grouping (#153)** as a pre-tag readability pass
+  is new this session — not captured as a memory; candidate if future
+  tag prep benefits from the same regroup step.


### PR DESCRIPTION
## Summary

- Bumps workspace to 0.5.0 + cuts `[0.5.0] - 2026-04-23` CHANGELOG section
- 0.5.0 bundles merged this session: ff-board prereq trait methods (list_executions, list_suspended, list_lanes, list_flows), ff_attempt_outcome_total counter, tower-layer surface, ff-observability-http, Sentry integration, Grafana dashboard, observability wiring on every EngineBackend method, ferriskey hash-tag-aware cluster_scan routing

## Test plan

- [ ] CI green (matrix + cargo-semver-checks expected to register the trait additions as breaking — accepted pre-1.0)
- [ ] Post-merge: tag + release to crates.io via existing release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to crate version bumps/manifest updates and new documentation/RFC draft markdown files, with no runtime code changes in this diff.
> 
> **Overview**
> Cuts a `0.5.0` release entry in `CHANGELOG.md` and bumps the workspace + internal crate versions from `0.4.0` to `0.5.0` (including `Cargo.lock` and per-crate `Cargo.toml` dependency version pins).
> 
> Adds several new RFC/draft and release/smoke verification markdown documents under `rfcs/drafts/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f37242c652b6cbe52568c434dc8bedbff8d2d79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->