### PR TITLE
feat(pg-wave1b): ff-core::waitpoint_hmac re-export + rotate_all trait method (Q4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **RFC-v0.7 Wave 1b: `EngineBackend::rotate_waitpoint_hmac_secret_all`
+  (migration-master Q4).** New additive trait method for cluster-wide
+  waitpoint HMAC kid rotation. Valkey impl fans out one
+  `ff_rotate_waitpoint_hmac_secret` FCALL per execution partition and
+  returns per-partition outcomes. Postgres impl (Wave 4) will resolve
+  to a single INSERT into the global `ff_waitpoint_hmac(kid, secret,
+  rotated_at)` table; Wave 1b lands the stub returning
+  `EngineError::Unavailable { op: "pg.rotate_waitpoint_hmac_secret_all" }`.
+  SDK exposes `FlowFabricWorker::rotate_waitpoint_hmac_secret_all`;
+  HookedBackend + PassthroughBackend dispatch the new method. The
+  pre-existing per-partition free-fn
+  `ff_sdk::admin::rotate_waitpoint_hmac_secret_all_partitions` is
+  unchanged for backwards compat.
+- **`ff_core::waitpoint_hmac` re-export module.** Consumer-facing
+  import path for the waitpoint HMAC wire types (`WaitpointHmac`,
+  `VerifyingKid`, `WaitpointHmacKids`) + rotation args/outcomes.
+  Signing and verification remain server-side (Lua on Valkey; Wave 4
+  stored procs on Postgres); the module doc captures the
+  sign/verify-location contract so external crates have one stable
+  path to consume from.
+
 ### Changed
 
 - **RFC-v0.7 Wave 1a: `ff-core::caps` extracted for backend-shared

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -36,7 +36,8 @@ use ff_core::contracts::{
     ListLanesPage, ListSuspendedPage, SetEdgeGroupPolicyResult,
 };
 use ff_core::contracts::{
-    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult, SuspendArgs,
+    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SuspendArgs,
     SuspendOutcome,
 };
 #[cfg(feature = "streaming")]
@@ -387,6 +388,20 @@ impl EngineBackend for PostgresBackend {
         _dimensions: UsageDimensions,
     ) -> Result<ReportUsageResult, EngineError> {
         unavailable("pg.report_usage")
+    }
+
+    // ── HMAC secret rotation (v0.7 migration-master Q4) ──
+    //
+    // Wave 4 replaces this stub with a single INSERT into
+    // `ff_waitpoint_hmac(kid, secret, rotated_at)`. Wave 0/1 keep
+    // the `Unavailable` shape so a running Postgres backend surfaces
+    // the unimplemented op loudly rather than silently no-op'ing.
+    #[tracing::instrument(name = "pg.rotate_waitpoint_hmac_secret_all", skip_all)]
+    async fn rotate_waitpoint_hmac_secret_all(
+        &self,
+        _args: RotateWaitpointHmacSecretAllArgs,
+    ) -> Result<RotateWaitpointHmacSecretAllResult, EngineError> {
+        unavailable("pg.rotate_waitpoint_hmac_secret_all")
     }
 
     // ── Stream reads (streaming feature) ──

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -42,9 +42,12 @@ use ff_core::contracts::{
     ClaimResumedExecutionResult, CompositeBody, CountKind, DeliverSignalArgs, DeliverSignalResult,
     EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, FlowStatus, FlowSummary,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
-    ResumeCondition, ResumePolicy, ResumeTarget, SignalMatcher, SuspendArgs, SuspendOutcome,
+    ResumeCondition, ResumePolicy, ResumeTarget, RotateWaitpointHmacSecretAllArgs,
+    RotateWaitpointHmacSecretAllEntry, RotateWaitpointHmacSecretAllResult,
+    RotateWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs, SuspendOutcome,
     SuspendOutcomeDetails, SuspendedExecutionEntry, WaitpointBinding,
 };
+use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::engine_error::{StateKind, ValidationKind};
 use ff_core::partition::PartitionKey;
 use ff_core::engine_backend::EngineBackend;
@@ -3851,6 +3854,51 @@ impl EngineBackend for ValkeyBackend {
                     "report_usage: FCALL ff_report_usage_and_check",
                 )
             })
