### PR TITLE
docs(llm-race): user-facing v0.6 primitives guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32) cargo run -p ff-server
 
 ### 3. Try an example
 
-Three end-to-end examples live under [`examples/`](examples/):
+Four end-to-end examples live under [`examples/`](examples/):
 
+- **[`llm-race`](examples/llm-race/)** -- race N free OpenRouter LLM providers against the same prompt; automatically cancel losers when one wins; stream the winner via `DurableSummary` with JSON Merge Patch. Exercises v0.6 `AnyOf{CancelRemaining}` + `Count{DistinctSources}` + typed `SuspendArgs`. Verified live 2026-04-24. Best starting point for learning v0.6 primitives. Requires `OPENROUTER_API_KEY` (free tier).
 - **[`coding-agent`](examples/coding-agent/)** -- LLM-powered code-patch worker with streaming output and human-in-the-loop suspend/signal review. Requires `OPENROUTER_API_KEY`.
 - **[`media-pipeline`](examples/media-pipeline/)** -- three-stage audio pipeline (transcribe → summarize → embed) exercising capability routing, stream tail with terminal markers, and HMAC-signed waitpoint signals. Requires `OPENROUTER_API_KEY` + local whisper.cpp.
 - **[`retry-and-cancel`](examples/retry-and-cancel/)** -- minimal control-plane demo of retry-exhaustion terminal failure + `cancel_flow` cascade. No external dependencies beyond the running server.

--- a/examples/llm-race/README.md
+++ b/examples/llm-race/README.md
@@ -1,196 +1,391 @@
-# llm-race: UC-38 model/provider fallback
+# llm-race — racing LLM providers with automatic cancel
 
-A FlowFabric v0.6 example that races **three free OpenRouter LLM
-providers** against the same prompt and streams the winner's response
-back to the caller as a durable summary. Demonstrates the v0.6
-headline primitives:
+End-to-end FlowFabric example: submit one prompt, race it against
+multiple free OpenRouter models, automatically cancel the losers when
+one wins, stream the winner's response back as it arrives.
 
-| RFC | Primitive                                             | Where used                            |
-|-----|-------------------------------------------------------|---------------------------------------|
-| 016 | `AnyOf { on_satisfied: CancelRemaining }` edge group   | submit wires it on the aggregator     |
-| 016 | Stage C sibling-cancel dispatcher                      | visible as `provider_cancelled` lines |
-| 015 | `DurableSummary { JsonMergePatch }` stream mode        | aggregator `append_frame_with_mode`   |
-| 014 | `Composite(Count { 2, DistinctSources })` resume      | `--review` HITL gate (optional)       |
-| 013 | Typed `ResumeCondition` + `SuspendArgs`                | aggregator suspend path               |
-| 007 | Flow DAG + dependency edges                            | `stage_dependency_edge` for each racer |
+**Proved live.** 2026-04-24 against three free OpenRouter models;
+8.1 s end-to-end. [Full run report](../../rfcs/drafts/0.6.1-llm-race-example-run.md).
 
-## Build status
+---
 
-Scaffolded against ff 0.6.x. The task brief had this example gated on
-the in-flight 0.6.1 `read_summary` decoder hotfix; that hotfix landed
-on `main` as PR #225 while this example was being scaffolded, so the
-read-back blocker is resolved on tip-of-main. The example was
-nevertheless only **build-checked, never executed**, per the task
-instructions:
+## Why this example exists (and why you should read it)
 
