### PR TITLE
rfc(014): multi-signal resume conditions (draft)

### DIFF
--- a/rfcs/drafts/RFC-014-challenges/ACCEPTED.md
+++ b/rfcs/drafts/RFC-014-challenges/ACCEPTED.md
@@ -1,0 +1,85 @@
+# RFC-014 — Unanimous ACCEPT after 3 rounds
+
+**Status:** Unanimous ACCEPT from K (correctness), L (ergonomics), and
+M (implementation) as of round 3. Ready for owner adjudication.
+
+**Branch:** `rfc/014-multi-signal-resume`
+**PR:** #210 (open, not merged)
+**RFC:** `rfcs/drafts/RFC-014-multi-signal-resume.md`
+
+## Round-by-round
+
+| Round | K | L | M | Net design change |
+|---|---|---|---|---|
+| 1 | DISSENT (6 findings) | DISSENT (5 findings) | DISSENT (4 findings) | None — all findings were spec fill-ins, rationale, and ergonomic surface. |
+| 2 | DISSENT (3 consistency drifts from round-1 edits) | ACCEPT | DISSENT (2 plan/body drifts) | None — doc consistency only. |
+| 3 | ACCEPT | ACCEPT | ACCEPT | — |
+
+## Material changes from original draft
+
+### Added during debate
+
+- **§1.4** — Canonical worked examples for the three §1.1 patterns,
+  picking shared-waitpoint + `DistinctSources` as canonical for the
+  2-of-5 reviewer shape.
+- **§3.1.1** — Cleanup owners named explicitly (deliver/cancel/expire
+  Lua sites); integration tests to catch owner drift.
+- **§3.1.2** — Per-suspension key budget delta stated (before/after).
+- **§3.2** — Source-type-in-token rationale + Q1 closure; leaf-token
+  shape restated; node:<path> only for non-leaf children.
+- **§3.3 step 2.5** — Node-local matcher filter in the algorithm;
+  `is_single_leaf` guard to prevent redundant node-tokens for leaf
+  `Single` under `AllOf`.
+- **§3.3 header** — Parse is per-invocation only (Valkey Functions
+  are stateless).
+- **§4.4** — Operator-diagnostic JSON now includes `sources_by_type`
+  breakdown for `DistinctSources` count nodes.
+- **§4.5** — Resume payload: `closer_signal_id` + `all_satisfier_signals`.
+- **§5.1.1** — `EngineError::InvalidCondition { kind, detail: String }`.
+- **§5.2** — Two new effects (`signal_ignored_matcher_failed`,
+  `appended_to_waitpoint_duplicate`).
+- **§5.5** — Cap rationale (depth 4, size 8 KiB; both soft).
+- **§6.1 table row for `auto_resume_with_timeout_signal`** — Rewritten
+  to match the "timeout token is universal node-satisfier" paragraph
+  (removed the "consumer opt-in via matcher" contradiction).
+- **§6.1 "Timeout token form" paragraph** — `timeout:<suspension_id>`
+  single token; node-level short-circuit, not a distinct-count
+  increment.
+- **§6.2** — `SuspensionTimedOut { partial_satisfiers }` idiom with
+  worked `match` snippet.
+- **§8** — All three open questions closed.
+- **§10.2** — Integration test list expanded to cover Q1 closure,
+  matcher-based filtering, cleanup owners, timeout token form, resume
+  payload shape, and cluster co-location.
+- **§10.3** — Full builder API enumerated, including `all_of_waitpoints`
+  shorthand, `on_waitpoint`/`on_waitpoints` split, and
+  `DistinctWaitpoints` default behavior.
+- **§10.4** — Tracing bullet lists all three new effects.
+
+### Unchanged (core design)
+
+- The enum extension strategy (variants on RFC-013's `ResumeCondition`,
+  not a parallel `MultiSignalCondition`).
+- The three `CountKind` values (`DistinctWaitpoints` / `DistinctSignals`
+  / `DistinctSources`) — no `DistinctUserSources` added; user-only
+  quorum expressed via `Count.matcher`.
+- The flat `satisfied_set` SET + write-once `member_map` HASH storage
+  model (O(1) Valkey keys per suspension regardless of condition
+  complexity).
+- The O(depth ≤ 4) per-signal evaluation cost; no per-node SETs.
+- No new `timeout_behavior` value; no new `PartialCount` variant.
+- No new waitpoint-spec fields; topology stays at the `ResumeCondition`
+  layer.
+
+## Final SHA
+
+`0d2a389` (round-2 revisions) — round-3 ACCEPT commit TBD by the
+orchestrator close-out commit.
+
+## Constraints respected
+
+- RFC-013's outer `ResumeCondition` shape was never challenged —
+  RFC-014 stays within the forward-compat contract stated in §0.
+- All challenges cited concrete §N text.
+- Revisions were committed + pushed per round.
+- PR #210 remains open for owner adjudication.

--- a/rfcs/drafts/RFC-014-challenges/round-1/K.md
+++ b/rfcs/drafts/RFC-014-challenges/round-1/K.md
@@ -1,0 +1,152 @@
+# RFC-014 Round 1 — K (correctness) challenge
+
+**Verdict:** DISSENT
+
+I like the overall shape (nested enum + flat SET + path map). Four correctness
+concerns block ACCEPT; each has a concrete minimal change to flip my vote.
+
+## Per-section verdict
+
+| Section | Signal | Notes |
+|---|---|---|
+| §0 Forward-compat | GREEN | Contract with RFC-013 is stated precisely. |
+| §1 Motivation | GREEN | |
+| §2.1 Enum shape | YELLOW | `Count.matcher` scope under nesting is unspecified — see K-1. |
+| §2.2/2.3 Why / rejected | GREEN | |
+| §3.1 Storage | YELLOW | Two keys added but no mention of TTL / orphan cleanup on `expire` / `cancel` paths — see K-2. |
+| §3.2 Satisfier tokens | **RED** | `DistinctSources` token `src:<source_type>:<source_identity>` collapses the `source_type` axis in a way that breaks the §8 Q1 answer — see K-3. |
+| §3.3 Matching algorithm | **RED** | Step 3/4 ordering assumes the `SADD` for a child node precedes parent's `evaluate_node`, but a leaf `Single`'s satisfaction is recorded as `wp:<id>` while `AllOf.evaluate_node` (§3.3 last bullet) reads `node:<child_path>` — inconsistent token shape. See K-4. |
+| §3.4 Rationale | GREEN | |
+| §4.1 Idempotency | GREEN | Two-layer dedup (signal-level + token-level) is correctly separated. |
+| §4.2 AllOf re-fire | GREEN | |
+| §4.3 Durability | YELLOW | Claim "handle never caches counts" — but the *resume* path (`claim_resumed_execution`) needs to know WHICH signal crossed the threshold for the continuation's `resumed_with` payload. Not addressed. See K-5. |
+| §4.4 Diagnostic | GREEN | |
+| §5 Errors | GREEN | Suspend-time validation set is well-scoped. |
+| §6 Timeouts | YELLOW | "Synthetic timeout signal added to `satisfied_set`" — what token form? `timeout:<suspension_id>`? Unspecified; re-evaluation against `CountKind` is undefined. See K-6. |
+| §7 Wire | GREEN | Version tag is good. |
+| §8 Open questions | YELLOW | Q1 (system-source) is load-bearing for correctness; cannot ship Draft→Accepted with it open. |
+| §9 Alternatives | GREEN | |
+| §10 Plan | GREEN | |
+
+## Concerns with concrete fixes
+
+### K-1 — `Count.matcher` scope under nesting
+
+§2.1: `Count { matcher: Option<ConditionMatcher>, waitpoints, ... }`. If the
+`Count` is nested inside `AllOf`, does the matcher filter signals at delivery
+time (pre-SADD) or at evaluation time (post-SADD)? §3.3 pseudocode does not
+invoke `node.matcher` anywhere. Under the current text, a signal whose
+`waitpoint_id` is in `member_map` contributes a satisfier token regardless of
+the node's `matcher`.
+
+**Minimal fix:** insert a step 2.5 in §3.3 pseudocode:
+
+```
+-- 2.5 Apply the node's local matcher, if any.
+if node.matcher ~= nil and not match(signal, node.matcher) then
+    return {effect = "signal_ignored_matcher_failed"}
+end
+```
+
+And add `signal_ignored_matcher_failed` to §5.2.
+
+### K-2 — Orphan `satisfied_set` / `member_map` on `cancel` / `expire`
+
+§3.1 says "deleted on resume/cancel/timeout." Which key-owner deletes them?
+Lua `cancel_execution` (RFC-013) + `expire_suspension` must explicitly DEL both
+keys. Without a named owner, I expect leaks on the `expire` path specifically
+because that path runs on the expirer thread, not the resume thread.
+
+**Minimal fix:** add §3.1.1 naming the three deletion sites
+(`resume_execution`, `cancel_execution`, `expire_suspension`) and an
+integration test `expire_deletes_satisfied_set_and_member_map`.
+
+### K-3 — `DistinctSources` collapses `source_type` axis
+
+§3.2 token: `src:<source_type>:<source_identity>`. The SET lookup treats
+`src:user:alice` and `src:system:alice` as distinct, which is correct. But §8
+Q1 asks whether system-origin signals count toward a `DistinctSources(n)` — if
+the answer is "count, but note in operator tooling," then the token must
+include source_type (it does). But if the answer is "DistinctSources is
+user-scoped," the token SHOULD be `src:<source_identity>` alone and
+source_type="system" signals should be rejected before SADD. The RFC cannot
+ship with this still open because it determines the token format, which is a
+persisted wire-level artifact.
+
+**Minimal fix:** either
+
+(a) close Q1 as "system signals do count; source_type is part of token" —
+which the current token format implies — and remove Q1 from §8, OR
+
+(b) add a new `CountKind::DistinctUserSources` and keep `DistinctSources` as
+the permissive form, explicitly noting which kind the cairn 2-of-5 pattern
+maps to.
+
+My recommendation: (a). It matches §1.1 pattern 1 and is unambiguous.
+
+### K-4 — Token shape inconsistency at leaves
+
+§3.2: "For `AllOf` members, the token is always `wp:` form." §3.3 last
+bullet: "`AllOf.evaluate_node` satisfied iff every member's synthetic
+`node:<child_path>` ∈ `satisfied_set` (leaf `Single` children use `wp:<id>`)."
+These two statements are consistent but subtle; a Lua implementer reading §3.3
+alone would not know to special-case leaf `Single`.
+
+**Minimal fix:** restate as two rules in §3.3:
+
+```
+AllOf.evaluate_node(node):
+  for each member m at child_path:
+    if m is Single:
+      require wp:<m.waitpoint_id> in satisfied_set
+    else:
+      require node:<child_path> in satisfied_set
+```
+
+This also changes §3.3 step 4: the "SADD node:... if satisfied" emission is
+skipped for leaf `Single` nodes (their `wp:` token IS the satisfaction
+marker).
+
+### K-5 — Resume continuation: which signal "closed" a Count?
+
+RFC-004's `resumed_with` payload surfaces the signal that unblocked the
+suspension. For `Count(3)`, the "third" signal is the closer — but what about
+`AllOf { Count(3), Single }`? Three signals arrive to the Count (closing it);
+later the Single arrives (closing the root). The closer of the root is the
+Single. But a consumer reading `resumed_with` may want to see all three Count
+signals too. Currently undefined.
+
+**Minimal fix:** add §4.5 "Resume payload under multi-signal":
+
+- `resumed_with.closer_signal_id` = the signal that closed the root.
+- `resumed_with.all_satisfier_signals` = `list_waitpoint_signals` restricted
+  to signals whose tokens are in `satisfied_set` at close time.
+
+Consumer then knows both "who closed it" and "full satisfier set."
+
+### K-6 — Timeout token form + interaction with CountKind
+
+§6.1 says synthetic timeout signal enters `satisfied_set`. Token form?
+`timeout:<suspension_id>` is one token, but `Count(3, DistinctSources)` needs
+three distinct source tokens — one synthetic timeout token adds exactly 1 to
+the count. So `auto_resume_with_timeout_signal` on a `Count(3)` with 2
+satisfiers becomes 3 only if the synthetic timeout counts as a distinct
+source, which is semantically weird (timeout has no source_identity).
+
+**Minimal fix:** §6.1 must state:
+
+- Timeout token is `timeout:<suspension_id>` (one global token).
+- `Count` nodes treat the timeout token as satisfying the *node*, not adding
+  to the count. I.e., if `timeout:` ∈ `satisfied_set` AND
+  `timeout_behavior == auto_resume_with_timeout_signal`, node short-circuits
+  to satisfied regardless of `n`.
+- Consumers wanting "resume if ≥2 of 3 arrived" can inspect
+  `list_waitpoint_signals` on the resumed worker per §6.2.
+
+This keeps the token algebra clean and matches §6.2's stated position.
+
+## Flip-to-ACCEPT requirements
+
+All six (K-1 through K-6) must be addressed in revisions. K-3 (close Q1) and
+K-4 (token shape) and K-6 (timeout token) are the blocking ones; K-1, K-2,
+K-5 are correctness gaps but small.