+    }
+
+    /// Cluster-wide waitpoint HMAC secret rotation (v0.7 Q4).
+    ///
+    /// Concretely fans out one
+    /// `ff_rotate_waitpoint_hmac_secret` FCALL per execution
+    /// partition, mirroring
+    /// [`ff_sdk::admin::rotate_waitpoint_hmac_secret_all_partitions`]'s
+    /// partial-success contract — a failure on one partition's
+    /// FCALL is recorded as an inner `Err` on that entry and the
+    /// fan-out continues. Sequential (one partition at a time) to
+    /// keep the implementation futures-free; callers that need
+    /// parallelism can wrap at a higher layer.
+    async fn rotate_waitpoint_hmac_secret_all(
+        &self,
+        args: RotateWaitpointHmacSecretAllArgs,
+    ) -> Result<RotateWaitpointHmacSecretAllResult, EngineError> {
+        let per_partition_args = RotateWaitpointHmacSecretArgs {
+            new_kid: args.new_kid.clone(),
+            new_secret_hex: args.new_secret_hex.clone(),
+            grace_ms: args.grace_ms,
+        };
+        let num = self.partition_config.num_flow_partitions;
+        let mut entries = Vec::with_capacity(num as usize);
+        for index in 0..num {
+            let partition = Partition {
+                family: PartitionFamily::Execution,
+                index,
+            };
+            let idx = IndexKeys::new(&partition);
+            let result = ff_script::functions::suspension::ff_rotate_waitpoint_hmac_secret(
+                &self.client,
+                &idx,
+                &per_partition_args,
+            )
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    transport_script(e),
+                    "rotate_waitpoint_hmac_secret_all: FCALL ff_rotate_waitpoint_hmac_secret",
+                )
+            });
+            entries.push(RotateWaitpointHmacSecretAllEntry::new(index, result));
+        }
+        Ok(RotateWaitpointHmacSecretAllResult::new(entries))
     }
 
     #[cfg(feature = "streaming")]

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2895,6 +2895,99 @@ pub enum RotateWaitpointHmacSecretOutcome {
     Noop { kid: String },
 }
 
+// ─── rotate_waitpoint_hmac_secret_all ───
+
+/// Args for [`EngineBackend::rotate_waitpoint_hmac_secret_all`] — the
+/// cluster-wide / backend-native rotation of the waitpoint HMAC
+/// signing kid.
+///
+/// **v0.7 migration-master Q4:** a single additive trait method
+/// replaces the per-partition fan-out that direct-Valkey consumers
+/// hand-rolled via
+/// [`ff_sdk::admin::rotate_waitpoint_hmac_secret_all_partitions`].
+/// On Valkey it fans out N FCALLs (one per execution partition);
+/// on Postgres (Wave 4) it resolves to a single INSERT against the
+/// global `ff_waitpoint_hmac(kid, secret, rotated_at)` table (no
+/// partition_id column). Consumers prefer this method for clarity —
+/// the pre-existing free-fn + per-partition surface stays available
+/// for backwards compat.
+///
+/// `#[non_exhaustive]` with a [`Self::new`] constructor per the
+/// project memory-rule (unbuildable non_exhaustive types are a dead
+/// API).
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct RotateWaitpointHmacSecretAllArgs {
+    pub new_kid: String,
+    pub new_secret_hex: String,
+    /// Grace window in ms for tokens signed by the outgoing kid.
+    /// Duration (not a clock value), identical to
+    /// [`RotateWaitpointHmacSecretArgs::grace_ms`].
+    pub grace_ms: u64,
+}
+
+impl RotateWaitpointHmacSecretAllArgs {
+    /// Build the args. Keeping the constructor so consumers don't
+    /// struct-literal past the `#[non_exhaustive]` marker.
+    pub fn new(
+        new_kid: impl Into<String>,
+        new_secret_hex: impl Into<String>,
+        grace_ms: u64,
+    ) -> Self {
+        Self {
+            new_kid: new_kid.into(),
+            new_secret_hex: new_secret_hex.into(),
+            grace_ms,
+        }
+    }
+}
+
+/// Per-partition entry of [`RotateWaitpointHmacSecretAllResult`].
+/// Mirrors [`ff_sdk::admin::PartitionRotationOutcome`] but typed at
+/// the `ff-core` layer so both Valkey and Postgres backends return
+/// the same shape without a Postgres→ferriskey dep.
+///
+/// On backends with no partition concept (Postgres) the entry list
+/// has length 1 with `partition = 0` and the outcome of the global
+/// row write.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct RotateWaitpointHmacSecretAllEntry {
+    pub partition: u16,
+    /// The per-partition (or global) rotation outcome. Per-partition
+    /// failures are surfaced as inner `Err` so the fan-out can report
+    /// partial success — matching the existing SDK free-fn contract.
+    pub result: Result<RotateWaitpointHmacSecretOutcome, crate::engine_error::EngineError>,
+}
+
+impl RotateWaitpointHmacSecretAllEntry {
+    pub fn new(
+        partition: u16,
+        result: Result<RotateWaitpointHmacSecretOutcome, crate::engine_error::EngineError>,
+    ) -> Self {
+        Self { partition, result }
+    }
+}
+
+/// Result of [`EngineBackend::rotate_waitpoint_hmac_secret_all`].
+///
+/// The Valkey backend returns one entry per execution partition. The
+/// Postgres backend (Wave 4) will return a single-entry vec with
+/// `partition = 0` since the Postgres schema stores one global row
+/// per kid (Q4 §adjudication). Consumers that want a uniform "did
+/// ALL rotations succeed?" view inspect each entry's `.result`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct RotateWaitpointHmacSecretAllResult {
+    pub entries: Vec<RotateWaitpointHmacSecretAllEntry>,
+}
+
+impl RotateWaitpointHmacSecretAllResult {
+    pub fn new(entries: Vec<RotateWaitpointHmacSecretAllEntry>) -> Self {
+        Self { entries }
+    }
+}
+
 // ─── list_waitpoint_hmac_kids ───
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -53,7 +53,8 @@ use crate::backend::{
     ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility,
 };
 use crate::contracts::{
-    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult, SuspendArgs,
+    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SuspendArgs,
     SuspendOutcome,
 };
 #[cfg(feature = "core")]
