### PR TITLE
rfc(013): Stage 1d suspend trait migration (draft)

### DIFF
--- a/rfcs/drafts/RFC-013-challenges/ACCEPTED.md
+++ b/rfcs/drafts/RFC-013-challenges/ACCEPTED.md
@@ -1,0 +1,38 @@
+# RFC-013 — Unanimous ACCEPT
+
+**Reached:** round 2 (2026-04-23)
+**Final commit:** `12106f6` on branch `rfc/013-stage-1d`
+**PR:** #211 (open; owner review pending)
+
+## Rounds
+
+### Round 1 — all three DISSENT
+- **K** (skeptic): 7 correctness clarifications (idempotency_key semantics, TTL cap, timeout-only-no-deadline validation, error rows, describe-retry, §9.2 Lua delta accuracy, TTL-expiry test).
+- **L** (consumer): 9 ergonomics items (constructors per `non_exhaustive_needs_constructor` memory rule, clock-skew doc, waitpoint_key cross-field validation, SDK auto-reconcile contract, `StateKind` non-exhaustive confirmation, `SuspendOutcomeDetails` definition, `stop_renewal` ordering / lease bleed).
+- **M** (impl): 7 feasibility items (§9.2 Lua delta, KEYS/ARGV slot accounting, `resume_delay_ms` wire path, `InvalidLeaseForSuspend` citation, `build_suspend_args` body, `PendingWaitpoint` → `UsePending` HMAC lookup, backend-serializer + scanner tests).
+
+**Author response:** conceded all 23 findings. No push-back. Revisions applied in commit `12106f6`.
+
+### Round 2 — all three ACCEPT
+- **K** ACCEPT: every round-1 item addressed with specific text; no new concerns.
+- **L** ACCEPT: constructors + ergonomics fixes land; `stop_renewal` reorder correct; no new concerns.
+- **M** ACCEPT: §9.2 Lua delta now accurate; slot counts and test matrix comprehensive; no new concerns.
+
+## Material changes during debate
+
+1. **§2.2** — `timeout_at` gets explicit clock-skew tolerance doc (10 min) + pointer to `server_time()` helper.
+2. **§2.2** — `idempotency_key` dedup TTL formula pinned: `min(timeout_at - now + SUSPEND_DEDUP_GRACE_MS, SUSPEND_DEDUP_MAX_TTL_MS=7d)`.
+3. **§2.2** — dedup-hit `suspension_id` echo contract made explicit (first-call's id wins).
+4. **§2.2.1** (new subsection) — constructors: `SuspendArgs::new` + `with_*` chain, `WaitpointBinding::fresh()` / `use_pending()`, `ResumePolicy::normal()`. Satisfies `non_exhaustive_needs_constructor`.
+5. **§2.4** — added `waitpoint_key` cross-field invariant (`WaitpointBinding::Fresh` vs `ResumeCondition::Single`).
+6. **§3.1** — describe-retry budget note added.
+7. **§4** — four new error-table rows (TimeoutOnly+no-deadline, waitpoint_key mismatch, UsePending-already-activated, handle-kind-precheck-not-dedup-dodgeable); `StateKind`/`ValidationKind` non-exhaustive confirmation with file-line pins; `InvalidLeaseForSuspend` pin.
+8. **§5.1** — `stop_renewal` reordered to fire only on committed `Suspended` outcome (no lease bleed on transport error); `SuspendOutcomeDetails` defined; `build_suspend_args` defaults spelled out; `PendingWaitpoint` → `UsePending` mapping clarified; no-SDK-auto-reconcile contract stated.
+9. **§9.2** — rewritten from "none required" to explicit Lua delta: +1 KEY (dedup hash) / +2 ARGV (idempotency_key, dedup_ttl_ms), 17→18 / 17→19 slot counts, three-step dedup branch, serialized-outcome version pin.
+10. **§9.3** — added tests: idempotency TTL expiry, `timeout_at == None` TTL cap, cross-field validation, TimeoutOnly-no-deadline validation, constructor round-trip, backend-internal ARGV-JSON serializer canary, scanner-interaction confirmation.
+
+## No design changes
+
+All 10 material changes are clarifications, constructors, or taxonomy tightening. The design decisions (typed `SuspendArgs`/`SuspendOutcome`, `ResumeCondition` enum with `Composite` reservation, `suspend` / `try_suspend` split, `idempotency_key` field) landed in round 0 and survived both debate rounds unchanged.
+
+Owner adjudications from 2026-04-23 (try_suspend split, flat composites dropped, `idempotency_key`) were not re-litigated — challengers respected the overrule carve-out.

--- a/rfcs/drafts/RFC-013-challenges/round-1/K.md
+++ b/rfcs/drafts/RFC-013-challenges/round-1/K.md
@@ -1,0 +1,47 @@
+# RFC-013 Round-1 — K (skeptic / correctness)
+
+**Bottom line:** DISSENT
+
+## Per-section
+
+- §Summary GREEN — problem statement is clear; scope bounded.
+- §Motivation GREEN — breakage list is concrete, ties to specific lines.
+- §Assumptions YELLOW — A1 says "enforcement is runtime, not compile-time — same model as complete/fail" but does NOT specify what the runtime error is when a caller passes a Suspended-kind handle *into* a pre-suspend op. §4 table covers `suspend` on Suspended handle → `State(AlreadySuspended)`, but the general inverse (e.g. `complete(&suspended_handle)`) is out of RFC-013 scope. Flag only — not a dissent driver.
+- §1 GREEN — file/line pins are precise.
+- §2.1 GREEN — signature matches round-7 precedent.
+- §2.2 RED { **`suspension_id` uniqueness semantics are unspecified when `idempotency_key` is set.** §2.2 says "`suspension_id` is worker-minted" and §3.3 says "`suspension_id` is echoed ... not for Lua-side dedup". But §2.2's idempotency_key note says "the first outcome is returned verbatim (including the original `suspension_id` ...)". Question: if the caller mints a NEW `suspension_id` on the retry but passes the SAME `idempotency_key`, does the backend (a) return the ORIGINAL `suspension_id` from the first call, or (b) return a mismatch error? The RFC implies (a) by "verbatim", but that means `suspension_id` on the wire is a *request* id that the backend may silently rewrite. That's surprising — callers who persist `suspension_id` pre-call to correlate logs will see a mismatch between what they sent and what came back. Needs one sentence clarifying this is the contract. Flip-fix: add a sentence to §2.2's idempotency_key doc: "On dedup hit, the returned `suspension_id` is the FIRST call's minted id, not the retry's — callers correlating by `suspension_id` should use the echoed value, not the sent value." } 
+- §2.2 RED { **`idempotency_key` dedup window vs timeout_at semantics are underspecified.** RFC says "TTL = suspension-timeout ceiling + grace". But `timeout_at` is `Option<TimestampMs>` — `None` means "suspend indefinitely". What is the dedup TTL when `timeout_at == None`? Worst case is unbounded, which is a memory leak in the dedup hash namespace. Flip-fix: specify a dedup TTL cap (e.g. `min(timeout_at - now + grace, DEDUP_MAX_TTL = 7d)`), and state what `None` falls back to (e.g. `DEDUP_MAX_TTL`). } 
+- §2.3 GREEN — enum shape is sound; handle substitution semantics clear.
+- §2.4 YELLOW { **`ResumeCondition::TimeoutOnly` + `timeout_at == None` is a contradiction.** If resume is timeout-only and no timeout is set, the exec suspends forever with no satisfier. Validation should reject this combo. Flip-fix: add to §4 error table: `ResumeCondition::TimeoutOnly` + `timeout_at.is_none()` → `Validation(InvalidInput { detail: "timeout_only_without_deadline" })`. }
+- §2.5 GREEN.
+- §2.6 GREEN.
+- §3.1 RED { **"describe-and-reconcile on any retry" creates an unbounded error recovery loop if `suspend` transport-errors and `describe_execution` also transport-errors.** The contract says caller MUST describe before retrying. But what if the describe call itself fails transiently? The RFC doesn't spec a retry budget. This is not a blocker for correctness, but it's a trap for implementers. Flip-fix: add a note to §3.1 contract: "Callers may retry `describe_execution` independently under normal transport-retry policy; `suspend` remains un-retryable until describe succeeds. With `idempotency_key`, this problem is moot." } 
+- §3.2 GREEN — invalid replay cases enumerated.
+- §3.3 GREEN after §2.2 fixes above.
+- §4 RED { **Missing row: `suspend` on an exec whose pending waitpoint (`UsePending`) has already been *activated* by a racing `suspend`.** Two workers on the same exec (which Round-4 disallows by lease, so probably impossible), OR one worker's first `suspend` committed and is now active, and a retry with `UsePending { waitpoint_id }` references the same waitpoint. What does Lua return? Probably `already_suspended` at the exec level before checking waitpoint state. Should be listed explicitly. Flip-fix: add a row: "`UsePending` waitpoint already activated by a prior committed suspend" → `State(AlreadySuspended)`, noting the check order (exec-level before waitpoint-level). }
+- §4 RED { **`HandleKind::Suspended` pre-check is described in §3.2 case 3 but not in §4 error path.** §3.2 says backend pattern-matches handle kind and returns `AlreadySuspended` without FCALL. The §4 table says "Handle kind is Suspended at entry → State(AlreadySuspended), Rust-side check, no FCALL." That's consistent. But the table also needs to say: this is a *bug detection*, not a retry-safe error — it is NOT retryable even with `idempotency_key`, because the key is namespaced on `(partition, execution_id, idempotency_key)` but the handle is already in an unusable kind. Clarify classification. Flip-fix: add a note to that row: "Not de-duped by `idempotency_key`; this is a pre-FCALL Rust-side rejection that fires before dedup lookup." }
+- §5.1 GREEN — split is sound, rationale crisp.
+- §5.2 GREEN.
+- §5.3 GREEN.
+- §6 GREEN.
+- §7 GREEN — remaining open questions are appropriately scoped.
+- §8.1-§8.6 GREEN.
+- §9.1 GREEN.
+- §9.2 GREEN — no Lua changes is a claim I want to verify. §2.2's idempotency_key note says "Lua stores a hash `ff:dedup:suspend:{p:N}:<execution_id>:<idempotency_key>` → serialized `SuspendOutcome`". That IS a Lua change (new write + read + TTL management inside `ff_suspend_execution`). §9.2 saying "None required" contradicts §2.2. Re-classify: **§9.2 RED**. Flip-fix: change §9.2 to "Lua adds a partition-scoped dedup hash write/read around the `already_suspended` check. The KEYS/ARGV contract grows by 2 keys (the dedup hash, and a TTL arg). Existing callers not passing `idempotency_key` pass empty-string ARGV; Lua no-ops the dedup branch."
+- §9.3 YELLOW { Test matrix doesn't cover the idempotency_key dedup-TTL-expiry case: call twice with same key, wait past TTL, call third time — third should act fresh. Flip-fix: add a third idempotency case to §9.3 item 1. }
+- §9.4 GREEN.
+- §9.5 GREEN.
+
+## Flip-to-ACCEPT changes
+
+Minimal edits to the RFC:
+
+1. **§2.2** (`idempotency_key` doc): add the "dedup hit returns FIRST call's suspension_id" clarification.
+2. **§2.2** (`idempotency_key` doc): add dedup TTL cap for `timeout_at == None`.
+3. **§2.4**: add `TimeoutOnly` + no-deadline validation row.
+4. **§4** error table: add `UsePending` already-activated row; add note on `HandleKind::Suspended` pre-check not dedup-dodgeable.
+5. **§3.1**: add one-line note on describe-retry budget.
+6. **§9.2**: correct the "none required" claim — dedup hash is a new Lua write.
+7. **§9.3**: add idempotency TTL-expiry test.
+
+All are clarifications; no design change.

--- a/rfcs/drafts/RFC-013-challenges/round-1/L.md
+++ b/rfcs/drafts/RFC-013-challenges/round-1/L.md
@@ -1,0 +1,42 @@
+# RFC-013 Round-1 — L (ergonomics / consumer)
+
+**Bottom line:** DISSENT
+
+Role: I am cairn-fabric. I consume `ff-sdk` and pattern-match `EngineError`. I'm reading this RFC cold to decide if the migration from today's `ClaimedTask::suspend` is tractable.
+
+## Per-section
+
+- §Summary GREEN.
+- §Motivation GREEN — the "cannot express AlreadySatisfied in Result<Handle, EngineError>" sentence lands.
+- §Assumptions GREEN.
+- §1 GREEN.
+- §2.1 GREEN.
+- §2.2 YELLOW { As a consumer, I have to supply `now: TimestampMs` and `timeout_at: Option<TimestampMs>` — both wall-clock caller-side. The RFC says the backend "uses server-time `TIME` for Lua correctness but carries the caller clock for correlation". What clock do I compare against when I compute `timeout_at`? If I use `SystemTime::now()` and the Valkey server clock drifts 10s behind, do I get spurious `Validation(InvalidInput { detail: "timeout_at_in_past" })`? The rustdoc should point me at a helper or at least say "use `backend.server_time()` as the reference clock" if that op exists. Flip-fix: add one doc-comment line on `timeout_at` clarifying clock-skew tolerance on the backend side — e.g. "validated against backend wall-clock with N ms tolerance; worker clock skew within N ms is accepted". }
+- §2.2 RED { **`WaitpointBinding::Fresh` forces me to mint `waitpoint_id` AND `waitpoint_key` myself.** That's two UUIDs per suspend call. The rustdoc doesn't say how to mint them — "worker-minted (UUID, `wpk:<uuid>`)" — but does the SDK expose a `WaitpointBinding::fresh()` constructor that does this for me, or am I writing `uuid::Uuid::new_v4()` + `format!("wpk:{}", id)` inline in my handler? Consumer pain: this is ceremony that the SDK should hide. Flip-fix: §5.1 should show a `WaitpointBinding::fresh()` or `SuspendArgs::builder()` helper. Without a constructor, the `#[non_exhaustive]` struct is unbuildable by cairn per our memory rule (`non_exhaustive_needs_constructor`). }
+- §2.2 RED { **`SuspendArgs` is `#[non_exhaustive]` with 10+ required fields.** As a consumer, I can't construct it with `SuspendArgs { … }` because of non-exhaustive, and the RFC doesn't specify a builder. This is the exact footgun called out in memory `non_exhaustive_needs_constructor` (applied during v0.3.2 smoke). Flip-fix: §2.2 must specify a constructor — either `SuspendArgs::new(required_fields) + with_timeout(...) + with_idempotency_key(...)` builder, or a `pub fn new(suspension_id, waitpoint, resume_condition, resume_policy, reason_code, requested_by, now) -> Self` with `timeout_at`/`timeout_behavior`/`continuation_metadata_pointer`/`idempotency_key` as setters. This is a landing-PR blocker for me. }
+- §2.3 GREEN — the enum is clear; pattern-matching on `Suspended{..}`/`AlreadySatisfied{..}` is what I expect.
+- §2.4 YELLOW { From pure rustdoc, `ResumeCondition::Single { waitpoint_key, matcher }` — what's the relationship between `waitpoint_key` here and `WaitpointBinding::{Fresh{waitpoint_key}, UsePending}`? Do they MUST match? If I pass `WaitpointBinding::Fresh { waitpoint_key: "wpk:abc" }` and `ResumeCondition::Single { waitpoint_key: "wpk:xyz", .. }`, is that a validation error? Intuition says yes, but the RFC doesn't say. Flip-fix: add to §4: `WaitpointBinding.waitpoint_key` / `ResumeCondition::Single.waitpoint_key` mismatch → `Validation(InvalidInput { detail: "waitpoint_key_mismatch" })`. }
+- §2.5 YELLOW { `ResumePolicy` has 5 bool/option fields, all `#[non_exhaustive]`. Same constructor gap as §2.2. What are the defaults? Is `consume_matched_signals: true` typical? The RFC doesn't say what cairn should pass for "normal" usage. Flip-fix: add either `ResumePolicy::default()` (if derivable) or `ResumePolicy::normal()` convenience with documented defaults, so I'm not copying magic bool values across handlers. }
+- §2.6 GREEN — enums are easy to exhaustively match.
+- §3 YELLOW { The §3.3 contract — "callers must describe-and-reconcile on any retry without idempotency_key" — means for every suspend call site in cairn I need to wrap with retry+describe logic, OR always pass an `idempotency_key`. That's a big ergonomic ask. Can the SDK wrapper do the describe-and-reconcile for me? §5.1's `suspend`/`try_suspend` don't mention it. Flip-fix: clarify in §5.1 whether the SDK-level `suspend`/`try_suspend` auto-reconciles on transport error, or whether cairn handlers own that loop. If the latter, a §5.4 "consumer retry playbook" subsection would save me re-deriving it. }
+- §4 RED { **Error taxonomy maps `Suspend strict + early-satisfied → State(AlreadySatisfied)` but I'm used to matching on `EngineError::{Contention,State,Validation,Transport}`. Is `AlreadySatisfied` a variant I already have, or a new `StateKind` added by this RFC?** §4 says "New kinds needed: one. `StateKind::AlreadySatisfied`". OK that's specified — but cairn currently matches `EngineError::State(kind)` with an exhaustive match. Adding a new variant to a `#[non_exhaustive]` enum is non-breaking; to a non-`#[non_exhaustive]` enum, it breaks every downstream match. The RFC should state whether `StateKind` is `#[non_exhaustive]`. Flip-fix: one-line in §4: "`StateKind` is already `#[non_exhaustive]` per Round-7; adding `AlreadySatisfied` is non-breaking for downstream consumers." (Verify by grep if needed.) }
+- §5.1 YELLOW { The `try_suspend` signature returns `TrySuspendOutcome` which is `enum { Suspended(SuspendedHandle), AlreadySatisfied { task, details } }`. What's `SuspendOutcomeDetails`? It's mentioned in the enum body but not defined. From the shape of `SuspendOutcome::AlreadySatisfied` in §2.3 (`suspension_id, waitpoint_id, waitpoint_key, waitpoint_token`), I can infer it. But the RFC should define `SuspendOutcomeDetails` explicitly or point at §2.3. Flip-fix: add a `pub struct SuspendOutcomeDetails { suspension_id, waitpoint_id, waitpoint_key, waitpoint_token }` code block, or inline the fields. }
+- §5.1 RED { **The strict `suspend` path in §5.1 says `self.stop_renewal();` runs BEFORE the FCALL, then if the FCALL errors with anything other than AlreadySatisfied, the lease is no longer being renewed but also not released Lua-side.** If the backend call transport-errors, `stop_renewal` has already fired → lease expires at heartbeat timeout → exec drops to reclaimable → worker has no way to re-claim the same exec cleanly. §3.1 says "describe-and-reconcile"; but the lease is bleeding out during that window. Is that acceptable? The cairn handler would expect either (a) the lease survives until FCALL resolution, or (b) the SDK retries the FCALL itself within lease ttl. Flip-fix: §5.1 strict suspend should call `stop_renewal` AFTER the FCALL resolves successfully, not before; OR the RFC should explicitly acknowledge the "lease bleeds during transport error" window as a known limitation with a documented reclaim path. This is a correctness-of-implementation point that affects my handler design. }
+- §5.2 GREEN — migration note is clear.
+- §5.3 GREEN.
+- §6 GREEN.
+- §7 GREEN.
+- §8 GREEN.
+- §9 GREEN.
+
+## Flip-to-ACCEPT changes
+
+1. **§2.2**: add `SuspendArgs::new(...)` constructor (or builder) — blocker per `non_exhaustive_needs_constructor`.
+2. **§2.2**: add `WaitpointBinding::fresh()` helper — mints id+key for me.
+3. **§2.5**: add `ResumePolicy::normal()` or `Default` impl with documented defaults.
+4. **§2.2**: clock-skew tolerance note on `timeout_at` / `now`.
+5. **§2.4** / **§4**: waitpoint_key mismatch between `WaitpointBinding` and `ResumeCondition::Single` is a validation error.
+6. **§3.3**: pointer to "does SDK auto-reconcile or does caller?"
+7. **§4**: confirm `StateKind` is `#[non_exhaustive]`; land `AlreadySatisfied` there.
+8. **§5.1**: define `SuspendOutcomeDetails` explicitly.
+9. **§5.1**: clarify renewal-stop ordering w.r.t. FCALL (either reorder or document the bleed window).

--- a/rfcs/drafts/RFC-013-challenges/round-1/M.md
+++ b/rfcs/drafts/RFC-013-challenges/round-1/M.md
@@ -1,0 +1,43 @@
+# RFC-013 Round-1 — M (implementation / feasibility)
+
+**Bottom line:** DISSENT
+
+Role: engineer implementing the Lua + Rust changes. I care about wire cost, scanner interaction, migration mechanics.
+
+## Per-section
+
+- §Summary GREEN.
+- §Motivation GREEN.
+- §Assumptions GREEN — A2 (HMAC unchanged) and A4 (`create_waitpoint` unchanged) are the load-bearing claims that keep the wire diff small.
+- §1 GREEN — line pins match my reading of the tree.
+- §2.1 GREEN.
+- §2.2 RED { **`idempotency_key` implementation cost is underestimated in §9.2 ("None required").** Per §2.2 doc, Lua must: (a) compute dedup hash key `ff:dedup:suspend:{p:N}:<execution_id>:<idempotency_key>`, (b) GET it BEFORE the `already_suspended` check, (c) if HIT: return serialized `SuspendOutcome` verbatim (skipping all state mutation), (d) if MISS: proceed with suspend, then SET the hash with TTL = suspension-timeout-ceiling + grace, serialize `SuspendOutcome` into it. This is a non-trivial Lua patch: ~30 LOC added to `ff_suspend_execution`, plus the serialized-outcome format needs to be stable across Lua versions (or the dedup entry becomes unparseable after a Lua upgrade). §9.2's "none required" is flat wrong. Flip-fix: rewrite §9.2 to specify the Lua delta and pin the serialized outcome format (length-prefixed positional array matching today's `parse_suspend_result`? Or JSON?). }
+- §2.2 RED { **KEYS/ARGV slot accounting is unspecified for the idempotency_key path.** Today's `ff_suspend_execution` uses 17 KEYS + 17 ARGV per §1. Adding dedup needs: +1 KEY (dedup hash) +1 ARGV (idempotency_key string, empty when None) +1 ARGV (dedup TTL). That's 18/19 slots. Need explicit spec so backend's `slot_count` assertion doesn't drift silently. Flip-fix: §9.2 enumerate the new KEYS/ARGV positions. }
+- §2.3 GREEN — outcome enum shape is fine.
+- §2.4 GREEN — matches the existing `ff_suspend_execution` `initialize_condition` helper's inputs.
+- §2.5 YELLOW { `ResumePolicy` has 5 fields; most map to existing `resume_policy_json` ARGV fields. But `resume_delay_ms: Option<u64>` — RFC-004 §Resume policy says "delay before execution becomes eligible". Is this carried in the existing Lua contract? If so, which ARGV slot? If not, it's a new write — §9.2 should call it out. Flip-fix: verify against current `ff_suspend_execution` and either confirm no-Lua-change or add to §9.2's delta. }
+- §2.6 GREEN — enum-to-string serialization is a trivial backend concern.
+- §3 GREEN from an impl POV (given §9.2 is corrected).
+- §4 YELLOW { `Validation(InvalidLeaseForSuspend)` — RFC says it was added in Round-4. Confirm this variant exists in current `EngineError::Validation` kind enum. If it doesn't, this RFC has to land it; not a blocker, just an accuracy check. Flip-fix: grep `InvalidLeaseForSuspend` and either leave as-is (if landed) or note it as a new variant in §4's "New kinds needed" bullet. }
+- §5.1 YELLOW { **`build_suspend_args` helper is called in §5.1's strict `suspend` body but not defined.** What does it do — construct a `SuspendArgs` with SDK-minted UUIDs for `suspension_id`/`waitpoint_id`/`waitpoint_key`, pack `timeout` into `timeout_at`+`timeout_behavior`, wire up `now` from `SystemTime::now`, and default `requested_by: Worker`, `continuation_metadata_pointer: None`, `idempotency_key: None`? That's a lot of implicit defaulting. Flip-fix: spell out `build_suspend_args`'s body OR point at a helper that the SDK ships. Also: does the SDK always default `idempotency_key: None`? If so, the strict-suspend retry contract per §3.3 is "never idempotent unless caller overrides". Document this in §5.1. }
+- §5.1 YELLOW { `try_suspend_on_pending` takes `&PendingWaitpoint`. What's the type? `create_waitpoint` returns something — presumably a struct with `waitpoint_id: WaitpointId` plus HMAC token. The SDK destructures this into `WaitpointBinding::UsePending { waitpoint_id }`. Is the HMAC token also fed in, or does the backend look it up from the waitpoint hash? Per §2.2 doc: "`UsePending` — The key + HMAC token were returned from that call; `suspend` resolves them from the waitpoint hash." OK, Lua looks it up. Then why does `create_waitpoint` hand the token back? Flip-fix: one-line note in §5.1: "`PendingWaitpoint` carries the `waitpoint_id` the SDK uses to build `WaitpointBinding::UsePending`; the HMAC token is resolved Lua-side from the partition waitpoint hash at `suspend` time." }
+- §5.2 GREEN.
+- §5.3 GREEN.
+- §6 GREEN.
+- §7 GREEN.
+- §8 GREEN.
+- §9.1 GREEN — landing order sequences types → trait → backend → SDK, which matches how Round-7 PRs shipped.
+- §9.2 RED { "None required" is incorrect once `idempotency_key` is counted — see §2.2 RED. Rewrite. }
+- §9.3 YELLOW { Integration tests list `suspend` against a live Valkey. Migration plan doesn't call out that the backend-side `ResumeCondition → ARGV JSON` serializer needs its own unit tests to catch schema drift. Flip-fix: add to §9.3: "Backend-internal serializer: for each `ResumeCondition` variant, assert the emitted ARGV JSON matches the exact string the legacy SDK produced, so the Lua no-change claim survives schema tweaks." }
+- §9.3 YELLOW { Scanner interaction is not tested. RFC-004's timeout scanner polls suspensions and fires timeout behaviors at `timeout_at`. This RFC doesn't change the scanner. But: `ResumeCondition::TimeoutOnly` + `timeout_behavior: Escalate` is a new-ish combo that the scanner may not exercise today. Flip-fix: add a scanner-integration test row to §9.3, OR state explicitly "scanner tests unchanged; existing RFC-004 scanner tests cover all `TimeoutBehavior` variants." }
+- §9.4 GREEN — risk call-out matches impl scope.
+- §9.5 GREEN — rollback plan is clean, zero durable-state changes.
+
+## Flip-to-ACCEPT changes
+
+1. **§9.2**: rewrite from "None required" to the explicit Lua delta for `idempotency_key` dedup (new KEYS/ARGV slots, dedup hash GET/SET, serialized outcome format, TTL computation).
+2. **§9.2**: verify `resume_delay_ms` path — is it a new ARGV or already carried?
+3. **§4**: confirm `InvalidLeaseForSuspend` already exists in `ValidationKind`.
+4. **§5.1**: spell out `build_suspend_args` body (or define it as SDK-internal helper with stated defaults: `requested_by=Worker, idempotency_key=None, continuation_metadata_pointer=None, now=SystemTime::now`).
+5. **§5.1**: one-line on `PendingWaitpoint` → `WaitpointBinding::UsePending` mapping and HMAC-token Lua lookup.
+6. **§9.3**: backend-internal ARGV-JSON serializer schema tests; scanner-interaction test coverage confirmation.

--- a/rfcs/drafts/RFC-013-challenges/round-1/author-response.md
+++ b/rfcs/drafts/RFC-013-challenges/round-1/author-response.md
@@ -1,0 +1,44 @@
+# RFC-013 Round-1 — Author response
+
+All three challengers DISSENT. Findings categorized below; author position on each, then the applied revisions.
+
+## K (skeptic) — concede all 7 findings
+
+1. **K1 — idempotency_key echoes FIRST call's `suspension_id`.** Concede. Clarify in §2.2 doc.
+2. **K2 — dedup TTL cap when `timeout_at == None`.** Concede. Add `DEDUP_MAX_TTL = 7d` cap, document in §2.2.
+3. **K3 — `TimeoutOnly` + no deadline is a validation error.** Concede. Add §4 row.
+4. **K4a — `UsePending` already-activated waitpoint.** Concede. Add §4 row. Lua check-order: exec-level `already_suspended` first, so this collapses to `State(AlreadySuspended)`.
+5. **K4b — `HandleKind::Suspended` pre-check not dedup-dodgeable.** Concede. Add note in §4.
+6. **K5 — describe-retry budget.** Concede. Add one-line note in §3.1.
+7. **K6 — §9.2 "None required" is wrong.** Concede, 100%. Also flagged by M. Rewrite §9.2 with Lua delta.
+8. **K7 — idempotency TTL-expiry test.** Concede. Add to §9.3.
+
+## L (consumer) — concede 9/9 findings
+
+1. **L1 — `SuspendArgs` constructor (blocker).** Concede. Memory rule `non_exhaustive_needs_constructor` applies directly. Add `SuspendArgs::new(...)` with required params + with_* setters in §2.2.
+2. **L2 — `WaitpointBinding::fresh()` helper.** Concede. Add to §2.2.
+3. **L3 — `ResumePolicy` defaults.** Concede. Add `ResumePolicy::normal()` constructor with documented v1 defaults.
+4. **L4 — clock-skew tolerance.** Concede. Add to `timeout_at` doc.
+5. **L5 — `waitpoint_key` cross-field validation.** Concede. Add §4 row. `WaitpointBinding::Fresh.waitpoint_key` must equal `ResumeCondition::Single.waitpoint_key` when both present.
+6. **L6 — SDK auto-reconcile or caller?** Concede — need to explicitly state: caller owns the describe-and-reconcile loop; SDK does NOT auto-reconcile on transport error of `suspend`. With `idempotency_key`, caller may retry directly.
+7. **L7 — `StateKind` is `#[non_exhaustive]`.** Confirmed via grep of `crates/ff-core/src/engine_error.rs:316`. Add confirmation note in §4.
+8. **L8 — define `SuspendOutcomeDetails`.** Concede. Define in §5.1.
+9. **L9 — `stop_renewal` ordering / lease bleed.** Concede with evidence: §5.1's current order (`stop_renewal` BEFORE FCALL) is wrong. Reorder so `stop_renewal` fires only on successful Suspend outcome (the Suspended handle's lease-state in Valkey is `unowned`, so the renewal loop would be a no-op anyway, but it's cleaner to stop renewal after we KNOW the exec committed to suspended). On transport error, renewal continues — worker's lease survives and the describe-and-reconcile path in §3.1 stays tractable.
+
+## M (impl) — concede all 7 findings
+
+1. **M1 — §9.2 Lua delta.** Concede. Rewrite with explicit new KEYS/ARGV.
+2. **M2 — KEYS/ARGV slot accounting.** Concede. Specify +1 KEY (dedup hash) +2 ARGV (idempotency_key, dedup_ttl_ms). New total: 18 KEYS, 19 ARGV.
+3. **M3 — `resume_delay_ms` Lua path.** Verified against RFC-004: `resume_delay_ms` is carried today in `resume_policy_json` ARGV slot; no new wire slot needed. Document this in §9.2.
+4. **M4 — `InvalidLeaseForSuspend` confirmed.** Grep: `crates/ff-core/src/engine_error.rs:183`. Already present. Note in §4.
+5. **M5 — `build_suspend_args` body.** Concede. Define in §5.1 with explicit defaulting.
+6. **M6 — `PendingWaitpoint` → `UsePending` mapping.** Concede. One-line note in §5.1.
+7. **M7 — backend-serializer + scanner tests.** Concede. Add to §9.3.
+
+## Nothing to push back on
+
+Every finding is either a genuine RFC gap or a valid clarification request. Applying all.
+
+## Revisions applied
+
+Commit: `rfc(013): round-1 revisions addressing K/L/M challenges` — see next push.

--- a/rfcs/drafts/RFC-013-challenges/round-2/K.md
+++ b/rfcs/drafts/RFC-013-challenges/round-2/K.md
@@ -1,0 +1,27 @@
+# RFC-013 Round-2 — K (skeptic / correctness)
+
+**Bottom line:** ACCEPT
+
+Re-reviewed revisions after round-1 commits. Every flip-to-ACCEPT item from round-1 was addressed with concrete, specific text. Checked each:
+
+- **K1** (dedup-hit `suspension_id` echo): §2.2 bullet now explicit — "the returned `SuspendOutcome::*.suspension_id` is the first call's minted id, NOT the retry's". GREEN.
+- **K2** (TTL cap for `timeout_at == None`): §2.2 specifies `SUSPEND_DEDUP_MAX_TTL_MS = 604_800_000` (7d) cap with the exact min() formula. GREEN.
+- **K3** (`TimeoutOnly` + no deadline): §4 row landed with `detail: "timeout_only_without_deadline"`. GREEN.
+- **K4a** (`UsePending` already-activated): §4 row explains the check-order collapse to `State(AlreadySuspended)`. GREEN.
+- **K4b** (handle-kind pre-check not dedup-dodgeable): §4 has a dedicated paragraph explaining the pre-FCALL rejection fires before dedup lookup and that `idempotency_key` does not help in that case. GREEN.
+- **K5** (describe-retry budget): §3.1 has the one-liner noting `describe_execution` may be independently retried under standard transport retry; `idempotency_key` makes this moot. GREEN.
+- **K6** (§9.2 "none required" correction): §9.2 completely rewritten — 18 KEYS, 19 ARGV, explicit Lua delta for dedup path, serialized-outcome stability note, resume_delay_ms confirmed on existing slot. GREEN.
+- **K7** (TTL-expiry test): §9.3 unit test list has TTL-expiry AND `timeout_at == None` TTL cap test. GREEN.
+
+## Per-section re-scan (looking for new issues introduced by revisions)
+
+- §2.2 GREEN — idempotency_key doc block is longer but coherent.
+- §2.2.1 GREEN — constructor set is minimal and addresses the memory rule without bloating the surface.
+- §2.4 GREEN — cross-field invariant is the right call.
+- §3.1 GREEN.
+- §4 error table GREEN — four new rows all map to existing or explicitly-new variants; `StateKind::AlreadySatisfied` is the only net-new addition.
+- §5.1 GREEN — `stop_renewal` reorder is correct (only fires on committed Suspend outcome). Comment makes the rationale explicit.
+- §9.2 GREEN — serialized-outcome version-pinning note is thoughtful forward-compat hedge.
+- §9.3 GREEN — test list is comprehensive.
+
+No new concerns.

--- a/rfcs/drafts/RFC-013-challenges/round-2/L.md
+++ b/rfcs/drafts/RFC-013-challenges/round-2/L.md
@@ -1,0 +1,35 @@
+# RFC-013 Round-2 — L (ergonomics / consumer)
+
+**Bottom line:** ACCEPT
+
+Re-reading as cairn consumer after revisions.
+
+## Round-1 items verification
+
+- **L1** `SuspendArgs::new` + `with_*`: §2.2.1 has the full constructor signature block. I can build a `SuspendArgs` without reaching inside a `#[non_exhaustive]` struct. GREEN.
+- **L2** `WaitpointBinding::fresh()`: §2.2.1 shows it + `use_pending(&PendingWaitpoint)`. GREEN.
+- **L3** `ResumePolicy::normal()`: §2.2.1 shows the body with explicit defaults. I don't have to guess what "normal" means. GREEN.
+- **L4** Clock-skew: `timeout_at` doc explicitly calls out 10 min tolerance + points at `ff_sdk::diagnostics::server_time()`. GREEN.
+- **L5** `waitpoint_key` mismatch: §2.4 + §4 both have it. GREEN.
+- **L6** SDK auto-reconcile?: §5.1 explicitly says SDK does NOT auto-reconcile; caller owns the loop or uses `idempotency_key`. GREEN.
+- **L7** `StateKind` is `#[non_exhaustive]`: §4 has the confirmation with file-line pin. GREEN.
+- **L8** `SuspendOutcomeDetails`: §5.1 defines it explicitly. GREEN.
+- **L9** `stop_renewal` ordering: §5.1 shows it inside the `Suspended` match arm with comment explaining the rationale. No more lease bleed on transport error. GREEN.
+
+## Per-section re-scan from consumer POV
+
+- §2.2 GREEN. My concern about "how do I get a valid `now`?" — `SystemTime::now()` defaults inside `build_suspend_args` per §5.1; I don't actually have to construct `SuspendArgs` by hand unless I'm calling the trait directly.
+- §2.2.1 GREEN — `SuspendArgs::new(suspension_id, waitpoint, resume_condition, resume_policy, reason_code, now)` is 6 required params. That's livable. The with_* chain covers the rest.
+- §2.3 GREEN.
+- §2.4 GREEN.
+- §2.5 GREEN — `ResumePolicy::normal()` is what I want 95% of the time.
+- §2.6 GREEN — enums are ergonomic to match.
+- §3 GREEN — retry contract is clear.
+- §4 GREEN — new rows + `StateKind` confirmation make the match ladder tractable.
+- §5.1 GREEN — split is clean, `stop_renewal` reorder is correct. `SuspendOutcomeDetails` is defined.
+- §5.2 GREEN — migration note is actionable.
+- §6–§9 GREEN.
+
+One micro-nit I'll NOT raise as a dissent driver: `SuspendArgs::new` takes `now: TimestampMs` as a required param even though the SDK always injects `SystemTime::now()`. For direct-trait consumers this is friction. But it's a deliberate choice (don't hide clock sources in constructors) and the SDK wrapper hides it. Not a blocker.
+
+No remaining dissent.

--- a/rfcs/drafts/RFC-013-challenges/round-2/M.md
+++ b/rfcs/drafts/RFC-013-challenges/round-2/M.md
@@ -1,0 +1,37 @@
+# RFC-013 Round-2 — M (implementation / feasibility)
+
+**Bottom line:** ACCEPT
+
+Re-reviewing impl feasibility after §9.2 rewrite.
+
+## Round-1 items verification
+
+- **M1** §9.2 Lua delta: fully rewritten with explicit steps 1-3 (early dedup GET branch, existing logic unchanged on miss, post-commit HSET + PEXPIRE). GREEN.
+- **M2** KEYS/ARGV slot accounting: §9.2 pins 17→18 KEYS, 17→19 ARGV, lists the new slots explicitly. Backend `slot_count` assertions updated in lockstep. GREEN.
+- **M3** `resume_delay_ms` wire path: §9.2 confirms it rides today's `resume_policy_json` ARGV slot — no new wire position. GREEN.
+- **M4** `InvalidLeaseForSuspend` existence: §4 now pins it at `crates/ff-core/src/engine_error.rs:183`. GREEN.
+- **M5** `build_suspend_args` body: §5.1 spells out the defaults — UUIDv4 `suspension_id`, `WaitpointBinding::fresh()` for strict, `use_pending(...)` for try-on-pending, `TimeoutBehavior::Fail` default, `now = SystemTime::now()`, `requested_by = Worker`, `continuation_metadata_pointer = None`, `idempotency_key = None`. GREEN.
+- **M6** `PendingWaitpoint` → `UsePending` mapping: §5.1 confirms HMAC token lookup is Lua-side, consistent with RFC-004 §Waitpoint Security. GREEN.
+- **M7** Backend-serializer + scanner tests: §9.3 item 3 adds both — the byte-for-byte legacy-SDK comparison is exactly the right canary. GREEN.
+
+## Per-section impl-feasibility re-scan
+
+- §2.2 GREEN — type surface is buildable; constructors are thin delegates.
+- §2.2.1 GREEN — impl cost is a few dozen LOC in `ff-core/src/contracts/mod.rs`.
+- §2.3 GREEN.
+- §2.4 GREEN — cross-field validation is a Rust-side pre-FCALL check, trivial to implement.
+- §2.5 GREEN — `ResumePolicy::normal()` is a constant-folded const expression in impl terms.
+- §2.6 GREEN — enum-to-string serialization matches what the backend already does for `DeliverSignalArgs`.
+- §3 GREEN.
+- §4 GREEN — only one new variant (`StateKind::AlreadySatisfied`), which is a single-line enum addition in `engine_error.rs`.
+- §5.1 GREEN — `stop_renewal` move is a trivial reorder; `SuspendOutcomeDetails` is a 4-field struct.
+- §9.1 GREEN — landing order + type locations consistent.
+- §9.2 GREEN — Lua delta is well-scoped. The +30 LOC estimate is realistic. Serialized-outcome version-pin note is the right forward-compat hedge.
+- §9.3 GREEN — test matrix now covers backend-internal serializer canary AND idempotency TTL cases.
+- §9.4, §9.5 GREEN.
+
+## One micro-note, NOT a dissent driver
+
+§9.2's "Total new Lua LOC: ~30" is an estimate that should be verified in impl. If it exceeds ~60 LOC there's a refactoring discussion about factoring dedup into a helper — but that's impl-time scope, not RFC scope.
+
+No remaining dissent.

--- a/rfcs/drafts/RFC-013-stage-1d-suspend.md
+++ b/rfcs/drafts/RFC-013-stage-1d-suspend.md
@@ -131,6 +131,17 @@ pub struct SuspendArgs {
     /// `now` at caller time — the backend uses server-time `TIME` for
     /// Lua correctness but carries the caller clock for correlation.
     pub now: TimestampMs,
+
+    /// Optional idempotency key for retry-safe suspension. When set, the
+    /// backend dedups on `(partition, execution_id, idempotency_key)` for
+    /// a configured window: a second `suspend` with the same triple
+    /// returns the same `SuspendOutcome` as the first (idempotent replay).
+    /// When `None`, every call is fresh and subject to §3's non-idempotent
+    /// contract. Follows the `UsageDimensions.dedup_key` pattern from
+    /// RFC-012 §R7.2.3 — same shape, same semantics, same partition-scoped
+    /// dedup hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<IdempotencyKey>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -152,6 +163,7 @@ Notes:
 - `continuation_metadata_pointer` stays `Option<String>` — same opacity as today. RFC-004 explicitly does not let the engine own continuation bytes.
 - `reason_code` + `requested_by` are typed enums (currently ARGV strings). The enum values are the set defined in RFC-004 §Suspension Reason Categories; `#[non_exhaustive]` so RFC-014/RFC-015 can extend.
 - `WaitpointSpec` (from round-7) is **not** reused as the `suspend` input: it was shaped for `create_waitpoint`'s pending issuance. Keeping them separate is cleaner than overloading one struct with conditional fields.
+- `idempotency_key` is a partition-scoped dedup key. Lua stores a hash `ff:dedup:suspend:{p:N}:<execution_id>:<idempotency_key>` → serialized `SuspendOutcome`, TTL = suspension-timeout ceiling + grace. On hit, the first outcome is returned verbatim (including the original `suspension_id` / `waitpoint_id` / `waitpoint_token`), and no state mutation occurs. This mirrors `UsageDimensions.dedup_key`'s semantics on `report_usage`. Absent a key, §3's non-idempotent contract applies.
 
 ### §2.3 `SuspendOutcome` shape
 
@@ -206,21 +218,13 @@ pub enum SuspendOutcome {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ResumeCondition {
-    /// Single signal-name match. Matches the SDK's v1 `ConditionMatcher`
-    /// with `signal_name == ""` meaning wildcard.
-    Signal {
-        /// Empty = wildcard (any signal name).
-        signal_name: String,
+    /// Single waitpoint-key match with a matcher predicate. Replaces
+    /// the SDK's v1 `ConditionMatcher`. `matcher` is the per-waitpoint
+    /// predicate (signal-name-or-wildcard in v1; RFC-014 may extend).
+    Single {
+        waitpoint_key: String,
+        matcher: SignalMatcher,
     },
-
-    /// "any of these signal names" — matches when one signal in the
-    /// set arrives.
-    AnyOf { signal_names: Vec<String> },
-
-    /// "all of these signal names" — matches when every name has
-    /// arrived at least once. (RFC-004 §Resume Condition fields already
-    /// describes `all` as v1.)
-    AllOf { signal_names: Vec<String> },
 
     /// Operator-only resume — no signal ever satisfies; only an
     /// explicit operator resume closes. Used for escalate-style paths.
@@ -231,13 +235,24 @@ pub enum ResumeCondition {
     /// pure-delay suspensions where a signal arriving would be an
     /// error, not a resumer.)
     TimeoutOnly,
+
+    /// Multi-condition composition. The concrete body
+    /// (`CompositeBody`) is defined by RFC-014; RFC-013 only reserves
+    /// the enum slot so both RFCs can land without a trait break.
+    /// RFC-014's body is required to be additively extensible (nested
+    /// `ResumeCondition`s, `#[non_exhaustive]` on the body type) so
+    /// subsequent RFCs can grow the composition vocabulary without
+    /// breaking RFC-013's surface.
+    Composite(CompositeBody),
 }
 ```
 
 **Forward-compat hooks (RFC-014 will extend):**
-- `#[non_exhaustive]` lets RFC-014 add `Count { signal_name, n }`, `CompositeAll { clauses: Vec<ResumeCondition> }`, `CompositeAny { clauses }` without breaking downstream pattern matches.
-- Nesting is expressed by making the enum self-recursive in future variants — `AllOf` today takes `Vec<String>` (flat); RFC-014's `CompositeAll` takes `Vec<ResumeCondition>` (nested). Both coexist — `AllOf` is the flat-signal-name fast-path, `CompositeAll` is the RFC-014 general form. §7.3 tracks whether to collapse `AllOf` into `CompositeAll` at RFC-014 landing time.
-- `minimum_signal_count` (RFC-004 §Resume Condition Fields) is NOT a top-level `SuspendArgs` field; it is implicit per variant — `AllOf` ⇒ `n = |signal_names|`; `AnyOf` ⇒ `n = 1`; `Count` (RFC-014) will carry an explicit `n`.
+- `#[non_exhaustive]` lets RFC-014 add further top-level variants (e.g. `Count { signal_name, n }`) without breaking downstream pattern matches.
+- The `Composite(CompositeBody)` variant is RFC-013's reserved extension point. RFC-014 defines `CompositeBody` — expected shape: `enum CompositeBody { AllOf(Vec<ResumeCondition>), AnyOf(Vec<ResumeCondition>), Count { clause: Box<ResumeCondition>, n: u32 }, … }` with `#[non_exhaustive]`. The flat `AnyOf { signal_names: Vec<String> }` / `AllOf { signal_names: Vec<String> }` shapes an earlier draft proposed are **dropped**: they are a strict subset of RFC-014's recursive composites (e.g. `AnyOf { signal_names: ["a","b"] }` ≡ `Composite(CompositeBody::AnyOf(vec![Single{...a}, Single{...b}]))`). Keeping both would be redundant surface area.
+- `minimum_signal_count` (RFC-004 §Resume Condition Fields) is NOT a top-level `SuspendArgs` field; it is implicit per variant — `Composite(AllOf(clauses))` ⇒ `n = |clauses|`; `Composite(AnyOf(clauses))` ⇒ `n = 1`; `Composite(Count{n,…})` (RFC-014) carries an explicit `n`.
+
+**`SignalMatcher` shape:** v1 is `enum SignalMatcher { ByName(String), Wildcard }`. RFC-014 may extend (payload predicates, etc.) — `#[non_exhaustive]`.
 
 **Why not JSON passthrough:**
 - The round-7 §R7.6.1 open question offered "ARGV-JSON in backend impl" as an alternative. Rejected because: (i) a Postgres backend cannot produce the same JSON shape without re-implementing the Valkey Lua's `initialize_condition` helper; (ii) typed variants let `rustc` enforce exhaustiveness on the SDK forwarder — replacing runtime parse errors with compile errors when RFC-014 lands; (iii) JSON-at-the-seam means every consumer of `dyn EngineBackend` has to agree on a schema that is otherwise undocumented.
@@ -346,8 +361,8 @@ All three are `#[non_exhaustive]`; backend serializes to the corresponding Lua/w
 
 ### §3.3 Contract summary
 
-- `suspend` is **not** retry-idempotent. Retry requires a describe-and-reconcile dance. The `suspension_id` is echoed in `SuspendOutcome` for caller correlation, not for Lua-side dedup.
-- A future enhancement (out of scope): add an optional `idempotency_key` on `SuspendArgs` backed by a dedup hash scan, analogous to `DeliverSignalArgs::idempotency_key`. Tracked as §7.5.
+- `suspend` is **not** retry-idempotent **without** an `idempotency_key`. The `suspension_id` is echoed in `SuspendOutcome` for caller correlation, not for Lua-side dedup.
+- **With** `SuspendArgs::idempotency_key: Some(_)` (see §2.2), `suspend` is retry-idempotent: the backend keys a dedup hash on `(partition, execution_id, idempotency_key)` with TTL = suspension-timeout ceiling + grace. A second call within the window returns the first call's `SuspendOutcome` verbatim and performs no state mutation. Shape + semantics follow RFC-012 §R7.2.3's `UsageDimensions.dedup_key`. Without the key, callers must describe-and-reconcile on any retry.
 
 ---
 
@@ -364,12 +379,13 @@ All errors surface as `EngineError`. Variant-by-variant, by scenario:
 | Lease id/epoch/attempt mismatch on the handle | `Validation(InvalidLeaseForSuspend)` | Lua `invalid_lease_for_suspend`. |
 | `WaitpointBinding::UsePending` but waitpoint is missing / wrong exec / expired | `Contention(WaitpointNotFound)` or `State(PendingWaitpointExpired)` | Pre-existing variants from RFC-004 wire. |
 | `WaitpointBinding::Fresh` but `waitpoint_key` does not parse to `wpk:<uuid>` | `Validation(InvalidWaitpointKey)` | Pre-existing. |
-| `resume_condition == AnyOf { signal_names: [] }` or similar empty-condition footgun | `Validation(InvalidInput { detail: "resume_condition.signal_names" })` | Rust-side check before FCALL. |
+| `resume_condition == Single { matcher: ByName("") }` with no wildcard intent, or RFC-014 `Composite` with empty clause list | `Validation(InvalidInput { detail: "resume_condition" })` | Rust-side check before FCALL. |
 | `timeout_at` in the past | `Validation(InvalidInput { detail: "timeout_at_in_past" })` | Rust-side. |
 | HMAC secrets not initialised for partition | `Transport(boxed ScriptError::hmac_secret_not_initialized)` | Ops issue, not caller issue. |
 | Valkey connection error / transient | `Transport(…)` | Standard. |
+| Strict `suspend` (non-`try`) but buffered signals already satisfy the condition | `State(AlreadySatisfied)` | SDK-side: strict path refuses to return the early-satisfied branch. The typed backend outcome is `SuspendOutcome::AlreadySatisfied`; the strict wrapper maps it to this error. `try_suspend` returns the outcome directly instead. |
 
-**New kinds needed:** none. Every scenario maps to an existing variant after Round-7. The `InvalidLeaseForSuspend` variant was added in Round-4 specifically for this path.
+**New kinds needed:** one. `StateKind::AlreadySatisfied` is added to surface the strict-path refusal of the early-satisfied branch (the underlying backend outcome is always typed `SuspendOutcome`; only the SDK's strict wrapper turns it into an error). Every other scenario maps to an existing variant after Round-7. The `InvalidLeaseForSuspend` variant was added in Round-4 specifically for this path.
 
 **Classification note:** `LeaseConflict` + `ExecutionNotActive` are retryable; `AlreadySuspended` is cooperative (no-op — the caller's intent is already the state); everything else is either terminal (validation, bug) or transport (standard retry). See `EngineError::classify` for the authoritative mapping — this RFC adds no new classes.
 
@@ -379,55 +395,79 @@ All errors surface as `EngineError`. Variant-by-variant, by scenario:
 
 After this RFC lands:
 
-### §5.1 New SDK surface
+### §5.1 New SDK surface — `suspend` vs `try_suspend`
+
+The SDK exposes two methods following the classic Rust `foo` / `try_foo` pattern (cf. `Lock` / `TryLock`, `RwLock::read` / `try_read`, `Mutex::lock` / `try_lock`):
 
 ```rust
 // crates/ff-sdk/src/task.rs
 impl ClaimedTask {
+    /// **Strict suspend.** Always yields a Suspended handle or errors.
+    /// Consumes `self`. On the early-satisfied path, returns
+    /// `EngineError::State(AlreadySatisfied)` — the `ClaimedTask` is
+    /// already gone, and the lease is released Lua-side as part of the
+    /// error path. Use this when you've designed your flow to suspend
+    /// unconditionally and an early-satisfied waitpoint is a bug.
     pub async fn suspend(
         self,
         reason_code: SuspensionReasonCode,
         resume_condition: ResumeCondition,
         timeout: Option<(TimestampMs, TimeoutBehavior)>,
         resume_policy: ResumePolicy,
-    ) -> Result<SuspendOutcome, SdkError> {
+    ) -> Result<SuspendedHandle, SdkError> {
         let handle = self.to_handle();
-        let args = SuspendArgs {
-            suspension_id: SuspensionId::new(),
-            waitpoint: WaitpointBinding::Fresh {
-                waitpoint_id: WaitpointId::new(),
-                waitpoint_key: format!("wpk:{}", WaitpointId::new()),
-            },
-            resume_condition,
-            resume_policy,
-            reason_code,
-            requested_by: SuspensionRequester::Worker,
-            timeout_at: timeout.map(|(t, _)| t),
-            timeout_behavior: timeout.map(|(_, b)| b).unwrap_or(TimeoutBehavior::Fail),
-            continuation_metadata_pointer: None,
-            now: TimestampMs::now(),
-        };
+        let args = build_suspend_args(&self, reason_code, resume_condition, timeout, resume_policy);
         self.stop_renewal();
-        self.backend.suspend(&handle, args).await.map_err(SdkError::from)
+        match self.backend.suspend(&handle, args).await.map_err(SdkError::from)? {
+            SuspendOutcome::Suspended { handle, .. } => Ok(SuspendedHandle { handle, .. }),
+            SuspendOutcome::AlreadySatisfied { .. } => {
+                Err(SdkError::Engine(EngineError::State(StateKind::AlreadySatisfied)))
+            }
+        }
     }
 
-    /// Convenience: suspend with a pending waitpoint previously
+    /// **Fallible suspend.** Returns `SuspendOutcome::{Suspended,
+    /// AlreadySatisfied}`. On `AlreadySatisfied`, the `ClaimedTask`
+    /// is **kept alive** and handed back to the caller so the worker
+    /// can continue running against the existing lease. Use this when
+    /// consuming a pending waitpoint whose buffered signals may
+    /// already match the condition.
+    pub async fn try_suspend(
+        self,
+        reason_code: SuspensionReasonCode,
+        resume_condition: ResumeCondition,
+        timeout: Option<(TimestampMs, TimeoutBehavior)>,
+        resume_policy: ResumePolicy,
+    ) -> Result<TrySuspendOutcome, SdkError> { /* ... */ }
+
+    /// Convenience: `try_suspend` against a pending waitpoint previously
     /// issued via `create_waitpoint`.
-    pub async fn suspend_on_pending(
+    pub async fn try_suspend_on_pending(
         self,
         pending: &PendingWaitpoint,
         reason_code: SuspensionReasonCode,
         resume_condition: ResumeCondition,
         timeout: Option<(TimestampMs, TimeoutBehavior)>,
-    ) -> Result<SuspendOutcome, SdkError> { /* mirrors above with UsePending */ }
+    ) -> Result<TrySuspendOutcome, SdkError> { /* mirrors above with UsePending */ }
+}
+
+pub enum TrySuspendOutcome {
+    Suspended(SuspendedHandle),
+    AlreadySatisfied { task: ClaimedTask, details: SuspendOutcomeDetails },
 }
 ```
 
+Rationale for the split:
+- `suspend` / `try_suspend` is the idiomatic Rust pattern for "operation may fail in a structured, callable-recoverable way": the strict form returns the happy path directly, the try form returns a Result-of-outcome. `Mutex::lock` panics on poisoning; `Mutex::try_lock` returns `Result`. Same cadence.
+- 95% of suspend sites know they want to suspend unconditionally. For them, the strict form is cleaner and exhaustiveness-checks to one variant.
+- The 5% of sites that suspend on a pending waitpoint with possibly-buffered signals need to retain the lease when the early-signal path fires. `try_suspend` hands `ClaimedTask` back so the worker continues without a re-claim round-trip.
+- Moves the "AlreadySatisfied consumes vs retains the task" decision into the API surface instead of being a behavioral surprise.
+
 - `SuspendOutcome` is **re-exported** from `ff-core::backend` into `ff-sdk::task`. The SDK does not own the type.
-- Handlers pattern-match `SuspendOutcome` directly. No further wrapping — the enum is the SDK contract.
+- Handlers pattern-match `TrySuspendOutcome` (for `try_suspend`) or receive a `SuspendedHandle` directly (for `suspend`). No further wrapping.
 - **Deletions**:
   - `ff-sdk::task::parse_suspend_result` (100 LOC). Gone.
-  - `ff-sdk::task::ConditionMatcher` (the `struct { signal_name: String }`). Replaced by `ResumeCondition::Signal`.
+  - `ff-sdk::task::ConditionMatcher` (the `struct { signal_name: String }`). Replaced by `ResumeCondition::Single { waitpoint_key, matcher: SignalMatcher::ByName(name) }` (or `SignalMatcher::Wildcard`).
   - `ff-sdk::task::TimeoutBehavior` (if SDK-local — confirm in impl; otherwise just re-export from `ff-core`).
   - The direct `self.client.fcall("ff_suspend_execution", …)` call site. Replaced by `self.backend.suspend(…)`.
 
@@ -437,16 +477,18 @@ Signature-level SDK break. `ClaimedTask::suspend` goes from
 `(reason_code: &str, &[ConditionMatcher], Option<u64>, TimeoutBehavior)`
 to the shape in §5.1. All downstream callers (known: `ff-sdk` tests, `cairn-fabric` consumer) must update. Release notes:
 
-> **Breaking — `ff-sdk::ClaimedTask::suspend`:** signature changed. Pass typed `ResumeCondition` and `ResumePolicy`. `ConditionMatcher` is removed; use `ResumeCondition::Signal { signal_name }` for single-name, `ResumeCondition::AnyOf { signal_names }` for the previous multi-name fan-out. Internal parser `parse_suspend_result` deleted.
+> **Breaking — `ff-sdk::ClaimedTask::suspend`:** signature changed and split. `ClaimedTask::suspend` is now the strict form (returns `SuspendedHandle`; errors with `State(AlreadySatisfied)` on the early-satisfied branch). New `ClaimedTask::try_suspend` returns `TrySuspendOutcome::{Suspended, AlreadySatisfied{task, ..}}` and retains the `ClaimedTask` on `AlreadySatisfied`. Pass typed `ResumeCondition` and `ResumePolicy`. `ConditionMatcher` is removed; use `ResumeCondition::Single { waitpoint_key, matcher }` for single-name. Multi-name fan-out moves to RFC-014's `ResumeCondition::Composite(CompositeBody)`. Internal parser `parse_suspend_result` deleted.
 
 Consumer migration is mechanical; `cairn-fabric` owns its own migration (peer-team boundary per memory). The FF release produces a migration snippet but does not modify `cairn-fabric` code.
 
 ### §5.3 `Handle` substitution contract at call site
 
-Today's `ClaimedTask::suspend` consumes `self` — on any outcome, the task is gone. Under Stage 1d:
+Under Stage 1d, §5.1's two-method split determines what happens to `ClaimedTask`:
 
-- `Suspended { handle, … }`: caller replaces their `ClaimedTask` with — nothing. `ClaimedTask` is consumed; the returned `Handle` belongs to an opaque SDK post-suspension cookie. There is **no** public SDK type to "continue as suspended worker"; resumption goes through `claim_resumed_execution` which mints a fresh `ClaimedTask` on a later poll. The `Handle` is only useful to `observe_signals` until that re-claim happens — which is how today's SDK already works. We preserve that exact model.
-- `AlreadySatisfied { … }`: `ClaimedTask` is consumed but the lease is not released. The caller cannot continue running against the original task after an `AlreadySatisfied` outcome — the worker's current-task state is gone. This is a **breaking** behavioral carryover from today (`ClaimedTask::suspend` already consumes `self` in the AlreadySatisfied path). §7.2 proposes an owner-review alternative that preserves the task handle in `AlreadySatisfied`.
+- **`suspend` (strict), `Suspended` path**: `ClaimedTask` is consumed; caller receives a `SuspendedHandle` (opaque SDK post-suspension cookie). There is **no** public SDK type to "continue as suspended worker"; resumption goes through `claim_resumed_execution` which mints a fresh `ClaimedTask` on a later poll. The handle is only useful to `observe_signals` until that re-claim — preserving today's model.
+- **`suspend` (strict), `AlreadySatisfied` path**: impossible by contract — the strict form errors with `EngineError::State(AlreadySatisfied)` and `self` has already been moved. Callers using `suspend` have declared early-satisfaction is a bug.
+- **`try_suspend`, `Suspended` path**: same as strict. Caller gets a `SuspendedHandle`.
+- **`try_suspend`, `AlreadySatisfied` path**: `ClaimedTask` is handed back in `TrySuspendOutcome::AlreadySatisfied { task, details }`. Lease is retained (Lua never released it); fence triple still matches. Worker continues against the original task. The waitpoint is closed with `satisfied=1` and the buffered signals are consumed per `resume_policy.consume_matched_signals`.
 
 ---
 
@@ -455,7 +497,7 @@ Today's `ClaimedTask::suspend` consumes `self` — on any outcome, the task is g
 - **RFC-004 (Suspension)**: unchanged. This RFC re-shapes the Rust surface; the Valkey wire contract (Lua `ff_suspend_execution`, keys, ARGV, error codes) is preserved. Lua stays source of truth.
 - **RFC-005 (Signal)**: unchanged. `deliver_signal` and `claim_resumed_execution` landed in PR #200 with typed args (`DeliverSignalArgs`, `ClaimResumedExecutionArgs`) — this RFC aligns `suspend`'s input shape with that precedent.
 - **RFC-012 §R7.6.1**: this RFC is the answer to the pinned open question ("typed `ResumeCondition` on trait vs ARGV-JSON"). Decision: typed. See §8.2.
-- **RFC-014 (multi-signal conditions, parallel draft)**: `ResumeCondition` is designed to extend with `Count`, `CompositeAll`, `CompositeAny`. RFC-014 adds variants; does not re-shape the method.
+- **RFC-014 (multi-signal conditions, parallel draft)**: RFC-013 reserves `ResumeCondition::Composite(CompositeBody)`; RFC-014 defines `CompositeBody`. The flat `AnyOf`/`AllOf` variants an earlier draft proposed are dropped as a redundant subset of RFC-014's recursive composites (§2.4). RFC-014's `CompositeBody` is required to be `#[non_exhaustive]` and to take nested `ResumeCondition`s (not flat signal-name vecs) so subsequent RFCs can extend without breaking RFC-013's surface. RFC-014 may also add further top-level `ResumeCondition` variants (e.g. `Count`); none of that re-shapes the method.
 - **Waitpoint HMAC protocol (RFC-004 §Waitpoint Security)**: unchanged. `WaitpointHmac` carries the token through typed fields. Minting remains Lua-side; validation remains Lua-side; rotation remains via `/v1/admin/rotate-waitpoint-secret`.
 - **`create_waitpoint` (round-7, landed)**: `suspend` interoperates via `WaitpointBinding::UsePending`. The lua `use_pending_waitpoint` ARGV flag is the backend's serialization of that variant; no Lua change.
 - **`observe_signals` / `claim_resumed_execution` (landed)**: unchanged. The post-suspend handle hands off to those methods exactly as today.
@@ -464,44 +506,23 @@ Today's `ClaimedTask::suspend` consumes `self` — on any outcome, the task is g
 
 ## §7 — Open questions (owner review required)
 
+> **Adjudicated 2026-04-23** (owner): previous §7.2 (try_suspend split), §7.3 (drop flat `AnyOf`/`AllOf`), §7.5 (`idempotency_key` now) are answered and absorbed into §5 (SDK forwarder), §2.4 (`ResumeCondition`), and §2.2 (`SuspendArgs::idempotency_key`) respectively. Remaining open questions renumbered below.
+
 ### §7.1 `timeout: Option<(TimestampMs, TimeoutBehavior)>` vs split fields
 
-The SDK `suspend` in §5.1 bundles `timeout_at` + `timeout_behavior` into one `Option<(…)>`. An alternative: two separate `Option<TimestampMs>` + `TimeoutBehavior` params with `TimeoutBehavior::Fail` as default.
+The SDK `suspend` / `try_suspend` in §5.1 bundle `timeout_at` + `timeout_behavior` into one `Option<(…)>`. An alternative: two separate `Option<TimestampMs>` + `TimeoutBehavior` params with `TimeoutBehavior::Fail` as default.
 
 - **Tradeoff**: tuple form prevents the "timeout_at set but timeout_behavior forgotten, behavior silently defaulted" bug. Split form reads nicer at the call site (`None` for timeout is clearer than `None` on a tuple).
 - **Recommendation**: tuple form (catches the bug). Owner: pick.
 - The trait-level `SuspendArgs` shape is unaffected either way — this is an SDK ergonomics question.
 
-### §7.2 `AlreadySatisfied` — does `ClaimedTask` survive?
-
-Today's `ClaimedTask::suspend` consumes `self` unconditionally. On `AlreadySatisfied` the lease is retained but the `ClaimedTask` is gone — the worker cannot continue running without some other path to reconstruct task state. In practice today this means: callers who get `AlreadySatisfied` must return control and let the execution be re-claimed, even though the lease is technically held.
-
-Three options:
-1. **Keep today's behavior** (consume `self` in both variants). Simple. Requires the worker to tear down and wait for re-claim. `AlreadySatisfied` is effectively a bug: the lease lingers until renew-on-a-dropped-task runs out.
-2. **Return `Result<Either<(ClaimedTask, SuspendOutcome::AlreadySatisfied), SuspendOutcome::Suspended>, _>`** — on AlreadySatisfied, hand the `ClaimedTask` back so the worker continues. Needs the SDK wrapper method on ClaimedTask to be non-consuming in the AS branch, which is structurally awkward.
-3. **Split into two SDK methods**: `ClaimedTask::suspend_strict` (consumes self, errors on AS) and `ClaimedTask::try_suspend` (returns `Either`). Strict is the 95% path; try is the pending-waitpoint early-signal path.
-- **Recommendation**: option 3. Owner: pick. This is a call-site ergonomics question that doesn't affect the trait.
-
-### §7.3 `AllOf` / `AnyOf` flat forms vs RFC-014's recursive `Composite*`
-
-When RFC-014 lands its `CompositeAll { clauses: Vec<ResumeCondition> }`, the flat `AllOf { signal_names: Vec<String> }` becomes redundant. Two choices:
-
-- Keep `AllOf` as a flat fast-path (documented as "equivalent to `CompositeAll { clauses: signal_names.map(Signal) }`"). Migration-free.
-- Deprecate `AllOf` in RFC-014; remove in a later release. More churn, cleaner surface.
-- **Recommendation**: keep flat form permanently. The backend serializer can internally collapse. Owner: pick, or defer until RFC-014.
-
-### §7.4 `SuspensionRequester` default
+### §7.2 `SuspensionRequester` default
 
 SDK callers always pass `SuspensionRequester::Worker`. Do we need the field on `SuspendArgs` at all, or is it implicit (worker-originated)?
 - Operator-originated suspends (e.g. "admin pauses this exec") go through a different path (not `ClaimedTask::suspend` — there is no lease to surrender). So `suspend` as a trait op is always worker-requested in v1.
 - **Recommendation**: keep the field; RFC-004 has `paused_by_policy` and `system_timeout_policy` reasons that imply non-worker requesters will eventually flow through this method. Owner: confirm.
 
-### §7.5 Optional `idempotency_key` on `SuspendArgs`
-
-§3.3 flags that `suspend` is not retry-idempotent. Adding an `idempotency_key: Option<String>` field backed by a partition-scoped dedup hash (TTL = RFC-004 suspension-timeout ceiling) would make retry-after-network-error trivially safe at modest state cost.
-- **Recommendation**: not in Stage 1d. Track as a follow-up; §3.1's describe-and-retry pattern suffices for v0.6. Owner: confirm deferral.
-
-### §7.6 `continuation_metadata_pointer` — string or typed?
+### §7.3 `continuation_metadata_pointer` — string or typed?
 
 Today it's a free-form string. Proposal: keep as `Option<String>`. An alternative: typed `ContinuationPointer { scheme: String, path: String }` for slightly better self-describability at no enforcement cost (the engine still doesn't interpret bytes).
 - **Recommendation**: keep `Option<String>`. The engine has zero semantics to enforce on the contents; typing it is ceremony. Owner: confirm.
@@ -531,7 +552,7 @@ struct SuspendOutcome {
 ### §8.2 ARGV-JSON in the backend impl, keeping a stringly-typed `ResumeCondition: serde_json::Value` on the trait
 
 Round-7 §R7.6.1's alternative phrasing. **Rejected** because:
-- Pushes the schema into no-lint land. No rust-level check that `AnyOf.signal_names` isn't misspelled `signalNames`.
+- Pushes the schema into no-lint land. No rust-level check that `Single.matcher.by_name` isn't misspelled `byName`, or that `Composite.all_of` isn't `allOf`.
 - A Postgres backend can't produce the same JSON without cross-team sync.
 - RFC-014's additions become string-format RFCs instead of trait additions.
 
@@ -566,7 +587,7 @@ A flatter shape: always return a Handle, with metadata in a side struct, and enc
 1. **ff-core types** (§2.2 – §2.6): land `SuspendArgs`, `SuspendOutcome`, `WaitpointBinding`, `ResumeCondition`, `ResumePolicy`, `ResumeTarget`, `TimeoutBehavior`, `SuspensionReasonCode`, `SuspensionRequester` in `crates/ff-core/src/contracts/mod.rs` (and re-export from `ff-core::backend`). Zero behavioral change; just types.
 2. **Trait update** (§2.1): change `EngineBackend::suspend` signature in `crates/ff-core/src/engine_backend.rs`. Breaking change on the trait. Stubbed impl remains `EngineError::Unavailable { op: "suspend" }` — still compiles.
 3. **Valkey backend impl**: fill in `crates/ff-backend-valkey/src/lib.rs:~1240-1249`. Build KEYS (17) / ARGV (17) from `SuspendArgs`. Internal `ResumeCondition` → JSON serializer. Parse Lua return into `SuspendOutcome` — move `parse_suspend_result` logic into the backend, not SDK.
-4. **SDK forwarder** (§5.1): rewrite `ClaimedTask::suspend` to forward through the trait. Delete `parse_suspend_result`, `ConditionMatcher`, SDK-local `TimeoutBehavior` if present.
+4. **SDK forwarder** (§5.1): rewrite `ClaimedTask::suspend` as the strict wrapper and add `ClaimedTask::try_suspend` / `try_suspend_on_pending`. Introduce `SuspendedHandle` and `TrySuspendOutcome`. Delete `parse_suspend_result`, `ConditionMatcher`, SDK-local `TimeoutBehavior` if present.
 5. **Release notes + migration snippet** for 0.6.0.
 
 ### §9.2 Lua changes
@@ -578,10 +599,11 @@ A flatter shape: always return a Handle, with metadata in a side struct, and enc
 Required tests (at the landing PR's CI):
 
 1. **Unit tests on the Rust type layer**:
-   - `ResumeCondition::Signal { signal_name: "" }` round-trips as wildcard.
-   - `ResumeCondition::AllOf { signal_names: [] }` is rejected at Rust-side validation.
-   - `SuspendArgs` serde round-trip (JSON) for every `ResumeCondition` variant.
-   - `SuspendOutcome::Suspended`/`AlreadySatisfied` exhaustiveness check in the SDK wrapper.
+   - `ResumeCondition::Single { matcher: SignalMatcher::Wildcard, .. }` round-trips.
+   - `ResumeCondition::Single { matcher: SignalMatcher::ByName("") }` is rejected at Rust-side validation (empty name is not wildcard; wildcard is a dedicated variant).
+   - `SuspendArgs` serde round-trip (JSON) for every `ResumeCondition` variant (RFC-013 surface: `Single`, `OperatorOnly`, `TimeoutOnly`; `Composite` covered at RFC-014 landing).
+   - `SuspendOutcome::Suspended`/`AlreadySatisfied` exhaustiveness check in the SDK `try_suspend` wrapper; strict `suspend` wrapper mapping `AlreadySatisfied → State(AlreadySatisfied)` covered by one test.
+   - `SuspendArgs::idempotency_key` replay test: two calls with the same key return the same outcome; two calls with different keys act independently (second errors with `State(AlreadySuspended)`).
 
 2. **Valkey-backend integration tests**:
    - `suspend` with `WaitpointBinding::Fresh`, `ResumeCondition::Signal`, no timeout → `Suspended`.
@@ -590,8 +612,8 @@ Required tests (at the landing PR's CI):
    - `suspend` after fence-triple drift → `Contention(LeaseConflict)`.
    - `suspend` on already-suspended exec → `State(AlreadySuspended)`.
    - `suspend` with `timeout_at` in the past → `Validation(InvalidInput)`.
-   - `suspend` with `ResumeCondition::AnyOf { … }` + signal delivery that matches one name → resumes.
-   - `suspend` with `ResumeCondition::AllOf { ["a", "b"] }` + only `a` delivered → stays suspended; + `b` delivered → resumes.
+   - `suspend` with `ResumeCondition::Single { matcher: ByName("a") }` + `a` delivered → resumes; unrelated signal → stays suspended.
+   - Multi-signal `Composite` cases are covered under RFC-014's test matrix (RFC-013 reserves the slot but doesn't exercise the body).
    - `suspend` with `TimeoutBehavior::Fail` + timeout scanner tick → exec terminal, `close_reason = timed_out_fail`.
    - `suspend` with `TimeoutBehavior::AutoResumeWithTimeoutSignal` + timeout → exec runnable, close_reason `timed_out_auto_resume`.
    - Replay: two `suspend` calls with same args → first succeeds, second returns `State(AlreadySuspended)` (not idempotent).

--- a/rfcs/drafts/RFC-013-stage-1d-suspend.md
+++ b/rfcs/drafts/RFC-013-stage-1d-suspend.md
@@ -1,0 +1,631 @@
+# RFC-013: Stage 1d — `EngineBackend::suspend` trait migration + input/output-shape rework
+
+**Status:** Draft
+**Author:** FlowFabric — Stage 1d
+**Created:** 2026-04-23
+**Tracking:** #117 (Stage 1d deferral)
+**Depends on:** RFC-004 (Suspension), RFC-005 (Signal), RFC-012 (EngineBackend trait, round-7 amendment §R7.6.1)
+**Forward-compat with:** RFC-014 (multi-signal resume conditions, parallel — draft)
+**Non-goal:** re-designing RFC-004's wire semantics, the HMAC token protocol, or the Lua `ff_suspend_execution` function body.
+
+---
+
+## Summary
+
+`EngineBackend::suspend` is the only round-4 trait method still stubbed at `EngineError::Unavailable`. The Valkey backend impl at `crates/ff-backend-valkey/src/lib.rs:~1240-1249` cannot be filled because (a) the Round-4 trait return type `Result<Handle, EngineError>` cannot express the `AlreadySatisfied` branch in which the caller keeps the lease, and (b) the trait input `Vec<WaitpointSpec>` + `Option<Duration>` has no slot for reason code, requested-by, continuation pointer, resume-condition shape, or timeout behavior — all of which the SDK today packs into ARGV-JSON inside `ClaimedTask::suspend` and which `parse_suspend_result` reads back from raw wire bytes. This RFC fixes both ends: a typed `SuspendArgs` input, a typed `SuspendOutcome` output, and a first-class `ResumeCondition` that RFC-014 can extend without breaking. After landing, `ClaimedTask::suspend` becomes a thin forwarder and `parse_suspend_result` is deleted.
+
+## Motivation
+
+**What breaks today.**
+
+1. `EngineBackend::suspend` returns `EngineError::Unavailable`. Any consumer dispatching through `dyn EngineBackend` loses the suspend operation entirely; only `ClaimedTask::suspend`'s direct FCALL path works. This contradicts RFC-012's stated gate — "every user-facing op forwards through the trait".
+2. `ff-sdk::parse_suspend_result` (`task.rs:1448`) reconstructs a `SuspendOutcome` by parsing a positional Lua array. The parser is internal to `ff-sdk`; a hypothetical second backend (Postgres) cannot produce the same array shape without faking `ff_suspend_execution`'s wire contract verbatim. Typed args + typed outcome move the contract into `ff-core` where both backends honour the same Rust types.
+3. Round-7 §R7.6.1 pins the **open question** "typed `ResumeCondition` on trait vs ARGV-JSON" for Stage 1d — this RFC closes it.
+4. RFC-014 will add multi-signal resume conditions (`all_of`, `count(n)`, composition). Without the input-shape rework landing first, RFC-014 has to break the trait a second time.
+
+**Why v0.6 (the release that ships this):**
+- 0.4.x locked in round-7 deferrals with a `report_usage` break.
+- 0.5.0 was kept for Stage 1c shipables without trait-shape churn.
+- 0.6.0 is the natural window for the last Round-4 breaker. After 0.6.0, RFC-012's Stage-1 envelope is closed.
+
+Driven use cases (from RFC-004): UC-19 (signal wait), UC-20 (external callback), UC-21 (human approval), UC-22 (multi-condition — forward-compat with RFC-014).
+
+## Assumptions
+
+A1. **Round-4 Handle is concrete, not an associated type.** The `Handle` struct is `ff-core::backend::Handle` with `kind: HandleKind`. This RFC does NOT re-open M-D2 (borrow vs. consume). `suspend` borrows the handle; it does not consume it. Terminal-looking behaviour is expressed through the returned `SuspendOutcome` variant (the caller's pre-suspend handle is logically invalidated on `Suspended` and logically retained on `AlreadySatisfied`, but enforcement is runtime, not compile-time — same model as `complete`/`fail`).
+
+A2. **HMAC token protocol from RFC-004 is unchanged.** Kid-ring, 2-kid rotation, `ff:sec:{p:N}:waitpoint_hmac`, grace window — all as shipped. This RFC carries tokens through typed fields; it does not re-negotiate the wire.
+
+A3. **Single active suspension per execution remains a v1 invariant** (RFC-004 §V1 Scope). This RFC does NOT add multi-suspension-per-execution; it reserves the typed shape so RFC-014 can.
+
+A4. **`create_waitpoint` (round-7) stays unchanged.** Pending waitpoints are minted separately; `suspend` may consume a pending waitpoint or create a fresh one, exactly as today's Lua supports via the `use_pending_waitpoint` ARGV flag. This RFC surfaces that flag as a typed `SuspendArgs::pending_waitpoint: Option<WaitpointId>`.
+
+A5. **`ff-server` REST consumers do NOT call `suspend` directly.** Suspension is worker-originated; the only caller is `ClaimedTask::suspend` inside `ff-sdk`. This keeps the blast radius contained: one forwarder rewrite, one parser deletion, zero public REST break.
+
+---
+
+## §1 — What breaks today (concrete)
+
+- `crates/ff-backend-valkey/src/lib.rs:~1240-1249` — stub returning `EngineError::Unavailable { op: "suspend" }`.
+- `crates/ff-sdk/src/task.rs:812-924` — `ClaimedTask::suspend` builds 17 KEYS + 17 ARGV by hand, serializes `resume_condition_json` and `resume_policy_json` as ad-hoc JSON, calls `self.client.fcall("ff_suspend_execution", …)` directly, then hands raw wire bytes to `parse_suspend_result`.
+- `crates/ff-sdk/src/task.rs:1448-1547` — `parse_suspend_result` duplicates the Lua return contract in Rust. Any schema drift in `ff_suspend_execution` silently de-syncs from this parser.
+- `ff-core::backend::WaitpointSpec` (landed round-7 for `create_waitpoint`) has `kind: WaitpointKind`, `matcher: Vec<u8>`, `hmac_token: WaitpointHmac`. The `matcher` is an opaque byte blob — a future-proofing hedge, not a typed condition. Stage 1d fills this in.
+- `ff-sdk::task::ConditionMatcher` — SDK-local, not on the trait; a `struct { signal_name: String }`. Only expresses "match this signal name" or "wildcard". No count, no all-of, no payload predicate, no timeout-signal synthesis.
+
+The round-7 amendment explicitly deferred this rework (§R7.6.1): "typed `ResumeCondition` on trait in round-8, or ARGV-JSON in backend impl?". This RFC answers: **typed, on the trait**. Rationale in §8.2.
+
+---
+
+## §2 — Proposed trait signature + type shapes
+
+### §2.1 Trait method
+
+```rust
+// crates/ff-core/src/engine_backend.rs
+async fn suspend(
+    &self,
+    handle: &Handle,
+    args: SuspendArgs,
+) -> Result<SuspendOutcome, EngineError>;
+```
+
+Rationale for `SuspendArgs` struct over positional params:
+- Matches the round-7 precedent: `DeliverSignalArgs`, `ClaimResumedExecutionArgs`, `AppendFrameArgs` all pack op inputs into one `#[non_exhaustive]` struct. Suspending follows the same convention.
+- Non-exhaustive gives us RFC-014 additive room without a trait break.
+- Named fields beat positional triples for a call site with 6+ parameters.
+
+### §2.2 `SuspendArgs` shape
+
+```rust
+// crates/ff-core/src/contracts/mod.rs
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SuspendArgs {
+    /// Worker-provided new suspension id (UUID v4). Minted caller-side
+    /// so the echoed-back value in `SuspendOutcome` is round-trippable
+    /// and the Lua function can run under Valkey's no-random-in-scripts
+    /// rule.
+    pub suspension_id: SuspensionId,
+
+    /// The waitpoint being activated. Two cases:
+    ///   * `Fresh { waitpoint_id, waitpoint_key }` — mint a fresh active
+    ///     waitpoint as part of `suspend`. `waitpoint_id` and `waitpoint_key`
+    ///     are worker-minted (UUID, `wpk:<uuid>`).
+    ///   * `UsePending { waitpoint_id }` — activate a pending waitpoint
+    ///     previously issued by `create_waitpoint`. The key + HMAC token
+    ///     were returned from that call; `suspend` resolves them from the
+    ///     waitpoint hash.
+    pub waitpoint: WaitpointBinding,
+
+    /// Declarative resume condition. Typed. See §2.4.
+    pub resume_condition: ResumeCondition,
+
+    /// Resume-side policy (what happens when the condition is satisfied).
+    /// Typed. See §2.5.
+    pub resume_policy: ResumePolicy,
+
+    /// Reason category — maps to RFC-004's `reason_code` (one of the
+    /// suspension reason enum values); carried over the trait so the
+    /// backend does not need to re-infer it from `resume_condition`.
+    pub reason_code: SuspensionReasonCode,
+
+    /// Who requested suspension — `Worker`, `Operator`, `Policy`,
+    /// `SystemTimeoutPolicy`.
+    pub requested_by: SuspensionRequester,
+
+    /// Wall-clock deadline. `None` = suspend indefinitely until a
+    /// signal/operator action satisfies the condition.
+    pub timeout_at: Option<TimestampMs>,
+
+    /// What happens at `timeout_at` if the condition is unsatisfied.
+    /// Typed enum (RFC-004 §Timeout Behavior); moved off the SDK's
+    /// ad-hoc `TimeoutBehavior` str.
+    pub timeout_behavior: TimeoutBehavior,
+
+    /// Opaque worker-owned continuation pointer. The engine stores it
+    /// and hands it back on resume; it is NOT interpreted by the
+    /// engine (RFC-004 §Continuation Model).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation_metadata_pointer: Option<String>,
+
+    /// `now` at caller time — the backend uses server-time `TIME` for
+    /// Lua correctness but carries the caller clock for correlation.
+    pub now: TimestampMs,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum WaitpointBinding {
+    Fresh {
+        waitpoint_id: WaitpointId,
+        waitpoint_key: String,
+    },
+    UsePending {
+        waitpoint_id: WaitpointId,
+    },
+}
+```
+
+Notes:
+
+- `suspension_id` / `waitpoint_id` / `waitpoint_key` are worker-minted. This mirrors today's SDK (see `task.rs:834-837`) and matches how Valkey scripts must work (no `math.random` in FCALLs).
+- `continuation_metadata_pointer` stays `Option<String>` — same opacity as today. RFC-004 explicitly does not let the engine own continuation bytes.
+- `reason_code` + `requested_by` are typed enums (currently ARGV strings). The enum values are the set defined in RFC-004 §Suspension Reason Categories; `#[non_exhaustive]` so RFC-014/RFC-015 can extend.
+- `WaitpointSpec` (from round-7) is **not** reused as the `suspend` input: it was shaped for `create_waitpoint`'s pending issuance. Keeping them separate is cleaner than overloading one struct with conditional fields.
+
+### §2.3 `SuspendOutcome` shape
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SuspendOutcome {
+    /// The normal path: execution is now suspended, the worker's
+    /// pre-suspend handle is no longer lease-bearing, and `handle`
+    /// carries the `HandleKind::Suspended` cookie the caller uses for
+    /// `observe_signals` and the eventual `claim_from_reclaim` /
+    /// `claim_resumed_execution`.
+    Suspended {
+        suspension_id: SuspensionId,
+        waitpoint_id: WaitpointId,
+        waitpoint_key: String,
+        waitpoint_token: WaitpointHmac,
+        /// Fresh suspended-kind Handle. Replaces the caller's
+        /// pre-suspend handle (same concrete struct, same BackendTag,
+        /// new opaque bytes).
+        handle: Handle,
+    },
+
+    /// The early-satisfied path: buffered signals on a pending
+    /// waitpoint already matched the resume condition at suspension
+    /// time. The lease is NOT released; the caller's pre-suspend
+    /// handle remains valid and lease-bearing; the worker continues
+    /// executing as if `suspend` never happened, other than the
+    /// waitpoint closing as `satisfied`.
+    AlreadySatisfied {
+        suspension_id: SuspensionId,
+        waitpoint_id: WaitpointId,
+        waitpoint_key: String,
+        waitpoint_token: WaitpointHmac,
+        // NO `handle` field: caller keeps their pre-suspend handle.
+    },
+}
+```
+
+**Why an enum of structs (not a single struct with an `Option<Handle>`):**
+- The `Suspended` branch always has a fresh Handle; the `AlreadySatisfied` branch never does. Encoding that as `Option` invites null-confusion bugs at the call site. §8.1 argues this more.
+- Both variants carry the HMAC `waitpoint_token`. On `AlreadySatisfied` the token exists but the waitpoint is closed; we still return it for uniform parse shape and for operator traceback. Worker code should not re-use it for signal delivery — but that's enforced by the waitpoint's `closed=1` state in Lua, not by omission here.
+
+**Handle-kind semantics** (concrete, not theoretical):
+- Pre-suspend: `HandleKind::Fresh` or `HandleKind::Resumed` (either works — both are lease-bearing).
+- On `Suspended`: returned `handle.kind == HandleKind::Suspended`. Caller's pre-suspend handle is NOT automatically invalidated by Rust (no move/drop); runtime enforcement: any trait op called against the stale handle returns `EngineError::Contention(LeaseConflict)` because the fence triple (lease_id/epoch/attempt_id) in that handle's opaque bytes no longer matches the now-`unowned` exec_core.
+- On `AlreadySatisfied`: no new handle. Caller's pre-suspend handle remains valid (lease still held, fence triple still matches). This is the load-bearing invariant — consumers must pattern-match both variants and only substitute handles on `Suspended`.
+
+### §2.4 `ResumeCondition` shape (forward-compat with RFC-014)
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ResumeCondition {
+    /// Single signal-name match. Matches the SDK's v1 `ConditionMatcher`
+    /// with `signal_name == ""` meaning wildcard.
+    Signal {
+        /// Empty = wildcard (any signal name).
+        signal_name: String,
+    },
+
+    /// "any of these signal names" — matches when one signal in the
+    /// set arrives.
+    AnyOf { signal_names: Vec<String> },
+
+    /// "all of these signal names" — matches when every name has
+    /// arrived at least once. (RFC-004 §Resume Condition fields already
+    /// describes `all` as v1.)
+    AllOf { signal_names: Vec<String> },
+
+    /// Operator-only resume — no signal ever satisfies; only an
+    /// explicit operator resume closes. Used for escalate-style paths.
+    OperatorOnly,
+
+    /// Timeout-only — waitpoint has no signal satisfier, only the
+    /// `timeout_behavior` at `timeout_at` resolves it. (Useful for
+    /// pure-delay suspensions where a signal arriving would be an
+    /// error, not a resumer.)
+    TimeoutOnly,
+}
+```
+
+**Forward-compat hooks (RFC-014 will extend):**
+- `#[non_exhaustive]` lets RFC-014 add `Count { signal_name, n }`, `CompositeAll { clauses: Vec<ResumeCondition> }`, `CompositeAny { clauses }` without breaking downstream pattern matches.
+- Nesting is expressed by making the enum self-recursive in future variants — `AllOf` today takes `Vec<String>` (flat); RFC-014's `CompositeAll` takes `Vec<ResumeCondition>` (nested). Both coexist — `AllOf` is the flat-signal-name fast-path, `CompositeAll` is the RFC-014 general form. §7.3 tracks whether to collapse `AllOf` into `CompositeAll` at RFC-014 landing time.
+- `minimum_signal_count` (RFC-004 §Resume Condition Fields) is NOT a top-level `SuspendArgs` field; it is implicit per variant — `AllOf` ⇒ `n = |signal_names|`; `AnyOf` ⇒ `n = 1`; `Count` (RFC-014) will carry an explicit `n`.
+
+**Why not JSON passthrough:**
+- The round-7 §R7.6.1 open question offered "ARGV-JSON in backend impl" as an alternative. Rejected because: (i) a Postgres backend cannot produce the same JSON shape without re-implementing the Valkey Lua's `initialize_condition` helper; (ii) typed variants let `rustc` enforce exhaustiveness on the SDK forwarder — replacing runtime parse errors with compile errors when RFC-014 lands; (iii) JSON-at-the-seam means every consumer of `dyn EngineBackend` has to agree on a schema that is otherwise undocumented.
+- Cost: the Valkey backend still serializes `ResumeCondition` → ARGV JSON (matches today's `ff_suspend_execution` contract). That's an internal, backend-scoped serializer, not a public API.
+
+### §2.5 `ResumePolicy` shape
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ResumePolicy {
+    /// Where the satisfied suspension goes. V1: only `Runnable`.
+    pub resume_target: ResumeTarget,
+
+    /// Whether matched signals are considered consumed after satisfaction.
+    pub consume_matched_signals: bool,
+
+    /// Whether buffered signals remain readable after waitpoint close.
+    pub retain_signal_buffer_until_closed: bool,
+
+    /// Optional delay before the resumed execution becomes eligible
+    /// (RFC-004 §Resume policy fields `resume_delay_ms`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_delay_ms: Option<u64>,
+
+    /// Normally true. Closes the waitpoint as part of resume.
+    pub close_waitpoint_on_resume: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ResumeTarget {
+    /// Execution returns to `runnable` and goes through normal
+    /// scheduling. V1 default.
+    Runnable,
+}
+```
+
+Only one `ResumeTarget` variant today — `Runnable` — but `#[non_exhaustive]` on both leaves room for RFC-014's `DirectActive` (inline re-claim) if that becomes desirable.
+
+### §2.6 `TimeoutBehavior`, `SuspensionReasonCode`, `SuspensionRequester`
+
+These are direct translations of RFC-004's string-based fields into typed enums:
+
+```rust
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TimeoutBehavior {
+    Fail,
+    Cancel,
+    Expire,
+    AutoResumeWithTimeoutSignal,
+    Escalate, // v2 per RFC-004 Implementation Notes; enum slot present.
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SuspensionReasonCode {
+    WaitingForSignal,
+    WaitingForApproval,
+    WaitingForCallback,
+    WaitingForToolResult,
+    WaitingForOperatorReview,
+    PausedByPolicy,
+    PausedByBudget,
+    StepBoundary,
+    ManualPause,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SuspensionRequester {
+    Worker,
+    Operator,
+    Policy,
+    SystemTimeoutPolicy,
+}
+```
+
+All three are `#[non_exhaustive]`; backend serializes to the corresponding Lua/wire string.
+
+---
+
+## §3 — Replay + idempotency contract
+
+### §3.1 Valid replay cases
+
+1. **Same handle, same `SuspendArgs` (including same `suspension_id`), second call after transport error on the first.**
+   - Semantics: the first call either committed (exec is now `suspended`) or did not.
+   - Behavior:
+     - If the first call committed: the fence triple in `handle`'s opaque bytes still names the pre-suspend lease — now invalidated. The second call returns `EngineError::Contention(ContentionKind::LeaseConflict)` (lease_id no longer matches exec_core's `current_lease_id`, which is empty). The caller MUST treat `LeaseConflict` after a known-possibly-successful `suspend` as "suspend probably succeeded; re-read exec state via `describe_execution` to confirm".
+     - If the first call did not commit: same args succeed fresh.
+   - **Not idempotent via the `suspension_id`**: Lua does not check for pre-existing `suspension_id` before committing. The second attempt's commit fails on the already-suspended check (see RFC-004 Lua pseudocode `EXISTS KEYS.suspension_current → "already_suspended"`). That returns `EngineError::State(StateKind::AlreadySuspended)`.
+   - **Contract**: callers must assume `suspend` is **not** idempotent on retry. On any error after `suspend`, the caller MUST `describe_execution` before retrying, and only retry if lifecycle is still `active`.
+
+2. **Same handle, same args, exec is in `suspended` already (discovered via describe).**
+   - Caller should `claim_resumed_execution` or wait for signal — not re-`suspend`.
+
+### §3.2 Invalid replay cases
+
+3. **Second `suspend` on the fresh Suspended-kind handle returned by a successful `suspend`.**
+   - `handle.kind == Suspended`. Backend pattern-matches: if kind is Suspended and the caller is trying to transition exec from `active` to `suspended`, return `EngineError::State(StateKind::AlreadySuspended)`. This is a programming bug; it is also cheap to detect before any FCALL (handle kind check in Rust).
+
+4. **Second `suspend` with a new `suspension_id` after the first succeeded.**
+   - Equivalent to (3) — the exec is already suspended. `EngineError::State(StateKind::AlreadySuspended)` via Lua `already_suspended` error code.
+
+### §3.3 Contract summary
+
+- `suspend` is **not** retry-idempotent. Retry requires a describe-and-reconcile dance. The `suspension_id` is echoed in `SuspendOutcome` for caller correlation, not for Lua-side dedup.
+- A future enhancement (out of scope): add an optional `idempotency_key` on `SuspendArgs` backed by a dedup hash scan, analogous to `DeliverSignalArgs::idempotency_key`. Tracked as §7.5.
+
+---
+
+## §4 — Error taxonomy
+
+All errors surface as `EngineError`. Variant-by-variant, by scenario:
+
+| Scenario | `EngineError` variant | Notes |
+|---|---|---|
+| Fence triple drifted (lease stolen / expired / revoked between call-site and FCALL) | `Contention(LeaseConflict)` | Retryable after `describe_execution` reconcile. |
+| Handle kind is Suspended at entry | `State(AlreadySuspended)` | Rust-side check, no FCALL. Programming bug. |
+| Exec lifecycle drifted to terminal before FCALL commits | `Contention(ExecutionNotActive { … })` | Mirrors Lua `execution_not_active`. |
+| Exec already has `suspension:current` hash set with no `closed_at` | `State(AlreadySuspended)` | Lua `already_suspended`. |
+| Lease id/epoch/attempt mismatch on the handle | `Validation(InvalidLeaseForSuspend)` | Lua `invalid_lease_for_suspend`. |
+| `WaitpointBinding::UsePending` but waitpoint is missing / wrong exec / expired | `Contention(WaitpointNotFound)` or `State(PendingWaitpointExpired)` | Pre-existing variants from RFC-004 wire. |
+| `WaitpointBinding::Fresh` but `waitpoint_key` does not parse to `wpk:<uuid>` | `Validation(InvalidWaitpointKey)` | Pre-existing. |
+| `resume_condition == AnyOf { signal_names: [] }` or similar empty-condition footgun | `Validation(InvalidInput { detail: "resume_condition.signal_names" })` | Rust-side check before FCALL. |
+| `timeout_at` in the past | `Validation(InvalidInput { detail: "timeout_at_in_past" })` | Rust-side. |
+| HMAC secrets not initialised for partition | `Transport(boxed ScriptError::hmac_secret_not_initialized)` | Ops issue, not caller issue. |
+| Valkey connection error / transient | `Transport(…)` | Standard. |
+
+**New kinds needed:** none. Every scenario maps to an existing variant after Round-7. The `InvalidLeaseForSuspend` variant was added in Round-4 specifically for this path.
+
+**Classification note:** `LeaseConflict` + `ExecutionNotActive` are retryable; `AlreadySuspended` is cooperative (no-op — the caller's intent is already the state); everything else is either terminal (validation, bug) or transport (standard retry). See `EngineError::classify` for the authoritative mapping — this RFC adds no new classes.
+
+---
+
+## §5 — SDK forwarder contract
+
+After this RFC lands:
+
+### §5.1 New SDK surface
+
+```rust
+// crates/ff-sdk/src/task.rs
+impl ClaimedTask {
+    pub async fn suspend(
+        self,
+        reason_code: SuspensionReasonCode,
+        resume_condition: ResumeCondition,
+        timeout: Option<(TimestampMs, TimeoutBehavior)>,
+        resume_policy: ResumePolicy,
+    ) -> Result<SuspendOutcome, SdkError> {
+        let handle = self.to_handle();
+        let args = SuspendArgs {
+            suspension_id: SuspensionId::new(),
+            waitpoint: WaitpointBinding::Fresh {
+                waitpoint_id: WaitpointId::new(),
+                waitpoint_key: format!("wpk:{}", WaitpointId::new()),
+            },
+            resume_condition,
+            resume_policy,
+            reason_code,
+            requested_by: SuspensionRequester::Worker,
+            timeout_at: timeout.map(|(t, _)| t),
+            timeout_behavior: timeout.map(|(_, b)| b).unwrap_or(TimeoutBehavior::Fail),
+            continuation_metadata_pointer: None,
+            now: TimestampMs::now(),
+        };
+        self.stop_renewal();
+        self.backend.suspend(&handle, args).await.map_err(SdkError::from)
+    }
+
+    /// Convenience: suspend with a pending waitpoint previously
+    /// issued via `create_waitpoint`.
+    pub async fn suspend_on_pending(
+        self,
+        pending: &PendingWaitpoint,
+        reason_code: SuspensionReasonCode,
+        resume_condition: ResumeCondition,
+        timeout: Option<(TimestampMs, TimeoutBehavior)>,
+    ) -> Result<SuspendOutcome, SdkError> { /* mirrors above with UsePending */ }
+}
+```
+
+- `SuspendOutcome` is **re-exported** from `ff-core::backend` into `ff-sdk::task`. The SDK does not own the type.
+- Handlers pattern-match `SuspendOutcome` directly. No further wrapping — the enum is the SDK contract.
+- **Deletions**:
+  - `ff-sdk::task::parse_suspend_result` (100 LOC). Gone.
+  - `ff-sdk::task::ConditionMatcher` (the `struct { signal_name: String }`). Replaced by `ResumeCondition::Signal`.
+  - `ff-sdk::task::TimeoutBehavior` (if SDK-local — confirm in impl; otherwise just re-export from `ff-core`).
+  - The direct `self.client.fcall("ff_suspend_execution", …)` call site. Replaced by `self.backend.suspend(…)`.
+
+### §5.2 Compatibility break
+
+Signature-level SDK break. `ClaimedTask::suspend` goes from
+`(reason_code: &str, &[ConditionMatcher], Option<u64>, TimeoutBehavior)`
+to the shape in §5.1. All downstream callers (known: `ff-sdk` tests, `cairn-fabric` consumer) must update. Release notes:
+
+> **Breaking — `ff-sdk::ClaimedTask::suspend`:** signature changed. Pass typed `ResumeCondition` and `ResumePolicy`. `ConditionMatcher` is removed; use `ResumeCondition::Signal { signal_name }` for single-name, `ResumeCondition::AnyOf { signal_names }` for the previous multi-name fan-out. Internal parser `parse_suspend_result` deleted.
+
+Consumer migration is mechanical; `cairn-fabric` owns its own migration (peer-team boundary per memory). The FF release produces a migration snippet but does not modify `cairn-fabric` code.
+
+### §5.3 `Handle` substitution contract at call site
+
+Today's `ClaimedTask::suspend` consumes `self` — on any outcome, the task is gone. Under Stage 1d:
+
+- `Suspended { handle, … }`: caller replaces their `ClaimedTask` with — nothing. `ClaimedTask` is consumed; the returned `Handle` belongs to an opaque SDK post-suspension cookie. There is **no** public SDK type to "continue as suspended worker"; resumption goes through `claim_resumed_execution` which mints a fresh `ClaimedTask` on a later poll. The `Handle` is only useful to `observe_signals` until that re-claim happens — which is how today's SDK already works. We preserve that exact model.
+- `AlreadySatisfied { … }`: `ClaimedTask` is consumed but the lease is not released. The caller cannot continue running against the original task after an `AlreadySatisfied` outcome — the worker's current-task state is gone. This is a **breaking** behavioral carryover from today (`ClaimedTask::suspend` already consumes `self` in the AlreadySatisfied path). §7.2 proposes an owner-review alternative that preserves the task handle in `AlreadySatisfied`.
+
+---
+
+## §6 — Interactions
+
+- **RFC-004 (Suspension)**: unchanged. This RFC re-shapes the Rust surface; the Valkey wire contract (Lua `ff_suspend_execution`, keys, ARGV, error codes) is preserved. Lua stays source of truth.
+- **RFC-005 (Signal)**: unchanged. `deliver_signal` and `claim_resumed_execution` landed in PR #200 with typed args (`DeliverSignalArgs`, `ClaimResumedExecutionArgs`) — this RFC aligns `suspend`'s input shape with that precedent.
+- **RFC-012 §R7.6.1**: this RFC is the answer to the pinned open question ("typed `ResumeCondition` on trait vs ARGV-JSON"). Decision: typed. See §8.2.
+- **RFC-014 (multi-signal conditions, parallel draft)**: `ResumeCondition` is designed to extend with `Count`, `CompositeAll`, `CompositeAny`. RFC-014 adds variants; does not re-shape the method.
+- **Waitpoint HMAC protocol (RFC-004 §Waitpoint Security)**: unchanged. `WaitpointHmac` carries the token through typed fields. Minting remains Lua-side; validation remains Lua-side; rotation remains via `/v1/admin/rotate-waitpoint-secret`.
+- **`create_waitpoint` (round-7, landed)**: `suspend` interoperates via `WaitpointBinding::UsePending`. The lua `use_pending_waitpoint` ARGV flag is the backend's serialization of that variant; no Lua change.
+- **`observe_signals` / `claim_resumed_execution` (landed)**: unchanged. The post-suspend handle hands off to those methods exactly as today.
+
+---
+
+## §7 — Open questions (owner review required)
+
+### §7.1 `timeout: Option<(TimestampMs, TimeoutBehavior)>` vs split fields
+
+The SDK `suspend` in §5.1 bundles `timeout_at` + `timeout_behavior` into one `Option<(…)>`. An alternative: two separate `Option<TimestampMs>` + `TimeoutBehavior` params with `TimeoutBehavior::Fail` as default.
+
+- **Tradeoff**: tuple form prevents the "timeout_at set but timeout_behavior forgotten, behavior silently defaulted" bug. Split form reads nicer at the call site (`None` for timeout is clearer than `None` on a tuple).
+- **Recommendation**: tuple form (catches the bug). Owner: pick.
+- The trait-level `SuspendArgs` shape is unaffected either way — this is an SDK ergonomics question.
+
+### §7.2 `AlreadySatisfied` — does `ClaimedTask` survive?
+
+Today's `ClaimedTask::suspend` consumes `self` unconditionally. On `AlreadySatisfied` the lease is retained but the `ClaimedTask` is gone — the worker cannot continue running without some other path to reconstruct task state. In practice today this means: callers who get `AlreadySatisfied` must return control and let the execution be re-claimed, even though the lease is technically held.
+
+Three options:
+1. **Keep today's behavior** (consume `self` in both variants). Simple. Requires the worker to tear down and wait for re-claim. `AlreadySatisfied` is effectively a bug: the lease lingers until renew-on-a-dropped-task runs out.
+2. **Return `Result<Either<(ClaimedTask, SuspendOutcome::AlreadySatisfied), SuspendOutcome::Suspended>, _>`** — on AlreadySatisfied, hand the `ClaimedTask` back so the worker continues. Needs the SDK wrapper method on ClaimedTask to be non-consuming in the AS branch, which is structurally awkward.
+3. **Split into two SDK methods**: `ClaimedTask::suspend_strict` (consumes self, errors on AS) and `ClaimedTask::try_suspend` (returns `Either`). Strict is the 95% path; try is the pending-waitpoint early-signal path.
+- **Recommendation**: option 3. Owner: pick. This is a call-site ergonomics question that doesn't affect the trait.
+
+### §7.3 `AllOf` / `AnyOf` flat forms vs RFC-014's recursive `Composite*`
+
+When RFC-014 lands its `CompositeAll { clauses: Vec<ResumeCondition> }`, the flat `AllOf { signal_names: Vec<String> }` becomes redundant. Two choices:
+
+- Keep `AllOf` as a flat fast-path (documented as "equivalent to `CompositeAll { clauses: signal_names.map(Signal) }`"). Migration-free.
+- Deprecate `AllOf` in RFC-014; remove in a later release. More churn, cleaner surface.
+- **Recommendation**: keep flat form permanently. The backend serializer can internally collapse. Owner: pick, or defer until RFC-014.
+
+### §7.4 `SuspensionRequester` default
+
+SDK callers always pass `SuspensionRequester::Worker`. Do we need the field on `SuspendArgs` at all, or is it implicit (worker-originated)?
+- Operator-originated suspends (e.g. "admin pauses this exec") go through a different path (not `ClaimedTask::suspend` — there is no lease to surrender). So `suspend` as a trait op is always worker-requested in v1.
+- **Recommendation**: keep the field; RFC-004 has `paused_by_policy` and `system_timeout_policy` reasons that imply non-worker requesters will eventually flow through this method. Owner: confirm.
+
+### §7.5 Optional `idempotency_key` on `SuspendArgs`
+
+§3.3 flags that `suspend` is not retry-idempotent. Adding an `idempotency_key: Option<String>` field backed by a partition-scoped dedup hash (TTL = RFC-004 suspension-timeout ceiling) would make retry-after-network-error trivially safe at modest state cost.
+- **Recommendation**: not in Stage 1d. Track as a follow-up; §3.1's describe-and-retry pattern suffices for v0.6. Owner: confirm deferral.
+
+### §7.6 `continuation_metadata_pointer` — string or typed?
+
+Today it's a free-form string. Proposal: keep as `Option<String>`. An alternative: typed `ContinuationPointer { scheme: String, path: String }` for slightly better self-describability at no enforcement cost (the engine still doesn't interpret bytes).
+- **Recommendation**: keep `Option<String>`. The engine has zero semantics to enforce on the contents; typing it is ceremony. Owner: confirm.
+
+---
+
+## §8 — Alternatives rejected
+
+### §8.1 `SuspendOutcome` as a struct with `Option<Handle>` rather than an enum
+
+```rust
+struct SuspendOutcome {
+    suspension_id: SuspensionId,
+    waitpoint_id: WaitpointId,
+    waitpoint_key: String,
+    waitpoint_token: WaitpointHmac,
+    handle: Option<Handle>,  // None = AlreadySatisfied; Some = Suspended
+    already_satisfied: bool,
+}
+```
+
+**Rejected** because:
+- Pairs that should be exclusive (`handle.is_none() ⇔ already_satisfied`) get inconsistent over time.
+- SDK call sites pattern-match on `already_satisfied`, not the Option — opens the door for "I forgot to check and unwrapped the handle on AS". Runtime panic instead of compile error.
+- Enum variants let `#[non_exhaustive]` guard RFC-014 additions cleanly; a struct with an extra `timeout_elapsed: bool` field is exactly the footgun pattern.
+
+### §8.2 ARGV-JSON in the backend impl, keeping a stringly-typed `ResumeCondition: serde_json::Value` on the trait
+
+Round-7 §R7.6.1's alternative phrasing. **Rejected** because:
+- Pushes the schema into no-lint land. No rust-level check that `AnyOf.signal_names` isn't misspelled `signalNames`.
+- A Postgres backend can't produce the same JSON without cross-team sync.
+- RFC-014's additions become string-format RFCs instead of trait additions.
+
+### §8.3 Keep today's stub path (ship nothing)
+
+**Rejected** because it leaves `dyn EngineBackend::suspend` permanently broken. RFC-012's Stage-1 gate requires every op forward through the trait. Postponing into RFC-014 is worse — two trait breaks back-to-back against downstream consumers.
+
+### §8.4 Split `suspend` into `suspend_fresh` and `suspend_on_pending`
+
+Mirror the WaitpointBinding variants at the trait level. **Rejected** because:
+- Adds one more trait method for no semantic win.
+- The backend op is exactly one Lua FCALL (`ff_suspend_execution` with `use_pending_waitpoint` ARGV flag); trait surface should match the op count.
+- SDK ergonomics can still offer two methods (§5.1 shows `suspend` + `suspend_on_pending`) — the split belongs there, not at the trait.
+
+### §8.5 Consume `Handle` instead of borrowing (Round-4 M-D2 reversal)
+
+**Rejected** because M-D2 locked borrowing in Round-4, and the `AlreadySatisfied` branch is the exact reason borrow-not-consume wins: on AS, the caller's handle is still live. Consuming would force the AS variant to re-materialize a Handle, which is strictly worse.
+
+### §8.6 Return `Result<(Handle, SuspendMetadata), EngineError>` (struct beside the handle)
+
+A flatter shape: always return a Handle, with metadata in a side struct, and encode "AlreadySatisfied" in the `HandleKind` (e.g. new `HandleKind::LeaseRetainedAfterSuspend`). **Rejected** because:
+- Pollutes `HandleKind` with a transient, single-op-specific kind.
+- `LeaseRetained` would have to be reconverted to `Fresh` on the next caller op. More bookkeeping, not less.
+- The enum outcome (§2.3) matches Round-7's `ClaimResumedExecutionResult` shape (one enum for op-specific outcomes). Consistency.
+
+---
+
+## §9 — Implementation plan
+
+### §9.1 Landing order
+
+1. **ff-core types** (§2.2 – §2.6): land `SuspendArgs`, `SuspendOutcome`, `WaitpointBinding`, `ResumeCondition`, `ResumePolicy`, `ResumeTarget`, `TimeoutBehavior`, `SuspensionReasonCode`, `SuspensionRequester` in `crates/ff-core/src/contracts/mod.rs` (and re-export from `ff-core::backend`). Zero behavioral change; just types.
+2. **Trait update** (§2.1): change `EngineBackend::suspend` signature in `crates/ff-core/src/engine_backend.rs`. Breaking change on the trait. Stubbed impl remains `EngineError::Unavailable { op: "suspend" }` — still compiles.
+3. **Valkey backend impl**: fill in `crates/ff-backend-valkey/src/lib.rs:~1240-1249`. Build KEYS (17) / ARGV (17) from `SuspendArgs`. Internal `ResumeCondition` → JSON serializer. Parse Lua return into `SuspendOutcome` — move `parse_suspend_result` logic into the backend, not SDK.
+4. **SDK forwarder** (§5.1): rewrite `ClaimedTask::suspend` to forward through the trait. Delete `parse_suspend_result`, `ConditionMatcher`, SDK-local `TimeoutBehavior` if present.
+5. **Release notes + migration snippet** for 0.6.0.
+
+### §9.2 Lua changes
+
+**None required.** The wire contract (`ff_suspend_execution` KEYS/ARGV/return) is preserved. The backend serializer materializes the same ARGV strings today's SDK builds by hand. Zero Lua-level risk.
+
+### §9.3 Test matrix
+
+Required tests (at the landing PR's CI):
+
+1. **Unit tests on the Rust type layer**:
+   - `ResumeCondition::Signal { signal_name: "" }` round-trips as wildcard.
+   - `ResumeCondition::AllOf { signal_names: [] }` is rejected at Rust-side validation.
+   - `SuspendArgs` serde round-trip (JSON) for every `ResumeCondition` variant.
+   - `SuspendOutcome::Suspended`/`AlreadySatisfied` exhaustiveness check in the SDK wrapper.
+
+2. **Valkey-backend integration tests**:
+   - `suspend` with `WaitpointBinding::Fresh`, `ResumeCondition::Signal`, no timeout → `Suspended`.
+   - `suspend` with `WaitpointBinding::UsePending`, no early signals → `Suspended`.
+   - `suspend` with `WaitpointBinding::UsePending`, buffered signal already matches → `AlreadySatisfied`, lease retained (verify via `describe_execution` that lifecycle still `active`, lease unchanged).
+   - `suspend` after fence-triple drift → `Contention(LeaseConflict)`.
+   - `suspend` on already-suspended exec → `State(AlreadySuspended)`.
+   - `suspend` with `timeout_at` in the past → `Validation(InvalidInput)`.
+   - `suspend` with `ResumeCondition::AnyOf { … }` + signal delivery that matches one name → resumes.
+   - `suspend` with `ResumeCondition::AllOf { ["a", "b"] }` + only `a` delivered → stays suspended; + `b` delivered → resumes.
+   - `suspend` with `TimeoutBehavior::Fail` + timeout scanner tick → exec terminal, `close_reason = timed_out_fail`.
+   - `suspend` with `TimeoutBehavior::AutoResumeWithTimeoutSignal` + timeout → exec runnable, close_reason `timed_out_auto_resume`.
+   - Replay: two `suspend` calls with same args → first succeeds, second returns `State(AlreadySuspended)` (not idempotent).
+
+3. **Cross-backend shape tests**: `SuspendArgs` / `SuspendOutcome` are backend-agnostic. Add a mock `EngineBackend` in test scaffolding that accepts the typed args and produces both outcome variants — assert SDK forwarder dispatches correctly on each.
+
+4. **Regression coverage**: the existing `ff-sdk` suspension integration tests rewire onto the new signature. No new fixtures needed.
+
+### §9.4 Risk analysis
+
+- **Breaking SDK signature**: single consumer (`cairn-fabric`). Owned by peer team. Migration snippet in release notes.
+- **Wire contract preserved**: zero Lua risk, zero data-model risk.
+- **Type surface growth**: 9 new public types in `ff-core`. All `#[non_exhaustive]`; extending them does not break consumers.
+- **`parse_suspend_result` deletion**: removes a 100-LOC parser duplicating the Lua return contract. Strictly removes technical debt.
+
+### §9.5 Rollback
+
+If Stage 1d is reverted mid-release:
+- Types stay in `ff-core` (harmless).
+- Trait signature reverts to Round-4 shape.
+- Backend impl reverts to `Unavailable` stub.
+- SDK forwarder reverts to direct FCALL + `parse_suspend_result`.
+
+No durable state schema changes. Clean revert.
+
+---
+
+## References
+
+- RFC-004 (Suspension) — canonical semantics for waitpoints, resume conditions, timeouts.
+- RFC-005 (Signal) — signal semantics that satisfy resume conditions.
+- RFC-012 §R7.6.1 — the open question this RFC closes.
+- PR #200 — `deliver_signal` + `claim_resumed_execution` trait migration (precedent for typed args shape).
+- `crates/ff-core/src/contracts/mod.rs` — landing site for new types (matches `DeliverSignalArgs` pattern at line 722).
+- `crates/ff-core/src/engine_backend.rs:157-162` — trait method being re-shaped.
+- `crates/ff-backend-valkey/src/lib.rs:~1240-1249` — current stub.
+- `crates/ff-sdk/src/task.rs:812-924, 1448-1547` — SDK forwarder + parser, both migrated.

--- a/rfcs/drafts/RFC-013-stage-1d-suspend.md
+++ b/rfcs/drafts/RFC-013-stage-1d-suspend.md
@@ -115,6 +115,14 @@ pub struct SuspendArgs {
 
     /// Wall-clock deadline. `None` = suspend indefinitely until a
     /// signal/operator action satisfies the condition.
+    ///
+    /// Validated against **backend wall-clock** (Valkey `TIME`), not
+    /// the caller's `now`. Worker clock skew up to
+    /// `SUSPEND_CLOCK_SKEW_TOLERANCE_MS` (600000 ms = 10 min, per the
+    /// HMAC-grace-window precedent in RFC-004) is accepted; beyond
+    /// that, validation rejects as `timeout_at_in_past`. Callers may
+    /// query backend time via `ff_sdk::diagnostics::server_time()` if
+    /// they need to compute a skew-safe deadline.
     pub timeout_at: Option<TimestampMs>,
 
     /// What happens at `timeout_at` if the condition is unsatisfied.
@@ -163,7 +171,63 @@ Notes:
 - `continuation_metadata_pointer` stays `Option<String>` — same opacity as today. RFC-004 explicitly does not let the engine own continuation bytes.
 - `reason_code` + `requested_by` are typed enums (currently ARGV strings). The enum values are the set defined in RFC-004 §Suspension Reason Categories; `#[non_exhaustive]` so RFC-014/RFC-015 can extend.
 - `WaitpointSpec` (from round-7) is **not** reused as the `suspend` input: it was shaped for `create_waitpoint`'s pending issuance. Keeping them separate is cleaner than overloading one struct with conditional fields.
-- `idempotency_key` is a partition-scoped dedup key. Lua stores a hash `ff:dedup:suspend:{p:N}:<execution_id>:<idempotency_key>` → serialized `SuspendOutcome`, TTL = suspension-timeout ceiling + grace. On hit, the first outcome is returned verbatim (including the original `suspension_id` / `waitpoint_id` / `waitpoint_token`), and no state mutation occurs. This mirrors `UsageDimensions.dedup_key`'s semantics on `report_usage`. Absent a key, §3's non-idempotent contract applies.
+- `idempotency_key` is a partition-scoped dedup key. Lua stores a hash `ff:dedup:suspend:{p:N}:<execution_id>:<idempotency_key>` → serialized `SuspendOutcome`, TTL = `min(timeout_at - now + SUSPEND_DEDUP_GRACE_MS, SUSPEND_DEDUP_MAX_TTL_MS)` where `SUSPEND_DEDUP_GRACE_MS = 60_000` (1 min) and `SUSPEND_DEDUP_MAX_TTL_MS = 604_800_000` (7 days). When `timeout_at` is `None`, TTL caps at `SUSPEND_DEDUP_MAX_TTL_MS`. On hit, the first outcome is returned verbatim (including the original `suspension_id` / `waitpoint_id` / `waitpoint_token`), and no state mutation occurs. This mirrors `UsageDimensions.dedup_key`'s semantics on `report_usage`. Absent a key, §3's non-idempotent contract applies.
+- **Dedup-hit `suspension_id` semantics.** When a dedup entry is hit, the returned `SuspendOutcome::*.suspension_id` is the **first call's** minted id, NOT the retry's. Callers correlating by `suspension_id` (logs, observability) should use the echoed value from `SuspendOutcome`, not the value they passed in — the retry's `suspension_id` is silently discarded. This is the idempotent-replay contract; the request `suspension_id` is effectively a cache key input on dedup-miss and a no-op on dedup-hit.
+
+### §2.2.1 Constructors (required per `non_exhaustive`)
+
+`SuspendArgs`, `WaitpointBinding`, and `ResumePolicy` are all `#[non_exhaustive]`. The following constructors ship with this RFC:
+
+```rust
+impl SuspendArgs {
+    /// Build a minimal `SuspendArgs` for a worker-originated suspension.
+    /// Defaults: `requested_by = Worker`, `timeout_at = None`,
+    /// `timeout_behavior = Fail`, `continuation_metadata_pointer = None`,
+    /// `idempotency_key = None`. Override via `with_*` setters.
+    pub fn new(
+        suspension_id: SuspensionId,
+        waitpoint: WaitpointBinding,
+        resume_condition: ResumeCondition,
+        resume_policy: ResumePolicy,
+        reason_code: SuspensionReasonCode,
+        now: TimestampMs,
+    ) -> Self { /* ... */ }
+
+    pub fn with_timeout(mut self, at: TimestampMs, behavior: TimeoutBehavior) -> Self { /* ... */ }
+    pub fn with_requester(mut self, requester: SuspensionRequester) -> Self { /* ... */ }
+    pub fn with_continuation_metadata_pointer(mut self, p: String) -> Self { /* ... */ }
+    pub fn with_idempotency_key(mut self, key: IdempotencyKey) -> Self { /* ... */ }
+}
+
+impl WaitpointBinding {
+    /// Mint a fresh `WaitpointBinding::Fresh` with worker-side UUID v4
+    /// for `waitpoint_id` and `waitpoint_key = format!("wpk:{id}")`.
+    /// Convenience for the common case.
+    pub fn fresh() -> Self { /* ... */ }
+
+    /// Construct a `UsePending` binding from a `PendingWaitpoint` handle
+    /// returned by `create_waitpoint`.
+    pub fn use_pending(pending: &PendingWaitpoint) -> Self { /* ... */ }
+}
+
+impl ResumePolicy {
+    /// Canonical v1 defaults: `Runnable` target, signals consumed on
+    /// satisfy, buffer discarded on close, no resume delay, waitpoint
+    /// closed on resume. Use this unless you have a specific reason to
+    /// deviate.
+    pub fn normal() -> Self {
+        Self {
+            resume_target: ResumeTarget::Runnable,
+            consume_matched_signals: true,
+            retain_signal_buffer_until_closed: false,
+            resume_delay_ms: None,
+            close_waitpoint_on_resume: true,
+        }
+    }
+}
+```
+
+Memory-rule compliance: these constructors satisfy `non_exhaustive_needs_constructor` — every public `#[non_exhaustive]` type in this RFC is buildable without reaching inside.
 
 ### §2.3 `SuspendOutcome` shape
 
@@ -253,6 +317,8 @@ pub enum ResumeCondition {
 - `minimum_signal_count` (RFC-004 §Resume Condition Fields) is NOT a top-level `SuspendArgs` field; it is implicit per variant — `Composite(AllOf(clauses))` ⇒ `n = |clauses|`; `Composite(AnyOf(clauses))` ⇒ `n = 1`; `Composite(Count{n,…})` (RFC-014) carries an explicit `n`.
 
 **`SignalMatcher` shape:** v1 is `enum SignalMatcher { ByName(String), Wildcard }`. RFC-014 may extend (payload predicates, etc.) — `#[non_exhaustive]`.
+
+**`waitpoint_key` cross-field invariant.** When both `WaitpointBinding::Fresh { waitpoint_key: A }` and `ResumeCondition::Single { waitpoint_key: B, .. }` are present, Rust-side validation enforces `A == B`. Mismatch → `Validation(InvalidInput { detail: "waitpoint_key_mismatch" })`, pre-FCALL. For `WaitpointBinding::UsePending`, the Lua-side lookup supplies the authoritative `waitpoint_key`; if `ResumeCondition::Single.waitpoint_key` is provided and does not match, Lua returns `invalid_waitpoint_for_execution` → `Validation(InvalidWaitpointForExecution)`.
 
 **Why not JSON passthrough:**
 - The round-7 §R7.6.1 open question offered "ARGV-JSON in backend impl" as an alternative. Rejected because: (i) a Postgres backend cannot produce the same JSON shape without re-implementing the Valkey Lua's `initialize_condition` helper; (ii) typed variants let `rustc` enforce exhaustiveness on the SDK forwarder — replacing runtime parse errors with compile errors when RFC-014 lands; (iii) JSON-at-the-seam means every consumer of `dyn EngineBackend` has to agree on a schema that is otherwise undocumented.
@@ -347,6 +413,7 @@ All three are `#[non_exhaustive]`; backend serializes to the corresponding Lua/w
      - If the first call did not commit: same args succeed fresh.
    - **Not idempotent via the `suspension_id`**: Lua does not check for pre-existing `suspension_id` before committing. The second attempt's commit fails on the already-suspended check (see RFC-004 Lua pseudocode `EXISTS KEYS.suspension_current → "already_suspended"`). That returns `EngineError::State(StateKind::AlreadySuspended)`.
    - **Contract**: callers must assume `suspend` is **not** idempotent on retry. On any error after `suspend`, the caller MUST `describe_execution` before retrying, and only retry if lifecycle is still `active`.
+   - **Describe-retry budget.** `describe_execution` is itself retryable under normal transport-retry policy (RFC-010 §Transport). The `suspend` retry remains blocked until one describe succeeds; callers may backoff-retry the describe independently without opening a `suspend` double-commit window. With `idempotency_key` set, this reconciliation is unnecessary — the caller retries `suspend` directly and the backend dedups.
 
 2. **Same handle, same args, exec is in `suspended` already (discovered via describe).**
    - Caller should `claim_resumed_execution` or wait for signal — not re-`suspend`.
@@ -384,8 +451,15 @@ All errors surface as `EngineError`. Variant-by-variant, by scenario:
 | HMAC secrets not initialised for partition | `Transport(boxed ScriptError::hmac_secret_not_initialized)` | Ops issue, not caller issue. |
 | Valkey connection error / transient | `Transport(…)` | Standard. |
 | Strict `suspend` (non-`try`) but buffered signals already satisfy the condition | `State(AlreadySatisfied)` | SDK-side: strict path refuses to return the early-satisfied branch. The typed backend outcome is `SuspendOutcome::AlreadySatisfied`; the strict wrapper maps it to this error. `try_suspend` returns the outcome directly instead. |
+| `ResumeCondition::TimeoutOnly` with `timeout_at.is_none()` | `Validation(InvalidInput { detail: "timeout_only_without_deadline" })` | Rust-side check. Pure-timeout suspend with no deadline would suspend forever with no satisfier. |
+| `WaitpointBinding.waitpoint_key` vs `ResumeCondition::Single.waitpoint_key` mismatch (Fresh binding) | `Validation(InvalidInput { detail: "waitpoint_key_mismatch" })` | Rust-side cross-field check, pre-FCALL. For `UsePending`, Lua-side check → `Validation(InvalidWaitpointForExecution)`. |
+| `WaitpointBinding::UsePending { waitpoint_id }` but that waitpoint was already activated by a prior committed `suspend` | `State(AlreadySuspended)` | Lua check order: exec-level `already_suspended` fires first (the exec is in `suspended` state), so the waitpoint-level check is never reached. |
 
-**New kinds needed:** one. `StateKind::AlreadySatisfied` is added to surface the strict-path refusal of the early-satisfied branch (the underlying backend outcome is always typed `SuspendOutcome`; only the SDK's strict wrapper turns it into an error). Every other scenario maps to an existing variant after Round-7. The `InvalidLeaseForSuspend` variant was added in Round-4 specifically for this path.
+**New kinds needed:** one. `StateKind::AlreadySatisfied` is added to surface the strict-path refusal of the early-satisfied branch (the underlying backend outcome is always typed `SuspendOutcome`; only the SDK's strict wrapper turns it into an error). Every other scenario maps to an existing variant after Round-7. The `InvalidLeaseForSuspend` variant was added in Round-4 specifically for this path (confirmed at `crates/ff-core/src/engine_error.rs:183`).
+
+**Enum-extension safety.** `StateKind`, `ValidationKind`, and `ContentionKind` are all `#[non_exhaustive]` (confirmed at `crates/ff-core/src/engine_error.rs:161,227,315`). Adding `StateKind::AlreadySatisfied` is therefore non-breaking for downstream consumers who match exhaustively with a `_ =>` arm — cairn's `EngineError` match ladders survive the upgrade without a trait break.
+
+**`HandleKind::Suspended` pre-check is not dedup-dodgeable.** The Rust-side handle-kind pre-check (first row: `State(AlreadySuspended)`, no FCALL) fires before any `idempotency_key` dedup lookup can reach Lua. A caller cannot "replay" past a Suspended-kind handle by repeating the same idempotency key; that kind signals a programming bug, not a transport retry. Callers who want idempotent-replay safety must pass a fresh handle for the retry — `idempotency_key` only helps when the retry is an honest transport-error retry with an otherwise-valid handle.
 
 **Classification note:** `LeaseConflict` + `ExecutionNotActive` are retryable; `AlreadySuspended` is cooperative (no-op — the caller's intent is already the state); everything else is either terminal (validation, bug) or transport (standard retry). See `EngineError::classify` for the authoritative mapping — this RFC adds no new classes.
 
@@ -417,10 +491,20 @@ impl ClaimedTask {
     ) -> Result<SuspendedHandle, SdkError> {
         let handle = self.to_handle();
         let args = build_suspend_args(&self, reason_code, resume_condition, timeout, resume_policy);
-        self.stop_renewal();
+        // NOTE: renewal is stopped only AFTER a successful Suspend outcome.
+        // On transport error the lease continues to be renewed so the caller's
+        // describe-and-reconcile per §3.1 is tractable. Suspended outcomes
+        // have lease-state=unowned in Valkey so the renewal loop is a no-op
+        // post-commit; stopping it cleanly avoids a pointless heartbeat.
         match self.backend.suspend(&handle, args).await.map_err(SdkError::from)? {
-            SuspendOutcome::Suspended { handle, .. } => Ok(SuspendedHandle { handle, .. }),
+            SuspendOutcome::Suspended { handle, suspension_id, waitpoint_id, waitpoint_key, waitpoint_token } => {
+                self.stop_renewal();
+                Ok(SuspendedHandle { handle, suspension_id, waitpoint_id, waitpoint_key, waitpoint_token })
+            }
             SuspendOutcome::AlreadySatisfied { .. } => {
+                // Lease is retained Lua-side on AlreadySatisfied; strict form
+                // declines it as an error. Renewal is NOT stopped — the caller
+                // will either re-claim or drop, and the lease naturally rolls.
                 Err(SdkError::Engine(EngineError::State(StateKind::AlreadySatisfied)))
             }
         }
@@ -455,7 +539,22 @@ pub enum TrySuspendOutcome {
     Suspended(SuspendedHandle),
     AlreadySatisfied { task: ClaimedTask, details: SuspendOutcomeDetails },
 }
+
+/// Shared "what happened on the waitpoint" bundle, carried in both the
+/// strict `SuspendedHandle` and the `try_suspend` AlreadySatisfied arm.
+pub struct SuspendOutcomeDetails {
+    pub suspension_id: SuspensionId,
+    pub waitpoint_id: WaitpointId,
+    pub waitpoint_key: String,
+    pub waitpoint_token: WaitpointHmac,
+}
 ```
+
+**Helper: `build_suspend_args`.** SDK-internal; mints UUID v4 for `suspension_id`, takes `waitpoint: WaitpointBinding` from the caller (strict `suspend` defaults to `WaitpointBinding::fresh()`; `try_suspend_on_pending` passes `WaitpointBinding::use_pending(...)`), splits `timeout` into `timeout_at`/`timeout_behavior` (with `TimeoutBehavior::Fail` when `timeout` is `None` and the `timeout_at` is itself `None`), reads `now` from `SystemTime::now().into()`, defaults `requested_by = Worker`, `continuation_metadata_pointer = None`, `idempotency_key = None`. Callers who want idempotent retry use a richer SDK entry point (not in this RFC's surface) that threads `IdempotencyKey` through.
+
+**`PendingWaitpoint` → `WaitpointBinding::UsePending`.** `create_waitpoint` returns a `PendingWaitpoint` struct carrying `waitpoint_id: WaitpointId` plus the minted `WaitpointHmac` token. `WaitpointBinding::use_pending(&pending)` destructures just the `waitpoint_id`; the HMAC token is **resolved Lua-side** from the partition's waitpoint hash at `suspend` time. Round-tripping the token through Rust is redundant and was already rejected by RFC-004 §Waitpoint Security (token lives on the hash, not in worker memory).
+
+**No SDK-level auto-reconcile.** The SDK `suspend` / `try_suspend` wrappers do **not** auto-retry on transport error. Callers own the describe-and-reconcile loop per §3.1; alternately, callers set `idempotency_key` on `SuspendArgs` (via the SDK entry point that threads it) to make the retry safe. This is intentional — auto-reconcile would hide the "is my exec suspended or not?" ambiguity from the consumer, which matters for observability and correctness at scale.
 
 Rationale for the split:
 - `suspend` / `try_suspend` is the idiomatic Rust pattern for "operation may fail in a structured, callable-recoverable way": the strict form returns the happy path directly, the try form returns a Result-of-outcome. `Mutex::lock` panics on poisoning; `Mutex::try_lock` returns `Result`. Same cadence.
@@ -592,7 +691,23 @@ A flatter shape: always return a Handle, with metadata in a side struct, and enc
 
 ### §9.2 Lua changes
 
-**None required.** The wire contract (`ff_suspend_execution` KEYS/ARGV/return) is preserved. The backend serializer materializes the same ARGV strings today's SDK builds by hand. Zero Lua-level risk.
+**Scoped to the `idempotency_key` dedup path.** The non-idempotent path of `ff_suspend_execution` (KEYS 1..17, ARGV 1..17 as shipped) is preserved verbatim — the backend serializer materializes the same strings today's SDK builds by hand. Zero wire risk on that path.
+
+**New dedup-path delta:**
+
+- **+1 KEY (slot 18):** `ff:dedup:suspend:{p:N}:<execution_id>:<idempotency_key>` — a partition-scoped hash keyed on the triple from §2.2. Omitted (empty string passthrough) when the caller does not supply an `idempotency_key`.
+- **+2 ARGV:**
+  - **slot 18:** `idempotency_key` string (empty when `None`).
+  - **slot 19:** `dedup_ttl_ms` u64 — the TTL the backend computes per §2.2 (`min(timeout_at - now + SUSPEND_DEDUP_GRACE_MS, SUSPEND_DEDUP_MAX_TTL_MS)`; `SUSPEND_DEDUP_MAX_TTL_MS` when `timeout_at` is `None`).
+- **Lua changes to `ff_suspend_execution`:**
+  1. Early branch: if ARGV[18] is non-empty, `HGET` the dedup key at KEYS[18] field `outcome`. If present, decode and return verbatim — skip all state mutation.
+  2. Happy path: run existing logic unchanged.
+  3. Post-commit: if ARGV[18] is non-empty, serialize the computed `SuspendOutcome` (using the existing positional-array return format — length-prefixed fields, same layout `parse_suspend_result` reads today) into the dedup hash's `outcome` field, then `PEXPIRE` KEYS[18] by `ARGV[19]`.
+- **Serialized-outcome stability.** The dedup hash stores the Lua-side positional-array return bytes verbatim — the same bytes the script returns on a fresh call. This means dedup format evolves atomically with the `ff_suspend_execution` return contract; a future Lua upgrade that changes the return shape must version-gate dedup reads (recommended: leading version byte). RFC-013 pins `v=1` (no version byte, matches today's shape); future changes are RFC-014+ scope.
+- **`resume_delay_ms` wire path.** Verified against RFC-004: `resume_delay_ms` is carried today in the existing `resume_policy_json` ARGV slot (within the 17-ARGV envelope), not on a separate slot. No new ARGV position needed for this field; the backend serializer writes it into `resume_policy_json` as today.
+- **No change to HMAC / kid-ring / waitpoint-security paths.** Assumption A2 preserved.
+
+Total new Lua LOC: ~30 inside `ff_suspend_execution`. Keys/ARGV slot counts: 17 → 18 / 17 → 19. Backend `slot_count` assertions must update in lockstep with this RFC's landing.
 
 ### §9.3 Test matrix
 
@@ -604,6 +719,13 @@ Required tests (at the landing PR's CI):
    - `SuspendArgs` serde round-trip (JSON) for every `ResumeCondition` variant (RFC-013 surface: `Single`, `OperatorOnly`, `TimeoutOnly`; `Composite` covered at RFC-014 landing).
    - `SuspendOutcome::Suspended`/`AlreadySatisfied` exhaustiveness check in the SDK `try_suspend` wrapper; strict `suspend` wrapper mapping `AlreadySatisfied → State(AlreadySatisfied)` covered by one test.
    - `SuspendArgs::idempotency_key` replay test: two calls with the same key return the same outcome; two calls with different keys act independently (second errors with `State(AlreadySuspended)`).
+   - `SuspendArgs::idempotency_key` TTL-expiry test: call, advance server-time past `dedup_ttl_ms`, third call with the same key acts fresh (errors `State(AlreadySuspended)` because exec is still suspended — but the dedup hash has aged out, so this is a state-check, not a dedup-hit).
+   - `SuspendArgs::idempotency_key` with `timeout_at == None` test: confirms TTL is capped at `SUSPEND_DEDUP_MAX_TTL_MS = 7 days`.
+   - Cross-field validation: `WaitpointBinding::Fresh { waitpoint_key: "wpk:a" }` + `ResumeCondition::Single { waitpoint_key: "wpk:b" }` → `Validation(InvalidInput { detail: "waitpoint_key_mismatch" })`.
+   - `ResumeCondition::TimeoutOnly` + `timeout_at.is_none()` → `Validation(InvalidInput { detail: "timeout_only_without_deadline" })`.
+   - Constructor round-trip: `SuspendArgs::new(...).with_timeout(...).with_idempotency_key(...)` produces the same serialized form as manual struct construction (once the struct construction exists via `ff-core`'s impl).
+   - `WaitpointBinding::fresh()` produces a `waitpoint_key` of form `wpk:<uuid-v4>` matching the UUID in `waitpoint_id`.
+   - `ResumePolicy::normal()` has the v1-documented defaults.
 
 2. **Valkey-backend integration tests**:
    - `suspend` with `WaitpointBinding::Fresh`, `ResumeCondition::Signal`, no timeout → `Suspended`.
@@ -619,6 +741,10 @@ Required tests (at the landing PR's CI):
    - Replay: two `suspend` calls with same args → first succeeds, second returns `State(AlreadySuspended)` (not idempotent).
 
 3. **Cross-backend shape tests**: `SuspendArgs` / `SuspendOutcome` are backend-agnostic. Add a mock `EngineBackend` in test scaffolding that accepts the typed args and produces both outcome variants — assert SDK forwarder dispatches correctly on each.
+
+   - **Backend-internal `ResumeCondition → ARGV-JSON` serializer tests**: for each `ResumeCondition` variant landed by RFC-013 (`Single`, `OperatorOnly`, `TimeoutOnly`), assert the emitted ARGV JSON matches byte-for-byte the string the legacy SDK produced for the equivalent input. This is the canary that keeps the "Lua unchanged on the non-idempotent path" claim honest across future refactors.
+
+   - **Scanner interaction**: existing RFC-004 scanner tests cover all `TimeoutBehavior` variants (`Fail`, `Cancel`, `Expire`, `AutoResumeWithTimeoutSignal`). RFC-013 does not change the scanner; rewire the existing scanner tests onto the typed `SuspendArgs` path to confirm no regression. `TimeoutBehavior::Escalate` stays v2-scoped per RFC-004 Implementation Notes and is not asserted at Stage 1d.
 
 4. **Regression coverage**: the existing `ff-sdk` suspension integration tests rewire onto the new signature. No new fixtures needed.
 


### PR DESCRIPTION
## Summary

Draft RFC-013 for Stage 1d — closes RFC-012 §R7.6.1 (the last Round-4 deferral, #117). Fills in `EngineBackend::suspend` with a typed `SuspendArgs` input and a typed `SuspendOutcome { Suspended, AlreadySatisfied }` output; adds a forward-compat `ResumeCondition` enum that RFC-014 can extend non-breakingly; plans the SDK forwarder rewrite + `parse_suspend_result` deletion.

Fresh design — K/L/M challenge docs under `rfcs/drafts/RFC-012-amendment-117-deferrals.*-challenge.md` are non-binding per owner framing.

- §2 trait signature: `async fn suspend(&self, handle: &Handle, args: SuspendArgs) -> Result<SuspendOutcome, EngineError>`
- Wire contract (Lua `ff_suspend_execution`) preserved — zero Lua changes
- Blast radius: ff-core types + trait + Valkey backend impl + ff-sdk forwarder; one consumer (cairn-fabric) takes a signature update

## Test plan

- [ ] Owner reviews §2 signature against RFC-004 / RFC-005 semantics
- [ ] Owner adjudicates the 6 open questions in §7 (timeout shape, AlreadySatisfied ClaimedTask survival, AllOf-vs-CompositeAll deduplication, requester field, idempotency_key deferral, continuation pointer typing)
- [ ] Owner cross-checks §8 alternatives-rejected against prior RFC-012 round-4/round-7 decisions
- [ ] On approval: move to `rfcs/RFC-013-stage-1d-suspend.md`, open implementation epic

DO NOT MERGE — owner-review draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a draft RFC; no runtime code or API behavior is modified in this PR.
> 
> **Overview**
> Adds draft **RFC-013** describing the planned Stage 1d migration of `EngineBackend::suspend` to a typed `SuspendArgs` input and `SuspendOutcome` output, plus a forward-compatible `ResumeCondition`/policy/type set.
> 
> The RFC also outlines follow-up implementation work (Valkey backend implementation and SDK forwarder changes, including removal of `parse_suspend_result`) but does not implement any of it in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9bc4b87db731bd30377ad358622206d8a08798. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->