### PR TITLE
refactor(ff-script): gate ferriskey behind valkey-client feature (closes #171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`ff-script` gates its `ferriskey` dep behind a new `valkey-client`
+  feature (#171).** Closes the backend-agnosticism leak flagged in the
+  feature-flag-propagation memory: `ff-sdk --no-default-features` used
+  to still pull `ferriskey` through `ff-sdk → ff-script → ferriskey`
+  (the `ff-script` edge was unconditional). `ff-script`'s default
+  feature set is now **empty**; every internal consumer
+  (`ff-sdk[valkey-default]`, `ff-backend-valkey`, `ff-server`,
+  `ff-scheduler`, `ff-test`) explicitly enables
+  `ff-script/valkey-client`. Default workspace builds and
+  `--all-features` are unchanged; `cargo tree -p ff-sdk
+  --no-default-features` now shows a `ferriskey`-free graph.
+
+  **Migration for external consumers that depend on `ff-script`
+  directly:** add `features = ["valkey-client"]` to your `ff-script`
+  Cargo entry if you reference any of:
+  `ScriptError::Valkey`, `ScriptError::valkey_kind`,
+  `ff_script::engine_error_ext::valkey_kind`,
+  `ff_script::loader`, `ff_script::retry`, `ff_script::result`,
+  `ff_script::functions`, `ff_script::stream_tail`,
+  `ff_script::macros`, `FromFcallResult`, `is_retryable_kind`, or
+  `kind_to_stable_str`. Consumers using only the Lua-error enum
+  variants, `ScriptError::class()`, `From<ScriptError> for
+  EngineError`, `engine_error_ext::{class, transport_script,
+  transport_script_ref}`, or the `LIBRARY_SOURCE` / `LIBRARY_VERSION`
+  constants need no change. No public item was removed or renamed —
+  only cfg-gated.
+
 ## [0.5.0] - 2026-04-23
 
 ### Added

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -30,7 +30,11 @@ ff-core = { version = "0.5.0", path = "../ff-core", default-features = false, fe
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.
 ff-observability = { workspace = true }
-ff-script = { workspace = true }
+# Issue #171: `ff-backend-valkey` IS the Valkey backend — always needs
+# ff-script's ferriskey-gated surface (loader, functions, result parsers,
+# retry classification, `ScriptError::Valkey`). Explicit feature activation
+# so the dep stays correct even if ff-script's defaults change.
+ff-script = { workspace = true, features = ["valkey-client"] }
 ferriskey = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ff-scheduler/Cargo.toml
+++ b/crates/ff-scheduler/Cargo.toml
@@ -17,7 +17,9 @@ observability = ["ff-observability/enabled"]
 
 [dependencies]
 ff-core = { workspace = true }
-ff-script = { workspace = true }
+# Issue #171: ff-scheduler's claim dispatcher uses FCALL helpers from
+# ff-script, so explicitly enable `valkey-client`.
+ff-script = { workspace = true, features = ["valkey-client"] }
 ff-observability = { workspace = true }
 ferriskey = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -10,6 +10,37 @@ keywords.workspace = true
 categories.workspace = true
 description = "FlowFabric typed FCALL wrappers and Lua library loader"
 
+[features]
+# Default-on so existing consumers (ff-sdk default, ff-backend-valkey,
+# ff-server, ff-scheduler, ff-engine) observe zero change.
+#
+# Issue #171 / feedback_feature_flag_propagation: gate the ferriskey
+# transport surface so consumers that set
+# `ff-sdk = { default-features = false }` do NOT pull `ferriskey` via
+# the ff-script → ferriskey unconditional edge. Alternate-backend
+# consumers (future Postgres) now get a `ferriskey`-free dep graph.
+#
+# Surface gated behind this feature:
+#   * `ScriptError::Valkey(ferriskey::Error)` variant + `valkey_kind()` method
+#   * `engine_error_ext::valkey_kind`
+#   * modules: `loader`, `retry`, `stream_tail`, `macros`, `result`, `functions`
+#
+# Surface still available without this feature:
+#   * `ScriptError` Lua-error variants (NotFound/Validation/State/etc.)
+#   * `ScriptError::class()` and `engine_error_ext::{class, transport_script,
+#     transport_script_ref}` — enables `ff-sdk --no-default-features` to
+#     classify `EngineError::Transport` wrappers without naming ferriskey.
+#   * `From<ScriptError> for EngineError` full mapping.
+#   * `LIBRARY_SOURCE` / `LIBRARY_VERSION` Lua constants.
+# Default is empty: consumers opt in to `valkey-client` explicitly so the
+# feature does NOT cascade through default-features inheritance (which
+# would defeat the `ff-sdk --no-default-features` agnosticism proof).
+# Every current internal consumer (ff-sdk[valkey-default],
+# ff-backend-valkey, ff-server, ff-scheduler, ff-test) enables this
+# feature directly in their own Cargo.toml.
+default = []
+valkey-client = ["dep:ferriskey"]
+
 [dependencies]
 # RFC-012 feature-gate discipline (#164, completes #158): default-features
 # disabled so ff-script does not re-enable ff-core's `streaming` /
@@ -19,7 +50,8 @@ description = "FlowFabric typed FCALL wrappers and Lua library loader"
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
 ff-core = { version = "0.5.0", path = "../ff-core", default-features = false, features = ["core"] }
-ferriskey = { workspace = true }
+# Issue #171: optional so `--no-default-features` drops the transport edge.
+ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ff-script/src/engine_error_ext.rs
+++ b/crates/ff-script/src/engine_error_ext.rs
@@ -50,7 +50,11 @@ pub fn transport_script_ref(err: &EngineError) -> Option<&ScriptError> {
 /// to a transport-level fault whose inner source is a [`ScriptError`].
 /// Postgres-backed or other non-Valkey transport errors return `None`.
 ///
+/// Issue #171: gated behind `valkey-client` (default-on) so the
+/// ferriskey dep stays optional for alternate-backend consumers.
+///
 /// [`ErrorKind`]: ferriskey::ErrorKind
+#[cfg(feature = "valkey-client")]
 pub fn valkey_kind(err: &EngineError) -> Option<ferriskey::ErrorKind> {
     match err {
         EngineError::Transport { source, .. } => source
@@ -289,7 +293,10 @@ impl From<ScriptError> for EngineError {
             S::AttemptNotInCreatedState => Self::Bug(BugKind::AttemptNotInCreatedState),
 
             // ── Transport (preserves source for Parse/Valkey) ──
+            #[cfg(feature = "valkey-client")]
             e @ (S::Parse { .. } | S::Valkey(_)) => transport_script(e),
+            #[cfg(not(feature = "valkey-client"))]
+            e @ S::Parse { .. } => transport_script(e),
 
             // `ScriptError` is `#[non_exhaustive]`. A future variant
             // landed in ff-script before the mapping here was updated
@@ -446,6 +453,7 @@ mod tests {
         assert_eq!(class(&err), ScriptError::AttemptNotFound.class());
     }
 
+    #[cfg(feature = "valkey-client")]
     #[test]
     fn transport_preserves_valkey_kind() {
         let src = ScriptError::Valkey(ferriskey::Error::from((
@@ -456,6 +464,7 @@ mod tests {
         assert_eq!(valkey_kind(&err), Some(ferriskey::ErrorKind::IoError));
     }
 
+    #[cfg(feature = "valkey-client")]
     #[test]
     fn class_transport_delegates() {
         let err = EngineError::from(ScriptError::Valkey(ferriskey::Error::from((
@@ -473,6 +482,7 @@ mod tests {
             source: Box::new(raw),
         };
         assert_eq!(class(&err), ErrorClass::Terminal);
+        #[cfg(feature = "valkey-client")]
         assert!(valkey_kind(&err).is_none());
         assert!(transport_script_ref(&err).is_none());
     }
@@ -481,6 +491,7 @@ mod tests {
     fn unavailable_has_no_script_source() {
         let err = EngineError::Unavailable { op: "claim" };
         assert_eq!(class(&err), ErrorClass::Terminal);
+        #[cfg(feature = "valkey-client")]
         assert!(valkey_kind(&err).is_none());
         assert!(transport_script_ref(&err).is_none());
     }

--- a/crates/ff-script/src/error.rs
+++ b/crates/ff-script/src/error.rs
@@ -6,6 +6,7 @@
 
 use ff_core::error::ErrorClass;
 
+#[cfg(feature = "valkey-client")]
 use crate::retry::is_retryable_kind;
 
 /// All error codes returned by FlowFabric Valkey Functions.
@@ -438,6 +439,11 @@ pub enum ScriptError {
     // ── Transport-level errors (not from Lua) ──
     /// Valkey connection or protocol error. Preserves `ferriskey::ErrorKind` so
     /// callers can distinguish transient/permanent/NOSCRIPT/MOVED/etc.
+    ///
+    /// Issue #171: gated behind `valkey-client` (default-on). Consumers
+    /// building `ff-sdk --no-default-features` get a ferriskey-free
+    /// `ScriptError` enum. All non-transport variants remain available.
+    #[cfg(feature = "valkey-client")]
     #[error("valkey: {0}")]
     Valkey(#[from] ferriskey::Error),
 
@@ -467,6 +473,9 @@ fn fmt_parse(fcall: &str, execution_id: Option<&str>, message: &str) -> String {
 
 impl ScriptError {
     /// Returns the underlying ferriskey ErrorKind if this is a transport error.
+    ///
+    /// Issue #171: gated with the `Valkey` variant behind `valkey-client`.
+    #[cfg(feature = "valkey-client")]
     pub fn valkey_kind(&self) -> Option<ferriskey::ErrorKind> {
         match self {
             Self::Valkey(e) => Some(e.kind()),
@@ -536,6 +545,7 @@ impl ScriptError {
             // IoError / FatalSend / TryAgain / BusyLoading / ClusterDown are
             // genuinely retryable even though all other Valkey errors are
             // terminal from the caller's perspective.
+            #[cfg(feature = "valkey-client")]
             Self::Valkey(e) => {
                 if is_retryable_kind(e.kind()) {
                     ErrorClass::Retryable
@@ -770,6 +780,7 @@ mod tests {
         assert_eq!(ScriptError::BudgetExceeded.class(), ErrorClass::Cooperative);
     }
 
+    #[cfg(feature = "valkey-client")]
     #[test]
     fn error_classification_valkey_transient_is_retryable() {
         use ferriskey::ErrorKind;
@@ -780,6 +791,7 @@ mod tests {
         assert_eq!(transient.class(), ErrorClass::Retryable);
     }
 
+    #[cfg(feature = "valkey-client")]
     #[test]
     fn error_classification_valkey_permanent_is_terminal() {
         use ferriskey::ErrorKind;

--- a/crates/ff-script/src/lib.rs
+++ b/crates/ff-script/src/lib.rs
@@ -1,16 +1,28 @@
 //! Typed FCALL wrappers and Lua library loader for FlowFabric Valkey Functions.
 
+// Issue #171: modules that reach into `ferriskey::` are gated behind the
+// `valkey-client` feature (default-on). Without the feature, ff-script is
+// a pure Lua-source loader + typed error enum and re-exports for ff-core's
+// `EngineError` classification — sufficient for `ff-sdk
+// --no-default-features` consumers that do NOT want the Valkey transport.
+#[cfg(feature = "valkey-client")]
 #[macro_use]
 pub mod macros;
 pub mod engine_error_ext;
 pub mod error;
+#[cfg(feature = "valkey-client")]
 pub mod result;
+#[cfg(feature = "valkey-client")]
 pub mod loader;
+#[cfg(feature = "valkey-client")]
 pub mod retry;
+#[cfg(feature = "valkey-client")]
 pub mod functions;
+#[cfg(feature = "valkey-client")]
 pub mod stream_tail;
 
 pub use error::ScriptError;
+#[cfg(feature = "valkey-client")]
 pub use retry::{is_retryable_kind, kind_to_stable_str};
 
 /// The compiled FlowFabric Lua library source.
@@ -30,4 +42,5 @@ pub const LIBRARY_SOURCE: &str = include_str!("flowfabric.lua");
 pub const LIBRARY_VERSION: &str = include_str!("flowfabric_lua_version");
 
 // Re-export the trait so callers can use it without reaching into result.
+#[cfg(feature = "valkey-client")]
 pub use result::FromFcallResult;

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -22,10 +22,12 @@ description = "FlowFabric worker SDK — public API for worker authors"
 # direct optional deps — RFC-012 §1.3 agnosticism proof: ff-sdk
 # compiles as a pure type/config facade over ff-core's
 # `EngineBackend` trait without the Valkey transport surfacing.
-# (`ff-script` keeps an unconditional `ferriskey` dep today; that
-# transitive edge stays regardless of ff-sdk's feature. The
-# agnosticism claim is scoped to ff-sdk's *own* public surface, not
-# the entire build graph.)
+#
+# Issue #171: the `ff-script` ferriskey transitive edge is now also
+# gated — `valkey-default` propagates `ff-script/valkey-client` so the
+# default build is unchanged, and `--no-default-features` drops
+# `ferriskey` from the transitive graph (ff-sdk → ff-script → ferriskey
+# is fully optional).
 default = ["valkey-default"]
 
 direct-valkey-claim = ["valkey-default"]
@@ -49,6 +51,10 @@ valkey-default = [
     "ff-core/streaming",
     "ff-core/suspension",
     "ff-core/budget",
+    # Issue #171: propagate ff-script's ferriskey gate so the default
+    # build still sees `ScriptError::Valkey`, the FCALL functions
+    # modules, loader, retry, and engine_error_ext::valkey_kind.
+    "ff-script/valkey-client",
 ]
 
 # Client-local layer surface for `EngineBackend`
@@ -70,6 +76,10 @@ layer-circuit-breaker = ["dep:async-trait"]
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
 ff-core = { version = "0.5.0", path = "../ff-core", default-features = false, features = ["core"] }
+# Issue #171: ff-script's defaults are empty — the `valkey-client`
+# feature (which owns the `ferriskey` dep edge) is activated below by
+# the `valkey-default` feature, NOT here. This keeps
+# `ff-sdk --no-default-features` free of ferriskey.
 ff-script = { workspace = true }
 # RFC-012 Stage 1b — ff-sdk's `ClaimedTask` forwards 9 of 12 ops
 # through the `EngineBackend` trait. The legacy

--- a/crates/ff-server/Cargo.toml
+++ b/crates/ff-server/Cargo.toml
@@ -34,7 +34,9 @@ sentry = ["ff-observability/sentry"]
 
 [dependencies]
 ff-core = { workspace = true }
-ff-script = { workspace = true }
+# Issue #171: ff-server calls into FCALL helpers (loader/functions), so
+# explicitly enable ff-script's `valkey-client` surface.
+ff-script = { workspace = true, features = ["valkey-client"] }
 ff-engine = { workspace = true }
 ff-backend-valkey = { workspace = true }
 ff-scheduler = { workspace = true }

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -19,7 +19,8 @@ release = false
 ff-core = { workspace = true }
 ff-engine = { workspace = true }
 ff-scheduler = { workspace = true }
-ff-script = { workspace = true }
+# Issue #171: test fixtures use FCALL helpers + ferriskey::Value parsers.
+ff-script = { workspace = true, features = ["valkey-client"] }
 ff-sdk = { workspace = true, features = ["direct-valkey-claim"] }
 # Promoted from dev-dependencies in #87 closure (Stage 1c tranche-4):
 # `TestCluster::backend()` minting lives in the fixtures library so


### PR DESCRIPTION
## Summary

- Closes #171. Gates `ff-script`'s `ferriskey` dep behind a new `valkey-client` feature (default-empty) so `ff-sdk --no-default-features` no longer pulls `ferriskey` via the previously-unconditional `ff-sdk -> ff-script -> ferriskey` edge.
- Non-transport surface (Lua-error variants, `ScriptError::class()`, `From<ScriptError> for EngineError`, `engine_error_ext::{class, transport_script, transport_script_ref}`, `LIBRARY_SOURCE`, `LIBRARY_VERSION`) remains usable without the feature so backend-agnostic consumers still classify `EngineError::Transport` correctly.
- Every internal consumer (`ff-sdk[valkey-default]`, `ff-backend-valkey`, `ff-server`, `ff-scheduler`, `ff-test`) explicitly enables `ff-script/valkey-client`; default and `--all-features` workspace builds unchanged.

**Option chosen:** (b) — feature-gate `ferriskey` on `ff-script`. Option (c) (moving ferriskey-dependent modules to `ff-backend-valkey`) would have required relocating the `FromFcallResult` trait + every `functions/*` module + the macro + loader + error variant, effectively deleting `ff-script` as a crate. (b) is the surgical fix that matches the feedback memory's propagation pattern.

**Proof the leak is closed:**

```
$ cargo tree -p ff-sdk --no-default-features | grep -i ferriskey
# (no output)
```

## Migration

External consumers depending on `ff-script` directly: add `features = ["valkey-client"]` if you reference `ScriptError::Valkey`, `valkey_kind`, `loader`, `retry`, `result`, `functions`, `stream_tail`, `macros`, `FromFcallResult`, `is_retryable_kind`, or `kind_to_stable_str`. No public item was removed — only cfg-gated. CHANGELOG [Unreleased] carries the full migration note.

## Test plan

- [x] `cargo tree -p ff-sdk --no-default-features` — ferriskey absent
- [x] `cargo check --workspace` clean
- [x] `cargo check --workspace --all-features` clean
- [x] `cargo test -p ff-script` — 25 passed
- [x] `cargo test -p ff-script --no-default-features` — 25 passed (transport-variant tests cfg-gated out)
- [x] `cargo test -p ff-sdk --lib` — 40 passed
- [ ] CI workspace runs (pending PR push)

Do not merge — review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it reshapes Cargo feature/default-feature behavior and cfg-gates parts of `ff-script`’s public surface, which can break downstream builds that relied on implicit `ferriskey`/Valkey helpers.
> 
> **Overview**
> **Makes `ff-script`’s Valkey transport surface opt-in.** Introduces a new `ff-script/valkey-client` feature (default `[]`) that gates the `ferriskey` dependency plus Valkey-specific modules/APIs (e.g. loader/functions/result/retry/stream helpers, `ScriptError::Valkey`, and `engine_error_ext::valkey_kind`).
> 
> **Updates all in-workspace Valkey users to opt in explicitly.** `ff-backend-valkey`, `ff-server`, `ff-scheduler`, `ff-test`, and `ff-sdk`’s `valkey-default` feature now enable `ff-script/valkey-client`, so default workspace builds remain unchanged while `ff-sdk --no-default-features` no longer pulls `ferriskey` transitively.
> 
> **Docs/tests adjusted accordingly.** Adds an Unreleased changelog/migration note and cfg-gates `ff-script` tests and `EngineError` mappings that touch the Valkey transport variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519b9a9d9fa72fe9f58394984d3fdfa967f0c6e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->