### PR TITLE
docs(rfcs): v0.7 Postgres migration master (consolidated survey)

### DIFF
--- a/rfcs/drafts/v0.7-master-challenges/ACCEPTED.md
+++ b/rfcs/drafts/v0.7-master-challenges/ACCEPTED.md
@@ -1,0 +1,78 @@
+# v0.7 migration master — debate-record marker
+
+**Status:** ACCEPTED (unanimous, both challengers, after round 2 + polish pass).
+**Target:** `rfcs/drafts/v0.7-migration-master.md`
+**Owning branch:** `docs/v0.7-migration-master` — PR #229
+**Debate protocol:** high-impact RFC, all-worker debate until unanimous ACCEPT (per team-debate protocol memo).
+
+## Outcome
+
+- Challenger K (correctness / atomicity / reconciler / dual-backend invariants) — **ACCEPT** at round 2, two remaining correctness risks + four clarification questions, all folded into polish pass.
+- Challenger L (cairn operations / migration / SDK deltas) — **ACCEPT** at round 2, two residual follow-ups (Q12 additive-boot-check branch, Q15 forward-only-cutover surfacing), both folded into polish pass.
+
+Owner sign-off (merge of PR #229) is the next gate. This record marks the debate itself closed.
+
+## Round 1 — findings (resolved in commit `5cc456a`)
+
+Challenge artifacts: `rfcs/drafts/v0.7-master-challenges/round-1/{K,L}.md` on the respective debate branches.
+
+**Challenger K (round 1) — 12 findings:**
+
+1. K-1 — isolation-level self-contradiction between executive summary and §L0.
+2. K-2 — cascade recursion transaction boundaries (per-hop vs one-fat-tx) unstated.
+3. K-3 — shared LISTEN channel as an SPOF; no reconnect contract.
+4. K-4 — NOTIFY-in-tx atomicity unclear vs outbox durability.
+5. K-5 — per-row NOTIFY trigger storm risk if misread as the design.
+6. K-6 — Q6 MAXLEN retention under tx contention.
+7. K-7 — RFC-015 MAXLEN characterisation (approximate-N is the deliberate choice, not a bug).
+8. K-8 — Q9 scanner drop proposal went too far; `budget_reconciler` + `quota_reconciler` must stay.
+9. K-9 — Stage A/B boundary deliverable set.
+10. K-10 — dual-backend failure modes unspecified.
+11. K-11 — fence-triple preservation across backends.
+12. K-12 — HMAC `kid` rollout + cutover union-seed.
+
+**Challenger L (round 1) — 11 findings:**
+
+- Op-gap 1 — schema migration ordering (Q12).
+- Op-gap 2 — dual-backend running mode (→ §8).
+- Op-gap 3 — metrics cardinality / labels-compat matrix.
+- Op-gap 4 — backup / PITR shape.
+- Op-gap 5 — reconciler-as-primary observability counters.
+- SDK-delta 1 — per-partition HMAC no-op on non-partitioned backends.
+- SDK-delta 2 — `ts_ms` monotonicity under PITR.
+- SDK-delta 3 — tail reconnect storm.
+- SDK-delta 4 — `backend_version()` pin policy (Q13).
+- SDK-delta 5 — new `BackendErrorKind` retry classes through ff-sdk.
+- Exec-summary 8-week framing calibration.
+
+All 23 round-1 findings resolved in revision commit `5cc456a` (round-1 revision, reviewed 2026-04-23).
+
+## Round 2 — residuals (folded in polish pass)
+
+Challenge artifacts: `round-2/K.md` on `rfc/v0.7-master-debate-K-r2`, `round-2/L.md` on `rfc/v0.7-master-debate-L-r2`.
+
+**Challenger K (round 2) — 5 residuals:**
+
+1. Q11 retry-exhaust should fall back to the appropriate reconciler rather than surface `SerializationFailure` to the SDK (cascade is idempotent; reconciler backstop already exists).
+2. Q12 rolling-upgrade policy silent on stored-proc signatures — needed an additive-only / `_v2`-suffix rule.
+3. §8.1 overclaimed `EngineError::Validation("cross-backend")`; actual behavior is `NotFound` at the ff-server local lookup miss (federation detection is structurally impossible without a bridge layer).
+4. §8.2 / Q15 drain had no bound for long-running HITL suspensions; needed explicit per-flow co-migrate-or-wait policy.
+5. Stage D missed flagging that `dependency_reconciler` on Postgres owns a transitive-descendant sweep — a real semantic delta from the Valkey single-hop model, not a transplant.
+
+**Challenger L (round 2) — 2 residuals:**
+
+- L-r2-1 — Q12 self-contradiction between the additive-matrix (old binaries stay read-write) and the earlier "read-only if ledger ahead" clause; resolved by annotating migrations `backward_compatible=true|false` and branching the boot check on the annotation.
+- L-r2-2 — Q15 forward-only rollback was buried in Q15 + §8.2; needed an executive-summary callout so a cairn operator reading the summary does not mis-assume per-tenant reversibility.
+
+All 7 residuals folded into polish commit `0e5582a` — no new design decisions introduced, no residuals escalated as needing new thinking.
+
+## Commits
+
+| Stage | SHA | Message |
+|---|---|---|
+| Round-1 revision | `5cc456a` | `rfc(v0.7-master): round-1 revisions addressing K+L challenges` |
+| Round-2 polish (final) | `0e5582a` | `rfc(v0.7-master): round-2 polish — K+L non-blocking clarifications` |
+
+## Next gate
+
+Owner review + merge of PR #229. Debate record closed; no further worker rounds planned.

--- a/rfcs/drafts/v0.7-master-challenges/round-1/author-response.md
+++ b/rfcs/drafts/v0.7-master-challenges/round-1/author-response.md
@@ -1,0 +1,203 @@
+# Author response — round-1 K + L challenges on v0.7 migration master
+
+Target: `rfcs/drafts/v0.7-migration-master.md` on `docs/v0.7-migration-master`
+(PR #229). This response adjudicates each challenge finding as CONCEDE,
+REVISE (concede + land text), or ARGUE-BACK. Q1–Q5 adjudications are locked
+and are not reopened by either challenger; new decisions needed are captured
+as Q11–Q15 and adjudicated inline in the master doc.
+
+## K's findings (correctness + distributed-systems)
+
+### K-1 — isolation-level self-contradiction — **CONCEDE + REVISE**
+
+K is right. Exec-summary L51 asserts a decision; §L0 L115–L117 defers to
+owner. Two different semantic regimes (SSI vs row-locked READ COMMITTED)
+with different caller-side retry contracts. Fix: lift to new **Q11** and
+adjudicate immediately. Default: `READ COMMITTED + SELECT FOR UPDATE SKIP
+LOCKED`; the ~3 composite FCALLs (`ff_resolve_dependency`, `ff_deliver_signal`
+composite-cond, `ff_suspend_execution` multi-waitpoint) declare `SERIALIZABLE`
+at proc entry with a documented `SQLSTATE 40001` retry contract. Exec-summary
+text rewritten to match.
+
+### K-2 — cascade recursion tx boundaries — **CONCEDE + REVISE**
+
+K is right. §3.1 L416–L418 names the choice but doesn't pick or state
+crash-recovery semantics. Decision: **per-hop commit** (latency-conservative;
+avoids seconds-long row-lock holds across a depth-50 cascade). Added crash-
+recovery contract: `dependency_reconciler`'s blocked-set scan spans the
+**transitive-descendant reachable set**, not just 1-hop children, and runs
+on a bounded interval. Captured as §3.1 invariant + amendment to §Q9
+adjudication.
+
+### K-3 — shared LISTEN SPOF — **CONCEDE + REVISE**
+
+K is right. Q2 adjudication said "ONE long-lived shared LISTEN connection"
+with no reconnect or pooler-compatibility contract. Fix: amended Q2 with
+(a) reconnect protocol (re-LISTEN all channels + synthetic poll-now wake
+to every parked tailer); (b) **PgBouncer transaction-pool mode unsupported
+for ff-server ↔ pg connections**; session-pool required; (c) a
+`ff_listen_connection_healthy` gauge + auto-restart watchdog.
+
+### K-4 — NOTIFY-in-transaction semantics — **CONCEDE + REVISE**
+
+K is right that the property is load-bearing and currently unstated.
+Added one paragraph under Q1 adjudication: NOTIFY-on-COMMIT makes the
+outbox-row + wake-up atomic by construction; single `BIGSERIAL event_id`
+suffices for ordering (no vector clock); reconciler role narrowed to
+subscriber-side drops only.
+
+### K-5 — per-row INSERT trigger NOTIFY storm — **CONCEDE + REVISE**
+
+K is right. "Row-level trigger on INSERT" is the worst option under a
+10k-frame/sec burst. Fix: §3.2 L463–L467 rewritten to specify
+**application-level NOTIFY at end of `append_frame` tx** (composable with
+batched inserts; natural coalescing if a single tx writes multiple
+frames). Per-row trigger explicitly rejected in text.
+
+### K-6 — Q6 retention-in-tx lock contention — **CONCEDE + REVISE**
+
+K is right; piggybacked `DELETE WHERE rank > N` on the INSERT tx is a
+contention trap and `ROW_NUMBER() OVER (PARTITION BY …)` is not index-
+only. Rewrote Q6 to: **async janitor, per-partition, approximate-N with
+bounded overshoot**, matching RFC-015's contract.
+
+### K-7 — RFC-015 MAXLEN mischaracterization — **CONCEDE + REVISE**
+
+K is right. "Approximate-N is a legacy Valkey artifact" misread RFC-015,
+which explicitly chose approximate trim for p99. Rewrote Q6 per K-7's
+minimal fix.
+
+### K-8 — Q9 scanner drop assumes stronger atomicity than Q1 provides — **CONCEDE + REVISE**
+
+K is right. `report_usage` runs on a separate connection/process/tx from
+the grant, so cross-process drift survives the SQL-tx-atomicity argument.
+Fix: **keep `budget_reconciler` + `quota_reconciler`** as-is; drop only
+`index_reconciler` (which is genuinely redundant when indexes are real
+pg indexes). Q9 proposal rewritten.
+
+### K-9 — Stage A/B boundary vs design-lock boundary — **CONCEDE + REVISE**
+
+K is right that Stage B bakes Q6/Q7/Q8 decisions that Stage A didn't lock.
+Per K's option (a), promoted Q6 + Q7 + Q8 into Stage A's design-lock set.
+Stage A's merge-blocker now requires all of Q1–Q8 adjudicated.
+
+### K-10 — dual-backend operator failure modes — **CONCEDE + REVISE (merges with L-2)**
+
+K and L both raise this from different angles. Fix: new §8 "Dual-backend
+running mode" with explicit statement: **v0.7 dual-backend = two
+independent logical engines, cairn migration is per-flow (or per-tenant)
+not per-execution, no cross-backend cascade resolution**. Cross-backend
+cascade is explicitly out-of-scope for v0.7.
+
+### K-11 — RFC-003 fence-triple preservation — **CONCEDE + REVISE**
+
+Trivial. Added line in §6 "What STAYS": RFC-003 fence-triple
+`(lease_id, lease_epoch, attempt_id)` preserved; every lease-fenced
+stored proc takes the triple in ARGV and rejects on mismatch.
+
+### K-12 — HMAC kid rollout — **CONCEDE + REVISE**
+
+K is right. Added rollout contract under Q4: Postgres `ff_waitpoint_hmac`
+seeded from the union of all Valkey partitions' kids at migration cutover;
+rotation thereafter is additive.
+
+### K scenarios 1–7 — **CONCEDE (answered inline)**
+
+All seven scenarios land in the revisions above:
+- (1) scanner death mid-cascade → §3.1 invariant (K-2)
+- (2) PgBouncer → Q2 (K-3)
+- (3) NOTIFY storm → §3.2 rewrite (K-5)
+- (4) rollback-after-NOTIFY + last_seen_event_id → Q1 addendum (K-4)
+- (5) cross-backend cascade → §8 (K-10/L-2)
+- (6) MAXLEN overshoot → Q6 rewrite (K-6/K-7)
+- (7) tail reconnect storm → Q2 reconnect spec includes jittered wake
+  (K-3)
+
+## L's findings (cairn ops + migration + consumer)
+
+### L-1 — schema-migration vs FUNCTION LOAD ordering — **CONCEDE + REVISE**
+
+L is right; Stage A deliverable list named `sqlx::migrate!` but didn't
+specify mode. Decision captured as **Q12**: **operator-applied
+out-of-band via `sqlx migrate run` + boot-time schema-version check that
+refuses start on mismatch**, mirroring Q5's boot-time partition-count
+check. Zero-downtime rollout story: forward-only migrations, add-column-
+then-deploy-binary pattern documented. Stage A deliverable amended.
+
+### L-2 — dual-backend running mode — **CONCEDE + REVISE**
+
+See K-10. New §8 covers per-binary vs per-cluster (answer: per-binary,
+each ff-server instance targets one backend), source-of-truth (the
+backend the instance is configured against), fan-out (no cross-backend
+`CompletionBackend` fan-out in v0.7), and rollback (covered in §8).
+
+### L-3 — metrics/dashboard + backup/PITR — **CONCEDE + REVISE**
+
+L is right that §6's "OTEL-via-sqlx swap is a config change" is
+structurally true but operationally incomplete. Added §9 operational
+runbook checklist covering: labels-compat matrix (Stage E), backup/PITR
+one-page runbook (Stage E), reconciler-as-primary-path alerting counter
+`ff_completion_recovered_by_reconciler` (Stage D), rollback procedure
+from Postgres to Valkey under SLO regression (Stage E).
+
+### L exec-summary critique (weeks estimate) — **CONCEDE (minor)**
+
+L is right that the 8-week "aggressive: Stages A–C only" framing is
+incoherent because Stage D is the transport layer. Rewrote the range
+bullets: aggressive = Stages A–D (no Stage E ops), realistic = full
+A–E including cairn staging week.
+
+### SDK-delta 1 — `rotate_waitpoint_hmac_secret(partition, …)` no-op — **CONCEDE + REVISE**
+
+L is right. Silent no-op is an ergonomic trap. Fix: Postgres impl logs a
+structured warning (`backend.hmac.per_partition_call_on_postgres` span
+event with partition arg echoed back) so admin tooling can detect the
+mismatch. Deprecation-and-remove deferred to v0.8 (separate RFC).
+
+### SDK-delta 2 — `StreamCursor::At(String)` ts_ms non-monotonicity under PITR/clock-skew — **CONCEDE + REVISE**
+
+L is right. Added Q3 invariant: ordering authoritative is `(ts_ms, seq)`
+tuple; `ts_ms` alone is advisory. Documented in §3.2 + Stage C spec.
+
+### SDK-delta 3 — `tail_stream` reconnect shape — **CONCEDE + REVISE**
+
+Same as K-3/scenario-7. Q2 amendment now includes jittered SDK-side
+reconnect budget when the backend is Postgres.
+
+### SDK-delta 4 — `backend_version()` pin policy — **CONCEDE + REVISE**
+
+L is right; added to Stage A deliverable: version-pin policy is **warn,
+not refuse** by default on the SDK side; operators can flip to refuse
+via config. Prevents ff-sdk pinning from becoming a hard deploy gate.
+
+### SDK-delta 5 — `BackendErrorKind` new retry classes — **CONCEDE + REVISE**
+
+L is right. Added to Stage B deliverable: ff-sdk retry-policy compat
+shim translates `SerializationFailure`/`DeadlockDetected` to the existing
+retryable-error classification cairn already handles.
+
+### L author-questions 1–9 — **answered inline in revisions above**
+
+All nine land in revisions L-1 through SDK-delta-5 and the new §8 + §9.
+
+## Escalations (owner decisions, flagged)
+
+None of K's or L's findings require escalation — all are mechanical
+tradeoffs resolvable by the feedback_decide_obvious_escalate_tradeoffs
+rule. The one borderline case is **Q11 (isolation level)**: strictly this
+is a correctness tradeoff with performance implications, but the choice
+(RC + row locks as default, SERIALIZABLE at the ~3 composite sites) is
+industry-standard for pg-backed job systems and matches the existing
+Valkey semantics (which are effectively SERIALIZABLE via slot lock) at
+the sites that need it.
+
+## Remaining follow-ups (tracked for round-2)
+
+- Concrete migration-tool spec for Valkey→Postgres state transfer (Stage E
+  deliverable, L walkthrough step 3). Currently named, not detailed.
+- Rollback runbook from Postgres back to Valkey (Stage E deliverable,
+  L walkthrough step 4). Currently named, not detailed.
+- Labels-compat matrix table (Stage E deliverable). Currently named.
+
+These three are Stage E content, not v0.7-master-doc content. They are
+referenced in §9 checklist so round-2 challengers can see them.

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -1,0 +1,953 @@
+# v0.7 Postgres backend migration master
+
+Consolidation of three read-only code surveys into a single spec for the v0.7
+Postgres-backend migration. This document is the entry point for (a) the owner
+sizing scope, and (b) the Postgres-backend author deciding what to build and
+in what order. It does not propose schema DDL — it names the Valkey primitive
+each surface point leans on, points at the translation pattern, and flags the
+questions that need an owner decision before code lands.
+
+**Source surveys (read, not duplicated):**
+
+- Worker-A — **`rfcs/drafts/v0.7-migration-survey-lua.md`** (branch
+  `docs/v0.7-migration-survey-lua`). 54 FCALLs across 11 Lua files, plus the
+  `ff-script` wrappers + loader + error taxonomy + the single non-FCALL
+  `stream_tail.rs` primitive.
+- Worker-B — **`rfcs/drafts/v0.7-migration-survey-core.md`** (branch
+  `docs/v0.7-migration-survey-core`). 30 `EngineBackend` trait methods, 93
+  key-builder functions in `ff-core::keys`, 13 non-FCALL direct call sites in
+  `ff-backend-valkey`, plus `handle_codec` + `CompletionBackend`.
+- Worker-C — **`rfcs/drafts/v0.7-migration-survey-engine.md`** (branch
+  `docs/v0.7-migration-survey-engine`). 17 scanners + 1 completion loop, the
+  `partition_router` + `completion_listener`, scheduler claim pipeline, server
+  boot sequence, 32 HTTP routes, admin + observability.
+
+Reference heavily, duplicate sparingly. When this document says "see
+Worker-A §1.1" it means: the full FCALL-by-FCALL table lives there; come back
+here for the cross-cutting picture.
+
+**Base commit.** All three surveys were taken against `origin/main` at or
+close to `bc17872` / `a54a38e` (2026-04-23).
+
+---
+
+## Executive summary
+
+**Total surface.**
+
+| Dimension | Count | Source |
+|---|---:|---|
+| Valkey-Function FCALLs | 54 (exc. `ff_version`) | Worker-A §1 |
+| `EngineBackend` trait methods | 30 (2 return `Unavailable`) | Worker-B §3 |
+| `ff-core::keys` key-builder fns | 93 | Worker-B §1 |
+| Non-FCALL direct Valkey call sites in `ff-backend-valkey` | 13 primary + 11 raw `fcall()` | Worker-B §7 |
+| Engine scanners | 17 + 1 completion loop | Worker-C §1 |
+| HTTP routes | 30 app + `/metrics` + `/healthz` = 32 | Worker-C §5 |
+| FCALL-backed `Server::` methods (raw ferriskey calls in `server.rs`) | 23 | Worker-C §5.2 |
+
+**Critical path (the 3–5 things that unlock everything else).**
+
+1. **Atomicity model.** Agree that every FCALL becomes a single `BEGIN…COMMIT`
+   under `SERIALIZABLE` (or explicit row-lock + `READ COMMITTED`). Every
+   trait-method port depends on this choice. (Part 1, §1.)
+2. **Stream ID + cursor shape.** `StreamCursor::At(String)` and
+   `AppendFrameOutcome.stream_id: String` carry Valkey `<ms>-<seq>` IDs on the
+   trait surface (Worker-B §4.1, §4.2). Pick the Postgres encoding before any
+   `append_frame`/`read_stream`/`tail_stream` code is written.
+3. **Completion transport.** `PUBLISH ff:dag:completions` feeds the engine's
+   `completion_listener` and is the wake-up for 7 terminal FCALLs (Worker-A
+   §3 Tier C, Worker-B §8.2, Worker-C §2.2). The `LISTEN/NOTIFY` vs
+   `ff_completion_event`-polling decision gates `CompletionBackend` +
+   `tail_stream` + the whole dependency-resolution push path.
+4. **Partition semantics survival.** Does `num_flow_partitions=256` survive
+   as a Postgres `partition_id smallint` column (cleanest port) or collapse
+   entirely (simpler schema, breaks sharded-DB deployments)? Affects 100%
+   of key-builders + every scanner's partition loop.
+5. **`claim` + `claim_from_reclaim` Valkey impls.** Both today return
+   `Unavailable` (Worker-B §9.10). The trait shape is only validated under a
+   working Valkey path; a second backend before the first is finished is a
+   recipe for trait churn.
+
+**Rough effort estimate (with calibration).** **8–14 engineer-weeks** of
+focused work to a Postgres backend that passes the current integration
+suite against Valkey-and-Postgres both. Calibration: one senior engineer
+full-time, assuming the owner answers Part 4's design questions upfront
+and cairn co-adopts so the external-consumer smoke test is real. Range:
+- 8 weeks: aggressive. Part 5 Stages A–C only. Scanner polling kept. No
+  performance tuning beyond "passes the existing suite."
+- 14 weeks: realistic. Stages A–E, performance parity measured, rotation
+  admin path + scanner LISTEN/NOTIFY adaptations landed, cairn smoke-test
+  cycle included.
+
+**"Needs a design decision before code" list (the five locks).**
+
+1. **Completion transport** — LISTEN/NOTIFY vs polling vs logical replication
+   (§4.1).
+2. **XREAD BLOCK semantics** — keep blocking tail, or flip SDK to pull +
+   backoff (§4.2).
+3. **Stream ID encoding** — composite `(ms, seq)` vs bigserial vs ULID
+   (§4.3).
+4. **HMAC secret scope** — per-partition (current) vs single global row
+   (§4.4).
+5. **Partition column survival** — keep hashed 256-partition model, or
+   collapse entirely (§4.5).
+
+Five smaller decisions live in §4.6–§4.10.
+
+---
+
+## Part 1 — Dimensional layers (Valkey → Postgres translation patterns)
+
+Every surface point in Part 2 translates through one or more of these
+patterns. Explained once; referenced from the inventory.
+
+### L0 — Atomic multi-key Lua → single transaction
+
+Valkey runs an FCALL body under the slot lock; every `HSET`/`ZADD`/`SREM`
+inside is atomic against the single hash-tag. Postgres replacement is one
+transaction per former FCALL.
+
+- Most FCALLs work fine under `READ COMMITTED` with explicit row locks
+  (`SELECT … FOR UPDATE`).
+- The quorum / K-of-N / composite-condition FCALLs (`ff_resolve_dependency`,
+  `ff_deliver_signal` composite eval, `ff_suspend_execution` multi-waitpoint)
+  need either `SERIALIZABLE` or careful advisory-locked sections.
+- Open: which isolation level is the default? Owner decision; proposal is
+  `READ COMMITTED` + row locks for the hot path, `SERIALIZABLE` for the ~3
+  composite FCALLs.
+
+### L1 — Hash-tag partitioning → row-level partitioning
+
+Every key carries `{fp:N}` / `{b:M}` / `{q:K}`. Valkey uses this for
+cluster-slot colocation; Postgres uses `PARTITION BY HASH(partition_key)`
+(or a plain column + index). `PartitionConfig{256,32,32}` stays meaningful
+as the declarative partition count.
+
+- `execution_partition(eid, config)` — decodes the tag from the ExecutionId
+  prefix. Survives verbatim (Worker-B §2).
+- CRC16-CCITT — deliberate match with Valkey slot algorithm but a pure Rust
+  function; survives.
+- `noop` key family (Worker-B §1.1, §1.7) — pure cluster-slot padding;
+  disappears entirely on Postgres.
+
+### L2 — XADD / XREAD BLOCK / XTRIM → append log + LISTEN
+
+Valkey Streams back the attempt frame log. Postgres candidates:
+
+- **`ff_stream_frame(exec_id, attempt, seq, fields jsonb, created_at, frame_id)`**
+  append-only table.
+- `XADD` → `INSERT`.
+- `XRANGE from to LIMIT n` → `SELECT … WHERE frame_id BETWEEN … ORDER BY …
+  LIMIT n`.
+- `MAXLEN ~ N` → either exact `DELETE … USING (rank)` retention job or
+  coarse partition-by-time with drop-partition (`pg_partman`). Approximate
+  is not a feature we need to preserve.
+- `XREAD BLOCK` → either `LISTEN ff_stream_<partition>` on INSERT trigger, or
+  long-poll select on `seq > :last` with backoff. This is §4.2.
+
+### L3 — PUBLISH / SUBSCRIBE → LISTEN/NOTIFY or outbox
+
+`PUBLISH ff:dag:completions` is the wake-up primitive for 7 terminal FCALLs
+(Worker-A §3 Tier C) plus the engine's `CompletionBackend` push path
+(Worker-B §8.2). Three candidates:
+
+1. **LISTEN/NOTIFY.** Closest structural match. Payload ≤ 8000 bytes (fine
+   for ~200B completion wire). No durability; the existing
+   `dependency_reconciler` already backs up dropped deliveries.
+2. **Logical replication / `pg_recvlogical`** — durable, overkill today.
+3. **Polling `ff_completion_event(seq BIGSERIAL, …)` with `WHERE seq > $last`
+   per subscriber.** Simplest; adds lag; the reconciler already does
+   approximately this against Valkey state.
+
+Decision in §4.1.
+
+### L4 — SADD / SMEMBERS / SISMEMBER / SCARD / SSCAN → SQL SELECT
+
+Sets are `CREATE TABLE set_members(set_key, member PRIMARY KEY (set_key,
+member))` OR a `tags jsonb` column with a GIN index, depending on
+cardinality + update pattern. The seventeen `lane_*` secondary-index SETs
+(Worker-B §1.2) become partial indexes on the main execution table. `SSCAN`
+in cluster-mode scanners collapses entirely — no SCAN on Postgres.
+
+### L5 — ZADD / ZRANGEBYSCORE / ZREMRANGEBYSCORE / ZCARD → B-tree index
+
+Every due-set scanner uses `ZRANGEBYSCORE -inf now LIMIT 0 N` (Worker-C §1.1).
+Postgres: `SELECT … WHERE expires_at <= now() ORDER BY expires_at LIMIT n
+FOR UPDATE SKIP LOCKED` with an index on `expires_at`. Sliding-window rate
+limits (Worker-A §1.9 `ff_check_admission_and_record`) translate to a
+`admissions(quota_id, ts)` table + `SELECT count(*) WHERE ts > now()-window`.
+
+### L6 — EXPIRE / PEXPIRE / PEXPIREAT / PERSIST → ttl column + janitor
+
+Keys with Valkey-native TTL (`claim_grant`, `idempotency_key`,
+`signal_dedup`, `suspend_dedup`, `usage_dedup`) become rows with
+`expires_at timestamptz` and a janitor `DELETE WHERE expires_at < now()`.
+Valkey's "strict eviction" becomes "eventually consistent" on Postgres —
+schedulers must cope, which they already do (Worker-C §1.1 lease_expiry
+scanner is exactly this shape, for Valkey, today).
+
+### L7 — INCR / DECR / SETNX → UPDATE RETURNING / INSERT ON CONFLICT
+
+- `INCR`/`DECR` → `UPDATE … SET n = n ± 1 RETURNING n` under row lock.
+- `SET key NX EX ttl` (dedup) → `INSERT INTO dedup(key, expires_at) …
+  ON CONFLICT DO NOTHING`, janitor as above.
+
+### L8 — cjson / sha1hex / HMAC-SHA1 → jsonb + rust `hmac` crate
+
+- `cjson.encode/decode` → `jsonb` native. `helpers.lua` composite-condition
+  tree evaluator (~400 lines, Worker-A §1.5) becomes Rust server code.
+- `redis.sha1hex` → `hmac` crate in Rust (already a ff-core dependency).
+  Actually **improves** testability: HMAC mint/validate moves out of the
+  sandbox into a Rust module both backends call.
+- **`struct.pack`: not used anywhere** (Worker-A §3). One less migration
+  concern.
+
+### L9 — `redis.call("TIME")` → `now()`
+
+The engine already threads `now_ms` through most ARGV signatures; `TIME`
+is a *defensive* second clock inside the sandbox (Worker-A §3 Tier A). v0.7
+is a natural place to centralize on a single caller-supplied clock.
+
+### L10 — FUNCTION LOAD → migration tooling
+
+`ff_script::loader::ensure_library` is a 4-step dance (Worker-A §2.1,
+Worker-C §4 step 3) that disappears entirely. Postgres equivalent is "ensure
+schema migration applied" — either the `flowfabric` schema + stored procs
+installed via `sqlx::migrate!` or similar. Needs coordination with migration
+tooling. This is step 3b+ of §4.5.
+
+---
+
+## Part 2 — Inventory (collapsed across all 3 surveys)
+
+Every Valkey surface point that needs a Postgres analog, in a stable format
+the backend author can walk top-to-bottom. **ID**s are stable labels:
+- `FCALL-<name>` for Lua functions (Worker-A §1).
+- `TRAIT-<method>` for `EngineBackend` methods (Worker-B §3, §6).
+- `KEY-<family>` for key-builder fns (Worker-B §1).
+- `NONFCALL-<method>` for direct Valkey calls in `ff-backend-valkey`
+  (Worker-B §7).
+- `SCANNER-<name>` (Worker-C §1.1).
+- `ROUTE-<method>:<path>` (Worker-C §5.1).
+- `BOOT-<step>` (Worker-C §4).
+
+**Difficulty:** T (trivial — one-line SQL), M (moderate — single SELECT/
+UPDATE or single-tx stored proc), H (hard — composite logic, multi-table
+cascade, or tricky atomicity), R (redesign — no direct analog, design
+decision required).
+
+### 2.1 L1 keys + partition math
+
+Walk Worker-B §1.1 through §1.7 for the 93-row full catalog. Summary:
+
+| ID | Layer | Name | Valkey primitive | Postgres analog | Difficulty | Open q |
+|---|---|---|---|---|---|---|
+| KEY-exec_context | L1 | `ExecKeyContext` 27 getters | `{fp:N}` hash tag + Hash/SET/ZSET keys | Columns on `ff_execution`, side tables for streams/attempts/deps | M | Q5 (partition column survival) |
+| KEY-index_keys | L1 | `IndexKeys` 18 getters | `{fp:N}` SETs/ZSETs as secondary indexes | Partial indexes on `ff_execution`/`ff_lease`/`ff_attempt` | T | — |
+| KEY-flow_context | L1 | `FlowKeyContext` 12 getters | `{fp:N}` flow-structural | Rows on `ff_flow`/`ff_flow_member`/`ff_edge` | T | — |
+| KEY-flow_index | L1 | `FlowIndexKeys` 3 getters | `{fp:N}` flow indexes | Indexes on `ff_flow` | T | — |
+| KEY-budget_context | L1 | `BudgetKeyContext` | `{b:M}` hash tag | Rows on `ff_budget*` | T | Q5 |
+| KEY-quota_context | L1 | `QuotaKeyContext` | `{q:K}` hash tag | Rows on `ff_quota*` | T | Q5 |
+| KEY-global | L1 | lane/worker/workers_index, lane_config, namespace_executions, tag_index | Global unhash-tagged keys | Global tables | T | — |
+| KEY-noop | L1 | `noop_key` | Valkey cluster-slot padding | n/a (delete) | T | — |
+| KEY-waitpoint_hmac | L1 | `IndexKeys::waitpoint_hmac_secrets` | Per-partition replicated Hash | Single `ff_waitpoint_hmac(kid, …)` row | M | Q4 (HMAC scope) |
+| KEY-dedups | L1 | `idempotency_key`, `signal_dedup`, `suspend_dedup`, `usage_dedup_key` | `SET … NX EX ttl` | `INSERT ON CONFLICT DO NOTHING` + janitor | T | — |
+
+### 2.2 L2 trait methods (`EngineBackend` 30)
+
+Full map at Worker-B §6. Grouped by translation shape:
+
+| ID | Method | Valkey primitive | Postgres analog | Difficulty | Open q |
+|---|---|---|---|---|---|
+| TRAIT-claim | `claim` | returns `Unavailable` today | Same | — | Q10 (must land Valkey impl first) |
+| TRAIT-claim_from_reclaim | `claim_from_reclaim` | returns `Unavailable` today | Same | — | Q10 |
+| TRAIT-renew | `renew` | FCALL `ff_renew_lease` | 1-tx: UPDATE lease + UPSERT expiry index | M | — |
+| TRAIT-progress | `progress` | FCALL `ff_update_progress` | UPDATE row (lease-fenced) | T | — |
+| TRAIT-append_frame | `append_frame` | FCALL `ff_append_frame` | INSERT frame + UPDATE summary + retention check | H | Q3 (stream ID) |
+| TRAIT-complete | `complete` | FCALL `ff_complete_execution` | 1-tx: UPDATE exec → terminal + remove indexes + INSERT frame + NOTIFY | M | Q1 (PUBLISH) |
+| TRAIT-fail | `fail` | FCALL `ff_fail_execution` + pre-read policy | Retry branch: UPDATE→delayed OR UPDATE→terminal + NOTIFY | H | Q1 |
+| TRAIT-cancel | `cancel` | FCALL `ff_cancel_execution` + pre-read current_waitpoint_id | 21-key cascade (largest) | H | Q1 |
+| TRAIT-suspend | `suspend` | FCALL `ff_suspend_execution` (+ multi-waitpoint RFC-014) | 1-tx: INSERT suspension + INSERT waitpoints + DELETE lease indexes + HMAC mint (in Rust) | H | — |
+| TRAIT-create_waitpoint | `create_waitpoint` | FCALL `ff_create_pending_waitpoint` | INSERT waitpoint (pre-suspend) + HMAC mint | M | — |
+| TRAIT-observe_signals | `observe_signals` | **no FCALL**: HGETALL + HMGET + pipeline HGETALL+GET | single SELECT + JOIN | T | — |
+| TRAIT-delay | `delay` | FCALL `ff_delay_execution` | UPDATE → delayed state | M | — |
+| TRAIT-wait_children | `wait_children` | FCALL `ff_move_to_waiting_children` | UPDATE → waiting_children | M | — |
+| TRAIT-describe_execution | `describe_execution` | HGETALL exec_core + HGETALL tags | SELECT + JOIN | T | — |
+| TRAIT-describe_flow | `describe_flow` | HGETALL flow_core (+ read_edge_groups) | SELECT + JOIN | T | — |
+| TRAIT-list_edges | `list_edges` | pipeline SMEMBERS + HGETALL per edge | single SELECT on `ff_edge` | T | — |
+| TRAIT-describe_edge | `describe_edge` | HGETALL edge | SELECT | T | — |
+| TRAIT-resolve_execution_flow_id | — | HGET exec_core.flow_id | SELECT column | T | — |
+| TRAIT-list_flows | `list_flows` | SMEMBERS flow_index + pipeline HGETALL | paginated SELECT | T | — |
+| TRAIT-list_lanes | `list_lanes` | SMEMBERS `ff:idx:lanes` | SELECT on `ff_lane` | T | — |
+| TRAIT-list_suspended | `list_suspended` | SCAN + ZRANGE + pipeline HMGET | single SELECT | T | — |
+| TRAIT-list_executions | `list_executions` | SMEMBERS `all_executions` + client-side sort | paginated SELECT ORDER BY | T | — |
+| TRAIT-deliver_signal | `deliver_signal` | FCALL `ff_deliver_signal` (composite cond eval) | 1-tx: INSERT signal + composite-eval in Rust + conditional wake | H | Q1 |
+| TRAIT-claim_resumed_execution | `claim_resumed_execution` | FCALL `ff_claim_resumed_execution` | 1-tx: claim variant | M | — |
+| TRAIT-cancel_flow | `cancel_flow` | FCALL `ff_cancel_flow` + async fan-out | 1-tx: INSERT pending-cancel rows per member + NOTIFY | H | Q1 |
+| TRAIT-set_edge_group_policy | `set_edge_group_policy` | FCALL `ff_set_edge_group_policy` | UPDATE `ff_edge_group` | T | — |
+| TRAIT-report_usage | `report_usage` | FCALL `ff_report_usage_and_check` | 1-tx: per-dim UPDATE RETURNING + limit check | M | — |
+| TRAIT-read_stream | `read_stream` (feat streaming) | XRANGE | SELECT ORDER BY frame_id LIMIT | M | Q3 |
+| TRAIT-tail_stream | `tail_stream` (feat streaming) | XREAD BLOCK via `stream_tail::xread_block` on duplicate_connection | LISTEN/NOTIFY + long-poll | R | Q2 |
+| TRAIT-read_summary | `read_summary` (feat streaming) | HGETALL summary | SELECT jsonb | T | — |
+
+### 2.3 L3 FCALL inventory (54 items, 11 files)
+
+The per-FCALL KEYS/ARGV/primitives/atomicity/difficulty table lives in
+**Worker-A §1.1 through §1.10**. Difficulty summary (Worker-A §4, recounted):
+
+- **Trivial (20):** `ff_create_flow`, `ff_ack_cancel_member`,
+  `ff_set_edge_group_policy`, `ff_drain_sibling_cancel_group`,
+  `ff_reconcile_sibling_cancel_group`, `ff_evaluate_flow_eligibility`,
+  `ff_set_flow_tags`, `ff_set_execution_tags`, `ff_change_priority`,
+  `ff_update_progress`, `ff_promote_delayed`, `ff_close_waitpoint`,
+  `ff_list_waitpoint_hmac_kids`, `ff_read_summary`, `ff_create_budget`,
+  `ff_reset_budget`, `ff_unblock_execution`, `ff_block_execution_for_admission`,
+  `ff_create_quota_policy`, `ff_release_admission`.
+- **Moderate (21):** `ff_create_execution`, `ff_claim_execution`,
+  `ff_complete_execution`, `ff_delay_execution`,
+  `ff_move_to_waiting_children`, `ff_expire_execution`,
+  `ff_add_execution_to_flow`, `ff_stage_dependency_edge`,
+  `ff_apply_dependency_to_child`, `ff_promote_blocked_to_eligible`,
+  `ff_issue_claim_grant`, `ff_issue_reclaim_grant`,
+  `ff_create_pending_waitpoint`, `ff_rotate_waitpoint_hmac_secret`,
+  `ff_claim_resumed_execution`, `ff_read_attempt_stream`,
+  `ff_renew_lease`, `ff_mark_lease_expired_if_due`, `ff_revoke_lease`,
+  `ff_report_usage_and_check`, `ff_check_admission_and_record`.
+- **Hard (12):** `ff_cancel_execution`, `ff_fail_execution`,
+  `ff_reclaim_execution`, `ff_cancel_flow`, `ff_resolve_dependency`,
+  `ff_replay_execution`, `ff_suspend_execution`, `ff_resume_execution`,
+  `ff_expire_suspension`, `ff_deliver_signal`,
+  `ff_buffer_signal_for_pending_waitpoint`, `ff_append_frame`.
+- **Redesign-adjacent idioms (not FCALLs):** XREAD BLOCK tail + PUBLISH
+  channel fan-out + FUNCTION LOAD (see Part 1 L2/L3/L10).
+
+Dead: `ff_version` → Rust constant (Worker-A §1.10).
+
+### 2.4 L4 non-FCALL call sites (`ff-backend-valkey`)
+
+Full list at Worker-B §7 + 11 raw `client.fcall()` sites. Categories:
+
+| ID | Site | Primitive | Postgres analog | Difficulty |
+|---|---|---|---|---|
+| NONFCALL-describe_execution | `describe_execution_impl` pipeline HGETALL+HGETALL | Pipelined reads | 1 SELECT+JOIN | T |
+| NONFCALL-list_suspended | `list_suspended_impl` cluster_scan / SCAN + pipelined ZRANGE + HMGET | SCAN for cluster enumeration | Indexed SELECT | T (collapses fully) |
+| NONFCALL-list_flows | `list_flows_impl` pipeline | Paginated HGETALL | Cursor SELECT (rustdoc already documents) | T |
+| NONFCALL-list_edges | `list_edges_impl` pipeline | HGETALL fan-out | Single SELECT | T |
+| NONFCALL-load_partition_config | `load_partition_config` | HGETALL config singleton | `SELECT * FROM ff_partition_config LIMIT 1` | T |
+| NONFCALL-observe_signals | `observe_signals_impl` hgetall + hget + pipeline HGETALL+GET | Signal-observe path | SELECT+JOIN | T |
+| NONFCALL-cancel_preread | `cancel_impl` pre-read `current_waitpoint_id` | HGET column | SELECT column | T |
+| NONFCALL-fail_preread | `fail_impl` pre-read `policy` GET | GET blob | SELECT | T |
+| NONFCALL-tail_stream | `tail_stream_impl` duplicate_connection + xread_block | XREAD BLOCK | LISTEN/NOTIFY + long-poll | R (Q2) |
+| NONFCALL-filter_gate | `completion.rs FilterGate::admits` HGET namespace+tag | Per-push tenant filter | Single SELECT | T |
+| NONFCALL-subscriber_loop | `completion.rs subscriber_loop` SUBSCRIBE + RESP3 push | PUBSUB stream | LISTEN/NOTIFY (§4.1) | R (Q1) |
+| NONFCALL-build_subscriber_client | `build_subscriber_client` dedicated RESP3 client | Per-subscriber connection | Per-LISTEN connection | M |
+| NONFCALL-raw_fcall_sites | 11 sites using `client.fcall::<Value>` rather than typed wrappers | FCALL via untyped dispatch | Same FCALL translation as §2.3 | — |
+
+### 2.5 L5 scanners (17)
+
+Full per-scanner table at **Worker-C §1.1**. Every scanner is the same
+pattern: `ZRANGEBYSCORE -inf now LIMIT 0 N → FCALL` (or for 3 of 17,
+direct multi-key mutation). Translation template is identical: `SELECT …
+WHERE ts ≤ now() ORDER BY ts LIMIT n FOR UPDATE SKIP LOCKED → stored proc`.
+
+| Category | Scanners | Difficulty | Notes |
+|---|---|---|---|
+| Due-ZSET → FCALL | lease_expiry, delayed_promoter, attempt_timeout, execution_deadline, suspension_timeout, pending_wp_expiry, budget_reset | M each | Template applies |
+| Due-ZSET + enumerate + multi-key cascade | retention_trimmer | H | Only scanner with direct mutation cascade — biggest candidate for SQL `DELETE CASCADE` + partition drop |
+| Integrity / drift audit | index_reconciler, budget_reconciler, quota_reconciler | T-R | Exist because Valkey can't atomic-update counter + set across hash-tags. Under a single SQL tx, **10 + 11 are eliminable entirely** (Worker-C Q5); 8 is redundant |
+| Capability union scan | unblock | M | Worker-caps union GET fan-out (~100 GETs/cycle) collapses to `WHERE required_caps <@ worker_caps` GIN query |
+| Push-primary / safety net | dependency_reconciler | M | Primary path is `completion_listener` push (§2.6); scanner is the miss-recovery backstop. LISTEN/NOTIFY + poll |
+| Aggregate projection | flow_projector | M | Natural fit for materialized view or incremental aggregate |
+| Cancel dispatch (RFC-016) | cancel_reconciler, edge_cancel_dispatcher, edge_cancel_reconciler | M-H | edge_cancel_dispatcher has p99 ≤ 500ms SLO — sensitive to LISTEN latency |
+
+### 2.6 L6 HTTP routes (32)
+
+Full table at **Worker-C §5.1**. The route layer (`api.rs`) is already a
+thin HTTP shim: only one direct Valkey call (`PING` in `/healthz`). The
+real backend-coupling lives in `Server::` methods (§5.2 — 23 ferriskey
+call-sites in `server.rs`). Routes translate via a `Backend` trait
+abstraction on those 23 sites — not the HTTP layer.
+
+Three routes have Valkey-specific handler logic that isn't just
+"call-a-trait-method":
+
+- `POST /v1/admin/rotate-waitpoint-secret` — per-partition HSET fan-out
+  (Worker-C §6.1). Needs a `Backend::rotate_waitpoint_secret(kid, hex)`
+  method; Postgres collapses the fan-out to one UPDATE.
+- `GET /v1/executions/{id}/attempts/{idx}/stream/tail` — XREAD BLOCK on a
+  dedicated tail client. Blocks on §4.2.
+- `GET /healthz` — `PING`. Trivially a `Backend::ping()`.
+
+### 2.7 L7 server boot + admin + observability
+
+Full breakdown at **Worker-C §4, §6**.
+
+- Backend-agnostic (survives verbatim): metrics/OTEL/Prometheus render,
+  Sentry init, audit log target, CLI `admin partition-collisions`.
+- Valkey-specific boot steps that need a backend abstraction:
+  `verify_valkey_version`, `validate_or_create_partition_config`,
+  `initialize_waitpoint_hmac_secret`, `ff_script::loader::ensure_library`,
+  `SADD ff:idx:lanes`, tail `ClientBuilder` + `xread_block_lock`.
+- The `ClientBuilder`-based connection setup itself (Worker-C §4 step 1)
+  needs a `Backend::connect(config) → Backend` factory to let both
+  backends slot in.
+
+---
+
+## Part 3 — Hotspots (where the effort concentrates)
+
+Five sections; each worker surfaced these independently.
+
+### 3.1 `partition_router::dispatch_dependency_resolution` (Worker-C §2.1)
+
+**What it is.** The push path that fires when an execution terminates:
+per downstream edge, read the upstream's terminal outcome, resolve the
+child's dependency state, cascade recursively (up to depth 50). Called by
+`completion_listener` and by `ff_server::cancel_flow`.
+
+**Why it's hard.**
+
+- 14-key atomic FCALL (`ff_resolve_dependency`) — the 250-line `helpers.lua`
+  quorum/K-of-N logic (Worker-A §1.2).
+- Cross-partition reads (child's `{p:N}` and upstream's co-located flow
+  `{fp:N}`) — on Valkey this is multi-slot, handled only because RFC-011
+  colocates exec with flow.
+- Cascade recursion is Rust-side; **the recursion crosses network RPCs**.
+  On Valkey that's fine (each RPC is a FCALL); on Postgres each recursion
+  hop is a fresh transaction or the whole cascade is one fat transaction.
+
+**Proposal sketch.** One stored procedure `ff_resolve_dependency_sp(child_eid,
+upstream_outcome, …)` returning `{status, next_children_to_cascade[]}`.
+The Rust cascade loop stays, iterates on the returned child list, calls the
+proc again. Hash-tag invariants drop entirely (single DB).
+
+**Depends on.** TRAIT-complete/fail/cancel Postgres impls (the
+resolution is triggered by their NOTIFY). The procedure signature must
+match the existing `ff_resolve_dependency` status return codes so the
+Rust cascade logic survives.
+
+### 3.2 `XREAD BLOCK` + PUBLISH fan-out (Worker-A §3 Tier C, Worker-B §8.2, Worker-C §2.2)
+
+**What it is.** Two separate Valkey-only idioms with overlapping migration
+shape:
+
+- `stream_tail.rs::xread_block` — long-held blocking tail on a dedicated
+  connection, used by `TRAIT-tail_stream` and `GET …/stream/tail`
+  (Worker-C §5).
+- `PUBLISH ff:dag:completions` — fan-out from 7 terminal FCALLs
+  (`ff_complete_execution`, `ff_fail_execution`, `ff_cancel_execution`,
+  `ff_expire_execution`, `ff_cancel_flow`, `ff_resume_execution`,
+  `ff_expire_suspension`) consumed by `CompletionBackend` + every
+  ff-server's `completion_listener`.
+
+**Why it's hard.**
+
+- Postgres has no native blocking stream tail. LISTEN/NOTIFY has payload
+  (~8KB), delivery (no fan-out guarantee under failure), and
+  connection-binding (one LISTEN = one held session) quirks that diverge
+  from Valkey PubSub.
+- Both touch SDK-visible contracts: `tail_stream` latency characteristics
+  matter to consumers; completion push matters to scheduler responsiveness.
+- Both rely on **dedicated connection-per-subscriber** patterns today
+  (`duplicate_connection` for tail, RESP3 `push_sender` subscriber for
+  completions). The pattern survives on Postgres but the connection
+  accounting changes.
+
+**Proposal sketch.**
+
+1. **Completions:** LISTEN `ff_completion` channel; payload is
+   `{execution_id, flow_id, outcome}` JSON. Every terminal FCALL's stored
+   proc does a single `NOTIFY`. If payload size becomes a constraint,
+   insert into `ff_completion_event(seq, …)` table and NOTIFY with just
+   the seq; subscribers SELECT the row. The `dependency_reconciler`
+   scanner survives as the safety net for dropped notifies.
+2. **Tail:** LISTEN `ff_stream_<exec_id>_<attempt>` — row-level trigger
+   on INSERT into `ff_stream_frame`. Tail implementation: after subscribe,
+   long-poll `SELECT … WHERE frame_id > :last` with a timeout backed by
+   the NOTIFY wake.
+
+**Depends on.** §4.1 (completion transport decision) and §4.2 (XREAD BLOCK
+semantics decision).
+
+### 3.3 `handle_codec` + `CompletionBackend` (Worker-B §8)
+
+**What it is.** `handle_codec.rs` encodes the 8-field Valkey attempt cookie
+(`execution_id`, `attempt_index`, `attempt_id`, `lease_id`, `lease_epoch`,
+`lease_ttl_ms`, `lane_id`, `worker_instance_id`) as bytes for SDK round-trip.
+`completion.rs` is the RESP3 subscriber + FilterGate + reconnect loop.
+
+**Why it's hard.**
+
+- `HandleOpaque` is declared backend-private — good, because the Postgres
+  backend gets to ship its own codec with its own version tag and its own
+  field set. The question is **what fields the Postgres codec actually
+  needs** (Worker-B §8.1 end).
+- `CompletionBackend` trait is clean (`subscribe_completions() →
+  CompletionStream`) — the Valkey implementation is not. Every
+  subscribed client needs a dedicated connection; under LISTEN/NOTIFY
+  the pattern is identical cost but the mechanics differ (LISTEN holds
+  the session).
+- `FilterGate` is a per-push HGET for namespace/tag match. Trivial to
+  port (single SELECT) but means every NOTIFY triggers a DB round-trip
+  per subscriber unless we bake the filter into the NOTIFY payload.
+
+**Proposal sketch.**
+
+- **Codec:** Postgres codec version tag `0x02`; fields are the minimum
+  to reconstruct trait-method ARGV: `execution_id`, `attempt_index`,
+  `attempt_id`, `lease_id`, `lease_epoch`, `worker_instance_id`. Likely
+  drop `lease_ttl_ms` (Postgres lease expiry is SQL-native; server reads
+  it). Drop `lane_id` if we can pick it up cheaply in the trait-method
+  stored proc; keep if metrics labels need it eagerly.
+- **CompletionBackend:** LISTEN-based impl that matches the Valkey
+  interface byte-for-byte from the engine's perspective. Carry
+  `namespace` + `instance_tag` in the NOTIFY payload so FilterGate
+  doesn't round-trip. Reconciler safety net unchanged.
+
+**Depends on.** §4.1.
+
+### 3.4 Scheduler claim pipeline — budget/quota admission (Worker-C §3)
+
+**What it is.** `Scheduler::claim_for_worker` is ~450 lines of orchestrated
+Valkey calls: `ZRANGEBYSCORE` eligible → capability CSV check → budget
+check (1 `HGETALL` + N `HGET`, cached) → quota admission (5-key FCALL
+sliding window + concurrency) → `FCALL ff_issue_claim_grant`.
+
+**Why it's hard.**
+
+- **It's the densest composition in the codebase.** Five separate atomic
+  units, ordered, each with its own error branch (e.g. Lua
+  `CapabilityMismatch` re-blocks; other Lua errors release the admission
+  via `ff_release_admission`).
+- Budget + quota each have their own per-cycle cache — MANDATORY on
+  Valkey (50K blocked candidates sharing a budget = 1 read, not 50K).
+  Postgres single-statement admission check removes the need, but only
+  if the new stored proc is as cheap as a cached read.
+- Capability matching today is CSV-subset (Rust short-circuit + Lua
+  authoritative). GIN `text[] @>` is the obvious SQL fit but the
+  contract currently emits CSV — Q7 (§4.7).
+
+**Proposal sketch.** One stored proc `ff_claim_try(worker_id,
+worker_instance_id, lane, caps[], rotation_cursor) → {status,
+grant?, block_reason?}` that does the full admission inside a single
+`SELECT … FOR UPDATE SKIP LOCKED` + row-lock'd quota/budget update. The
+scheduler's partition-walk + rotation + per-worker FNV jitter stay
+Rust-local (Worker-C §3.1 steps 1–4). Keeping it in SQL improves
+concurrency (no client-side cache needed; quota drift disappears —
+§4.5 dependency on partition semantics survival.)
+
+**Depends on.** Q5 (partition column), Q7 (capability contract).
+
+### 3.5 `ff_suspend_execution` + signal machinery (Worker-A §1.4, §1.5)
+
+**What it is.** The largest FCALL in the library: 18+3N KEYS, multi-
+waitpoint RFC-014 Pattern-3, HMAC token mint with `redis.sha1hex` + kid
+grace. Pairs with `ff_deliver_signal` (14 KEYS, `helpers.lua`
+composite-condition tree evaluator ~400 lines of AND/OR/K-of-N/sequence
+walk) and `ff_buffer_signal_for_pending_waitpoint`.
+
+**Why it's hard.**
+
+- Not exotic, just **big**: the FCALL body touches suspension record,
+  waitpoint rows, satisfaction sets, member maps, lease indexes, attempt
+  stream close, and mints HMAC tokens — all atomic.
+- HMAC-sha1 in Lua is a correctness-sensitive cryptographic path;
+  porting to Rust `hmac` is a testability win but also a rotation-
+  migration question (Q4).
+- Composite-condition eval is 400 lines of pure-Lua with side tables
+  (`satisfied_set` / `member_map`). Porting to Rust is straight — it's
+  pure code — but the test coverage is in `ff-script` integration
+  tests that run against a real Valkey.
+
+**Proposal sketch.** Per-op stored proc; HMAC moves to a
+`ff-core::waitpoint_hmac` Rust module both backends call (Worker-A Q7 says
+the same); composite-condition evaluator moves to `ff-core::signal_eval`
+or lives in the scheduler/server Rust side and the stored proc receives
+a pre-evaluated "does this signal satisfy the condition" boolean. Second
+option avoids having SQL mirror the Lua logic.
+
+**Depends on.** Q4 (HMAC scope).
+
+---
+
+## Part 4 — Open design questions (consolidated)
+
+Merged list. Each question states where it surfaces across the three
+surveys, our proposed resolution, and the impact if we get it wrong.
+Items Q1–Q5 are the "before you write code" locks from the executive
+summary; Q6–Q10 are smaller but still need an answer before the stage
+they affect lands.
+
+### Q1 — Completion transport (PUBSUB → ?)
+
+- **Surfaces:** Worker-A §5 Q1; Worker-B §9.2 + §8.2; Worker-C §2.2,
+  §7.1, §7.2.
+- **Statement:** Replace `PUBLISH ff:dag:completions` with LISTEN/NOTIFY,
+  outbox-poll, or logical replication?
+- **Proposal:** LISTEN/NOTIFY with small JSON payload (`{execution_id,
+  flow_id, outcome, namespace, instance_tag}`), `dependency_reconciler`
+  continues as the safety net for drops. Fallback: if payload-size or
+  delivery-reliability tests fail, move to outbox-poll on
+  `ff_completion_event`.
+- **Impact if wrong:** Scheduler dependency-resolution latency spike
+  (push path is the primary mechanism; poll-only would add ~one
+  scanner-cycle of latency per hop). Not catastrophic — scanner is the
+  backstop — but enough to regress SLOs.
+
+### Q2 — XREAD BLOCK semantics
+
+- **Surfaces:** Worker-A §5 Q2; Worker-B §9.3; Worker-C §5.1, §7.7.
+- **Statement:** Keep blocking SDK tail (LISTEN-backed long-poll) or
+  flip SDK consumers to pull-with-backoff?
+- **Proposal:** Keep the blocking contract. LISTEN on
+  `ff_stream_<exec>_<attempt>` + short-poll select when notified. SDK
+  clients see unchanged semantics. Current `xread_block_lock` server-
+  wide Mutex (Worker-C §4 step 5) disappears.
+- **Impact if wrong:** If we flip to pull-with-backoff, SDK consumers
+  see breaking latency/throughput change — documented contract break.
+
+### Q3 — Stream ID encoding
+
+- **Surfaces:** Worker-A §5 Q3; Worker-B §9.1 + §4.1 + §4.2.
+- **Statement:** Valkey `<ms>-<seq>` IDs are lex-orderable strings. Pg
+  alternatives: (a) `(ts_ms bigint, seq int)` composite with a combined
+  index; (b) `bigserial` + materialized `ms-seq` string; (c) ULID.
+- **Proposal:** (a). Composite `(ts_ms, seq)`. Keep `StreamCursor::At`
+  wire as string + add a typed `StreamEntryId` constructor (Worker-B §4.1
+  migration sketch). SDK compat: `At(String)` still works; parser rejects
+  malformed IDs at the boundary.
+- **Impact if wrong:** Lock-in of wire shape affects historical-frame
+  export + cross-backend migration tooling. Picking ULID later forces
+  a second parser path.
+
+### Q4 — HMAC secret scope
+
+- **Surfaces:** Worker-A §5 Q4; Worker-B §4.9 + §1.2; Worker-C §3
+  (grant signing), §6.1 (admin rotation).
+- **Statement:** Valkey keeps per-partition replicated
+  `waitpoint_hmac_secrets` hash for FCALL co-location. Postgres needs
+  no replication. Do we (a) keep per-partition semantics for a shared
+  contract, or (b) collapse to one global `ff_waitpoint_hmac(kid, ...)`
+  row?
+- **Proposal:** (b). Collapse to global. `admin rotate-waitpoint-secret`
+  becomes one UPDATE. Per-partition survives on Valkey side only.
+- **Impact if wrong:** Keeping per-partition on Postgres forces every
+  FCALL-equivalent stored proc to read N secret rows — pointless cost.
+
+### Q5 — Partition column survival
+
+- **Surfaces:** Worker-B §2.2 + §9.5; Worker-C §7.3 + §3.1 + §7.3.
+- **Statement:** Does `num_flow_partitions=256` remain a meaningful
+  concept on Postgres (row-level hash partitioning, `partition_id
+  smallint` column) or collapse entirely?
+- **Proposal:** **Keep.** As `PARTITION BY HASH(partition_key)
+  PARTITIONS 256`. Three reasons: (1) keeps `ExecutionId` prefix and
+  `PartitionKey` wire-stable; (2) leaves open sharded-DB deployments
+  (Citus/Postgres-XL); (3) lets the `partition-collisions` CLI and
+  RFC-011 co-location invariant stay meaningful. Cost: one `smallint`
+  column on every row. Negligible.
+- **Impact if wrong:** Collapsing too early means cairn's `ExecutionId`
+  shape has to change (public API break). Keeping too long means dead
+  schema complexity — but dead complexity is cheap; breaking cairn isn't.
+
+### Q6 — MAXLEN retention semantics
+
+- **Surfaces:** Worker-A §5 Q5.
+- **Statement:** `XADD MAXLEN ~ N` is approximate. Pg can be strict
+  (count-limited `DELETE`) or approximate (partition-drop).
+- **Proposal:** Strict, via a retention job that runs on `append_frame`
+  write (piggy-back, not scheduled) — `DELETE WHERE rank > N` using a
+  window function. If retention cost dominates, fall back to partition-
+  by-time (`pg_partman`) with drop-partition; the "approximate N" is a
+  legacy Valkey artifact, not a contract we want to preserve.
+- **Impact if wrong:** If strict retention's `DELETE` is too slow under
+  hot `append_frame`, p99 on that method regresses. Mitigation: make
+  retention async via a trigger or a janitor.
+
+### Q7 — Capability matching surface
+
+- **Surfaces:** Worker-A §5 Q7; Worker-C §3.2, §7.4.
+- **Statement:** Today `required_capabilities` is a CSV on the contract
+  layer, with Rust short-circuit and Lua authoritative `missing_capabilities`
+  (tight token/length bounds). GIN `text[] @>` is the SQL fit. Do we
+  port the contract to `text[]` too, or keep CSV and map client-side?
+- **Proposal:** Move capability logic into a shared `ff-core::caps`
+  module (both backends call) using `Vec<String>`/`text[]` internally;
+  keep CSV as the **wire** shape for cairn compat (ff-sdk serialises
+  CSV on the edge). Zero-churn for cairn; clean for the backend.
+- **Impact if wrong:** Forcing CSV downstream means Postgres can't use
+  GIN; every admission check becomes a scan of all workers. Punt-risk:
+  performance.
+
+### Q8 — Loader/version negotiation cross-backend
+
+- **Surfaces:** Worker-A §5 Q6; Worker-C §7.8.
+- **Statement:** With two backends, `ff-script::LIBRARY_VERSION` becomes
+  Valkey-only. SDKs currently pin against it. Do we (a) expose a
+  `Backend::backend_version() → (name, version)` method, or (b) rely on
+  semver of the Rust crate?
+- **Proposal:** (a). A trait method returning `("valkey", 26)` or
+  `("postgres", schema_migration_version)`. SDKs can assert
+  backend identity + version for mixed-rollout safety.
+- **Impact if wrong:** Mixed-version rollouts during migration can't
+  distinguish "old Valkey server + new Postgres server" from
+  "mismatched schema."
+
+### Q9 — Scanner polling vs push
+
+- **Surfaces:** Worker-C §7.2, §7.9.
+- **Statement:** 14 of 17 scanners poll due-ZSETs. Postgres supports
+  `LISTEN/NOTIFY` on triggers — could replace polling for at least 6
+  scanners (lease_expiry, delayed_promoter, attempt_timeout,
+  execution_deadline, suspension_timeout, pending_wp_expiry).
+- **Proposal:** **Keep polling** in v0.7. The template is identical,
+  the tests are identical, and the cost of polling on Postgres is well-
+  understood (`SELECT FOR UPDATE SKIP LOCKED` is the canonical pattern).
+  Revisit push in v0.8 if latency becomes a concern. Drop scanners 10
+  + 11 (budget_reconciler, quota_reconciler) entirely since SQL tx
+  atomicity removes the drift they correct.
+- **Impact if wrong:** Dropping the reconcilers assumes every admission
+  path is strictly atomic — if any path escapes (e.g. a partial failure
+  outside the DB), drift accumulates silently.
+
+### Q10 — `claim` + `claim_from_reclaim` Valkey impls first
+
+- **Surfaces:** Worker-B §9.10.
+- **Statement:** Both methods return `Unavailable` on the trait today.
+  Fresh-claim and reclaim-claim go through SDK paths that predate the
+  trait.
+- **Proposal:** **Finish the Valkey impls before writing the Postgres
+  backend.** Otherwise we validate the trait shape under a second
+  backend before the primary one, and any trait churn becomes a
+  double-rewrite.
+- **Impact if wrong:** Trait churn. Wasted implementation work.
+
+---
+
+## Part 5 — Proposed stage plan (strawman for owner debate)
+
+Five stages. Each is self-contained and CI-green-at-the-end
+(workspace tests pass with both backends compiled, Postgres tests
+gated on a `ff-backend-postgres` feature + a `TESTPG=1` env var).
+Stages can overlap in wall-clock time if parallel agents are
+available, but every stage has a "merge-blocker" that the next
+stage depends on.
+
+### Stage A — Scaffolding + Valkey-completion (weeks 0–2)
+
+**Goal.** Ship a compilable `ff-backend-postgres` crate stub; close
+out `TRAIT-claim` + `TRAIT-claim_from_reclaim` Valkey impls (Q10);
+resolve design locks Q1/Q2/Q3/Q4/Q5.
+
+**Deliverables:**
+- Crate `ff-backend-postgres` with `EngineBackend` + `CompletionBackend`
+  stubs returning `Unavailable`.
+- `sqlx::migrate!`-based schema loader wired into a new boot step
+  equivalent to `ff_script::loader::ensure_library`.
+- Valkey impls for `TRAIT-claim` and `TRAIT-claim_from_reclaim` landed.
+- Owner-decided resolutions for Q1–Q5 recorded as RFC-017 (or similar).
+- `Backend::connect(config)` + `Backend::backend_version()` trait
+  methods added to `ff-core`.
+
+**Merge blocker:** Valkey CI green; Postgres CI runs compile-check only.
+
+### Stage B — Trivial + moderate trait-method ports (weeks 2–5)
+
+**Goal.** Land Postgres impls for every T/M trait method (~22 of 30).
+Every read-only method (`describe_*`, `list_*`) collapses to a single
+SELECT. Every moderate write method (`renew`, `progress`, `delay`,
+`wait_children`, `create_waitpoint`, `report_usage`, etc.) becomes a
+stored proc.
+
+**Deliverables:**
+- Schema migration 0001 covering `ff_flow`, `ff_execution`, `ff_attempt`,
+  `ff_lease`, `ff_waitpoint`, `ff_signal`, `ff_budget*`, `ff_quota*`,
+  `ff_edge*` + the partial indexes replacing `IndexKeys`.
+- 22 trait-method impls with stored procs.
+- Shared `ff-core::caps` + `ff-core::waitpoint_hmac` modules (Q7
+  resolution + HMAC rust-native).
+- `handle_codec` v2 for Postgres (`BackendTag::Postgres`).
+
+**Merge blocker:** Postgres CI runs integration tests for the 22 methods
+(parity-tested against Valkey). Cairn smoke-runs against Postgres build
+for the methods shipped.
+
+### Stage C — Hard FCALLs + hotspot FCALLs (weeks 5–9)
+
+**Goal.** Land the 12 "Hard" FCALL ports plus the four hotspots from
+Part 3.
+
+**Deliverables:**
+- Stored procs for `ff_cancel_execution`, `ff_fail_execution`,
+  `ff_reclaim_execution`, `ff_cancel_flow`, `ff_resolve_dependency`,
+  `ff_replay_execution`, `ff_suspend_execution`, `ff_resume_execution`,
+  `ff_expire_suspension`, `ff_deliver_signal`,
+  `ff_buffer_signal_for_pending_waitpoint`, `ff_append_frame`.
+- Composite-condition evaluator ported to Rust (`ff-core::signal_eval`).
+- `partition_router::dispatch_dependency_resolution` works against
+  Postgres backend.
+- `Scheduler::claim_for_worker` Postgres stored-proc path.
+
+**Merge blocker:** All 30 trait methods green on both backends.
+Cairn smoke completes.
+
+### Stage D — Transport layer (weeks 9–11)
+
+**Goal.** Port the pubsub + tail primitives per Q1/Q2.
+
+**Deliverables:**
+- `CompletionBackend` Postgres impl (LISTEN/NOTIFY on `ff_completion`).
+- `TRAIT-tail_stream` Postgres impl (LISTEN on per-attempt channel +
+  long-poll select).
+- Completion + tail integration tests on both backends.
+- Drop scanners `budget_reconciler` + `quota_reconciler` + make
+  `index_reconciler` Postgres-optional (Q9 resolution).
+
+**Merge blocker:** Latency parity within agreed SLOs (scheduler
+dependency-resolution end-to-end + tail wake).
+
+### Stage E — Admin, ops, docs, deprecation (weeks 11–14)
+
+**Goal.** Close the loop: admin path, boot step parity, deprecation
+path for `ff_script::loader`, migration tooling for cairn-running-Valkey.
+
+**Deliverables:**
+- `Backend::rotate_waitpoint_secret` + `/v1/admin/rotate-waitpoint-secret`
+  Postgres path.
+- `admin partition-collisions` unchanged (already backend-agnostic).
+- Migration tooling for Valkey→Postgres state transfer (one-shot dump +
+  load). Spec only if cairn's migration doesn't need it.
+- Release `ff-backend-postgres` v0.1 + RELEASING.md update + release.toml
+  update (per the release-publish-list-drift lesson).
+- Scanner cadence re-tuning for Postgres round-trip costs.
+
+**Merge blocker:** Cairn running entirely on Postgres in staging for
+a full week.
+
+---
+
+## Part 6 — What STAYS (backend-agnostic work already done)
+
+Calling out upfront so readers know the migration isn't starting from
+scratch:
+
+- **RFC-012 Stage 1 `EngineBackend` trait abstraction** — the 30-method
+  trait already exists (Worker-B §3). Most signatures are generic; the
+  few Valkey leaks are isolated (Worker-B §4) and have migration sketches.
+- **RFC-011 exec-flow co-location** — exec keys already hash-tag to the
+  parent flow's partition. On Postgres the "co-location" degenerates to
+  "same `partition_id` column" with no correctness cost.
+- **`CompletionBackend` trait** — already pubsub-shaped with
+  `subscribe_completions()`. Valkey impl is swappable (Worker-B §8.2).
+- **`completion_listener` engine code** — already backend-agnostic.
+  Consumes a `CompletionStream`. Only the downstream
+  `dispatch_dependency_resolution` call is Valkey-coupled
+  (Worker-C §2.2) and that's Hotspot 3.1.
+- **`ff-observability` + tower-layer + `ff-observability-http` +
+  handler-DI patterns** — pure Rust, no Valkey references (Worker-C §6.2).
+- **Sentry + Grafana dashboards** — backend-agnostic metric names.
+  OTEL-via-ferriskey means OTEL-via-sqlx swap is a config change
+  (per 2026-04-22 owner lock on metrics=OTEL).
+- **`PartitionFamily` + `PartitionConfig` + `CRC16-CCITT` partition math**
+  — Worker-B §2.1. Survives verbatim.
+- **`ExecutionId`, `FlowId`, `LeaseId`, `AttemptId`, etc.** — UUIDv4
+  newtypes via `uuid_id!` macro. Direct Postgres `uuid` column.
+- **`EngineError` taxonomy** — all top-level variants + sub-kinds are
+  backend-agnostic except `BackendErrorKind`'s `Cluster` / `ScriptNotLoaded`
+  (which become `SerializationFailure`/`DeadlockDetected` via the
+  `#[non_exhaustive]` additive path) and the downcast helpers in
+  `ff_script::engine_error_ext` (which mirror cleanly in
+  `ff_backend_postgres::engine_error_ext`).
+- **`admin partition-collisions` CLI** — pure function over
+  `PartitionConfig`. No change (Worker-C §6.1).
+- **HTTP layer (`api.rs`)** — already a thin HTTP shim. Only `/healthz`
+  `PING` is Valkey-coupled (Worker-C §5.2). Backend trait hides everything
+  else.
+- **Schedule rotation / FNV jitter / capability CSV validation** —
+  pure Rust in `ff-scheduler` (Worker-C §3.1 steps 1–3). No port needed.
+- **`FailureTracker` + `supervised_spawn`** — process-local supervisor
+  primitives. No change.
+
+---
+
+## Part 7 — Risks + unknowns
+
+### 7.1 "Nothing's proven until we have a consumer on Postgres"
+
+The project-thesis memo and the 2026-04-22 owner locks both assume
+cairn co-adopts Postgres. If cairn stays on Valkey indefinitely, v0.7
+ships without a real consumer smoke; the "Smoke after publish" lesson
+(v0.3.2 ScannerFilter + CompletionBackend accessor blockers) applies
+squarely here. Mitigation: Stage B's cairn smoke gate is load-bearing;
+if cairn can't migrate in the window, extend Stage B until they can.
+
+### 7.2 Performance parity assumptions
+
+- `LISTEN/NOTIFY` at Valkey PubSub's fan-out rate: unverified. Benchmark
+  in Stage D before declaring completion-transport done.
+- `SELECT FOR UPDATE SKIP LOCKED` scanner semantics under high partition
+  count (256) + high cardinality: well-understood, but untested under
+  FlowFabric's load profile. Benchmark in Stage B.
+- `append_frame` retention cost: strict-N DELETE may dominate on hot
+  attempts. Q6 has a fallback.
+- Scheduler claim-latency under Postgres admission stored proc vs the
+  current 5-call Valkey composite: the cached-budget-reads optimization
+  disappears (no cache needed) but the single stored proc must fit in a
+  budget comparable to cached Valkey.
+
+**The "Perf honesty" memo applies.** If a benchmark regresses, revert;
+don't rationalise.
+
+### 7.3 Migration tooling for the cairn-running-Valkey case
+
+Not a v0.7 scope item *per the peer-team-boundaries memo* — cairn's
+migration is their RFC. But if cairn chooses not to co-adopt, v0.7 has
+no forcing function for migration tooling and it becomes a dead feature
+in the roadmap. Flag for Stage E.
+
+### 7.4 Trait drift during the port
+
+Hot unknowns that could force `EngineBackend` changes in-flight:
+- `StreamCursor::At(String)` → `At(StreamEntryId)` (Worker-B §4.1)
+  requires a deprecation cycle or a breaking change.
+- `AppendFrameOutcome.stream_id: String` same shape.
+- `BackendTag` enum needs a `Postgres` variant (Worker-B §3 notes it's
+  declared `#[non_exhaustive]`).
+
+Mitigation: land all trait surface changes in Stage A before impl work
+starts. Don't discover mid-Stage-C.
+
+### 7.5 Mixed-version rollouts during migration
+
+Two-backend coexistence means ff-server can be Valkey-backed while a
+replica is Postgres-backed (for smoke). Q8 addresses the SDK side; the
+operational side is harder — shared secrets, shared idempotency state,
+shared completion channels. Not a code risk; an operator-doc risk. Flag
+for Stage E.
+
+### 7.6 Documentation + RFC debt
+
+Every FCALL's contract is documented only in its Lua source + the RFC
+that introduced it. Porting the contract to Rust stored procs loses the
+Lua as a reference. Mitigation: the Rust side must preserve the RFC
+link in doc comments; CI diff on RFC ↔ code drift per the
+`release-publish-list-drift` lesson pattern.
+
+---
+
+## References
+
+- Worker-A survey — `rfcs/drafts/v0.7-migration-survey-lua.md` on
+  `docs/v0.7-migration-survey-lua`.
+- Worker-B survey — `rfcs/drafts/v0.7-migration-survey-core.md` on
+  `docs/v0.7-migration-survey-core`.
+- Worker-C survey — `rfcs/drafts/v0.7-migration-survey-engine.md` on
+  `docs/v0.7-migration-survey-engine`.
+- RFC-010 — Valkey-native state model (primary Lua contract reference).
+- RFC-011 — Exec-flow co-location (exec keys hash-tag to flow partition).
+- RFC-012 — `EngineBackend` trait abstraction (Stage 1 landed).
+- RFC-013 — Flow engine + quorum dependency resolution.
+- RFC-014 — Multi-waitpoint / suspension patterns.
+- RFC-015 — Dynamic MAXLEN + DurableSummary.
+- RFC-016 — Edge-group sibling cancel.
+- `rfcs/drafts/v06-v07-scope.md` — v0.7 Postgres plan (owner scope doc).

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -662,7 +662,7 @@ they affect lands.
 - **Impact if wrong:** Lock-in of wire shape affects historical-frame
   export + cross-backend migration tooling.
 
-### Q4 — HMAC secret scope
+### Q4 — HMAC secret scope [adjudicated 2026-04-24]
 
 - **Surfaces:** Worker-A §5 Q4; Worker-B §4.9 + §1.2; Worker-C §3
   (grant signing), §6.1 (admin rotation).
@@ -671,10 +671,26 @@ they affect lands.
   no replication. Do we (a) keep per-partition semantics for a shared
   contract, or (b) collapse to one global `ff_waitpoint_hmac(kid, ...)`
   row?
-- **Proposal:** (b). Collapse to global. `admin rotate-waitpoint-secret`
-  becomes one UPDATE. Per-partition survives on Valkey side only.
+- **Adjudication:** **(b) collapse to global on Postgres + add
+  additive trait method `rotate_waitpoint_hmac_secret_all(..)`.**
+  - Postgres stores `ff_waitpoint_hmac(kid, secret, rotated_at)` —
+    one row per live kid, no `partition_id`. Rotation = one INSERT.
+  - New trait method `rotate_waitpoint_hmac_secret_all(RotateArgs) ->
+    RotateAllResult` lands additively on `EngineBackend`. Valkey impl
+    fans out across all partitions internally; Postgres impl writes
+    one row. SDK/admin consumer calls the new method for a clean
+    "rotate everywhere" semantic.
+  - Existing `rotate_waitpoint_hmac_secret(partition, ..)` stays on
+    the trait (backwards compat). Valkey keeps its per-partition
+    semantics; Postgres impl ignores the `partition` arg and writes
+    globally, with a rustdoc note that consumers should prefer
+    `rotate_waitpoint_hmac_secret_all` for clarity.
+- **Why not keep per-partition on Postgres:** the shape existed purely
+  as a Valkey FCALL-atomicity workaround. Carrying it forward adds N×
+  storage + N× rotation work for zero functional gain.
 - **Impact if wrong:** Keeping per-partition on Postgres forces every
-  FCALL-equivalent stored proc to read N secret rows — pointless cost.
+  FCALL-equivalent stored proc to read N secret rows — pointless
+  cost + audit complexity.
 
 ### Q5 — Partition column survival
 

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -578,21 +578,29 @@ Items Q1–Q5 are the "before you write code" locks from the executive
 summary; Q6–Q10 are smaller but still need an answer before the stage
 they affect lands.
 
-### Q1 — Completion transport (PUBSUB → ?)
+### Q1 — Completion transport (PUBSUB → ?) [adjudicated 2026-04-24]
 
 - **Surfaces:** Worker-A §5 Q1; Worker-B §9.2 + §8.2; Worker-C §2.2,
   §7.1, §7.2.
 - **Statement:** Replace `PUBLISH ff:dag:completions` with LISTEN/NOTIFY,
   outbox-poll, or logical replication?
-- **Proposal:** LISTEN/NOTIFY with small JSON payload (`{execution_id,
-  flow_id, outcome, namespace, instance_tag}`), `dependency_reconciler`
-  continues as the safety net for drops. Fallback: if payload-size or
-  delivery-reliability tests fail, move to outbox-poll on
-  `ff_completion_event`.
-- **Impact if wrong:** Scheduler dependency-resolution latency spike
-  (push path is the primary mechanism; poll-only would add ~one
-  scanner-cycle of latency per hop). Not catastrophic — scanner is the
-  backstop — but enough to regress SLOs.
+- **Adjudication:** **LISTEN/NOTIFY with row-id pointer + outbox-table
+  replay on reconnect.** Listener is a single long-lived tokio task per
+  subscriber holding a `tokio-postgres` connection — negligible cost
+  on modern Postgres (connections are cheap for idle LISTENers). NOTIFY
+  payload carries only the `completion_event` row id, sidestepping the
+  8 KB payload cap. On subscriber reconnect, replay from
+  `last_seen_event_id` against the `ff_completion_event` outbox table;
+  the outbox is the durable source of truth, NOTIFY is the wake-up.
+  `dependency_reconciler` remains the safety net for any notify lost
+  between commit and listener delivery.
+- **Why not pure outbox-poll:** push latency matters for scheduler
+  dependency-resolution — poll-only adds ~one scanner-cycle per hop.
+- **Why not logical replication:** operational complexity + coupling
+  to a Postgres feature that cairn deployments may not have enabled.
+- **Impact if wrong:** Scheduler dependency-resolution latency spike.
+  Not catastrophic — `dependency_reconciler` is the backstop — but
+  enough to regress SLOs under load.
 
 ### Q2 — XREAD BLOCK semantics
 

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -99,6 +99,15 @@ and cairn co-adopts so the external-consumer smoke test is real. Range:
 
 Five smaller decisions live in §4.6–§4.10.
 
+**Forward-only cutover (surface up-front, round-2 L-r2-2).** Once
+writes land on Postgres for a tenant, rollback requires v0.6.x
+redeploy of the `ff-server` binary on that tenant's instances —
+forward data is not replicated back to Valkey in v0.7. The one-shot
+Valkey→Postgres migration tool is unidirectional by design (§Q15,
+§8.2). Plan cutover assuming the Valkey→Postgres direction is
+terminal per tenant; rollback abandons or retains Postgres-side
+state and reroutes to the Valkey-backed ff-server.
+
 ---
 
 ## Part 1 — Dimensional layers (Valkey → Postgres translation patterns)
@@ -449,6 +458,13 @@ only 1-hop children. Sweep interval SLO: `≤ 15s` (matches current Valkey
 `dependency_reconciler` cadence — Worker-C §1.1 row 13). This invariant
 is a Stage C test-gate: fault-inject a crash at hop 2 of 4 and assert
 all descendants reach terminal state within one reconciler cycle.
+
+**Same backstop covers retry-exhaust (Q11 fallback).** When the
+`SERIALIZABLE` retry loop on `ff_resolve_dependency_sp` exhausts, the
+cascade loop drops the hop rather than surfacing to the SDK (§Q11).
+The reconciler's transitive-descendant sweep is what reconverges the
+blocked set — the crash-recovery path and the retry-exhaust path share
+the same recovery primitive.
 
 **Proposal sketch.** One stored procedure `ff_resolve_dependency_sp(child_eid,
 upstream_outcome, …)` returning `{status, next_children_to_cascade[]}`.
@@ -958,6 +974,18 @@ they affect lands.
   (3 attempts, 50/100/200ms jittered) on `SQLSTATE 40001`;
   `EngineError::Backend(SerializationFailure)` is the terminal class
   after retry exhaustion.
+- **Retry-exhaust fallback (round-2 K follow-up).** When the 3-attempt
+  SERIALIZABLE retry loop exhausts at `ff_resolve_dependency` /
+  `ff_deliver_signal` / `ff_suspend_execution`, the cascade loop MUST
+  NOT surface `SerializationFailure` to the SDK. The cascade is
+  idempotent (re-running hop K converges), so the safe fallback is
+  to drop the hop and let the appropriate reconciler
+  (`dependency_reconciler` for resolve; `signal_reconciler` /
+  `suspension_reconciler` for the other two) pick it up on the next
+  scan cycle. The caller path returns success-with-recovery-deferred;
+  the reconciler-delivered counter (§9.3) is the observability signal
+  that the fallback fired. The `>0.1%` retry-exhaust alert remains —
+  it's the health signal, not a caller-visible error.
 - **Why not SERIALIZABLE everywhere:** SSI predicate-lock overhead
   on hot-path methods (`renew`, `progress`, `append_frame`,
   `report_usage`) is a performance tax for invariants we don't need
@@ -984,14 +1012,12 @@ they affect lands.
   ff-server binary at boot (auto-apply via `sqlx::migrate!`), or by
   the operator out-of-band (`sqlx migrate run` before deploy)?
 - **Adjudication:** **Operator-applied out-of-band, with boot-time
-  schema-version check that refuses start on mismatch.** Mirrors the
-  existing Q5 boot-time partition-count check contract: the ff-server
-  process queries the applied-migration ledger on boot and refuses to
-  start if the ledger's `latest_applied_version` is less than the
-  binary's `REQUIRED_SCHEMA_VERSION`, or (more subtly) logs a warning
-  and serves read-only if it is greater (the binary is older than
-  the schema — common during a rolling deploy of a schema-backward-
-  compatible change).
+  schema-version check that branches on migration category.** Mirrors
+  the existing Q5 boot-time partition-count check contract: the
+  ff-server process queries the applied-migration ledger on boot and
+  compares `latest_applied_version` to the binary's
+  `REQUIRED_SCHEMA_VERSION`. The branch rules are spelled out in the
+  rolling-upgrade subsection below (round-2 L-r2-1 resolution).
 - **Zero-downtime rolling upgrade story:**
   1. **Additive schema change (add column, add table):** operator
      applies migration first; old binaries ignore the new column
@@ -1001,6 +1027,32 @@ they affect lands.
      is one release.
   3. **Destructive change (drop column that old binary reads):** not
      supported in a rolling upgrade; requires full drain + flag-day.
+  4. **Stored-proc signatures (round-2 K follow-up):** additive-only
+     across schema versions. New procs are free to add; existing proc
+     signatures keep their argument shape. A genuine breaking change
+     (argument-removal, type-narrow, semantic flip) requires a new
+     name with a `_v2` suffix — never a silent-redefine. Old binaries
+     continue calling the old-name proc until drained, mirroring the
+     column-rename two-phase rule.
+- **Boot-check branches on migration category (round-2 L-r2-1).**
+  Each migration file is annotated `backward_compatible=true` (all
+  additive patterns above, including stored-proc additions and `_v2`
+  rolls that retain the old proc) or `backward_compatible=false`
+  (destructive). The boot check:
+  - `ledger < required` — refuse to start (the schema is older than
+    the binary expects; operator must apply migrations first).
+  - `ledger > required` AND every intervening migration is
+    `backward_compatible=true` — start normally, read-write. This is
+    the rolling-deploy common case: a newer binary elsewhere applied
+    an additive migration; older binaries co-exist safely.
+  - `ledger > required` AND any intervening migration is
+    `backward_compatible=false` — refuse to start; destructive
+    changes force a simultaneous-all-instances restart
+    (operator-coordinated flag-day), not a rolling deploy.
+  This resolves the round-2 ambiguity between the additive matrix
+  ("old binaries stay read-write") and the earlier "read-only if
+  ledger ahead" clause: read-only is NOT the additive-case behaviour,
+  refuse-to-start IS the destructive-case behaviour.
 - **Why not auto-apply at boot:** auto-apply makes rolling deploys
   racy (N replicas all trying to apply the same migration; `sqlx`
   takes a pg advisory lock but the loser-replicas block boot until
@@ -1153,6 +1205,13 @@ Cairn smoke completes.
 - Drop `index_reconciler`; keep `budget_reconciler` +
   `quota_reconciler` (revised Q9 adjudication). Add
   `stream_frame_janitor` scanner (Q6).
+- **`dependency_reconciler` semantic delta (round-2 K-2 follow-up).**
+  On Postgres, `dependency_reconciler` picks up transitive-descendant
+  sweep responsibility per §3.1's per-hop-tx decision; the single-hop
+  Valkey model no longer sufficient. Treat the Postgres reconciler as
+  new work rather than a straight transplant: it must reachability-
+  traverse from any execution that reached terminal state within the
+  last interval, not just scan the 1-hop blocked-set.
 - **`ff_completion_recovered_by_reconciler` counter (L-3 / Op-gap-5).**
   Per-scanner counter of completions delivered by the reconciler
   fallback vs pushed via LISTEN. Threshold alert wired in Stage E's
@@ -1336,9 +1395,16 @@ and scanner-maintained rows do not overlap.
 - **Cross-backend cascade resolution is explicitly out-of-scope for
   v0.7.** If flow F has executions E1 on Valkey and E2 on Postgres, E1's
   terminal NOTIFY does NOT wake dep-resolution on E2, and vice versa.
-  Any attempt to create child executions on a different backend than
-  their parent returns `EngineError::Validation("cross-backend dep not
-  supported in v0.7")`.
+  Cairn's routing layer is what enforces that parent + child land on
+  the same backend. At the ff-server layer, an attempt to create a
+  child whose parent lives on a different backend surfaces as
+  `EngineError::NotFound` — the local `execution_id` lookup misses
+  because the foreign id can't be resolved locally. This is the same
+  error path as a genuinely nonexistent parent; ff-server has no
+  federation visibility to distinguish the two cases, and v0.7 does
+  not add it. (Round-2 K follow-up — the earlier claim of an explicit
+  `EngineError::Validation("cross-backend")` overstated what ff-server
+  can detect.)
 
 ### 8.2 Cairn migration cutover shape
 
@@ -1351,6 +1417,26 @@ migrates by:
    primitive).
 3. Waiting for in-flight executions in that partition to reach terminal
    state (the scheduler's existing drain semantics cover this).
+
+   **Suspended executions drain explicitly, per flow (round-2 K / Q15
+   follow-up).** Suspended executions — particularly long-running
+   human-in-the-loop waitpoints gated on days-long approvals — have
+   no intrinsic drain bound. They ARE drained via per-flow cutover
+   policy, not silently migrated mid-state. Operators with multi-day
+   HITL suspensions must choose one of:
+   - **Migrate the flow together with its suspended executions**
+     via the Stage E migration tool (which dumps suspension rows +
+     waitpoint state alongside execution history). This is the
+     supported path for tenants whose suspensions outlast a normal
+     drain window.
+   - **Wait for the HITL to complete on the old Valkey backend**
+     before flipping the cairn routing layer. The flow stays on
+     Valkey until the suspension resolves terminally.
+
+   There is no drop-after-timeout option: cutover does not
+   unilaterally time out a suspended execution. The same rule
+   applies to Q15 rollback: a Postgres-side suspension when
+   rollback fires must be drained or co-migrated, not abandoned.
 4. Running the **Valkey→Postgres one-shot migration tool** (Stage E
    deliverable) against that partition's keys: dumps flow-definition +
    terminal-execution history to a Postgres-shaped SQL import.

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -692,21 +692,38 @@ they affect lands.
   FCALL-equivalent stored proc to read N secret rows — pointless
   cost + audit complexity.
 
-### Q5 — Partition column survival
+### Q5 — Partition column survival [adjudicated 2026-04-24]
 
 - **Surfaces:** Worker-B §2.2 + §9.5; Worker-C §7.3 + §3.1 + §7.3.
 - **Statement:** Does `num_flow_partitions=256` remain a meaningful
   concept on Postgres (row-level hash partitioning, `partition_id
   smallint` column) or collapse entirely?
-- **Proposal:** **Keep.** As `PARTITION BY HASH(partition_key)
-  PARTITIONS 256`. Three reasons: (1) keeps `ExecutionId` prefix and
-  `PartitionKey` wire-stable; (2) leaves open sharded-DB deployments
-  (Citus/Postgres-XL); (3) lets the `partition-collisions` CLI and
-  RFC-011 co-location invariant stay meaningful. Cost: one `smallint`
-  column on every row. Negligible.
-- **Impact if wrong:** Collapsing too early means cairn's `ExecutionId`
-  shape has to change (public API break). Keeping too long means dead
-  schema complexity — but dead complexity is cheap; breaking cairn isn't.
+- **Adjudication:** **Keep.** All tables use
+  `PARTITION BY HASH(partition_key) PARTITIONS 256`.
+  - `ExecutionId` wire format `{fp:N}:uuid` unchanged → cross-backend
+    wire-compat preserved → cairn can run Valkey + Postgres
+    side-by-side during migration without consumer-code changes.
+  - Scanners + `partition_router` transplant unchanged.
+  - Native pg partitioning delivers real operational benefits:
+    query-planner pruning, per-partition VACUUM, parallel index scans.
+  - RFC-011 exec-flow co-location invariant stays meaningful (execs
+    and their parent flow land on the same partition).
+- **Explicit boot-time contract (preserved from Valkey behavior):**
+  `ServerConfig.num_flow_partitions` at `Server::start` must match
+  the schema's partition count byte-for-byte. Mismatch refuses to
+  boot. On Valkey this is the `ff:config:partitions` check; on
+  Postgres it's a catalog query against the child-partition count of
+  the primary table. Operator error surfaces immediately at boot,
+  same as today.
+- **Future evolution:** if v0.8+ retires Valkey, collapsing 256 → 1
+  is a data migration, not an API break — the partition_key column
+  can stay as a constant `0` under a single partition and the ID
+  shape is unchanged.
+- **Impact if wrong:** Collapsing to (c) prematurely breaks
+  cross-backend wire compat + forces cairn to choose one backend at
+  migration time instead of rolling. Keeping (a) has a small
+  schema-complexity carrying cost that's worth it for the migration
+  story alone.
 
 ### Q6 — MAXLEN retention semantics
 

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -602,17 +602,37 @@ they affect lands.
   Not catastrophic — `dependency_reconciler` is the backstop — but
   enough to regress SLOs under load.
 
-### Q2 — XREAD BLOCK semantics
+### Q2 — XREAD BLOCK semantics [adjudicated 2026-04-24]
 
 - **Surfaces:** Worker-A §5 Q2; Worker-B §9.3; Worker-C §5.1, §7.7.
 - **Statement:** Keep blocking SDK tail (LISTEN-backed long-poll) or
   flip SDK consumers to pull-with-backoff?
-- **Proposal:** Keep the blocking contract. LISTEN on
-  `ff_stream_<exec>_<attempt>` + short-poll select when notified. SDK
-  clients see unchanged semantics. Current `xread_block_lock` server-
-  wide Mutex (Worker-C §4 step 5) disappears.
-- **Impact if wrong:** If we flip to pull-with-backoff, SDK consumers
-  see breaking latency/throughput change — documented contract break.
+- **Adjudication:** **Keep the blocking SDK contract, but decouple it
+  from pg connection lifetime.** A tailer does NOT hold a pg connection
+  while blocked.
+  - ff-backend-postgres runs ONE long-lived shared LISTEN connection
+    subscribed to all `ff_stream_<eid>_<aidx>` channels.
+  - In-memory map routes each NOTIFY to the tokio waiters subscribed to
+    that channel (`Arc<StreamNotifier>` with a channel → `Vec<Notify>`
+    table, or equivalent with tokio `broadcast`/`mpsc` primitives).
+  - SDK `tail_stream(after, block_ms, count)` registers a waiter and
+    parks a tokio task. On wake (NOTIFY arrived OR block_ms elapsed),
+    the task grabs a pg connection from the pool, runs the
+    `SELECT WHERE id > cursor LIMIT count`, returns frames, releases
+    the connection.
+  - Cost model: 10 k active tailers = 10 k parked tokio tasks + 1 pg
+    LISTEN connection + N pool connections borrowed during read bursts.
+    pg connection count scales with active READS, not with active
+    WAITERS.
+- **Why this matters:** naive LISTEN-per-tailer would tie up a pg
+  backend process per tailer. Tokio tasks are free; pg backends aren't.
+  The architectural cost shifts to the application where it belongs.
+- **SDK compat:** `tail_stream` return shape unchanged. Multiplexed
+  consumers (one worker tailing N streams) cost N tokio tasks + 0
+  extra pg connections while idle.
+- **Impact if wrong:** Without the shared-notifier pattern, pg backend
+  process consumption scales 1:1 with tailers. Breaks operationally
+  at scale.
 
 ### Q3 — Stream ID encoding
 

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -634,19 +634,33 @@ they affect lands.
   process consumption scales 1:1 with tailers. Breaks operationally
   at scale.
 
-### Q3 — Stream ID encoding
+### Q3 — Stream ID encoding [adjudicated 2026-04-24]
 
 - **Surfaces:** Worker-A §5 Q3; Worker-B §9.1 + §4.1 + §4.2.
 - **Statement:** Valkey `<ms>-<seq>` IDs are lex-orderable strings. Pg
   alternatives: (a) `(ts_ms bigint, seq int)` composite with a combined
   index; (b) `bigserial` + materialized `ms-seq` string; (c) ULID.
-- **Proposal:** (a). Composite `(ts_ms, seq)`. Keep `StreamCursor::At`
-  wire as string + add a typed `StreamEntryId` constructor (Worker-B §4.1
-  migration sketch). SDK compat: `At(String)` still works; parser rejects
-  malformed IDs at the boundary.
+- **Adjudication:** **Option (a) — composite `(ts_ms, seq)` column pair,
+  server-authoritative generation.**
+  - Column pair: `(ts_ms bigint NOT NULL, seq int NOT NULL)`, combined
+    btree index. Closest faithful translation of Valkey stream-entry
+    semantics; `seq` disambiguates frames inserted in the same ms.
+  - Generated server-side on INSERT via
+    `(extract(epoch from clock_timestamp())*1000, nextval(seq_for_stream))`
+    so ordering stays server-authoritative (matches Valkey's XADD
+    behavior). Clients never mint IDs.
+  - `StreamCursor::At(String)` SDK wire stays unchanged. Backend parses
+    `"1714012345678-0"` at the boundary; malformed strings rejected
+    with `EngineError::Validation`.
+  - Timestamp queries ("frames since T") map to
+    `WHERE ts_ms > T ORDER BY ts_ms, seq`.
+- **Why not bigserial:** loses wall-clock tie-in; no natural answer for
+  "since timestamp" queries without a second indexed column.
+- **Why not ULID:** requires extension or Rust-side generation (trusts
+  client clocks); gains nothing over option (a) given we're already
+  server-side.
 - **Impact if wrong:** Lock-in of wire shape affects historical-frame
-  export + cross-backend migration tooling. Picking ULID later forces
-  a second parser path.
+  export + cross-backend migration tooling.
 
 ### Q4 — HMAC secret scope
 

--- a/rfcs/drafts/v0.7-migration-master.md
+++ b/rfcs/drafts/v0.7-migration-master.md
@@ -47,9 +47,12 @@ close to `bc17872` / `a54a38e` (2026-04-23).
 
 **Critical path (the 3–5 things that unlock everything else).**
 
-1. **Atomicity model.** Agree that every FCALL becomes a single `BEGIN…COMMIT`
-   under `SERIALIZABLE` (or explicit row-lock + `READ COMMITTED`). Every
-   trait-method port depends on this choice. (Part 1, §1.)
+1. **Atomicity model.** Every FCALL becomes a single `BEGIN…COMMIT`. Default
+   isolation is `READ COMMITTED + SELECT FOR UPDATE SKIP LOCKED`; the ~3
+   composite FCALLs with cross-row predicate invariants declare
+   `SERIALIZABLE` at proc entry with a documented `SQLSTATE 40001` retry
+   contract (Q11). Every trait-method port depends on this choice.
+   (Part 1 §L0, Part 4 §Q11.)
 2. **Stream ID + cursor shape.** `StreamCursor::At(String)` and
    `AppendFrameOutcome.stream_id: String` carry Valkey `<ms>-<seq>` IDs on the
    trait surface (Worker-B §4.1, §4.2). Pick the Postgres encoding before any
@@ -73,11 +76,13 @@ focused work to a Postgres backend that passes the current integration
 suite against Valkey-and-Postgres both. Calibration: one senior engineer
 full-time, assuming the owner answers Part 4's design questions upfront
 and cairn co-adopts so the external-consumer smoke test is real. Range:
-- 8 weeks: aggressive. Part 5 Stages A–C only. Scanner polling kept. No
-  performance tuning beyond "passes the existing suite."
-- 14 weeks: realistic. Stages A–E, performance parity measured, rotation
-  admin path + scanner LISTEN/NOTIFY adaptations landed, cairn smoke-test
-  cycle included.
+- 8–10 weeks: aggressive. Stages A–D only (i.e. including the transport
+  layer, without which there is no shippable Postgres server). No Stage E
+  ops deliverables (no labels-compat matrix, no PITR runbook, no cairn
+  staging week). Scanner polling kept.
+- 12–14 weeks: realistic. Stages A–E, performance parity measured,
+  rotation admin path + scanner LISTEN/NOTIFY adaptations landed, cairn
+  smoke-test cycle included, operational runbook (§9) shipped.
 
 **"Needs a design decision before code" list (the five locks).**
 
@@ -107,14 +112,17 @@ Valkey runs an FCALL body under the slot lock; every `HSET`/`ZADD`/`SREM`
 inside is atomic against the single hash-tag. Postgres replacement is one
 transaction per former FCALL.
 
-- Most FCALLs work fine under `READ COMMITTED` with explicit row locks
-  (`SELECT … FOR UPDATE`).
-- The quorum / K-of-N / composite-condition FCALLs (`ff_resolve_dependency`,
-  `ff_deliver_signal` composite eval, `ff_suspend_execution` multi-waitpoint)
-  need either `SERIALIZABLE` or careful advisory-locked sections.
-- Open: which isolation level is the default? Owner decision; proposal is
-  `READ COMMITTED` + row locks for the hot path, `SERIALIZABLE` for the ~3
-  composite FCALLs.
+- **Default:** `READ COMMITTED + SELECT FOR UPDATE SKIP LOCKED`. Applies to
+  every FCALL port unless it explicitly escalates. No caller-side 40001
+  retry loop on the default path. (Q11 adjudication.)
+- **Escalated to `SERIALIZABLE`:** the three composite-predicate FCALLs
+  that cross rows: `ff_resolve_dependency` (quorum / K-of-N),
+  `ff_deliver_signal` (composite-condition eval), `ff_suspend_execution`
+  (multi-waitpoint RFC-014). These declare `BEGIN ISOLATION LEVEL
+  SERIALIZABLE` at proc entry and document the `SQLSTATE 40001` retry
+  contract; the Rust caller wraps the call in a bounded retry loop
+  (3 attempts with jitter).
+- See Part 4 §Q11 for the adjudication + rationale.
 
 ### L1 — Hash-tag partitioning → row-level partitioning
 
@@ -154,6 +162,14 @@ Valkey Streams back the attempt frame log. Postgres candidates:
 1. **LISTEN/NOTIFY.** Closest structural match. Payload ≤ 8000 bytes (fine
    for ~200B completion wire). No durability; the existing
    `dependency_reconciler` already backs up dropped deliveries.
+   **Transactional-NOTIFY invariant:** pg queues NOTIFY at `COMMIT`, not
+   at statement execution — the outbox INSERT and the NOTIFY become
+   atomic by construction. If the tx rolls back, the NOTIFY is silently
+   dropped (correct). This narrows the reconciler's role to
+   subscriber-side delivery gaps (reconnect window, payload loss on a
+   downed LISTENer) rather than commit-ordering races. It also means a
+   single `BIGSERIAL event_id` suffices for ordering — no vector clock
+   needed.
 2. **Logical replication / `pg_recvlogical`** — durable, overkill today.
 3. **Polling `ff_completion_event(seq BIGSERIAL, …)` with `WHERE seq > $last`
    per subscriber.** Simplest; adds lag; the reconciler already does
@@ -263,7 +279,7 @@ Full map at Worker-B §6. Grouped by translation shape:
 | TRAIT-claim_from_reclaim | `claim_from_reclaim` | returns `Unavailable` today | Same | — | Q10 |
 | TRAIT-renew | `renew` | FCALL `ff_renew_lease` | 1-tx: UPDATE lease + UPSERT expiry index | M | — |
 | TRAIT-progress | `progress` | FCALL `ff_update_progress` | UPDATE row (lease-fenced) | T | — |
-| TRAIT-append_frame | `append_frame` | FCALL `ff_append_frame` | INSERT frame + UPDATE summary + retention check | H | Q3 (stream ID) |
+| TRAIT-append_frame | `append_frame` | FCALL `ff_append_frame` | INSERT frame + UPDATE summary + end-of-tx NOTIFY (retention is async per Q6) | H | Q3 (stream ID) |
 | TRAIT-complete | `complete` | FCALL `ff_complete_execution` | 1-tx: UPDATE exec → terminal + remove indexes + INSERT frame + NOTIFY | M | Q1 (PUBLISH) |
 | TRAIT-fail | `fail` | FCALL `ff_fail_execution` + pre-read policy | Retry branch: UPDATE→delayed OR UPDATE→terminal + NOTIFY | H | Q1 |
 | TRAIT-cancel | `cancel` | FCALL `ff_cancel_execution` + pre-read current_waitpoint_id | 21-key cascade (largest) | H | Q1 |
@@ -413,13 +429,33 @@ child's dependency state, cascade recursively (up to depth 50). Called by
   `{fp:N}`) — on Valkey this is multi-slot, handled only because RFC-011
   colocates exec with flow.
 - Cascade recursion is Rust-side; **the recursion crosses network RPCs**.
-  On Valkey that's fine (each RPC is a FCALL); on Postgres each recursion
-  hop is a fresh transaction or the whole cascade is one fat transaction.
+  On Valkey that's fine (each RPC is a FCALL); on Postgres the two
+  options are per-hop tx vs one fat cascade tx.
+
+**Cascade-tx decision: per-hop commit (latency-conservative).** Each
+recursion hop is a fresh transaction. Rationale: a depth-50 cascade
+under one fat tx would hold `SELECT FOR UPDATE` row locks across every
+descendant for the entire cascade duration (potentially seconds under a
+wide flow), blocking any concurrent write to those rows. Per-hop commit
+keeps each hop's lock footprint small at the cost of 50 commit-points
+per depth-50 cascade.
+
+**Crash-recovery contract.** If the server crashes after hop K commits
+and before hop K+1 runs, hops 1..K are independently durable and hops
+K+1..N are recovered by `dependency_reconciler`. **The reconciler's
+blocked-set scan spans the transitive-descendant reachable set from any
+terminal execution committed within the last reconciler-interval**, not
+only 1-hop children. Sweep interval SLO: `≤ 15s` (matches current Valkey
+`dependency_reconciler` cadence — Worker-C §1.1 row 13). This invariant
+is a Stage C test-gate: fault-inject a crash at hop 2 of 4 and assert
+all descendants reach terminal state within one reconciler cycle.
 
 **Proposal sketch.** One stored procedure `ff_resolve_dependency_sp(child_eid,
 upstream_outcome, …)` returning `{status, next_children_to_cascade[]}`.
 The Rust cascade loop stays, iterates on the returned child list, calls the
-proc again. Hash-tag invariants drop entirely (single DB).
+proc again (per-hop commit). The proc declares `SERIALIZABLE` per §Q11
+because of the quorum / K-of-N cross-row predicate. Hash-tag invariants
+drop entirely (single DB).
 
 **Depends on.** TRAIT-complete/fail/cancel Postgres impls (the
 resolution is triggered by their NOTIFY). The procedure signature must
@@ -461,10 +497,20 @@ shape:
    insert into `ff_completion_event(seq, …)` table and NOTIFY with just
    the seq; subscribers SELECT the row. The `dependency_reconciler`
    scanner survives as the safety net for dropped notifies.
-2. **Tail:** LISTEN `ff_stream_<exec_id>_<attempt>` — row-level trigger
-   on INSERT into `ff_stream_frame`. Tail implementation: after subscribe,
-   long-poll `SELECT … WHERE frame_id > :last` with a timeout backed by
-   the NOTIFY wake.
+2. **Tail:** LISTEN `ff_stream_<exec_id>_<attempt>`. **Application-level
+   NOTIFY at end of the `append_frame` tx**, *not* a per-row INSERT
+   trigger. Rationale: a per-row trigger under a 10k-frame/sec burst
+   fires 10k NOTIFYs/sec through the shared LISTEN connection with no
+   coalescing; an application-level NOTIFY at the tx boundary naturally
+   coalesces a batched INSERT into a single wake and keeps the control
+   point in Rust where we can rate-limit if needed. The stored proc
+   issues exactly one `NOTIFY ff_stream_<eid>_<aidx>, :max_frame_id`
+   immediately before return, so the NOTIFY is queued-on-COMMIT with the
+   INSERTs. Tail implementation: after subscribe, long-poll `SELECT …
+   WHERE frame_id > :last LIMIT count` with a timeout backed by the
+   NOTIFY wake. **Advisory `ts_ms` invariant:** ordering is authoritative
+   by the `(ts_ms, seq)` tuple; `ts_ms` alone is advisory and may
+   regress under clock skew or post-PITR (see §Q3).
 
 **Depends on.** §4.1 (completion transport decision) and §4.2 (XREAD BLOCK
 semantics decision).
@@ -594,6 +640,16 @@ they affect lands.
   the outbox is the durable source of truth, NOTIFY is the wake-up.
   `dependency_reconciler` remains the safety net for any notify lost
   between commit and listener delivery.
+- **Transactional-NOTIFY + ordering invariant:** pg queues NOTIFY at
+  `COMMIT`, making the outbox INSERT + wake-up atomic by construction.
+  Rolled-back txs drop the NOTIFY silently (correct). A single
+  `BIGSERIAL event_id` on `ff_completion_event` is sufficient ordering
+  — no vector clock. The `last_seen_event_id` cursor is **persisted on
+  the subscriber side** (per-subscriber row in `ff_listener_cursor` or
+  equivalent local state), not inferred from `MAX(event_id)` — otherwise
+  a listener restart between flush and rejoin would miss the window of
+  events in flight. Stage D test-gate: kill-listener-between-commit-and-
+  read; assert zero completion loss.
 - **Why not pure outbox-poll:** push latency matters for scheduler
   dependency-resolution — poll-only adds ~one scanner-cycle per hop.
 - **Why not logical replication:** operational complexity + coupling
@@ -633,6 +689,30 @@ they affect lands.
 - **Impact if wrong:** Without the shared-notifier pattern, pg backend
   process consumption scales 1:1 with tailers. Breaks operationally
   at scale.
+- **LISTEN connection failure-mode contract (added round-1 K-3):**
+  - **Reconnect protocol.** On `tokio-postgres` connection error, the
+    shared LISTEN task reconnects with exponential backoff (50ms →
+    5s cap), re-issues `LISTEN` for every channel with any registered
+    waiter, then broadcasts a single synthetic `poll-now` wake to
+    every parked waiter (with ±25% jitter to avoid thundering herd).
+    Parked waiters respond by re-running `SELECT … WHERE id > cursor
+    LIMIT count` — they catch up via the persisted cursor, not via
+    replayed NOTIFYs (NOTIFY has no replay on reconnect).
+  - **Pooler compatibility.** PgBouncer in **transaction-pool mode is
+    incompatible with LISTEN** and is UNSUPPORTED for ff-server ↔ pg
+    connections. Operators must configure session-pool mode (or a
+    direct connection) for the ff-server pool. ff-server logs a
+    structured warning on boot if it detects a transaction-pool
+    proxy in front (best-effort detection via session-variable
+    probe); the warning is non-fatal but highlighted.
+  - **Health signal.** `ff_listen_connection_healthy{partition}`
+    gauge (1 = subscribed, 0 = reconnecting). A watchdog task
+    restarts the LISTEN process if the gauge is 0 for ≥ 30s.
+    Alert fires in §9 operational runbook.
+  - **Reconnect latency degradation.** While the LISTEN connection is
+    down, tail p99 latency degrades from NOTIFY-latency (~ms) to
+    block_ms (~seconds). SDK reconnect budget on the cairn side is
+    separately jittered per SDK-delta-3; documented in §9.
 
 ### Q3 — Stream ID encoding [adjudicated 2026-04-24]
 
@@ -661,6 +741,14 @@ they affect lands.
   server-side.
 - **Impact if wrong:** Lock-in of wire shape affects historical-frame
   export + cross-backend migration tooling.
+- **Ordering invariant (added round-1 L SDK-delta-2):** The
+  **authoritative ordering** of frames within a stream is the
+  `(ts_ms, seq)` *tuple*, not `ts_ms` alone. Under clock skew or
+  post-PITR restore, `clock_timestamp()` can regress; `seq_for_stream`
+  (a per-stream Postgres sequence) monotonically disambiguates. SDK
+  consumers filtering on `ts_ms` in isolation must treat it as
+  advisory. Stage C spec + rustdoc on `StreamCursor::At` carry this
+  note.
 
 ### Q4 — HMAC secret scope [adjudicated 2026-04-24]
 
@@ -691,6 +779,20 @@ they affect lands.
 - **Impact if wrong:** Keeping per-partition on Postgres forces every
   FCALL-equivalent stored proc to read N secret rows — pointless
   cost + audit complexity.
+- **Cutover rollout contract (added round-1 K-12):** At migration
+  cutover, `ff_waitpoint_hmac` is **seeded from the union of all
+  Valkey partitions' kids** (one row per distinct kid, most-recent
+  rotated_at wins on collision). Rotation thereafter is additive: new
+  kids accumulate until operator prunes them via a dedicated admin
+  procedure. This ensures any suspend-token minted on Valkey
+  pre-cutover validates on Postgres post-cutover.
+- **Structured-warning compat (added round-1 L SDK-delta-1):** The
+  Postgres impl of the legacy `rotate_waitpoint_hmac_secret(partition,
+  …)` method emits a structured warning span event
+  (`backend.hmac.per_partition_call_on_postgres`) echoing the ignored
+  `partition` arg, so admin tooling that loops per-partition can
+  detect the no-op and adjust its progress reporting. Deprecate-and-
+  remove deferred to v0.8 via a separate RFC.
 
 ### Q5 — Partition column survival [adjudicated 2026-04-24]
 
@@ -725,19 +827,42 @@ they affect lands.
   schema-complexity carrying cost that's worth it for the migration
   story alone.
 
-### Q6 — MAXLEN retention semantics
+### Q6 — MAXLEN retention semantics [adjudicated 2026-04-24]
 
 - **Surfaces:** Worker-A §5 Q5.
 - **Statement:** `XADD MAXLEN ~ N` is approximate. Pg can be strict
-  (count-limited `DELETE`) or approximate (partition-drop).
-- **Proposal:** Strict, via a retention job that runs on `append_frame`
-  write (piggy-back, not scheduled) — `DELETE WHERE rank > N` using a
-  window function. If retention cost dominates, fall back to partition-
-  by-time (`pg_partman`) with drop-partition; the "approximate N" is a
-  legacy Valkey artifact, not a contract we want to preserve.
-- **Impact if wrong:** If strict retention's `DELETE` is too slow under
-  hot `append_frame`, p99 on that method regresses. Mitigation: make
-  retention async via a trigger or a janitor.
+  (count-limited `DELETE`) or approximate (async janitor).
+- **Adjudication:** **Approximate-N via an async per-partition janitor
+  scanner with bounded overshoot.** This is the contract RFC-015
+  deliberately locked on Valkey (approximate trim for p99 stability);
+  Postgres preserves it.
+  - A `stream_frame_janitor` scanner (new, joins the 17 existing
+    scanners) walks partitions on a 5s cadence. Per attempt where
+    `frame_count > MAXLEN + overshoot_threshold`, it runs
+    `DELETE … WHERE (ts_ms, seq) < (cutoff_ts, cutoff_seq)` where
+    the cutoff is chosen by a single indexed LIMIT/OFFSET lookup.
+    Overshoot_threshold is configurable (default 10% of MAXLEN).
+  - **Not piggybacked on `append_frame`.** Piggybacking a `DELETE
+    WHERE rank > N` inside the INSERT tx would require a
+    `ROW_NUMBER() OVER (PARTITION BY stream ORDER BY ts_ms, seq
+    DESC)` scan of the attempt's frames on every INSERT (non-
+    index-only) and take row locks on the oldest-N frames under
+    hot-append contention. Rejected for p99 latency.
+  - Overshoot bound under worst-case burst: per-attempt overshoot ≤
+    `threshold + (burst_rate × scanner_interval)`. With 100
+    frames/sec and 5s cadence, worst-case overshoot = threshold +
+    500. Documented in §9 operational runbook.
+- **Why not strict-in-tx:** see K-6 in the round-1 challenges
+  (`rfcs/drafts/v0.7-master-challenges/round-1/K.md`). Lock contention
+  on the oldest-N window + non-index-only rank computation makes it
+  a latency trap.
+- **Why not partition-drop:** partition-by-time would force every
+  stream's MAXLEN to share the same time window, breaking per-stream
+  retention semantics.
+- **Impact if wrong:** If the 5s cadence is too slow for a specific
+  workload shape, the overshoot bound above characterizes the
+  upper bound on excess storage; tuning is a scanner-cadence knob,
+  not a schema change.
 
 ### Q7 — Capability matching surface
 