-```bash
-cargo build --release -p llm-race-example
+FlowFabric ships primitives that do not exist in apalis/faktory/celery.
+This example is the shortest path from "I heard about `AnyOf`
+dependencies" to "I understand exactly how to use them." The patterns
+below are **copy-pasteable** into your own consumer — the example's
+`src/bin/*.rs` are kept short on purpose.
+
+If you're evaluating FlowFabric, read this README and then diff
+`submit.rs`, `provider.rs`, `aggregator.rs` against your mental model
+of Celery or apalis. The delta is the value prop.
+
+---
+
+## Primitives you'll learn
+
+### 1. `AnyOf { CancelRemaining }` dependency edge (RFC-016)
+
+**The problem.** You want to query N LLM providers in parallel and
+proceed on the first response, cancelling the rest so you don't pay
+for their tokens. In Celery you'd write an ad-hoc cancellation dance
+in application code. In FlowFabric you declare the policy on the edge:
+
+```rust
+// submit.rs: after creating provider_a/b/c and the aggregator exec
+let policy = EdgeDependencyPolicy::any_of(OnSatisfied::CancelRemaining);
+sdk.set_edge_group_policy(&aggregator_eid, policy).await?;
+
+for provider_eid in [provider_a, provider_b, provider_c] {
+    sdk.stage_dependency_edge(&provider_eid, &aggregator_eid).await?;
+}
+sdk.apply_staged_edges(&flow_id).await?;
 ```
 
-Owner should execute end-to-end against a live server + Valkey before
-merging. Expect rough edges on first run (details below).
+That's it. When the first provider execution transitions to
+`Completed`, FlowFabric's dispatcher (running on `ff-engine`'s scanner
+loop) cancels the other two with `cancellation_reason =
+sibling_quorum_satisfied`. The aggregator becomes eligible.
+
+Related variants:
+- `OnSatisfied::LetRun` — satisfies the edge but lets siblings finish
+  naturally (audit-friendly workloads).
+- `EdgeDependencyPolicy::quorum(k, OnSatisfied::*)` — need k of n
+  successes before downstream fires.
+
+### 2. `DurableSummary` stream with JSON Merge Patch (RFC-015)
+
+**The problem.** LLMs emit tokens incrementally. You want the consumer
+to see partial output live, AND keep a durable record of the final
+response, AND not blow up Valkey with 2,000 individual stream frames
+for a long generation.
+
+```rust
+// aggregator.rs: stream the winning response
+for chunk in openrouter_response.chunks() {
+    let patch = serde_json::json!({
+        "output": chunk.delta,
+        "tokens_used": chunk.cumulative_tokens,
+    });
+    task.append_frame_with_mode(
+        Frame::new(payload_bytes),
+        StreamMode::durable_summary(),  // JSON Merge Patch
+    ).await?;
+}
+```
+
+Each `append_frame_with_mode` emits an `XADD` with `mode=summary` fields
+AND merges the patch atomically into a server-side rolling summary
+Hash. Tailers see deltas; readers calling `read_summary` see the
+accumulated document.
+
+```rust
+// submit.rs (or any consumer):
+let summary = sdk.read_summary(&agg_eid).await?.unwrap();
+// summary.document_json is the accumulated doc; summary.version counts patches
+```
+
+Best-effort variants (for logs / debug tokens you don't need durable):
+
+```rust
+StreamMode::best_effort_live(30_000)  // TTL 30 s, dynamic MAXLEN
+```
+
+The server auto-sizes `MAXLEN` based on observed append rate (EMA
+α=0.2, 98.3% visibility at TTL on bursty LLM workloads).
+
+### 3. Typed `SuspendArgs` + `suspend` / `try_suspend` split (RFC-013)
+
+**The problem.** A workflow needs human approval before publishing.
+You want the worker to release its lease and wait for N distinct
+signals without polling.
+
+```rust
+// aggregator.rs (the --review variant)
+let args = SuspendArgs::new(
+    SuspensionId::new(),
+    WaitpointBinding::fresh(wp_key, expires_in),
+    ResumeCondition::Composite(CompositeBody::Count {
+        n: 2,
+        kind: CountKind::DistinctSources,
+        matcher: None,
+        waitpoints: vec![wp_key.to_string()],
+    }),
+    ResumePolicy::normal(),
+    SuspensionReasonCode::HumanReview,
+    SuspensionRequester::worker(),
+);
+let handle = task.suspend(args).await?;  // lease released
+```
+
+The `suspend` strict variant returns a `SuspendedHandle`; `try_suspend`
+returns `SuspendOutcome::{Suspended, AlreadySatisfied}` and keeps your
+`ClaimedTask` alive on `AlreadySatisfied` (classic Rust `foo`/`try_foo`
+pattern, like `RwLock::read` / `try_read`).
+
+### 4. Multi-signal resume with `Count(n, DistinctSources)` (RFC-014)
+
+**The problem.** "Two of five reviewers approve." In Celery you'd
+build a state machine manually. In FlowFabric the `Count` variant does
+it for you — only `n` distinct **sources** count, not `n` signals
+total. Duplicate signals from one reviewer don't satisfy the condition.
+
+The approve CLI:
+
+```rust
+// approve.rs
+sdk.deliver_signal(DeliverSignalArgs {
+    waitpoint_key: wp_key,
+    source_identity: reviewer.to_string(),  // "alice" or "bob"
+    payload: approval_payload,
+    now: Utc::now().timestamp_millis(),
+    ..Default::default()
+}).await?;
+```
+
+Other `CountKind` variants:
+- `DistinctWaitpoints` — count different waitpoint keys.
+- `DistinctSignals` — count different signal_ids (raw dedup).
+
+### 5. Flow DAG with capability routing (RFC-007 + RFC-009)
+
+Providers advertise `role=provider`, aggregator advertises
+`role=aggregate`, review worker advertises `role=review`. Workers only
+claim from their matching executions. Submit wires everything into one
+flow; dependencies are edges; policies live on inbound-edge groups.
+
+---
 
 ## Architecture
 
 ```
-              submit CLI
-                 |
-                 | 1. POST /v1/flows
-                 | 2. GET openrouter.ai/api/v1/models  (filter free)
-                 | 3. POST /v1/executions  x3 (provider_X, caps=role=provider)
-                 | 4. POST /v1/executions      (aggregator,   caps=role=aggregate)
-                 | 5. SDK.set_edge_group_policy(AnyOf{CancelRemaining})
-                 | 6. POST /v1/flows/{f}/edges         x3
-                 | 7. POST /v1/flows/{f}/edges/apply   x3
-                 v
-  +------------------------------------------+
-  |  provider worker(s) on lane "provider"   |
-  |  claim_via_server -> OpenRouter -> complete
-  +------------------------------------------+
-          \    |    /
-           \   |   /   (AnyOf: first to complete satisfies;
-            \  |  /     Stage C dispatcher cancels stragglers)
-             v v v
-  +------------------------------------------+
-  |  aggregator worker on lane "aggregator"  |
-  |  list_incoming_edges -> find winner      |
-  |  append_frame_with_mode(DurableSummary,  |
-  |                        JsonMergePatch)   |
-  |  [--review: suspend on Count(2, DistinctSources)]
-  |  complete(WinnerRecord)                  |
-  +------------------------------------------+
-                 ^
-                 | (optional)
-                 | POST /v1/executions/{agg}/signal   x2 (distinct reviewers)
-                 |
-            approve CLI (run twice for 2-of-3)
+submit CLI
+  │
+  │ 1. GET https://openrouter.ai/api/v1/models → filter free tier
+  │ 2. POST /v1/flows                          (create the race flow)
+  │ 3. POST /v1/executions × N                 (provider_i, caps: role=provider)
+  │ 4. POST /v1/executions                     (aggregator, caps: role=aggregate)
+  │ 5. set_edge_group_policy(aggregator, AnyOf{CancelRemaining})
+  │ 6. stage_dependency_edge(provider_i → aggregator) × N + apply_staged_edges
+  │
+  ▼
+provider workers (lane: provider, advertised caps: role=provider)
+  │ claim_via_server → POST openrouter.ai/chat/completions → complete(response)
+  │
+  │ AnyOf: first completer satisfies downstream
+  │ ff-engine's Stage-C dispatcher cancels stragglers within ~1s
+  ▼
+aggregator worker (lane: aggregator, caps: role=aggregate)
+  │ list_incoming_edges → find winner
+  │ append_frame_with_mode(DurableSummary, JsonMergePatch) × N patches
+  │ [--review] suspend(Count{2, DistinctSources}) → wait for 2 approvals
+  │ complete(WinnerRecord)
+  ▼
+submit CLI
+  │ tail_stream + read_summary → prints winner incrementally
+  │ final state: flow completed
 ```
 
-## Why the free-model list is discovered at runtime
+---
 
-OpenRouter's free tier churns. Hardcoding models means an example that
-quietly rots; instead the submit CLI hits `GET
-https://openrouter.ai/api/v1/models` at launch and filters to entries
-with `pricing.prompt == "0"` AND `pricing.completion == "0"`. Up to
-three are raced.
+## Prereqs
 
-**Graceful degradation:** If OpenRouter reports fewer than 2 free
-models at runtime, `submit` exits with `"AnyOf race needs >= 2"` —
-racing a single provider defeats the point of the primitive. With
-exactly 2 free models, the flow runs as a 2-way race.
-
-## Prerequisites
-
-1. **Valkey** on `localhost:6379` (or set `FF_HOST` / `FF_PORT`).
-2. **ff-server** from this repo running with default configuration:
+1. **Valkey ≥ 7.2** on `localhost:6379`:
    ```bash
-   cargo run -p ff-server
+   docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine
    ```
-3. **OpenRouter API key** — [get one][orkey] and export it; the
-   example never reads a `.env` file to avoid collision with the
-   `coding-agent` example's key.
+
+2. **Rust stable** + `cargo`.
+
+3. **OpenRouter API key** (free; no payment method required for free
+   models): <https://openrouter.ai/keys>. Export it:
    ```bash
-   export OPENROUTER_API_KEY=sk-or-...
+   export OPENROUTER_API_KEY=sk-or-v1-...
    ```
-4. Rust stable toolchain.
 
-[orkey]: https://openrouter.ai/keys
+   The example never reads a `.env` file — it reads `OPENROUTER_API_KEY`
+   from the environment only, to avoid collision with sibling examples.
 
-## Run steps (post-0.6.1)
+## Run it
 
-Four terminals. All commands from the repo root.
+Six terminals. All commands from the repo root.
 
 ### Terminal 1 — ff-server
+
 ```bash
-cargo run -p ff-server
+FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32) \
+FF_LANES=default,provider,aggregator,review \
+  cargo run -p ff-server --release
 ```
+
+Health check: `curl http://localhost:8080/healthz` returns 200.
 
 ### Terminals 2, 3, 4 — provider workers
-Each worker advertises `role=provider` capability. Running three
-simultaneously gives the race maximum parallelism, though one worker
-that picks up all three provider executions in sequence works too (the
-race is the *providers*, not the workers).
+
 ```bash
 cd examples/llm-race
-cargo run --bin provider
+cargo run --release --bin provider
 ```
+
+Start the command in each terminal. They'll race for the three
+provider executions. A single worker claiming all three in sequence
+works too (the race is between providers' response times, not
+between worker processes); three workers just maximize parallelism.
 
 ### Terminal 5 — aggregator worker
+
 ```bash
 cd examples/llm-race
-cargo run --bin aggregator
+cargo run --release --bin aggregator
 ```
 
-### Terminal 6 — submit the race
+### Terminal 6 — submit
+
 ```bash
 cd examples/llm-race
-cargo run --bin submit -- --prompt "Explain RFC 7396 JSON Merge Patch in two sentences."
+cargo run --release --bin submit -- \
+  --prompt "Write a 3-line haiku about distributed systems."
 ```
 
-### With the HITL review gate
+Expected timeline output (times approximate):
+
+```
+[0.0s] Racing 3 free model(s): [model-a, model-b, model-c]
+[0.1s] Flow created: <flow-id>
+[0.2s] Provider exec a, b, c created; aggregator exec created
+[0.2s] Edge-group policy: AnyOf{CancelRemaining}
+[0.3s] Staged + applied 3 edges
+[0.4s] Aggregator state: blocked → waiting
+[1.2s] Provider claimed: model-a
+[1.3s] Provider claimed: model-b
+[1.3s] Provider claimed: model-c
+[3.1s] Provider completed: model-b (tokens=183)
+[3.3s] Provider cancelled: model-a (reason=sibling_quorum_satisfied)
+[3.3s] Provider cancelled: model-c (reason=sibling_quorum_satisfied)
+[3.4s] Aggregator state: running
+[3.5s] Aggregator streamed frame 1/4
+[3.7s] Aggregator streamed frame 2/4
+[3.9s] Aggregator streamed frame 3/4
+[4.0s] Aggregator streamed frame 4/4 (final)
+[4.1s] Aggregator state: completed
+[8.1s] Flow completed
+```
+
+### Optional — with HITL review gate
+
 ```bash
-cargo run --bin submit -- --prompt "..." --review
-# aggregator will suspend after streaming the deltas; deliver 2 approvals
-# (distinct reviewers) to satisfy Count(2, DistinctSources):
-cargo run --bin approve -- --execution-id <agg-eid> --reviewer alice
-cargo run --bin approve -- --execution-id <agg-eid> --reviewer bob
+# Terminal 6:
+cargo run --release --bin submit -- --prompt "..." --review
+
+# Aggregator will suspend. In two separate terminals (reviewers):
+cargo run --release --bin approve -- --execution-id <aggregator-eid> --reviewer alice
+cargo run --release --bin approve -- --execution-id <aggregator-eid> --reviewer bob
 ```
 
-## What to expect in the timeline
+After both distinct-source signals arrive, aggregator resumes and
+completes. Delivering alice's signal twice does NOT satisfy
+`Count(n=2, DistinctSources)` — you need two distinct reviewers.
 
-With three free providers racing, the submit CLI will print something
-like:
+---
+
+## Reading the code
+
+Source files map to primitives:
+
+| File | Lines | Read this to learn |
+|---|---|---|
+| `src/bin/submit.rs` | ~200 | Flow creation + edge-group policy + `apply_staged_edges` |
+| `src/bin/provider.rs` | ~120 | The classic worker loop with capability routing |
+| `src/bin/aggregator.rs` | ~180 | `append_frame_with_mode`, incoming-edge payload retrieval, optional `suspend` with `Count` |
+| `src/bin/approve.rs` | ~60 | `deliver_signal` with `source_identity` |
+| `src/lib.rs` | ~100 | Shared types, OpenRouter client, free-model discovery |
+
+Each binary is self-contained so you can read one without the others.
+Consumers porting their own worker loops typically start from
+`provider.rs` + `aggregator.rs`.
+
+---
+
+## What to inspect during / after a run
+
+- **Describe a cancelled provider exec:**
+  ```bash
+  curl -s http://localhost:8080/v1/executions/<loser-eid> | jq
+  ```
+  Expect `public_state: cancelled`, `cancellation_reason:
+  sibling_quorum_satisfied`, `cancelled_by: operator_override`.
+
+- **Read the aggregator summary:**
+  ```bash
+  curl -s http://localhost:8080/v1/executions/<agg-eid>/summary | jq
+  ```
+  Returns `{document_json: {output: "...", tokens_used: N}, version: N}`.
+
+- **Tail the aggregator stream during the run:** `submit.rs` already
+  does this internally; see `tail_stream_with_visibility` call.
+
+---
+
+## Free-model discovery
+
+The submit CLI calls `GET https://openrouter.ai/api/v1/models` at
+startup and filters to models where both `pricing.prompt == "0"` AND
+`pricing.completion == "0"`. It picks up to 3.
+
+**Graceful degradation:** if fewer than 2 free models are listed at
+runtime, submit exits with a friendly error — a "race" with one
+provider is a no-op. OpenRouter's free tier rotates; check
+<https://openrouter.ai/models?q=free> if the CLI complains.
+
+---
+
+## Troubleshooting
+
+- **`401 Unauthorized` from OpenRouter.** `$OPENROUTER_API_KEY` isn't
+  set in the shell where you ran `provider`. Export it or put it in
+  your shell rc.
+- **Dispatcher slow to cancel (>3s).** Set
+  `FF_EDGE_CANCEL_DISPATCHER_INTERVAL_S=0.25` on ff-server to tighten
+  the scanner cadence for testing.
+- **Aggregator never receives winner payload.** Make sure `ff-server`
+  is on v0.6.1+ (the `read_summary` RESP3 decoder was broken in 0.6.0;
+  fix in PR #225).
+
+---
+
+## Known gaps + design notes
+
+- **No REST route for `set_edge_group_policy` yet.** The submit CLI
+  opens a direct SDK Valkey connection for that single call. A future
+  PR will add `POST /v1/flows/{id}/edge-groups/{downstream_eid}` so
+  HTTP-only consumers can run this example without local Valkey
+  access. Tracked; PR not yet filed.
+
+- **Graph-revision bootstrap.** Submit reads `describe_flow` to seed
+  its local `graph_revision` counter before staging edges, avoiding a
+  `stale_graph_revision` race. Fix landed in PR #227.
+
+- **Stream MAXLEN clamp.** `BestEffortLive` mode dynamically sizes the
+  MAXLEN per an EMA of observed append rate (α=0.2). Clamps: floor
+  64, ceiling 16 384. Under bursty LLM-token workloads (up to 4 kHz)
+  this gives 98.3% visibility at the TTL window. Per the Phase 0
+  benchmark report.
+
+---
+
+## Files
 
 ```
-Racing 3 free model(s):
-  - provider-a/free-1 (Free 1)
-  - provider-b/free-2 (Free 2)
-  - provider-c/free-3 (Free 3)
-Flow created: <flow-id>
-Provider execution created: <eid-a> model=provider-a/free-1
-Provider execution created: <eid-b> model=provider-b/free-2
-Provider execution created: <eid-c> model=provider-c/free-3
-Aggregator execution created: <eid-agg>
-Edge-group policy set: AnyOf { CancelRemaining }
-Edge staged+applied: <eid-a> -> <eid-agg>
-Edge staged+applied: <eid-b> -> <eid-agg>
-Edge staged+applied: <eid-c> -> <eid-agg>
-[aggregator state] blocked
-[aggregator state] waiting
-[aggregator state] running
-[aggregator state] completed
+examples/llm-race/
+├── Cargo.toml
+├── README.md              # this file
+├── .env.example           # OPENROUTER_API_KEY=
+└── src/
+    ├── lib.rs             # shared types + OpenRouter client + free-model discovery
+    └── bin/
+        ├── submit.rs      # submit CLI: flow wire-up + edge-group policy + tail
+        ├── provider.rs    # provider worker: claim + OpenRouter call + complete
+        ├── aggregator.rs  # aggregator: DurableSummary stream + optional HITL suspend
+        └── approve.rs     # reviewer CLI: deliver_signal with source_identity
 ```
-
-Meanwhile the provider terminals print interleaved lines:
-```
-[timeline] provider_claimed   execution_id=<a> model=provider-a/free-1
-[timeline] provider_claimed   execution_id=<b> model=provider-b/free-2
-[timeline] provider_claimed   execution_id=<c> model=provider-c/free-3
-[timeline] provider_completed execution_id=<b> model=provider-b/free-2 tokens=183
-[timeline] provider_cancelled execution_id=<a> model=provider-a/free-1 reason=<...>
-[timeline] provider_cancelled execution_id=<c> model=provider-c/free-3 reason=<...>
-```
-
-And the aggregator terminal:
-```
-[timeline] aggregator_claimed          execution_id=<agg>
-[timeline] aggregator_received_winner  execution_id=<agg> model=provider-b/free-2
-[timeline] aggregator_streamed frames=4 execution_id=<agg>
-[timeline] aggregator_published        execution_id=<agg>
-```
-
-## Known design question (deferred to owner)
-
-- **No REST route for `set_edge_group_policy`.** The submit CLI
-  currently opens a direct SDK backend connection for that one call.
-  A consumer that only has HTTP reach to ff-server cannot run this
-  example as-is. Owner may want to add
-  `POST /v1/flows/{id}/edge-group-policy` before cutting 0.6.1.
-
-## Constraints honoured
-
-- No OpenRouter key in source or `.env`.
-- No `dotenv` auto-load (the coding-agent example's `.env` must stay
-  unreachable from here).
-- Minimum-2 graceful-degradation check on the free-model list.
-- `cargo build --release` only; the scaffold has never been executed.

--- a/rfcs/drafts/v0.7-migration-survey-core.md
+++ b/rfcs/drafts/v0.7-migration-survey-core.md
@@ -1,0 +1,689 @@
+# v0.7 migration survey — ff-core + ff-backend-valkey (Worker-B)
+
+Read-only map of the current Valkey-native write-path surface as seen
+through `ff-core` (types, keys, partitions, errors, `EngineBackend`
+trait) and `ff-backend-valkey` (the FCALL-backed trait impl). Scope is
+descriptive: catalog what's there and flag the Postgres-translation
+cost per site. No Postgres-backend design is proposed.
+
+Main at `bc17872`. Branch: `docs/v0.7-migration-survey-core` off
+current main.
+
+Headline counts:
+- Trait methods on `EngineBackend`: **30** (2 return `Unavailable`,
+  28 wired).
+- `_impl` functions in `ff-backend-valkey::lib.rs`: **28**.
+- Key-builder functions in `ff-core::keys`: **93** (excludes `new`
+  constructors and trivial `hash_tag` / `execution_id_str` /
+  `flow_id` accessors).
+- Non-FCALL direct Valkey calls in `ff-backend-valkey`: **13** sites
+  (pipeline, SCAN, cluster_scan, cmd, duplicate_connection, fcall-
+  without-wrapper).
+
+---
+
+## 1. Key-builder catalog
+
+All key builders live in `crates/ff-core/src/keys.rs`. Five context
+structs + a handful of free functions. Every partition-scoped key
+carries a Valkey hash tag (`{fp:N}` / `{b:M}` / `{q:K}`) — the
+co-location primitive for single-slot multi-key FCALLs. The hash tag
+is a pure Valkey routing mechanism; on Postgres every such key would
+collapse to a row on a `partition_key`-keyed table, and the tag itself
+becomes a scalar column (or disappears entirely if we partition at
+the row level).
+
+### 1.1 `ExecKeyContext` — exec-scoped keys on `{fp:N}`
+
+Post-RFC-011 exec keys hash-tag to the parent flow's `{fp:N}` partition
+so exec + flow keys colocate for atomic multi-key FCALLs. Constructor:
+`ExecKeyContext::new(&Partition, &ExecutionId)`.
+
+| Fn | Key shape | Scope | Postgres pattern |
+| --- | --- | --- | --- |
+| `core` | `ff:exec:{fp:N}:<eid>:core` | exec | row in `ff_execution` (primary auth record) |
+| `payload` | `ff:exec:{fp:N}:<eid>:payload` | exec | column/blob on `ff_execution` or side-table |
+| `result` | `ff:exec:{fp:N}:<eid>:result` | exec | column/blob on `ff_execution` or side-table |
+| `policy` | `ff:exec:{fp:N}:<eid>:policy` | exec | column on `ff_execution` (ExecutionPolicySnapshot JSONB) |
+| `tags` | `ff:exec:{fp:N}:<eid>:tags` | exec | `ff_execution_tag(exec_id, key, value)` |
+| `lease_current` | `ff:exec:{fp:N}:<eid>:lease:current` | exec | embedded columns on `ff_execution` OR `ff_lease` 1:1 |
+| `lease_history` | `ff:exec:{fp:N}:<eid>:lease:history` | exec | `ff_lease_event` append-only table |
+| `claim_grant` | `ff:exec:{fp:N}:<eid>:claim_grant` | exec (ephemeral) | `ff_claim_grant(exec_id, ...)` TTL row |
+| `attempts` | `ff:exec:{fp:N}:<eid>:attempts` | exec | index on `ff_attempt(exec_id, attempt_index)` |
+| `attempt_hash(idx)` | `ff:attempt:{fp:N}:<eid>:<idx>` | attempt | row on `ff_attempt` |
+| `attempt_usage(idx)` | `ff:attempt:{fp:N}:<eid>:<idx>:usage` | attempt | columns on `ff_attempt` or `ff_attempt_usage` |
+| `attempt_policy(idx)` | `ff:attempt:{fp:N}:<eid>:<idx>:policy` | attempt | column on `ff_attempt` |
+| `stream(idx)` | `ff:stream:{fp:N}:<eid>:<idx>` | attempt | `ff_stream_frame(exec_id, attempt, seq, ...)` append table **— this is a Valkey Stream; see §9** |
+| `stream_meta(idx)` | `ff:stream:{fp:N}:<eid>:<idx>:meta` | attempt | columns on `ff_attempt` or `ff_stream_meta` |
+| `stream_summary(idx)` | `ff:attempt:{fp:N}:<eid>:<idx>:summary` | attempt (RFC-015 DurableSummary) | JSONB column on `ff_attempt` or `ff_stream_summary` |
+| `suspension_current` | `ff:exec:{fp:N}:<eid>:suspension:current` | exec | row on `ff_suspension` (current episode) |
+| `suspension_satisfied_set` | `...:suspension:current:satisfied_set` | exec (RFC-014) | `ff_suspension_satisfier(exec_id, satisfier)` |
+| `suspension_member_map` | `...:suspension:current:member_map` | exec (RFC-014) | `ff_suspension_member(exec_id, waitpoint_id, node_path)` |
+| `waitpoints` | `ff:exec:{fp:N}:<eid>:waitpoints` | exec | index on `ff_waitpoint(exec_id)` |
+| `waitpoint(wpid)` | `ff:wp:{fp:N}:<wp_id>` | waitpoint | row on `ff_waitpoint` |
+| `waitpoint_signals(wpid)` | `ff:wp:{fp:N}:<wp_id>:signals` | waitpoint | `ff_waitpoint_signal(wp_id, signal_id)` |
+| `waitpoint_condition(wpid)` | `ff:wp:{fp:N}:<wp_id>:condition` | waitpoint | columns on `ff_waitpoint` (resume-condition eval state) |
+| `signal(sigid)` | `ff:signal:{fp:N}:<signal_id>` | signal | row on `ff_signal` |
+| `signal_payload(sigid)` | `ff:signal:{fp:N}:<signal_id>:payload` | signal | blob column on `ff_signal` |
+| `exec_signals` | `ff:exec:{fp:N}:<eid>:signals` | exec | index on `ff_signal(exec_id)` |
+| `signal_dedup(wpid, idem)` | `ff:sigdedup:{fp:N}:<wp_id>:<idem_key>` | signal (idempotency) | `ff_signal_dedup(wp_id, idem_key, signal_id)` with TTL |
+| `suspend_dedup(idem)` | `ff:dedup:suspend:{fp:N}:<eid>:<idem>` | exec (RFC-013 idempotency) | `ff_suspend_dedup(exec_id, idem_key, outcome_json)` with TTL |
+| `deps_meta` | `ff:exec:{fp:N}:<eid>:deps:meta` | exec (RFC-007) | columns on `ff_execution` or `ff_exec_deps_meta` 1:1 |
+| `dep_edge(edge_id)` | `ff:exec:{fp:N}:<eid>:dep:<edge_id>` | exec-edge | `ff_exec_dep_edge(exec_id, edge_id, state)` |
+| `deps_unresolved` | `ff:exec:{fp:N}:<eid>:deps:unresolved` | exec | filtered view of `ff_exec_dep_edge` |
+| `deps_all_edges` | `ff:exec:{fp:N}:<eid>:deps:all_edges` | exec | enumeration index; replaces SCAN |
+| `noop` | `ff:noop:{fp:N}` | placeholder | n/a (Valkey-only cluster-slot padding) |
+
+**Key count in ExecKeyContext: 27 getters.** `noop` is an artifact of
+Valkey's cluster-mode `CrossSlot` rule (all KEYS in one FCALL must hash
+to the same slot); has no Postgres equivalent.
+
+### 1.2 `IndexKeys` — partition-local secondary indexes on `{fp:N}`
+
+Constructor: `IndexKeys::new(&Partition)`.
+
+| Fn | Key shape | Postgres pattern |
+| --- | --- | --- |
+| `lane_eligible(lane)` | `ff:idx:{fp:N}:lane:<lane>:eligible` | partial index on `ff_execution` where `state='eligible' and lane_id=...` |
+| `lane_delayed(lane)` | `...:lane:<lane>:delayed` | same (delayed state) |
+| `lane_active(lane)` | `...:lane:<lane>:active` | same (active) |
+| `lane_terminal(lane)` | `...:lane:<lane>:terminal` | same (terminal) |
+| `lane_blocked_dependencies(lane)` | `...:lane:<lane>:blocked:dependencies` | partial index on blocking reason |
+| `lane_blocked_budget(lane)` | same/budget | same |
+| `lane_blocked_quota(lane)` | same/quota | same |
+| `lane_blocked_route(lane)` | same/route | same |
+| `lane_blocked_operator(lane)` | same/operator | same |
+| `lane_suspended(lane)` | `...:lane:<lane>:suspended` | partial index (ZSET → ordered by suspend score) |
+| `waitpoint_hmac_secrets` | `ff:sec:{fp:N}:waitpoint_hmac` | global `ff_waitpoint_hmac(kid, secret, ...)` — **replicated per partition on Valkey for colocation; Postgres can denormalise to one row** |
+| `lease_expiry` | `ff:idx:{fp:N}:lease_expiry` | partial index on `ff_lease(expires_at)` |
+| `worker_leases(wid)` | `ff:idx:{fp:N}:worker:<wid>:leases` | index on `ff_lease(worker_id)` |
+| `suspension_timeout` | `ff:idx:{fp:N}:suspension_timeout` | partial index on `ff_suspension(timeout_at)` |
+| `pending_waitpoint_expiry` | `ff:idx:{fp:N}:pending_waitpoint_expiry` | partial index on `ff_waitpoint(expires_at) where state='pending'` |
+| `attempt_timeout` | `ff:idx:{fp:N}:attempt_timeout` | partial index on `ff_attempt(timeout_at)` |
+| `execution_deadline` | `ff:idx:{fp:N}:execution_deadline` | partial index on `ff_execution(deadline_at)` |
+| `all_executions` | `ff:idx:{fp:N}:all_executions` | index on `ff_execution(partition_key)` — SCAN-replacement for cluster mode, trivial on Postgres |
+
+Every `lane_*` key is a Valkey SET/ZSET whose purpose is acting as a
+secondary index the engine can SMEMBERS / ZRANGEBYSCORE without a
+keyspace scan. On Postgres these are all partial indexes; the
+explicit key-as-set disappears.
+
+### 1.3 `FlowKeyContext` — flow-structural keys on `{fp:N}`
+
+| Fn | Key shape | Postgres pattern |
+| --- | --- | --- |
+| `core` | `ff:flow:{fp:N}:<flow_id>:core` | row on `ff_flow` |
+| `members` | `...:members` | index on `ff_flow_member(flow_id, exec_id)` |
+| `tags` | `...:tags` | `ff_flow_tag(flow_id, key, value)` |
+| `member(eid)` | `...:member:<eid>` | row on `ff_flow_member` |
+| `edge(edge_id)` | `...:edge:<edge_id>` | row on `ff_edge` |
+| `outgoing(upstream)` | `...:out:<upstream_eid>` | index on `ff_edge(upstream_eid)` |
+| `incoming(downstream)` | `...:in:<downstream_eid>` | index on `ff_edge(downstream_eid)` |
+| `edgegroup(downstream)` | `...:edgegroup:<downstream_eid>` (RFC-016) | row on `ff_edge_group` |
+| `events` | `...:events` | `ff_flow_event(flow_id, seq, ...)` append table |
+| `summary` | `...:summary` | view / materialized view on flow state |
+| `grant(mutation_id)` | `...:grant:<mutation_id>` | `ff_flow_grant(flow_id, mutation_id)` with TTL |
+| `pending_cancels` | `...:pending_cancels` | `ff_flow_pending_cancel(flow_id, exec_id)` |
+
+### 1.4 `FlowIndexKeys` — flow-partition-local indexes
+
+| Fn | Key shape | Postgres pattern |
+| --- | --- | --- |
+| `flow_index` | `ff:idx:{fp:N}:flow_index` | index on `ff_flow(partition_key)` |
+| `cancel_backlog` | `ff:idx:{fp:N}:cancel_backlog` | partial index on pending-cancel dispatch |
+| `pending_cancel_groups` | `ff:idx:{fp:N}:pending_cancel_groups` | sibling-cancel dispatch queue |
+
+### 1.5 `BudgetKeyContext` — budget-scoped on `{b:M}`
+
+`definition`, `limits`, `usage`, `executions` — maps 1:1 to rows /
+side tables on Postgres (`ff_budget`, `ff_budget_limit`,
+`ff_budget_usage`, `ff_budget_execution`). Free functions
+`budget_attach_key`, `budget_resets_key`, `budget_policies_index`
+are the partition-local attachment + reset-schedule indexes.
+
+### 1.6 `QuotaKeyContext` — quota-scoped on `{q:K}`
+
+`definition`, `window(dim)`, `concurrency`, `admitted(eid)`,
+`admitted_set` — same pattern. Free functions `quota_policies_index`,
+`quota_attach_key`.
+
+### 1.7 Cross-partition + global keys
+
+| Fn | Key shape | Scope | Postgres note |
+| --- | --- | --- | --- |
+| `lane_config_key` | `ff:lane:<lane>:config` | global | `ff_lane(lane_id)` |
+| `lane_counts_key` | `ff:lane:<lane>:counts` | global | materialized stats |
+| `worker_key` | `ff:worker:<wid>` | global | `ff_worker(wid)` |
+| `worker_caps_key` | `ff:worker:<wid>:caps` | global | `ff_worker_capability(wid, cap)` |
+| `workers_index_key` | `ff:idx:workers` | global | index on `ff_worker` |
+| `workers_capability_key(k, v)` | `ff:idx:workers:cap:<k>:<v>` | global | index |
+| `lanes_index_key` | `ff:idx:lanes` | global | index on `ff_lane` |
+| `global_config_partitions` | `ff:config:partitions` | global | `ff_partition_config` singleton |
+| `namespace_executions_key(ns)` | `ff:ns:<ns>:executions` | global | `ff_namespace_execution(ns, exec_id)` cross-partition index |
+| `idempotency_key(tag, ns, k)` | `ff:idem:{fp:N}:<ns>:<k>` | partition-scoped | `ff_create_execution_idem(ns, k, exec_id)` with TTL |
+| `noop_key(tag)` | `ff:noop:{fp:N}` | padding | n/a |
+| `tag_index_key(ns, k, v)` | `ff:tag:<ns>:<k>:<v>` | global | index on exec tags |
+| `waitpoint_key_resolution(tag, wpkey)` | `ff:wpkey:{fp:N}:<key>` | partition | `ff_waitpoint_key(tag, key, wp_id)` |
+| `USAGE_DEDUP_KEY_PREFIX` | `ff:usagededup:` | const | — |
+| `usage_dedup_key(tag, id)` | `ff:usagededup:{b:M}:<id>` | budget-scoped idempotency | `ff_usage_dedup(budget, id)` with TTL |
+
+---
+
+## 2. Partition abstractions
+
+Defined in `crates/ff-core/src/partition.rs`. Split into two buckets:
+
+### 2.1 Generic — keep verbatim for Postgres
+
+- `Partition { family, index }` — routing handle.
+- `PartitionFamily { Flow, Execution, Budget, Quota }` — logical family
+  label. Post-RFC-011 `Execution` is a deliberate alias for `Flow`
+  (same hash tag) retained for cairn-fabric source compat.
+- `PartitionConfig { num_flow_partitions, num_budget_partitions,
+  num_quota_partitions }` — deployment-time fanout config. Reads as
+  "N row-level partitions" on Postgres verbatim.
+- `execution_partition(eid, config)` — decodes the partition out of
+  the `ExecutionId` hash-tag prefix (does NOT re-hash). Transparently
+  works against Postgres: the partition is baked into the id.
+- `flow_partition(fid, config) = crc16(fid) % num_flow_partitions`.
+- `budget_partition`, `quota_partition` — same pattern.
+- `solo_partition` + `SoloPartitioner` trait + `Crc16SoloPartitioner`
+  (RFC-011 §5.6 escape hatch for birthday-paradox traffic amplification).
+
+CRC16-CCITT hashing is a deliberate match with Valkey Cluster's slot
+algorithm, not an inherent Valkey dependency — the function can
+continue to compute Postgres row-partition indexes with zero change.
+
+### 2.2 Valkey-specific — need reinterpretation
+
+- `Partition::hash_tag() -> "{fp:N}"` returns a Valkey cluster hash
+  tag. On Postgres the equivalent surface is a scalar `partition_key`
+  column or a declarative partition name. We can keep the string form
+  and treat it as an opaque partition id (consumers already do —
+  see `PartitionKey`), but the literal `{...}` braces exist purely to
+  bias Valkey's cluster slot computation.
+- `PartitionKey(String)` — the opaque wire form of a `Partition`.
+  Public contract already says "consumers treat as opaque; don't parse
+  hash tags." The contract survives a Postgres migration unchanged as
+  long as we either keep emitting `{fp:N}` literals or bump the opaque
+  shape behind the existing `#[serde(transparent)]` newtype.
+  `PartitionKey::parse` → `Partition` stays generic; only the string
+  shape is Valkey-biased.
+
+Round-trip contract quirk: `Execution` collapses to `Flow` on parse
+because both produce `{fp:N}`. That behaviour is a Valkey hash-tag
+artifact; on Postgres where we have no hash-tag requirement, we could
+keep `Execution` as a distinct family label with its own column value,
+OR leave the collapse in place. Either works; no forcing function.
+
+---
+
+## 3. Trait-method Valkey-isms
+
+The trait (`crates/ff-core/src/engine_backend.rs`) is intentionally
+written to name generic types — `EngineError`, `Handle`, `Frame`,
+`AppendFrameOutcome`, `ExecutionId`, `FlowId`, `Partition`,
+`PartitionKey`. Most signatures do NOT leak Valkey shape. The few
+that do:
+
+- `StreamCursor` (read_stream, tail_stream) — enum over `Start` /
+  `End` / `At(String)` where the string is a Valkey Stream id
+  (`<ms>-<seq>`). See §4.
+- `ReclaimToken { grant: ReclaimGrant }` (claim_from_reclaim) — grant
+  shape originated in the Valkey scanner; newtype-wrapped per §3.3.0
+  so the internal shape can evolve without a trait break.
+- `AppendFrameOutcome { stream_id: String, ... }` — `stream_id` is a
+  Valkey Stream entry id. `Option<u64>` `summary_version` generalises.
+  See §4.
+- `Handle { backend: BackendTag, kind, opaque: HandleOpaque }` —
+  `BackendTag` only has a `Valkey` variant today; `HandleOpaque` is
+  declared backend-private bytes so the migration cost is "add a
+  `BackendTag::Postgres` variant + a new codec". The trait is
+  clean here.
+- `report_usage` takes `UsageDimensions.dedup_key` — stringly-typed
+  but explicitly backend-agnostic (the FCALL-side dedup becomes a
+  Postgres upsert with the same key).
+- `subscribe_completions` / `subscribe_completions_filtered` live on
+  `CompletionBackend`, not `EngineBackend` — §9.
+
+Signature call-outs by method (30 total; feature-gating noted):
+
+| Method | Valkey-ism? | Notes |
+| --- | --- | --- |
+| `claim` | none | returns `Unavailable` today |
+| `renew` | none | borrows `&Handle` |
+| `progress` | none | scalar Hash write |
+| `append_frame` | `AppendFrameOutcome.stream_id: String` | Valkey Stream id leaks through |
+| `complete` | none | `Option<Vec<u8>>` payload |
+| `fail` | none | |
+| `cancel` | none | |
+| `suspend` | none | `SuspendOutcome` generalises |
+| `create_waitpoint` | `PendingWaitpoint.hmac_token: WaitpointHmac` | HMAC shape is `kid:hex`, generic |
+| `observe_signals` | none | |
+| `claim_from_reclaim` | `ReclaimToken` wraps internal `ReclaimGrant` | see §4 |
+| `delay`, `wait_children` | none | |
+| `describe_execution`, `describe_flow` | none (feature `core`) | |
+| `list_edges`, `describe_edge`, `resolve_execution_flow_id` | none (feature `core`) | |
+| `list_flows`, `list_lanes`, `list_suspended`, `list_executions` | `PartitionKey` arg + cursor types | generic on shape |
+| `deliver_signal`, `claim_resumed_execution` | none | |
+| `cancel_flow` | none | |
+| `set_edge_group_policy` | none (feature `core`) | |
+| `report_usage` | none | |
+| `read_stream`, `tail_stream` | `StreamCursor` | Valkey Stream id semantics leak (§4) |
+| `read_summary` | none (feature `streaming`) | |
+
+Round-7 §R7 discussion (engine_backend.rs:82-83) already landed the
+`StreamCursor` + `SummaryDocument` + trigger-surface changes; the
+remaining Valkey-leak is `AppendFrameOutcome.stream_id` + the
+`StreamCursor::At(String)` inner shape. Both are tracked in §4.
+
+Object-safety: asserted via `_assert_dyn_compatible` at
+`engine_backend.rs:630`. All methods are `&self` + `async_trait`;
+the trait is `Send + Sync + 'static`. No Postgres impl work blocked
+on dyn-safety.
+
+---
+
+## 4. Wire types with Valkey shape
+
+### 4.1 `StreamCursor` (contracts/mod.rs:992)
+
+Enum over `Start` / `End` / `At(String)`. `At` carries a raw Valkey
+Stream id (`<ms>` or `<ms>-<seq>`). `to_wire()` lowers to `-` / `+` /
+id for XRANGE/XREAD.
+
+Migration plan sketch: replace `At(String)` with `At(StreamEntryId)`
+where `StreamEntryId` is a backend-agnostic `(ms: u64, seq: u32)` pair.
+Postgres serialises as `bigint, smallint` pair keyed with the stream
+row. Current `At(String)` callers (public SDK) continue to work
+because `StreamEntryId` can `From<&str>`.
+
+### 4.2 `AppendFrameOutcome.stream_id: String`
+
+§R7.5.6 / MD2 deliberately punted a typed `StreamId` newtype. Today's
+string is `<ms>-<seq>`. Same migration path as StreamCursor.
+
+### 4.3 `HandleOpaque` (backend.rs:89)
+
+`Box<[u8]>` — declared backend-private. Valkey codec in
+`ff-backend-valkey::handle_codec`: version tag `0x01`, then
+length-prefixed `execution_id` / `attempt_index` / `attempt_id` /
+`lease_id` / `lease_epoch` / `lease_ttl_ms` / `lane_id` /
+`worker_instance_id`. Postgres backend ships its own codec (different
+fields, different version tag, same `Box<[u8]>` wire); no ff-core
+change needed.
+
+### 4.4 `LeaseId`, `AttemptId`, `SignalId`, `WaitpointId`, `SuspensionId`, `BudgetId`, `QuotaPolicyId`, `EdgeId`
+
+All UUIDv4 newtypes via the `uuid_id!` macro (types.rs:271-338).
+No Valkey bias — direct Postgres `uuid` column.
+
+### 4.5 `ExecutionId`
+
+Bespoke newtype (types.rs:107) — `"{fp:N}:<uuid>"`. The `{fp:N}`
+prefix is a Valkey hash-tag construct that survived into the id
+shape so `execution_partition(&eid, _config)` can decode the
+partition without re-hashing. On Postgres the prefix can stay as
+an opaque id shape (Postgres doesn't care) or the partition can
+become a separate column. Either way `ExecutionId::parse` already
+gates the shape, and existing consumers treat it as opaque.
+
+### 4.6 `FlowId`
+
+UUIDv4 via `uuid_id!` — no bias.
+
+### 4.7 `AttemptIndex(pub u32)`
+
+Scalar — no bias.
+
+### 4.8 `TimestampMs(pub i64)`
+
+Scalar monotonic ms — no bias.
+
+### 4.9 `WaitpointToken`, `WaitpointHmac`
+
+`kid:hex-digest` — HMAC is a crypto primitive, not a Valkey one.
+The `HSET ff:sec:{fp:N}:waitpoint_hmac` replication-per-partition
+lives in `IndexKeys::waitpoint_hmac_secrets` (see §1.2) and is
+Valkey-specific (done for hash-tag colocation). On Postgres a single
+`ff_waitpoint_hmac(kid, secret, previous_kid, ...)` row suffices.
+
+### 4.10 `ReclaimToken` + `ReclaimGrant`
+
+Newtype wrap + opaque `grant_key` field. Stage 0 (§3.3.0) notes the
+grant originated in the Valkey scanner; the newtype makes the internal
+shape swappable without a trait break. Migration: swap `ReclaimGrant`
+internals for whatever the Postgres reclaim path hands back; trait
+signature does not change.
+
+### 4.11 `ClaimGrant` / `ReclaimGrant` DTOs
+
+`partition_key: PartitionKey` on both — opaque string. Migration is
+pass-through.
+
+### 4.12 `PublicFlowState`, `PublicExecutionState`, `ExecutionSnapshot`, `FlowSnapshot`
+
+Contracts; no Valkey leak.
+
+---
+
+## 5. EngineError variants
+
+File: `crates/ff-core/src/engine_error.rs`.
+
+All top-level variants of `EngineError` are backend-agnostic:
+`NotFound { entity }`, `Validation { kind, detail }`, `Contention(..)`,
+`Conflict(..)`, `State(..)`, `Bug(..)`, `Transport { backend, source }`,
+`Unavailable { op }`, `Contextual { source, context }`.
+
+Sub-kind exhaustive review:
+
+### Generic — survive Postgres migration verbatim
+
+- `ValidationKind` (22 variants) — every variant maps to a caller
+  contract violation, none are Valkey-specific.
+- `ContentionKind` (17 variants) — lease / grant / eligibility states;
+  generic.
+- `ConflictKind` (9 variants) — cycle / duplicate / budget-attach;
+  generic.
+- `StateKind` (30 variants) — terminal-state observations; generic.
+  `StreamClosed` / `StaleOwnerCannotAppend` refer to stream semantics
+  but the *concept* is not Valkey-specific.
+- `BugKind::AttemptNotInCreatedState` — generic.
+
+### Valkey-shaped — need generalisation
+
+- `EngineError::Transport { backend: &'static str, source: Box<dyn
+  Error> }` — the variant is backend-agnostic; but today's only
+  populated source is `ff_script::error::ScriptError`, and the
+  downcast helpers in `ff_script::engine_error_ext` are the
+  Valkey-specific path. A Postgres backend needs its own
+  source-error type + downcast helpers, routed through the same
+  variant; `backend: "postgres"`.
+- `BackendError::Valkey { kind, message }` (engine_error.rs:417) — the
+  enum itself is `#[non_exhaustive]` and the rustdoc explicitly
+  anticipates a `Postgres` variant landing additively.
+- `BackendErrorKind` (8 variants: `Transport, Protocol, Timeout, Auth,
+  Cluster, BusyLoading, ScriptNotLoaded, Other`) — all backend-
+  agnostic in name BUT the variant mapping table lives in the Valkey
+  side. `Cluster` (MOVED/ASK/CLUSTERDOWN) and `ScriptNotLoaded`
+  (FUNCTION LOAD required) are Valkey concepts; on Postgres they
+  map to `Other` or a new (additive) variant (`SerializationFailure`
+  for `40001`, `DeadlockDetected` for `40P01`, etc.). The
+  `#[non_exhaustive]` guard + `as_stable_str` mapping make this
+  additive.
+
+### Classification table (`EngineError::class`)
+
+Retryable/Terminal/Cooperative/Informational/Bug classification is
+pure semantics on the typed variant — stays.
+
+Note: `ff-core::engine_error::class()` returns `Terminal` for
+`Transport` by default because ff-core can't downcast the boxed
+source. `ff_script::engine_error_ext::class` is the
+Valkey-aware override. A Postgres sibling (`ff_pg::engine_error_ext`)
+would add the equivalent downcast.
+
+---
+
+## 6. ff-backend-valkey trait-method → FCALL map
+
+`crates/ff-backend-valkey/src/lib.rs`. The `impl EngineBackend for
+ValkeyBackend` block at line 3429 dispatches 30 trait methods to 28
+`_impl` helpers (2 return `Unavailable`). Every `_impl` wraps its
+error with `backend_context(e, "<method>: <action-string>")` so
+operator logs see the call-site label.
+
+| Trait method | Forwarder / kind | FCALL / direct | ff-script wrapper |
+| --- | --- | --- | --- |
+| `claim` | `Err(Unavailable)` | — | — |
+| `renew` | `renew_impl` | FCALL `ff_renew_lease` | none (direct `client.fcall`) |
+| `progress` | `progress_impl` | FCALL `ff_update_progress` | direct |
+| `append_frame` | `append_frame_impl` | FCALL `ff_append_frame` | direct |
+| `complete` | `complete_impl` | FCALL `ff_complete_execution` | direct |
+| `fail` | `fail_impl` | FCALL `ff_fail_execution` + pre-read of `policy` via `client.get` for retry JSON | direct |
+| `cancel` | `cancel_impl` | FCALL `ff_cancel_execution` + pre-read `HGET core.current_waitpoint_id` | direct |
+| `suspend` | `suspend_impl` | FCALL `ff_suspend_execution` | direct (pre-validates args in Rust) |
+| `create_waitpoint` | `create_waitpoint_impl` | FCALL `ff_create_pending_waitpoint` | direct |
+| `observe_signals` | `observe_signals_impl` | **no FCALL** — HGETALL `suspension:current` + HMGET matcher slots + pipelined HGETALL signal + GET payload | direct commands only |
+| `claim_from_reclaim` | `Err(Unavailable)` | — | — |
+| `delay` | `delay_impl` | FCALL `ff_delay_execution` | direct |
+| `wait_children` | `wait_children_impl` | FCALL `ff_move_to_waiting_children` | direct |
+| `describe_execution` | `describe_execution_impl` | HGETALL `exec_core` + HGETALL tags (composite, no FCALL) | direct |
+| `describe_flow` | `describe_flow_impl` | HGETALL `flow_core` (+ read_edge_groups helper) | direct |
+| `list_edges` | `list_edges_impl` | pipeline SMEMBERS adjacency + HGETALL each edge | direct |
+| `describe_edge` | `describe_edge_impl` | HGETALL edge | direct |
+| `resolve_execution_flow_id` | `resolve_execution_flow_id_impl` | HGET `exec_core.flow_id` | direct |
+| `list_flows` | `list_flows_impl` | SMEMBERS `flow_index` + pipelined HGETALL `flow_core` | direct |
+| `list_lanes` | `list_lanes_impl` | SMEMBERS `ff:idx:lanes` | direct |
+| `list_suspended` | `list_suspended_impl` | SCAN / cluster_scan + ZRANGE WITHSCORES (pipeline) + HMGET reason_code (pipeline) | direct + cluster_scan |
+| `list_executions` | `list_executions_impl` | SMEMBERS `all_executions` + client-side sort/filter | direct |
+| `deliver_signal` | `deliver_signal_impl` | FCALL `ff_deliver_signal` | **`ff_script::functions::signal::ff_deliver_signal`** wrapper |
+| `claim_resumed_execution` | `claim_resumed_execution_impl` | FCALL `ff_claim_resumed_execution` | **`ff_script::functions::signal::ff_claim_resumed_execution`** wrapper |
+| `cancel_flow` | `cancel_flow_fcall` | FCALL `ff_cancel_flow` | **`ff_script::functions::flow::ff_cancel_flow`** wrapper |
+| `set_edge_group_policy` | `set_edge_group_policy_impl` | FCALL `ff_set_edge_group_policy` | **`ff_script::functions::flow::ff_set_edge_group_policy`** wrapper |
+| `report_usage` | `report_usage_impl` | FCALL `ff_report_usage_and_check` | direct |
+| `read_stream` (feat streaming) | `read_stream_impl` | XRANGE | **`ff_script::functions::stream::ff_read_attempt_stream`** wrapper |
+| `tail_stream` (feat streaming) | `tail_stream_impl` | XREAD BLOCK via `ff_script::stream_tail::xread_block` on a `duplicate_connection` | ff-script helper |
+| `read_summary` (feat streaming) | `read_summary_impl` | HGETALL summary | direct |
+
+**Thin forwarder count: 18** (every FCALL wrapper: renew, progress,
+append_frame, complete, fail, cancel, suspend, create_waitpoint,
+delay, wait_children, report_usage, deliver_signal,
+claim_resumed_execution, cancel_flow, set_edge_group_policy,
+create_waitpoint, read_stream, tail_stream) — each is ~60 lines of
+"build KEYS+ARGV; fcall; decode via FcallResult::parse". Each is a
+direct Postgres translation candidate: replace FCALL with a
+transaction running the same atomic steps.
+
+**Composite Lua-plus-Rust methods: 10** (observe_signals,
+describe_execution, describe_flow + read_edge_groups, list_edges,
+describe_edge, resolve_execution_flow_id, list_flows, list_lanes,
+list_suspended, list_executions, read_summary). These do pure reads
+without FCALL — they pipeline direct commands against the Hash / SET
+/ ZSET structures. On Postgres every one collapses to a single SELECT
++ optional JOIN; the client-side sort/filter in `list_executions` /
+`list_suspended` goes server-side.
+
+---
+
+## 7. Non-FCALL direct Valkey calls
+
+Grep `client.cmd | client.pipeline | cluster_scan | xread_block |
+duplicate_connection`:
+
+| Line | Call | Site | Cost note |
+| --- | --- | --- | --- |
+| lib.rs:553 | `client.pipeline()` | `describe_execution_impl` | Pipelined HGETALL exec_core + HGETALL tags. Postgres: single SELECT with JOIN. |
+| lib.rs:639 | `client.cluster_scan(&cursor, args)` | `list_suspended_impl` (cluster branch) | Partition-scoped SCAN across `ff:idx:{tag}:lane:*:suspended`. Postgres: SELECT with `partition_key = $1 AND state='suspended'`; no SCAN. |
+| lib.rs:659 | `client.cmd("SCAN")` | `list_suspended_impl` (standalone branch) | Same call replaced by pg query. |
+| lib.rs:689 | `client.pipeline()` | `list_suspended_impl` — pipelined ZRANGE WITHSCORES per lane | Subsumed by single pg SELECT ORDER BY suspend_score. |
+| lib.rs:764 | `client.pipeline()` | `list_suspended_impl` — pipelined HMGET reason_code | Subsumed by the same SELECT (reason_code is a column). |
+| lib.rs:1108 | `client.pipeline()` | `list_flows_impl` — pipelined HGETALL flow_core per id | `SELECT ... FROM ff_flow WHERE partition=$1 AND flow_id > $2 ORDER BY flow_id LIMIT $3+1` (rustdoc already documents this). |
+| lib.rs:1213 | `client.pipeline()` | `list_edges_impl` — pipelined HGETALL edge per id | JOIN on `ff_edge`. |
+| lib.rs:1499 | `client.hgetall(...)` | `load_partition_config` | Config singleton → `SELECT * FROM ff_partition_config LIMIT 1`. |
+| lib.rs:1610 / 1673 / 2034 / 2111 / 2198 / 2322 / 2374 / 2444 / 2543 / 2642 / 3262 | `client.fcall::<ferriskey::Value>(...)` | 11 FCALL sites using direct `fcall()` rather than a typed wrapper (`ff_renew_lease`, `ff_update_progress`, `ff_append_frame`, `ff_create_pending_waitpoint`, `ff_report_usage_and_check`, `ff_delay_execution`, `ff_move_to_waiting_children`, `ff_complete_execution`, `ff_cancel_execution`, `ff_fail_execution`, `ff_suspend_execution`) | Each is a Postgres-translation question: the Lua body becomes a transaction body. |
+| lib.rs:1707 | `client.hgetall(ctx.suspension_current())` | `observe_signals_impl` | `SELECT ... FROM ff_suspension WHERE exec_id=$1`. |
+| lib.rs:1733 | `client.hget(&wp_cond_key, "total_matchers")` | `observe_signals_impl` | Column read on waitpoint row. |
+| lib.rs:1780 | `client.pipeline()` | `observe_signals_impl` — pipelined HGETALL signal + GET payload | JOIN. |
+| lib.rs:2488 | `client.hget(&ctx.core(), "current_waitpoint_id")` | `cancel_impl` pre-read | Column read. |
+| lib.rs:2766 | `client.get(&ctx.policy())` | `fail_impl` pre-read (retry policy JSON) | `SELECT policy FROM ff_execution WHERE id=$1`. |
+| lib.rs:4010 | `client.duplicate_connection()` | `tail_stream_impl` | Opens a per-call Valkey connection for XREAD BLOCK. On Postgres this is either `LISTEN/NOTIFY` on a per-attempt channel OR a long-poll on `ff_stream_frame(exec_id, attempt, seq > $last)` — see §9. |
+| lib.rs:4015 | `ff_script::stream_tail::xread_block(...)` | `tail_stream_impl` | XREAD BLOCK primitive — see §9. |
+| completion.rs:152 / 172 | `client.cmd("HGET").arg(...).arg(...).execute()` | `FilterGate::admits` | Per-push HGET for namespace / tag filter. Postgres: single SELECT. |
+| completion.rs:236 | `client.cmd("SUBSCRIBE").arg(COMPLETION_CHANNEL)` | `subscriber_loop` | RESP3 SUBSCRIBE. See §9 — LISTEN/NOTIFY or logical replication on Postgres. |
+| completion.rs:299-309 | `ClientBuilder ... .push_sender(push_tx) ... .build()` | `build_subscriber_client` | Dedicated RESP3 subscriber client. Parallels the `duplicate_connection` in tail_stream — Postgres pubsub needs its own dedicated connection-per-subscriber pattern (LISTEN holds a lock on the connection). |
+
+Total non-FCALL direct call sites: **13** primary (excluding the 11
+`client.fcall` invocations which are FCALLs, just using direct
+dispatch rather than typed wrappers).
+
+---
+
+## 8. Handle codec + CompletionBackend — depth dive
+
+### 8.1 `handle_codec.rs`
+
+**Purpose:** encode the Valkey attempt-cookie as bytes so
+`ff-sdk::ClaimedTask::synth_handle` can round-trip a handle on every
+op without refactoring its own struct (RFC-012 Stage 1b option A).
+
+**Wire layout** (version-tagged, crate-private):
+
+```
+[0]       u8    version tag = 0x01
+[1..5]    u32   execution_id len (LE)
+[5..]     utf8  execution_id string ({fp:N}:<uuid>)
+[..+4]    u32   attempt_index
+[..+4]    u32   attempt_id len; utf8 attempt_id
+[..+4]    u32   lease_id len; utf8 lease_id
+[..+8]    u64   lease_epoch
+[..+8]    u64   lease_ttl_ms
+[..+4]    u32   lane_id len; utf8 lane_id
+[..+4]    u32   worker_instance_id len; utf8 worker_instance_id
+```
+
+`HandleOpaque` is declared backend-private in ff-core; the codec lives
+entirely in ff-backend-valkey. A future Postgres backend ships its own
+codec under a `BackendTag::Postgres` variant — same `HandleOpaque`
+wire, different version tag, different field set (likely omits
+`lease_ttl_ms` if leases are SQL-native). No ff-core change.
+
+The fields the Valkey codec encodes are the minimum to reconstruct
+FCALL ARGV on every op: execution id, attempt identity, lease fence
+triple (id / epoch / ttl), worker identity, lane for metrics labels.
+The Postgres backend's field set is a design question, not a
+compatibility question.
+
+### 8.2 `completion.rs` — CompletionBackend + RESP3 subscriber
+
+**Purpose:** implement `ff_core::completion_backend::CompletionBackend`
+for `ValkeyBackend`. Opens a dedicated RESP3 subscriber, issues
+`SUBSCRIBE ff:dag:completions`, parses push frames, and forwards
+`CompletionPayload` (exec_id, outcome, produced_at_ms, flow_id) to a
+bounded `mpsc` that the consumer reads as a `Stream`.
+
+The Valkey-specific surface:
+
+- **Dedicated subscriber connection** (`ValkeyConnection` on the
+  `ValkeyBackend`; built via `ClientBuilder::new().protocol(RESP3)
+  .push_sender(tx).host(...).cluster().tls().build()`). RESP3 is
+  required because RESP2 would block the main multiplexed connection.
+- **Channel name** `"ff:dag:completions"` — a single global channel.
+  Lua emitters on `ff_complete_execution` / `ff_fail_execution` /
+  `ff_cancel_execution` PUBLISH to it.
+- **Push decoding** — matches on `PushKind::Message`, verifies the
+  channel literal, parses the payload as JSON `{execution_id,
+  flow_id, outcome}`.
+- **Backpressure** — STREAM_CAPACITY=1024 bounded mpsc; send awaits.
+- **Filter gate** (issue #122) — post-parse HGET against `exec_core`
+  (namespace) + exec-tags hash (instance_tag); non-admit drops.
+  Cross-tenant isolation for deployments that share a keyspace.
+- **Reconnect loop** — 1s backoff on build/SUBSCRIBE failure. The
+  `dependency_reconciler` safety net covers any completions dropped
+  while disconnected.
+
+**Postgres translation question:** the pure pubsub primitive is a
+named topic with multi-subscriber fan-out, at-most-once delivery,
+tolerant of drops because a reconciler backs it up. Three Postgres
+design candidates (not proposing any — flagging the trade-off per
+worker-D's consolidation):
+
+1. **LISTEN/NOTIFY** — closest structural match. A dedicated
+   subscriber connection per consumer. NOTIFY payload capped at 8000
+   bytes (sufficient for the current wire shape of ~200 bytes). No
+   durability; matches the "reconciler backs it up" contract.
+2. **Logical replication / `pg_recvlogical`** — durable; overkill for
+   the current drop-tolerant contract but adds at-least-once for
+   free.
+3. **Polling a `ff_completion_event(seq BIGSERIAL, ...)` table** with
+   `WHERE seq > $last` — simplest; adds lag. Matches how the
+   reconciler already walks Valkey state today.
+
+The `FilterGate` HGETs survive any choice — they're cheap single-row
+SELECTs on Postgres.
+
+---
+
+## 9. Cross-cutting Postgres-translation questions
+
+### 9.1 Stream cursor shape
+
+`StreamCursor::At(String)` carries `<ms>-<seq>`. Postgres backend has
+no native stream; ff_stream_frame becomes a table, cursor becomes
+either a monotonic `(seq_ms, seq_subseq)` pair or a single `bigserial`.
+SDK compat: keep `At(String)` + add a typed constructor; internal
+shape swappable.
+
+### 9.2 Pubsub model
+
+See §8.2. LISTEN/NOTIFY vs polling trade-off; the `CompletionBackend`
+trait is already pubsub-shaped (`async fn subscribe_completions() ->
+CompletionStream`) so either implementation honours the trait.
+
+### 9.3 XREAD BLOCK / `tail_stream`
+
+`tail_stream_impl` opens a dedicated connection (`duplicate_connection`)
+and calls `xread_block` with a `block_ms`. On Postgres:
+LISTEN/NOTIFY + stream-frame INSERT (pushes notification) is the
+analogue; or a polling loop with 100ms tick until `block_ms` elapses
+or new rows appear.
+
+### 9.4 Cluster-mode SCAN replacement
+
+The 11 index keys in ff:idx:*:{…} (§1.2, §1.4) exist to replace
+keyspace SCAN in cluster mode. On Postgres they collapse to partial
+indexes; the explicit SETs/ZSETs can disappear (or stay as cache
+tables if we want symmetric multi-backend projectors).
+
+### 9.5 Hash-tag colocation → row partitioning
+
+Every `{fp:N}` / `{b:M}` / `{q:K}` key is a Valkey cluster-slot
+biasing mechanism. On Postgres the equivalent is declarative row-
+level `PARTITION BY HASH(partition_key) PARTITIONS N` with N matching
+`num_flow_partitions` / budget / quota counts. The
+`PartitionConfig::default() = 256 / 32 / 32` stays meaningful —
+it's the row-partition count.
+
+### 9.6 Atomicity contract (RFC-012 §3.4)
+
+"Per-op state transitions MUST be atomic." On Valkey this is single-
+FCALL; on Postgres it's single-transaction. The 16 FCALL-backed
+methods each become a single transaction (some reading across
+multiple partitions — flow + exec + stream — which is fine on
+Postgres, not-fine on Valkey Cluster; that's why we colocated). The
+reverse is trivially easier on Postgres.
+
+### 9.7 HMAC secret replication
+
+`IndexKeys::waitpoint_hmac_secrets` is replicated per partition on
+Valkey because every FCALL that mints/validates a waitpoint token
+needs the secret co-located with its KEYS. Postgres: single
+`ff_waitpoint_hmac` row read via `SELECT` — no replication needed.
+
+### 9.8 FCALL error → EngineError mapping
+
+Today's `From<ScriptError> for EngineError` (in ff-script) decodes the
+Lua error string into a typed variant. Postgres: SQLSTATE codes map
+to variants (`40001` → `Contention`, `23505` → `Conflict`, etc.).
+The `#[non_exhaustive]` guards on every sub-kind make the mapping
+table additive. One new helper module per backend
+(`ff-backend-postgres::engine_error_ext`) matching the shape of
+`ff_script::engine_error_ext`.
+
+### 9.9 Dedicated subscriber connection pattern
+
+Both `subscribe_completions` (RESP3) and `tail_stream`
+(`duplicate_connection`) rely on a Valkey-specific per-call dedicated
+connection. Postgres LISTEN holds a connection; the pattern survives
+with identical cost characteristics (one subscribed connection per
+consumer).
+
+### 9.10 Open: `claim` + `claim_from_reclaim` implementations
+
+Today both return `EngineError::Unavailable`; fresh-work claim and
+reclaim-based claim are served through SDK paths that pre-date the
+trait. Migration to Postgres depends on first landing Valkey impls
+for them (RFC-012 Stage 1d continuation) so the trait shape is
+validated under a working Valkey path before a second backend lands.
+Call-out, not design.

--- a/rfcs/drafts/v0.7-migration-survey-engine.md
+++ b/rfcs/drafts/v0.7-migration-survey-engine.md
@@ -1,0 +1,433 @@
+# v0.7 migration survey — ff-engine + ff-scheduler + ff-server (Worker-C)
+
+Scope: `crates/ff-engine`, `crates/ff-scheduler`, `crates/ff-server`.
+Branch: `docs/v0.7-migration-survey-engine`. Base: `main` @ `bc17872`.
+Read-only survey for the v0.7 Postgres-backend migration. Worker-D
+consolidates.
+
+Call-site line numbers are approximate and reference the named file. No
+line-level rewrites are proposed here — this is a mapping, not a plan.
+
+---
+
+## 1. Scanner inventory
+
+All scanners are registered in `crates/ff-engine/src/lib.rs::start_internal`
+(`EngineConfig` surfaces all 17 intervals). Every scanner implements the
+`Scanner` trait (`scanner/mod.rs`) and is driven by `ScannerRunner::spawn`,
+which:
+
+- Loops `0..num_partitions`, calls `scan_partition` per partition.
+- Optionally samples `sample_backlog_depth` (override only on
+  `cancel_reconciler`) for a gauge.
+- Records per-cycle latency into `ff_observability::Metrics`.
+- Sleeps `max(interval, 100ms).saturating_sub(elapsed)`; shutdown via
+  `watch` channel.
+- `supervisor::supervised_spawn` wraps with panic restart (+backoff).
+
+A per-candidate `ScannerFilter` (from `ff-core`) short-circuits
+cross-tenant candidates. The helper `scanner/mod.rs::should_skip_candidate`
+issues 0–2 HGETs per candidate against `ff:exec:{fp:N}:{fp:N}:<uuid>:core`
+or `…:tags` to match namespace / instance_tag. All ten execution-shaped
+scanners apply it; the four non-execution ones (budget_reconciler,
+budget_reset, quota_reconciler, flow_projector) accept it for API
+uniformity but do not apply.
+
+### 1.1 Per-scanner table
+
+| # | Scanner | Default | Family / partitions | Key pattern scanned | Action on hit | Migration notes |
+|---|---|---|---|---|---|---|
+| 1 | `lease_expiry` | 1.5s | Execution `{p:N}` × num_flow | `ZRANGEBYSCORE ff:idx:{p:N}:lease_expiry -inf now LIMIT 0 batch` | `FCALL ff_mark_lease_expired_if_due`; `TIME` for clock | Classic due-zset scan — replace with SQL `SELECT … WHERE expires_at<=now() FOR UPDATE SKIP LOCKED`; Lua→SQL function |
+| 2 | `delayed_promoter` | 750ms | Execution × lane | `ZRANGEBYSCORE ff:idx:{p:N}:lane:<lane>:delayed` | `FCALL ff_promote_delayed` | Same pattern; lane is column, partition is column |
+| 3 | `attempt_timeout` | 2s | Execution × lane | `ZRANGEBYSCORE ff:idx:{p:N}:attempt_timeout`; `HMGET` attempt fields | `FCALL ff_expire_execution` | Lifecycle multi-state transition — SQL CTE |
+| 4 | `execution_deadline` | 5s | Execution × lane | `ZRANGEBYSCORE ff:idx:{p:N}:execution_deadline` | `FCALL ff_expire_execution` | Same shape as attempt_timeout; separate index |
+| 5 | `suspension_timeout` | 2s | Execution | `ZRANGEBYSCORE ff:idx:{p:N}:suspension_timeout`; multiple `HGET` for policy | `FCALL ff_expire_suspension` | Suspension policy branching already split from timeout index |
+| 6 | `pending_wp_expiry` | 5s | Execution | `ZRANGEBYSCORE ff:idx:{p:N}:pending_waitpoint_expiry`; `HGET` owner | `FCALL ff_close_waitpoint` | Waitpoint table will get a partial index on `expires_at` |
+| 7 | `retention_trimmer` | 60s | Execution × lane | `ZRANGEBYSCORE ff:idx:{p:N}:lane:<lane>:terminal`; `HMGET`, `SMEMBERS`, `ZRANGE`, per-object `DEL`, `ZREM`, `SREM` | Direct Rust cascading delete — no FCALL | Rust-only scanner; biggest multi-key cascade → candidate for SQL `DELETE … CASCADE` + TTL partitions |
+| 8 | `index_reconciler` | 45s | Execution | `SSCAN ff:idx:{p:N}:all_executions`; `HMGET` fields; `ZSCORE` expected index | Log-only today (Phase 1) | SQL table integrity checks are redundant; could be deprecated on Postgres |
+| 9 | `budget_reset` | 15s | Budget `{b:M}` × num_budget | `ZRANGEBYSCORE ff:idx:{b:M}:budget_resets` | `FCALL ff_reset_budget` | Periodic recompute over budgets table |
+| 10 | `budget_reconciler` | 30s | Budget | `SSCAN ff:idx:{b:M}:all_budgets`; `HGETALL` limits+usage; `SREM`, `HSET`, `HDEL` | Rust reconciliation against execution summaries | Drift correction exists because counter writes aren't atomic with lease acquire across partitions — **SQL-native scope: eliminable under single-transaction lease** |
+| 11 | `quota_reconciler` | 30s | Quota `{q:K}` × num_quota | `SMEMBERS`/`SSCAN` admitted sets; `HGET` cap, `ZREMRANGEBYSCORE` sliding window, `EXISTS` guard, `SET` drift markers | Drift clean-up on concurrency counters | Same story as budget reconciler — mostly eliminable |
+| 12 | `unblock` | 5s | Execution × lane | `ZRANGEBYSCORE ff:idx:{p:N}:lane:<lane>:blocked:{budget,quota,route}`; `HGET blocking_reason`; `SSCAN ff:idx:workers` union + fan-out `GET ff:worker:*:caps` once per cycle | `FCALL ff_unblock_execution` per cleared | Worker-caps-union sweep (~100 GETs) is a `waiting_for_capable_worker` retry. On Postgres: WHERE cap_set ⊆ worker_caps in SQL |
+| 13 | `dependency_reconciler` | 15s | Execution × lane | `ZRANGEBYSCORE ff:idx:{p:N}:lane:<lane>:blocked:deps`; `SMEMBERS deps_unresolved`; per-upstream `HGET` terminal_outcome cross-partition | `FCALL ff_resolve_dependency` | Safety net — the primary promotion path is push via `completion_listener` (§2.2). On Postgres: LISTEN/NOTIFY + SELECT for missed messages |
+| 14 | `flow_projector` | 15s | Flow `{fp:N}` × num_flow | `SSCAN ff:idx:{fp:N}:flow_index`; per-flow `SCARD`, `SRANDMEMBER` members, `HGET public_state` cross-partition, `HSET` summary, `SREM` stale | Projected aggregate — writes `:summary.public_flow_state` only | Natural fit for a materialized view or incremental aggregate |
+| 15 | `cancel_reconciler` | 15s | Flow | `ZCARD`, `ZRANGEBYSCORE cancel_backlog`; per-flow `EXISTS`, `DEL`, `ZREM`, `SRANDMEMBER pending_cancels`, `HGET cancel_reason`, `SREM` member, `FCALL ff_cancel_execution`, `FCALL ff_ack_cancel_member` | Grace-window drain of `cancel_flow` member fan-out | Exports backlog-depth gauge via `sample_backlog_depth` — only scanner to do so |
+| 16 | `edge_cancel_dispatcher` (RFC-016 Stage C) | 1s | Flow | `SRANDMEMBER ff:idx:{fp:N}:pending_cancel_groups`; `HMGET` edgegroup fields; per-sibling `FCALL ff_cancel_execution`; `FCALL ff_drain_sibling_cancel_group` | Sibling-quorum cancel fan-out | p99 ≤ 500ms SLO (RFC-016 §4.2) — sensitive to Postgres LISTEN latency |
+| 17 | `edge_cancel_reconciler` (RFC-016 Stage D) | 10s | Flow | `SRANDMEMBER pending_cancel_groups`; `FCALL ff_reconcile_sibling_cancel_group` | Crash-recovery safety net for #16 | Same shape as #16 but slower cadence |
+
+**Total: 17 scanners + 1 completion dispatch loop** (plumbed via
+`start_with_completions`).
+
+### 1.2 Cross-cutting scanner observations
+
+- **Universal pattern**: due-ZSET scan (`ZRANGEBYSCORE -inf now LIMIT 0
+  N`) → candidate loop → atomic Lua FCALL → next cycle. Maps cleanly to
+  `SELECT … WHERE <ts> <= now() ORDER BY <ts> LIMIT n FOR UPDATE SKIP
+  LOCKED` + a stored function.
+- **Per-partition isolation**: every key is single-tagged `{p:N}`/
+  `{b:M}`/`{q:K}`/`{fp:N}` and the scanner runner walks partitions
+  sequentially. A partition maps cleanly to a SQL row-set filtered by a
+  `partition` column; the runner's per-partition loop becomes unnecessary
+  on Postgres (index on `(partition, ts)` suffices).
+- **Failure tracker** (`scanner/mod.rs::FailureTracker`): process-local,
+  backend-agnostic. No migration change.
+- **`sample_backlog_depth`**: only `cancel_reconciler` overrides today —
+  feeds `ff_cancel_backlog_depth` gauge. Backend-agnostic trait hook.
+- **Rust-only scanner**: `retention_trimmer` is the only scanner that
+  issues direct multi-key mutations (`DEL`/`ZREM`/`SREM`) without an
+  FCALL. It's also the deepest cascade — every other scanner is a scan +
+  single FCALL. Biggest surface for a straight SQL `DELETE` rewrite.
+
+---
+
+## 2. Partition router + completion listener
+
+Both live at the tightest Valkey coupling in `ff-engine`.
+
+### 2.1 `partition_router.rs`
+
+- `PartitionRouter` is a thin wrapper around `PartitionConfig` from
+  `ff-core`. Its `partition_for(eid)` delegates to
+  `ff_core::partition::execution_partition`, which post-RFC-011 returns
+  the parent flow's partition (exec keys co-locate with flow). The
+  router does **not** carry a connection — a single `ferriskey::Client`
+  is shared across all partitions and relies on the ferriskey cluster
+  driver's transparent slot routing via the `{p:N}` / `{fp:N}` hash
+  tags baked into every key.
+- The heavy method `dispatch_dependency_resolution` (called inline by
+  `completion_listener` and by `ff_server::cancel_flow`) per-downstream:
+  1. `HGET exec_core terminal_outcome`
+  2. Parse `flow_id` → `FlowKeyContext` on `{fp:N}`
+  3. `SMEMBERS` of outgoing adjacency
+  4. Per edge: `HGET edge downstream_execution_id`, `HGET exec_core
+     lane_id`, `HGET exec_core current_attempt_index`
+  5. `FCALL ff_resolve_dependency` with 14 KEYS + 5 ARGV across the
+     child's `{p:N}` partition, the child's flow `{fp:N}`, and the
+     upstream's result co-located via flow membership.
+  6. Cascade recursion when result slot 3 is `child_skipped` (capped at
+     `MAX_CASCADE_DEPTH = 50`).
+- **Migration cost**: 14-key atomic Lua → single-statement SQL stored
+  procedure. The shape (KEYS/ARGV layered by RFC-016 Stage A/C) maps to a
+  stored-proc parameter list; hash-tag invariants disappear under a
+  single DB. The cascade loop stays as-is (Rust-side recursion).
+- **Hash-tag invariant**: `exec_keys` + `index_keys` construct
+  `ExecKeyContext` / `IndexKeys` from `Partition` structs. On Postgres
+  the "hash tag" degenerates to a `partition_id` column; the
+  `ff_core::keys::*` key-builder surface stays but its consumers
+  shouldn't need per-key strings.
+
+### 2.2 `completion_listener.rs`
+
+- **Already backend-agnostic.** Consumes a `CompletionStream` (alias for
+  `Pin<Box<dyn Stream<Item=CompletionPayload> + Send + Unpin>>`) from
+  `ff_core::completion_backend::CompletionBackend`. The Valkey subscription
+  machinery lives in `ff-backend-valkey`; the engine sees only
+  `CompletionPayload`s.
+- `spawn_dispatch_loop` (a) drains the stream, (b) spawns a task per
+  completion calling `dispatch_dependency_resolution` (Valkey-coupled —
+  see §2.1), (c) exits on `watch` shutdown or stream-end.
+- The module docstring explicitly calls out Postgres: a future backend
+  "would implement it over LISTEN/NOTIFY."
+- **Migration gap**: the stream contract is clean, but
+  `handle_completion` ultimately fires a Valkey-coupled FCALL via the
+  router. The seam needs a backend-agnostic "resolve dependency" method
+  on `CompletionBackend` (or a peer trait) so a Postgres build can
+  execute the resolution inside the same DB that produced the NOTIFY —
+  otherwise the push path still routes through ferriskey.
+- **Fan-out semantics**: module notes that in Valkey Cluster a single
+  PUBLISH fans out to every node, so every ff-server in a fleet receives
+  every completion (dedup-free, idempotent FCALL). Postgres LISTEN/NOTIFY
+  broadcasts to every listener on the same channel — same semantics, no
+  change needed.
+- **Partitioned pubsub**: module also notes a fallback to sharded
+  `SPUBLISH`/`SSUBSCRIBE` keyed by flow partition if contention surfaces.
+  Deferred on Valkey, not needed on Postgres.
+
+---
+
+## 3. Scheduler claim-grant pipeline
+
+`crates/ff-scheduler/src/claim.rs::Scheduler::claim_for_worker` — one
+method, ~450 lines, end-to-end.
+
+### 3.1 Step-by-step
+
+1. **Clock snap**: `TIME` on Valkey (L555) for rotation cursor + block
+   timestamps. Migration: `NOW()`.
+2. **Rotation cursor** (L568): advance a packed atomic every
+   `rotation_window_ms`; per-worker FNV jitter via
+   `ff_core::hash::fnv1a_u16_mod(worker_instance_id, num_partitions)`
+   (pure Rust).
+3. **Capability CSV validation** (L497-541): local Rust — ingress
+   validation only.
+4. **Bounded partition walk** (`iter_partitions`, L591): probe at most
+   `max_partitions_per_scan` (default 32 of 256). Per partition:
+   1. `ZRANGEBYSCORE ff:idx:{p:N}:lane:<lane>:eligible -inf +inf LIMIT
+      0 1` (L602). Lowest score = highest priority.
+   2. `HGET exec_core required_capabilities` (L676) — Rust-side caps
+      subset pre-check to avoid a cross-slot quota-admission write
+      storm on unmatchable top-of-zset.
+   3. **Budget pre-check** (`check_budgets`, L884):
+      - `HGET exec_core budget_ids` (L894). Empty ⇒ skip.
+      - Per budget: `BudgetChecker::check_budget` (L110) reads
+        `ff:budget:{b:M}:<id>:limits` via `hgetall`, then per-dimension
+        `HGET ff:budget:{b:M}:<id>:usage <dim>`. Cached per cycle —
+        MANDATORY (50K blocked candidates sharing a budget ⇒ 1 read,
+        not 50K).
+      - Breach ⇒ `block_candidate` fires
+        `FCALL ff_block_execution_for_admission` against
+        `blocked:budget` index.
+   4. **Quota pre-check** (`check_quota`, L928):
+      - `HGET exec_core quota_policy_id` (L937).
+      - 4× `HGET` of rate/window/concurrency/jitter from
+        `ff:quota:{q:K}:<id>`.
+      - `FCALL ff_check_admission_and_record` on 5 `{q:K}` keys: window
+        ZSET (sliding), concurrency counter, policy hash, per-eid
+        admission marker, admitted_set. Parses `ADMITTED` /
+        `RATE_EXCEEDED` / `CONCURRENCY_EXCEEDED` / `ALREADY_ADMITTED`.
+        Fail-closed on unknown status.
+   5. **Grant issuance** (L771): `FCALL ff_issue_claim_grant` with 3
+      KEYS (exec_core, claim_grant, eligible_zset) + 9 ARGV (eid,
+      worker_id, worker_instance_id, lane, capability_hash, ttl_ms,
+      route_snapshot_json, admission_summary, worker_caps_csv sorted).
+   6. On Lua reject: `CapabilityMismatch` ⇒ re-block (narrow race with
+      #4.ii); anything else ⇒ release admission via
+      `FCALL ff_release_admission` (L1177, parses FcallResult properly
+      since #88 rename).
+
+### 3.2 Migration mapping
+
+| Step | Valkey primitive | Postgres equivalent |
+|------|---|---|
+| Clock | `TIME` | `CURRENT_TIMESTAMP` |
+| Rotation cursor | Atomic u64, FNV jitter | Unchanged (Rust-local) |
+| Eligible-set pick | `ZRANGEBYSCORE … LIMIT 0 1` per partition | `SELECT … WHERE lane=? ORDER BY priority LIMIT 1 FOR UPDATE SKIP LOCKED`, partition column indexed |
+| Capability pre-check | `HGET required_capabilities` | Column select (or `caps @> required_caps` via GIN) |
+| Budget check | `HGETALL limits` + per-dim `HGET` | `SELECT … FROM budget_limits JOIN budget_usage ON …` single query |
+| Quota admission | 5-KEY Lua on `{q:K}` | Single stored proc with row-lock on quota row + sliding-window table |
+| Grant issuance | `FCALL ff_issue_claim_grant` | Stored proc: update exec row to `claimed`, insert grant, delete from eligible index — one transaction |
+| Block / release | `FCALL ff_block_execution_for_admission` / `ff_release_admission` | Stored procs |
+
+**Capability matching**: today a CSV-subset check (Rust short-circuit
+via `caps_subset`, authoritative Lua `missing_capabilities` in
+`scheduling.lua`). On Postgres a GIN index over `required_capabilities
+text[]` with `worker_caps @> required_capabilities` is an O(log n) SQL
+WHERE — RFC-009 §7.5 already flags this as a candidate transformation.
+
+**Admission control** is the densest Lua surface: 5-key Stage D
+(`ff_check_admission_and_record`) and the 3-key release path. Both
+compose into a single row-locked SELECT + UPDATE on Postgres.
+
+**Grant signing + redemption**: the wire-level `ClaimGrant` /
+`ReclaimGrant` structs live in `ff-core::contracts` (re-exported here at
+L51–60). HMAC signing + expiry are handled in the `ff_issue_claim_grant`
+Lua and redeemed by `ff-sdk::claim_from_grant` / `claim_from_reclaim_grant`
+(both public pre-session per the cairn-blocking archived notes). The
+HMAC secret lives in `ff:exec:{fp:N}:{fp:N}:…:hmac_secrets` per
+partition (installed at boot — see §4). Migration note: secret hash per
+partition generalizes to a single `waitpoint_secrets` table
+keyed by `(kid)` when partitions collapse; the FCALL signs on the server
+so no rework on the SDK side.
+
+---
+
+## 4. ff-server boot sequence
+
+`crates/ff-server/src/server.rs::Server::start_with_metrics` (L362):
+
+| # | Step | Valkey-specific? | Notes |
+|---|---|---|---|
+| 1 | `ClientBuilder::new().host(…).tls().cluster().build()` → PING | **Yes** | ferriskey connection; generalize via a backend connection trait |
+| 1b | `verify_valkey_version` — INFO parse, requires `valkey_version ≥ 8.0`; 60s rolling-upgrade budget | **Yes** | Drops entirely on Postgres |
+| 2 | `validate_or_create_partition_config` — `HGETALL ff:config:partitions` or 3× `HSET` on first boot | **Yes** | Becomes a `partition_config` table row + RFC-011 mismatch guard |
+| 2b | `initialize_waitpoint_hmac_secret` — per-partition `HGET kid`, atomic HSET install on fresh; 16-way parallel across 256 partitions; classifies each as Match/Mismatch/Repaired/Installed (RFC-004 §Waitpoint Security) | **Yes** | Collapses to one secrets table on Postgres; per-partition install is a Valkey artefact |
+| 3 | `ff_script::loader::ensure_library` — FUNCTION LOAD; skippable via `skip_library_load` for tests | **Yes, entirely** | Lua is Valkey-only. Postgres equivalent: ensure `flowfabric` schema + stored procs installed via migration |
+| 3b | `SADD ff:idx:lanes <lanes>` — global non-hash-tagged SET | **Yes** | Lanes table on Postgres |
+| 4 | Build `ValkeyBackend` + `subscribe_completions` → `CompletionStream` → `Engine::start_with_completions` | Mostly | The engine side is backend-agnostic; the subscribe is Valkey. Swap for a `PostgresBackend` implementing `CompletionBackend` |
+| 5 | Build dedicated tail `ClientBuilder` (PING); `stream_semaphore` (max concurrent stream ops); `xread_block_lock` Mutex | **Yes** | XREAD BLOCK / HMGET stream_meta — Postgres equivalent is LISTEN on a `stream_write` channel |
+| 6 | `admin_rotate_semaphore = Semaphore(1)` | No | Local concurrency gate |
+| 7 | Log missing `FF_API_TOKEN` warning, log partition counts | No | |
+| 8 | `Scheduler::with_metrics(client, partition_config, metrics)` | No | Scheduler opens no new connection; reuses main client |
+
+**Valkey-specific boot steps**: 1, 1b, 2 (key shape), 2b, 3, 3b, 4
+(subscribe wire work), 5. Everything else generalizes.
+
+---
+
+## 5. HTTP routes → backend map
+
+Router built in `api.rs::router_with_metrics` (L350). `/metrics`
+(observability feature on) is merged as a separate Router with its own
+`State<Arc<Metrics>>` so scrapes bypass the Bearer auth middleware.
+
+Route count: **30 app routes + `/metrics` + `/healthz`** (32 endpoints).
+Every route maps to a method on `Server` (see `server.rs`); the handlers
+in `api.rs` are thin type-conversion wrappers. Only one direct Valkey
+call exists in `api.rs` — `healthz` issues `PING` at L1298.
+
+### 5.1 Full route table
+
+| Route | Method | Handler | `Server::` method | Backend surface |
+|---|---|---|---|---|
+| `/v1/executions` | GET | `list_executions` | `list_executions_page` | SSCAN/ZRANGE on exec index; cursor-based |
+| `/v1/executions` | POST | `create_execution` | `create_execution` | `FCALL ff_create_execution` |
+| `/v1/executions/{id}` | GET | `get_execution` | `get_execution` | HGET exec_core |
+| `/v1/executions/{id}/state` | GET | `get_execution_state` | `get_execution_state` | HGET public_state |
+| `/v1/executions/{id}/pending-waitpoints` | GET | `list_pending_waitpoints` | — | HMGET waitpoint fields (HMAC tokens returned) |
+| `/v1/executions/{id}/result` | GET | `get_execution_result` | — | GET payload blob |
+| `/v1/executions/{id}/cancel` | POST | `cancel_execution` | — | `FCALL ff_cancel_execution` |
+| `/v1/executions/{id}/signal` | POST | `deliver_signal` | — | `FCALL ff_deliver_signal` |
+| `/v1/executions/{id}/priority` | PUT | `change_priority` | — | `FCALL ff_change_priority` |
+| `/v1/executions/{id}/replay` | POST | `replay_execution` | — | `FCALL ff_replay_execution` |
+| `/v1/executions/{id}/revoke-lease` | POST | `revoke_lease` | — | `FCALL ff_revoke_lease` |
+| `/v1/workers/{worker_id}/claim` | POST | `claim_for_worker` | `scheduler.claim_for_worker` | See §3 |
+| `/v1/executions/{id}/attempts/{idx}/stream` | GET | `read_attempt_stream` | — | XREAD on tail_client |
+| `/v1/executions/{id}/attempts/{idx}/stream/tail` | GET | `tail_attempt_stream` | — | XREAD BLOCK on tail_client |
+| `/v1/flows` | POST | `create_flow` | — | `FCALL ff_create_flow` |
+| `/v1/flows/{id}/members` | POST | `add_execution_to_flow` | — | `FCALL ff_add_execution_to_flow` |
+| `/v1/flows/{id}/cancel` | POST | `cancel_flow` | — | `FCALL ff_cancel_flow` + async member fan-out |
+| `/v1/flows/{id}/edges` | POST | `stage_dependency_edge` | — | `FCALL ff_stage_dependency_edge` |
+| `/v1/flows/{id}/edges/apply` | POST | `apply_dependency_to_child` | — | `FCALL ff_apply_dependency_to_child` |
+| `/v1/budgets` | POST | `create_budget` | — | `FCALL ff_create_budget` |
+| `/v1/budgets/{id}` | GET | `get_budget_status` | — | HGETALL usage+limits |
+| `/v1/budgets/{id}/usage` | POST | `report_usage` | — | `FCALL ff_report_usage` |
+| `/v1/budgets/{id}/reset` | POST | `reset_budget` | — | `FCALL ff_reset_budget` |
+| `/v1/quotas` | POST | `create_quota_policy` | — | `FCALL ff_create_quota_policy` |
+| `/v1/admin/rotate-waitpoint-secret` | POST | `rotate_waitpoint_secret` | — | Per-partition HSET fanout; single-permit semaphore |
+| `/healthz` | GET | `healthz` | — | `client.cmd("PING")` (only direct Valkey call in api.rs) |
+| `/metrics` | GET | `metrics::metrics_handler` | — | Pure Rust (OTEL render) |
+
+### 5.2 Direct-Valkey bypasses
+
+- Essentially none in `api.rs`; the only bypass is `PING` in `healthz`
+  (L1298), which is appropriate — a backend-agnostic `Backend::ping()`
+  is trivial.
+- **All Valkey call-sites concentrate in `server.rs`**: 23
+  `cmd`/`fcall`/`hgetall` occurrences. Plus the three supporting crates
+  (`ff-engine` scanners, `ff-scheduler` claim loop, `ff-backend-valkey`
+  subscribe). `api.rs` is already a clean HTTP-only layer.
+- **Structural implication for v0.7**: the HTTP-to-backend seam is
+  `Server::<method>()`. Every method in `server.rs` is a candidate for
+  backend-trait abstraction; today they hold raw ferriskey calls inline.
+
+---
+
+## 6. Admin + observability
+
+### 6.1 Admin surface
+
+- HTTP: **`/v1/admin/rotate-waitpoint-secret`** (POST) is the only
+  runtime admin route. Auth via global Bearer middleware (only installed
+  when `FF_API_TOKEN` is set). Guarded by `admin_rotate_semaphore`
+  (single permit server-wide). Implementation in `server.rs` fans out
+  HSET to every `{p:N}` partition's `waitpoint_hmac_secrets` hash —
+  **Valkey-specific write path, not via the backend trait**.
+- CLI: **`ff-server admin partition-collisions`** (entry point in
+  `main.rs` → `admin.rs::PartitionCollisionsReport`). Pure computation
+  over lanes + `PartitionConfig`; no Valkey connection. Backend-agnostic.
+  Reads `FF_LANES` / `FF_FLOW_PARTITIONS` / … env.
+
+### 6.2 Observability
+
+- `metrics.rs` is a thin wrapper around `ff_observability::Metrics`.
+  `/metrics` endpoint is pure Rust (OTEL → Prometheus text render);
+  HTTP middleware records `method` + `MatchedPath` + `status` +
+  duration. Backend-agnostic.
+- `main.rs`: `init_sentry` (gated on `sentry` feature) → sentry_tracing
+  layer. Backend-agnostic per the observability RFC — confirmed; no
+  Valkey references.
+- Tracing filter default: `ff_server=info,ff_engine=info,ff_script=info,
+  tower_http=debug,audit=info` — the `audit=info` target is non-
+  negotiable (rotation + security events). Backend-agnostic.
+
+### 6.3 Assertions
+
+- **Metrics + Sentry + audit log: backend-agnostic.** No changes on
+  Postgres migration.
+- **HTTP `/v1/admin/rotate-waitpoint-secret`: NOT agnostic.** The per-
+  partition fan-out is the only admin write path that bypasses a
+  backend trait. Requires a `Backend::rotate_waitpoint_secret(kid, hex)`
+  method on the backend trait to port.
+- **CLI `admin partition-collisions`: agnostic.** It's a pure function
+  over env-declared `PartitionConfig`.
+
+---
+
+## 7. Cross-cutting migration questions
+
+For Worker-D + v0.7 RFC authors.
+
+1. **Completion transport abstraction.**
+   `CompletionStream` is backend-agnostic but the dispatch handler
+   immediately calls into `ff_resolve_dependency` (Valkey FCALL via the
+   router). Options:
+   (a) Elevate dependency-resolution to a trait method on
+   `CompletionBackend` so each backend resolves in-band.
+   (b) Keep the FCALL, introduce a `DependencyResolver` trait consumed
+   by the dispatcher.
+   Same question for `dispatch_dependency_resolution` cascade recursion —
+   should it stay in engine, or move inside the backend?
+
+2. **Scanner runner polling vs push.**
+   Scanners 1–14 all poll due-ZSETs. On Postgres, `LISTEN/NOTIFY` +
+   trigger on insert-with-future-due-time could replace polling for at
+   least `lease_expiry`, `delayed_promoter`, `attempt_timeout`,
+   `execution_deadline`, `suspension_timeout`, `pending_wp_expiry`. But
+   partition-scoped indexing means the trigger payload is large. Do we
+   keep poll semantics (cleanest port) or adopt push (lower latency,
+   bigger rewrite)?
+
+3. **Partition semantics on Postgres.**
+   Today `num_flow_partitions` = 256 drives hash-tag slot routing.
+   Under a single Postgres database the partitions degenerate to a
+   `partition_id smallint` column. The boot-time `partition-collisions`
+   probe (for lane birthday-paradox) becomes meaningless unless we keep
+   the same hashing in userland for sharded-DB deployments — need an
+   RFC call on whether partitions survive as a concept.
+
+4. **Capability matching index.**
+   Today: Rust `caps_subset` short-circuit + Lua `missing_capabilities`
+   authoritative, both CSV-based. GIN `text[]` with `@>` is the obvious
+   SQL fit. Does the public `required_capabilities` CSV shape survive
+   the port, or do we move to `text[]` on the contract-level type too?
+
+5. **Budget / quota reconcilers under SQL transactions.**
+   Both scanners exist because Valkey can't atomically update a counter
+   and a membership set across hash-tags. Under Postgres a
+   single-statement UPDATE removes the drift. Do we delete scanners
+   10 + 11 in v0.7 or keep as long-cycle audits?
+
+6. **Grant signing + HMAC secret storage.**
+   Per-partition `waitpoint_hmac_secrets` hash + `kid` promotion
+   (k1→k2→…) fits a secrets table cleanly. But the current rotation
+   admin path fans out HSET across partitions; the migration wants a
+   single UPDATE. Any replay-safety tests around mid-rotation? (Worker-B
+   likely has visibility into the Lua side of token verification.)
+
+7. **Tail client semantics.**
+   ff-server keeps a dedicated tail `ferriskey::Client` (second TCP
+   connection, same host/port/TLS) just for XREAD BLOCK + HMGET
+   stream_meta, plus a server-wide Mutex (`xread_block_lock`) — because
+   a blocking XREAD on the main mux would head-of-line-block every
+   other FCALL. Under Postgres LISTEN/NOTIFY the dedicated connection
+   stays (LISTEN holds a session), but the lock disappears. Does
+   RFC-006 still want the semaphore + Mutex shape, or do we simplify?
+
+8. **Boot-time `FUNCTION LOAD`.**
+   `ff_script::loader::ensure_library` is Valkey-only; on Postgres we
+   want an equivalent "ensure schema migration applied" step. It's not
+   purely a Worker-A (ff-core) concern because `server.rs` calls it at
+   boot — needs coordination with migration tooling.
+
+9. **Engine scanner cadence coupling.**
+   `EngineConfig` exposes 17 intervals; most defaults were tuned for
+   Valkey round-trip latency (~0.1ms LAN) and per-partition per-cycle
+   cost. Postgres cycle costs will differ significantly; the defaults
+   need re-tuning, and the RFC should assert whether these stay public.
+
+10. **`Backend` trait boundaries.**
+    `server.rs` holds ~23 direct ferriskey call-sites. These are NOT
+    currently routed through a single `Backend` trait — there are
+    fragments (`EngineBackend`, `CompletionBackend`). V0.7 migration
+    needs a full audit of which `Server::<method>()` paths need new
+    trait methods vs. which already have backend abstractions.


### PR DESCRIPTION
Rewrites the llm-race example README to teach consumers the v0.6 primitives with copy-pasteable snippets keyed to RFC numbers. Adds llm-race to the top-level README example list as the recommended v0.6 starting point. Verified-live status called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes: a substantial rewrite/addition of documentation with no runtime/code-path impact beyond the potential for outdated guidance if the referenced APIs/RFCs drift.
> 
> **Overview**
> Updates top-level `README.md` to list **four** examples and positions `examples/llm-race` as the recommended v0.6 starting point.
> 
> Rewrites `examples/llm-race/README.md` into a user-facing, copy-pasteable guide that explains v0.6 primitives (notably `AnyOf{CancelRemaining}`, `DurableSummary` JSON Merge Patch streaming, and typed `SuspendArgs`/`Count{DistinctSources}`) and adds verified-live run instructions and expected timeline output.
> 
> Adds two new RFC draft documents, `rfcs/drafts/v0.7-migration-survey-core.md` and `rfcs/drafts/v0.7-migration-survey-engine.md`, cataloging Valkey-specific surfaces and mapping areas to consider for a future Postgres backend migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae52e9995321482f71513dbde4d3eeaa7c2e1e73. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->