--- a/rfcs/drafts/RFC-014-challenges/round-1/L.md
+++ b/rfcs/drafts/RFC-014-challenges/round-1/L.md
@@ -1,0 +1,159 @@
+# RFC-014 Round 1 — L (ergonomics) challenge
+
+**Verdict:** DISSENT
+
+The design is expressive, but expressiveness ≠ ergonomic. The 2-of-5
+reviewer pattern is the canonical cairn use case, and walking through it
+end-to-end with this RFC surfaces three ergonomic gaps. Each has a minimal
+fix.
+
+## Per-section verdict
+
+| Section | Signal | Notes |
+|---|---|---|
+| §0 Forward-compat | GREEN | |
+| §1.1 Motivation patterns | YELLOW | Pattern 1 (2-of-5 reviewers) is listed but no worked example is given — see L-1. |
+| §2.1 Enum shape | YELLOW | `waitpoints: Vec<WaitpointKey>` for 2-of-5 is repetitive — see L-2. |
+| §2.2/2.3 Rationale | GREEN | |
+| §3 Storage + algorithm | GREEN | Internal detail; consumer never sees it. |
+| §4 Idempotency | GREEN | |
+| §5 Errors | YELLOW | Error taxonomy is correct, but the *user-facing* message for `condition_depth_exceeded` doesn't tell the consumer what depth their condition was — see L-3. |
+| §6 Timeouts | YELLOW | §6.2 "write it as two sequential suspensions" is a non-answer. See L-4. |
+| §7 Wire | GREEN | |
+| §8 Open questions | YELLOW | Q3 is an ergonomic question, not resolved. |
+| §9 Alternatives | GREEN | |
+| §10.3 SDK ergonomics | **RED** | The Phase 3 builder sketch is too thin — reviewing it against the cairn 2-of-5 pattern shows the shape forces consumers into verbose construction. See L-5. |
+
+## Concerns with concrete fixes
+
+### L-1 — Worked example missing
+
+§1.1 lists patterns but doesn't show what code a consumer writes. For a
+design RFC this is tolerable, but "can it be expressed clearly" is literally
+my challenge question, and I cannot answer without the author's intended
+surface. I need to see:
+
+```rust
+// cairn: 2-of-5 reviewer approval
+let cond = ResumeCondition::count(2)
+    .distinct_sources()
+    .on_waitpoints([wp_review_alice, wp_review_bob, wp_review_carol,
+                    wp_review_dave, wp_review_eve]);
+```
+
+vs.
+
+```rust
+// cairn: 2-of-5 reviewer approval, single shared waitpoint
+let cond = ResumeCondition::count(2)
+    .distinct_sources()
+    .on_waitpoint(wp_reviewers);  // one waitpoint, 5 signals land on it
+```
+
+The RFC hints both are expressible but doesn't pick a canonical. Cairn
+operators reading this RFC will not know which to reach for.
+
+**Minimal fix:** add §1.4 "Canonical worked examples" covering the three
+§1.1 patterns with concrete pseudo-Rust using the §10 Phase 3 builder.
+
+### L-2 — Repetition in 2-of-5 with distinct waitpoints
+
+If the team adopts the "one waitpoint per reviewer" style, the consumer
+writes 5 `WaitpointSpec`s plus the `Count` list. Ergonomic pain point:
+creating a waitpoint per reviewer is a per-execution fan-out that may not
+even be known at suspend-time (reviewer list comes from policy).
+
+**Minimal fix:** pick one style as canonical in §1.4 and recommend the
+shared-waitpoint form for "N-of-M human reviewers where M comes from
+policy." Explicitly note: single waitpoint + `DistinctSources` is the
+preferred shape; multi-waitpoint + `DistinctWaitpoints` is for "heterogeneous
+subsystems must each report" (pattern 3).
+
+### L-3 — Error message fidelity
+
+§5.1 lists error kinds but not the payload shape. For a consumer hitting
+`condition_depth_exceeded`, "depth 5 > cap 4" is actionable;
+"condition_depth_exceeded" alone is not.
+
+**Minimal fix:** add §5.1.1:
+
+```rust
+EngineError::InvalidCondition {
+    kind: ConditionErrorKind,
+    detail: String,   // human-readable: "depth 5 exceeds cap 4 at path members[0].members[0].members[0]"
+}
+```
+
+Trivial, but the detail field is what cairn's error-surfacing code actually
+renders.
+
+### L-4 — §6.2 punts ergonomics to retry-handler
+
+Current §6.2: "if a consumer wants *condition-level* 'count(3) OR
+timeout-partial,' they must write it as two sequential suspensions." This
+is punt, not answer. The natural cairn pattern is "wait 30m for 2-of-5; if
+only 1 arrived, escalate to manager; if 2+ arrived, proceed." Two sequential
+suspensions means:
+
+1. Suspend `Count(2-of-5) timeout=30m behavior=fail`.
+2. Catch failure in worker code, inspect `list_waitpoint_signals`, decide.
+
+This works but forces try/catch around `suspend` for what a consumer reads
+as "main-path" logic.
+
+**Minimal fix:** keep the design (no new variant — I agree with §6.3's
+rejection) but document the idiom in §6.2 as:
+
+```rust
+match self.suspend(spec, cond_count_2_of_5, timeout_30m).await {
+    Ok(resume) => handle_full_quorum(resume),
+    Err(EngineError::SuspensionTimedOut { partial_satisfiers }) =>
+        handle_partial(partial_satisfiers),
+}
+```
+
+Requires `SuspensionTimedOut` to carry `partial_satisfiers` (tokens that
+DID land). That's an additive ergonomic change that unblocks the pattern
+without a new variant.
+
+### L-5 — Phase 3 builder sketch is too thin
+
+§10.3: "`ResumeCondition::all_of([...])`, `ResumeCondition::count(n).distinct_sources().on_waitpoints([...])`."
+
+Review against the three canonical patterns from §1.1:
+
+- Pattern 1 (2-of-5): builder works cleanly.
+- Pattern 2 (N callbacks from webhook): `count(n).distinct_signals().on_waitpoint(wp)`? The sketch doesn't show the signal-mode variant.
+- Pattern 3 (all-of distinct event types): `all_of([Single::of(wp1), Single::of(wp2), Single::of(wp3)])` is verbose. A shorthand `all_of_waitpoints([wp1, wp2, wp3])` saves ten characters × every consumer.
+
+**Minimal fix:** §10.3 must enumerate the builder API explicitly, not
+sketch it. At minimum:
+
+```rust
+impl ResumeCondition {
+    pub fn single(wp: WaitpointKey, matcher: ConditionMatcher) -> Self;
+    pub fn all_of(members: impl IntoIterator<Item = ResumeCondition>) -> Self;
+    pub fn all_of_waitpoints(wps: impl IntoIterator<Item = WaitpointKey>) -> Self; // shorthand
+    pub fn count(n: u32) -> CountBuilder;
+}
+
+impl CountBuilder {
+    pub fn distinct_waitpoints(self) -> Self;
+    pub fn distinct_signals(self) -> Self;
+    pub fn distinct_sources(self) -> Self;
+    pub fn with_matcher(self, m: ConditionMatcher) -> Self;
+    pub fn on_waitpoints(self, wps: impl IntoIterator<Item = WaitpointKey>) -> ResumeCondition;
+    pub fn on_waitpoint(self, wp: WaitpointKey) -> ResumeCondition; // shorthand for single
+}
+```
+
+Doctests for the three §1.1 patterns each.
+
+## Flip-to-ACCEPT requirements
+
+- L-1 + L-5 merged: add §1.4 worked examples AND expand §10.3 with the
+  builder surface. These are the same ergonomic gap and must be closed
+  together.
+- L-2: pick a canonical style for the 2-of-5 pattern.
+- L-3: specify `detail: String` on the error.
+- L-4: add the `SuspensionTimedOut { partial_satisfiers }` idiom to §6.2.

--- a/rfcs/drafts/RFC-014-challenges/round-1/M.md
+++ b/rfcs/drafts/RFC-014-challenges/round-1/M.md
@@ -1,0 +1,119 @@
+# RFC-014 Round 1 — M (implementation) challenge
+
+**Verdict:** DISSENT
+
+The storage model is reasonable. The per-signal re-evaluation cost is
+bounded. But three implementation costs are underspecified in ways that
+will either drift at implementation time or force a follow-up RFC. Fix
+those in-doc and I flip to ACCEPT.
+
+## Per-section verdict
+
+| Section | Signal | Notes |
+|---|---|---|
+| §0 Forward-compat | GREEN | |
+| §1 Motivation | GREEN | |
+| §2.1 Enum shape | GREEN | Wire size bounded by §5.1 8 KiB cap — good. |
+| §3.1 Storage | YELLOW | Two keys per suspension is fine; key-count budget not stated — see M-1. |
+| §3.2 Satisfier tokens | GREEN | String tokens are Valkey-native (SET members), no serialization overhead. |
+| §3.3 Algorithm | YELLOW | `parse_resume_condition` — is this re-parsed on every signal, or cached in Function-scope? §3.3 says "cached" but doesn't say what happens on Function reload. See M-2. |
+| §3.4 Rationale | GREEN | |
+| §4 Idempotency | GREEN | |
+| §5.1 Error table | YELLOW | Depth cap = 4 and size cap = 8 KiB are asserted but not justified by measurement — see M-3. |
+| §6 Timeouts | GREEN | |
+| §7.1 `WaitpointSpec` unchanged | GREEN | Good — keeps the existing shape. |
+| §7.2 Serde version tag | GREEN | |
+| §8 Open questions | GREEN | |
+| §9 Alternatives | GREEN | |
+| §10 Plan | **RED** | Phase 2 integration tests omit Valkey-cluster / hash-slot co-location tests. See M-4. |
+
+## Concerns with concrete fixes
+
+### M-1 — Per-suspension key budget not stated
+
+RFC-010 tracks a per-suspension key budget. Today a suspension owns
+`suspension:current` (HASH) and waitpoint-list keys. RFC-014 adds
+`satisfied_set` (SET) and `member_map` (HASH). §3.1 says "+2 keys per
+suspension regardless of condition complexity" but doesn't roll up the total
+or confirm the cluster-shard impact.
+
+**Minimal fix:** add §3.1.2 "Key budget impact":
+
+- Before RFC-014: suspension owns {current HASH, waitpoints ZSET}.
+- After RFC-014: suspension owns {current HASH, waitpoints ZSET,
+  satisfied_set SET, member_map HASH}.
+- All keys share the `{p:N}:<execution_id>` hash-tag → same shard, same
+  Function call.
+- Impact on `ff_suspension_key_count` metric (if one exists) — state
+  whether the metric name is stable.
+
+This is two sentences; the reader-confidence payoff is high.
+
+### M-2 — Function-scope parse cache
+
+§3.3: "Load condition topology (parsed once, cached in function-scope
+table)." Function-scope == per-Valkey-Function-invocation or per-execution?
+Valkey Functions are stateless across calls; "cached" must mean within the
+single `deliver_signal` call. If the author means cross-call caching,
+that's a cluster correctness bug (different shard → different cache).
+
+**Minimal fix:** clarify §3.3 line 1 to: "Parse `resume_condition_json`
+locally inside this `deliver_signal` invocation. No cross-call caching —
+Valkey Functions are stateless across invocations."
+
+Parse cost is O(condition size) ≤ O(8 KiB) per signal. At depth 4 and
+typical condition size < 1 KiB, this is well within budget.
+
+### M-3 — Depth cap 4 and size cap 8 KiB are unjustified
+
+§5.1: depth > 4 rejected, size > 8 KiB rejected. Where do 4 and 8 KiB come
+from? Reasoning I can reconstruct:
+
+- depth 4 → O(depth) walk per signal = 4 node evaluations. Fine.
+- 8 KiB → roughly 200 nested `Single`s or 40 `Count`s with 5 waitpoints
+  each. Above real need, below ARGV limits.
+
+But these are asserted caps without trace. If a future consumer hits them,
+we're in "lift the cap" territory without understanding why it was set.
+
+**Minimal fix:** add §5.5 "Cap rationale":
+
+- Depth 4 = max realistic compositional depth (§8 Q2 notes consumers have
+  not presented > 2). 4 gives 2× headroom.
+- Size 8 KiB = 10% of Valkey's 64 KiB ARGV soft limit per parameter, leaves
+  headroom for other ARGV fields in the same `suspend_execution` call.
+- Both caps are soft: bumping either requires only a validator constant
+  change, not a wire-format change.
+
+Named so the next person who wants to lift them knows what they're
+trading.
+
+### M-4 — Cluster / hash-slot tests missing from Phase 2
+
+§10.2 lists integration tests. None assert Valkey-cluster behavior
+specifically. RFC-014 adds two keys that MUST co-locate with
+`suspension:current` via hash-tag. If the tag derivation drifts (see past
+hash-tag-drift bugs on this project), signals cross-shard and Lua fails
+with `CROSSSLOT`.
+
+**Minimal fix:** add to §10.2 integration test list:
+
+- `satisfied_set_colocated_with_suspension_in_cluster_mode` — asserts both
+  new keys hash to the same slot as `suspension:current` under
+  `valkey-cluster` topology.
+- `member_map_colocated_with_suspension_in_cluster_mode` — same for
+  `member_map`.
+
+These belong in `crates/ff-backend-valkey/tests/cluster/`. This is the
+same class of test RFC-012 added for the flow/exec co-location and
+caught drift early. RFC-014 inherits the pattern.
+
+## Flip-to-ACCEPT requirements
+
+- M-1: state the key budget delta.
+- M-2: clarify "cached" means within-call only.
+- M-3: add §5.5 cap rationale.
+- M-4: add cluster co-location tests to §10.2.
+
+All are doc-only; no design changes. If the author makes these edits I
+ACCEPT.

