### PR TITLE
impl(RFC-v0.7): Wave 0 scaffold — ff-backend-postgres crate + migrate infra

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,11 @@
 #     `publish-new` + `publish-update`.
 #   - GITHUB_TOKEN is auto-provided by GHA; `gh release create` uses it.
 #
-# Publish set (10 crates, topologically ordered):
+# Publish set (11 crates, topologically ordered):
 #   ferriskey -> ff-core -> ff-script -> ff-observability
 #     -> ff-observability-http
-#     -> ff-backend-valkey -> ff-engine -> ff-scheduler
+#     -> ff-backend-valkey -> ff-backend-postgres
+#     -> ff-engine -> ff-scheduler
 #     -> ff-sdk -> ff-server
 # ff-test is dev-only (publish = false) and not in the set.
 # The former telemetrylib sub-crate was inlined into ferriskey
@@ -224,6 +225,22 @@ jobs:
             exit 1
           }
       - run: sleep 30
+      - name: publish ff-backend-postgres
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          VER="${TAG_VERSION#v}"
+          cargo publish -p ff-backend-postgres --no-verify || {
+            echo "::error::cargo publish ff-backend-postgres failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
+            echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-observability-http"
+            echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
+            exit 1
+          }
+      - run: sleep 30
       - name: publish ff-engine
         env:
           TAG_VERSION: ${{ github.ref_name }}
@@ -237,6 +254,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-observability"
             echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
+            echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
             exit 1
           }
       - run: sleep 30
@@ -253,6 +271,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-observability"
             echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
+            echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             exit 1
           }
@@ -270,6 +289,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-observability"
             echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
+            echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             exit 1
@@ -288,6 +308,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-observability"
             echo "::error::  cargo yank --version ${VER} ff-observability-http"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
+            echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             echo "::error::  cargo yank --version ${VER} ff-sdk"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +65,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -509,10 +533,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -582,6 +615,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +643,21 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -626,6 +685,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +719,15 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -707,6 +790,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -758,6 +853,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtor"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +884,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -798,6 +902,28 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -862,6 +988,23 @@ dependencies = [
  "versions",
  "which",
  "zstd",
+]
+
+[[package]]
+name = "ff-backend-postgres"
+version = "0.6.1"
+dependencies = [
+ "async-trait",
+ "ff-core",
+ "ff-observability",
+ "ff-script",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1053,6 +1196,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1298,6 +1452,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1306,6 +1462,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1340,12 +1505,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1462,7 +1645,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1486,6 +1669,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1711,6 +1918,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1725,6 +1935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1948,28 @@ checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1806,6 +2044,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1915,6 +2163,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,12 +2194,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2023,6 +2299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,9 +2322,18 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2084,10 +2375,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2328,6 +2646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,7 +2730,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2458,6 +2785,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2870,6 +3217,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,6 +3270,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2928,6 +3296,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2940,6 +3311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,10 +3329,229 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strum"
@@ -3176,6 +3775,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3350,10 +3960,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -3380,7 +4011,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3443,6 +4074,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3508,6 +4145,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3629,6 +4272,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
@@ -3646,6 +4298,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,10 +4317,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3667,6 +4382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3704,6 +4428,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -3726,6 +4465,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3738,6 +4483,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3747,6 +4498,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3768,6 +4525,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3777,6 +4540,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3792,6 +4561,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3801,6 +4576,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/ff-server",
     "crates/ff-readiness-tests",
     "crates/ff-backend-valkey",
+    "crates/ff-backend-postgres",
     "crates/ff-observability",
     "crates/ff-observability-http",
 ]
