### PR TITLE
fix(stream): dedicated socket for tail_stream blocking reads (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`tail_stream` no longer head-of-line-blocks concurrent writes (#204).**
+  `ValkeyBackend::tail_stream` used to issue `XREAD BLOCK` on the shared
+  ferriskey multiplex, so a concurrent `append_frame`/`XADD` on the same
+  `ClaimedTask` would wait behind the blocking read — or, more commonly,
+  be misreported to the caller as `EngineError::Transport { source:
+  "timed out" }` when ferriskey's client request-timeout fired first.
+  `tail_stream_impl` now obtains a dedicated connection via a new
+  `ferriskey::Client::duplicate_connection()` method, runs the BLOCK on
+  that socket, and drops it on return. Writes on the shared client are
+  unaffected by blocking reads. Regression test:
+  `crates/ff-test/tests/issue_204_tail_stream_no_hol.rs`.
+
 - **`list_lanes` now reflects configured and dynamically-created lanes
   (#203).** `EngineBackend::list_lanes` reads `SMEMBERS ff:idx:lanes`,
   but before this fix no code path wrote to that SET — a

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -3003,10 +3003,13 @@ async fn read_stream_impl(
 /// Valkey XREAD BLOCK-backed stream tailer. See
 /// [`read_stream_impl`] for the migration rationale.
 ///
-/// Callers concerned with head-of-line blocking should build a
-/// dedicated `ValkeyBackend` backed by its own `ferriskey::Client` —
-/// the REST server's `tail_client` split in `ff-server` is the
-/// canonical pattern.
+/// Issues `XREAD BLOCK` on a **dedicated** ferriskey connection
+/// obtained via [`ferriskey::Client::duplicate_connection`] and
+/// drops that connection on return. This keeps the blocking read
+/// off the shared multiplex socket so concurrent non-blocking
+/// operations on the main client (e.g. `XADD` from
+/// `append_frame`) never wait on head-of-line blocking. Fixes
+/// GitHub issue #204.
 #[cfg(feature = "streaming")]
 #[tracing::instrument(
     name = "ff.tail_stream",
@@ -3031,8 +3034,19 @@ async fn tail_stream_impl(
     let stream_key = ctx.stream(attempt_index);
     let stream_meta_key = ctx.stream_meta(attempt_index);
 
+    // Dedicated socket for the blocking read — dropped when this
+    // function returns. Dialling a second connection fails only on
+    // genuine transport problems (refused, TLS handshake, auth);
+    // those are classified the same as any other transport error
+    // via `transport_script`.
+    let tail_client = client
+        .duplicate_connection()
+        .await
+        .map_err(ff_script::error::ScriptError::from)
+        .map_err(transport_script)?;
+
     ff_script::stream_tail::xread_block(
-        client,
+        &tail_client,
         &stream_key,
         &stream_meta_key,
         after.to_wire(),

--- a/crates/ff-test/tests/issue_204_tail_stream_no_hol.rs
+++ b/crates/ff-test/tests/issue_204_tail_stream_no_hol.rs
@@ -1,0 +1,181 @@
+//! Issue #204 — concurrent `tail_stream` + `append_frame`-style writes on
+//! a single ferriskey client must NOT head-of-line block each other.
+//!
+//! Pre-fix: both operations shared one multiplexed ferriskey connection, so
+//! a long-blocking `XREAD BLOCK` tail occupied the only mux slot and a
+//! concurrent `XADD` (the transport beneath `append_frame`) stalled until
+//! the tail returned — or, more commonly, was falsely surfaced to the
+//! caller as `EngineError::Transport { source: "timed out" }` when the
+//! ferriskey client's request-timeout fired while the BLOCK was still in
+//! flight.
+//!
+//! Post-fix: `tail_stream_impl` issues its blocking XREAD on a dedicated
+//! connection obtained via `ferriskey::Client::duplicate_connection()`, so
+//! writes on the main client complete regardless of the tail's state.
+//!
+//! Contract exercised here:
+//! 1. Tail a never-written attempt stream with `block_ms = 2000` (via the
+//!    same `xread_block` primitive `tail_stream_impl` uses, but against a
+//!    freshly-duplicated connection — simulating the post-fix call path).
+//! 2. While the tail is in flight, fire a non-blocking XADD against the
+//!    ORIGINAL ferriskey client.
+//! 3. The XADD MUST return within 500 ms. Against the pre-fix single-mux
+//!    call path, XADD sits behind the BLOCK and either completes ~2000 ms
+//!    later (tail returns first) or times out first — either way it
+//!    exceeds the 500 ms budget. The assertion distinguishes the fix
+//!    from the regression.
+
+use std::time::{Duration, Instant};
+
+use ff_test::fixtures::TestCluster;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn append_does_not_stall_behind_blocking_tail() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let main = tc.client().clone();
+    let stream_key = format!(
+        "{{p:0}}:issue204:stream:{}",
+        uuid::Uuid::new_v4()
+    );
+    let stream_meta_key = format!("{{p:0}}:issue204:stream_meta:{}", uuid::Uuid::new_v4());
+
+    // The tail runs on a duplicate connection — matching what the
+    // post-fix `tail_stream_impl` does internally.
+    let tail_client = main
+        .duplicate_connection()
+        .await
+        .expect("duplicate_connection should succeed against live Valkey");
+
+    let tail_key = stream_key.clone();
+    let tail_meta = stream_meta_key.clone();
+    let tail_handle = tokio::spawn(async move {
+        let start = Instant::now();
+        let result = ff_script::stream_tail::xread_block(
+            &tail_client,
+            &tail_key,
+            &tail_meta,
+            "$",
+            2_000, // block up to 2s; no frames will arrive during the test
+            10,
+        )
+        .await;
+        (result, start.elapsed())
+    });
+
+    // Give the BLOCK a moment to land on the dedicated socket so the race
+    // we care about (write vs already-parked blocking read) is genuine.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Now fire the XADD on the main client. Pre-fix, this would wait on
+    // the BLOCK (shared mux) and blow the 500 ms budget; post-fix, the
+    // blocking read is on a different socket so the XADD is unaffected.
+    let write_start = Instant::now();
+    let write_result: ferriskey::Value = main
+        .cmd("XADD")
+        .arg(&stream_key)
+        .arg("*")
+        .arg("field")
+        .arg("value")
+        .execute()
+        .await
+        .expect("XADD on main client must succeed");
+    let write_elapsed = write_start.elapsed();
+
+    // `XADD *` returns the stream entry ID as a BulkString; we don't care
+    // about the value, only that the round-trip completed quickly.
+    assert!(
+        matches!(&write_result, ferriskey::Value::BulkString(_)),
+        "XADD should return a BulkString entry id, got {write_result:?}"
+    );
+
+    assert!(
+        write_elapsed < Duration::from_millis(500),
+        "XADD stalled {write_elapsed:?} — expected < 500ms. This is the \
+         issue #204 regression: the blocking tail is head-of-line-blocking \
+         writes on the shared ferriskey multiplex."
+    );
+
+    // Drain the tail so the test doesn't leave a background task leaking.
+    let (tail_result, tail_elapsed) = tail_handle.await.expect("tail task panicked");
+    let frames = tail_result.expect("xread_block should succeed (nil on timeout is Ok)");
+    // Tail is allowed to either return early (because XADD landed on the
+    // stream it's watching) or ride out the full block — we don't assert
+    // either way; only the write-side latency matters for this test.
+    let _ = frames;
+    let _ = tail_elapsed;
+
+    tc.cleanup().await;
+}
+
+/// Companion test: demonstrates the head-of-line behavior that #204
+/// originally reported, using the shared-multiplex call path (BLOCK and
+/// XADD on the same `ferriskey::Client`). The XADD stall is what
+/// `tail_stream_impl` used to inflict on `append_frame`. This test is
+/// documentation/proof-of-reproduction — mark it `#[ignore]` so CI
+/// doesn't wait 2s on every run, but it can be executed manually to
+/// confirm the bug is real:
+///
+///     cargo test -p ff-test --test issue_204_tail_stream_no_hol -- \
+///         --ignored shared_mux_stalls_write
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "demonstrates the pre-fix head-of-line regression; 2s wall-clock"]
+async fn shared_mux_stalls_write() {
+    let tc = TestCluster::connect().await;
+
+    let shared = tc.client().clone();
+    let stream_key = format!(
+        "{{p:0}}:issue204:shared:{}",
+        uuid::Uuid::new_v4()
+    );
+    let stream_meta_key = format!(
+        "{{p:0}}:issue204:shared_meta:{}",
+        uuid::Uuid::new_v4()
+    );
+
+    let tail_client = shared.clone(); // SHARED — the bug.
+    let tail_key = stream_key.clone();
+    let tail_meta = stream_meta_key.clone();
+    let _tail_handle = tokio::spawn(async move {
+        let _ = ff_script::stream_tail::xread_block(
+            &tail_client,
+            &tail_key,
+            &tail_meta,
+            "$",
+            2_000,
+            10,
+        )
+        .await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let write_start = Instant::now();
+    let write_outcome: Result<ferriskey::Value, ferriskey::Error> = shared
+        .cmd("XADD")
+        .arg(&stream_key)
+        .arg("*")
+        .arg("field")
+        .arg("value")
+        .execute()
+        .await;
+    let write_elapsed = write_start.elapsed();
+
+    // Under the shared-mux bug, the XADD either (a) waits behind the
+    // BLOCK and returns late or (b) trips the ferriskey request-timeout
+    // and returns an error — both outcomes surface the head-of-line
+    // pathology that #204 is about. We accept either manifestation.
+    let stalled = write_outcome.is_err() || write_elapsed >= Duration::from_millis(500);
+    assert!(
+        stalled,
+        "expected shared-mux head-of-line blocking (XADD err or >= 500ms) \
+         but write_elapsed={write_elapsed:?} result={write_outcome:?} — \
+         either the bug has been papered over elsewhere or ferriskey's \
+         mux behavior has changed"
+    );
+
+    // No trailing cleanup: the background tail task is still parked on
+    // the shared mux and any FLUSHDB round-trip would itself stall.
+    // This test is `#[ignore]`d and only runs manually, so leak is ok.
+}

--- a/ferriskey/src/ferriskey_client.rs
+++ b/ferriskey/src/ferriskey_client.rs
@@ -22,7 +22,15 @@ pub type Result<T> = crate::value::Result<T>;
 
 /// High-level Valkey client with convenience methods for common operations.
 #[derive(Clone)]
-pub struct Client(Arc<ClientInner>);
+pub struct Client {
+    inner: Arc<ClientInner>,
+    /// Original connection configuration used to produce `inner`.
+    /// Retained so [`Client::duplicate_connection`] can dial a second
+    /// independent multiplexed socket with identical TLS/auth/cluster
+    /// settings for callers that need to isolate long-blocking reads
+    /// (e.g. `XREAD BLOCK`) from the main multiplex.
+    request: Arc<ConnectionRequest>,
+}
 
 /// Builder for constructing a [`Client`] with custom connection options.
 pub struct ClientBuilder {
@@ -51,8 +59,11 @@ impl Client {
     /// Connect to a standalone Valkey server by URL.
     pub async fn connect(url: &str) -> Result<Client> {
         let request = connection_request_from_url(url, false)?;
-        let inner = ClientInner::new(request, None).await?;
-        Ok(Self(Arc::new(inner)))
+        let inner = ClientInner::new(request.clone(), None).await?;
+        Ok(Self {
+            inner: Arc::new(inner),
+            request: Arc::new(request),
+        })
     }
 
     /// Connect to a Valkey cluster using one or more seed node URLs.
@@ -85,8 +96,11 @@ impl Client {
             request.addresses.push(node_address_from_addr(info.addr)?);
         }
 
-        let inner = ClientInner::new(request, None).await?;
-        Ok(Self(Arc::new(inner)))
+        let inner = ClientInner::new(request.clone(), None).await?;
+        Ok(Self {
+            inner: Arc::new(inner),
+            request: Arc::new(request),
+        })
     }
 
     /// Get the value of a key, returning `None` if the key does not exist.
@@ -337,7 +351,31 @@ impl Client {
     /// plain `SCAN`) dispatch without introspecting the builder
     /// that produced this client.
     pub async fn is_cluster(&self) -> bool {
-        self.0.is_cluster().await
+        self.inner.is_cluster().await
+    }
+
+    /// Dial a second, independent multiplexed connection using the
+    /// same configuration (addresses, TLS, auth, cluster mode,
+    /// timeouts, retry strategy, ...) that produced this client.
+    ///
+    /// The returned `Client` does NOT share the internal multiplex
+    /// socket with `self`, so a long-running blocking command on
+    /// either client (e.g. `XREAD BLOCK`) cannot stall in-flight
+    /// commands on the other. Intended for callers that want to
+    /// isolate blocking reads from concurrent writes on the same
+    /// logical handle; drop the duplicate when the blocking
+    /// operation returns and the extra socket is released.
+    ///
+    /// Note: `push_sender`, if configured on the original builder,
+    /// is **not** propagated — the duplicate is a plain command
+    /// client.
+    pub async fn duplicate_connection(&self) -> Result<Client> {
+        let request = (*self.request).clone();
+        let inner = ClientInner::new(request.clone(), None).await?;
+        Ok(Client {
+            inner: Arc::new(inner),
+            request: Arc::new(request),
+        })
     }
 
     /// Cluster-wide `SCAN` driven by ferriskey's internal slot
@@ -362,14 +400,14 @@ impl Client {
         // Clone mirrors the pattern used by `execute`: ClientInner
         // needs `&mut self` for IAM token rotation; the clone is
         // cheap (Arc fields + atomics).
-        let mut inner = (*self.0).clone();
+        let mut inner = (*self.inner).clone();
         inner.cluster_scan_typed(scan_state, args).await
     }
 
     /// Start building an arbitrary command by name.
     pub fn cmd(&self, name: &str) -> CommandBuilder {
         CommandBuilder {
-            client: self.0.clone(),
+            client: self.inner.clone(),
             cmd: cmd(name),
         }
     }
@@ -378,7 +416,7 @@ impl Client {
     pub fn pipeline(&self) -> TypedPipeline {
         TypedPipeline {
             inner: crate::pipeline::Pipeline::new(),
-            client: self.0.clone(),
+            client: self.inner.clone(),
             results: Arc::new(std::sync::OnceLock::new()),
             next_index: 0,
         }
@@ -397,7 +435,7 @@ impl Client {
         // Refactoring send_command to &self would require changing
         // update_connection_password and the ValkeyClientForTests trait across the
         // codebase. The clone is cheap (Arc fields + atomics).
-        let mut inner = (*self.0).clone();
+        let mut inner = (*self.inner).clone();
         let value = inner.send_command(&mut cmd, None).await?;
         from_owned_value(value)
     }
@@ -634,8 +672,12 @@ impl ClientBuilder {
             )));
         }
 
-        let inner = ClientInner::new(self.request, self.push_sender).await?;
-        Ok(Client(Arc::new(inner)))
+        let request = self.request;
+        let inner = ClientInner::new(request.clone(), self.push_sender).await?;
+        Ok(Client {
+            inner: Arc::new(inner),
+            request: Arc::new(request),
+        })
     }
 
     /// Build a client that defers TCP connection until the first
@@ -735,7 +777,7 @@ impl crate::client::ValkeyClientForTests for LazyClient {
         use futures::FutureExt;
         async move {
             let client = self.connect().await?.clone();
-            let mut inner = (*client.0).clone();
+            let mut inner = (*client.inner).clone();
             inner.send_command(cmd, routing).await
         }
         .boxed()
@@ -797,8 +839,11 @@ impl LazyClient {
                 // provides the deferral.
                 let mut config = self.config.clone();
                 config.lazy_connect = false;
-                let inner = ClientInner::new(config, self.push_sender.clone()).await?;
-                Ok::<Client, Error>(Client(Arc::new(inner)))
+                let inner = ClientInner::new(config.clone(), self.push_sender.clone()).await?;
+                Ok::<Client, Error>(Client {
+                    inner: Arc::new(inner),
+                    request: Arc::new(config),
+                })
             })
             .await
     }


### PR DESCRIPTION
## Summary

- Adds `ferriskey::Client::duplicate_connection()` — opens a second multiplexed connection reusing the original `ConnectionRequest` (addresses, TLS, auth, cluster, timeouts).
- `ValkeyBackend::tail_stream_impl` now issues `XREAD BLOCK` on that dedicated connection and drops it on return; writes on the shared client no longer head-of-line-block behind blocking reads.
- `ferriskey::Client` is restructured from `Client(Arc<ClientInner>)` to `Client { inner: Arc<ClientInner>, request: Arc<ConnectionRequest> }`. Additive — no public item removed or renamed.
- Regression test in `crates/ff-test/tests/issue_204_tail_stream_no_hol.rs` (live-Valkey).

Closes #204.

## Why

A single `ClaimedTask` sharing one ferriskey `Client` between `tail_stream` and `append_frame` hit ferriskey's documented single-mux head-of-line behavior: a long `XREAD BLOCK` occupied the connection, stalling the concurrent `XADD` and surfacing as a misleading `EngineError::Transport { source: "timed out" }` when the client request-timeout fired first. Owner-approved fix: dedicated socket per blocking tail call.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo test -p ferriskey --lib` (262 pass)
- [x] `cargo test -p ff-test --test issue_204_tail_stream_no_hol` — GREEN test passes (XADD < 500ms with blocking tail on dedicated socket)
- [x] `#[ignore]` RED companion test manually verified to reproduce the pre-fix `timed out` stall
- [x] `cargo test -p ff-test -- --test-threads=1` — full suite passes serially (pre-existing parallel cross-test pollution on some tests; unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Valkey streaming behavior and restructures `ferriskey::Client`, which could impact connection lifecycle/resource usage and any downstream code relying on the previous client internals.
> 
> **Overview**
> Fixes a Valkey streaming regression where `tail_stream`’s blocking `XREAD BLOCK` could head-of-line-block concurrent writes on the same ferriskey multiplex.
> 
> `ValkeyBackend::tail_stream_impl` now dials a **dedicated** socket per tail call via new `ferriskey::Client::duplicate_connection()` (dropped on return), keeping `append_frame`/`XADD` and other non-blocking operations unaffected. ferriskey’s high-level `Client` is reshaped to retain its `ConnectionRequest` so it can spawn identical independent connections, and a new integration regression test (`issue_204_tail_stream_no_hol`) asserts writes complete quickly while a blocking tail is in flight; changelog updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fec1bc4305e5c85e07bf9a5c134b33b8882e398. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->