--- a/rfcs/drafts/RFC-014-challenges/round-1/author-response.md
+++ b/rfcs/drafts/RFC-014-challenges/round-1/author-response.md
@@ -1,0 +1,42 @@
+# RFC-014 Round 1 — author response
+
+Three DISSENTs (K, L, M). All findings are concede-worthy; none of them
+dispute the core enum shape, storage model, or matching algorithm. The
+revisions are either (a) spelling out invariants the author held in head
+but not on page, or (b) minor ergonomic surface additions.
+
+## Disposition
+
+| Finding | Disposition | Location |
+|---|---|---|
+| K-1 matcher scope under nesting | CONCEDE — added step 2.5 to §3.3 pseudocode; added `signal_ignored_matcher_failed` to §5.2. |
+| K-2 orphan cleanup owners | CONCEDE — added §3.1.1 naming three Lua sites; added `expire_` and `cancel_delete_...` integration tests to §10.2. |
+| K-3 DistinctSources Q1 | CONCEDE — closed Q1 in §8 as "system sources count; source_type is part of token"; moved rationale into §3.2; added `count_2_distinct_sources_counts_system_signal` + `count_matcher_filters_user_only_sources` tests. No new `DistinctUserSources` variant (matcher-based filtering is enough). |
+| K-4 leaf token shape | CONCEDE — restated `evaluate_node` rule explicitly with `m is Single` vs non-`Single` branches; added `is_single_leaf` guard in §3.3 step 4 so leaf `Single`s don't emit redundant `node:` tokens. |
+| K-5 resume payload | CONCEDE — added §4.5 with `closer_signal_id` + `all_satisfier_signals`; added `resume_payload_exposes_...` test. |
+| K-6 timeout token form | CONCEDE — specified token is `timeout:<suspension_id>`, treated as a node-level short-circuit (not a distinct-count increment); added `timeout_token_short_circuits_count_node` test. |
+| L-1 worked examples | CONCEDE — added §1.4 with concrete builder-form for all three §1.1 patterns. |
+| L-2 canonical 2-of-5 style | CONCEDE — §1.4 picks shared waitpoint + `DistinctSources` as canonical for N-of-M-reviewers; multi-waitpoint is canonical for heterogeneous-subsystem pattern 3. |
+| L-3 error detail field | CONCEDE — added §5.1.1 with `EngineError::InvalidCondition { kind, detail: String }`. |
+| L-4 timeout-partial idiom | CONCEDE — §6.2 now shows the `SuspensionTimedOut { partial_satisfiers }` match idiom; no new variant, additive error field. |
+| L-5 builder API fully specified | CONCEDE — §10.3 now enumerates the full `CountBuilder` + `ResumeCondition` builder surface including `all_of_waitpoints` shorthand and `on_waitpoint`/`on_waitpoints` split. |
+| M-1 key budget | CONCEDE — added §3.1.2 naming the before/after key set and hash-tag co-location. |
+| M-2 parse-scope clarity | CONCEDE — §3.3 first line now explicit: "per-invocation only, no cross-call cache." |
+| M-3 cap rationale | CONCEDE — added §5.5 justifying depth 4 and size 8 KiB with headroom math and "both caps are soft" note. |
+| M-4 cluster co-location tests | CONCEDE — added two cluster-mode tests in `crates/ff-backend-valkey/tests/cluster/`. |
+
+## No arguments back
+
+Nothing to push back on in round-1. All findings improve the RFC without
+compromising the core design. If reviewers want to argue against the
+shape (the enum extension vs parallel type, the SET+HASH vs nested
+storage, the node-level timeout short-circuit vs a new `PartialCount`
+variant), that fight belongs in round 2 — but §9 already argues against
+each alternative and none of K/L/M disputed those.
+
+## Changes to core design
+
+None. The enum shape (§2.1), storage model (§3.1), matching algorithm
+(§3.3), and timeout composition (§6) are unchanged in structure.
+Everything else is clarifications, rationale, cleanup owners, tests, and
+builder surface.

--- a/rfcs/drafts/RFC-014-challenges/round-2/K.md
+++ b/rfcs/drafts/RFC-014-challenges/round-2/K.md
@@ -1,0 +1,96 @@
+# RFC-014 Round 2 — K (correctness) challenge
+
+**Verdict:** DISSENT (two residual correctness inconsistencies introduced
+by round-1 edits; both small, both blocking).
+
+Round-1 revisions addressed all six of my correctness findings. I audited
+the revised RFC top-to-bottom for (a) regressions introduced by the
+edits and (b) anything I missed the first time. Two real issues.
+
+## Per-section verdict
+
+| Section | Signal | Notes |
+|---|---|---|
+| §0 Forward-compat | GREEN | Unchanged, still good. |
+| §1.1–1.4 | GREEN | §1.4 canonical examples close L-1; correctness-wise clean. |
+| §2 Enum | GREEN | |
+| §3.1 + 3.1.1 + 3.1.2 | GREEN | Cleanup owners + key budget closed K-2 / M-1. |
+| §3.2 | GREEN | Source-type-in-token closed K-3; leaf-token paragraph closed K-4. |
+| §3.3 | GREEN | Step 2.5 closed K-1; `is_single_leaf` guard closed K-4. |
+| §4.1–4.2 | GREEN | |
+| §4.3 | GREEN | |
+| §4.4 | YELLOW | Narrative says output "includes per-DistinctSources source_type breakdowns" but the JSON example at §4.4 lines 365–373 doesn't show one. Consumer implementing against the example will miss it. See K-R2-1. |
+| §4.5 | GREEN | Closed K-5. |
+| §5.1 + 5.1.1 | GREEN | `detail: String` closed L-3. |
+| §5.2 | YELLOW | Missing entry for `appended_to_waitpoint_duplicate`. It's referenced in §3.3 pseudocode and §4.2 but not in the §5.2 effect table. See K-R2-2. |
+| §5.3–5.5 | GREEN | |
+| §6.1 | **RED** | The `timeout_behavior` table row for `auto_resume_with_timeout_signal` (line 493) says "If the condition treats the timeout token as satisfying (consumer opt-in via matcher, §6.2), resumes. Otherwise falls through to fail." The paragraph that follows (lines 500–514, the round-1 addition) contradicts this: "A `Count { n, kind }` node that sees the timeout token short-circuits to satisfied ... it does NOT increment the distinct-satisfier count. ... The short-circuit fires only when `timeout_behavior == auto_resume_with_timeout_signal`." Either it's consumer-opt-in-via-matcher OR unconditional-node-short-circuit — can't be both. A reader will not know which is authoritative. See K-R2-3. |
+| §6.2–6.3 | GREEN | |
+| §7–10 | GREEN | |
+
+## Residual concerns
+
+### K-R2-1 — §4.4 JSON example missing source_type breakdown
+
+The text after the JSON block says source_type breakdowns are included.
+The JSON block doesn't show one. Consumers implement against examples
+before they read surrounding prose.
+
+**Minimal fix:** update the JSON example in §4.4 to show a
+`DistinctSources` node with the breakdown field:
+
+```json
+{ "path": "members[0]", "kind": "Count(2-of-3, DistinctSources)",
+  "satisfied": false, "sources_by_type": { "user": 1, "system": 0 } }
+```
+
+### K-R2-2 — `appended_to_waitpoint_duplicate` missing from §5.2
+
+Round-1's §3.3 pseudocode returns `appended_to_waitpoint_duplicate` when
+SADD returns 0 (token already present). §4.2 references it by name. §5.2
+("Late-detection at signal delivery") does NOT list it. Either it's an
+effect or it's an error — and the RFC text treats it as an effect, but
+the §5.2 table is the authoritative effect enumeration.
+
+**Minimal fix:** add a row to §5.2:
+
+| `appended_to_waitpoint_duplicate` (existing, clarified by RFC-014) | Signal matches a satisfier token already in `satisfied_set`. Signal is recorded on the waitpoint's signal list; no re-evaluation. Pre-existing RFC-005 effect extended to token-level dedup per §4.1. |
+
+### K-R2-3 — §6.1 table row contradicts the round-1 clarification
+
+Line 493 (table): `auto_resume_with_timeout_signal` → "If the condition
+treats the timeout token as satisfying (consumer opt-in via matcher,
+§6.2), resumes. Otherwise falls through to fail."
+
+Lines 500–514 (round-1 addition): "A `Count { n, kind }` node that sees
+the timeout token short-circuits to satisfied ... The short-circuit
+fires only when `timeout_behavior == auto_resume_with_timeout_signal`."
+
+The table says "opt-in via matcher." The paragraph says "unconditional
+short-circuit when the behavior is set." These are incompatible
+descriptions of the same thing.
+
+Correct semantics (inferable from §6.2–6.3 which reject a `PartialCount`
+variant and push application-level logic to the worker): the
+`auto_resume_with_timeout_signal` behavior unconditionally resumes with
+the synthetic timeout token added; the worker decides on the resumed
+side. There is no "consumer opt-in via matcher" — the matcher is on the
+`Count`, and a timeout token has no source_identity for the matcher to
+test.
+
+**Minimal fix:** rewrite the §6.1 table row for
+`auto_resume_with_timeout_signal`:
+
+| `auto_resume_with_timeout_signal` | Synthetic timeout token `timeout:<suspension_id>` added to `satisfied_set`. Root condition is treated as satisfied (the timeout token is a universal node-satisfier; see paragraph below). Execution resumes. The worker inspects `list_waitpoint_signals` and `all_satisfier_signals` (§4.5) to branch on "was this timeout-induced or full-quorum" per §6.2. |
+
+This matches the round-1 paragraph and removes the contradiction.
+
+## Flip-to-ACCEPT requirements
+
+- K-R2-1: update §4.4 JSON example to show source_type breakdown.
+- K-R2-2: add `appended_to_waitpoint_duplicate` row to §5.2.
+- K-R2-3: rewrite `auto_resume_with_timeout_signal` row in §6.1 table
+  to match the round-1 clarification; drop the "consumer opt-in via
+  matcher" phrasing.
+
+All three are doc consistency fixes. No design change.

--- a/rfcs/drafts/RFC-014-challenges/round-2/L.md
+++ b/rfcs/drafts/RFC-014-challenges/round-2/L.md
@@ -1,0 +1,50 @@
+# RFC-014 Round 2 — L (ergonomics) challenge
+
+**Verdict:** ACCEPT (with one note that does not block).
+
+All five round-1 ergonomic findings were addressed directly:
+
+| Finding | Round-2 verdict |
+|---|---|
+| L-1 worked examples | §1.4 covers the three patterns concretely. Clear which is canonical. |
+| L-2 canonical 2-of-5 style | §1.4 picks shared-waitpoint + `DistinctSources` unambiguously. |
+| L-3 error detail | §5.1.1 adds `detail: String`. |
+| L-4 timeout-partial idiom | §6.2 adds the `SuspensionTimedOut { partial_satisfiers }` match idiom. |
+| L-5 builder surface | §10.3 enumerates the full `ResumeCondition` + `CountBuilder` API. |
+
+## Per-section verdict
+
+| Section | Signal |
+|---|---|
+| §1 including §1.4 | GREEN |
+| §2 | GREEN |
+| §3 | GREEN (ergonomically — internal) |
+| §4 | GREEN |
+| §5 | GREEN |
+| §6 | GREEN (idiom documented) |
+| §7 | GREEN |
+| §8 | GREEN (all Qs closed) |
+| §9 | GREEN |
+| §10 | GREEN |
+
+## One non-blocking note
+
+**§10.3 `CountBuilder` has no compile-time guarantee that a `CountKind`
+was chosen before `on_waitpoint(s)`.** Calling `ResumeCondition::count(2).on_waitpoint(wp)`
+with no `.distinct_sources()` / `.distinct_signals()` / `.distinct_waitpoints()`
+will either silently default or runtime-error. The RFC doesn't say
+which. Typed-state builders could make this a compile error. Not a
+blocker because: (a) the RFC is about condition semantics, not SDK
+type-level proof; (b) a runtime default to `DistinctWaitpoints` matches
+the existing `satisfier_token` fallback in §3.3 (`node.kind or
+"DistinctWaitpoints"`); (c) doctests in Phase 3 will expose the default
+behavior quickly.
+
+If the author wants to address this as a drive-by: state in §10.3 that
+`CountBuilder::on_waitpoint(s)` with no kind set defaults to
+`DistinctWaitpoints` (single-waitpoint + DistinctWaitpoints = classic
+single-signal satisfied-once semantics). Two lines of text.
+
+I do not require this for ACCEPT.
+
+## ACCEPT

--- a/rfcs/drafts/RFC-014-challenges/round-2/M.md
+++ b/rfcs/drafts/RFC-014-challenges/round-2/M.md
@@ -1,0 +1,61 @@
+# RFC-014 Round 2 — M (implementation) challenge
+
+**Verdict:** DISSENT (one small implementation-plan gap).
+
+All four round-1 findings are addressed. One residual that surfaced when
+I re-read the full plan top-to-bottom.
+
+## Per-section verdict
+
+| Section | Signal |
+|---|---|
+| §0–3 | GREEN |
+| §3.1.2 key budget | GREEN — closed M-1. |
+| §3.3 parse-scope | GREEN — closed M-2. |
+| §5.5 cap rationale | GREEN — closed M-3. |
+| §10.2 cluster tests | GREEN — closed M-4. |
+| §4 | GREEN |
+| §5 | GREEN |
+| §6 | GREEN |
+| §7 | GREEN |
+| §8 | GREEN |
+| §9 | GREEN |
+| §10.1 Phase 1 | **YELLOW** | Phase-1 exit text at line 666 names `EngineError::InvalidCondition { kind }` without the `detail: String` field that §5.1.1 (round-1 addition) requires. Inconsistent. See M-R2-1. |
+| §10.4 Phase 4 tracing bullet | YELLOW | The tracing bullet at line 751 lists `appended_to_waitpoint_duplicate` and `signal_ignored_not_in_condition` as the effects to trace, but `signal_ignored_matcher_failed` (added in round 1 §3.3 step 2.5 + §5.2) is omitted. Operator won't see matcher-rejection traces. See M-R2-2. |
+
+## Residual concerns
+
+### M-R2-1 — Phase-1 exit enum shape drifted from §5.1.1
+
+Line 666:
+
+> Add suspend-time validators (§5.1) returning `EngineError::InvalidCondition { kind }` variants.
+
+§5.1.1 defines `InvalidCondition { kind, detail: String }`. Phase-1
+implementer reading the exit bullet as spec will ship the one-field
+form. Then Phase 3 doctests (which render `detail`) won't compile.
+
+**Minimal fix:** update line 666 to match §5.1.1 exactly:
+
+> Add suspend-time validators (§5.1) returning `EngineError::InvalidCondition { kind, detail }` per §5.1.1.
+
+### M-R2-2 — Phase-4 tracing bullet omits `signal_ignored_matcher_failed`
+
+Line 751:
+
+> Tracing: per-signal log of `effect` including new `appended_to_waitpoint_duplicate` and `signal_ignored_not_in_condition`.
+
+`signal_ignored_matcher_failed` (from round-1 §3.3 step 2.5) is a new
+effect too, and it's specifically the one that operator-facing tooling
+needs visibility on: a matcher-rejected signal looks "lost" otherwise.
+
+**Minimal fix:** update line 751:
+
+> Tracing: per-signal log of `effect` including new `appended_to_waitpoint_duplicate`, `signal_ignored_not_in_condition`, and `signal_ignored_matcher_failed`.
+
+## Flip-to-ACCEPT requirements
+
+- M-R2-1: align Phase-1 exit text with §5.1.1's `InvalidCondition { kind, detail }` shape.
+- M-R2-2: add `signal_ignored_matcher_failed` to the Phase-4 tracing bullet.
+
+Both are one-line edits. No design change.