@@ -534,6 +535,39 @@ pub trait EngineBackend: Send + Sync + 'static {
         downstream_execution_id: &ExecutionId,
         policy: crate::contracts::EdgeDependencyPolicy,
     ) -> Result<crate::contracts::SetEdgeGroupPolicyResult, EngineError>;
+
+    // ── HMAC secret rotation (v0.7 migration-master Q4) ──
+
+    /// Rotate the waitpoint HMAC signing kid **cluster-wide**.
+    ///
+    /// **v0.7 migration-master Q4 (adjudicated 2026-04-24).**
+    /// Additive trait surface so Valkey and Postgres backends can
+    /// both expose the "rotate everywhere" semantic under one name.
+    ///
+    /// * Valkey impl fans out an `ff_rotate_waitpoint_hmac_secret`
+    ///   FCALL per execution partition. `entries.len() == num_flow_partitions`
+    ///   and per-partition failures are surfaced as inner `Err`
+    ///   entries — the call as a whole does not fail when one
+    ///   partition's FCALL fails, matching
+    ///   [`ff_sdk::admin::rotate_waitpoint_hmac_secret_all_partitions`]'s
+    ///   partial-success contract.
+    /// * Postgres impl (Wave 4) writes one row to
+    ///   `ff_waitpoint_hmac(kid, secret, rotated_at)` and returns a
+    ///   single-entry vec with `partition = 0`.
+    ///
+    /// The default impl returns
+    /// [`EngineError::Unavailable`] with
+    /// `op = "rotate_waitpoint_hmac_secret_all"` so backends that
+    /// haven't implemented the method surface the miss loudly rather
+    /// than silently no-op'ing. Both concrete backends override.
+    async fn rotate_waitpoint_hmac_secret_all(
+        &self,
+        _args: RotateWaitpointHmacSecretAllArgs,
+    ) -> Result<RotateWaitpointHmacSecretAllResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "rotate_waitpoint_hmac_secret_all",
+        })
+    }
 
     // ── Budget ──
 

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod partition;
 pub mod policy;
 pub mod state;
 pub mod types;
+pub mod waitpoint_hmac;
 
 // Convenience re-export so consumers can write `ff_core::EngineError`.
 pub use engine_error::EngineError;

