### PR TITLE
docs(benches): refresh COMPARISON.md on v0.5.0

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -516,11 +516,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "ff-script"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/benches/comparisons/apalis/Cargo.lock
+++ b/benches/comparisons/apalis/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -621,11 +621,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "ff-script"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/benches/comparisons/baseline/Cargo.lock
+++ b/benches/comparisons/baseline/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -499,11 +499,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "ff-script"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/benches/results/COMPARISON.md
+++ b/benches/results/COMPARISON.md
@@ -4,83 +4,135 @@ Side-by-side numbers across the five scenarios defined in
 `benches/README.md`. Each cell is `throughput_ops_per_sec` on the first
 line and `p50 / p95 / p99` latency in milliseconds on the second.
 
-This page is filled incrementally: Phase A ships scenario 1 for
-FlowFabric + the hand-rolled `baseline`. Phase B + C close the
-remaining cells.
+Current HEAD: **`4aac1c8`** (workspace v0.5.0 bump). Host: AMD EPYC 9R14
+× 16, Valkey 7.2.4. See `benches/results/*-4aac1c8.json` for full
+configs and notes.
 
-## Scenario 1 — submit → claim → complete throughput
+## Scenario 1 — submit → claim → complete throughput (10 000 tasks, 16 workers)
 
-| system      | 1 000 tasks          | 10 000 tasks         | 100 000 tasks |
-| ----------- | -------------------- | -------------------- | ------------- |
-| flowfabric  | _pending first run_  | _pending first run_  | _Phase B large-size toggle_ |
-| baseline    | _pending first run_  | _pending first run_  | _Phase B_     |
-| apalis      | _Phase C_            | _Phase C_            | _Phase C_     |
-| faktory     | _Phase C_            | _Phase C_            | _Phase C_     |
+| system      | throughput (ops/s) | p50 / p95 / p99 (ms) |
+| ----------- | ------------------ | -------------------- |
+| flowfabric  | **2 966**          | 0.393 / 0.695 / 0.837 |
+| baseline    | **14 462**         | 0.275 / 0.357 / 0.482 |
+| apalis      | 98                 | — (not captured)      |
+| faktory     | _Phase C_          | _Phase C_             |
 
-## Scenario 2 — suspend → signal → resume latency
+*flowfabric throughput is the criterion 10 000-task estimate mean
+(3.37 s per 10 k drain). baseline = raw `redis-rs` RPUSH/BLMPOP/INCR
+with no leases or flows — it's the Valkey ceiling, not a peer engine.
+apalis 1.0.0-rc.7 + `apalis-redis`: default JSON codec, no lease-backed
+fencing; `latency_ms` is not surfaced by the apalis harness.*
+
+## Scenario 2 — suspend → signal → resume latency (tight-loop poll)
 
 | system          | p50 (ms)           | p95 (ms)           | p99 (ms)           | throughput (ops/s) |
 | --------------- | ------------------ | ------------------ | ------------------ | ------------------ |
-| flowfabric      | _Phase B (W2)_     | _Phase B (W2)_     | _Phase B (W2)_     | _Phase B (W2)_     |
+| flowfabric      | **9.111**          | **9.988**          | **11.162**         | **109.8**          |
 | apalis 🚫       | _no native suspend_| —                  | —                  | —                  |
 | faktory 🚫      | _no native suspend_| —                  | —                  | —                  |
 | baseline 🚫     | _no primitive_     | —                  | —                  | —                  |
 
-**Why apalis / faktory / baseline have no number here.** FlowFabric's
-`task.suspend()` releases the lease and mints an HMAC-bound waitpoint
-token in a single Lua call; the execution sits in `suspended` state
-and resumes when the signed signal arrives (RFC-004). Apalis has no
-equivalent: the closest shape is a retry-middleware workaround (job
-errors with a backoff, polls Redis for a signal key on each retry
-tick). Investigated during Phase B/C but NOT shipped — the retry-poll
-floor (~100 ms × retry interval) measures a fundamentally different
-primitive (polled retries, unauthenticated signal keys), not a
-suspend/resume comparison. Implementing it would publish a number
-that misleads readers into treating the systems as comparable here.
-Faktory has no middleware story for this at all; baseline (raw
-redis-rs) has no lease semantics.
+Production-projected p50 with default `claim_poll_interval_ms=1000` is
+~509 ms (tight-loop bench uses 1 ms poll). Apalis/faktory/baseline have
+no equivalent primitive — retry-middleware workaround measures a
+different shape (polled retries + unauthenticated signal keys), not
+suspend/resume.
 
-Recorded as a differentiator: the cell is structurally "FlowFabric
-only".
+## Scenario 3 — 5-minute steady-state, 100 workers, 10 000-task seed
 