@@ -768,22 +893,38 @@ they affect lands.
   distinguish "old Valkey server + new Postgres server" from
   "mismatched schema."
 
-### Q9 — Scanner polling vs push
+### Q9 — Scanner polling vs push [adjudicated 2026-04-24]
 
 - **Surfaces:** Worker-C §7.2, §7.9.
 - **Statement:** 14 of 17 scanners poll due-ZSETs. Postgres supports
   `LISTEN/NOTIFY` on triggers — could replace polling for at least 6
   scanners (lease_expiry, delayed_promoter, attempt_timeout,
   execution_deadline, suspension_timeout, pending_wp_expiry).
-- **Proposal:** **Keep polling** in v0.7. The template is identical,
+- **Adjudication:** **Keep polling** in v0.7. The template is identical,
   the tests are identical, and the cost of polling on Postgres is well-
   understood (`SELECT FOR UPDATE SKIP LOCKED` is the canonical pattern).
-  Revisit push in v0.8 if latency becomes a concern. Drop scanners 10
-  + 11 (budget_reconciler, quota_reconciler) entirely since SQL tx
-  atomicity removes the drift they correct.
-- **Impact if wrong:** Dropping the reconcilers assumes every admission
-  path is strictly atomic — if any path escapes (e.g. a partial failure
-  outside the DB), drift accumulates silently.
+  Revisit push in v0.8 if latency becomes a concern.
+- **Reconciler disposition (revised round-1 K-8):**
+  - **Drop `index_reconciler`** — genuinely redundant because the
+    "indexes" it audits become actual Postgres indexes, maintained
+    atomically by the engine.
+  - **Keep `budget_reconciler` + `quota_reconciler`** — their purpose
+    on Valkey is to correct cross-hash-tag drift, which K-8 rightly
+    notes has a pg-equivalent: `report_usage` runs on a **different
+    connection from a different process** (the worker, not the
+    scheduler) *after* the grant was issued and consumed. That
+    cross-process window is exactly where counter drift accumulates
+    on partial failure, regardless of per-tx SQL atomicity. The
+    reconcilers stay with the same scan+reconcile shape.
+  - **Add `stream_frame_janitor`** — per Q6.
+  - Net scanner delta: −1 (`index_reconciler`), +1
+    (`stream_frame_janitor`). Total unchanged at 17.
+- **Impact if wrong:** The previous draft proposed dropping all three
+  reconcilers on the theory that SQL tx atomicity eliminates drift.
+  That theory only holds if every admission path is inside ONE tx;
+  the scheduler→worker→`report_usage` flow spans multiple txs across
+  processes, so budget/quota drift is a real-world scenario the
+  reconcilers continue to cover.
 
 ### Q10 — `claim` + `claim_from_reclaim` Valkey impls first
 