--- a/rfcs/drafts/RFC-014-challenges/round-2/author-response.md
+++ b/rfcs/drafts/RFC-014-challenges/round-2/author-response.md
@@ -1,0 +1,26 @@
+# RFC-014 Round 2 — author response
+
+L: ACCEPT. K and M: DISSENT on small doc-consistency gaps introduced by
+round-1 edits (two contradictions + two cross-reference drifts). All
+concede-worthy.
+
+## Disposition
+
+| Finding | Disposition |
+|---|---|
+| K-R2-1 §4.4 JSON example missing source_type breakdown | CONCEDE — JSON example updated to show `sources_by_type: { "user": 1, "system": 1 }` on the Count node; explanatory line added. |
+| K-R2-2 `appended_to_waitpoint_duplicate` missing from §5.2 | CONCEDE — added as a new row in §5.2 with the AllOf-re-fire case explicit. |
+| K-R2-3 §6.1 table / paragraph contradiction on `auto_resume_with_timeout_signal` | CONCEDE — rewrote the table row to match the round-1 paragraph (unconditional node-satisfier short-circuit; no "consumer opt-in via matcher"). The table and the paragraph now agree. |
+| L non-blocking: `CountKind` default | CONCEDE (drive-by) — §10.3 now specifies `DistinctWaitpoints` as the default when no kind selector is called, with rationale. |
+| M-R2-1 Phase-1 exit enum shape drift | CONCEDE — Phase-1 bullet now says `InvalidCondition { kind, detail }` per §5.1.1. |
+| M-R2-2 Phase-4 tracing bullet missing `signal_ignored_matcher_failed` | CONCEDE — added to the tracing bullet. |
+
+## No arguments back
+
+All six findings are consistency drift from round-1 edits. Nothing to
+defend.
+
+## Changes to core design
+
+None. All edits are §4.4 example, §5.2 table, §6.1 table, §10.1 exit
+bullet, §10.3 default-kind note, §10.4 tracing bullet. Text-only.

--- a/rfcs/drafts/RFC-014-challenges/round-3/K.md
+++ b/rfcs/drafts/RFC-014-challenges/round-3/K.md
@@ -1,0 +1,39 @@
+# RFC-014 Round 3 — K (correctness) challenge
+
+**Verdict:** ACCEPT
+
+Round-2 revisions closed all three residual correctness findings (K-R2-1
+JSON example, K-R2-2 §5.2 dedup row, K-R2-3 timeout-table contradiction).
+I re-audited §§2–7 end-to-end after the edits and found no further
+correctness gaps.
+
+## Per-section verdict (final)
+
+| Section | Signal |
+|---|---|
+| §0 Forward-compat | GREEN |
+| §1 Motivation + §1.4 | GREEN |
+| §2 Enum shape | GREEN |
+| §3.1 + 3.1.1 + 3.1.2 storage + cleanup + budget | GREEN |
+| §3.2 satisfier tokens (Q1 closed; leaf rule clear) | GREEN |
+| §3.3 algorithm (matcher step, single-leaf guard) | GREEN |
+| §3.4 rationale | GREEN |
+| §4.1 two-layer dedup | GREEN |
+| §4.2 AllOf re-fire | GREEN |
+| §4.3 durability | GREEN |
+| §4.4 diagnostic (JSON now shows source_type) | GREEN |
+| §4.5 resume payload | GREEN |
+| §5.1 + 5.1.1 error shape | GREEN |
+| §5.2 effects (dedup row present) | GREEN |
+| §5.3 early-detection rationale | GREEN |
+| §5.4 invariants | GREEN |
+| §5.5 cap rationale | GREEN |
+| §6.1 timeout (table + paragraph consistent) | GREEN |
+| §6.2 partial-count idiom | GREEN |
+| §6.3 PartialCount rejection | GREEN |
+| §7 wire / interactions | GREEN |
+
+## ACCEPT
+
+No correctness concerns remain. The RFC is ready for owner adjudication
+from a correctness standpoint.

--- a/rfcs/drafts/RFC-014-challenges/round-3/L.md
+++ b/rfcs/drafts/RFC-014-challenges/round-3/L.md
@@ -1,0 +1,25 @@
+# RFC-014 Round 3 — L (ergonomics) challenge
+
+**Verdict:** ACCEPT
+
+I ACCEPTed in round 2; re-confirming after the round-2 edits. The
+drive-by addition of `CountKind` default to §10.3 closes the only
+non-blocking note I raised.
+
+## Per-section verdict (final)
+
+All GREEN. Specifically:
+
+- §1.4 canonical worked examples for all three §1.1 patterns — clear
+  which is canonical for each use case.
+- §5.1.1 `detail: String` on `InvalidCondition` — consumer error-surfacing
+  renders actionable messages.
+- §6.2 `SuspensionTimedOut { partial_satisfiers }` idiom documented with
+  worked `match` snippet.
+- §10.3 full `ResumeCondition` + `CountBuilder` API enumerated, including
+  `all_of_waitpoints` + `on_waitpoint`/`on_waitpoints` split and the
+  `DistinctWaitpoints` default behavior.
+
+## ACCEPT
+
+Nothing further to argue.

--- a/rfcs/drafts/RFC-014-challenges/round-3/M.md
+++ b/rfcs/drafts/RFC-014-challenges/round-3/M.md
@@ -1,0 +1,23 @@
+# RFC-014 Round 3 — M (implementation) challenge
+
+**Verdict:** ACCEPT
+
+Round-2 revisions closed M-R2-1 (Phase-1 exit text now names
+`InvalidCondition { kind, detail }`) and M-R2-2 (Phase-4 tracing bullet
+now lists `signal_ignored_matcher_failed`). Re-audit §10 end-to-end
+surfaces no remaining drift between the phased plan and the
+body-of-RFC specifications.
+
+## Per-section verdict (final)
+
+| Section | Signal |
+|---|---|
+| §10.1 Phase 1 | GREEN — exit text matches §5.1.1. |
+| §10.2 Phase 2 | GREEN — integration tests cover Q1 closure, matcher filtering, cleanup owners, timeout token form, resume payload shape, cluster co-location. |
+| §10.3 Phase 3 | GREEN — full builder API + default-kind note. |
+| §10.4 Phase 4 | GREEN — tracing covers all three new effects. |
+| §10.5 Non-goals | GREEN — consistent with §§3, 7. |
+
+## ACCEPT
+
+Implementation plan is ready to execute once RFC-013 lands.

--- a/rfcs/drafts/RFC-014-multi-signal-resume.md
+++ b/rfcs/drafts/RFC-014-multi-signal-resume.md
@@ -367,11 +367,18 @@ RFC-005 §323 defines `evaluate_resume_conditions(execution_id)` as an operator 
   satisfied_set: [...tokens],
   nodes: [
     { path: "", kind: "AllOf", satisfied: false, remaining_members: 1 },
-    { path: "members[0]", kind: "Count(2-of-3)", satisfied: true  },
+    { path: "members[0]", kind: "Count(2-of-3, DistinctSources)",
+      satisfied: true,
+      sources_by_type: { "user": 1, "system": 1 } },
     { path: "members[1]", kind: "Single", satisfied: false }
   ]
 }
 ```
+
+`sources_by_type` is populated only on `Count` nodes with
+`kind = DistinctSources`; it maps `source_type` → count of distinct
+satisfier tokens of that type currently in `satisfied_set` under this
+node.
 
 This is Class C (derived/read-only). No state transitions from this call.
 
@@ -437,6 +444,7 @@ code (e.g. cairn's reviewer panel) renders the `detail` string verbatim.
 | `invalid_resume_condition` (RFC-004 §412) | Extended: also fires if `resume_condition_json` fails to parse in Lua at suspend (catch-all). |
 | `signal_ignored_not_in_condition` (new) | Signal delivered to a waitpoint whose `waitpoint_id` is not in `member_map`. Signal is recorded, no satisfaction attempted. Returns this effect for observability. |
 | `signal_ignored_matcher_failed` (new) | Signal delivered to a waitpoint whose `waitpoint_id` IS in `member_map`, but the local node's `Count.matcher` (§2.1) rejects it. Signal is recorded on the waitpoint's signal list (RFC-005 semantics) but does not contribute a satisfier token. |
+| `appended_to_waitpoint_duplicate` (existing, clarified by RFC-014) | Signal matches a satisfier token already in `satisfied_set` (idempotent re-delivery, or `AllOf` member re-firing after root satisfaction). Signal is recorded on the waitpoint's signal list; no re-evaluation. Extends the pre-existing RFC-005 effect to cover token-level dedup per §4.1. |
 
 ### 5.3 Why early detection for `count_exceeds_waitpoint_set`
 
@@ -490,7 +498,7 @@ The `timeout_behavior` values (from RFC-004 §254) already support this:
 | `timeout_behavior` | Effect on partially-satisfied multi-signal condition |
 |---|---|
 | `fail` | Execution transitions to terminal failure regardless of partial satisfaction. (Most strict.) |
-| `auto_resume_with_timeout_signal` | Synthetic timeout token added to `satisfied_set`. Condition re-evaluated. If the condition treats the timeout token as satisfying (consumer opt-in via matcher, §6.2), resumes. Otherwise falls through to `fail`. |
+| `auto_resume_with_timeout_signal` | Synthetic timeout token `timeout:<suspension_id>` added to `satisfied_set`. Root condition is treated as satisfied (the timeout token is a universal node-satisfier — see the "Timeout token form" paragraph below). Execution resumes. The resumed worker inspects `list_waitpoint_signals` and `all_satisfier_signals` (§4.5) to branch on "was this timeout-induced or full-quorum" per §6.2. |
 | `cancel` | Execution cancels; no partial work propagated. |
 | `expire` | Suspension expires; execution state is what RFC-004 defines. |
 | `escalate` | Operator-notified, no auto-advance. |
@@ -663,7 +671,7 @@ None of these are blockers for multi-signal resume. Multi-signal works with v1's
 **Crates touched:** `ff-core` (types), `ff-sdk` (wire), `ff-backend-valkey` (argv build).
 
 - Add `AllOf` + `Count` variants + `CountKind` enum to `ResumeCondition`.
-- Add suspend-time validators (§5.1) returning `EngineError::InvalidCondition { kind }` variants.
+- Add suspend-time validators (§5.1) returning `EngineError::InvalidCondition { kind, detail }` per §5.1.1.
 - Wire-level serde with `v: 1` version tag (§7.2).
 - Unit tests: validator rejects impossible conditions; serde roundtrip; nesting depth bound.
 
@@ -736,6 +744,17 @@ impl CountBuilder {
 }
 ```
 
+**`CountKind` default.** If a `CountBuilder` reaches `on_waitpoint(s)`
+without any of `.distinct_waitpoints()` / `.distinct_signals()` /
+`.distinct_sources()` being called, the kind defaults to
+`DistinctWaitpoints`. Rationale: with a single waitpoint, this default
+reduces to classic single-signal satisfied-once semantics (one satisfier
+token, SADD dedups); with multiple waitpoints it yields
+"one-per-distinct-waitpoint," which is the least-surprising behavior.
+Consumers who want distinct-signal or distinct-source quorum must call
+the kind selector explicitly. Doctests cover both the default and each
+explicit kind.
+
 - Doc tests in `ff-sdk/src/suspend.rs` covering each §1.4 canonical
   pattern: 2-of-5 reviewers (shared waitpoint), N webhook callbacks
   (distinct signals), all-of heterogeneous subsystems.