-## Scenario 3 — 5-minute steady-state, 100 workers, 10 000 tasks
+| metric                                   | flowfabric `4aac1c8` |
+| ---------------------------------------- | -------------------- |
+| whole-run throughput (ops/s)             | **8.64**             |
+| steady-state throughput (ops/s, 60 s win)| 2.0                  |
+| p50 / p95 / p99 completion latency (ms)  | 3 004.5 / 3 006.8 / 3 007.6 |
+| missed-deadline % (submit→complete)      | 4.18 %               |
+| RSS slope (MB/min)                       | −2.61                |
+| lease-renewal overhead (%)               | 0.00018              |
 
-_Phase B (W2)._
+Samples = 1 (single long run per protocol). Apalis/faktory/baseline not
+ported for this scenario.
 
-## Scenario 4 — linear 10-node flow DAG
+## Scenario 4 — linear 10-node flow DAG (100 flows × 10 nodes)
 
 | system     | throughput (flows/s) | p50 total (ms) | p99 total (ms) |
 | ---------- | -------------------- | -------------- | -------------- |
-| flowfabric | _fill from flow_dag_linear-<sha>.json_ | _…_ | _…_ |
-| apalis 🚫  | _no DAG primitive_   | —              | —              |
+| flowfabric | **17.01**            | **474.74**     | **5 816.08**   |
+| apalis     | 9.34 (10.71 s mean wall, N=5) | — (not surfaced) | — |
 | faktory 🚫 | _no DAG primitive_   | —              | —              |
 | baseline 🚫| _no primitive_       | —              | —              |
 
-The flow_dag report's `notes` field carries the breakdown:
-`flow_setup_p50_ms`, `exec_p50_ms`, `exec_p95_ms`, `exec_p99_ms`,
-`stage_latency_p50_ms`, `stage_latency_p99_ms`, `setup_exec_ratio`.
-Copy the three headline numbers from
-`benches/results/flow_dag_linear-<sha>.json` into the flowfabric row;
-paste the notes line immediately below the table.
+flowfabric notes (from `flow_dag_linear-4aac1c8.json`):
+`flow_setup_p50_ms=167.37, exec_p50_ms=308.55, exec_p95_ms=5399.07,
+exec_p99_ms=5644.25, stage_latency_p50_ms=21.00,
+stage_latency_p95_ms=152.00, stage_latency_p99_ms=5311.00,
+setup_exec_ratio=0.54`. Apalis uses `apalis-workflow::Workflow`
+(sequential and_then) per issue #51 methodology.
 
-## Scenario 5 — capability-routed claim
+## Scenario 5 — capability-routed claim (happy mode, 100 workers × 1 000 tasks)
 
