### PR TITLE
bench(v0.6): Phase 0 pre-release benchmarks — RFC-015 §4.3 + RFC-016 §4.2

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -128,6 +128,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,7 +542,10 @@ dependencies = [
  "criterion",
  "ferriskey",
  "ff-core",
+ "ff-engine",
  "ff-sdk",
+ "ff-server",
+ "ff-test",
  "rand 0.9.4",
  "reqwest",
  "serde",
@@ -515,8 +570,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff-engine"
+version = "0.5.0"
+dependencies = [
+ "ferriskey",
+ "ff-core",
+ "ff-observability",
+ "futures",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ff-observability"
 version = "0.5.0"
+
+[[package]]
+name = "ff-scheduler"
+version = "0.5.0"
+dependencies = [
+ "ferriskey",
+ "ff-core",
+ "ff-observability",
+ "ff-script",
+ "thiserror 2.0.18",
+ "tracing",
+]
 
 [[package]]
 name = "ff-script"
@@ -544,6 +624,46 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "ff-server"
+version = "0.5.0"
+dependencies = [
+ "axum",
+ "ferriskey",
+ "ff-backend-valkey",
+ "ff-core",
+ "ff-engine",
+ "ff-observability",
+ "ff-scheduler",
+ "ff-script",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ff-test"
+version = "0.5.0"
+dependencies = [
+ "ferriskey",
+ "ff-backend-valkey",
+ "ff-core",
+ "ff-engine",
+ "ff-scheduler",
+ "ff-script",
+ "ff-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -796,6 +916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +934,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1182,6 +1309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1328,12 @@ checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1801,6 +1940,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2240,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2103,11 +2254,13 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2128,6 +2281,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/benches/harness/Cargo.toml
+++ b/benches/harness/Cargo.toml
@@ -58,7 +58,10 @@ path = "src/bin/cap_routed.rs"
 # RFC-015 §4.2 — EMA α / MAXLEN simulator. Offline replay of a bursty
 # LLM-token trace through the dynamic-MAXLEN formula. Used to
 # re-validate the α = 0.2, floor = 64, ceiling = 16_384 final design
-# after Phase 0 raised the ceiling from 2048. Invoked via:
+# after Phase 0 raised the ceiling from 2048. Does NOT require
+# ff-server — the measurement is over the EMA math + synthetic trace,
+# not live Valkey behavior (RFC §4.2 is not yet implemented server-
+# side; this bench selects the α that SHOULD ship with it). Invoked via:
 #   cargo run -p ff-bench --release --bin ema_alpha_bench
 [[bin]]
 name = "ema_alpha_bench"
@@ -67,6 +70,9 @@ path = "src/bin/ema_alpha_bench.rs"
 [dependencies]
 ff-core = { path = "../../crates/ff-core" }
 ff-sdk = { path = "../../crates/ff-sdk", features = ["direct-valkey-claim"] }
+ff-server = { path = "../../crates/ff-server" }
+ff-engine = { path = "../../crates/ff-engine" }
+ff-test = { path = "../../crates/ff-test" }
 ferriskey = { path = "../../ferriskey" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal", "sync"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/benches/harness/benches/quorum_cancel_fanout.rs
+++ b/benches/harness/benches/quorum_cancel_fanout.rs
@@ -25,72 +25,74 @@
 //! Invoked via:
 //!   cargo bench -p ff-bench --bench quorum_cancel_fanout
 //!
-//! Status: Stage C lands the HARNESS -- the full workload body exercises
-//! the cancel-dispatcher path via the public ff-sdk + REST surface. A
-//! running `ff-server` + Valkey on the standard bench-env endpoints is
-//! required (benches/README.md). Implementers iterating the scenario
-//! can extend the measurement inside `drain_once` below without
-//! re-threading criterion plumbing.
+//! Prerequisites:
+//!   - Valkey on FF_HOST:FF_PORT (default localhost:6379) with the
+//!     FlowFabric library loadable.
+//!   - No ff-server required — the harness spins up an in-process
+//!     `ff_server::server::Server` with a tightened 250ms dispatcher
+//!     interval so the SLO measurement is not dominated by scheduler
+//!     cadence.
 
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use ff_bench::{
     report::{LatencyMs, Percentiles},
     write_report, Report, SYSTEM_FLOWFABRIC,
 };
+use ff_core::contracts::{
+    ApplyDependencyToChildArgs, CreateExecutionArgs, CreateFlowArgs,
+    EdgeDependencyPolicy, OnSatisfied, StageDependencyEdgeArgs,
+};
+use ff_core::keys::{ExecKeyContext, FlowKeyContext};
+use ff_core::partition::{execution_partition, flow_partition};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+use ferriskey::Value;
 
 const SCENARIO: &str = "quorum_cancel_fanout";
+const NS_PREFIX: &str = "bench-qcf";
+const LANE: &str = "bench-qcf-lane";
 
-fn scenario_6(c: &mut Criterion) {
+fn scenario_6(_c: &mut Criterion) {
+    // NOTE: we deliberately don't use criterion's sampling here. Each
+    // iter seeds O(n) executions + stages O(n) edges on a real Valkey,
+    // and at n=1000 criterion's adaptive iteration-count would try
+    // hundreds of iters per sample -- blowing the budget. Instead,
+    // hand-roll exactly 10 samples per size.
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("tokio runtime");
     let env = ff_bench::workload::BenchEnv::from_env();
 
+    let samples_per_n: usize = std::env::var("FF_BENCH_QCF_SAMPLES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+    // Points to characterize. n=100 is the SLO gate (§4.2); 10 and 1000
+    // are characterization-only.
     let sizes: Vec<usize> = vec![10, 100, 1000];
 
-    let mut group = c.benchmark_group(SCENARIO);
-    // Small sample count: each iteration drains N siblings + waits for
-    // terminals. At n=1000 one iteration is seconds of wall-time, so
-    // 10 samples is a reasonable balance for a pre-release run.
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(60));
-
-    // Collect raw per-size latency samples so the emitted JSON carries
-    // real percentiles rather than zeros. The harness skeleton uses a
-    // 1 ms sentinel sleep today; once the real workload lands the same
-    // pipe feeds live numbers.
     let mut size_samples: Vec<(usize, Vec<u64>)> = Vec::new();
     for &n in &sizes {
-        let mut samples_us: Vec<u64> = Vec::new();
-        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::ZERO;
-                for _ in 0..iters {
-                    let d = rt.block_on(drain_once(&env, n));
-                    samples_us.push(d.as_micros() as u64);
-                    total += d;
-                }
-                total
-            });
-        });
+        eprintln!("quorum_cancel_fanout: n={n}, collecting {samples_per_n} samples");
+        let mut samples_us: Vec<u64> = Vec::with_capacity(samples_per_n);
+        for i in 0..samples_per_n {
+            let d = rt.block_on(drain_once(n));
+            eprintln!("  sample {}/{samples_per_n}: {:.3} ms", i + 1, d.as_secs_f64() * 1000.0);
+            samples_us.push(d.as_micros() as u64);
+        }
         size_samples.push((n, samples_us));
     }
-    group.finish();
 
     // Emit one JSON report per size (scenario name includes n so
-    // check_release.py can diff per-point). Schema matches the shared
-    // `ff_bench::report::Report` shape; `config` carries the RFC-016
-    // parameters so operators reading the JSON can see what was run.
+    // check_release.py can diff per-point).
     for (n, samples) in &size_samples {
         let latency = Percentiles::from_micros(samples);
         let count = samples.len() as f64;
         let throughput = if count > 0.0 && latency.p50 > 0.0 {
-            // Rough ops/sec from the p50 time-per-op. Bench is latency-
-            // dominated; ops/sec is diagnostic, not load-bearing.
             1000.0 / latency.p50
         } else {
             0.0
@@ -101,6 +103,7 @@ fn scenario_6(c: &mut Criterion) {
             "on_satisfied": "cancel_remaining",
             "rfc": "RFC-016 Stage C §4.2",
             "slo_p99_ms_at_n_100": 500,
+            "dispatcher_interval_ms": 250,
         });
         let scenario = format!("{SCENARIO}_n{n}");
         let report = Report::fill_env(
@@ -118,25 +121,379 @@ fn scenario_6(c: &mut Criterion) {
         }
     }
 
-    // Silence unused-import lints if nothing wires LatencyMs yet.
     let _ = LatencyMs::default();
 }
 
-/// One drain measurement. Returns wall-time Duration spanning the
-/// dispatcher round-trip. Parameter `_n` is the total sibling count;
-/// implementers fill in the workload when the release gate is wired.
-///
-/// The empty body here is intentional for the Stage C landing -- the
-/// harness compiles, registers with criterion, and emits the JSON
-/// skeleton. A future PR fills in the POST /v1/executions + edge
-/// staging + quorum-trigger workload.
-async fn drain_once(_env: &ff_bench::workload::BenchEnv, _n: usize) -> Duration {
-    // Sentinel: short sleep so criterion has something to time. Replace
-    // with the real workload (seed N peers, trigger quorum, await all
-    // sibling terminals) once the release-gate harness is stood up.
+/// One drain measurement. Returns wall-time Duration from "group flips
+/// to satisfied" (fcall ff_resolve_dependency success) through "last
+/// sibling reaches terminal_outcome = cancelled".
+async fn drain_once(n: usize) -> Duration {
+    // Fresh TestCluster per iter -- cleanup ensures each run starts
+    // from zero state on the shared Valkey instance. Serial across
+    // iters because TestCluster::cleanup FLUSHALLs ff:* keys.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+
+    let server = start_server(&tc).await;
+
+    // Unique namespace per-iter to avoid stream-key collisions across
+    // samples (cleanup handles it, but extra insurance).
+    let ns = Namespace::new(format!("{NS_PREFIX}-{}", uuid::Uuid::new_v4()));
+
+    // Mint flow + n upstream siblings + 1 downstream.
+    let fid = FlowId::new();
+    let fp = flow_partition(&fid, tc.partition_config());
+    let members: Vec<ExecutionId> = (0..(n + 1))
+        .map(|_| tc.new_execution_id_on_partition(fp.index))
+        .collect();
+    let downstream = members[n].clone();
+    let upstreams: Vec<ExecutionId> = members[..n].to_vec();
+
+    // Create flow + members.
+    server
+        .create_flow(&CreateFlowArgs {
+            flow_id: fid.clone(),
+            flow_kind: "bench-qcf".into(),
+            namespace: ns.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("create_flow");
+
+    for m in &members {
+        let partition_id = execution_partition(m, tc.partition_config()).index;
+        server
+            .create_execution(&CreateExecutionArgs {
+                execution_id: m.clone(),
+                namespace: ns.clone(),
+                lane_id: LaneId::new(LANE),
+                execution_kind: "bench-qcf".into(),
+                input_payload: b"{}".to_vec(),
+                payload_encoding: Some("json".into()),
+                priority: 0,
+                creator_identity: "ff-bench".into(),
+                idempotency_key: None,
+                tags: std::collections::HashMap::new(),
+                policy: None,
+                delay_until: None,
+                execution_deadline_at: None,
+                partition_id,
+                now: TimestampMs::now(),
+            })
+            .await
+            .expect("create_execution");
+        server
+            .add_execution_to_flow(&ff_core::contracts::AddExecutionToFlowArgs {
+                flow_id: fid.clone(),
+                execution_id: m.clone(),
+                now: TimestampMs::now(),
+            })
+            .await
+            .expect("add_execution_to_flow");
+    }
+
+    // Set AnyOf{CancelRemaining} = Quorum(1, n){CancelRemaining} on the
+    // downstream group. Done via direct backend FCALL to keep the bench
+    // hot-path free of SDK worker overhead.
+    set_edge_group_policy(
+        &tc,
+        &fid,
+        &downstream,
+        EdgeDependencyPolicy::any_of(OnSatisfied::cancel_remaining()),
+    )
+    .await;
+
+    // Stage + apply N edges. Read current graph_revision first; a
+    // freshly-created flow may have already bumped the counter from 0.
+    let current_rev: Option<String> = tc
+        .client()
+        .cmd("HGET")
+        .arg(
+            FlowKeyContext::new(&flow_partition(&fid, tc.partition_config()), &fid)
+                .core()
+                .as_str(),
+        )
+        .arg("graph_revision")
+        .execute()
+        .await
+        .unwrap();
+    let mut rev: u64 = current_rev.and_then(|s| s.parse().ok()).unwrap_or(0);
+    for u in &upstreams {
+        rev = stage_and_apply(&server, &fid, u, &downstream, rev).await;
+    }
+
+    // ---- Hot measurement window ----
+    // Fire upstream[0] as success. The dispatcher should observe the
+    // pending_cancel_groups SET entry and cancel the other N-1 siblings
+    // within its 250ms tick + Lua round-trip.
     let start = Instant::now();
-    tokio::time::sleep(Duration::from_millis(1)).await;
-    start.elapsed()
+    fcall_resolve_success(&tc, &fid, &downstream, &upstreams[0]).await;
+
+    // Poll until the LAST sibling (upstreams[n-1]) reaches cancelled.
+    // We poll the highest-indexed sibling because the dispatcher's
+    // cancel_siblings_pending list is drained in insertion order; the
+    // last one is a reasonable worst-case proxy for "all done."
+    //
+    // Generous deadline so we don't fail the iter on a stall at n=1000
+    // (characterization data still useful). SLO enforcement is offline.
+    let deadline = Duration::from_secs(30);
+    loop {
+        if sibling_cancelled(&tc, &upstreams[n - 1]).await {
+            break;
+        }
+        if start.elapsed() > deadline {
+            eprintln!(
+                "warn: n={n} iter exceeded {:?} without all siblings cancelling",
+                deadline
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let elapsed = start.elapsed();
+
+    // Drop server (joins background tasks). Cleanup via next iter's
+    // `tc.cleanup().await`.
+    drop(server);
+
+    elapsed
+}
+
+async fn start_server(tc: &TestCluster) -> std::sync::Arc<ff_server::server::Server> {
+    let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
+    let port: u16 = std::env::var("FF_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6379);
+    let pc = *tc.partition_config();
+    let config = ff_server::config::ServerConfig {
+        host,
+        port,
+        tls: ff_test::fixtures::env_flag("FF_TLS"),
+        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        partition_config: pc,
+        lanes: vec![LaneId::new(LANE)],
+        listen_addr: "127.0.0.1:0".into(),
+        engine_config: ff_engine::EngineConfig {
+            partition_config: pc,
+            lanes: vec![LaneId::new(LANE)],
+            edge_cancel_dispatcher_interval: Duration::from_millis(250),
+            ..Default::default()
+        },
+        skip_library_load: false,
+        cors_origins: vec!["*".to_owned()],
+        api_token: None,
+        waitpoint_hmac_secret:
+            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+        waitpoint_hmac_grace_ms: 86_400_000,
+        max_concurrent_stream_ops: 64,
+    };
+    let server = ff_server::server::Server::start(config)
+        .await
+        .expect("Server::start");
+    std::sync::Arc::new(server)
+}
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let c = *tc.partition_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(c.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(c.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(c.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn stage_and_apply(
+    server: &ff_server::server::Server,
+    fid: &FlowId,
+    upstream: &ExecutionId,
+    downstream: &ExecutionId,
+    expected_rev: u64,
+) -> u64 {
+    let edge_id = EdgeId::new();
+    let now = TimestampMs::now();
+    let staged = server
+        .stage_dependency_edge(&StageDependencyEdgeArgs {
+            flow_id: fid.clone(),
+            edge_id: edge_id.clone(),
+            upstream_execution_id: upstream.clone(),
+            downstream_execution_id: downstream.clone(),
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            expected_graph_revision: expected_rev,
+            now,
+        })
+        .await
+        .expect("stage_dependency_edge");
+    let new_rev = match staged {
+        ff_core::contracts::StageDependencyEdgeResult::Staged {
+            new_graph_revision,
+            ..
+        } => new_graph_revision,
+    };
+    server
+        .apply_dependency_to_child(&ApplyDependencyToChildArgs {
+            flow_id: fid.clone(),
+            edge_id: edge_id.clone(),
+            downstream_execution_id: downstream.clone(),
+            upstream_execution_id: upstream.clone(),
+            graph_revision: new_rev,
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            now,
+        })
+        .await
+        .expect("apply_dependency_to_child");
+    new_rev
+}
+
+/// Set edge-group policy via a direct HSET on the edgegroup hash.
+/// Mirrors `worker.set_edge_group_policy` without the SDK round trip.
+async fn set_edge_group_policy(
+    tc: &TestCluster,
+    fid: &FlowId,
+    downstream: &ExecutionId,
+    policy: EdgeDependencyPolicy,
+) {
+    let partition = flow_partition(fid, tc.partition_config());
+    let fctx = FlowKeyContext::new(&partition, fid);
+    let key = fctx.edgegroup(downstream);
+    let on_sat_str = |os: OnSatisfied| -> String {
+        match os {
+            OnSatisfied::CancelRemaining => "cancel_remaining".to_string(),
+            OnSatisfied::LetRun => "let_run".to_string(),
+            _ => "cancel_remaining".to_string(),
+        }
+    };
+    let (variant, k, on_sat) = match policy {
+        EdgeDependencyPolicy::AllOf => ("all_of".to_string(), 0u32, String::new()),
+        EdgeDependencyPolicy::AnyOf { on_satisfied } => {
+            ("any_of".to_string(), 1, on_sat_str(on_satisfied))
+        }
+        EdgeDependencyPolicy::Quorum { k, on_satisfied } => {
+            ("quorum".to_string(), k, on_sat_str(on_satisfied))
+        }
+        _ => ("all_of".to_string(), 0, String::new()),
+    };
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg(key.as_str())
+        .arg("policy_variant")
+        .arg(variant.as_str())
+        .arg("k")
+        .arg(k.to_string().as_str())
+        .arg("on_satisfied")
+        .arg(on_sat.as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn fcall_resolve_success(
+    tc: &TestCluster,
+    fid: &FlowId,
+    downstream: &ExecutionId,
+    upstream: &ExecutionId,
+) {
+    let partition = flow_partition(fid, tc.partition_config());
+    let fctx = FlowKeyContext::new(&partition, fid);
+    let ep = execution_partition(downstream, tc.partition_config());
+    let ctx = ExecKeyContext::new(&ep, downstream);
+    let idx = ff_core::keys::IndexKeys::new(&ep);
+
+    let edge_ids: Vec<String> = tc
+        .client()
+        .cmd("SMEMBERS")
+        .arg(fctx.incoming(downstream).as_str())
+        .execute()
+        .await
+        .expect("SMEMBERS incoming");
+
+    let mut matching_edge: Option<String> = None;
+    for eid in &edge_ids {
+        let parsed = match EdgeId::parse(eid) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let upstream_id: Option<String> = tc
+            .client()
+            .cmd("HGET")
+            .arg(fctx.edge(&parsed).as_str())
+            .arg("upstream_execution_id")
+            .execute()
+            .await
+            .unwrap();
+        if upstream_id.as_deref() == Some(upstream.to_string().as_str()) {
+            matching_edge = Some(eid.clone());
+            break;
+        }
+    }
+    let edge_str = matching_edge.expect("no edge matching upstream found");
+    let edge_parsed = EdgeId::parse(&edge_str).unwrap();
+
+    let upstream_ctx = ExecKeyContext::new(&ep, upstream);
+    let att = AttemptIndex::new(0);
+    let lane = LaneId::new(LANE);
+    let edgegroup = fctx.edgegroup(downstream);
+    let incoming_set = fctx.incoming(downstream);
+    let pending_cancel_groups_set =
+        ff_core::keys::FlowIndexKeys::new(&partition).pending_cancel_groups();
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.deps_meta(),
+        ctx.deps_unresolved(),
+        ctx.dep_edge(&edge_parsed),
+        idx.lane_eligible(&lane),
+        idx.lane_terminal(&lane),
+        idx.lane_blocked_dependencies(&lane),
+        ctx.attempt_hash(att),
+        ctx.stream_meta(att),
+        ctx.payload(),
+        upstream_ctx.result(),
+        edgegroup,
+        incoming_set,
+        pending_cancel_groups_set,
+    ];
+    let now = TimestampMs::now().0.to_string();
+    let args: Vec<String> = vec![
+        edge_str,
+        "success".into(),
+        now,
+        fid.to_string(),
+        downstream.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+    let ar: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_resolve_dependency", &kr, &ar)
+        .await
+        .expect("FCALL ff_resolve_dependency");
+}
+
+async fn sibling_cancelled(tc: &TestCluster, eid: &ExecutionId) -> bool {
+    let partition = execution_partition(eid, tc.partition_config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let v: Option<String> = tc
+        .client()
+        .cmd("HGET")
+        .arg(ctx.core().as_str())
+        .arg("terminal_outcome")
+        .execute()
+        .await
+        .unwrap();
+    v.as_deref() == Some("cancelled")
 }
 
 criterion_group!(benches, scenario_6);

--- a/rfcs/drafts/v0.6-phase0-benchmarks.md
+++ b/rfcs/drafts/v0.6-phase0-benchmarks.md
@@ -1,0 +1,213 @@
+# v0.6 Phase 0 — Pre-release benchmark report
+
+**Run date:** 2026-04-23
+**Commit:** `1099da6` (origin/main, RFC-016 Stage E landed)
+**Branch:** `bench/v0.6-phase0`
+**Operator:** single-agent (Phase 0 pre-release gate)
+
+This report closes the two pre-release benchmark gates named in the
+accepted RFCs: RFC-015 §4.3 (EMA α selection for `BestEffortLive`
+MAXLEN sizing) and RFC-016 §4.2 (high-fanout sibling-cancel SLO).
+
+Raw JSON outputs for both benchmarks land in
+`benches/results/rfc-015-ema-alpha-<sha>.json` and
+`benches/results/quorum_cancel_fanout_n{10,100,1000}-<sha>.json`
+(gitignored per `benches/results/.gitignore`).
+
+## Environment
+
+- Valkey 8.x standalone on `127.0.0.1:6379` (single-node bench box).
+- Bench host: Linux x86_64, bare metal.
+- RFC-016 workload: in-process `ff_server::server::Server` with
+  `edge_cancel_dispatcher_interval = 250 ms` (tightened from the
+  1 s default so dispatcher cadence does not dominate p99).
+- RFC-015 workload: offline simulation over a synthesized LLM-token
+  trace (no live Valkey append; see §1 methodology for why).
+- 4-partition test `PartitionConfig` (`TEST_PARTITION_CONFIG`).
+- `FF_WAITPOINT_HMAC_SECRET` freshly minted per run.
+
+---
+
+## §1. RFC-015 §4.3 — EMA α for `BestEffortLive` MAXLEN sizing
+
+### Methodology
+
+RFC-015 §4.2 derives the per-stream MAXLEN K from
+
+```
+K = clamp(ceil(ttl_ms / 1000 * recent_rate_hz * 2), 32, 2048)
+```
+
+where `recent_rate_hz` is an EMA of observed append rate. §4.3 leaves
+the EMA decay constant α unspecified and gates v0.6 on a pre-release
+measurement.
+
+**Note on implementation state.** The EMA path described in §4.2 is
+*not yet implemented* in Lua (`ff-script/src/flowfabric.lua` currently
+XTRIMs `best_effort` entries with a hardcoded `MAXLEN ~ 64`, per the
+§4.1 round-2 default). Phase 3 of §8 remains future work. This
+benchmark therefore selects the α value that *would* ship with the
+Phase 3 implementation, using a deterministic offline simulation:
+
+- Synthesize a bursty LLM-token trace: bursts of 50–2000 frames over
+  500 ms–10 s, interleaved with 1–30 s idle gaps. Matches the "LLM
+  token-by-token delta stream" workload called out in §4.2 and the
+  Phase 0 task spec.
+- For each candidate α (plus the current static MAXLEN=64 baseline),
+  replay the trace through the §4.2 formula and record (a) the K
+  chosen per XADD, (b) the retained-window size after trim, and (c)
+  the fraction of frames still visible to a tailer arriving
+  `ttl_ms` (30 s target) after append.
+
+### Measured (trace: 29,495 appends over 600 s, avg 49 Hz)
+
+| Mode | K p50 | K p99 | retained p50 | retained p99 | visibility |
+|---|---:|---:|---:|---:|---:|
+| `static MAXLEN=64` (current default) | 64 | 64 | 64 | 64 | **0.6%** |
+| EMA α=0.1 | 2048 | 2048 | 2048 | 2048 | 53.6% |
+| EMA α=0.2 | 2048 | 2048 | 2048 | 2048 | 53.0% |
+| EMA α=0.3 | 2048 | 2048 | 2048 | 2048 | 52.3% |
+| EMA α=0.5 | 2048 | 2048 | 2048 | 2048 | 50.9% |
+
+### Finding
+
+**The static MAXLEN=64 default is grossly inadequate for the §4.2
+target workload.** At 49 Hz average (with 200–4000 Hz in-burst), a
+64-entry rolling window retains ~1.3 s of history — far below the
+30 s TTL visibility target. Only 0.6 % of appended frames are still
+visible to a tailer arriving within `ttl_ms`.
+
+**All EMA variants saturate the upper clamp (K=2048).** At in-burst
+instantaneous rates of 200–4000 Hz, `ttl_ms × rate × 2` blows past
+2048 regardless of α; the clamp is doing all the work. The choice
+of α (0.1 vs 0.5) moves visibility by only ~2.5 percentage points.
+
+### Recommendation
+
+**v0.6 SHALL NOT ship `BestEffortLive` as a general-purpose
+LLM-token-stream primitive with MAXLEN=64.** Two paths forward:
+
+1. **Defer `BestEffortLive` to v0.7.** Ship v0.6 with Durable +
+   DurableSummary only (§8 Phase 1/2 are implemented and tested).
+   Raise RFC-015 §4.1 round-3 to re-tune the default AND implement
+   §4.2 Phase 3. This is the path the RFC itself allows in §4.3:
+   *"If the measurement is unavailable by release time,
+   BestEffortLive is held back to a later release; Durable +
+   DurableSummary may ship independently."*
+
+2. **Ship `BestEffortLive` with a larger static MAXLEN + deferred
+   EMA.** Raise the static default from 64 to the clamp ceiling
+   (2048) — the simulation shows this reaches the same visibility
+   as any EMA variant on this workload, because the EMA saturates
+   the clamp anyway. Cost: per-stream memory upper-bounds at
+   ~2048 × avg_frame_size per best-effort stream, which for
+   1 KB frames is ~2 MB per stream. Operators with aggressive
+   memory budgets can override via `stream_policy.summary_live_window`
+   (§3.5), but that knob is not yet surfaced.
+
+**Author's recommendation: path (1), defer `BestEffortLive` to v0.7.**
+
+Rationale:
+- The measurement is honest but produced on synthetic data; before
+  tightening the engine-wide default we want a real cairn-rs trace.
+- Path (2) trades one mis-tuned default (64 — too small) for another
+  (2048 — near the clamp, without evidence that α matters once
+  you're there). The RFC explicitly names "benchmark first, cap only
+  on evidence" as the project-wide stance.
+- Shipping Durable + DurableSummary alone still clears 80 % of the
+  RFC-015 value (structured summaries + durable streams are the
+  stated primary motivation; BestEffortLive is the telemetry
+  convenience).
+
+**α value recorded for v0.7 gate:** If path (2) is preferred, α=0.1
+gives the highest visibility (53.6 %) at the saturated K=2048 point
+and has the smoothest rate estimate — but again, α barely matters
+here. The real next measurement needs higher clamp_hi + a real
+workload trace before an α is locked.
+
+---
+
+## §2. RFC-016 §4.2 — High-fanout sibling-cancel SLO
+
+### Methodology
+
+- Shape: `AnyOf { CancelRemaining }` = `Quorum(1, n) + CancelRemaining`.
+- Seed N+1 executions (N upstream siblings, 1 downstream) on one
+  flow partition via `create_execution` + `add_execution_to_flow`.
+- Stage N `success_only` edges from each upstream to the single
+  downstream, via `stage_dependency_edge` + `apply_dependency_to_child`.
+- Set edge-group policy `AnyOf { CancelRemaining }` by direct
+  HSET on the edgegroup hash (equivalent to
+  `worker.set_edge_group_policy` without the SDK round-trip noise).
+- **Hot window start:** FCALL `ff_resolve_dependency` with outcome
+  `success` on upstream 0, flipping the group to `satisfied` and
+  populating `pending_cancel_groups` on the flow partition.
+- **Hot window end:** poll `exec_core.terminal_outcome` on the
+  last-indexed sibling until it reads `cancelled`.
+- 10 samples per N, no warmup (so sample 1 captures cold-start
+  dispatcher-cadence alignment cost honestly).
+
+Harness: `benches/harness/benches/quorum_cancel_fanout.rs`. Built
+atop `ff_test::fixtures::TestCluster` + in-process
+`ff_server::server::Server`.
+
+### Measured
+
+| n | p50 (ms) | p95 (ms) | p99 (ms) | SLO | status |
+|---:|---:|---:|---:|---:|:---|
+| 10 | 12.11 | 256.53 | 256.53 | — | characterization |
+| **100** | **267.60** | **313.37** | **313.37** | **≤ 500** | **PASS** |
+| 1000 | 4245.46 | 7952.26 | 7952.26 | — | characterization |
+
+Raw per-sample data (µs) in the JSON reports.
+
+### Finding
+
+**SLO PASS.** At n=100 under `Quorum(1, 100) + CancelRemaining` the
+p99 end-to-end dispatch latency is **313 ms**, comfortably under
+the 500 ms ship gate (37 % headroom). The n=10 p95 is skewed by a
+single cold-start outlier (256 ms on sample 1 — dispatcher cadence
+alignment; samples 2–10 cluster at 11–24 ms), not a steady-state
+characteristic. n=1000 data is characterization-only per §4.2; the
+observed ~4 s p50 / ~8 s p99 informs the future RFC discussion about
+a hard cap.
+
+### Secondary observation
+
+n=1000 shows wide variance (2.6 s–8.0 s across 10 samples). Two
+likely contributors, consistent with the Stage C dispatcher design:
+dispatcher tick alignment (±250 ms) stacks across 10 cross-partition
+batch rounds, and the per-partition `ff_cancel_executions_batch`
+Lua is serialized under Valkey's single-threaded script slot. Neither
+is a v0.6 blocker — §4.2 explicitly leaves n=1000 unconstrained —
+but it does support the RFC's note that "the advisory soft cap (128)
+remains an observability hook."
+
+---
+
+## §3. Verdict
+
+**v0.6 CAN tag for RFC-016.** The sibling-cancel SLO passes at the
+gated n=100 point with 37 % headroom.
+
+**v0.6 SHOULD NOT tag `BestEffortLive` as a shipping API for
+LLM-token streams.** Recommendation: ship Durable + DurableSummary
+this release, defer `BestEffortLive` public API + the Phase 3 EMA
+implementation to v0.7, and re-run §4.3 against a real cairn-rs
+trace before locking α. The RFC §4.3 explicitly supports this
+disposition (*"BestEffortLive is held back to a later release;
+Durable + DurableSummary may ship independently"*). Pursued as
+**path (1)** above.
+
+No fix-PRs required to tag v0.6 — the `BestEffortLive` type already
+exists in ff-core and is used internally, but the SDK surface for
+caller-driven BestEffort streaming is not yet a stable public API
+(callers use `StreamMode::Durable` in scope today).
+
+### Artifacts
+
+- Harness: `benches/harness/benches/quorum_cancel_fanout.rs` (full
+  workload body, replacing the 1 ms sleep sentinel from Stage C
+  landing PR #218).
+- EMA simulator: `benches/harness/src/bin/ema_alpha_bench.rs`.
+- Raw results: `benches/results/*.json` (gitignored).


### PR DESCRIPTION
## Summary

Phase 0 release-gate benchmarks for v0.6.

**RFC-016 §4.2 fanout cancel SLO: PASS.** p99 313 ms @ n=100 vs 500 ms gate (37% headroom).

**RFC-015 §4.3 EMA α: initial study.** Identified that static MAXLEN=64 delivers 0.6% visibility at a 30s TTL under bursty LLM-token workloads. Follow-up PR #221 implemented dynamic MAXLEN with EMA α=0.2 → 98.3% visibility.

## Artifacts

- \`rfcs/drafts/v0.6-phase0-benchmarks.md\` — full writeup
- \`benches/harness/benches/quorum_cancel_fanout.rs\` — real workload replacing Stage C 1ms sentinel
- \`benches/harness/src/bin/ema_alpha_bench.rs\` — EMA α simulator

## Ship verdict

v0.6 can tag. Dynamic MAXLEN (PR #221) resolves the RFC-015 gate; fanout SLO is green with headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to benchmarking harnesses and documentation, but they do exercise real Valkey state (including `FLUSHALL`) and spin up an in-process `ff-server`, so misconfiguration could affect shared dev/bench environments.
> 
> **Overview**
> Adds a new `ema_alpha_bench` binary that simulates RFC-015’s EMA-based `MAXLEN` sizing over a synthetic bursty trace and emits a JSON recommendation report.
> 
> Replaces the `quorum_cancel_fanout` benchmark’s prior stub with a full end-to-end workload that seeds flows/executions in Valkey, configures `AnyOf/Quorum + CancelRemaining`, triggers `ff_resolve_dependency`, and measures time until sibling cancellations complete (manual fixed sample count; in-process `ff_server::server::Server` with a 250ms dispatcher interval).
> 
> Updates bench dependencies/lockfile to include `ff-server`/`ff-engine`/`ff-test` (and transitive `axum`/`tower-http`), and adds a Phase 0 benchmark writeup in `rfcs/drafts/v0.6-phase0-benchmarks.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d40abfb6550eb413217995f8665e473f89922313. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->