@@ -797,9 +938,123 @@ they affect lands.
   double-rewrite.
 - **Impact if wrong:** Trait churn. Wasted implementation work.
 
----
+### Q11 — Isolation-level default [adjudicated 2026-04-24, round-1 K-1]
 
-## Part 5 — Proposed stage plan (strawman for owner debate)
+- **Surfaces:** round-1 K-1 (self-contradiction between exec-summary
+  and §L0). Part 1 §L0 previously marked this "owner decision."
+- **Statement:** Is the default isolation level `READ COMMITTED + SELECT
+  FOR UPDATE SKIP LOCKED` or `SERIALIZABLE`? The two have different
+  caller-side retry contracts (40001 retry required for SSI,
+  no retry for RC+row-lock).
+- **Adjudication:** **Default: `READ COMMITTED + SELECT FOR UPDATE
+  SKIP LOCKED`.** The ~3 composite-predicate FCALLs escalate to
+  `SERIALIZABLE` at proc entry:
+  1. `ff_resolve_dependency` — quorum / K-of-N across child's
+     predecessor rows.
+  2. `ff_deliver_signal` — composite-condition evaluator walks
+     AND/OR/K-of-N trees against `satisfied_set`.
+  3. `ff_suspend_execution` — multi-waitpoint RFC-014 Pattern-3.
+  The Rust caller wraps these three calls in a bounded retry loop
+  (3 attempts, 50/100/200ms jittered) on `SQLSTATE 40001`;
+  `EngineError::Backend(SerializationFailure)` is the terminal class
+  after retry exhaustion.
+- **Why not SERIALIZABLE everywhere:** SSI predicate-lock overhead
+  on hot-path methods (`renew`, `progress`, `append_frame`,
+  `report_usage`) is a performance tax for invariants we don't need
+  at those sites. Valkey's slot-lock gave us SERIALIZABLE semantics
+  for free because each FCALL is single-slot; Postgres charges for
+  it. Pay where it's load-bearing.
+- **Why not READ COMMITTED everywhere:** the three composite FCALLs
+  each evaluate a predicate that reads multiple rows before deciding
+  — phantom reads under RC would allow a state transition that
+  violates the predicate. SERIALIZABLE is the cheapest way to state
+  the invariant correctly.
+- **Impact if wrong:** If the default is wrong-side (SERIALIZABLE
+  everywhere), every hot-path call-site needs 40001 retry logic and
+  p99 latency tax. If the composite sites run RC, we can ship a
+  subtle quorum-race bug that only shows under concurrent
+  dependency-resolution with shared children.
+
+### Q12 — Schema-migration application mode [adjudicated 2026-04-24, round-1 L-1]
+
+- **Surfaces:** round-1 L-1 + Part 1 §L10 (migration tooling) + Stage A
+  deliverable (previously said only "`sqlx::migrate!`-based schema
+  loader").
+- **Statement:** Is the Postgres schema migration applied by the
+  ff-server binary at boot (auto-apply via `sqlx::migrate!`), or by
+  the operator out-of-band (`sqlx migrate run` before deploy)?
+- **Adjudication:** **Operator-applied out-of-band, with boot-time
+  schema-version check that refuses start on mismatch.** Mirrors the
+  existing Q5 boot-time partition-count check contract: the ff-server
+  process queries the applied-migration ledger on boot and refuses to
+  start if the ledger's `latest_applied_version` is less than the
+  binary's `REQUIRED_SCHEMA_VERSION`, or (more subtly) logs a warning
+  and serves read-only if it is greater (the binary is older than
+  the schema — common during a rolling deploy of a schema-backward-
+  compatible change).
+- **Zero-downtime rolling upgrade story:**
+  1. **Additive schema change (add column, add table):** operator
+     applies migration first; old binaries ignore the new column
+     (they don't read it); new binaries use it. Deploy in any order.
+  2. **Column-rename / type-narrow:** two-phase. Phase 1 add new
+     column, dual-write both. Phase 2 drop old column. Each phase
+     is one release.
+  3. **Destructive change (drop column that old binary reads):** not
+     supported in a rolling upgrade; requires full drain + flag-day.
+- **Why not auto-apply at boot:** auto-apply makes rolling deploys
+  racy (N replicas all trying to apply the same migration; `sqlx`
+  takes a pg advisory lock but the loser-replicas block boot until
+  the winner finishes). Auto-apply also fights the peer-team-
+  boundaries memo: cairn's SRE owns when DDL runs.
+- **Why not lockstep binary + schema:** forces flag-day for every
+  release; incompatible with cairn's rolling-deploy model.
+- **Impact if wrong:** Auto-apply racing across replicas stalls a
+  rolling deploy; lockstep forces flag-day. The chosen option
+  keeps cairn's deploy story intact.
+
+### Q13 — SDK version-pin policy [adjudicated 2026-04-24, round-1 L SDK-delta-4]
+
+- **Surfaces:** round-1 L SDK-delta-4 + §Q8 (which added
+  `Backend::backend_version()`).
+- **Statement:** When ff-sdk detects a backend/server version skew via
+  the new `backend_version()` method, does it **refuse** to talk
+  (hard gate) or **warn** and continue?
+- **Adjudication:** **Warn by default; operator can flip to refuse via
+  SDK config.** The default preserves cairn's existing rolling-deploy
+  freedom — a v0.7.1 SDK against a v0.7.0 ff-server is expected
+  during a deploy window. Operators who want strict pinning (e.g.
+  staging smoke where a mismatch should block) can set
+  `FerriskeyConfig::version_check_mode = VersionCheckMode::Refuse`.
+- **Scope of the check:** (name, major, minor). Patch mismatches are
+  ignored; major mismatch is always refused (not configurable);
+  minor mismatch is the warn-vs-refuse knob.
+- **Impact if wrong:** Hard-refuse by default would turn every
+  ff-sdk bump into a deploy-order coordination problem.
+
+### Q14 — Dual-backend running mode [see §8]
+
+Adjudication lives inline in the new §8 below. Captured here as Q14 so
+the "open questions" list is complete.
+
+### Q15 — Rollback contract from Postgres → Valkey
+
+- **Surfaces:** round-1 L-walkthrough step 4.
+- **Statement:** If cairn runs Postgres-backed ff-server in staging and
+  hits a latency-SLO regression, what is the supported path back to
+  Valkey-backed v0.6.x?
+- **Proposed resolution (Stage E deliverable):** Because §8 locks
+  dual-backend as **per-instance**, rollback is: redeploy the v0.6.x
+  binary pointing at the Valkey cluster. The in-flight executions on
+  the Postgres side are either drained (scheduler waits for current
+  leases to terminate) or abandoned (their state stays in Postgres
+  and is recovered when Postgres is re-enabled). The one-shot
+  Valkey→Postgres migration tool in Stage E is deliberately
+  unidirectional; reverse migration is not automated in v0.7. The
+  operational mitigation is: **don't move state-of-record to Postgres
+  until staging soak is clean**.
+- **Impact if wrong:** If rollback requires reverse migration and we
+  didn't build it, cairn has no safe exit. The §8 per-instance
+  model avoids that trap by keeping each backend's state separable.
 
 Five stages. Each is self-contained and CI-green-at-the-end
 (workspace tests pass with both backends compiled, Postgres tests
@@ -812,19 +1067,33 @@ stage depends on.
 
 **Goal.** Ship a compilable `ff-backend-postgres` crate stub; close
 out `TRAIT-claim` + `TRAIT-claim_from_reclaim` Valkey impls (Q10);
-resolve design locks Q1/Q2/Q3/Q4/Q5.
+resolve design locks Q1–Q8 + Q11–Q13 (promoted per round-1 K-9).
 
 **Deliverables:**
 - Crate `ff-backend-postgres` with `EngineBackend` + `CompletionBackend`
   stubs returning `Unavailable`.
-- `sqlx::migrate!`-based schema loader wired into a new boot step
-  equivalent to `ff_script::loader::ensure_library`.
+- **Schema migration tooling.** `sqlx::migrate!` ledger + `sqlx migrate
+  run` CLI entry, applied **out-of-band by the operator** (Q12). The
+  ff-server binary does NOT auto-apply; it runs a boot-time
+  `REQUIRED_SCHEMA_VERSION` check against the applied-migration ledger
+  and refuses to start on mismatch, mirroring the existing Q5
+  boot-time partition-count check.
 - Valkey impls for `TRAIT-claim` and `TRAIT-claim_from_reclaim` landed.
-- Owner-decided resolutions for Q1–Q5 recorded as RFC-017 (or similar).
+- Owner-decided resolutions for Q1–Q8 + Q11 + Q12 + Q13 recorded as
+  RFC-017 (or similar). Q6 (retention), Q7 (capability contract),
+  Q8 (backend-version pin) are **promoted to Stage A** because Stage B
+  stored procs (`append_frame`, `report_usage`, `backend_version()`)
+  depend on them.
 - `Backend::connect(config)` + `Backend::backend_version()` trait
-  methods added to `ff-core`.
+  methods added to `ff-core`. SDK-side version-pin policy per Q13:
+  warn-by-default, operator-flippable to refuse.
+- **Old-SDK compat posture (L walkthrough step 1):** ff-server v0.7.0
+  accepts v0.6.x SDKs for at minimum one minor-release window. The
+  `Unavailable`-returning legacy claim routes remain as deprecated
+  fallbacks until v0.8. Documented in Stage A deliverable README.
 
-**Merge blocker:** Valkey CI green; Postgres CI runs compile-check only.
+**Merge blocker:** Valkey CI green; Postgres CI runs compile-check only;
+Q1–Q8 + Q11–Q13 all adjudicated.
 
 ### Stage B — Trivial + moderate trait-method ports (weeks 2–5)
 
@@ -842,6 +1111,12 @@ stored proc.
 - Shared `ff-core::caps` + `ff-core::waitpoint_hmac` modules (Q7
   resolution + HMAC rust-native).
 - `handle_codec` v2 for Postgres (`BackendTag::Postgres`).
+- **SDK retry-policy compat shim (L SDK-delta-5):** ff-sdk translates
+  `BackendErrorKind::SerializationFailure` +
+  `BackendErrorKind::DeadlockDetected` to the same retryable
+  classification cairn already uses for Valkey transient errors.
+  Ships with Stage B so cairn's error-handling path doesn't see net-
+  new retry classes mid-port.
 
 **Merge blocker:** Postgres CI runs integration tests for the 22 methods
 (parity-tested against Valkey). Cairn smoke-runs against Postgres build
@@ -873,10 +1148,18 @@ Cairn smoke completes.
 **Deliverables:**
 - `CompletionBackend` Postgres impl (LISTEN/NOTIFY on `ff_completion`).
 - `TRAIT-tail_stream` Postgres impl (LISTEN on per-attempt channel +
-  long-poll select).
+  long-poll select, application-level NOTIFY per §3.2).
 - Completion + tail integration tests on both backends.
-- Drop scanners `budget_reconciler` + `quota_reconciler` + make
-  `index_reconciler` Postgres-optional (Q9 resolution).
+- Drop `index_reconciler`; keep `budget_reconciler` +
+  `quota_reconciler` (revised Q9 adjudication). Add
+  `stream_frame_janitor` scanner (Q6).
+- **`ff_completion_recovered_by_reconciler` counter (L-3 / Op-gap-5).**
+  Per-scanner counter of completions delivered by the reconciler
+  fallback vs pushed via LISTEN. Threshold alert wired in Stage E's
+  §9 runbook. Without this counter, a silently-degraded LISTEN path
+  is indistinguishable from a healthy one.
+- **LISTEN connection health gauge** `ff_listen_connection_healthy`
+  + reconnect-watchdog task (per Q2 reconnect contract, round-1 K-3).
 
 **Merge blocker:** Latency parity within agreed SLOs (scheduler
 dependency-resolution end-to-end + tail wake).
@@ -890,8 +1173,15 @@ path for `ff_script::loader`, migration tooling for cairn-running-Valkey.
 - `Backend::rotate_waitpoint_secret` + `/v1/admin/rotate-waitpoint-secret`
   Postgres path.
 - `admin partition-collisions` unchanged (already backend-agnostic).
-- Migration tooling for Valkey→Postgres state transfer (one-shot dump +
-  load). Spec only if cairn's migration doesn't need it.
+- **Migration tooling for Valkey→Postgres state transfer (one-shot
+  dump + load) — unconditional deliverable.** Rationale: L-walkthrough
+  step 3 notes that the entire *point* of co-adoption is that cairn
+  migrates; the previous "spec only if cairn's migration doesn't need
+  it" conditional is self-contradictory. Includes kid-union seeding
+  for `ff_waitpoint_hmac` per Q4 cutover contract.
+- **Operational runbook** per new §9 — metrics labels-compat matrix,
+  backup/PITR one-page runbook, reconciler-degradation alert rules,
+  rollback procedure from Postgres back to Valkey (Q15).
 - Release `ff-backend-postgres` v0.1 + RELEASING.md update + release.toml
   update (per the release-publish-list-drift lesson).
 - Scanner cadence re-tuning for Postgres round-trip costs.
@@ -942,6 +1232,14 @@ scratch:
   pure Rust in `ff-scheduler` (Worker-C §3.1 steps 1–3). No port needed.
 - **`FailureTracker` + `supervised_spawn`** — process-local supervisor
   primitives. No change.
+- **RFC-003 fence-triple invariant (round-1 K-11).** Every lease-fenced
+  stored proc accepts `(lease_id, lease_epoch, attempt_id)` in ARGV and
+  rejects writes on mismatch. This is a cross-backend invariant: the
+  Postgres port MUST preserve the triple — a future stored-proc author
+  MUST NOT simplify it away (e.g. trusting `attempt_id` alone or
+  dropping `lease_epoch`). The `handle_codec` v2 proposal (§3.3) drops
+  `lease_ttl_ms` because pg resolves it server-side; the fence-triple
+  is not touched.
 
 ---
 
@@ -996,9 +1294,10 @@ starts. Don't discover mid-Stage-C.
 
 Two-backend coexistence means ff-server can be Valkey-backed while a
 replica is Postgres-backed (for smoke). Q8 addresses the SDK side; the
-operational side is harder — shared secrets, shared idempotency state,
-shared completion channels. Not a code risk; an operator-doc risk. Flag
-for Stage E.
+operational side lands in new §8 (per-instance dual-backend) + §9
+(operational runbook). See §8 for the explicit statement: v0.7 does NOT
+support shared state across backends — each ff-server instance targets
+one backend, cairn migration is per-flow/per-tenant not per-execution.
 
 ### 7.6 Documentation + RFC debt
 
@@ -1007,6 +1306,140 @@ that introduced it. Porting the contract to Rust stored procs loses the
 Lua as a reference. Mitigation: the Rust side must preserve the RFC
 link in doc comments; CI diff on RFC ↔ code drift per the
 `release-publish-list-drift` lesson pattern.
+
+---
+
+## Part 8 — Dual-backend running mode (v0.7 contract)
+
+Added round-1 (K-10 + L-2). The previous draft leaned on "cairn can run
+Valkey + Postgres side-by-side during migration" (Q5 adjudication L703–
+L705) without specifying what "side-by-side" means operationally. This
+section makes the contract explicit.
+
+### 8.1 Scope of dual-backend support in v0.7
+
+**v0.7 supports per-instance dual-backend only.** Each ff-server process
+is compiled against both backends but runs against exactly one at a time,
+chosen at boot via `FerriskeyConfig::backend = Backend::Valkey |
+Backend::Postgres`. The two backends' state pools are independent: their
+executions, flows, leases, dedup keys, HMAC secrets, completion channels,
+and scanner-maintained rows do not overlap.
+
+**Consequences:**
+- **Source-of-truth** is the backend each instance is configured against.
+  There is no "shadow" mode, no dual-write, no cross-backend replication
+  in v0.7.
+- **Fan-out of `CompletionBackend`** is per-instance. Engine code
+  subscribes to exactly one backend's completion stream. A flow whose
+  executions live on Valkey cannot have its completions consumed by a
+  Postgres-backed listener.
+- **Cross-backend cascade resolution is explicitly out-of-scope for
+  v0.7.** If flow F has executions E1 on Valkey and E2 on Postgres, E1's
+  terminal NOTIFY does NOT wake dep-resolution on E2, and vice versa.
+  Any attempt to create child executions on a different backend than
+  their parent returns `EngineError::Validation("cross-backend dep not
+  supported in v0.7")`.
+
+### 8.2 Cairn migration cutover shape
+
+**Cutover is per-flow (or per-tenant), not per-execution.** Cairn
+migrates by:
+
+1. Choosing a partition of flows (e.g. tenant T's flows) for cutover.
+2. **Draining:** marking those flows' namespace as "no new executions"
+   on the Valkey ff-server (via existing cairn-side routing, not an ff
+   primitive).
+3. Waiting for in-flight executions in that partition to reach terminal
+   state (the scheduler's existing drain semantics cover this).
+4. Running the **Valkey→Postgres one-shot migration tool** (Stage E
+   deliverable) against that partition's keys: dumps flow-definition +
+   terminal-execution history to a Postgres-shaped SQL import.
+5. Flipping the cairn routing layer to point tenant T at the Postgres-
+   backed ff-server.
+6. New executions under tenant T start on Postgres.
+
+**Atomic cutover across ALL tenants** is not a v0.7 goal; the one-shot
+migration tool is designed for per-partition batches.
+
+### 8.3 Why not "one logical flowfabric spanning both backends"
+
+That design would require:
+- A federation layer routing reads/writes to the correct backend per
+  `execution_id` — doable.
+- Cross-backend cascade resolution (flow F's child on Postgres waits on
+  parent's completion on Valkey) — requires either a bridge that
+  subscribes to both completion streams, or a logical-replication link
+  carrying completion events, or a polling bridge.
+- Shared HMAC secrets + shared idempotency keys across the two backends.
+
+All of this is material v0.8+ scope, and none of it is needed for
+cairn's migration (which is per-flow per L-walkthrough).
+
+### 8.4 Rollback (Q15 summary)
+
+Covered in §Q15. Short form: redeploy v0.6.x binary pointing at Valkey;
+the pre-cutover Valkey state is still there because dual-backend is
+per-instance with independent state pools. The Postgres-side state
+persists until operator-initiated cleanup.
+
+---
+
+## Part 9 — Operational runbook checklist (Stage E deliverables)
+
+Added round-1 (L-3 / Op-gap-3/4/5). The master doc lists these as
+concrete deliverables so they don't fall through as "operator-doc risk."
+
+### 9.1 Metrics labels-compat matrix
+
+Stage E ships a table enumerating every metric emitted by ff-server,
+categorised as:
+
+- **Stable across backends** — same name, same labels, same cardinality.
+- **Renamed on Postgres** — valkey-command-specific names replaced with
+  query-specific names. Old name is still emitted for one release under
+  a deprecation label.
+- **New on Postgres** — e.g. `ff_pg_pool_acquire_latency_ms`,
+  `ff_listen_connection_healthy`, `ff_completion_recovered_by_reconciler`.
+- **Dropped on Postgres** — valkey-command-cardinality metrics with no
+  pg analog.
+
+Cairn's Grafana dashboards are checked against the matrix before
+Stage E merges. Any panel that would go blank gets a documented
+replacement query.
+
+### 9.2 Backup + PITR runbook (one page)
+
+Covers:
+- `pg_basebackup` cadence + retention.
+- WAL archiving config (`archive_mode=on` + `archive_command`).
+- PITR recovery target semantics vs in-flight leases: a restored
+  cluster's `ff_lease` rows carry wall-clock expiry; leases that had
+  not expired at backup time + are past expiry at restore time are
+  reclaimed via the existing `lease_expiry` scanner, same as after a
+  process crash. No special handling needed.
+- LISTEN/NOTIFY post-PITR caveat: any completions between the
+  restore point and the crash are in the outbox table (durable) and
+  replayed via reconciler on listener reconnect. The outbox is the
+  guarantee; NOTIFY is just the wake-up.
+- Streaming replication vs nightly `pg_dump` t-shirt-sizing guidance.
+
+### 9.3 Alerts + thresholds
+
+- `ff_completion_recovered_by_reconciler` counter — if >5% of
+  completions land via reconciler over a 5-min window, LISTEN/NOTIFY
+  is silently degraded. Alert.
+- `ff_listen_connection_healthy` gauge — 0 for >30s. Alert + auto-
+  restart watchdog (landed Stage D).
+- Scanner `serialization_failure` retry-exhaust rate on the three
+  `SERIALIZABLE` composite procs (Q11) — if retries exhaust >0.1%
+  of calls, investigate lock contention.
+
+### 9.4 Rollback procedure (Q15)
+
+Documented step-by-step: drain Postgres-backed instances (scheduler
+waits for in-flight leases to terminate), redeploy v0.6.x binary
+configured for Valkey, verify Valkey state hasn't drifted, resume.
+Reverse migration (Postgres → Valkey) is NOT automated in v0.7.
 
 ---
 


### PR DESCRIPTION
## Summary

Consolidates three worker surveys (Worker-A Lua+ff-script, Worker-B ff-core+ff-backend-valkey, Worker-C ff-engine+scheduler+server) into a single v0.7 Postgres-backend migration spec. Two audiences: owner (scope sizing) and Postgres-backend author (implementation spec).

## What's in it

- **Executive summary** — total surface counts, critical path, 8-14 engineer-week range, five design locks.
- **Part 1** — 11 dimensional translation patterns (Valkey -> Postgres), explained once, referenced throughout.
- **Part 2** — collapsed inventory across all 3 surveys with stable IDs (FCALL-/TRAIT-/KEY-/NONFCALL-/SCANNER-/ROUTE-/BOOT-) and T/M/H/R difficulty.
- **Part 3** — 5 hotspots (partition_router dependency resolution, XREAD BLOCK + PUBSUB, handle_codec + CompletionBackend, scheduler claim pipeline, suspend + signal composite eval).
- **Part 4** — 10 consolidated open design questions with proposals.
- **Part 5** — 5-stage strawman plan (Scaffolding -> Trivial/Moderate -> Hard FCALLs -> Transport -> Admin/Ops), each CI-green at boundaries.
- **Part 6** — explicit "what stays" list (RFC-012 trait, RFC-011 co-location, ff-observability, etc).
- **Part 7** — risks (cairn co-adoption, perf parity, trait drift, mixed-version).

Source surveys referenced inline, not duplicated.

**DO NOT MERGE** — owner review.

## Test plan

- [ ] Owner reviews executive summary + Part 4 open questions
- [ ] Owner decides Q1-Q5 before Stage A starts
- [ ] Postgres-backend author sanity-checks Part 2 inventory for missing items
- [ ] Cross-reference to source surveys verified (links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds an RFC draft document and does not change runtime code paths. The main risk is process-related (reviewers may treat the draft plan as committed scope/decisions).
> 
> **Overview**
> Adds a new RFC draft, `rfcs/drafts/v0.7-migration-master.md`, that consolidates the three existing v0.7 Postgres migration surveys into a single “master” implementation spec.
> 
> The document provides an end-to-end inventory of Valkey-dependent surfaces (FCALLs, `EngineBackend`/`CompletionBackend` methods, key families, scanners, routes, boot steps), proposes Valkey→Postgres translation patterns, calls out key design decisions that must be made before coding, and outlines a staged execution plan with effort/risk notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5b1c1b065e2f0d5caed87fda25b3dad05bf265. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->