### PR TITLE
docs(rfcs): v0.6.0 published-artifact smoke report

### DIFF
--- a/rfcs/drafts/0.6.0-published-smoke.md
+++ b/rfcs/drafts/0.6.0-published-smoke.md
@@ -1,0 +1,366 @@
+# v0.6.0 published-artifact smoke (2026-04-23)
+
+Smoke against crates.io-published FlowFabric v0.6.0 artifacts (no
+path-deps, no git refs). Post-release smoke covering the build-smoke
+plus 11 runtime scenarios end-to-end (matrix per the smoke brief).
+
+All 10 target crates at 0.6.0 — `ferriskey`, `ff-core`, `ff-script`,
+`ff-observability`, `ff-observability-http`, `ff-backend-valkey`,
+`ff-engine`, `ff-scheduler`, `ff-sdk`, `ff-server`.
+
+## Environment
+
+- `rustc 1.90.0 (1159e78c4 2025-09-14)`
+- `cargo 1.90.0 (840b83a10 2025-07-30)`
+- Valkey `7.2.12` on `127.0.0.1:6379` (fresh FLUSHALL per scenario;
+  `ff:config:partitions` pre-seeded to `num_flow_partitions=4`)
+- Scratch crate: `/tmp/ff-published-smoke-0.6.0/` (edition 2024), deleted
+  after evidence captured.
+- Direct deps pulled from crates.io (`cargo tree --depth 1`):
+
+```
+axum v0.8.9
+ferriskey v0.6.0
+ff-backend-valkey v0.6.0
+ff-core v0.6.0
+ff-engine v0.6.0
+ff-observability v0.6.0
+ff-observability-http v0.6.0
+ff-sdk v0.6.0
+ff-server v0.6.0
+reqwest v0.12.28
+tokio v1.52.1
+```
+
+## Verdict
+
+**10 of 12 scenarios PASS. 1 FAIL (Scenario 6 — DurableSummary
+read path). 1 DEFERRED (Scenario 4 idempotency_key path fully
+proven but not reachable via the `ClaimedTask` SDK surface).**
+
+**Headline finding:** `EngineBackend::read_summary` — the read half
+of RFC-015 DurableSummary — is broken on Valkey 7.2 + ferriskey's
+default (RESP3) decode path. Writes and `summary_version`
+increments are correct, but every `read_summary` call returns
+`Ok(None)` regardless of what's in the `stream_summary` Hash. See
+Scenario 6 for the reproducer and proposed fix.
+
+Secondary DX finding: `ClaimedTask::try_suspend` does not expose
+`idempotency_key`; consumers who want the RFC-013 §3 dedup-replay
+contract must drop to the `EngineBackend` trait directly, and that
+itself requires encoding a `Handle` through `ValkeyBackend::encode_handle`
+because `synth_handle` is private. The idempotency-replay contract
+**is** intact at the backend layer — Scenario 4B confirms it — but
+the ergonomic path is missing.
+
+## Scenario 1 — build smoke
+
+**PASS.** Fresh `cargo init` + `cargo add` against the crates.io
+registry pulled all ten 0.6.0 crates. `cargo build --release` from a
+cold registry cache finished in 57.39s. No `#[non_exhaustive]` DX
+regressions (the v0.3.2 lesson held — every RFC-015/016 non-exhaustive
+enum ships a constructor helper).
+
+## Scenario 2 — claim → progress → complete
+
+**PASS.** Flow:
+
+1. `Server::start(ServerConfig { .. })` → in-process server.
+2. `server.create_execution(...)` — solo exec minted via
+   `ExecutionId::solo(&lane, &pc)`.
+3. `FlowFabricWorker::connect(...)`.
+4. `server.claim_for_worker(lane, wid, wiid, &caps, 30_000)` → `ClaimGrant`.
+5. `worker.claim_from_grant(lane, grant)` → `ClaimedTask`.
+6. `task.append_frame("progress", b"half", None)` + `task.update_progress(50, "half")`.
+7. `task.complete(Some(b"done".to_vec()))`.
+8. Poll `worker.describe_execution(&eid)` until
+   `public_state == PublicState::Completed`.
+
+Evidence: `complete_round_trip_us = 580` (one sample, release build,
+localhost Valkey). Terminal state observed inside one 50 ms poll tick.
+
+## Scenario 3 — append_frame + tail_stream (#204 fix verification)
+
+**PASS.** Detached writer appended 5 frames at 100 ms intervals via
+`task.append_frame("smoke_frame", payload, None)`. A concurrent
+`tail_stream(cursor, 300ms block, 50 count)` loop on the **same
+`ClaimedTask`** read every frame back.
+
+Evidence:
+- `seen = 5/5` within 6 s deadline.
+- `write_errs = []` — the 0.5.0 smoke's `Transport/timed_out` on
+  the companion XADD is gone.
+- `tail_errs = []`.
+
+PR #204's "dedicated socket for tail_stream blocking reads" fix is
+live. The 0.5.0 smoke's DX-friction callout (concurrent tail+write
+on one `ClaimedTask` misreporting as `Transport/timed_out`) is
+resolved.
+
+## Scenario 4 — suspend + deliver_signal + idempotency_key replay
+
+**PASS.** Two parts:
+
+**4A — public SDK suspend/resume:**
+`task.suspend(WaitingForSignal, ResumeCondition::Single{ wp_key, Wildcard }, None, ResumePolicy::normal())`
+returned a `SuspendedHandle` carrying `waitpoint_id` + `waitpoint_token`.
+`worker.deliver_signal(&eid, &wp_id, Signal{ ..., waitpoint_token })`
+returned `TriggeredResume`. Observed `public_state` transition from
+`Suspended` → `Waiting` (eligible for re-claim) within the 5 s
+deadline.
+
+**4B — idempotency-replay at the backend layer:**
+Minted a fresh execution + claim, then called
+`EngineBackend::suspend(&handle, SuspendArgs::new(...).with_idempotency_key("smoke-s4-idem-key"))`
+twice with identical args. Contract: second call is a dedup-replay of
+the first.
+
+Evidence:
+- First call: `wp_id=8a1f9e6b-d325-4014-9b9a-554c33a03918 susp_id=aa74e825-...`
+- Replay: `wp_id=8a1f9e6b-d325-4014-9b9a-554c33a03918 susp_id=aa74e825-...`
+- Both outcomes match field-for-field — the RFC-013 §3 idempotency
+  contract holds.
+
+**DX finding (deferred, not release-blocking).**
+`ClaimedTask::try_suspend` and friends take individual args
+(`reason_code`, `resume_condition`, `timeout`, `resume_policy`) but
+**do not** expose `idempotency_key`. To exercise the replay contract,
+the smoke had to:
+
+1. Dial `worker.backend()` to get the `Arc<dyn EngineBackend>`.
+2. Call `ValkeyBackend::encode_handle(...)` directly — `synth_handle`
+   on `ClaimedTask` is private, so the SDK has no convenience for
+   minting a `Handle`-shaped value from a live `ClaimedTask`.
+3. Also bind `WaitpointBinding::Fresh { waitpoint_id, waitpoint_key }`
+   explicitly with the matching `waitpoint_key` from the
+   `ResumeCondition::Single`, because
+   `WaitpointBinding::fresh()`'s default key is rejected by the
+   `waitpoint_key_mismatch` validator when paired with a
+   condition that names its own key.
+
+None of this is a blocker — the backend contract works and the
+wrap points are straightforward — but a 0.6.x follow-up that widens
+`ClaimedTask::try_suspend` (and/or adds a `try_suspend_with_opts`
+overload) to accept `Option<IdempotencyKey>` would close the gap.
+The composite/timeout/resume-policy surface is already fully-typed;
+only the idempotency slot is missing.
+
+## Scenario 5 — RFC-014 composite Count{n=2, DistinctSources}
+
+**PASS.** Suspended with
+`ResumeCondition::Composite(CompositeBody::Count { n: 2, count_kind: DistinctSources, matcher: None, waitpoints: vec![wp_key] })`.
+Delivered 2 signals to that waitpoint from distinct
+`source_identity` values (`alice`, `bob`). Second signal returned
+`TriggeredResume`; the first returned
+`Accepted{effect="appended_to_waitpoint"}`. Execution transitioned
+to `Waiting` (eligible) within the 5 s deadline. The composite
+evaluator's `DistinctSources` counter is live end-to-end.
+
+## Scenario 6 — RFC-015 DurableSummary + read_summary
+
+**FAIL (functional bug in `ff-backend-valkey` v0.6.0).**
+
+Write path is correct:
+
+```
+s6 append #0 stream_id=1776997864483-0 summary_version=Some(1)
+s6 append #1 stream_id=1776997864483-1 summary_version=Some(2)
+s6 append #2 stream_id=1776997864483-2 summary_version=Some(3)
+```
+
+`AppendFrameOutcome::summary_version` increments `1 → 2 → 3` exactly
+as RFC-015 §3.1 specifies. Direct `HGETALL` on the
+`ff:attempt:{fp:1}:{fp:1}:<eid>:0:summary` Hash via a raw ferriskey
+client returns five correct fields:
+
+```
+version          3
+document         {"a":1,"c":3,"b":2}
+patch_kind       json-merge-patch
+last_updated_ms  1776997864483
+first_applied_ms 1776997864483
+```
+
+But `backend.read_summary(&eid, attempt_index)` returns `Ok(None)`.
+
+**Root cause: decoder does not handle the RESP3 `Value::Map`
+variant.** `ff_backend_valkey::lib::read_summary_impl` at
+`crates/ff-backend-valkey/src/lib.rs:4069` matches only on
+`ferriskey::Value::Array(arr)` when parsing the HGETALL response.
+On Valkey 7.2 with ferriskey's default protocol, HGETALL returns
+`Value::Map([...])` (variant discriminant 6 per a direct
+`std::mem::discriminant` check). The match falls through to the
+`_ => Vec::new()` arm, `entries.is_empty()` fires, and the function
+returns `Ok(None)`.
+
+**Impact:**
+- Every `read_summary` call returns `None` on the v0.6.0 published
+  artifact against Valkey 7.2.
+- The RFC-015 §6.3 "consumer polls rolling summary" API is
+  functionally broken.
+- This did not surface in-workspace because `crates/ff-test/.../engine_backend_stream_modes.rs:618`'s
+  `read_summary_absent_returns_empty` test exercises only the
+  genuinely-absent path and `ff-test`'s write-then-read paths would
+  have caught this if they existed — I did not find a
+  published-consumer-shape test for the populated-read path in the
+  workspace.
+
+**Fix:** widen `read_summary_impl` to also match `Value::Map` (and
+the same sites anywhere else the codebase assumes Array-shaped
+HGETALL). The in-tree `cmd::<Vec<(String, String)>>("HGETALL")`
+call in the smoke's diagnostic succeeded — ferriskey already has a
+Map-aware typed decoder path; `read_summary_impl` just chose the
+wrong raw-Value entry point.
+
+Filed here as the release-blocking finding; releasing a 0.6.1 point
+release with the Map-aware decoder is the owner's call. Consumers
+on v0.6.0 who depend on `read_summary` should pin to v0.5.0 until
+the fix ships.
+
+## Scenario 7 — RFC-015 BestEffortLive dynamic MAXLEN
+
+**PASS.** Appended 100 best-effort frames back-to-back under
+`StreamMode::BestEffortLive { config: BestEffortLiveConfig::with_ttl(5_000) }`.
+Read the stream-meta Hash directly via ferriskey and inspected the
+RFC-015 §4.2 sizing fields.
+
+Evidence:
+- `ema_rate_hz = 999.999999747` (EMA converged to ~1 kHz — the burst
+  rate of back-to-back synchronous appends from one worker).
+- `maxlen_applied_last = 10000` — well above the `maxlen_floor = 64`
+  default, confirming the dynamic formula (`K = clamp(ceil(rate * ttl /
+  1000) * 2, floor, ceiling)`) kicked in and sized the stream for the
+  observed burst.
+- `has_durable_frame = 0`, `durability_mode = "durable_full"` — the
+  best-effort frames are being tracked per §6.1 wire token.
+
+## Scenario 8 — RFC-016 AnyOf{CancelRemaining} of 3
+
+**PASS.** 3-upstream fan-in:
+
+1. `Server::create_flow(...)` + 3 upstream execs + 1 downstream exec,
+   all minted co-located via `ExecutionId::for_flow(&flow_id, &pc)`.
+2. `worker.set_edge_group_policy(&fid, &downstream, EdgeDependencyPolicy::any_of(OnSatisfied::cancel_remaining()))`
+   (called BEFORE the first edge per RFC-016 §4.2 ordering
+   requirement).
+3. 3× `stage_dependency_edge` + `apply_dependency_to_child`, carrying
+   `graph_revision` through the chain. The initial `graph_revision`
+   after `set_edge_group_policy` was 4 (the policy-write bumps the
+   revision counter).
+4. Claim + complete one upstream via the normal worker protocol
+   (no test-harness `fcall_resolve_with` shortcut — this is a pure
+   published-consumer path).
+5. Poll `describe_execution` for downstream + 2 siblings.
+
+Evidence:
+- `upstream[0]` completed → `terminal=success`.
+- Downstream transitioned to `PublicState::Waiting` (eligible for
+  re-claim).
+- Both other siblings transitioned to `PublicState::Cancelled`
+  within the 5 s deadline. The Stage D sibling-cancel reconciler
+  shipped in PR #219 is live end-to-end against a published
+  artifact.
+
+## Scenario 9 — RFC-016 Quorum{k=2, LetRun} of 3
+
+**PASS.** Same harness as Scenario 8, policy changed to
+`EdgeDependencyPolicy::quorum(2, OnSatisfied::let_run())`. Drove 2
+upstreams to success via claim+complete.
+
+Evidence:
+- Downstream: `PublicState::Waiting` (quorum satisfied).
+- 3rd sibling (uncompleted): `PublicState::Waiting` — NOT cancelled,
+  as `LetRun` mandates. Checked again after a 1.5 s sleep to make
+  sure no late reconciler tick cancels it.
+
+Both OnSatisfied variants (`CancelRemaining` in Scenario 8, `LetRun`
+here) behave correctly end-to-end on v0.6.0.
+
+## Scenario 10 — list_executions / list_flows / list_lanes / list_suspended
+
+**PASS.** After seeding 2 solo execs + 1 flow:
+
+| Call | Result |
+|------|--------|
+| `list_executions(partition_key, None, 100)` | 2 entries, `next_cursor=None` |
+| `list_flows(flow_partition_key, None, 100)` | 1 entry |
+| `list_lanes(None, 100)` | **2 entries** — `[s10-lane, smoke-lane]` |
+| `list_suspended(partition_key, None, 100)` | 0 entries |
+
+**Notably fixed vs. 0.5.0 smoke:** `list_lanes` is no longer always
+empty. The 0.5.0 smoke reported 0 lanes on a freshly booted system
+because `ff:idx:lanes` had no writer; 0.6.0's #203 fix seeds the
+registry from `ServerConfig.lanes` at `Server::start` boot
+(cluster-safe SADD across partition keys). The 0.5.1-candidate DX
+finding from the prior smoke is now closed.
+
+## Scenario 11 — ff-observability-http /metrics
+
+**PASS.** `ff_observability_http::router(metrics)` mounted on an
+ephemeral-port `tokio::net::TcpListener` via `axum::serve`; GET
+`/metrics` via `reqwest`:
+
+- `status = 200 OK`
+- `body_len = 359`
+- `has_help_or_type_prelude = true` — response carries at least one
+  `# HELP` / `# TYPE` line matching the Prometheus text-exposition
+  contract.
+
+## Scenario 12 — dead-port Transport error surface
+
+**PASS.** `ValkeyBackend::connect(BackendConfig::valkey("127.0.0.1", 1))`
+returned `Err(EngineError::Transport { .. })` cleanly — no panic, no
+`Unavailable` leak. Matches the 0.4.0/0.5.0 contract.
+
+## Aggregated results
+
+| # | Scenario | Result |
+|---|----------|--------|
+| 1 | Build smoke | PASS |
+| 2 | claim → progress → complete | PASS |
+| 3 | append_frame + tail_stream (#204) | PASS |
+| 4 | suspend + idempotency_key replay | PASS (with DX finding) |
+| 5 | RFC-014 composite Count DistinctSources | PASS |
+| 6 | RFC-015 DurableSummary read_summary | **FAIL** |
+| 7 | RFC-015 BestEffortLive dynamic MAXLEN | PASS |
+| 8 | RFC-016 AnyOf{CancelRemaining} | PASS |
+| 9 | RFC-016 Quorum{2, LetRun} | PASS |
+| 10 | list_* read models (incl. #203 fix) | PASS |
+| 11 | ff-observability-http /metrics | PASS |
+| 12 | Dead-port Transport error | PASS |
+
+## Findings summary
+
+1. **BUG (functional, v0.6.0):** `read_summary_impl` in
+   `ff-backend-valkey` only matches `Value::Array` for HGETALL;
+   Valkey 7.2 + ferriskey returns `Value::Map`, so `read_summary`
+   always returns `Ok(None)`. Write + `summary_version` path works.
+   Recommend: widen the decoder to accept both variants and ship a
+   0.6.1 point release. Pin consumers to 0.5.0 in the interim if
+   they depend on this read path.
+
+2. **DX gap (non-blocking):** `ClaimedTask::try_suspend` has no
+   `idempotency_key` parameter. RFC-013 §3 dedup replay works, but
+   only via dropping to `EngineBackend::suspend` directly — which
+   requires `ValkeyBackend::encode_handle` (the SDK's `synth_handle`
+   is private) and explicit `WaitpointBinding::Fresh { waitpoint_id,
+   waitpoint_key }` construction to pin the condition's
+   `waitpoint_key`. Consider either widening `try_suspend` or adding
+   a `try_suspend_with_opts` overload in 0.7.
+
+3. **WIN:** `list_lanes` is now non-empty on freshly booted systems
+   (`ServerConfig.lanes` seeded at boot, #203). The 0.5.1-candidate
+   DX finding from the prior smoke is closed.
+
+4. **WIN:** Concurrent `append_frame` + `tail_stream` on a single
+   `ClaimedTask` is no longer misreported as `Transport/timed_out`.
+   PR #204's dedicated blocking-read socket fix is live end-to-end
+   against the published artifact.
+
+## Deletion
+
+```
+rm -rf /tmp/ff-published-smoke-0.6.0
+```
+
+Only this .md report retained.


### PR DESCRIPTION
## Summary

- Post-release smoke against crates.io v0.6.0 artifacts. 10/12 scenarios PASS.
- Headline **FAIL**: `read_summary_impl` in `ff-backend-valkey` matches only `Value::Array` on HGETALL; Valkey 7.2 + ferriskey default returns `Value::Map`, so `EngineBackend::read_summary` always returns `Ok(None)` in v0.6.0. Write + `summary_version` path works. Suggests a 0.6.1 point-release (decoder widening).
- DX gap: `ClaimedTask::try_suspend` does not expose `idempotency_key`; RFC-013 §3 replay works only via dropping to `EngineBackend::suspend` directly (documented with reproducer in the report).
- Wins confirmed: `list_lanes` now non-empty on fresh boot (#203); concurrent `append_frame` + `tail_stream` on one `ClaimedTask` no longer surfaces `Transport/timed_out` (#204).

## Scenario map

| # | Scenario | Result |
|---|----------|--------|
| 1 | Build smoke | PASS |
| 2 | claim → progress → complete | PASS |
| 3 | append_frame + tail_stream (#204) | PASS |
| 4 | suspend + idempotency_key replay | PASS (DX finding) |
| 5 | RFC-014 composite Count DistinctSources | PASS |
| 6 | RFC-015 DurableSummary read_summary | **FAIL** |
| 7 | RFC-015 BestEffortLive dynamic MAXLEN | PASS |
| 8 | RFC-016 AnyOf{CancelRemaining} | PASS |
| 9 | RFC-016 Quorum{2, LetRun} | PASS |
| 10 | list_* (incl. #203 seed) | PASS |
| 11 | ff-observability-http /metrics | PASS |
| 12 | Dead-port Transport error | PASS |

## Test plan

- [ ] Owner reviews Scenario 6 reproducer + root-cause analysis
- [ ] Decide: ship 0.6.1 with widened HGETALL decoder in `read_summary_impl`, or document known-issue
- [ ] Decide: follow-up for `ClaimedTask::try_suspend` idempotency_key ergonomics (0.7 candidate)
- [ ] Merge after review (do not squash-auto-merge; owner admin-merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a post-release smoke report; no code or runtime behavior is modified.
> 
> **Overview**
> Adds a new RFC draft report `rfcs/drafts/0.6.0-published-smoke.md` documenting an end-to-end smoke run against crates.io-published FlowFabric `v0.6.0` artifacts.
> 
> The report records scenario outcomes and highlights a **release-blocking functional bug** (`EngineBackend::read_summary` returning `Ok(None)` due to `HGETALL` RESP3 `Value::Map` decoding) plus a **non-blocking SDK ergonomics gap** around missing `idempotency_key` exposure on `ClaimedTask::try_suspend`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f6a18c50ea290b6f2f117bde0cc6a8b044eb01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->