### PR TITLE
hotfix(v0.6.1): read_summary RESP3 Map decode (regression from v0.6.0 smoke)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-24
+
+### Fixed
+
+- **RFC-015 `read_summary` RESP3 `Value::Map` decode (release-blocker
+  regression from v0.6.0).** `ff-backend-valkey::read_summary_impl`
+  matched only `Value::Array` for the `HGETALL` reply. ferriskey's
+  default client on Valkey 7.2 negotiates RESP3, where `HGETALL`
+  returns `Value::Map`, so every call to `EngineBackend::read_summary`
+  returned `Ok(None)` regardless of whether a summary existed — breaking
+  RFC-015 DurableSummary reads end-to-end. Writes and `summary_version`
+  increments were unaffected. The decoder now accepts both
+  `Value::Array` (RESP2) and `Value::Map` (RESP3) and normalizes into
+  the same `HashMap<String, String>` before parsing into
+  `SummaryDocument`. Caught by the v0.6.0 published-artifact smoke
+  (PR #224). No wire-format, trait, or Lua changes.
+
 ## [0.6.0] - 2026-04-23
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "crc16",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "ff-observability",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "ferriskey",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "ferriskey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -34,17 +34,17 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.6.0", path = "crates/ff-core" }
-ff-script = { version = "0.6.0", path = "crates/ff-script" }
-ff-engine = { version = "0.6.0", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.6.0", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.6.0", path = "crates/ff-sdk" }
-ff-server = { version = "0.6.0", path = "crates/ff-server" }
+ff-core = { version = "0.6.1", path = "crates/ff-core" }
+ff-script = { version = "0.6.1", path = "crates/ff-script" }
+ff-engine = { version = "0.6.1", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.6.1", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.6.1", path = "crates/ff-sdk" }
+ff-server = { version = "0.6.1", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.6.0", path = "crates/ff-backend-valkey" }
-ff-observability = { version = "0.6.0", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.6.0", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.6.0", path = "ferriskey" }
+ff-backend-valkey = { version = "0.6.1", path = "crates/ff-backend-valkey" }
+ff-observability = { version = "0.6.1", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.6.1", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.6.1", path = "ferriskey" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.6.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -4059,6 +4059,12 @@ async fn read_summary_impl(
     let ctx = ExecKeyContext::new(&partition, execution_id);
     let summary_key = ctx.stream_summary(attempt_index);
 
+    // HGETALL decodes differently by protocol:
+    //   - RESP2 → `Value::Array` of alternating keys/values.
+    //   - RESP3 → `Value::Map` of `(key, value)` pairs.
+    // ferriskey's default on Valkey 7.2 negotiates RESP3, so we must
+    // accept both shapes (v0.6.0 regression: Array-only match always
+    // returned `Ok(None)` on RESP3).
     let raw: ferriskey::Value = client
         .cmd("HGETALL")
         .arg(&summary_key)
@@ -4066,29 +4072,35 @@ async fn read_summary_impl(
         .await
         .map_err(transport_fk)?;
 
-    // HGETALL returns a flat array of alternating keys/values. Empty ⇒ no
-    // summary (RFC-015 §6.3 returns `Ok(None)`).
-    let entries: Vec<String> = match raw {
-        ferriskey::Value::Array(arr) => arr
-            .into_iter()
-            .filter_map(|v| match v {
-                Ok(ferriskey::Value::BulkString(b)) => {
-                    Some(String::from_utf8_lossy(&b).into_owned())
-                }
-                Ok(ferriskey::Value::SimpleString(s)) => Some(s),
-                _ => None,
-            })
-            .collect(),
-        _ => Vec::new(),
-    };
-    if entries.is_empty() {
-        return Ok(None);
+    fn value_to_string(v: ferriskey::Value) -> Option<String> {
+        match v {
+            ferriskey::Value::BulkString(b) => {
+                Some(String::from_utf8_lossy(&b).into_owned())
+            }
+            ferriskey::Value::SimpleString(s) => Some(s),
+            _ => None,
+        }
     }
 
     let mut map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-    let mut it = entries.into_iter();
-    while let (Some(k), Some(v)) = (it.next(), it.next()) {
-        map.insert(k, v);
+    match raw {
+        ferriskey::Value::Array(arr) => {
+            let mut it = arr.into_iter().filter_map(|r| r.ok().and_then(value_to_string));
+            while let (Some(k), Some(v)) = (it.next(), it.next()) {
+                map.insert(k, v);
+            }
+        }
+        ferriskey::Value::Map(pairs) => {
+            for (k, v) in pairs {
+                if let (Some(k), Some(v)) = (value_to_string(k), value_to_string(v)) {
+                    map.insert(k, v);
+                }
+            }
+        }
+        _ => {}
+    }
+    if map.is_empty() {
+        return Ok(None);
     }
     let document_json = map
         .remove("document")

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -49,7 +49,7 @@ valkey-client = ["dep:ferriskey"]
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.6.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: optional so `--no-default-features` drops the transport edge.
 ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -75,7 +75,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.6.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-script's defaults are empty — the `valkey-client`
 # feature (which owns the `ferriskey` dep edge) is activated below by
 # the `valkey-default` feature, NOT here. This keeps

--- a/crates/ff-test/tests/read_summary_resp3.rs
+++ b/crates/ff-test/tests/read_summary_resp3.rs
@@ -1,0 +1,163 @@
+//! Regression: `EngineBackend::read_summary` must decode the RESP3
+//! `Value::Map` shape returned by `HGETALL` on Valkey 7.2.
+//!
+//! v0.6.0 (`ff-backend-valkey::read_summary_impl`) matched only
+//! `Value::Array`, so every call returned `Ok(None)` on RESP3 — the
+//! ferriskey-default protocol. This test writes a `DurableSummary`
+//! delta via the same `ff_append_frame` FCALL the production path
+//! uses, then reads it back through the backend trait. It must return
+//! the written document, not `None`.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test read_summary_resp3 -- --test-threads=1
+
+use std::sync::Arc;
+
+use ferriskey::Value;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::ExecKeyContext;
+use ff_core::partition::execution_partition;
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    ValkeyBackend::from_client_and_partitions(
+        tc.client().clone(),
+        ff_test::fixtures::TEST_PARTITION_CONFIG,
+    )
+}
+
+/// Lean attempt seed — mirrors the fixture used by
+/// `engine_backend_stream_modes.rs` but kept local so this test can
+/// compile standalone.
+struct SeededAttempt {
+    tc: TestCluster,
+    eid: ExecutionId,
+    attempt_index: u32,
+    attempt_id: String,
+    lease_id: String,
+    lease_epoch: String,
+}
+
+impl SeededAttempt {
+    async fn setup() -> Self {
+        let tc = TestCluster::connect().await;
+        tc.cleanup().await;
+        let eid = tc.new_execution_id();
+        let partition = execution_partition(&eid, tc.partition_config());
+        let ctx = ExecKeyContext::new(&partition, &eid);
+
+        let now_ms = TimestampMs::now().0;
+        let lease_id = format!("lease-{}", uuid::Uuid::new_v4());
+        let lease_epoch = "1".to_owned();
+        let attempt_index: u32 = 0;
+        let attempt_id = format!("attempt-{}", uuid::Uuid::new_v4());
+
+        let core_key = ctx.core();
+        let fields: Vec<(&str, String)> = vec![
+            ("current_attempt_index", attempt_index.to_string()),
+            ("current_lease_id", lease_id.clone()),
+            ("current_lease_epoch", lease_epoch.clone()),
+            ("lease_expires_at", (now_ms + 30_000).to_string()),
+            ("lifecycle_phase", "active".to_owned()),
+            ("ownership_state", "owned".to_owned()),
+        ];
+        for (f, v) in &fields {
+            tc.client()
+                .hset(&core_key, *f, v.as_str())
+                .await
+                .unwrap_or_else(|e| panic!("HSET {core_key} {f} failed: {e}"));
+        }
+
+        Self {
+            tc,
+            eid,
+            attempt_index,
+            attempt_id,
+            lease_id,
+            lease_epoch,
+        }
+    }
+
+    fn ctx(&self) -> ExecKeyContext {
+        let partition = execution_partition(&self.eid, self.tc.partition_config());
+        ExecKeyContext::new(&partition, &self.eid)
+    }
+
+    async fn append_summary_delta(&self, payload: &str) -> Value {
+        let ctx = self.ctx();
+        let att_idx = AttemptIndex::new(self.attempt_index);
+        let keys: Vec<String> = vec![
+            ctx.core(),
+            ctx.stream(att_idx),
+            ctx.stream_meta(att_idx),
+            ctx.stream_summary(att_idx),
+        ];
+        let now = TimestampMs::now();
+        let args: Vec<String> = vec![
+            self.eid.to_string(),
+            self.attempt_index.to_string(),
+            self.lease_id.clone(),
+            self.lease_epoch.clone(),
+            "summary_token".to_owned(),
+            now.to_string(),
+            payload.to_owned(),
+            "utf8".to_owned(),
+            String::new(),
+            "worker".to_owned(),
+            "0".to_owned(),
+            self.attempt_id.clone(),
+            "65536".to_owned(),
+            "summary".to_owned(),
+            "json-merge-patch".to_owned(),
+            "0".to_owned(),
+            "0".to_owned(),
+            "0".to_owned(),
+            "0".to_owned(),
+        ];
+        let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        self.tc
+            .client()
+            .fcall("ff_append_frame", &key_refs, &arg_refs)
+            .await
+            .expect("FCALL ff_append_frame failed")
+    }
+}
+
+/// Regression for v0.6.0 read_summary RESP3 Map decode bug.
+///
+/// Pre-fix: ferriskey's RESP3 client made `HGETALL` return
+/// `Value::Map`, but `read_summary_impl` matched only `Value::Array`,
+/// so this test would see `Ok(None)` after a successful delta write.
+/// Post-fix: the decoder accepts both shapes and this returns the
+/// written document.
+#[tokio::test]
+#[serial_test::serial]
+async fn read_summary_decodes_resp3_map() {
+    let f = SeededAttempt::setup().await;
+
+    // Write one summary delta via the production FCALL path.
+    let _ = f.append_summary_delta(r#"{"hello":"resp3","n":7}"#).await;
+
+    // Read back via the trait — this is the path that broke on v0.6.0.
+    let backend = build_backend(&f.tc);
+    let attempt_index = AttemptIndex::new(f.attempt_index);
+    let doc = backend
+        .read_summary(&f.eid, attempt_index)
+        .await
+        .expect("read_summary call succeeded");
+
+    let doc = doc.expect(
+        "read_summary must return Some(..) after a delta write; \
+         Ok(None) here means the RESP3 Map regression is back",
+    );
+
+    assert_eq!(doc.version, 1, "version == 1 after first delta");
+
+    let parsed: serde_json::Value = serde_json::from_slice(&doc.document_json)
+        .expect("summary document is valid JSON");
+    assert_eq!(parsed.get("hello").and_then(|v| v.as_str()), Some("resp3"));
+    assert_eq!(parsed.get("n").and_then(|v| v.as_i64()), Some(7));
+}

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

Release-blocker hotfix for v0.6.0. `ff-backend-valkey::read_summary_impl` matched only `Value::Array` for the `HGETALL` response. ferriskey's default client on Valkey 7.2 negotiates RESP3, where `HGETALL` returns `Value::Map`, so every call to `EngineBackend::read_summary` returned `Ok(None)` — RFC-015 DurableSummary reads were broken end-to-end. Writes and `summary_version` increments were unaffected.

Caught by the v0.6.0 published-artifact smoke (PR #224).

## Fix

Widen the match in `crates/ff-backend-valkey/src/lib.rs::read_summary_impl` to accept both `Value::Array` (RESP2) and `Value::Map` (RESP3), normalizing into the same `HashMap<String, String>` before parsing into `SummaryDocument`. Mirrors the precedent in `ff-script/src/functions/stream.rs` where both shapes are already handled.

## Sibling HGETALL audit

Every `HGETALL` site in `ff-backend-valkey/src/` was inspected:

- 8 sites use typed `let raw: HashMap<String, String> = client.cmd("HGETALL")…execute()` or `pipe.cmd::<HashMap<String, String>>("HGETALL")`. ferriskey's `FromOwnedValue` for `HashMap` handles both shapes internally — **not affected**.
- 1 site (`read_summary_impl`, line ~4062) hand-rolled the raw `Value` match and was the only vulnerable site.

No sibling fixes needed.

## Regression test

`crates/ff-test/tests/read_summary_resp3.rs` — writes one `DurableSummary` delta via `ff_append_frame` and reads it back through `EngineBackend::read_summary`.

- Pre-fix: `Ok(None)` → test **FAILS** (verified by stashing the decoder change)
- Post-fix: returns the written `SummaryDocument` with `version == 1` → test **PASSES**

## Non-changes

- `read_summary` trait signature unchanged.
- `SummaryDocument` shape unchanged.
- No wire-format or ARGV changes.
- Lua library unchanged (stays at version 26).

## Version

Workspace bumped `0.6.0` → `0.6.1` across `Cargo.toml`, `ferriskey/Cargo.toml`, and all `crates/*/Cargo.toml` dep sections. CHANGELOG `[0.6.1] - 2026-04-24` entry added.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings` clean
- [x] Regression test FAILS against pre-fix decoder, PASSES with fix
- [x] FF workspace test suite passes locally against live Valkey 7.2 (RESP3)
- [ ] CI green before admin-merge

Do NOT auto-merge — owner admin-merges + tags v0.6.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Valkey backend decoding for `EngineBackend::read_summary`, so a bug could affect summary retrieval across environments (RESP2/RESP3) even though the change is small and now regression-tested.
> 
> **Overview**
> Fixes a v0.6.0 regression where `EngineBackend::read_summary` returned `Ok(None)` under RESP3 because `HGETALL` responses were only decoded from `Value::Array`; the backend now accepts both RESP2 `Array` and RESP3 `Map` and normalizes into the same key/value map before parsing a `SummaryDocument`.
> 
> Adds a regression integration test (`ff-test/tests/read_summary_resp3.rs`) that writes a `DurableSummary` delta via `ff_append_frame` and asserts `read_summary` returns the stored document under the RESP3 client. Bumps workspace/crate versions to `0.6.1` and records the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83027dfa83e23a67de2193ff247091902616a5e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->