-_Phase B. This is FlowFabric's differentiator — apalis/faktory skip.
-Expected cells: flowfabric + baseline (baseline cannot route, documents
-the gap)._
+| system     | throughput (ops/s) | p50 / p95 / p99 correct-claim (ms) | correct-routing rate |
+| ---------- | ------------------ | ---------------------------------- | -------------------- |
+| flowfabric | **1 795.7**        | 416.7 / 531.2 / 550.0              | 1.0000               |
+| apalis 🚫  | _no native capability routing_     | — | —                                  |
+| baseline 🚫| _no primitive_     | —                                  | —                    |
+
+Scarce / partial modes not re-run this cycle (no prior-SHA parity for
+partial/scarce on this host class; happy mode is the headline).
+
+## Regression vs. prior SHAs
+
+| scenario                          | prior SHA (most recent)   | prior thr  | new thr    | delta     | notes |
+| --------------------------------- | ------------------------- | ---------- | ---------- | --------- | ----- |
+| submit_claim_complete             | `01f6327` (2026-04-20)    | 2 171.6    | 2 966.0    | **+36.6 %** | improvement — criterion warn "unable to complete 10 samples in 30 s" at 10k size, but estimate is stable |
+| suspend_signal_resume             | `01f6327` (2026-04-20)    | 105.1      | 109.8      | +4.5 %    | within noise; p99 11.162 vs 11.908 ms |
+| long_running (steady-state)       | `01f6327` (2026-04-20)    | 2.0        | 2.0        | flat      | refill-bound (20 tasks / 10 s); expected floor |
+| long_running (missed-deadline %)  | `01f6327`                 | 3.73 %     | 4.18 %     | +0.45 pp  | within bimodal bench variance (baseline doc: 1.98–7.04 %) |
+| cap_routed-happy                  | `1b2cce5` (2026-04-17)    | 114.1 @ 20 tasks | 1 795.7 @ 1 000 tasks | n/a | scale changed 20→1 000 tasks; not directly comparable |
+| submit_claim_complete-apalis      | `1b2cce5` (2026-04-17)    | 51.9       | 97.8       | +88.7 %   | apalis-redis upgrade / client tuning since April 17 |
+| flow_dag-apalis                   | `1b2cce5` (approx, hand-rolled chain) | 1.02 | 9.34     | n/a       | methodology switched to `apalis-workflow::Workflow` per #51 |
+| submit_claim_complete-baseline    | `0181f30` (2026-04-18)    | 14 724.3   | 14 462.2   | −1.8 %    | within Valkey ceiling noise |
+
+No regressions exceed release-gate thresholds (FAIL: thr > 10 % drop,
+p99 > 20 % drop). `submit_claim_complete` shows a material uplift since
+`01f6327`; likely driven by the trait-split / observability work in the
+v0.5.0 bundle.
+
+## Benches that failed to run
+
+None. All 8 scheduled runs completed on `4aac1c8`. One operational
+incident: an inter-bench `valkey-cli FLUSHALL` wiped the HMAC
+partition-seeded secrets that `ff-server` installs at boot; the
+subsequent `suspend_signal_resume` iterations returned
+`hmac_secret_not_initialized`. Mitigation was to restart `ff-server`
+after the flush and rerun; the captured run is the clean one. Protocol
+note: don't `FLUSHALL` without restarting `ff-server` (or rotating
+secrets via the admin endpoint).
+
+## Artifacts
+
+JSON reports captured this cycle (all tagged `-4aac1c8`):
+
+- `submit_claim_complete-4aac1c8.json`
+- `suspend_signal_resume-4aac1c8.json`
+- `long_running_steady_state-4aac1c8.json`
+- `flow_dag_linear-4aac1c8.json`
+- `cap_routed-happy-4aac1c8.json`
+- `submit_claim_complete-baseline-4aac1c8.json`
+- `submit_claim_complete-apalis-4aac1c8.json`
+- `flow_dag-apalis-4aac1c8.json`
+
+Prior-SHA JSON preserved in `benches/results/` (no deletions).
 
 ## How to regenerate
 
 ```
 # From benches/
-cargo bench --bench submit_claim_complete          # scenario 1
-cargo run --release --bin flow_dag -- --flows 100 --nodes 10   # scenario 4
+cargo bench --bench submit_claim_complete
+cargo bench --bench suspend_signal_resume
+cargo run --release --bin long_running -- --workers 100 --seed 10000 --duration 300
+cargo run --release --bin flow_dag -- --flows 100 --nodes 10
+cargo run --release --bin cap_routed -- --mode happy
 cd comparisons/baseline && cargo run --release --bin baseline-scenario1
+cd comparisons/apalis   && cargo run --release --bin apalis-scenario1
+cd comparisons/apalis   && cargo run --release --bin apalis-scenario4
 ```
-
-Then copy the `throughput_ops_per_sec` and `latency_ms` triples from
-each scenario's JSON in `benches/results/` into the tables above.
-
-Automation for this will land with a subsequent PR once ≥ 4 scenarios
-have FlowFabric-side numbers; hand-written for now to keep the schema
-work focused on the bench runners themselves.


### PR DESCRIPTION
## Summary

Refreshes \`benches/results/COMPARISON.md\` with the 8-run bench matrix on v0.5.0 HEAD (4aac1c8).

Headline numbers:
- **Scenario 1** (submit→claim→complete, 10k tasks): FF **2966 ops/s** (+36.6% vs prior SHA 01f6327) vs apalis 98 ops/s vs baseline 14462 ops/s
- **Scenario 4** (flow-DAG 100×10): FF **17.0 flows/s** vs apalis 9.34 flows/s (**~1.82×**)
- **Scenario 2** (suspend→signal→resume): FF 110 ops/s, p99 11.16 ms — apalis has no primitive
- **Scenario 3** (5-min steady state, 100W × 10k tasks): flat refill-bound floor ~2.0 ops/s; missed-deadline 4.18 % (within documented 1.98–7.04 % bimodal band)
- **Scenario 5** (capability-routed): 1796 ops/s, routing match rate 1.0

**No regressions exceed release-gate thresholds.**

## Closes
Refs #51 (apalis comparison dialogue — numbers refreshed).

## Test plan

- [x] 8 bench runs on v0.5.0 HEAD completed, JSON artifacts captured locally (top-level files are gitignored per \`benches/results/.gitignore\`)
- [ ] Follow-up: document the FLUSHALL-wipes-HMAC-partition-secrets operational gotcha + \`/v1/health\` → \`/healthz\` README drift (separate issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to benchmark documentation updates and version bumps in bench `Cargo.lock` files, with no runtime/production code modifications.
> 
> **Overview**
> Updates the benchmark comparison report (`benches/results/COMPARISON.md`) with fresh v0.5.0 results across scenarios 1–5, including new throughput/latency tables, regression notes vs prior SHAs, and an expanded regeneration protocol.
> 
> Bumps FlowFabric workspace crate versions referenced by the bench lockfiles (`ferriskey`, `ff-*`) from `0.4.0` to `0.5.0` across `benches/Cargo.lock` and the comparison harness lockfiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b801d15b1849498e152fbc232845ce1b08252d1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->