@@ -748,7 +767,7 @@ impl CountBuilder {
 
 - `evaluate_resume_conditions` output wired to `ff-board-sdk` (if/when that lands).
 - Metric: `ff_suspension_condition_depth` histogram (per §5.4 invariant, catch drift).
-- Tracing: per-signal log of `effect` including new `appended_to_waitpoint_duplicate` and `signal_ignored_not_in_condition`.
+- Tracing: per-signal log of `effect` including new `appended_to_waitpoint_duplicate`, `signal_ignored_not_in_condition`, and `signal_ignored_matcher_failed`.
 
 **Exit:** operator can answer "why is this execution still suspended?" via `evaluate_resume_conditions` without reading Lua.
 

--- a/rfcs/drafts/RFC-014-multi-signal-resume.md
+++ b/rfcs/drafts/RFC-014-multi-signal-resume.md
@@ -43,6 +43,8 @@ Today consumers expressing pattern (3) must spin an internal coordinator executi
 
 ### 1.3 What is **not** in scope (inherited deferrals stay deferred)
 
+(See §1.4 below for the canonical worked examples of patterns 1–3.)
+
 RFC-005 §Designed-for-deferred lists seven deferrals. This RFC takes two: `all_of` and `count(n)`. The remaining five **stay deferred** and must not drift into scope:
 
 - Signal routing to flow coordinator — RFC-016 concern.
@@ -52,6 +54,52 @@ RFC-005 §Designed-for-deferred lists seven deferrals. This RFC takes two: `all_
 - Bulk signal delivery — separate RFC (API surface).
 
 §9 names these explicitly under "Out of scope by choice, not oversight."
+
+### 1.4 Canonical worked examples
+
+The three §1.1 patterns map to these concrete builder-form constructions
+(see §10.3 for the full builder API):
+
+**Pattern 1 — 2-of-5 human reviewers (canonical style: shared waitpoint +
+`DistinctSources`).** Reviewer identity comes from policy at runtime;
+creating a waitpoint per reviewer forces a fan-out the policy engine cannot
+commit to at suspend-time. Preferred shape:
+
+```rust
+let cond = ResumeCondition::count(2)
+    .distinct_sources()
+    .on_waitpoint(wp_reviewers);  // one waitpoint, N signals land on it
+```
+
+A signal's `source_identity` is the reviewer's user id. Two signals from
+the same reviewer dedup at the token layer (§4.1).
+
+**Pattern 2 — N external callbacks from the same webhook endpoint.** Each
+callback carries its own `idempotency_key` / `signal_id`. Use
+`DistinctSignals`:
+
+```rust
+let cond = ResumeCondition::count(n)
+    .distinct_signals()
+    .on_waitpoint(wp_webhook);
+```
+
+**Pattern 3 — all-of distinct event types (heterogeneous subsystems).** Each
+subsystem owns its own waitpoint. Use `all_of_waitpoints`:
+
+```rust
+let cond = ResumeCondition::all_of_waitpoints([
+    wp_db_migration_complete,
+    wp_cache_warmed,
+    wp_feature_flag_set,
+]);
+```
+
+**When to prefer multi-waitpoint over shared-waitpoint.** Use one waitpoint
+per source when the subsystems are heterogeneous (different matchers,
+different payload schemas, different TTLs). Use a shared waitpoint when the
+signals are homogeneous and only the source_identity distinguishes them (the
+2-of-5 pattern).
 
 ---
 
@@ -138,6 +186,33 @@ RFC-010 §64 already defines `ff:exec:{p:N}:<execution_id>:suspension:current` H
 | `ff:exec:{p:N}:<execution_id>:suspension:current:satisfied_set` | SET | created at `suspend_execution`, deleted on resume/cancel/timeout | Populated with "satisfier tokens" — see §3.2. Membership is the durable satisfaction state. |
 | `ff:exec:{p:N}:<execution_id>:suspension:current:member_map` | HASH | same lifetime | Static map from `waitpoint_id` → `condition_path` (a JSON path like `"members[0]"` or `"members[1]"`). Written once at suspend-time; read at each signal delivery to locate which `AllOf` / `Count` node a signal affects. |
 
+#### 3.1.1 Cleanup owners
+
+Both keys are created at `suspend_execution` commit. They MUST be deleted
+by each of the three suspension-terminating paths, named explicitly:
+
+| Terminator | Deletion site |
+|---|---|
+| `resume_execution` (signal-driven, §3.3 root-satisfied path) | Lua `ff_deliver_signal.lua` at `close_and_resume` |
+| `cancel_execution` (RFC-013) | Lua `ff_cancel_execution.lua` |
+| `expire_suspension` (timeout expirer thread, RFC-004 §timeout-behavior) | Lua `ff_expire_suspension.lua` |
+
+Phase-2 integration test list (§10.2) includes
+`expire_deletes_satisfied_set_and_member_map` and
+`cancel_deletes_satisfied_set_and_member_map` to catch owner drift.
+
+#### 3.1.2 Key budget impact
+
+- Before RFC-014: suspension owns `{current HASH, waitpoints ZSET}`.
+- After RFC-014: suspension owns `{current HASH, waitpoints ZSET,
+  satisfied_set SET, member_map HASH}`. Net delta: +2 keys per active
+  suspension.
+- All four keys share the `{p:N}:<execution_id>` hash-tag → co-located on
+  the same cluster shard, accessible from a single Valkey Function call.
+- Key count is O(1) in condition complexity: nested depth and waitpoint-set
+  size do not add keys (both are encoded inside the SET/HASH values, not
+  as separate keys).
+
 Rationale:
 - **SET** gives O(1) "have we seen this satisfier before" (§4 idempotency).
 - **HASH** is a static lookup table, not touched by signal delivery except read. Write-once at suspend commit.
@@ -151,11 +226,27 @@ A satisfier token is the element stored in `satisfied_set`. Format depends on `C
 |---|---|---|
 | `DistinctWaitpoints` | `"wp:<waitpoint_id>"` | `wp:WP-abc123` |
 | `DistinctSignals` | `"sig:<signal_id>"` | `sig:SG-def456` |
-| `DistinctSources` | `"src:<source_type>:<source_identity>"` | `src:user:alice@example.com` |
+| `DistinctSources` | `"src:<source_type>:<source_identity>"` | `src:user:alice@example.com`, `src:system:operator-override` |
 
-For `AllOf` members, the token is always of the `wp:` form, since `AllOf` is satisfied per-member-waitpoint.
+**Source-type inclusion is intentional.** `source_type` is part of the
+token precisely so `src:user:alice` and `src:system:alice` count as
+distinct satisfiers. This closes §8 Q1: system-origin signals (e.g.
+operator overrides via `send_signal`) DO count toward a `DistinctSources`
+count. Operator tooling surfaces source_type breakdowns on
+`evaluate_resume_conditions` (§4.4) so "2 operator overrides" is visibly
+distinguishable from "2 user approvals."
 
-For nested conditions (`AllOf { members: [Count { ... }] }`), the `Count` sub-node maintains its own virtual satisfaction in-condition, and once satisfied contributes a synthetic `"node:<path>"` token to the parent's `satisfied_set`. See §3.4.
+Consumers that want "user-only" quorum encode the constraint via the
+`Count.matcher` field (§2.1), e.g. `matcher = source_type == "user"`. No
+separate `CountKind::DistinctUserSources` variant is introduced (rejected
+as overlapping with matcher-based filtering).
+
+**Token shape at leaves under `AllOf`.** For a direct `Single` child of
+`AllOf`, the satisfier token is `wp:<waitpoint_id>` — the `wp:` token IS
+the satisfaction marker, no synthetic `node:<path>` is emitted. For a
+non-`Single` child (`AllOf` or `Count`), once the child is satisfied a
+synthetic `node:<child_path>` token is SADDed. See §3.3 step 4 for the
+ordering and §3.3's restated `AllOf.evaluate_node` rule.
 
 ### 3.3 Matching algorithm (extends RFC-005 §8.3)
 
@@ -163,7 +254,11 @@ Lua pseudocode lives in `ff-script/src/functions/signal.rs`'s `deliver_signal` p
 
 ```
 on deliver_signal(signal, execution_id):
-    -- Load condition topology (parsed once, cached in function-scope table)
+    -- Parse condition topology. NOTE: "parse" is per-invocation only —
+    -- Valkey Functions are stateless across calls, so there is no
+    -- cross-call cache. Parse cost is O(condition size) ≤ O(8 KiB) per
+    -- signal (§5.1 cap). The parsed `cond` is a function-local table for
+    -- the duration of this single deliver_signal invocation only.
     local cond       = parse_resume_condition(HGET suspension:current resume_condition_json)
     local member_map = HGETALL suspension:current:member_map
     local satisfied  = SMEMBERS suspension:current:satisfied_set
@@ -179,6 +274,13 @@ on deliver_signal(signal, execution_id):
     -- 2. Compute the satisfier token for this signal against this node.
     local token = satisfier_token(signal, node.kind or "DistinctWaitpoints")
 
+    -- 2.5 Apply the node's local matcher, if any. A signal that fails the
+    --     matcher is recorded on the waitpoint (RFC-005 semantics) but
+    --     does not contribute a satisfier token to this node.
+    if node.matcher ~= nil and not match(signal, node.matcher) then
+        return {effect = "signal_ignored_matcher_failed"}
+    end
+
     -- 3. Idempotency: SADD returns 0 if already present.
     local added = SADD suspension:current:satisfied_set token
     if added == 0 then
@@ -186,8 +288,11 @@ on deliver_signal(signal, execution_id):
     end
 
     -- 4. Re-evaluate satisfaction of every node on the path to the root.
-    --    Satisfaction propagates upward: a satisfied child adds its
-    --    synthetic node-token to the parent's satisfied_set.
+    --    Satisfaction propagates upward: a non-leaf satisfied child adds
+    --    its synthetic `node:<child_path>` token to the parent's
+    --    satisfied_set. Leaf `Single` children need no synthetic token —
+    --    their `wp:<id>` IS the satisfaction marker (see §3.2 + the
+    --    restated AllOf rule below).
     local path = ancestor_path(node_path)   -- e.g. ["members[0]", ""]
     for _, p in ipairs(path) do
         local n = descend(cond, p)
@@ -195,7 +300,7 @@ on deliver_signal(signal, execution_id):
             if p == "" then
                 -- root satisfied → close suspension, mark resume-eligible
                 return close_and_resume(execution_id, signal)
-            else
+            elseif not is_single_leaf(n) then
                 SADD suspension:current:satisfied_set ("node:" .. p)
             end
         end
@@ -204,10 +309,15 @@ on deliver_signal(signal, execution_id):
     return {effect = "appended_to_waitpoint"}
 ```
 
-`evaluate_node` rules:
+`evaluate_node` rules (restated for clarity — leaf `Single` case is
+distinct from non-leaf):
+
 - `Single`: satisfied iff `wp:<waitpoint_id>` ∈ `satisfied_set`.
-- `AllOf { members }`: satisfied iff every member's synthetic `node:<child_path>` ∈ `satisfied_set` (leaf `Single` children use `wp:<id>`).
-- `Count { n, kind, waitpoints }`: satisfied iff `|{tokens in satisfied_set matching this node's kind+waitpoints}| >= n`.
+- `AllOf { members }`: satisfied iff, for each member `m` at child_path `cp`:
+  - if `m` is a `Single`, `wp:<m.waitpoint_id>` ∈ `satisfied_set`;
+  - else (`m` is `AllOf` or `Count`), `node:<cp>` ∈ `satisfied_set`.
+- `Count { n, kind, waitpoints }`: satisfied iff
+  `|{tokens in satisfied_set matching this node's kind+waitpoints}| >= n`.
 
 ### 3.4 Why a flat SET + path map, not nested HASHes
 
@@ -265,6 +375,28 @@ RFC-005 §323 defines `evaluate_resume_conditions(execution_id)` as an operator 
 
 This is Class C (derived/read-only). No state transitions from this call.
 
+The operator-facing output includes per-`DistinctSources` source_type
+breakdowns (e.g. `{ "user": 1, "system": 1 }`) so "2 operator overrides"
+is visibly distinguishable from "2 user approvals" (see §3.2 on Q1
+closure).
+
+### 4.5 Resume payload under multi-signal
+
+RFC-004's `resumed_with` payload surfaces what signal(s) unblocked the
+suspension. For a `Single`, this is the single signal. For multi-signal
+conditions it is two fields:
+
+| Field | Meaning |
+|---|---|
+| `closer_signal_id` | The signal whose acceptance + SADD caused `evaluate_node` at the root to flip to satisfied. Exactly one per resume. |
+| `all_satisfier_signals` | The subset of `list_waitpoint_signals` whose satisfier tokens are present in `satisfied_set` at close time. For a `Count(3, DistinctSources)`, this is three signals (one per source). For `AllOf { Count(3), Single }`, this is four signals. |
+
+Consumers that need only "who closed it" read `closer_signal_id`. Consumers
+that need the full satisfier set (e.g. to attribute approvals in an audit
+log) iterate `all_satisfier_signals`. Signals that landed but did not
+contribute a satisfier (duplicates, matcher-failed) are NOT in
+`all_satisfier_signals` but remain visible via `list_waitpoint_signals`.
+
 ---
 
 ## 5. Error taxonomy
@@ -280,12 +412,31 @@ This is Class C (derived/read-only). No state transitions from this call.
 | `condition_depth_exceeded` | Recursive nest depth > 4 | Suspend-time. Hard cap. |
 | `condition_size_exceeded` | Total serialized `resume_condition_json` > 8 KiB | Suspend-time. Bounds Lua parse cost. |
 
+#### 5.1.1 Error payload shape
+
+All new kinds map to a single structured error type:
+
+```rust
+pub enum EngineError {
+    // ...existing variants...
+    InvalidCondition {
+        kind: ConditionErrorKind,
+        detail: String,  // human-readable: "depth 5 exceeds cap 4 at path members[0].members[0].members[0]"
+    },
+}
+```
+
+`detail` is consumer-facing and MUST be specific enough to locate the
+offending subtree (depth, path, cardinality values). Consumer error-surfacing
+code (e.g. cairn's reviewer panel) renders the `detail` string verbatim.
+
 ### 5.2 Late-detection (at signal delivery)
 
 | Error (existing, clarified by RFC-014) | Condition |
 |---|---|
 | `invalid_resume_condition` (RFC-004 §412) | Extended: also fires if `resume_condition_json` fails to parse in Lua at suspend (catch-all). |
 | `signal_ignored_not_in_condition` (new) | Signal delivered to a waitpoint whose `waitpoint_id` is not in `member_map`. Signal is recorded, no satisfaction attempted. Returns this effect for observability. |
+| `signal_ignored_matcher_failed` (new) | Signal delivered to a waitpoint whose `waitpoint_id` IS in `member_map`, but the local node's `Count.matcher` (§2.1) rejects it. Signal is recorded on the waitpoint's signal list (RFC-005 semantics) but does not contribute a satisfier token. |
 
 ### 5.3 Why early detection for `count_exceeds_waitpoint_set`
 
@@ -304,6 +455,27 @@ RFC-014 chooses **suspend-time** validation for size/cardinality errors for thre
 3. Signal acceptance and satisfaction evaluation are atomic within a single Valkey Function call (Class A), consistent with RFC-005 §306.
 4. No nested condition exceeds depth 4. (Soft-cap; consumers have not presented a real pattern > 2.)
 5. `member_map` is write-once — read-only after `suspend_execution` commits.
+
+### 5.5 Cap rationale (depth 4, size 8 KiB)
+
+Both caps are soft — bumping either requires only a validator constant
+change, not a wire-format or schema change. The current values are chosen
+as:
+
+- **Depth 4.** Real consumer patterns top out at depth 2 (`AllOf { Count,
+  Single }` = depth 2). Depth 4 gives 2× headroom for future patterns
+  without inviting arbitrary recursion. Per-signal cost is O(depth); at
+  depth 4 the walk is four `evaluate_node` calls, each O(|members|) or
+  O(|tokens|). Fits in a single `deliver_signal` Function budget.
+- **Size 8 KiB.** Roughly 10% of Valkey's default ARGV soft limit (64 KiB
+  per parameter), leaving headroom for other ARGV fields in the same
+  `suspend_execution` call (waitpoint specs, continuation payload,
+  idempotency key). A condition at 8 KiB can encode ~200 nested `Single`s
+  or ~40 `Count`s with 5 waitpoints each — above observed real need.
+
+If a future consumer hits either cap, lifting them is a single-PR change
+(validator constant + the cap-rationale paragraph here). No persisted
+data migrates.
 
 ---
 
@@ -325,11 +497,44 @@ The `timeout_behavior` values (from RFC-004 §254) already support this:
 
 **This RFC does NOT introduce a new timeout mode.** It defines how existing modes compose with multi-signal conditions.
 
+**Timeout token form.** The synthetic timeout token is
+`timeout:<suspension_id>` — exactly one token per suspension, regardless of
+`CountKind`. A `Count { n, kind }` node that sees the timeout token
+short-circuits to satisfied (i.e. the timeout token is treated as a
+universal node-satisfier), it does NOT increment the distinct-satisfier
+count. Rationale: a timeout has no source_identity / signal_id /
+waitpoint_id, so it cannot contribute a distinct satisfier under any
+`CountKind`; treating it as a node-level short-circuit keeps the token
+algebra clean. The short-circuit fires only when
+`timeout_behavior == auto_resume_with_timeout_signal`; under `fail` the
+token is not SADDed and the execution transitions to failure directly.
+
+Consumers that want "resume only if ≥k of n signals arrived AND timeout
+fired" must express that as application-layer logic on the resumed
+worker — see §6.2.
+
 ### 6.2 Consumer opt-in for partial-count resume
 
 The pattern "resume with whatever count we have if timeout fires" is expressible **without** a new variant: put the timeout-handling logic in the resumed worker code. The execution resumes with `timeout_behavior = auto_resume_with_timeout_signal`, and the worker inspects `list_waitpoint_signals` to see what actually arrived. This keeps the condition language minimal.
 
 If a consumer wants *condition-level* "count(3) OR timeout-partial", they must write it as two sequential suspensions — one `Count(3)` with `fail` timeout, a retry-handler that runs a second suspension with a shorter timeout. This is verbose but expressible.
+
+**Idiomatic surface.** To make the common "wait for 2-of-5 with 30m
+timeout; on partial-quorum, escalate" pattern ergonomic, the
+`SuspensionTimedOut` error variant carries `partial_satisfiers` so the
+caller can branch without a second `evaluate_resume_conditions` round-trip:
+
+```rust
+match self.suspend(spec, cond_count_2_of_5, timeout_30m).await {
+    Ok(resume) => handle_full_quorum(resume),
+    Err(EngineError::SuspensionTimedOut { partial_satisfiers, .. }) =>
+        handle_partial(partial_satisfiers),
+}
+```
+
+`partial_satisfiers: Vec<SatisfierToken>` echoes the `satisfied_set`
+contents at timeout time. This is an additive error-field change; no new
+condition variant and no new `timeout_behavior` value.
 
 ### 6.3 Why not introduce `PartialCount` variant
 
@@ -384,11 +589,19 @@ RFC-016 addresses flow-edge quorum (DAG join semantics). RFC-014 handles waitpoi
 
 ## 8. Open questions
 
-1. **Do we support `CountKind::DistinctSources` with `source_type = "system"` signals?** Operator-override signals via `send_signal` with source_type=system could trivially satisfy a `DistinctSources(2)` count. Leaning: yes, count them, but note this in operator tooling so "2 operator overrides != 2 user approvals" is visible. Escalate to owner.
+All prior open questions are closed as of round-1 challenge revisions:
 
-2. **Should `AllOf` short-circuit evaluation on a satisfied signal that doesn't advance the root?** Current design: always evaluate up to root (§3.3 step 4). Alternative: mark node-satisfied only, defer root evaluation to a "maybe ready" queue. Leaning: no — root eval is O(depth ≤ 4) and happens per-signal. Not worth the complexity.
-
-3. **Is per-waitpoint quorum (`Count(2, kind=DistinctSources, waitpoints=[single_wp])`) enough to express "2-of-5 reviewers one waitpoint" OR do we need a `WaitpointSpec.expected_signal_count` hint to size TTL/cleanup?** Leaning: the `Count` variant already expresses it; TTL/cleanup is RFC-004's concern. But worth a round of review against real `cairn-fabric` review-approval flows before locking.
+1. **Closed — system-source signals count.** `CountKind::DistinctSources`
+   counts signals with `source_type = "system"` as distinct satisfiers;
+   `source_type` is part of the token (§3.2). Consumers that want
+   user-only quorum use `Count.matcher = source_type == "user"`.
+2. **Closed — no short-circuit.** Per-signal root evaluation is O(depth ≤ 4);
+   the "maybe ready" queue alternative adds complexity without measurable
+   win. Design stays as §3.3 step 4.
+3. **Closed — shared waitpoint is canonical.** The shared-waitpoint form
+   (`Count(2, DistinctSources, waitpoints=[wp_reviewers])`) is the
+   canonical 2-of-5 shape (§1.4). No `WaitpointSpec.expected_signal_count`
+   hint is added; signal TTL is out of scope per §1.3.
 
 ---
 
@@ -466,10 +679,21 @@ None of these are blockers for multi-signal resume. Multi-signal works with v1's
 - Integration tests in `crates/ff-backend-valkey/tests/`:
   - `count_2_distinct_sources_resumes_on_second_source`
   - `count_2_distinct_sources_ignores_duplicate_source`
+  - `count_2_distinct_sources_counts_system_signal` (Q1 closure)
+  - `count_matcher_filters_user_only_sources` (matcher-based filtering)
   - `allof_three_waitpoints_resumes_when_all_fired`
   - `allof_replay_after_partial_count_preserves_state`
   - `count_exceeds_waitpoint_set_rejected_at_suspend`
   - `timeout_with_partial_count_uses_timeout_behavior`
+  - `timeout_token_short_circuits_count_node` (§6.1 token form)
+  - `suspension_timed_out_error_carries_partial_satisfiers` (§6.2 idiom)
+  - `expire_deletes_satisfied_set_and_member_map` (§3.1.1 owner)
+  - `cancel_deletes_satisfied_set_and_member_map` (§3.1.1 owner)
+  - `resume_payload_exposes_closer_and_all_satisfiers` (§4.5)
+- Cluster-mode integration tests in
+  `crates/ff-backend-valkey/tests/cluster/`:
+  - `satisfied_set_colocated_with_suspension_in_cluster_mode`
+  - `member_map_colocated_with_suspension_in_cluster_mode`
 
 **Exit:** integration tests green against Valkey 8.x; `evaluate_resume_conditions` diagnostic reflects correct partial state.
 
@@ -477,9 +701,46 @@ None of these are blockers for multi-signal resume. Multi-signal works with v1's
 
 **Crates:** `ff-sdk`.
 
-- Public builder API: `ResumeCondition::all_of([...])`, `ResumeCondition::count(n).distinct_sources().on_waitpoints([...])`.
-- Doc tests in `ff-sdk/src/suspend.rs` covering the three canonical patterns from §1.1.
-- Smoke example in `examples/` that runs a 2-of-3 approval flow end-to-end.
+Public builder API (full surface; doctests cover each entry point):
+
+```rust
+impl ResumeCondition {
+    pub fn single(wp: WaitpointKey, matcher: ConditionMatcher) -> Self;
+
+    /// Explicit all-of with heterogeneous members (nested Count, etc.).
+    pub fn all_of(members: impl IntoIterator<Item = ResumeCondition>) -> Self;
+
+    /// Shorthand for the common `AllOf { members: [Single, Single, ...] }`
+    /// shape (pattern 3 — heterogeneous-subsystems-each-fired).
+    pub fn all_of_waitpoints(
+        wps: impl IntoIterator<Item = WaitpointKey>,
+    ) -> Self;
+
+    pub fn count(n: u32) -> CountBuilder;
+}
+
+impl CountBuilder {
+    pub fn distinct_waitpoints(self) -> Self;
+    pub fn distinct_signals(self) -> Self;
+    pub fn distinct_sources(self) -> Self;
+    pub fn with_matcher(self, m: ConditionMatcher) -> Self;
+
+    /// Multi-waitpoint terminator (pattern 3 variant).
+    pub fn on_waitpoints(
+        self,
+        wps: impl IntoIterator<Item = WaitpointKey>,
+    ) -> ResumeCondition;
+
+    /// Single-waitpoint terminator (canonical pattern 1 / 2 shape).
+    pub fn on_waitpoint(self, wp: WaitpointKey) -> ResumeCondition;
+}
+```
+
+- Doc tests in `ff-sdk/src/suspend.rs` covering each §1.4 canonical
+  pattern: 2-of-5 reviewers (shared waitpoint), N webhook callbacks
+  (distinct signals), all-of heterogeneous subsystems.
+- Smoke example in `examples/` that runs a 2-of-3 approval flow
+  end-to-end against a published artifact.
 
 **Exit:** scratch-project smoke (per the "smoke after publish" memory) validates the three patterns against a published artifact.
 

--- a/rfcs/drafts/RFC-014-multi-signal-resume.md
+++ b/rfcs/drafts/RFC-014-multi-signal-resume.md
@@ -1,0 +1,513 @@
+# RFC-014: Multi-signal resume conditions (`all_of`, `count(n)`)
+
+**Status:** Draft
+**Author:** FlowFabric Team (Worker-2)
+**Created:** 2026-04-23
+**Tracks:** RFC-005 §Designed-for-deferred (lines 772–779) — the `all_of` + `count(n)` deferrals.
+**Depends-on:** RFC-013 (Stage 1d `suspend` trait + base `ResumeCondition` shape)
+**Extends:** RFC-004 §Resume Condition Model, RFC-005 §8 Signal Matching
+
+---
+
+## 0. Forward-compat contract with RFC-013
+
+RFC-013 (parallel) is the canonical owner of the `suspend` trait signature and the **base** `ResumeCondition` shape. This RFC **extends** that base shape with multi-signal variants. The forward-compat contract is:
+
+| Property required from RFC-013 | Why RFC-014 needs it | If RFC-013 doesn't deliver it |
+|---|---|---|
+| `ResumeCondition` is an **enum** (not an opaque JSON blob on the trait) | RFC-014 adds variants; a JSON blob defers parsing to Lua and makes Rust-side validation impossible. | RFC-014 becomes Lua-only — wire-format-defined. Rust typing is lost. Revisit. |
+| `ResumeCondition` is **nestable / composable** (variants may hold `Vec<ResumeCondition>` or `Vec<WaitpointKey>`) | `AllOf` is a list of sub-conditions / waitpoints by definition. A flat non-composable enum cannot express it. | **BLOCKER.** RFC-014 cannot land. The alternative is a second parallel enum `MultiSignalCondition`, which we explicitly reject in §9. |
+| `ResumeCondition` is **serde-stable** across engine and backend crates | Matching runs in Lua; the Rust side emits `resume_condition_json` per RFC-004 §Storage. | If serde is unstable RFC-014 must version-tag the JSON (§7). |
+| `WaitpointSpec` remains **condition-agnostic** (carries only per-waitpoint matcher hints, not multi-signal topology) | Keeps the multi-signal structure at the `ResumeCondition` layer, not per-waitpoint. See §7. | RFC-014 would need to invert topology onto `WaitpointSpec`, which duplicates structure. |
+
+**Action on blocker:** if RFC-013's adjudicated shape is non-nestable, this RFC parks at Draft and reopens only after an RFC-013 amendment. Do not ship a parallel `MultiSignalCondition` type.
+
+---
+
+## 1. Motivation
+
+### 1.1 What consumers are asking for
+
+Canonical patterns from `cairn-fabric` + real workflow consumers:
+
+1. **Human-in-the-loop approval with N reviewers** — `count(2-of-5)` reviewers must approve before the execution proceeds. Reviewers are distinct; one reviewer signalling twice must count once.
+2. **Aggregate N callbacks from external webhooks** — an execution fans work out to N external systems, each posts back a callback signal. Execution resumes when all N land. Retry-sent duplicates of the same callback count once.
+3. **All-of distinct event types** — a deployment waits on `db-migration-complete`, `cache-warmed`, `feature-flag-set`. Each is its own waitpoint. Execution resumes only when all three have fired.
+4. **Per-waitpoint quorum** — `k-of-n` where the `n` is the *same waitpoint* receiving multiple signals from distinct sources. (Edge-level quorum in flow DAGs is RFC-016's concern; this RFC covers waitpoint-local quorum only.)
+
+### 1.2 What v1 shipped
+
+RFC-004 and RFC-005 shipped with a single-signal `ResumeCondition` + the `signal_match_mode` hint (`any` / `all` / `count(n)`) on the waitpoint. RFC-005 §283 explicitly flags: "the primary path is `signal_match_mode = any` with a single matcher. The multi-signal machinery exists for correctness but complex multi-condition evaluation is a v1-should-have, not a must-have."
+
+Today consumers expressing pattern (3) must spin an internal coordinator execution that waits single-signal, re-emits, and rechains. That is a workaround, not a primitive.
+
+### 1.3 What is **not** in scope (inherited deferrals stay deferred)
+
+RFC-005 §Designed-for-deferred lists seven deferrals. This RFC takes two: `all_of` and `count(n)`. The remaining five **stay deferred** and must not drift into scope:
+
+- Signal routing to flow coordinator — RFC-016 concern.
+- Signal payload schema validation — separate RFC (validation engine).
+- Signal TTL — separate RFC (signal lifecycle).
+- Signal replay — separate RFC (observability/debug tooling).
+- Bulk signal delivery — separate RFC (API surface).
+
+§9 names these explicitly under "Out of scope by choice, not oversight."
+
+---
+
+## 2. Extended `ResumeCondition` enum
+
+### 2.1 Proposed shape (atop RFC-013's base)
+
+Assuming RFC-013 settles a base of the form:
+
+```rust
+// Provided by RFC-013 (base; RFC-014 does not own this):
+pub enum ResumeCondition {
+    Single { waitpoint_key: WaitpointKey, matcher: ConditionMatcher },
+    // ... RFC-013 may add Timeout-only, OperatorOnly, etc.
+}
+```
+
+RFC-014 adds two variants:
+
+```rust
+pub enum ResumeCondition {
+    Single { waitpoint_key: WaitpointKey, matcher: ConditionMatcher },
+
+    /// All listed sub-conditions must be satisfied. Order-independent.
+    /// Once satisfied, further signals to member waitpoints are observed
+    /// but do not re-open satisfaction.
+    AllOf {
+        members: Vec<ResumeCondition>,  // nestable
+    },
+
+    /// At least `n` *distinct satisfiers* (see CountKind) must match.
+    /// `n` must be ≥ 1 and ≤ upper bound derived from CountKind (see §5).
+    Count {
+        n: u32,
+        kind: CountKind,
+        /// Optional: constrains which signals participate. If `None`, any
+        /// signal delivered to any waitpoint in `waitpoints` counts (subject
+        /// to CountKind).
+        matcher: Option<ConditionMatcher>,
+        waitpoints: Vec<WaitpointKey>,
+    },
+}
+
+pub enum CountKind {
+    /// n distinct waitpoint_keys in `waitpoints` must be satisfied.
+    /// Idempotent: same waitpoint fired twice counts once.
+    DistinctWaitpoints,
+
+    /// n distinct signal_ids accepted across the waitpoint set.
+    /// Suitable for "N callbacks from same webhook endpoint,
+    /// each callback has its own idempotency_key".
+    DistinctSignals,
+
+    /// n distinct `source_identity` values (from signal.source_identity,
+    /// RFC-005 §Signal fields). Suitable for "2-of-5 reviewers" where
+    /// each reviewer's source_identity is their user id.
+    DistinctSources,
+}
+```
+
+### 2.2 Why this shape, not alternatives
+
+- **`AllOf` nests `ResumeCondition`** rather than `Vec<WaitpointKey>` so `AllOf { members: [Count{…}, Single{…}] }` is expressible. Non-nestable alternative forces a 2D topology where consumers can't say "2-of-3 reviewers AND db-migration-complete." Nestable wins.
+- **`Count.kind` is explicit.** Implicit "distinct by what?" caused real pain in prior workflow engines (Argo, Temporal). We make the discriminant a required enum field, not a mode string.
+- **`Count.waitpoints` is required** (non-empty). A `Count(n)` with no declared waitpoint set is meaningless — see §5 (error taxonomy).
+- **`Count.matcher` is optional.** Lets consumers say "2 signals named `approval` from distinct sources against this one waitpoint" without duplicating the matcher on every sub-condition.
+
+### 2.3 Variants we explicitly did not add
+
+- `AnyOf` — **not** added. `AnyOf { members: [a, b] }` is expressible as `Count { n: 1, kind: DistinctWaitpoints, waitpoints: [a, b] }`. Adding a third variant with overlapping semantics bloats the matching algorithm in §3.
+- `Quorum { k, n }` — rejected. `Count { n: k, waitpoints: [...n waitpoints] }` covers it. Per-flow-edge quorum is RFC-016's concern.
+- `NotOf` / negation — rejected. Negative conditions require a timeout to ever fire, and RFC-004's timeout-behavior already covers "advance if no signal arrived." Adding negation here doubles the algorithm's state space for one pattern already served.
+
+---
+
+## 3. Lua storage + matching algorithm
+
+### 3.1 Storage model (extends RFC-010 §Waitpoint keys)
+
+RFC-010 §64 already defines `ff:exec:{p:N}:<execution_id>:suspension:current` HASH with a `resume_condition_json` field. RFC-014 adds two new keys, scoped to the active suspension:
+
+| Key | Type | Lifetime | Fields |
+|---|---|---|---|
+| `ff:exec:{p:N}:<execution_id>:suspension:current:satisfied_set` | SET | created at `suspend_execution`, deleted on resume/cancel/timeout | Populated with "satisfier tokens" — see §3.2. Membership is the durable satisfaction state. |
+| `ff:exec:{p:N}:<execution_id>:suspension:current:member_map` | HASH | same lifetime | Static map from `waitpoint_id` → `condition_path` (a JSON path like `"members[0]"` or `"members[1]"`). Written once at suspend-time; read at each signal delivery to locate which `AllOf` / `Count` node a signal affects. |
+
+Rationale:
+- **SET** gives O(1) "have we seen this satisfier before" (§4 idempotency).
+- **HASH** is a static lookup table, not touched by signal delivery except read. Write-once at suspend commit.
+- Both keys live **in Valkey, not in the handle**, so worker crashes between signal 2 and signal 3 of a `count(3)` don't lose the count (§4 replay).
+
+### 3.2 Satisfier tokens
+
+A satisfier token is the element stored in `satisfied_set`. Format depends on `CountKind`:
+
+| CountKind | Token format | Example |
+|---|---|---|
+| `DistinctWaitpoints` | `"wp:<waitpoint_id>"` | `wp:WP-abc123` |
+| `DistinctSignals` | `"sig:<signal_id>"` | `sig:SG-def456` |
+| `DistinctSources` | `"src:<source_type>:<source_identity>"` | `src:user:alice@example.com` |
+
+For `AllOf` members, the token is always of the `wp:` form, since `AllOf` is satisfied per-member-waitpoint.
+
+For nested conditions (`AllOf { members: [Count { ... }] }`), the `Count` sub-node maintains its own virtual satisfaction in-condition, and once satisfied contributes a synthetic `"node:<path>"` token to the parent's `satisfied_set`. See §3.4.
+
+### 3.3 Matching algorithm (extends RFC-005 §8.3)
+
+Lua pseudocode lives in `ff-script/src/functions/signal.rs`'s `deliver_signal` path, replacing the single-matcher check at RFC-005 §262–281:
+
+```
+on deliver_signal(signal, execution_id):
+    -- Load condition topology (parsed once, cached in function-scope table)
+    local cond       = parse_resume_condition(HGET suspension:current resume_condition_json)
+    local member_map = HGETALL suspension:current:member_map
+    local satisfied  = SMEMBERS suspension:current:satisfied_set
+
+    -- 1. Identify which condition node this signal pertains to.
+    local node_path = member_map[signal.waitpoint_id]
+    if node_path == nil then
+        return {effect = "signal_ignored_not_in_condition"}
+    end
+
+    local node = descend(cond, node_path)
+
+    -- 2. Compute the satisfier token for this signal against this node.
+    local token = satisfier_token(signal, node.kind or "DistinctWaitpoints")
+
+    -- 3. Idempotency: SADD returns 0 if already present.
+    local added = SADD suspension:current:satisfied_set token
+    if added == 0 then
+        return {effect = "appended_to_waitpoint_duplicate"}
+    end
+
+    -- 4. Re-evaluate satisfaction of every node on the path to the root.
+    --    Satisfaction propagates upward: a satisfied child adds its
+    --    synthetic node-token to the parent's satisfied_set.
+    local path = ancestor_path(node_path)   -- e.g. ["members[0]", ""]
+    for _, p in ipairs(path) do
+        local n = descend(cond, p)
+        if evaluate_node(n, satisfied_set) then
+            if p == "" then
+                -- root satisfied → close suspension, mark resume-eligible
+                return close_and_resume(execution_id, signal)
+            else
+                SADD suspension:current:satisfied_set ("node:" .. p)
+            end
+        end
+    end
+
+    return {effect = "appended_to_waitpoint"}
+```
+
+`evaluate_node` rules:
+- `Single`: satisfied iff `wp:<waitpoint_id>` ∈ `satisfied_set`.
+- `AllOf { members }`: satisfied iff every member's synthetic `node:<child_path>` ∈ `satisfied_set` (leaf `Single` children use `wp:<id>`).
+- `Count { n, kind, waitpoints }`: satisfied iff `|{tokens in satisfied_set matching this node's kind+waitpoints}| >= n`.
+
+### 3.4 Why a flat SET + path map, not nested HASHes
+
+A nested-structure-per-node (one SET per condition sub-node) would be cleaner reading, but requires **N extra Valkey keys** per suspension. Flat `satisfied_set` + `member_map` keeps Valkey key count at `O(1)` per suspension regardless of condition complexity. Evaluation cost is `O(depth)` per signal — bounded by a hard depth cap (§5 invariant 5.4).
+
+---
+
+## 4. Idempotency + replay
+
+### 4.1 Idempotency contract
+
+**Same signal delivered twice must count once.** Enforcement is the `SADD` return value at step 3 above — if the token already existed, we return `appended_to_waitpoint_duplicate` and do not re-evaluate. This is stronger than RFC-005's existing `idempotency_key`-based dedup because:
+
+1. `idempotency_key` dedup happens at signal acceptance (signal-level).
+2. Token-based dedup happens at satisfaction (condition-level).
+
+Both are kept. Example of why: a `DistinctSources` count may accept two *different* signals with different signal_ids and different idempotency_keys but the **same source_identity** — RFC-005's dedup doesn't fire, but RFC-014's SADD does. Correct behavior: both signals are accepted and recorded (RFC-005 semantics preserved), but only the first increments the count.
+
+### 4.2 `AllOf` re-fire semantics
+
+If a waitpoint inside an `AllOf` is fired, then fired again later, the second signal:
+- Is accepted (RFC-005 semantics).
+- Is appended to the waitpoint's signal list (RFC-005 §list_waitpoint_signals).
+- Does NOT re-satisfy the parent — parent is already satisfied.
+- Returns effect `appended_to_waitpoint_duplicate`.
+
+This preserves the existing invariant "waitpoint close is one-way" from RFC-004 §State Transitions.
+
+### 4.3 Durability + replay
+
+**Requirement:** if a worker crashes after 2 of 3 `count(3)` signals have satisfied, replay must see the 2 already-counted.
+
+Design:
+- `satisfied_set` is a Valkey SET. It survives worker crashes by construction.
+- The handle (worker-local) does NOT carry satisfaction state. On replay (`claim_resumed_execution`), the worker reads the handle's continuation pointer (RFC-004), does not consult satisfaction state directly, and proceeds.
+- Third signal arrives → Lua reads `satisfied_set` (2 tokens present) → SADDs token 3 → `evaluate_node` finds count ≥ 3 → resumes execution.
+
+The durable path is self-healing: Lua is the single source of truth; the handle never caches counts.
+
+### 4.4 Non-crash replay: `evaluate_resume_conditions` operator tool
+
+RFC-005 §323 defines `evaluate_resume_conditions(execution_id)` as an operator diagnostic. RFC-014 extends its output to return the per-node satisfaction state:
+
+```
+{
+  condition: <parsed tree>,
+  satisfied_set: [...tokens],
+  nodes: [
+    { path: "", kind: "AllOf", satisfied: false, remaining_members: 1 },
+    { path: "members[0]", kind: "Count(2-of-3)", satisfied: true  },
+    { path: "members[1]", kind: "Single", satisfied: false }
+  ]
+}
+```
+
+This is Class C (derived/read-only). No state transitions from this call.
+
+---
+
+## 5. Error taxonomy
+
+### 5.1 Validation at `suspend_execution` (early detection)
+
+| Error (new) | Condition | When |
+|---|---|---|
+| `count_exceeds_waitpoint_set` | `Count { n, waitpoints }` with `n > waitpoints.len()` and `kind = DistinctWaitpoints` | At suspend-time (Rust-side validation before Valkey call). Impossible condition → reject synchronously. |
+| `count_n_zero` | `n == 0` | Suspend-time. Degenerate — caller should use timeout-only condition. |
+| `allof_empty_members` | `AllOf { members: [] }` | Suspend-time. Trivially satisfied condition is ambiguous; force caller to spell intent. |
+| `count_waitpoints_empty` | `Count { waitpoints: [], ... }` | Suspend-time. Meaningless: no waitpoints can satisfy. |
+| `condition_depth_exceeded` | Recursive nest depth > 4 | Suspend-time. Hard cap. |
+| `condition_size_exceeded` | Total serialized `resume_condition_json` > 8 KiB | Suspend-time. Bounds Lua parse cost. |
+
+### 5.2 Late-detection (at signal delivery)
+
+| Error (existing, clarified by RFC-014) | Condition |
+|---|---|
+| `invalid_resume_condition` (RFC-004 §412) | Extended: also fires if `resume_condition_json` fails to parse in Lua at suspend (catch-all). |
+| `signal_ignored_not_in_condition` (new) | Signal delivered to a waitpoint whose `waitpoint_id` is not in `member_map`. Signal is recorded, no satisfaction attempted. Returns this effect for observability. |
+
+### 5.3 Why early detection for `count_exceeds_waitpoint_set`
+
+RFC-014 chooses **suspend-time** validation for size/cardinality errors for three reasons:
+
+1. Suspend-time is synchronous in the worker; error propagates to user code. Late detection at signal time leaves the execution in a permanently-unsatisfiable state until timeout fires — silent failure.
+2. The validation is cheap: `n <= waitpoints.len()` is O(1).
+3. Consumer debuggability: a test "suspend with `count(5)` on 3 waitpoints" should fail loudly, not hang until timeout.
+
+`DistinctSignals` and `DistinctSources` **cannot** be validated at suspend time (no upper bound on arriving signals/sources is known). Those rely on timeout behavior (§6) for non-termination.
+
+### 5.4 Invariants
+
+1. `satisfied_set` cardinality monotonically increases during suspension lifetime.
+2. Satisfaction is one-way: `evaluate_node(n) == true` at time T implies `evaluate_node(n) == true` at all T' > T (until suspension closes).
+3. Signal acceptance and satisfaction evaluation are atomic within a single Valkey Function call (Class A), consistent with RFC-005 §306.
+4. No nested condition exceeds depth 4. (Soft-cap; consumers have not presented a real pattern > 2.)
+5. `member_map` is write-once — read-only after `suspend_execution` commits.
+
+---
+
+## 6. Interaction with timeouts
+
+### 6.1 Choice: synthetic timeout-signal, not terminal failure
+
+When a `Count(3)` has a timeout and 2 satisfiers have arrived by timeout, **we generate a synthetic `timeout` signal** that is passed to `evaluate_node` as an additional token source, and we set `timeout_behavior` to decide what the node does with it.
+
+The `timeout_behavior` values (from RFC-004 §254) already support this:
+
+| `timeout_behavior` | Effect on partially-satisfied multi-signal condition |
+|---|---|
+| `fail` | Execution transitions to terminal failure regardless of partial satisfaction. (Most strict.) |
+| `auto_resume_with_timeout_signal` | Synthetic timeout token added to `satisfied_set`. Condition re-evaluated. If the condition treats the timeout token as satisfying (consumer opt-in via matcher, §6.2), resumes. Otherwise falls through to `fail`. |
+| `cancel` | Execution cancels; no partial work propagated. |
+| `expire` | Suspension expires; execution state is what RFC-004 defines. |
+| `escalate` | Operator-notified, no auto-advance. |
+
+**This RFC does NOT introduce a new timeout mode.** It defines how existing modes compose with multi-signal conditions.
+
+### 6.2 Consumer opt-in for partial-count resume
+
+The pattern "resume with whatever count we have if timeout fires" is expressible **without** a new variant: put the timeout-handling logic in the resumed worker code. The execution resumes with `timeout_behavior = auto_resume_with_timeout_signal`, and the worker inspects `list_waitpoint_signals` to see what actually arrived. This keeps the condition language minimal.
+
+If a consumer wants *condition-level* "count(3) OR timeout-partial", they must write it as two sequential suspensions — one `Count(3)` with `fail` timeout, a retry-handler that runs a second suspension with a shorter timeout. This is verbose but expressible.
+
+### 6.3 Why not introduce `PartialCount` variant
+
+Rejected: adds a 4th variant to handle a policy decision (what to do on timeout with N<required), bloating the enum with orthogonal concern. Policy belongs in `timeout_behavior`, topology in `ResumeCondition`.
+
+---
+
+## 7. Wire format + interactions
+
+### 7.1 Does `WaitpointSpec` need condition-level info?
+
+**No.** `ResumeCondition` owns the topology; `WaitpointSpec` stays per-waitpoint (name, matcher hints, payload schema hints).
+
+At `suspend_execution` time:
+- The worker constructs `Vec<WaitpointSpec>` (one per waitpoint to create) and `ResumeCondition` (the topology).
+- `ResumeCondition` references waitpoints by `WaitpointKey`, which the suspend call resolves to `waitpoint_id`s.
+- Lua receives `resume_condition_json` + `waitpoint_specs_json` as separate ARGV fields, writes `suspension:current:member_map` from their intersection.
+
+This cleanly separates "what waitpoints exist" from "how their signals combine," matching RFC-004 §§Object Definition where these are already two fields.
+
+### 7.2 Serde stability
+
+`resume_condition_json` is the wire format. We version-tag it:
+
+```json
+{
+  "v": 1,
+  "kind": "AllOf",
+  "members": [
+    { "v": 1, "kind": "Single", "waitpoint_key": "..." },
+    { "v": 1, "kind": "Count", "n": 2, "count_kind": "DistinctSources",
+      "waitpoints": ["..."] }
+  ]
+}
+```
+
+Lua rejects `v > 1` with `invalid_resume_condition`. Future RFCs increment `v`.
+
+### 7.3 Interaction with RFC-013
+
+RFC-013 owns the typed `ResumeCondition` on the `suspend` trait. RFC-014 variants flow through it. The SDK forwarder (RFC-012 stage 1d) serializes to `resume_condition_json` and the Valkey backend writes it unchanged. No additional trait method is introduced by RFC-014.
+
+### 7.4 Interaction with RFC-016 (flow DAGs, future)
+
+RFC-016 addresses flow-edge quorum (DAG join semantics). RFC-014 handles waitpoint-local quorum only. If a flow edge needs `k-of-n` across *executions*, that is a flow-level join, not a waitpoint condition. The two layers compose: a flow-join waits on one-child-execution-per-branch; each branch may use RFC-014 locally.
+
+### 7.5 Interaction with RFC-005 `send_signal`
+
+`send_signal` (RFC-005 §310) signature is unchanged. The matching logic it invokes expands to §3.3. Existing single-signal consumers see no behavior change because the default `ResumeCondition::Single` branch of the matching algorithm reduces to RFC-005 §8.3.
+
+---
+
+## 8. Open questions
+
+1. **Do we support `CountKind::DistinctSources` with `source_type = "system"` signals?** Operator-override signals via `send_signal` with source_type=system could trivially satisfy a `DistinctSources(2)` count. Leaning: yes, count them, but note this in operator tooling so "2 operator overrides != 2 user approvals" is visible. Escalate to owner.
+
+2. **Should `AllOf` short-circuit evaluation on a satisfied signal that doesn't advance the root?** Current design: always evaluate up to root (§3.3 step 4). Alternative: mark node-satisfied only, defer root evaluation to a "maybe ready" queue. Leaning: no — root eval is O(depth ≤ 4) and happens per-signal. Not worth the complexity.
+
+3. **Is per-waitpoint quorum (`Count(2, kind=DistinctSources, waitpoints=[single_wp])`) enough to express "2-of-5 reviewers one waitpoint" OR do we need a `WaitpointSpec.expected_signal_count` hint to size TTL/cleanup?** Leaning: the `Count` variant already expresses it; TTL/cleanup is RFC-004's concern. But worth a round of review against real `cairn-fabric` review-approval flows before locking.
+
+---
+
+## 9. Alternatives rejected
+
+### 9.1 Parallel `MultiSignalCondition` type (not an enum variant extension)
+
+A separate top-level type passed alongside `ResumeCondition`:
+
+```rust
+// REJECTED
+fn suspend(
+    spec: Vec<WaitpointSpec>,
+    cond: ResumeCondition,          // single-signal from RFC-013
+    multi: Option<MultiSignalCondition>,  // new, parallel
+);
+```
+
+Rejected because:
+- Two types that both describe "when does this resume" is an API smell. Consumers must learn both; trait signatures grow.
+- Composition (`AllOf { members: [count, single] }`) is awkward across two types.
+- If RFC-013 delivers a non-nestable `ResumeCondition`, the correct move is to amend RFC-013, not fork the shape in RFC-014.
+
+### 9.2 Condition-expressed-as-JSONata (or similar external predicate language)
+
+Rejected: violates RFC-004 §Invariants (no external predicates in v1). Lua would execute untrusted expressions; scope creep into validation engine; debuggability loss.
+
+### 9.3 Per-waitpoint `expected_signal_count` on `WaitpointSpec`
+
+An alternative to `Count { n, waitpoints: [wp] }` where the `wp` itself carries `expected_signal_count = 3`. Rejected:
+- Duplicates topology into per-waitpoint fields.
+- Multi-waitpoint count (`Count { n: 2, waitpoints: [wp1, wp2, wp3] }`) is not expressible.
+- RFC-004 `WaitpointSpec` is already at its size limit; adding count semantics there inflates an unrelated type.
+
+### 9.4 Adding `AnyOf`, `NotOf`, `Quorum` variants
+
+All expressible via `Count`. Extra variants ≡ extra matching paths in Lua. See §2.3.
+
+### 9.5 Out of scope by choice, not oversight
+
+The following RFC-005 §Designed-for-deferred items are **explicitly not in scope** for RFC-014. Adding them here would bloat an already-dense RFC and block on unrelated designs:
+
+- **Signal routing to flow coordinator** — RFC-016 (flow DAGs).
+- **Signal payload schema validation** — separate RFC (type registry / schema engine).
+- **Signal TTL** — separate RFC (signal lifecycle + GC).
+- **Signal replay** — separate RFC (debug/observability tooling).
+- **Bulk signal delivery** — separate RFC (API surface; ties into batch ergonomics).
+
+None of these are blockers for multi-signal resume. Multi-signal works with v1's signal semantics; these are additive future concerns.
+
+---
+
+## 10. Implementation plan
+
+**Dependency:** RFC-013 must land first with a nestable `ResumeCondition` enum. If RFC-013 ships a non-nestable shape, this RFC parks pending an RFC-013 amendment.
+
+### Phase 1 — Rust-side enum + validation
+
+**Crates touched:** `ff-core` (types), `ff-sdk` (wire), `ff-backend-valkey` (argv build).
+
+- Add `AllOf` + `Count` variants + `CountKind` enum to `ResumeCondition`.
+- Add suspend-time validators (§5.1) returning `EngineError::InvalidCondition { kind }` variants.
+- Wire-level serde with `v: 1` version tag (§7.2).
+- Unit tests: validator rejects impossible conditions; serde roundtrip; nesting depth bound.
+
+**Exit:** `cargo test -p ff-core -p ff-sdk` green. No Lua changes yet.
+
+### Phase 2 — Lua evaluator
+
+**Files:** `ff-script/src/functions/signal.rs`, `ff-script/lua/ff_deliver_signal.lua` (or equivalent), `ff-script/lua/ff_suspend_execution.lua`.
+
+- `suspend_execution` writes `suspension:current:member_map`.
+- `deliver_signal` replaces its single-matcher branch with the §3.3 algorithm.
+- `evaluate_resume_conditions` (RFC-005 §323) extended per §4.4.
+- Integration tests in `crates/ff-backend-valkey/tests/`:
+  - `count_2_distinct_sources_resumes_on_second_source`
+  - `count_2_distinct_sources_ignores_duplicate_source`
+  - `allof_three_waitpoints_resumes_when_all_fired`
+  - `allof_replay_after_partial_count_preserves_state`
+  - `count_exceeds_waitpoint_set_rejected_at_suspend`
+  - `timeout_with_partial_count_uses_timeout_behavior`
+
+**Exit:** integration tests green against Valkey 8.x; `evaluate_resume_conditions` diagnostic reflects correct partial state.
+
+### Phase 3 — SDK ergonomics
+
+**Crates:** `ff-sdk`.
+
+- Public builder API: `ResumeCondition::all_of([...])`, `ResumeCondition::count(n).distinct_sources().on_waitpoints([...])`.
+- Doc tests in `ff-sdk/src/suspend.rs` covering the three canonical patterns from §1.1.
+- Smoke example in `examples/` that runs a 2-of-3 approval flow end-to-end.
+
+**Exit:** scratch-project smoke (per the "smoke after publish" memory) validates the three patterns against a published artifact.
+
+### Phase 4 — Observability
+
+- `evaluate_resume_conditions` output wired to `ff-board-sdk` (if/when that lands).
+- Metric: `ff_suspension_condition_depth` histogram (per §5.4 invariant, catch drift).
+- Tracing: per-signal log of `effect` including new `appended_to_waitpoint_duplicate` and `signal_ignored_not_in_condition`.
+
+**Exit:** operator can answer "why is this execution still suspended?" via `evaluate_resume_conditions` without reading Lua.
+
+### Non-goals during implementation
+
+- No change to `send_signal` / `send_signal_to_waitpoint` signatures.
+- No change to waitpoint creation API.
+- No change to `idempotency_key` semantics (§4.1 keeps both dedup layers).
+- No new Valkey keys beyond `satisfied_set` + `member_map` per §3.1.
+
+---
+
+## References
+
+- RFC-004 §Resume Condition Model — base condition schema.
+- RFC-005 §8 Signal Matching — existing single-signal algorithm this RFC extends.
+- RFC-005 §Designed-for-deferred (lines 772–779) — the deferral catalog this RFC partially addresses.
+- RFC-010 §Waitpoint keys (line 64) — storage conventions for `suspension:current`.
+- RFC-010 §Lua helpers (line 780) — `initialize_condition(json)` is where parsing lives.
+- RFC-012 §Stage 1d — `suspend` trait migration (parallel with RFC-013).
+- RFC-013 (parallel) — base `ResumeCondition` shape + `suspend` trait signature.
+- RFC-016 (future) — flow DAG edge quorum; composes with, does not supersede, RFC-014.
+- PR #200 — `deliver_signal` + `claim_resumed_execution` landing.


### PR DESCRIPTION
## Summary

Draft RFC-014 extending RFC-013's base `ResumeCondition` with two new variants — `AllOf` and `Count { n, kind }` — to close the `all_of` + `count(n)` items from RFC-005 §Designed-for-deferred (lines 772-779). The other five RFC-005 deferrals (signal TTL, replay, payload schema validation, bulk delivery, flow-coordinator routing) stay explicitly out of scope.

- Nestable enum extension: `AllOf { members: Vec<ResumeCondition> }`, `Count { n, kind: CountKind, matcher, waitpoints }` with `CountKind = DistinctWaitpoints | DistinctSignals | DistinctSources`.
- Lua storage: flat `satisfied_set` SET + static `member_map` HASH on `suspension:current`; O(depth) matching, durable across worker crash.
- Forward-compat contract with RFC-013 stated up-front — if RFC-013's adjudicated shape is non-nestable, RFC-014 parks pending amendment rather than forking a parallel `MultiSignalCondition` type.

## Draft location

`rfcs/drafts/RFC-014-multi-signal-resume.md` (513 lines, under the 1000-line cap).

## Do not merge

This is a draft for review. No code changes. Owner adjudication pending on §8 open questions (system-source counting, `cairn-fabric` reviewer pattern validation).

## Test plan

- [ ] Cross-review against RFC-013's settled base shape once it lands.
- [ ] Validate §1.1 canonical patterns against real `cairn-fabric` approval flows.
- [ ] Confirm §9.5 scope carve-out with team before Phase 1 implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a draft RFC; no runtime code or behavior changes. Risk is limited to design churn/ambiguity until the proposal is implemented.
> 
> **Overview**
> Adds **draft RFC-014** describing a proposed extension to `ResumeCondition` with multi-signal semantics: `AllOf { members }` and `Count { n, kind, matcher?, waitpoints }` (with `CountKind` for distinct waitpoints/signals/sources).
> 
> The RFC outlines planned Valkey/Lua matching storage (`satisfied_set` + `member_map`), idempotency/replay behavior, suspend-time validation errors, and timeout/observability interactions, while explicitly keeping other RFC-005 deferrals out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e0caa84b613616fe2f948521e8b67445c2d937. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->