@@ -42,6 +43,7 @@ ff-sdk = { version = "0.6.1", path = "crates/ff-sdk" }
 ff-server = { version = "0.6.1", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
 ff-backend-valkey = { version = "0.6.1", path = "crates/ff-backend-valkey" }
+ff-backend-postgres = { version = "0.6.1", path = "crates/ff-backend-postgres" }
 ff-observability = { version = "0.6.1", path = "crates/ff-observability" }
 ff-observability-http = { version = "0.6.1", path = "crates/ff-observability-http" }
 ferriskey = { version = "0.6.1", path = "ferriskey" }
@@ -62,3 +64,7 @@ futures = "0.3"
 # (issue #90). Pulled in instead of the full `futures` crate to keep
 # ff-core's dep surface narrow — ff-core is the schema crate.
 futures-core = "0.3"
+# RFC-v0.7 Wave 0 — Postgres backend transport. Pinned at workspace
+# root so any future consumer (ff-server, migration CLI) picks up
+# the same version/features.
+sqlx = { version = "0.8", default-features = false }

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "ff-backend-postgres"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "FlowFabric EngineBackend impl — Postgres backend (RFC-v0.7, Wave 0 scaffold)"
+
+[features]
+# Mirror ff-core's `core` + `streaming` features so the backend's
+# method-gate `#[cfg]`s line up with the trait surface. `core` is
+# default-on (ff-core's `core` is always-needed for the minimal
+# write surface; ff-backend-valkey takes the same stance via its
+# hard ff-core feature activation). `streaming` tracks ff-core's
+# `streaming` default.
+default = ["core", "streaming"]
+core = ["ff-core/core"]
+streaming = ["ff-core/streaming"]
+# Issue #154 — enable real OTEL metric emission via `ff-observability`.
+# Off by default; mirrors `ff-backend-valkey`.
+observability = ["ff-observability/enabled"]
+
+[dependencies]
+# Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
+# ff-core feature set so the Postgres backend honours the same
+# `EngineBackend` method surface.
+ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+# ff-script brings the typed `ScriptError` + result parsers the
+# trait surface already speaks. ff-script's `default = []` means
+# inheriting workspace-as-is already gives us `valkey-client=false`
+# — the Postgres backend does NOT activate ferriskey transitively.
+ff-script = { workspace = true }
+# Always-present observability shim (no-op unless `observability`
+# feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
+ff-observability = { workspace = true }
+
+# Postgres transport. sqlx with tokio-rustls + the macros feature
+# (enables `sqlx::migrate!` compile-time migration loading).
+sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls", "macros", "migrate", "uuid", "chrono"] }
+
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/crates/ff-backend-postgres/migrations/0001_placeholder.sql
+++ b/crates/ff-backend-postgres/migrations/0001_placeholder.sql
@@ -1,0 +1,10 @@
+-- RFC-v0.7 Wave 0 placeholder migration.
+--
+-- `sqlx::migrate!` refuses to compile without at least one file in
+-- the migrations directory. This placeholder establishes the
+-- migrations machinery so `ff_backend_postgres::migrate::apply_migrations`
+-- has something to apply from tests, and so future waves can simply
+-- drop in `0002_*.sql` etc. Wave 3 replaces this with the real
+-- schema (tables, indexes, partitions per Q5, and the
+-- `backward_compatible` annotation column per Q12).
+SELECT 1;

--- a/crates/ff-backend-postgres/src/error.rs
+++ b/crates/ff-backend-postgres/src/error.rs
@@ -1,0 +1,81 @@
+//! `sqlx::Error` → [`EngineError`] mapping for the Postgres backend.
+//!
+//! **RFC-v0.7 Wave 0.** This is a map-sketch: enough surface for
+//! subsequent waves' trait-method bodies to route transport faults
+//! through `EngineError::Transport { backend: "postgres", .. }` plus
+//! the two typed cases the design-question matrix already pinned:
+//!
+//! * `SqlState::UniqueViolation` (`23505`) → [`EngineError::Conflict`]
+//!   — mirrors the Valkey backend's conflict classification for
+//!   duplicate-key writes (e.g. waitpoint id collision, unique
+//!   index violation on `ff_completion_event` etc.).
+//! * `SqlState::SerializationFailure` (`40001`) / `DeadlockDetected`
+//!   (`40P01`) → [`EngineError::Contention`] — per Q11 (isolation
+//!   level default) these are the retryable serialization faults
+//!   SERIALIZABLE can raise; callers retry per RFC-010 §10.7.
+//!
+//! Every other `sqlx::Error` boxes through `Transport` as a safe
+//! default. Future waves refine (e.g. `RowNotFound` → `NotFound`,
+//! connection-pool-closed → `Unavailable`).
+
+use ff_core::engine_error::{ConflictKind, ContentionKind, EngineError};
+
+/// Convert a `sqlx::Error` into an [`EngineError`].
+///
+/// Kept as a free function (rather than a `From` impl) so call sites
+/// can thread extra context (method label, key, etc.) through
+/// [`ff_core::engine_error::backend_context`] alongside. A blanket
+/// `From<sqlx::Error> for EngineError` is also provided below for
+/// ergonomics in `?` chains where no extra context is needed.
+pub fn map_sqlx_error(err: sqlx::Error) -> EngineError {
+    if let Some(db_err) = err.as_database_error()
+        && let Some(code) = db_err.code()
+    {
+        // SQLSTATE codes are 5-char strings. Match the Q11-pinned
+        // pair first; everything else falls through to Transport.
+        match code.as_ref() {
+            // unique_violation
+            "23505" => {
+                return EngineError::Conflict(ConflictKind::RotationConflict(
+                    db_err.message().to_string(),
+                ));
+            }
+            // serialization_failure / deadlock_detected
+            "40001" | "40P01" => {
+                return EngineError::Contention(ContentionKind::LeaseConflict);
+            }
+            _ => {}
+        }
+    }
+    EngineError::Transport {
+        backend: "postgres",
+        source: Box::new(err),
+    }
+}
+
+impl From<sqlx::Error> for PostgresTransportError {
+    fn from(err: sqlx::Error) -> Self {
+        PostgresTransportError(err)
+    }
+}
+
+/// Thin newtype over `sqlx::Error` so a blanket
+/// `From<sqlx::Error> for EngineError` doesn't conflict with
+/// ff-core's own orphan rules when downstream crates add their own.
+/// Backend-internal call sites use [`map_sqlx_error`] directly; this
+/// wrapper exists for future cases where we want to attach a
+/// typed source to a different `EngineError` variant.
+#[derive(Debug)]
+pub struct PostgresTransportError(pub sqlx::Error);
+
+impl std::fmt::Display for PostgresTransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "postgres transport: {}", self.0)
+    }
+}
+
+impl std::error::Error for PostgresTransportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1,0 +1,430 @@
+//! `EngineBackend` implementation backed by Postgres.
+//!
+//! **RFC-v0.7 Wave 0 — scaffold.** This crate lands the
+//! [`PostgresBackend`] struct + the `impl EngineBackend` block with
+//! every method stubbed to return `EngineError::Unavailable`.
+//! Subsequent waves fill in bodies:
+//!
+//! * Wave 1: cross-cutting error/helpers.
+//! * Wave 2: describe / list / resolve (read surface).
+//! * Wave 3: schema migrations (replaces the Wave 0 placeholder).
+//! * Wave 4: LISTEN/NOTIFY wiring + stream reads/tails.
+//! * Wave 5-7: hot-path write methods.
+//! * Wave 8: ff-server wire-up + dual-backend running.
+//!
+//! The trait stays object-safe; consumers can hold
+//! `Arc<dyn EngineBackend>`. No ferriskey dep — this crate's
+//! transport is `sqlx`.
+
+#![allow(clippy::result_large_err)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use ff_core::backend::{
+    AppendFrameOutcome, BackendConfig, CancelFlowPolicy, CancelFlowWait, CapabilitySet,
+    ClaimPolicy, FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal,
+    PendingWaitpoint, ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility,
+    UsageDimensions,
+};
+#[cfg(feature = "core")]
+use ff_core::contracts::{
+    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs, DeliverSignalResult,
+    EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot, ListExecutionsPage, ListFlowsPage,
+    ListLanesPage, ListSuspendedPage, SetEdgeGroupPolicyResult,
+};
+use ff_core::contracts::{
+    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult, SuspendArgs,
+    SuspendOutcome,
+};
+#[cfg(feature = "streaming")]
+use ff_core::contracts::{StreamCursor, StreamFrames};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::EngineError;
+#[cfg(feature = "core")]
+use ff_core::partition::PartitionKey;
+use ff_core::partition::PartitionConfig;
+#[cfg(feature = "streaming")]
+use ff_core::types::AttemptIndex;
+#[cfg(feature = "core")]
+use ff_core::types::EdgeId;
+use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
+use sqlx::PgPool;
+
+pub mod error;
+pub mod listener;
+pub mod migrate;
+pub mod pool;
+pub mod version;
+
+pub use error::{map_sqlx_error, PostgresTransportError};
+pub use listener::StreamNotifier;
+pub use migrate::{apply_migrations, MigrationError};
+pub use version::check_schema_version;
+
+// Re-export the new `PostgresConnection` shape so consumers can name
+// it from this crate directly without dipping into `ff_core::backend`.
+// `BackendConfig` is already imported above and is part of the
+// `connect()` signature, so it re-exports transparently via
+// rustdoc — no explicit `pub use` needed.
+pub use ff_core::backend::PostgresConnection;
+
+/// Postgres-backed `EngineBackend`.
+///
+/// Wave 0 shape: holds a `sqlx::PgPool`, the deployment's
+/// [`PartitionConfig`] (Q5 — partition column survives on Postgres
+/// with hash partitioning across the same 256 slots Valkey uses),
+/// and an optional `ff_observability::Metrics` handle mirroring
+/// [`ff_backend_valkey::ValkeyBackend`]. Future waves add the
+/// [`StreamNotifier`] handle once Wave 4 wires up LISTEN/NOTIFY.
+pub struct PostgresBackend {
+    #[allow(dead_code)] // filled in across waves 2-7
+    pool: PgPool,
+    #[allow(dead_code)]
+    partition_config: PartitionConfig,
+    #[allow(dead_code)]
+    metrics: Option<Arc<ff_observability::Metrics>>,
+}
+
+impl PostgresBackend {
+    /// Dial Postgres with [`BackendConfig`] and return the backend as
+    /// `Arc<dyn EngineBackend>`. Modeled on
+    /// [`ff_backend_valkey::ValkeyBackend::connect`] so ff-server /
+    /// SDK call sites can swap backends without changing the
+    /// constructor shape.
+    ///
+    /// **Wave 0:** builds the pool and constructs the backend. Does
+    /// NOT run migrations (Q12 — operator out-of-band). Does NOT run
+    /// the schema-version check (Wave 3 adds the version const and
+    /// wires [`check_schema_version`] in). Does NOT start the LISTEN
+    /// task (Wave 4).
+    ///
+    /// Returns `EngineError::Unavailable` when the config's
+    /// connection arm is not Postgres.
+    pub async fn connect(config: BackendConfig) -> Result<Arc<dyn EngineBackend>, EngineError> {
+        let pool = pool::build_pool(&config).await?;
+        let backend = Self {
+            pool,
+            partition_config: PartitionConfig::default(),
+            metrics: None,
+        };
+        Ok(Arc::new(backend))
+    }
+
+    /// Test / advanced constructor: build a `PostgresBackend` from an
+    /// already-constructed `PgPool` + explicit partition config. No
+    /// network I/O. Useful for integration tests against a shared
+    /// pool and for a future migration CLI that wants to reuse a pool
+    /// across migrate-run + smoke-check.
+    pub fn from_pool(pool: PgPool, partition_config: PartitionConfig) -> Arc<Self> {
+        Arc::new(Self {
+            pool,
+            partition_config,
+            metrics: None,
+        })
+    }
+}
+
+/// Short helper: every stub method returns this. Kept as a function
+/// (rather than a macro) so rust-analyzer / IDE jumps show a single
+/// definition site for the Wave 0 stub pattern.
+#[inline]
+fn unavailable<T>(op: &'static str) -> Result<T, EngineError> {
+    Err(EngineError::Unavailable { op })
+}
+
+#[async_trait]
+impl EngineBackend for PostgresBackend {
+    // ── Claim + lifecycle ──
+
+    #[tracing::instrument(name = "pg.claim", skip_all)]
+    async fn claim(
+        &self,
+        _lane: &LaneId,
+        _capabilities: &CapabilitySet,
+        _policy: ClaimPolicy,
+    ) -> Result<Option<Handle>, EngineError> {
+        unavailable("pg.claim")
+    }
+
+    #[tracing::instrument(name = "pg.renew", skip_all)]
+    async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+        unavailable("pg.renew")
+    }
+
+    #[tracing::instrument(name = "pg.progress", skip_all)]
+    async fn progress(
+        &self,
+        _handle: &Handle,
+        _percent: Option<u8>,
+        _message: Option<String>,
+    ) -> Result<(), EngineError> {
+        unavailable("pg.progress")
+    }
+
+    #[tracing::instrument(name = "pg.append_frame", skip_all)]
+    async fn append_frame(
+        &self,
+        _handle: &Handle,
+        _frame: Frame,
+    ) -> Result<AppendFrameOutcome, EngineError> {
+        unavailable("pg.append_frame")
+    }
+
+    #[tracing::instrument(name = "pg.complete", skip_all)]
+    async fn complete(
+        &self,
+        _handle: &Handle,
+        _payload: Option<Vec<u8>>,
+    ) -> Result<(), EngineError> {
+        unavailable("pg.complete")
+    }
+
+    #[tracing::instrument(name = "pg.fail", skip_all)]
+    async fn fail(
+        &self,
+        _handle: &Handle,
+        _reason: FailureReason,
+        _classification: FailureClass,
+    ) -> Result<FailOutcome, EngineError> {
+        unavailable("pg.fail")
+    }
+
+    #[tracing::instrument(name = "pg.cancel", skip_all)]
+    async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {
+        unavailable("pg.cancel")
+    }
+
+    #[tracing::instrument(name = "pg.suspend", skip_all)]
+    async fn suspend(
+        &self,
+        _handle: &Handle,
+        _args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        unavailable("pg.suspend")
+    }
+
+    #[tracing::instrument(name = "pg.create_waitpoint", skip_all)]
+    async fn create_waitpoint(
+        &self,
+        _handle: &Handle,
+        _waitpoint_key: &str,
+        _expires_in: Duration,
+    ) -> Result<PendingWaitpoint, EngineError> {
+        unavailable("pg.create_waitpoint")
+    }
+
+    #[tracing::instrument(name = "pg.observe_signals", skip_all)]
+    async fn observe_signals(
+        &self,
+        _handle: &Handle,
+    ) -> Result<Vec<ResumeSignal>, EngineError> {
+        unavailable("pg.observe_signals")
+    }
+
+    #[tracing::instrument(name = "pg.claim_from_reclaim", skip_all)]
+    async fn claim_from_reclaim(
+        &self,
+        _token: ReclaimToken,
+    ) -> Result<Option<Handle>, EngineError> {
+        unavailable("pg.claim_from_reclaim")
+    }
+
+    #[tracing::instrument(name = "pg.delay", skip_all)]
+    async fn delay(
+        &self,
+        _handle: &Handle,
+        _delay_until: TimestampMs,
+    ) -> Result<(), EngineError> {
+        unavailable("pg.delay")
+    }
+
+    #[tracing::instrument(name = "pg.wait_children", skip_all)]
+    async fn wait_children(&self, _handle: &Handle) -> Result<(), EngineError> {
+        unavailable("pg.wait_children")
+    }
+
+    // ── Read / admin ──
+
+    #[tracing::instrument(name = "pg.describe_execution", skip_all)]
+    async fn describe_execution(
+        &self,
+        _id: &ExecutionId,
+    ) -> Result<Option<ExecutionSnapshot>, EngineError> {
+        unavailable("pg.describe_execution")
+    }
+
+    #[tracing::instrument(name = "pg.describe_flow", skip_all)]
+    async fn describe_flow(
+        &self,
+        _id: &FlowId,
+    ) -> Result<Option<FlowSnapshot>, EngineError> {
+        unavailable("pg.describe_flow")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.list_edges", skip_all)]
+    async fn list_edges(
+        &self,
+        _flow_id: &FlowId,
+        _direction: EdgeDirection,
+    ) -> Result<Vec<EdgeSnapshot>, EngineError> {
+        unavailable("pg.list_edges")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.describe_edge", skip_all)]
+    async fn describe_edge(
+        &self,
+        _flow_id: &FlowId,
+        _edge_id: &EdgeId,
+    ) -> Result<Option<EdgeSnapshot>, EngineError> {
+        unavailable("pg.describe_edge")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.resolve_execution_flow_id", skip_all)]
+    async fn resolve_execution_flow_id(
+        &self,
+        _eid: &ExecutionId,
+    ) -> Result<Option<FlowId>, EngineError> {
+        unavailable("pg.resolve_execution_flow_id")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.list_flows", skip_all)]
+    async fn list_flows(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<FlowId>,
+        _limit: usize,
+    ) -> Result<ListFlowsPage, EngineError> {
+        unavailable("pg.list_flows")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.list_lanes", skip_all)]
+    async fn list_lanes(
+        &self,
+        _cursor: Option<LaneId>,
+        _limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        unavailable("pg.list_lanes")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.list_suspended", skip_all)]
+    async fn list_suspended(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError> {
+        unavailable("pg.list_suspended")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.list_executions", skip_all)]
+    async fn list_executions(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError> {
+        unavailable("pg.list_executions")
+    }
+
+    // ── Trigger ops (issue #150) ──
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.deliver_signal", skip_all)]
+    async fn deliver_signal(
+        &self,
+        _args: DeliverSignalArgs,
+    ) -> Result<DeliverSignalResult, EngineError> {
+        unavailable("pg.deliver_signal")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.claim_resumed_execution", skip_all)]
+    async fn claim_resumed_execution(
+        &self,
+        _args: ClaimResumedExecutionArgs,
+    ) -> Result<ClaimResumedExecutionResult, EngineError> {
+        unavailable("pg.claim_resumed_execution")
+    }
+
+    #[tracing::instrument(name = "pg.cancel_flow", skip_all)]
+    async fn cancel_flow(
+        &self,
+        _id: &FlowId,
+        _policy: CancelFlowPolicy,
+        _wait: CancelFlowWait,
+    ) -> Result<CancelFlowResult, EngineError> {
+        unavailable("pg.cancel_flow")
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.set_edge_group_policy", skip_all)]
+    async fn set_edge_group_policy(
+        &self,
+        _flow_id: &FlowId,
+        _downstream_execution_id: &ExecutionId,
+        _policy: EdgeDependencyPolicy,
+    ) -> Result<SetEdgeGroupPolicyResult, EngineError> {
+        unavailable("pg.set_edge_group_policy")
+    }
+
+    // ── Budget ──
+
+    #[tracing::instrument(name = "pg.report_usage", skip_all)]
+    async fn report_usage(
+        &self,
+        _handle: &Handle,
+        _budget: &BudgetId,
+        _dimensions: UsageDimensions,
+    ) -> Result<ReportUsageResult, EngineError> {
+        unavailable("pg.report_usage")
+    }
+
+    // ── Stream reads (streaming feature) ──
+
+    #[cfg(feature = "streaming")]
+    #[tracing::instrument(name = "pg.read_stream", skip_all)]
+    async fn read_stream(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _from: StreamCursor,
+        _to: StreamCursor,
+        _count_limit: u64,
+    ) -> Result<StreamFrames, EngineError> {
+        unavailable("pg.read_stream")
+    }
+
+    #[cfg(feature = "streaming")]
+    #[tracing::instrument(name = "pg.tail_stream", skip_all)]
+    async fn tail_stream(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _after: StreamCursor,
+        _block_ms: u64,
+        _count_limit: u64,
+        _visibility: TailVisibility,
+    ) -> Result<StreamFrames, EngineError> {
+        unavailable("pg.tail_stream")
+    }
+
+    #[cfg(feature = "streaming")]
+    #[tracing::instrument(name = "pg.read_summary", skip_all)]
+    async fn read_summary(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+    ) -> Result<Option<SummaryDocument>, EngineError> {
+        unavailable("pg.read_summary")
+    }
+}

--- a/crates/ff-backend-postgres/src/listener.rs
+++ b/crates/ff-backend-postgres/src/listener.rs
@@ -1,0 +1,42 @@
+//! Shared LISTEN connection + in-memory notifier (placeholder).
+//!
+//! **RFC-v0.7 Wave 0 — placeholder only.** The spec (Q1 completion
+//! transport + Q2 XREAD-BLOCK semantics) pins the architecture:
+//!
+//! * ONE long-lived `tokio-postgres` connection per `PostgresBackend`
+//!   subscribed to every `ff_stream_<eid>_<aidx>` channel with a
+//!   registered waiter.
+//! * An in-memory `channel → Vec<Notify>` (or `broadcast`/`mpsc`)
+//!   map routes NOTIFY payloads to parked waiters.
+//! * Reconnect contract with exponential backoff + jittered
+//!   `poll-now` wake-up after re-subscribe (round-1 K-3).
+//! * PgBouncer transaction-pool mode is incompatible; session-pool
+//!   mode (or direct) is required.
+//!
+//! Wave 4 (Agent 8) fills this in. Wave 0 leaves the placeholder
+//! struct so upstream types can name it (`Arc<StreamNotifier>` on
+//! `PostgresBackend` in a later wave) without breaking API shape.
+
+use std::sync::Arc;
+
+/// Placeholder for the shared LISTEN notifier. Wave 4 fills in the
+/// `channel → waiters` routing table + reconnect task.
+///
+/// Intentionally opaque at Wave 0: no public fields, no public
+/// constructor surface beyond [`StreamNotifier::placeholder`], which
+/// exists solely so call sites compile. Once Wave 4 lands the real
+/// fields + constructor, the placeholder is either deleted or
+/// rewrapped with `#[doc(hidden)]` + `#[deprecated]`.
+pub struct StreamNotifier {
+    _private: (),
+}
+
+impl StreamNotifier {
+    /// Wave 0 placeholder constructor. Returns a non-functional
+    /// notifier; do not call from production paths. Wave 4 replaces
+    /// this with a `spawn_on(pool: &PgPool, ...)` async constructor
+    /// that owns the LISTEN task lifetime.
+    pub fn placeholder() -> Arc<Self> {
+        Arc::new(Self { _private: () })
+    }
+}

--- a/crates/ff-backend-postgres/src/migrate.rs
+++ b/crates/ff-backend-postgres/src/migrate.rs
@@ -1,0 +1,42 @@
+//! Schema-migration application.
+//!
+//! **RFC-v0.7 Wave 0, Q12.** Migrations are applied **out-of-band by
+//! the operator** via a future `sqlx migrate run` CLI entry (or this
+//! `apply_migrations` function in tests). The ff-server binary does
+//! NOT auto-apply on backend connect; at boot it runs a
+//! schema-version check ([`crate::version::check_schema_version`])
+//! and refuses to start on mismatch per Q12's branch rules. The
+//! rationale lives in the adjudication block in
+//! `rfcs/drafts/v0.7-migration-master.md §Q12`:
+//!
+//! 1. Auto-apply across N replicas races on the sqlx advisory lock
+//!    and stalls rolling deploys.
+//! 2. Auto-apply fights peer-team-boundaries — cairn's SRE owns DDL
+//!    timing.
+
+use sqlx::PgPool;
+
+/// Apply all pending migrations bundled in this crate's
+/// `migrations/` directory.
+///
+/// **Out-of-band only.** Wave 0 ships a placeholder `0001_*.sql`
+/// (just `SELECT 1;`) so the machinery is exercised; wave 3
+/// replaces it with the real schema. Callers: tests + a future
+/// `ff-migrate` CLI. Must NOT be called from
+/// `PostgresBackend::connect`.
+pub async fn apply_migrations(pool: &PgPool) -> Result<(), MigrationError> {
+    sqlx::migrate!("./migrations").run(pool).await?;
+    Ok(())
+}
+
+/// Migration application failure. Thin newtype over
+/// `sqlx::migrate::MigrateError` so we can attach crate-local context
+/// in later waves (e.g. DDL-lock-timeout hint, destructive-migration
+/// guard) without breaking the public fn signature.
+#[derive(Debug, thiserror::Error)]
+pub enum MigrationError {
+    /// Wrap sqlx's typed migration error (version mismatch, checksum
+    /// failure, connection error, etc.).
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::migrate::MigrateError),
+}

--- a/crates/ff-backend-postgres/src/pool.rs
+++ b/crates/ff-backend-postgres/src/pool.rs
@@ -1,0 +1,47 @@
+//! PgPool construction helper.
+//!
+//! **RFC-v0.7 Wave 0.** Reads `BackendConnection::Postgres { url,
+//! max_connections, min_connections, acquire_timeout }` and builds a
+//! `sqlx::PgPool`. Future waves add TLS root-store plumbing, LISTEN-
+//! connection setup (Q1 + Q2), transaction-pooler detection (Q2
+//! footnote on PgBouncer session-mode requirement), etc. Today this
+//! is a thin pass-through to `sqlx::postgres::PgPoolOptions` so the
+//! backend `connect` constructor has a single call site for pool
+//! setup.
+
+use ff_core::backend::{BackendConfig, BackendConnection, PostgresConnection};
+use ff_core::engine_error::EngineError;
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+
+use crate::error::map_sqlx_error;
+
+/// Build a `sqlx::PgPool` from a [`BackendConfig`] whose connection
+/// arm is [`BackendConnection::Postgres`].
+///
+/// Returns `EngineError::Unavailable { op: "pg.pool.build" }` when
+/// the config's connection arm is not Postgres — the Valkey backend
+/// has its own dial path, and a mis-routed config is a programmer
+/// error the backend surfaces as a typed error rather than a panic.
+pub async fn build_pool(config: &BackendConfig) -> Result<PgPool, EngineError> {
+    let BackendConnection::Postgres(pg) = &config.connection else {
+        return Err(EngineError::Unavailable {
+            op: "pg.pool.build (non-Postgres BackendConnection)",
+        });
+    };
+    build_pool_from_connection(pg).await
+}
+
+/// Lower-level helper: build a `PgPool` directly from a
+/// [`PostgresConnection`]. Separated from [`build_pool`] so tests +
+/// future migration-CLI tooling can feed a bare connection shape
+/// without constructing a full `BackendConfig`.
+pub async fn build_pool_from_connection(pg: &PostgresConnection) -> Result<PgPool, EngineError> {
+    PgPoolOptions::new()
+        .max_connections(pg.max_connections)
+        .min_connections(pg.min_connections)
+        .acquire_timeout(pg.acquire_timeout)
+        .connect(&pg.url)
+        .await
+        .map_err(map_sqlx_error)
+}

--- a/crates/ff-backend-postgres/src/version.rs
+++ b/crates/ff-backend-postgres/src/version.rs
@@ -1,0 +1,75 @@
+//! Boot-time schema-version check.
+//!
+//! **RFC-v0.7 Wave 0, Q12.** Mirrors the Valkey boot-time
+//! partition-count check (Q5). Reads the `_sqlx_migrations` ledger
+//! sqlx writes as part of `sqlx::migrate!` application and compares
+//! the latest applied version to `required`:
+//!
+//! * `ledger < required` → refuse to start
+//!   ([`EngineError::Unavailable { op: "schema_version" }`]).
+//! * `ledger == required` → pass.
+//! * `ledger > required` → pass + log-warn iff every intervening
+//!   migration is annotated `backward_compatible=true`. Wave 3
+//!   adds the annotation column to `_sqlx_migrations` (or a
+//!   sibling table); Wave 0 skips the annotation read and
+//!   unconditionally log-warns on a ledger-ahead match so the
+//!   boot-diagnostic channel is exercised. The destructive-migration
+//!   refuse-to-start branch also lands in Wave 3.
+
+use sqlx::PgPool;
+use sqlx::Row;
+use tracing::warn;
+
+use ff_core::engine_error::EngineError;
+
+use crate::error::map_sqlx_error;
+
+/// Compare the Postgres migration ledger against the binary's
+/// required schema version and enforce Q12's boot-time contract.
+///
+/// `required` is the migration version the caller's binary was
+/// built against (typically a `const REQUIRED_SCHEMA_VERSION: u32`
+/// ff-server embeds).
+///
+/// Wave 0 scope: implements the `<` (refuse) + `==` (pass) +
+/// `>` (warn) branches against sqlx's `_sqlx_migrations` table.
+/// Wave 3 extends the `>` branch to read the per-migration
+/// `backward_compatible` annotation and refuse-to-start on a
+/// destructive-ahead ledger.
+pub async fn check_schema_version(pool: &PgPool, required: u32) -> Result<(), EngineError> {
+    // `_sqlx_migrations(version BIGINT, ...)` is sqlx's own ledger.
+    // When the migrator has never run the table doesn't exist —
+    // treat that as "ledger = 0" (below any `required >= 1`).
+    let ledger: i64 = match sqlx::query(
+        "SELECT MAX(version) FROM _sqlx_migrations WHERE success = TRUE",
+    )
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(Some(row)) => row.try_get::<Option<i64>, _>(0).ok().flatten().unwrap_or(0),
+        Ok(None) => 0,
+        // Missing-table (undefined_table): fresh database → ledger = 0.
+        Err(sqlx::Error::Database(ref db)) if db.code().as_deref() == Some("42P01") => 0,
+        Err(other) => return Err(map_sqlx_error(other)),
+    };
+    let required_i = required as i64;
+
+    if ledger < required_i {
+        return Err(EngineError::Unavailable {
+            op: "schema_version",
+        });
+    }
+    if ledger > required_i {
+        // Wave 3 will gate this on a per-migration
+        // `backward_compatible` annotation and refuse-to-start on
+        // a destructive-ahead ledger (Q12 branch 3). For Wave 0
+        // we unconditionally warn so the boot-diagnostic channel
+        // is exercised.
+        warn!(
+            ledger,
+            required = required_i,
+            "postgres schema ledger is ahead of binary — Wave 3 will gate this on the backward_compatible annotation"
+        );
+    }
+    Ok(())
+}

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -1090,13 +1090,48 @@ impl ValkeyConnection {
     }
 }
 
+/// Postgres-specific connection parameters (RFC-v0.7 Wave 0).
+///
+/// `url` is a standard libpq/sqlx connection string
+/// (`postgres://user:pass@host:port/db`). Pool sizing + acquire
+/// timeout are carried on this struct rather than
+/// [`BackendTimeouts`] / [`BackendRetry`] because they map directly
+/// to `sqlx::postgres::PgPoolOptions` and have no Valkey equivalent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PostgresConnection {
+    /// Postgres connection URL.
+    pub url: String,
+    /// Maximum number of pool connections.
+    pub max_connections: u32,
+    /// Minimum number of idle pool connections.
+    pub min_connections: u32,
+    /// Per-acquire pool timeout.
+    pub acquire_timeout: Duration,
+}
+
+impl PostgresConnection {
+    /// Build a Postgres connection from a URL with defaults for pool
+    /// sizing (matches sqlx's out-of-box defaults: max=10, min=0,
+    /// acquire=30s).
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            max_connections: 10,
+            min_connections: 0,
+            acquire_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
 /// Discriminated union over per-backend connection shapes. Stage 1a
-/// ships the Valkey arm; future backends (Postgres) land additively
-/// under the `#[non_exhaustive]` guard.
+/// shipped the Valkey arm; RFC-v0.7 Wave 0 adds the Postgres arm
+/// additively under the `#[non_exhaustive]` guard.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum BackendConnection {
     Valkey(ValkeyConnection),
+    Postgres(PostgresConnection),
 }
 
 /// Configuration passed to `ValkeyBackend::connect` (and, later, to
@@ -1123,6 +1158,16 @@ impl BackendConfig {
     pub fn valkey(host: impl Into<String>, port: u16) -> Self {
         Self {
             connection: BackendConnection::Valkey(ValkeyConnection::new(host, port)),
+            timeouts: BackendTimeouts::default(),
+            retry: BackendRetry::default(),
+        }
+    }
+
+    /// Build a Postgres BackendConfig from a URL. Other fields take
+    /// backend defaults. RFC-v0.7 Wave 0.
+    pub fn postgres(url: impl Into<String>) -> Self {
+        Self {
+            connection: BackendConnection::Postgres(PostgresConnection::new(url)),
             timeouts: BackendTimeouts::default(),
             retry: BackendRetry::default(),
         }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,7 @@ This doc covers the operator workflow for cutting a release. Tooling lives in
 
 ## What gets published
 
-Ten crates, all pinned to the same version, published in topological order:
+Eleven crates, all pinned to the same version, published in topological order:
 
 1. `ferriskey`       — Valkey client (reparented fork of glide-core;
    the former `telemetrylib` sub-crate was inlined during the Tier 1
@@ -28,15 +28,21 @@ Ten crates, all pinned to the same version, published in topological order:
    set in v0.3.2 after v0.3.1 partial-published (ff-sdk depends on
    it as a workspace dep and its publish step fails without it
    being on crates.io).
-7. `ff-engine`       — cross-partition dispatch + scanners
+7. `ff-backend-postgres` — RFC-v0.7 EngineBackend trait Postgres
+   impl. Wave 0 scaffold ships the crate as an `Unavailable`-stub
+   implementation so `sqlx`/migrations infrastructure is in place
+   before Wave 1+ fills in method bodies. Published alongside the
+   Valkey backend so dual-backend ff-server builds resolve against
+   crates.io.
+8. `ff-engine`       — cross-partition dispatch + scanners
    (includes the `completion_listener` module for push-based DAG
    promotion; see [`rfc011-operator-runbook.md`](rfc011-operator-runbook.md)
    §"DAG promotion: push listener + safety-net reconciler")
-8. `ff-scheduler`    — claim-grant scheduler
-9. `ff-sdk`          — worker SDK. `direct-valkey-claim` feature is
-   off by default; production deployments use the scheduler-routed
-   HTTP path via `FlowFabricWorker::claim_via_server`
-10. `ff-server`      — HTTP server library + binary
+9. `ff-scheduler`    — claim-grant scheduler
+10. `ff-sdk`         — worker SDK. `direct-valkey-claim` feature is
+    off by default; production deployments use the scheduler-routed
+    HTTP path via `FlowFabricWorker::claim_via_server`
+11. `ff-server`      — HTTP server library + binary
 
 Excluded from publish:
 

--- a/release.toml
+++ b/release.toml
@@ -3,7 +3,7 @@
 # This config drives `cargo release <level>` to perform a consolidated,
 # workspace-wide version bump across the publishable crates:
 #   ferriskey, ff-core, ff-script, ff-observability,
-#   ff-observability-http, ff-backend-valkey,
+#   ff-observability-http, ff-backend-valkey, ff-backend-postgres,
 #   ff-engine, ff-scheduler, ff-sdk, ff-server
 # The former telemetrylib sub-crate was inlined into ferriskey in
 # PR #18; it is no longer a separate publish target. ff-observability


### PR DESCRIPTION
## Summary

Lands the Wave 0 skeleton for the v0.7 Postgres migration. Nothing
implements anything yet: every `EngineBackend` method on the new
`PostgresBackend` returns `EngineError::Unavailable`. This PR is the
foundation every subsequent Wave builds on.

Authority: [`rfcs/drafts/v0.7-migration-master.md`](../blob/main/rfcs/drafts/v0.7-migration-master.md)
(merged in #229). Specifically:

- **Part 5 Stage A** — Scaffolding + Valkey-completion deliverables.
- **Q12** — Schema migrations applied out-of-band by the operator;
  ff-server binary runs a boot-time version check and refuses to
  start on mismatch. `PostgresBackend::connect` does NOT auto-apply.
- **Q5** — Partition column survives on Postgres; `PartitionConfig`
  reused from `ff-core`, not redefined.
- **Q4** — `BackendConnection::Postgres` variant additive under the
  existing `#[non_exhaustive]` enum guard; Valkey variant untouched.
- **Q11** — SQLSTATE `40001` / `40P01` map to
  `EngineError::Contention`; `23505` maps to `EngineError::Conflict`
  (map-sketch only; future waves refine per-op).
- **Q1 + Q2** — `src/listener.rs` ships `StreamNotifier` placeholder;
  Wave 4 fills in the shared-LISTEN + in-memory notifier.

## Deliverables

1. **New crate `crates/ff-backend-postgres/`**
   - `Cargo.toml` mirroring `ff-backend-valkey`; `sqlx` (postgres,
     runtime-tokio-rustls, macros, migrate, uuid, chrono),
     `ff-script` with `valkey-client=false`, no `ferriskey` dep.
   - `src/lib.rs` — `PostgresBackend` struct + `connect()` +
     `from_pool()` + full `impl EngineBackend` with every method
     stubbed via `unavailable("pg.<op>")` + `#[tracing::instrument]`
     per the observability convention.
   - `src/error.rs` — `map_sqlx_error` + `PostgresTransportError`.
   - `src/pool.rs` — `build_pool(&BackendConfig)` +
     `build_pool_from_connection(&PostgresConnection)`.
   - `src/migrate.rs` — `apply_migrations(pool)` +
     `MigrationError`.
   - `src/version.rs` — `check_schema_version(pool, required)`
     reading `_sqlx_migrations`; enforces Q12's `<` / `==` / `>`
     branches (Wave 3 extends the `>` branch with the
     `backward_compatible` annotation).
   - `src/listener.rs` — `StreamNotifier` placeholder only.
   - `migrations/0001_placeholder.sql` — `SELECT 1;`.

2. **Additive `ff-core` extension**
   - `BackendConnection::Postgres(PostgresConnection)` variant.
   - `PostgresConnection { url, max_connections, min_connections,
     acquire_timeout }` (+ `::new`).
   - `BackendConfig::postgres(url)` constructor.

3. **Workspace + release**
   - Register `crates/ff-backend-postgres` in members + workspace
     deps.
   - `cargo publish -p ff-backend-postgres` step in `release.yml`
     (between ff-backend-valkey and ff-engine).
   - Publish-list drift check passes (11 publishable ↔ 11 steps).
   - `docs/RELEASING.md` + `release.toml` updated.

## Verify

Gates, all locally green:

- [x] `cargo check --workspace --all-features` clean.
- [x] `cargo clippy -p ff-backend-postgres -- -D warnings` clean.
- [x] Workspace `cargo clippy --all-features` clean for every
      FlowFabric crate (pre-existing ferriskey warnings unchanged).
- [x] `cargo test -p ff-backend-postgres` passes (0 tests).
- [x] Publish-list drift diff is empty.

## Test plan

- [ ] CI: workspace build + clippy + publish-list-drift all green.
- [ ] `cargo check -p ff-backend-postgres --no-default-features`
      (verify core/streaming feature gating is consistent with
      the `cfg(feature = "core"|"streaming")` method guards).

## Out of scope

- ff-backend-valkey is untouched (Wave 0 constraint).
- No trait-method bodies beyond `Unavailable` (Wave 1+).
- `listener.rs` is a placeholder only (Wave 4).
- Migrations do NOT auto-run on connect (Q12).
- ff-server wiring (Wave 8).

## Merge note

Do NOT merge via this PR — owner admin-merges to unblock Wave 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `sqlx`-based backend crate and expands core config types/workspace deps, which affects build graph and future backend selection, but runtime behavior is largely stubbed (`Unavailable`) and release changes are procedural.
> 
> **Overview**
> Adds a new publishable crate, `ff-backend-postgres`, as the Wave 0 scaffold for a Postgres `EngineBackend` implementation. It includes pool construction via `sqlx::PgPool`, migration plumbing (`apply_migrations` with a placeholder migration), a boot-time schema ledger check (`check_schema_version`), and an initial `sqlx::Error`→`EngineError` mapping; all `EngineBackend` methods are currently stubbed to return `EngineError::Unavailable`.
> 
> Extends `ff-core` backend configuration to support Postgres by adding `PostgresConnection`, a `BackendConnection::Postgres` variant, and a `BackendConfig::postgres(...)` constructor. Updates workspace wiring to include the new crate and pins `sqlx` at the workspace root, and adjusts release automation/docs (`release.yml`, `docs/RELEASING.md`, `release.toml`) to publish **11** crates including `ff-backend-postgres`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260123e67be31429b139302c0a98d6b29bca3acd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->