--- a/crates/ff-core/src/waitpoint_hmac.rs
+++ b/crates/ff-core/src/waitpoint_hmac.rs
@@ -1,0 +1,48 @@
+//! Consumer-facing import path for the waitpoint HMAC wire types and
+//! rotation args.
+//!
+//! **v0.7 migration-master Q4.** Today (Valkey backend) all
+//! signing and verification of waitpoint HMAC tokens happens
+//! **server-side inside the FlowFabric Lua library** — the
+//! `ff_sign_waitpoint_token` / `ff_validate_waitpoint_token` FCALLs
+//! read the per-partition `waitpoint_hmac_secrets` hash under the
+//! same redis.call("TIME") clock as suspension / signal delivery.
+//! There is no pure-Rust sign or verify code in the workspace, and
+//! the v0.7 Postgres backend (Wave 4) will continue the pattern via
+//! stored procedures on the global `ff_waitpoint_hmac(kid, secret,
+//! rotated_at)` table.
+//!
+//! This module exists so external crates have ONE stable path
+//! (`ff_core::waitpoint_hmac`) to import the wire-token type, the
+//! per-partition keystore snapshot shape, and the rotation Args /
+//! Result shapes from. Re-exports from `ff_core::backend` and
+//! `ff_core::contracts` — no new types live here and no logic runs
+//! through this module.
+//!
+//! # Signing + verification location
+//!
+//! | Backend  | Where `sign` lives                                    | Where `verify` lives                                   |
+//! |----------|-------------------------------------------------------|--------------------------------------------------------|
+//! | Valkey   | `lua/waitpoint_hmac.lua` (FCALL `ff_sign_waitpoint_token`) | `lua/waitpoint_hmac.lua` (FCALL `ff_validate_waitpoint_token`) |
+//! | Postgres | Wave-4 stored proc on `ff_waitpoint_hmac`             | Wave-4 stored proc on `ff_waitpoint_hmac`              |
+//!
+//! Consumers never touch the raw HMAC-SHA256 computation from Rust —
+//! the backend owns the secret material, so the signing / verifying
+//! code runs co-located with the key-storage primitive on each
+//! backend.
+//!
+//! # Rotation
+//!
+//! See [`EngineBackend::rotate_waitpoint_hmac_secret_all`](crate::engine_backend::EngineBackend::rotate_waitpoint_hmac_secret_all)
+//! for the cluster-wide rotation method added in v0.7. The existing
+//! per-partition free-function helper
+//! [`ff_sdk::admin::rotate_waitpoint_hmac_secret_all_partitions`]
+//! stays available for direct-Valkey consumers on older SDKs.
+
+pub use crate::backend::WaitpointHmac;
+pub use crate::contracts::{
+    ListWaitpointHmacKidsArgs, RotateWaitpointHmacSecretAllArgs,
+    RotateWaitpointHmacSecretAllEntry, RotateWaitpointHmacSecretAllResult,
+    RotateWaitpointHmacSecretArgs, RotateWaitpointHmacSecretOutcome, VerifyingKid,
+    WaitpointHmacKids,
+};

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -25,7 +25,8 @@ use ff_core::contracts::{
     CancelFlowResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
     DeliverSignalResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
-    SuspendArgs, SuspendOutcome,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SuspendArgs,
+    SuspendOutcome,
 };
 use ff_core::partition::PartitionKey;
 #[cfg(feature = "valkey-default")]
@@ -362,6 +363,17 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
             self,
             "report_usage",
             self.inner.report_usage(handle, budget, dimensions).await
+        )
+    }
+
+    async fn rotate_waitpoint_hmac_secret_all(
+        &self,
+        args: RotateWaitpointHmacSecretAllArgs,
+    ) -> Result<RotateWaitpointHmacSecretAllResult, EngineError> {
+        with_hooks!(
+            self,
+            "rotate_waitpoint_hmac_secret_all",
+            self.inner.rotate_waitpoint_hmac_secret_all(args).await
         )
     }
 

--- a/crates/ff-sdk/src/layer/test_support.rs
+++ b/crates/ff-sdk/src/layer/test_support.rs
@@ -21,7 +21,8 @@ use ff_core::contracts::{
     CancelFlowResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
     DeliverSignalResult, EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
-    SuspendArgs, SuspendOutcome, SuspendOutcomeDetails,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SuspendArgs,
+    SuspendOutcome, SuspendOutcomeDetails,
 };
 use ff_core::partition::PartitionKey;
 #[cfg(feature = "valkey-default")]
