### PR TITLE
fix(examples): use ExecutionId helpers to mint hash-tagged ids

### DIFF
--- a/examples/coding-agent/Cargo.lock
+++ b/examples/coding-agent/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -431,11 +431,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "ff-script"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/coding-agent/src/submit.rs
+++ b/examples/coding-agent/src/submit.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 
 use clap::Parser;
 use common::{TaskPayload, DEFAULT_LANE, DEFAULT_NAMESPACE, DEFAULT_SERVER_URL};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{ExecutionId, LaneId};
 use serde::Deserialize;
 
 #[derive(Parser)]
@@ -41,6 +43,11 @@ struct Args {
     #[arg(long, default_value_t = 100)]
     priority: i32,
 
+    /// Number of flow partitions the server is configured with
+    /// (matches `FF_FLOW_PARTITIONS`; default 256).
+    #[arg(long, default_value_t = 256)]
+    flow_partitions: u16,
+
     /// Exit immediately after submit (don't poll for state changes).
     #[arg(long)]
     no_wait: bool,
@@ -51,7 +58,12 @@ async fn main() {
     let args = Args::parse();
     let client = reqwest::Client::new();
 
-    let execution_id = uuid::Uuid::new_v4().to_string();
+    let partition_config = PartitionConfig {
+        num_flow_partitions: args.flow_partitions,
+        ..PartitionConfig::default()
+    };
+    let execution_id =
+        ExecutionId::solo(&LaneId::from(args.lane.as_str()), &partition_config).to_string();
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("clock")

--- a/examples/media-pipeline/Cargo.lock
+++ b/examples/media-pipeline/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -914,11 +914,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "ff-script"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/media-pipeline/src/bin/submit.rs
+++ b/examples/media-pipeline/src/bin/submit.rs
@@ -23,6 +23,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{ExecutionId, FlowId};
 use media_pipeline::{
     PipelineInput, SummarizeResult, TranscribeResult, FRAME_FIELD_PAYLOAD,
     FRAME_FIELD_TYPE, KIND_EMBED, KIND_SUMMARIZE, KIND_TRANSCRIBE, LABEL_EMBED,
@@ -69,6 +71,11 @@ struct Args {
     /// don't synchronize ZRANGEBYSCORE hits on an idle lane.
     #[arg(long, default_value_t = 2000)]
     poll_ms: u64,
+
+    /// Number of flow partitions the server is configured with
+    /// (matches `FF_FLOW_PARTITIONS`; default 256).
+    #[arg(long, default_value_t = 256)]
+    flow_partitions: u16,
 }
 
 #[tokio::main]
@@ -98,10 +105,15 @@ async fn main() -> Result<()> {
 async fn run_pipeline(client: &Client, args: &Args, stdout: &Arc<Mutex<Stdout>>) -> Result<()> {
     // Flow + execution IDs up-front — we need them for dependency edges
     // before each execution is created.
-    let flow_id = uuid::Uuid::new_v4().to_string();
-    let eid_transcribe = uuid::Uuid::new_v4().to_string();
-    let eid_summarize = uuid::Uuid::new_v4().to_string();
-    let eid_embed = uuid::Uuid::new_v4().to_string();
+    let partition_config = PartitionConfig {
+        num_flow_partitions: args.flow_partitions,
+        ..PartitionConfig::default()
+    };
+    let flow_id_typed = FlowId::new();
+    let flow_id = flow_id_typed.to_string();
+    let eid_transcribe = ExecutionId::for_flow(&flow_id_typed, &partition_config).to_string();
+    let eid_summarize = ExecutionId::for_flow(&flow_id_typed, &partition_config).to_string();
+    let eid_embed = ExecutionId::for_flow(&flow_id_typed, &partition_config).to_string();
 
     // Print the flow ID + transcribe EID up-front so diagnostics can
     // correlate early failures. The summarize and embed EIDs are


### PR DESCRIPTION
## Summary

- Fixes Bug A from the Phase 3 example-run report: `POST /v1/executions` requires the `{fp:N}:` hash-tag prefix (RFC-011 §2.3), so the bare `uuid::Uuid::new_v4()` calls in `examples/coding-agent/src/submit.rs` and `examples/media-pipeline/src/bin/submit.rs` were yielding 422 on submit.
- Mint execution ids via the proper helpers — `ExecutionId::solo(&lane, &cfg)` for the coding-agent (solo execution, no parent flow) and `ExecutionId::for_flow(&flow_id, &cfg)` for the three media-pipeline flow members.
- Add a `--flow-partitions` CLI flag (default `256`, matching the server's `FF_FLOW_PARTITIONS` default) so operators running a non-default partition count can override without recompiling. `FlowId::new()` remains a bare uuid — `FlowId` is not hash-tagged.

Server + production API untouched; worker.rs and approve.rs untouched (Bug B is separate).

## Test plan

- [x] `cargo build --release --bin submit` in both examples.
- [x] Boot `ff-server` on a fresh Valkey with `FF_WAITPOINT_HMAC_SECRET=… FF_LANES=default,bench,media`.
- [x] `examples/coding-agent` submit returns `Created execution: {fp:86}:…` (was 422).
- [x] `examples/media-pipeline` submit emits `flow_id=…` + `transcribe={fp:227}:…` and creates the flow + transcribe execution without 422 before hanging on `wait_terminal` (expected with no workers running).

Do NOT merge — the caller asked me to leave this open.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to example CLIs and dependency lockfiles, mainly affecting how IDs are generated and a new CLI flag defaulting to existing server behavior.
> 
> **Overview**
> Fixes the example `submit` CLIs to generate **hash-tagged** execution IDs using `ff_core::types::ExecutionId` helpers instead of raw UUIDs, avoiding 422s when submitting to servers that require RFC-011 partition prefixes.
> 
> Adds a `--flow-partitions` flag (default `256`) in both examples to match server partition configuration when minting IDs, and updates example `Cargo.lock` files to `ff-*`/`ferriskey` `0.5.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5462d56b9fec0d19afdefb08f29017ac00f21dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->