### PR TITLE
feat(pg-wave1a): extract ff-core::caps for backend-shared capability matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **RFC-v0.7 Wave 1a: `ff-core::caps` extracted for backend-shared
+  capability matching.** The capability subset predicate previously lived
+  as `ff_scheduler::claim::caps_subset` (private) and was implicitly
+  duplicated by the Lua authority in `lua/scheduling.lua`. The Rust
+  predicate now lives in `ff-core::caps` so `ff-backend-valkey` and the
+  future `ff-backend-postgres` share one definition. New public surface:
+  `ff_core::caps::{matches, matches_csv, CapabilityRequirement}`.
+  `ff-scheduler` now calls `ff_core::caps::matches_csv` for the fast-path
+  short-circuit; the Lua `ff_issue_claim_grant` FCALL remains the atomic
+  authority for Valkey. **No behavior change**: `matches_csv` is the
+  line-for-line replacement of the old private helper (same case-sensitive
+  subset semantics, same empty-required-matches-any default). Token
+  validation and `CAPS_MAX_{BYTES,TOKENS}` bounds stay at the existing
+  ingress sites. Ref: RFC-v0.7 §Q7, PR #230 (Wave 0 scaffold).
+
+### Fixed
+
+- **`ff-core` unit tests compile against `BackendConnection` enum added
+  in Wave 0 (#230).** `backend_config_valkey_ctor` used an irrefutable
+  `let` pattern that broke when the `Postgres` variant landed; switched
+  to `let-else` with a descriptive panic. Pure test-only fix.
+
 ## [0.6.1] - 2026-04-24
 
 ### Fixed

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -1744,10 +1744,12 @@ mod tests {
     #[test]
     fn backend_config_valkey_ctor() {
         let c = BackendConfig::valkey("host.local", 6379);
-        // Same-crate match against an otherwise `#[non_exhaustive]`
-        // enum is irrefutable — no wildcard needed and `let-else`
-        // would trip `irrefutable_let_patterns`.
-        let BackendConnection::Valkey(v) = &c.connection;
+        // Wave 0 (#230) added `BackendConnection::Postgres`, so the
+        // match is no longer irrefutable. `let-else` keeps the test
+        // focused on the Valkey arm without a full `match`.
+        let BackendConnection::Valkey(v) = &c.connection else {
+            panic!("expected Valkey connection, got Postgres");
+        };
         assert_eq!(v.host, "host.local");
         assert_eq!(v.port, 6379);
         assert!(!v.tls);

--- a/crates/ff-core/src/caps.rs
+++ b/crates/ff-core/src/caps.rs
@@ -1,0 +1,262 @@
+//! Backend-shared capability matching predicate (RFC-v0.7 Q7).
+//!
+//! **Why this module exists.** `ff-backend-valkey` and `ff-backend-postgres`
+//! both need to answer: "does worker W satisfy execution E's
+//! `required_capabilities`?" In Valkey that's a Rust short-circuit in the
+//! scheduler + authoritative Lua subset-check in `ff_issue_claim_grant`.
+//! In Postgres it's a `WHERE required_caps <@ worker_caps` GIN query.
+//! The *predicate* is identical across backends; only the storage
+//! (CSV field vs `text[]`) differs.
+//!
+//! This module owns the pure-Rust predicate so both backends share one
+//! definition + one test suite. The Valkey-side Lua (`lua/scheduling.lua`
+//! `parse_capability_csv` + `missing_capabilities`) remains the atomic
+//! authority inside the FCALL — this is a fast-path short-circuit.
+//!
+//! **Callers today:**
+//!   - `ff-scheduler::claim` — Rust short-circuit before quota admission.
+//!   - `ff-backend-postgres` (future) — direct predicate in the admission
+//!     SQL / in-process query layer.
+//!
+//! **Wire shape.** `required_capabilities` is stored as a comma-separated
+//! CSV on the Valkey contract layer (`RoutingRequirements::required_capabilities`
+//! is serialized to CSV when written to the execution hash). Postgres will
+//! store as `text[]`. This module accepts both:
+//!   - [`matches_csv`] — CSV-form required set (existing call site).
+//!   - [`matches`] — structured [`CapabilityRequirement`] (future call sites).
+//!
+//! The predicate semantics are **case-sensitive subset**: every non-empty
+//! token in the required set must appear verbatim in the worker's
+//! [`CapabilitySet`]. An empty required set trivially matches any worker
+//! (backwards-compat default; see `RoutingRequirements` rustdoc).
+//!
+//! Bound constants ([`crate::policy::CAPS_MAX_BYTES`],
+//! [`crate::policy::CAPS_MAX_TOKENS`]) live in `ff-core::policy` and are
+//! enforced at ingress — not here. This module is a pure predicate.
+
+use crate::backend::CapabilitySet;
+use std::collections::BTreeSet;
+
+/// A pre-parsed capability requirement (the "execution requires X" shape).
+///
+/// Thin newtype over a sorted token set — sorted so CSV serialization is
+/// deterministic and log correlation is stable. The Valkey wire form is
+/// the CSV join of this set; the Postgres wire form is the `text[]`
+/// projection of `tokens`.
+///
+/// Constructed via [`CapabilityRequirement::new`] or parsed from CSV via
+/// [`CapabilityRequirement::from_csv`]. The struct is `#[non_exhaustive]`
+/// — additions (e.g. semver predicates, tier hints) land additively.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CapabilityRequirement {
+    /// Required tokens. Empty → match any worker.
+    pub tokens: BTreeSet<String>,
+}
+
+impl CapabilityRequirement {
+    /// Build from any iterable of string-like tokens.
+    ///
+    /// Empty strings are dropped (they can't satisfy anything and would
+    /// pollute the CSV form). Duplicates collapse via the `BTreeSet`.
+    pub fn new<I, S>(tokens: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            tokens: tokens
+                .into_iter()
+                .map(Into::into)
+                .filter(|t| !t.is_empty())
+                .collect(),
+        }
+    }
+
+    /// Parse from the Valkey wire form: comma-separated tokens.
+    ///
+    /// Mirrors Lua `parse_capability_csv` in `lua/scheduling.lua`:
+    /// empty tokens (from `",gpu,,cuda,"`) are dropped. No validation
+    /// of token contents — that's ingress's job (see
+    /// `ff-scheduler::claim` and `ff-sdk::FlowFabricWorker::connect`).
+    pub fn from_csv(csv: &str) -> Self {
+        Self::new(csv.split(',').filter(|t| !t.is_empty()))
+    }
+
+    /// True iff no tokens are required (matches any worker).
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}
+
+/// Subset predicate: every required token appears in the worker's set.
+///
+/// Case-sensitive, exact-string match. Empty `required` → `true`. This
+/// is the pure-Rust mirror of Lua `missing_capabilities` in
+/// `lua/scheduling.lua`.
+///
+/// Called from:
+///   - `ff-scheduler::claim` (fast-path short-circuit before quota admission)
+///   - `ff-backend-postgres` (future; direct predicate in admission path)
+pub fn matches(required: &CapabilityRequirement, worker: &CapabilitySet) -> bool {
+    if required.is_empty() {
+        return true;
+    }
+    // `CapabilitySet` is `Vec<String>` today; linear scan is fine for the
+    // bounded sizes (CAPS_MAX_TOKENS = 256). If that changes, promote to
+    // a HashSet lookup here.
+    let worker_tokens: &[String] = &worker.tokens;
+    required
+        .tokens
+        .iter()
+        .all(|t| worker_tokens.iter().any(|w| w == t))
+}
+
+/// CSV-form subset predicate. Used by `ff-scheduler::claim` so the HGET
+/// result can be fed in directly without parsing allocation.
+///
+/// Semantics identical to [`matches`]: every non-empty comma-separated
+/// token in `required_csv` must appear in `worker_caps`. Empty or
+/// all-separator CSV → `true`.
+///
+/// Kept as a separate entry point (rather than routing through
+/// [`CapabilityRequirement::from_csv`] + [`matches`]) to avoid the
+/// `BTreeSet` allocation on the scheduler hot path — the current call
+/// site already has a `&BTreeSet<String>` of worker caps in hand.
+pub fn matches_csv(required_csv: &str, worker_caps: &BTreeSet<String>) -> bool {
+    required_csv
+        .split(',')
+        .filter(|t| !t.is_empty())
+        .all(|t| worker_caps.contains(t))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── matches_csv (scheduler hot path) ──
+
+    #[test]
+    fn empty_required_csv_matches_any_worker() {
+        let worker: BTreeSet<String> = BTreeSet::new();
+        assert!(matches_csv("", &worker));
+        assert!(matches_csv("", &BTreeSet::from(["gpu".to_owned()])));
+    }
+
+    #[test]
+    fn all_separator_csv_matches_any_worker() {
+        // Regression: ",,," must still parse as empty-required.
+        let worker = BTreeSet::from(["gpu".to_owned()]);
+        assert!(matches_csv(",,,", &worker));
+    }
+
+    #[test]
+    fn exact_match_csv() {
+        let worker = BTreeSet::from(["gpu".to_owned(), "cuda".to_owned()]);
+        assert!(matches_csv("gpu,cuda", &worker));
+    }
+
+    #[test]
+    fn subset_match_csv() {
+        let worker = BTreeSet::from([
+            "gpu".to_owned(),
+            "cuda".to_owned(),
+            "fp16".to_owned(),
+        ]);
+        assert!(matches_csv("gpu,cuda", &worker));
+        assert!(matches_csv("gpu", &worker));
+    }
+
+    #[test]
+    fn missing_token_rejects_csv() {
+        let worker = BTreeSet::from(["gpu".to_owned()]);
+        assert!(!matches_csv("gpu,cuda", &worker));
+        assert!(!matches_csv("cuda", &worker));
+    }
+
+    #[test]
+    fn case_sensitive_csv() {
+        // Documented: matching is case-sensitive. "GPU" ≠ "gpu".
+        // Ingress is expected to normalize if callers want case-insensitive.
+        let worker = BTreeSet::from(["gpu".to_owned()]);
+        assert!(!matches_csv("GPU", &worker));
+        assert!(matches_csv("gpu", &worker));
+    }
+
+    // ── matches (structured API) ──
+
+    #[test]
+    fn structured_empty_required_matches_any() {
+        let req = CapabilityRequirement::default();
+        let worker = CapabilitySet::default();
+        assert!(matches(&req, &worker));
+        assert!(matches(&req, &CapabilitySet::new(["gpu"])));
+    }
+
+    #[test]
+    fn structured_subset_match() {
+        let req = CapabilityRequirement::new(["gpu", "cuda"]);
+        let worker = CapabilitySet::new(["gpu", "cuda", "fp16"]);
+        assert!(matches(&req, &worker));
+    }
+
+    #[test]
+    fn structured_missing_token_rejects() {
+        let req = CapabilityRequirement::new(["gpu", "cuda"]);
+        let worker = CapabilitySet::new(["gpu"]);
+        assert!(!matches(&req, &worker));
+    }
+
+    #[test]
+    fn structured_case_sensitive() {
+        let req = CapabilityRequirement::new(["GPU"]);
+        let worker = CapabilitySet::new(["gpu"]);
+        assert!(!matches(&req, &worker));
+    }
+
+    #[test]
+    fn from_csv_drops_empty_tokens() {
+        let req = CapabilityRequirement::from_csv(",gpu,,cuda,");
+        assert_eq!(req.tokens.len(), 2);
+        assert!(req.tokens.contains("gpu"));
+        assert!(req.tokens.contains("cuda"));
+    }
+
+    #[test]
+    fn from_csv_empty_string_is_empty_requirement() {
+        let req = CapabilityRequirement::from_csv("");
+        assert!(req.is_empty());
+    }
+
+    // ── cross-API equivalence ──
+
+    #[test]
+    fn matches_and_matches_csv_agree() {
+        // Same logical input via both entry points must give same answer.
+        let cases = [
+            ("", vec!["gpu"], true),
+            ("gpu", vec!["gpu"], true),
+            ("gpu,cuda", vec!["gpu"], false),
+            ("gpu,cuda", vec!["gpu", "cuda", "fp16"], true),
+            (",gpu,", vec!["gpu"], true),
+            ("GPU", vec!["gpu"], false),
+        ];
+        for (req_csv, worker_tokens, expected) in cases {
+            let worker_btree: BTreeSet<String> =
+                worker_tokens.iter().map(|s| (*s).to_owned()).collect();
+            let worker_set = CapabilitySet::new(worker_tokens.iter().copied());
+            let req = CapabilityRequirement::from_csv(req_csv);
+
+            assert_eq!(
+                matches_csv(req_csv, &worker_btree),
+                expected,
+                "matches_csv({req_csv:?}) mismatch"
+            );
+            assert_eq!(
+                matches(&req, &worker_set),
+                expected,
+                "matches({req_csv:?}) mismatch"
+            );
+        }
+    }
+}

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Core types, state enums, partition math, key builders, and error codes for FlowFabric.
 
 pub mod backend;
+pub mod caps;
 pub mod completion_backend;
 pub mod contracts;
 pub mod engine_backend;

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -18,25 +18,7 @@ use ff_script::retry::is_retryable_kind;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// Short stable digest of a worker's capability CSV. Used in per-mismatch
-/// log lines so a worker-caps-CSV up to 4KB does not get echoed on every
-/// capability_mismatch event (would swamp aggregators during an incident).
-/// The full CSV is logged once at WARN when the worker connects; operators
-/// cross-reference this 8-hex prefix to the full set.
-/// Return true iff every non-empty comma-separated token in `required_csv`
-/// is present in `worker_caps`. Mirrors the authoritative Lua subset check
-/// in scheduling.lua (parse_capability_csv + missing_capabilities) — this
-/// is a fast-path Rust short-circuit so we can skip the quota-admission
-/// write for executions we already know the worker can't claim. Empty /
-/// all-separator CSV → subset holds trivially.
-fn caps_subset(required_csv: &str, worker_caps: &BTreeSet<String>) -> bool {
-    required_csv
-        .split(',')
-        .filter(|t| !t.is_empty())
-        .all(|t| worker_caps.contains(t))
-}
-
-/// Short, stable digest of a worker's caps CSV for per-event log lines.
+/// Short stable digest of a worker's caps CSV for per-event log lines.
 /// Thin wrapper around the shared helper so call sites read as
 /// "worker_caps_digest" locally while the algorithm lives in one place.
 fn worker_caps_digest(csv: &str) -> String {
@@ -694,7 +676,7 @@ impl Scheduler {
             };
             if let Some(req) = required_caps_csv.as_deref()
                 && !req.is_empty()
-                && !caps_subset(req, worker_capabilities)
+                && !ff_core::caps::matches_csv(req, worker_capabilities)
             {
                 // Move this execution out of eligible into blocked_route
                 // so we don't hot-loop on it every tick (RFC-009 §564). A


### PR DESCRIPTION
## Summary

Wave 1a of the RFC-v0.7 Postgres migration. Successor to Wave 0 scaffold (#230).

Extracts the capability subset predicate out of `ff-scheduler` (private `caps_subset`) into a new `ff-core::caps` module so `ff-backend-valkey` (today) and `ff-backend-postgres` (future) share one definition. The Lua authority in `lua/scheduling.lua` remains the atomic authority inside the `ff_issue_claim_grant` FCALL — `ff-core::caps` owns only the Rust predicate surface.

**Parallel siblings (not touched here):** Wave 1b `ff-core::waitpoint_hmac`, Wave 1c `handle_codec v2`.

## What moved

- **New module:** `crates/ff-core/src/caps.rs`
  - `CapabilityRequirement` (`#[non_exhaustive]`) with `new`, `from_csv`, `is_empty`
  - `matches(req, worker)` — structured form accepting `&CapabilityRequirement` + `&CapabilitySet`
  - `matches_csv(csv, worker_btree)` — CSV fast-path for the scheduler hot path (avoids `BTreeSet` allocation per tick)
- **Re-export:** `pub mod caps;` in `ff-core/src/lib.rs`

## What stayed

- `CapabilitySet` lives where it was (`ff-core::backend`) — already backend-shared, no need to move.
- `CAPS_MAX_BYTES` / `CAPS_MAX_TOKENS` stay in `ff-core::policy` (they're ingress bounds, not predicate concerns).
- Token validation (empty / comma-free / no whitespace) stays at the scheduler ingress site — those are policy enforcement, not predicate logic.
- Lua `parse_capability_csv` + `missing_capabilities` in `lua/scheduling.lua` — atomic authority inside FCALL, unchanged.

## Consumer migrations

- **`ff-scheduler`**: private `caps_subset` deleted; call site in `claim::scan_for_candidate` now dispatches to `ff_core::caps::matches_csv`. Algorithm byte-identical — no behavior change.
- **`ff-backend-valkey`**: no duplicate existed (it delegates to Lua). Nothing to delete.
- **Postgres backend** (future): will import `ff_core::caps::matches` against `text[]` GIN query results.

## Tests

13 new unit tests in `ff-core::caps` covering:
- Empty-required matches any worker (CSV + structured)
- Exact / subset match (CSV + structured)
- Missing-token rejection (CSV + structured)
- Case-sensitivity (documented as case-sensitive; ingress may normalize)
- CSV edge cases: all-separator (`",,,"`), leading/trailing/adjacent commas
- `from_csv` drops empty tokens
- Cross-API equivalence: `matches` and `matches_csv` give identical answers for shared inputs

## Drive-by fix

`backend_config_valkey_ctor` in `ff-core::backend` used an irrefutable `let` pattern that stopped compiling once Wave 0 (#230) added `BackendConnection::Postgres`. `cargo test -p ff-core --lib` was red on `origin/main` before this PR. Switched to `let-else` with a descriptive panic — pure test-only fix in a one-variant context. Per team policy ("pre-existing is not an excuse"), fixing in-place rather than filing and shipping.

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo clippy -p ff-core -p ff-scheduler -p ff-backend-valkey -- -D warnings` — clean
- `cargo test -p ff-core --lib` — 187 pass (incl. 13 new `caps::` tests)
- `cargo test -p ff-scheduler` — 10 pass
- `cargo test -p ff-readiness-tests` — compile-clean; integration tests gated on live Valkey as usual

## Backward-compat guarantee

- No wire-format changes.
- Scheduler predicate semantics byte-identical (same `split(',').filter(!empty).all(contains)` shape moved verbatim from private helper to public fn).
- No trait method signatures touched.
- CHANGELOG `[Unreleased] ### Changed` entry cites the extraction.

## Ref

- RFC-v0.7 §Q7 (Capability matching surface)
- Predecessor: #230 (Wave 0 scaffold — ff-backend-postgres crate)

## Test plan

- [x] Unit tests added for predicate semantics
- [x] Scheduler integration unchanged (existing tests pass)
- [x] Workspace check + clippy clean
- [ ] Do not merge — wait for siblings Wave 1b/1c to coordinate merge order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily a refactor that centralizes an existing capability subset check and updates one scheduler call site, plus a test-only pattern fix; runtime behavior is intended to remain unchanged.
> 
> **Overview**
> Adds new `ff_core::caps` module that exposes a backend-shared capability-matching predicate (`CapabilityRequirement`, `matches`, `matches_csv`) with unit tests covering CSV and structured forms.
> 
> Updates the scheduler claim fast-path to call `ff_core::caps::matches_csv` instead of a private `caps_subset` helper, and wires the module into `ff-core`’s public API via `lib.rs`. Also fixes an `ff-core` unit test to handle the now-non-irrefutable `BackendConnection` enum (`Valkey` vs `Postgres`) using `let-else`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3fab762e12c4c55148596219c78b69c675fa1e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->