@@ -300,6 +301,16 @@ impl EngineBackend for PassthroughBackend {
     ) -> Result<ReportUsageResult, EngineError> {
         self.record("report_usage")?;
         Err(EngineError::Unavailable { op: "report_usage" })
+    }
+
+    async fn rotate_waitpoint_hmac_secret_all(
+        &self,
+        _args: RotateWaitpointHmacSecretAllArgs,
+    ) -> Result<RotateWaitpointHmacSecretAllResult, EngineError> {
+        self.record("rotate_waitpoint_hmac_secret_all")?;
+        Err(EngineError::Unavailable {
+            op: "rotate_waitpoint_hmac_secret_all",
+        })
     }
 
     async fn list_executions(

--- a/crates/ff-sdk/src/snapshot.rs
+++ b/crates/ff-sdk/src/snapshot.rs
@@ -25,7 +25,8 @@
 
 use ff_core::contracts::{
     EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListExecutionsPage,
-    ListFlowsPage, ListLanesPage, ListSuspendedPage,
+    ListFlowsPage, ListLanesPage, ListSuspendedPage, RotateWaitpointHmacSecretAllArgs,
+    RotateWaitpointHmacSecretAllResult,
 };
 use ff_core::partition::{execution_partition, flow_partition, PartitionKey};
 use ff_core::types::{EdgeId, ExecutionId, FlowId, LaneId};
@@ -239,6 +240,28 @@ impl FlowFabricWorker {
         Ok(self
             .backend_ref()
             .list_executions(partition, cursor, limit)
+            .await?)
+    }
+
+    /// Cluster-wide rotation of the waitpoint HMAC signing kid
+    /// (v0.7 Q4).
+    ///
+    /// Thin forwarder onto
+    /// [`EngineBackend::rotate_waitpoint_hmac_secret_all`](ff_core::engine_backend::EngineBackend::rotate_waitpoint_hmac_secret_all).
+    /// On the Valkey backend this fans out one FCALL per execution
+    /// partition; on the Postgres backend (Wave 4) this resolves to a
+    /// single global INSERT. Consumers call this for the clean
+    /// "rotate everywhere" semantic — the older per-partition
+    /// [`crate::admin::rotate_waitpoint_hmac_secret_all_partitions`]
+    /// free function stays available for direct-Valkey callers on
+    /// legacy SDKs.
+    pub async fn rotate_waitpoint_hmac_secret_all(
+        &self,
+        args: RotateWaitpointHmacSecretAllArgs,
+    ) -> Result<RotateWaitpointHmacSecretAllResult, SdkError> {
+        Ok(self
+            .backend_ref()
+            .rotate_waitpoint_hmac_secret_all(args)
             .await?)
     }
 

--- a/crates/ff-test/tests/rotate_hmac_secret_all.rs
+++ b/crates/ff-test/tests/rotate_hmac_secret_all.rs
@@ -1,0 +1,150 @@
+//! Integration test for
+//! [`ff_core::engine_backend::EngineBackend::rotate_waitpoint_hmac_secret_all`]
+//! on the Valkey-backed impl (v0.7 migration-master Q4).
+//!
+//! Proves the new cluster-wide rotation method installs the fresh kid
+//! across EVERY execution partition by:
+//!
+//! 1. Bootstrapping each of the 4 test partitions with `kid-a`.
+//! 2. Invoking `rotate_waitpoint_hmac_secret_all` with `kid-b`.
+//! 3. Reading back each partition's keystore via
+//!    `ff_list_waitpoint_hmac_kids` and asserting `current_kid ==
+//!    "kid-b"` with `kid-a` surfaced as the (grace-windowed)
+//!    verifying kid.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test rotate_hmac_secret_all -- --test-threads=1
+
+use ff_core::contracts::{
+    ListWaitpointHmacKidsArgs, RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretArgs,
+    RotateWaitpointHmacSecretOutcome,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::IndexKeys;
+use ff_core::partition::{Partition, PartitionFamily};
+use ff_script::functions::suspension::{
+    ff_list_waitpoint_hmac_kids, ff_rotate_waitpoint_hmac_secret,
+};
+use ff_test::fixtures::TestCluster;
+
+// Fixture secrets — public, test-only values. See
+// waitpoint_hmac_rotation_fcall.rs for the CodeQL rationale note.
+// codeql[rust/cleartext-logging-sensitive-data]
+const SECRET_A: &str = "11111111111111111111111111111111";
+// codeql[rust/cleartext-logging-sensitive-data]
+const SECRET_B: &str = "22222222222222222222222222222222";
+const GRACE_MS: u64 = 60_000;
+
+fn partition(index: u16) -> Partition {
+    Partition {
+        family: PartitionFamily::Execution,
+        index,
+    }
+}
+
+async fn clear_partition(tc: &TestCluster, p: &Partition) {
+    let idx = IndexKeys::new(p);
+    let key = idx.waitpoint_hmac_secrets();
+    let _: Option<i64> = tc
+        .client()
+        .cmd("DEL")
+        .arg(key.as_str())
+        .execute()
+        .await
+        .expect("DEL during test cleanup must succeed");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn rotate_all_fans_out_across_every_partition() {
+    let tc = TestCluster::connect().await;
+    let cfg = *tc.partition_config();
+    let num = cfg.num_flow_partitions;
+    assert!(
+        num >= 2,
+        "test needs >=2 partitions to prove fan-out (got {num})"
+    );
+
+    // 1. Cleanup + bootstrap every partition with kid-a so the rotation
+    //    surfaces kid-a as the verifying kid on every partition.
+    for i in 0..num {
+        let p = partition(i);
+        clear_partition(&tc, &p).await;
+        let idx = IndexKeys::new(&p);
+        ff_rotate_waitpoint_hmac_secret(
+            tc.client(),
+            &idx,
+            &RotateWaitpointHmacSecretArgs {
+                new_kid: "kid-a".to_owned(),
+                new_secret_hex: SECRET_A.to_owned(),
+                grace_ms: GRACE_MS,
+            },
+        )
+        .await
+        .unwrap_or_else(|e| panic!("bootstrap partition {i}: {e}"));
+    }
+
+    // 2. Invoke the new trait method via ValkeyBackend (the Arc<dyn
+    //    EngineBackend> is the same shape ff-sdk FlowFabricWorker
+    //    forwards through).
+    let backend: std::sync::Arc<dyn EngineBackend> =
+        ff_backend_valkey::ValkeyBackend::from_client_and_partitions(tc.client().clone(), cfg);
+    let result = backend
+        .rotate_waitpoint_hmac_secret_all(RotateWaitpointHmacSecretAllArgs::new(
+            "kid-b", SECRET_B, GRACE_MS,
+        ))
+        .await
+        .expect("rotate_waitpoint_hmac_secret_all must succeed");
+
+    // 3a. One entry per partition, all Ok, all Rotated with previous =
+    //     Some("kid-a").
+    assert_eq!(result.entries.len(), num as usize);
+    for (i, entry) in result.entries.iter().enumerate() {
+        assert_eq!(entry.partition, i as u16);
+        let outcome = entry
+            .result
+            .as_ref()
+            .unwrap_or_else(|e| panic!("partition {i} rotation failed: {e}"));
+        match outcome {
+            RotateWaitpointHmacSecretOutcome::Rotated {
+                previous_kid,
+                new_kid,
+                gc_count: _,
+            } => {
+                assert_eq!(previous_kid.as_deref(), Some("kid-a"));
+                assert_eq!(new_kid, "kid-b");
+            }
+            other => panic!("partition {i}: expected Rotated, got {other:?}"),
+        }
+    }
+
+    // 3b. Read-back: every partition's keystore now has kid-b as
+    //     current_kid + kid-a in verifying.
+    for i in 0..num {
+        let p = partition(i);
+        let idx = IndexKeys::new(&p);
+        let listing = ff_list_waitpoint_hmac_kids(tc.client(), &idx, &ListWaitpointHmacKidsArgs {})
+            .await
+            .unwrap_or_else(|e| panic!("list partition {i}: {e}"));
+        assert_eq!(
+            listing.current_kid.as_deref(),
+            Some("kid-b"),
+            "partition {i}: current_kid"
+        );
+        assert_eq!(
+            listing.verifying.len(),
+            1,
+            "partition {i}: exactly one verifying kid"
+        );
+        assert_eq!(
+            listing.verifying[0].kid, "kid-a",
+            "partition {i}: verifying kid name"
+        );
+    }
+
+    // 4. Cleanup — other tests share the keyspace so leave no state.
+    for i in 0..num {
+        let p = partition(i);
+        clear_partition(&tc, &p).await;
+    }
+}


### PR DESCRIPTION
## Summary

RFC-v0.7 Wave 1b — migration-master §Q4 adjudication.

- Adds additive `EngineBackend::rotate_waitpoint_hmac_secret_all(args)` for cluster-wide waitpoint HMAC kid rotation. Valkey impl fans out one `ff_rotate_waitpoint_hmac_secret` FCALL per execution partition and returns per-partition outcomes; Postgres impl stubbed to `EngineError::Unavailable` (Wave 4 lands the single global-row INSERT).
- Adds `ff_core::waitpoint_hmac` re-export module as the consumer-facing import path for waitpoint HMAC wire types + rotation args. **Re-export-only shape** — no pure-Rust sign/verify code exists to extract today: signing and verification are server-side (Lua on Valkey; Wave 4 stored procs on Postgres). Module rustdoc documents this contract for consumers.
- New `#[non_exhaustive]` types `RotateWaitpointHmacSecretAllArgs` / `RotateWaitpointHmacSecretAllEntry` / `RotateWaitpointHmacSecretAllResult` with constructors (project memory-rule).
- `FlowFabricWorker::rotate_waitpoint_hmac_secret_all`, HookedBackend + PassthroughBackend dispatch.
- Pre-existing per-partition free-fn `ff_sdk::admin::rotate_waitpoint_hmac_secret_all_partitions` unchanged for backwards compat.

## Design note: default-impl scope

The task brief requested a trait default impl that fans out across partitions so Valkey would need no override. The trait's `&self` surface has no handle on `num_flow_partitions` or a client, so a purely-default fan-out would require adding more plumbing (`partition_config()` accessor, or a per-partition trait method) — invasive design decisions outside Wave 1b. Chosen shape: trait default returns `EngineError::Unavailable`, Valkey overrides with a concrete fan-out (~35 lines), Postgres overrides to `Unavailable`. The integration test proves the Valkey override installs the new kid on every partition.

## References

- `rfcs/drafts/v0.7-migration-master.md` §Q4 (consolidated survey, PR #229)
- Wave 0 scaffold: PR #230
- Existing per-partition paths: `ff_sdk::admin::rotate_waitpoint_hmac_secret_all_partitions`, `ff_script::functions::suspension::ff_rotate_waitpoint_hmac_secret`

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-core -p ff-sdk -p ff-backend-valkey -p ff-backend-postgres -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings` clean
- [x] `cargo test -p ff-test --test rotate_hmac_secret_all -- --test-threads=1` green against local Valkey (1 test, fans out across 4 test partitions, verifies read-back)
- [x] `cargo test -p ff-test --test waitpoint_hmac_rotation_fcall -- --test-threads=1` still green (10 tests)
- [x] `cargo test -p ff-sdk --lib` still green

## Constraints honoured

- File-lane discipline: untouched `ff-core/src/caps.rs` (Wave 1a) and any `handle_codec` file (Wave 1c).
- Additive only: no breaking changes to existing HMAC types or per-partition surfaces.

Do NOT merge — coordinating with parallel Wave 1 branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `EngineBackend` trait method and new public contract types, requiring backend and SDK plumbing and introducing new rotation behavior on Valkey. Risk is moderated by additive-only changes and a new integration test, but it touches security-adjacent key-rotation paths.
> 
> **Overview**
> Adds a new additive `EngineBackend::rotate_waitpoint_hmac_secret_all` API for **cluster-wide waitpoint HMAC kid rotation**, plus new `ff-core` contract types (`RotateWaitpointHmacSecretAllArgs/Entry/Result`) to report per-partition outcomes.
> 
> Implements the method in the Valkey backend by sequentially fanning out `ff_rotate_waitpoint_hmac_secret` FCALLs across all execution partitions (capturing partial failures per partition), while the Postgres backend is wired as an explicit `Unavailable` stub for now. The SDK forwards the new operation via `FlowFabricWorker` and hook/layer backends, and adds a new `ff_core::waitpoint_hmac` re-export module to provide a stable consumer import path for the waitpoint-HMAC wire/rotation types.
> 
> Adds an integration test (`rotate_hmac_secret_all`) that bootstraps multiple partitions, runs the new cluster-wide rotation, and verifies every partition’s keystore reflects the new/current kid and previous verifying kid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee1ff9ae885e75bdcd331630e301b8262ac1a5bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->