### PR TITLE
feat(pg-wave1c): ff-core::handle_codec v2 with BackendTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   subset semantics, same empty-required-matches-any default). Token
   validation and `CAPS_MAX_{BYTES,TOKENS}` bounds stay at the existing
   ingress sites. Ref: RFC-v0.7 §Q7, PR #230 (Wave 0 scaffold).
+- **RFC-v0.7 Wave 1c: `Handle.opaque` codec moved to
+  `ff_core::handle_codec` with embedded `BackendTag`.** The
+  byte-layout / wire-version logic that previously lived at
+  `ff_backend_valkey::handle_codec` is now a public module in
+  `ff_core` so the future Postgres backend decodes the same shape.
+  New wire format v2 prefixes the buffer with a `0x02` magic byte +
+  one-byte wire version + one-byte `BackendTag` so cross-backend
+  migration tooling can detect which backend minted a given handle
+  without parsing the payload. Pre-Wave-1c (v1) Valkey handles still
+  decode cleanly under `BackendTag::Valkey` via a compat path keyed
+  off the legacy leading byte `0x01` — backward wire compat is
+  non-negotiable per the master spec. New public types:
+  `ff_core::handle_codec::{HandlePayload, DecodedHandle, encode,
+  decode, HandleDecodeError}`; new enum variant
+  `BackendTag::Postgres`; new enum variant
+  `ValidationKind::HandleFromOtherBackend` (returned by backends when
+  a handle tagged for one backend is presented to another). No
+  behaviour change for existing Valkey call sites — `ValkeyBackend`
+  continues to produce and accept handles identically modulo the new
+  leading byte, and the crate-internal `HandleFields` alias still
+  names the same shape.
 
 ### Fixed
 

--- a/crates/ff-backend-postgres/src/handle_codec.rs
+++ b/crates/ff-backend-postgres/src/handle_codec.rs
@@ -1,0 +1,101 @@
+//! Postgres-side thin wrapper over [`ff_core::handle_codec`].
+//!
+//! **RFC-v0.7 Wave 1c scaffold.** Mirrors
+//! `ff_backend_valkey::handle_codec` so the Postgres trait impls
+//! (Waves 4+) have a symmetric encode/decode path and so the
+//! workspace has compile-time evidence that the core codec is
+//! backend-agnostic.
+//!
+//! At Wave 1c the Postgres backend still returns `Unavailable` for
+//! every trait method that touches a [`Handle`], so the bodies here
+//! are unused by the live hot path today — they exist to lock in the
+//! backend-tag invariant (a Postgres backend never accepts a
+//! Valkey-tagged handle) and to give Wave 4 a ready-to-use API.
+
+use ff_core::backend::{BackendTag, Handle, HandleKind, HandleOpaque};
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::handle_codec::{decode as core_decode, encode as core_encode, HandlePayload};
+
+/// Encode a [`HandlePayload`] into a Postgres-tagged [`Handle`].
+#[allow(dead_code)] // Wired up in Wave 4+ when Handle-bearing ops land.
+pub(crate) fn encode_handle(payload: &HandlePayload, kind: HandleKind) -> Handle {
+    let opaque: HandleOpaque = core_encode(BackendTag::Postgres, payload);
+    Handle::new(BackendTag::Postgres, kind, opaque)
+}
+
+/// Decode a [`Handle`] under the Postgres-backend invariant. A
+/// Valkey-tagged handle decodes successfully at the core codec layer
+/// but is rejected here with `ValidationKind::HandleFromOtherBackend`.
+#[allow(dead_code)] // Wired up in Wave 4+.
+pub(crate) fn decode_handle(handle: &Handle) -> Result<HandlePayload, EngineError> {
+    if handle.backend != BackendTag::Postgres {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::HandleFromOtherBackend,
+            detail: format!(
+                "expected={:?} actual={:?}",
+                BackendTag::Postgres,
+                handle.backend
+            ),
+        });
+    }
+    let decoded = core_decode(&handle.opaque)?;
+    if decoded.tag != BackendTag::Postgres {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::HandleFromOtherBackend,
+            detail: format!(
+                "expected={:?} actual={:?} (embedded tag)",
+                BackendTag::Postgres,
+                decoded.tag
+            ),
+        });
+    }
+    Ok(decoded.payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_core::partition::PartitionConfig;
+    use ff_core::types::{
+        AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, WorkerInstanceId,
+    };
+
+    fn sample_payload() -> HandlePayload {
+        HandlePayload::new(
+            ExecutionId::solo(&LaneId::new("default"), &PartitionConfig::default()),
+            AttemptIndex::new(1),
+            AttemptId::new(),
+            LeaseId::new(),
+            LeaseEpoch(1),
+            30_000,
+            LaneId::new("default"),
+            WorkerInstanceId::new("pg-worker-1"),
+        )
+    }
+
+    #[test]
+    fn round_trip_fresh() {
+        let p = sample_payload();
+        let h = encode_handle(&p, HandleKind::Fresh);
+        assert_eq!(h.backend, BackendTag::Postgres);
+        let back = decode_handle(&h).expect("round-trip");
+        assert_eq!(back, p);
+    }
+
+    /// Wave 1c spec: a Valkey-tagged handle presented to the Postgres
+    /// backend decodes at the core codec layer but the backend
+    /// rejects with `HandleFromOtherBackend`.
+    #[test]
+    fn valkey_handle_rejected_as_other_backend() {
+        let p = sample_payload();
+        let valkey_opaque = ff_core::handle_codec::encode(BackendTag::Valkey, &p);
+        let handle = Handle::new(BackendTag::Valkey, HandleKind::Fresh, valkey_opaque);
+        let err = decode_handle(&handle).unwrap_err();
+        match err {
+            EngineError::Validation { kind, .. } => {
+                assert_eq!(kind, ValidationKind::HandleFromOtherBackend);
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+}

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -55,6 +55,7 @@ use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 use sqlx::PgPool;
 
 pub mod error;
+pub mod handle_codec;
 pub mod listener;
 pub mod migrate;
 pub mod pool;

--- a/crates/ff-backend-valkey/src/handle_codec.rs
+++ b/crates/ff-backend-valkey/src/handle_codec.rs
@@ -1,240 +1,92 @@
-//! Internal [`HandleOpaque`] encoding for the Valkey backend.
+//! Valkey-side thin wrapper over [`ff_core::handle_codec`].
 //!
-//! **RFC-012 Stage 1b, option A (synth_handle per op).** ff-sdk's
-//! `ClaimedTask` does not yet refactor its shape onto a `Handle` —
-//! that lands in Stage 1d. For Stage 1b the SDK encodes the minimal
-//! attempt-cookie fields into a `HandleOpaque` on every forwarder
-//! entry, and this crate decodes them back on every FCALL. The
-//! format is private to this crate — no consumer ever sees the bytes
-//! — so it can change freely across stages.
+//! **RFC-v0.7 Wave 1c.** The byte-layout + wire-version logic moved to
+//! `ff_core::handle_codec` so both this crate and the Postgres backend
+//! decode the same shape. This file now (a) adapts the core codec's
+//! [`HandlePayload`] / [`DecodedHandle`] types to the Valkey-internal
+//! `HandleFields` alias the rest of the crate already names, (b)
+//! builds / validates the `Handle` wrapper (backend tag = Valkey +
+//! [`HandleKind`]), and (c) maps [`HandleDecodeError`] into
+//! [`EngineError`] at the trait boundary.
 //!
-//! # Wire layout (version-tagged)
-//!
-//! ```text
-//! [0]       u8    version tag (today: 0x01)
-//! [1..5]    u32   execution_id length (LE)
-//! [5..]     utf8  execution_id bytes
-//! [..+4]    u32   attempt_index (LE)
-//! [..+4]    u32   attempt_id length (LE)
-//! [..]      utf8  attempt_id bytes
-//! [..+4]    u32   lease_id length (LE)
-//! [..]      utf8  lease_id bytes
-//! [..+8]    u64   lease_epoch (LE)
-//! [..+8]    u64   lease_ttl_ms (LE)
-//! [..+4]    u32   lane_id length (LE)
-//! [..]      utf8  lane_id bytes
-//! [..+4]    u32   worker_instance_id length (LE)
-//! [..]      utf8  worker_instance_id bytes
-//! ```
-//!
-//! Length fields are `u32`s so any string up to 4 GiB encodes losslessly
-//! — far past realistic ExecutionId / UUID / lane lengths. The version
-//! tag is a forward-compat door: if the field set changes between
-//! Stage 1b and 1d, a future `0x02` branch can land additively without
-//! breaking in-flight handles (handles do not persist across process
-//! boundaries today, so even a hard switch would be safe — but the tag
-//! is cheap insurance).
+//! Wire-format compatibility note: v1 (pre-Wave-1c) Valkey handles
+//! decode cleanly on the core codec's v1-compat path. The v2 format
+//! (leading `0x02` magic + embedded `BackendTag`) is produced by all
+//! encode paths from Wave 1c onward. See `ff_core::handle_codec` for
+//! the full wire spec.
 
 use ff_core::backend::{BackendTag, Handle, HandleKind, HandleOpaque};
-use ff_core::engine_error::EngineError;
-use ff_core::types::{
-    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, WorkerInstanceId,
-};
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::handle_codec::{decode as core_decode, encode as core_encode, HandlePayload};
 
-/// Decoded view of a `HandleOpaque` — the minimum set of fields every
-/// Stage 1b forwarder needs to construct its Lua KEYS + ARGV.
-///
-/// Produced by [`encode_handle`] (via `ClaimedTask::synth_handle`) and
-/// consumed by [`decode_handle`] on each trait method entry.
-#[derive(Clone, Debug)]
-pub(crate) struct HandleFields {
-    pub execution_id: ExecutionId,
-    pub attempt_index: AttemptIndex,
-    pub attempt_id: AttemptId,
-    pub lease_id: LeaseId,
-    pub lease_epoch: LeaseEpoch,
-    pub lease_ttl_ms: u64,
-    pub lane_id: LaneId,
-    pub worker_instance_id: WorkerInstanceId,
-}
-
-const VERSION_TAG: u8 = 0x01;
+// Keep the crate-internal alias so the rest of ff-backend-valkey keeps
+// naming the payload as `HandleFields` without churn.
+pub(crate) type HandleFields = HandlePayload;
 
 /// Encode a `HandleFields` into a `Handle` carrying a Valkey-tagged
 /// `HandleOpaque`. Kind is caller-supplied (`Fresh` for `claim_next` /
-/// `claim_from_grant`, `Resumed` for `claim_from_reclaim_grant`).
+/// `claim_from_grant`, `Resumed` for `claim_from_reclaim_grant`,
+/// `Suspended` for `suspend`).
 pub(crate) fn encode_handle(fields: &HandleFields, kind: HandleKind) -> Handle {
-    let mut buf: Vec<u8> = Vec::with_capacity(256);
-    buf.push(VERSION_TAG);
-    // Every string field here is produced by an SDK type's `.to_string()`
-    // / `.as_str()`: UUID = 36 bytes, LaneId/WorkerInstanceId are
-    // config-bounded (WorkerConfig validator rejects >1KiB today),
-    // ExecutionId prefixed partition tag + UUID ≈ 50 bytes. None
-    // approach 4 GiB. `write_str` clamps at `u32::MAX`; on the
-    // vanishingly improbable path of an attacker-controlled
-    // oversized caller, the encoded slot length is clamped to
-    // u32::MAX and the trailing bytes are dropped — the `decode_handle`
-    // side detects the truncation (`Validation(InvalidInput)`) on the
-    // next op and the worker fails loudly rather than silently.
-    write_str(&mut buf, &fields.execution_id.to_string());
-    buf.extend_from_slice(&fields.attempt_index.0.to_le_bytes());
-    write_str(&mut buf, &fields.attempt_id.to_string());
-    write_str(&mut buf, &fields.lease_id.to_string());
-    buf.extend_from_slice(&fields.lease_epoch.0.to_le_bytes());
-    buf.extend_from_slice(&fields.lease_ttl_ms.to_le_bytes());
-    write_str(&mut buf, fields.lane_id.as_str());
-    write_str(&mut buf, fields.worker_instance_id.as_str());
-    Handle::new(BackendTag::Valkey, kind, HandleOpaque::new(buf.into_boxed_slice()))
+    let opaque: HandleOpaque = core_encode(BackendTag::Valkey, fields);
+    Handle::new(BackendTag::Valkey, kind, opaque)
 }
 
 /// Decode a `Handle` into its backing `HandleFields`. Returns
 /// `EngineError::Validation` on any shape / version / parse mismatch
 /// — the Valkey backend will not route an op on a malformed handle.
+///
+/// Also enforces the backend-tag invariant: a handle minted by
+/// another backend (e.g. Postgres) is rejected with
+/// `ValidationKind::HandleFromOtherBackend` without attempting to
+/// parse the rest of the buffer.
 pub(crate) fn decode_handle(handle: &Handle) -> Result<HandleFields, EngineError> {
     if handle.backend != BackendTag::Valkey {
-        return Err(invalid("handle backend tag is not Valkey"));
+        return Err(EngineError::Validation {
+            kind: ValidationKind::HandleFromOtherBackend,
+            detail: format!(
+                "expected={:?} actual={:?}",
+                BackendTag::Valkey,
+                handle.backend
+            ),
+        });
     }
-    let bytes = handle.opaque.as_bytes();
-    let mut cur = Cursor::new(bytes);
-    let version = cur.read_u8()?;
-    if version != VERSION_TAG {
-        return Err(invalid(&format!(
-            "handle version tag {version:#x} not recognised (expected {VERSION_TAG:#x})"
-        )));
+    let decoded = core_decode(&handle.opaque)?;
+    // The core codec also carries the backend tag in the buffer. If
+    // the embedded tag disagrees with the Handle's `backend` field,
+    // something up-stream is lying — treat that as
+    // `HandleFromOtherBackend` too.
+    if decoded.tag != BackendTag::Valkey {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::HandleFromOtherBackend,
+            detail: format!(
+                "expected={:?} actual={:?} (embedded tag)",
+                BackendTag::Valkey,
+                decoded.tag
+            ),
+        });
     }
-    let execution_id_str = cur.read_str()?;
-    let execution_id = ExecutionId::parse(&execution_id_str)
-        .map_err(|e| invalid(&format!("handle execution_id parse failed: {e}")))?;
-    let attempt_index = AttemptIndex::new(cur.read_u32()?);
-    let attempt_id_str = cur.read_str()?;
-    let attempt_id = AttemptId::parse(&attempt_id_str)
-        .map_err(|e| invalid(&format!("handle attempt_id parse failed: {e}")))?;
-    let lease_id_str = cur.read_str()?;
-    let lease_id = LeaseId::parse(&lease_id_str)
-        .map_err(|e| invalid(&format!("handle lease_id parse failed: {e}")))?;
-    let lease_epoch = LeaseEpoch(cur.read_u64()?);
-    let lease_ttl_ms = cur.read_u64()?;
-    let lane_id_str = cur.read_str()?;
-    let lane_id = LaneId::new(lane_id_str);
-    let worker_str = cur.read_str()?;
-    let worker_instance_id = WorkerInstanceId::new(worker_str);
-    cur.expect_eof()?;
-    Ok(HandleFields {
-        execution_id,
-        attempt_index,
-        attempt_id,
-        lease_id,
-        lease_epoch,
-        lease_ttl_ms,
-        lane_id,
-        worker_instance_id,
-    })
-}
-
-fn write_str(buf: &mut Vec<u8>, s: &str) {
-    let bytes = s.as_bytes();
-    // Clamp rather than panic: if a caller somehow hands in a
-    // >4 GiB string (impossible at the SDK's attempt-cookie scale),
-    // we write a u32::MAX length prefix + the first 4 GiB of bytes.
-    // `decode_handle` will detect the trailing truncation and return
-    // `EngineError::Validation(InvalidInput)` on the first op — the
-    // worker fails loudly at op time rather than on the spawn-path
-    // stack, which matches the crate-wide strict-parse posture
-    // (gemini-code-assist review finding on PR #119: avoid `expect`
-    // on storage-adjacent data paths).
-    let (len, take) = match u32::try_from(bytes.len()) {
-        Ok(n) => (n, bytes.len()),
-        Err(_) => (u32::MAX, u32::MAX as usize),
-    };
-    buf.extend_from_slice(&len.to_le_bytes());
-    buf.extend_from_slice(&bytes[..take]);
-}
-
-fn invalid(msg: &str) -> EngineError {
-    EngineError::Validation {
-        kind: ff_core::engine_error::ValidationKind::InvalidInput,
-        detail: format!("invalid Valkey backend handle: {msg}"),
-    }
-}
-
-struct Cursor<'a> {
-    bytes: &'a [u8],
-    pos: usize,
-}
-
-impl<'a> Cursor<'a> {
-    fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes, pos: 0 }
-    }
-
-    fn take(&mut self, n: usize) -> Result<&'a [u8], EngineError> {
-        if self.pos + n > self.bytes.len() {
-            return Err(invalid(&format!(
-                "truncated handle: needed {n} bytes at offset {pos}, have {len}",
-                pos = self.pos,
-                len = self.bytes.len()
-            )));
-        }
-        let slice = &self.bytes[self.pos..self.pos + n];
-        self.pos += n;
-        Ok(slice)
-    }
-
-    fn read_u8(&mut self) -> Result<u8, EngineError> {
-        Ok(self.take(1)?[0])
-    }
-
-    fn read_u32(&mut self) -> Result<u32, EngineError> {
-        let mut b = [0u8; 4];
-        b.copy_from_slice(self.take(4)?);
-        Ok(u32::from_le_bytes(b))
-    }
-
-    fn read_u64(&mut self) -> Result<u64, EngineError> {
-        let mut b = [0u8; 8];
-        b.copy_from_slice(self.take(8)?);
-        Ok(u64::from_le_bytes(b))
-    }
-
-    fn read_str(&mut self) -> Result<String, EngineError> {
-        let len = self.read_u32()? as usize;
-        let bytes = self.take(len)?;
-        String::from_utf8(bytes.to_vec())
-            .map_err(|e| invalid(&format!("handle string is not valid UTF-8: {e}")))
-    }
-
-    fn expect_eof(&self) -> Result<(), EngineError> {
-        if self.pos != self.bytes.len() {
-            return Err(invalid(&format!(
-                "trailing bytes in handle: pos={pos}, len={len}",
-                pos = self.pos,
-                len = self.bytes.len()
-            )));
-        }
-        Ok(())
-    }
+    Ok(decoded.payload)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use ff_core::partition::PartitionConfig;
-    use ff_core::types::FlowId;
+    use ff_core::types::{AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId,
+        WorkerInstanceId};
 
     fn sample() -> HandleFields {
-        HandleFields {
-            execution_id: ExecutionId::solo(
-                &LaneId::new("default"),
-                &PartitionConfig::default(),
-            ),
-            attempt_index: AttemptIndex::new(3),
-            attempt_id: AttemptId::new(),
-            lease_id: LeaseId::new(),
-            lease_epoch: LeaseEpoch(7),
-            lease_ttl_ms: 30_000,
-            lane_id: LaneId::new("default"),
-            worker_instance_id: WorkerInstanceId::new("worker-1"),
-        }
+        HandlePayload::new(
+            ExecutionId::solo(&LaneId::new("default"), &PartitionConfig::default()),
+            AttemptIndex::new(3),
+            AttemptId::new(),
+            LeaseId::new(),
+            LeaseEpoch(7),
+            30_000,
+            LaneId::new("default"),
+            WorkerInstanceId::new("worker-1"),
+        )
     }
 
     #[test]
@@ -244,14 +96,7 @@ mod tests {
         assert_eq!(handle.backend, BackendTag::Valkey);
         assert_eq!(handle.kind, HandleKind::Fresh);
         let decoded = decode_handle(&handle).expect("round-trip");
-        assert_eq!(decoded.execution_id, fields.execution_id);
-        assert_eq!(decoded.attempt_index, fields.attempt_index);
-        assert_eq!(decoded.attempt_id, fields.attempt_id);
-        assert_eq!(decoded.lease_id, fields.lease_id);
-        assert_eq!(decoded.lease_epoch, fields.lease_epoch);
-        assert_eq!(decoded.lease_ttl_ms, fields.lease_ttl_ms);
-        assert_eq!(decoded.lane_id, fields.lane_id);
-        assert_eq!(decoded.worker_instance_id, fields.worker_instance_id);
+        assert_eq!(decoded, fields);
     }
 
     #[test]
@@ -263,32 +108,17 @@ mod tests {
     }
 
     #[test]
-    fn truncated_handle_rejected() {
-        // Only version tag, no fields.
-        let handle = Handle::new(
-            BackendTag::Valkey,
-            HandleKind::Fresh,
-            HandleOpaque::new(Box::new([VERSION_TAG])),
-        );
+    fn rejects_postgres_tagged_handle() {
+        // Postgres-tagged handle presented to Valkey decode path.
+        let fields = sample();
+        let pg_opaque = ff_core::handle_codec::encode(BackendTag::Postgres, &fields);
+        let handle = Handle::new(BackendTag::Postgres, HandleKind::Fresh, pg_opaque);
         let err = decode_handle(&handle).unwrap_err();
-        assert!(format!("{err}").contains("truncated"));
-    }
-
-    #[test]
-    fn bad_version_rejected() {
-        let handle = Handle::new(
-            BackendTag::Valkey,
-            HandleKind::Fresh,
-            HandleOpaque::new(Box::new([0xFF])),
-        );
-        let err = decode_handle(&handle).unwrap_err();
-        assert!(format!("{err}").contains("version tag"));
-    }
-
-    // FlowId is used elsewhere in the crate; touch it here to silence
-    // an unused-import warning if the tests file is added standalone.
-    #[allow(dead_code)]
-    fn _flow_id_touch() -> FlowId {
-        FlowId::new()
+        match err {
+            EngineError::Validation { kind, .. } => {
+                assert_eq!(kind, ValidationKind::HandleFromOtherBackend);
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
     }
 }

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -318,7 +318,7 @@ impl ValkeyBackend {
         worker_instance_id: WorkerInstanceId,
         kind: HandleKind,
     ) -> Handle {
-        let fields = handle_codec::HandleFields {
+        let fields = handle_codec::HandleFields::new(
             execution_id,
             attempt_index,
             attempt_id,
@@ -327,7 +327,7 @@ impl ValkeyBackend {
             lease_ttl_ms,
             lane_id,
             worker_instance_id,
-        };
+        );
         handle_codec::encode_handle(&fields, kind)
     }
 }

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -57,6 +57,30 @@ use std::time::Duration;
 pub enum BackendTag {
     /// The Valkey FCALL-backed implementation.
     Valkey,
+    /// The Postgres-backed implementation (RFC-v0.7 Wave 1c).
+    Postgres,
+}
+
+impl BackendTag {
+    /// Stable single-byte wire encoding for the tag. Embedded inside
+    /// [`HandleOpaque`] so cross-backend migration tooling can detect
+    /// which backend minted a given handle without parsing the rest of
+    /// the payload (see [`crate::handle_codec`]).
+    pub const fn wire_byte(self) -> u8 {
+        match self {
+            BackendTag::Valkey => 0x01,
+            BackendTag::Postgres => 0x02,
+        }
+    }
+
+    /// Inverse of [`Self::wire_byte`].
+    pub const fn from_wire_byte(b: u8) -> Option<Self> {
+        match b {
+            0x01 => Some(BackendTag::Valkey),
+            0x02 => Some(BackendTag::Postgres),
+            _ => None,
+        }
+    }
 }
 
 /// Lifecycle kind carried inside a [`Handle`]. Backends validate `kind`

--- a/crates/ff-core/src/engine_error.rs
+++ b/crates/ff-core/src/engine_error.rs
@@ -219,6 +219,16 @@ pub enum ValidationKind {
     /// Classified as `Terminal`: a consumer retrying the read will
     /// see the same bytes. Surface to the operator; do not loop.
     Corruption,
+    /// The [`crate::backend::Handle`] presented to a backend op was
+    /// minted by a different backend (e.g. a Valkey-tagged handle
+    /// passed to the Postgres backend). RFC-v0.7 Wave 1c: cross-backend
+    /// migration tooling emits Handles from one backend that must not
+    /// decode as the other; backends detect the mismatch at op entry
+    /// and return this variant.
+    ///
+    /// `detail` carries `"expected=<tag> actual=<tag>"` for operator
+    /// diagnostics.
+    HandleFromOtherBackend,
 }
 
 /// Contention sub-kinds (retryable per RFC-010 §10.7). Caller should

--- a/crates/ff-core/src/handle_codec.rs
+++ b/crates/ff-core/src/handle_codec.rs
@@ -1,0 +1,471 @@
+//! Backend-agnostic codec for [`HandleOpaque`] payloads.
+//!
+//! **RFC-v0.7 Wave 1c.** Extracted from `ff-backend-valkey` so the
+//! Postgres backend (Wave 4+) decodes the same wire shape. Worker-B
+//! §4.1 flagged `handle_codec` as one of the top Valkey-shape-leaking
+//! subsystems in the v0.7 migration master spec; this module is the
+//! relocation target.
+//!
+//! # Responsibilities
+//!
+//! * Serialize a [`HandlePayload`] (attempt-cookie fields every
+//!   backend needs to route an op) into the opaque byte buffer carried
+//!   inside a [`Handle`]. See [`encode`].
+//! * Parse that buffer back into a [`HandlePayload`] plus the
+//!   [`BackendTag`] that minted it. See [`decode`].
+//! * Expose a typed [`HandleDecodeError`] mapping cleanly to
+//!   `EngineError::Validation { kind: Corruption, .. }` at the backend
+//!   boundary. See [`From<HandleDecodeError> for EngineError`].
+//!
+//! # Wire format v2
+//!
+//! New-format opaque buffers are self-identifying — the leading byte
+//! distinguishes pre-Wave-1c (Valkey-only) buffers from v2 buffers:
+//!
+//! ```text
+//! v2 layout (Wave 1c+):
+//!   [0]       u8    magic (0x02) — new-format marker
+//!   [1]       u8    wire version (today: 0x01)
+//!   [2]       u8    BackendTag wire byte (0x01 = Valkey, 0x02 = Postgres)
+//!   [3..]             fields (see §Fields)
+//!
+//! v1 layout (pre-Wave-1c, Valkey-only — read-only compat):
+//!   [0]       u8    wire version (0x01)
+//!   [1..]             fields (§Fields)
+//! ```
+//!
+//! ## §Fields
+//!
+//! ```text
+//! u32(LE)  execution_id length
+//! utf8     execution_id bytes
+//! u32(LE)  attempt_index
+//! u32(LE)  attempt_id length
+//! utf8     attempt_id bytes
+//! u32(LE)  lease_id length
+//! utf8     lease_id bytes
+//! u64(LE)  lease_epoch
+//! u64(LE)  lease_ttl_ms
+//! u32(LE)  lane_id length
+//! utf8     lane_id bytes
+//! u32(LE)  worker_instance_id length
+//! utf8     worker_instance_id bytes
+//! ```
+//!
+//! # Backward-compat
+//!
+//! v1 is Valkey-only: any pre-Wave-1c handle in-flight at upgrade time
+//! decodes under `BackendTag::Valkey`. The magic byte `0x02` was
+//! chosen to be disjoint from the v1 leading byte (`0x01` = version
+//! tag) — the decoder switches on the first byte.
+
+use crate::backend::{BackendTag, HandleOpaque};
+use crate::engine_error::{EngineError, ValidationKind};
+use crate::types::{
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, WorkerInstanceId,
+};
+
+/// v2 "new-format" marker. Disjoint from the v1 leading byte
+/// (`V1_VERSION_TAG = 0x01`) so the decoder can switch cleanly.
+const V2_MAGIC: u8 = 0x02;
+/// v2 wire version. Bumped when field layout changes.
+const V2_WIRE_VERSION: u8 = 0x01;
+/// v1 (pre-Wave-1c) leading byte. Present only for the compat decode path.
+const V1_VERSION_TAG: u8 = 0x01;
+
+/// Decoded view of an encoded [`HandleOpaque`] — the minimum set of
+/// fields every backend needs to construct its per-op KEYS + ARGV.
+///
+/// `#[non_exhaustive]`: fields grow additively when new attempt-cookie
+/// state lands (e.g. a Wave-5 partition routing hint). Construct via
+/// [`HandlePayload::new`]; field-access is via the pub fields.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct HandlePayload {
+    pub execution_id: ExecutionId,
+    pub attempt_index: AttemptIndex,
+    pub attempt_id: AttemptId,
+    pub lease_id: LeaseId,
+    pub lease_epoch: LeaseEpoch,
+    pub lease_ttl_ms: u64,
+    pub lane_id: LaneId,
+    pub worker_instance_id: WorkerInstanceId,
+}
+
+impl HandlePayload {
+    /// Construct a payload. All fields are mandatory at Wave 1c — the
+    /// `#[non_exhaustive]` guard lets future fields land additively.
+    #[allow(clippy::too_many_arguments)] // all 8 fields are required attempt-cookie state
+    pub fn new(
+        execution_id: ExecutionId,
+        attempt_index: AttemptIndex,
+        attempt_id: AttemptId,
+        lease_id: LeaseId,
+        lease_epoch: LeaseEpoch,
+        lease_ttl_ms: u64,
+        lane_id: LaneId,
+        worker_instance_id: WorkerInstanceId,
+    ) -> Self {
+        Self {
+            execution_id,
+            attempt_index,
+            attempt_id,
+            lease_id,
+            lease_epoch,
+            lease_ttl_ms,
+            lane_id,
+            worker_instance_id,
+        }
+    }
+}
+
+/// Output of [`decode`] — the decoded [`HandlePayload`] plus the
+/// [`BackendTag`] embedded in the opaque buffer (or inferred from the
+/// v1 compat path).
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DecodedHandle {
+    pub tag: BackendTag,
+    pub payload: HandlePayload,
+}
+
+impl DecodedHandle {
+    pub fn new(tag: BackendTag, payload: HandlePayload) -> Self {
+        Self { tag, payload }
+    }
+}
+
+/// Typed decode-failure classification. Mapped to
+/// `EngineError::Validation { kind: Corruption, .. }` at the backend
+/// boundary via the [`From`] impl.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HandleDecodeError {
+    /// Buffer shorter than required by the current read position.
+    Truncated { needed: usize, at: usize, have: usize },
+    /// Trailing bytes after the last expected field.
+    TrailingBytes { pos: usize, len: usize },
+    /// v2 wire-version byte did not match a supported version.
+    BadWireVersion { got: u8 },
+    /// v1-path version byte did not match the expected tag.
+    BadV1Version { got: u8 },
+    /// v2 backend-tag byte did not map to a known [`BackendTag`].
+    BadBackendTag { got: u8 },
+    /// A length-prefixed string had invalid UTF-8.
+    InvalidUtf8 { field: &'static str },
+    /// A parsed id/field failed its own validation (e.g. `ExecutionId::parse`).
+    ParseField { field: &'static str, detail: String },
+}
+
+impl std::fmt::Display for HandleDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HandleDecodeError::Truncated { needed, at, have } => write!(
+                f,
+                "truncated handle: needed {needed} bytes at offset {at}, have {have}"
+            ),
+            HandleDecodeError::TrailingBytes { pos, len } => {
+                write!(f, "trailing bytes in handle: pos={pos}, len={len}")
+            }
+            HandleDecodeError::BadWireVersion { got } => {
+                write!(f, "handle v2 wire-version byte {got:#x} not recognised")
+            }
+            HandleDecodeError::BadV1Version { got } => write!(
+                f,
+                "handle v1 version byte {got:#x} not recognised (expected {V1_VERSION_TAG:#x})"
+            ),
+            HandleDecodeError::BadBackendTag { got } => {
+                write!(f, "handle backend-tag byte {got:#x} not recognised")
+            }
+            HandleDecodeError::InvalidUtf8 { field } => {
+                write!(f, "handle field `{field}` is not valid UTF-8")
+            }
+            HandleDecodeError::ParseField { field, detail } => {
+                write!(f, "handle field `{field}` parse failed: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HandleDecodeError {}
+
+impl From<HandleDecodeError> for EngineError {
+    fn from(err: HandleDecodeError) -> Self {
+        EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("handle_codec: {err}"),
+        }
+    }
+}
+
+/// Encode a [`HandlePayload`] into a [`HandleOpaque`] tagged with
+/// `tag`. Produces a v2 buffer — callers decoding via [`decode`] always
+/// get the tag they encoded.
+pub fn encode(tag: BackendTag, payload: &HandlePayload) -> HandleOpaque {
+    let mut buf: Vec<u8> = Vec::with_capacity(256);
+    buf.push(V2_MAGIC);
+    buf.push(V2_WIRE_VERSION);
+    buf.push(tag.wire_byte());
+    write_fields(&mut buf, payload);
+    HandleOpaque::new(buf.into_boxed_slice())
+}
+
+/// Decode a [`HandleOpaque`] into a [`DecodedHandle`]. Accepts both
+/// v2 buffers (leading `V2_MAGIC`) and legacy v1 Valkey buffers
+/// (leading `V1_VERSION_TAG`); the v1 path returns
+/// `tag = BackendTag::Valkey`.
+pub fn decode(opaque: &HandleOpaque) -> Result<DecodedHandle, HandleDecodeError> {
+    let bytes = opaque.as_bytes();
+    let mut cur = Cursor::new(bytes);
+    let lead = cur.read_u8()?;
+    let tag = match lead {
+        V2_MAGIC => {
+            let wire_version = cur.read_u8()?;
+            if wire_version != V2_WIRE_VERSION {
+                return Err(HandleDecodeError::BadWireVersion { got: wire_version });
+            }
+            let tag_byte = cur.read_u8()?;
+            BackendTag::from_wire_byte(tag_byte)
+                .ok_or(HandleDecodeError::BadBackendTag { got: tag_byte })?
+        }
+        V1_VERSION_TAG => BackendTag::Valkey,
+        other => return Err(HandleDecodeError::BadV1Version { got: other }),
+    };
+    let payload = read_fields(&mut cur)?;
+    cur.expect_eof()?;
+    Ok(DecodedHandle { tag, payload })
+}
+
+// ── Field serialization ─────────────────────────────────────────────────
+
+fn write_fields(buf: &mut Vec<u8>, f: &HandlePayload) {
+    write_str(buf, &f.execution_id.to_string());
+    buf.extend_from_slice(&f.attempt_index.0.to_le_bytes());
+    write_str(buf, &f.attempt_id.to_string());
+    write_str(buf, &f.lease_id.to_string());
+    buf.extend_from_slice(&f.lease_epoch.0.to_le_bytes());
+    buf.extend_from_slice(&f.lease_ttl_ms.to_le_bytes());
+    write_str(buf, f.lane_id.as_str());
+    write_str(buf, f.worker_instance_id.as_str());
+}
+
+fn read_fields(cur: &mut Cursor<'_>) -> Result<HandlePayload, HandleDecodeError> {
+    let execution_id_str = cur.read_str("execution_id")?;
+    let execution_id = ExecutionId::parse(&execution_id_str).map_err(|e| {
+        HandleDecodeError::ParseField {
+            field: "execution_id",
+            detail: e.to_string(),
+        }
+    })?;
+    let attempt_index = AttemptIndex::new(cur.read_u32()?);
+    let attempt_id_str = cur.read_str("attempt_id")?;
+    let attempt_id =
+        AttemptId::parse(&attempt_id_str).map_err(|e| HandleDecodeError::ParseField {
+            field: "attempt_id",
+            detail: e.to_string(),
+        })?;
+    let lease_id_str = cur.read_str("lease_id")?;
+    let lease_id = LeaseId::parse(&lease_id_str).map_err(|e| HandleDecodeError::ParseField {
+        field: "lease_id",
+        detail: e.to_string(),
+    })?;
+    let lease_epoch = LeaseEpoch(cur.read_u64()?);
+    let lease_ttl_ms = cur.read_u64()?;
+    let lane_id_str = cur.read_str("lane_id")?;
+    let lane_id = LaneId::new(lane_id_str);
+    let worker_str = cur.read_str("worker_instance_id")?;
+    let worker_instance_id = WorkerInstanceId::new(worker_str);
+    Ok(HandlePayload {
+        execution_id,
+        attempt_index,
+        attempt_id,
+        lease_id,
+        lease_epoch,
+        lease_ttl_ms,
+        lane_id,
+        worker_instance_id,
+    })
+}
+
+fn write_str(buf: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    // Clamp rather than panic: if a caller somehow hands in a
+    // >4 GiB string (impossible at the SDK's attempt-cookie scale),
+    // we write a u32::MAX length prefix + the first 4 GiB of bytes.
+    // decode() will detect the trailing truncation.
+    let (len, take) = match u32::try_from(bytes.len()) {
+        Ok(n) => (n, bytes.len()),
+        Err(_) => (u32::MAX, u32::MAX as usize),
+    };
+    buf.extend_from_slice(&len.to_le_bytes());
+    buf.extend_from_slice(&bytes[..take]);
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], HandleDecodeError> {
+        if self.pos + n > self.bytes.len() {
+            return Err(HandleDecodeError::Truncated {
+                needed: n,
+                at: self.pos,
+                have: self.bytes.len(),
+            });
+        }
+        let slice = &self.bytes[self.pos..self.pos + n];
+        self.pos += n;
+        Ok(slice)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, HandleDecodeError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn read_u32(&mut self) -> Result<u32, HandleDecodeError> {
+        let mut b = [0u8; 4];
+        b.copy_from_slice(self.take(4)?);
+        Ok(u32::from_le_bytes(b))
+    }
+
+    fn read_u64(&mut self) -> Result<u64, HandleDecodeError> {
+        let mut b = [0u8; 8];
+        b.copy_from_slice(self.take(8)?);
+        Ok(u64::from_le_bytes(b))
+    }
+
+    fn read_str(&mut self, field: &'static str) -> Result<String, HandleDecodeError> {
+        let len = self.read_u32()? as usize;
+        let bytes = self.take(len)?;
+        String::from_utf8(bytes.to_vec())
+            .map_err(|_| HandleDecodeError::InvalidUtf8 { field })
+    }
+
+    fn expect_eof(&self) -> Result<(), HandleDecodeError> {
+        if self.pos != self.bytes.len() {
+            return Err(HandleDecodeError::TrailingBytes {
+                pos: self.pos,
+                len: self.bytes.len(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::partition::PartitionConfig;
+
+    fn sample_payload() -> HandlePayload {
+        HandlePayload {
+            execution_id: ExecutionId::solo(
+                &LaneId::new("default"),
+                &PartitionConfig::default(),
+            ),
+            attempt_index: AttemptIndex::new(3),
+            attempt_id: AttemptId::new(),
+            lease_id: LeaseId::new(),
+            lease_epoch: LeaseEpoch(7),
+            lease_ttl_ms: 30_000,
+            lane_id: LaneId::new("default"),
+            worker_instance_id: WorkerInstanceId::new("worker-1"),
+        }
+    }
+
+    #[test]
+    fn round_trip_valkey_v2() {
+        let p = sample_payload();
+        let opaque = encode(BackendTag::Valkey, &p);
+        // v2 leading byte.
+        assert_eq!(opaque.as_bytes()[0], V2_MAGIC);
+        assert_eq!(opaque.as_bytes()[1], V2_WIRE_VERSION);
+        assert_eq!(opaque.as_bytes()[2], BackendTag::Valkey.wire_byte());
+        let decoded = decode(&opaque).expect("round-trip");
+        assert_eq!(decoded.tag, BackendTag::Valkey);
+        assert_eq!(decoded.payload, p);
+    }
+
+    #[test]
+    fn round_trip_postgres_v2() {
+        let p = sample_payload();
+        let opaque = encode(BackendTag::Postgres, &p);
+        assert_eq!(opaque.as_bytes()[2], BackendTag::Postgres.wire_byte());
+        let decoded = decode(&opaque).expect("round-trip");
+        assert_eq!(decoded.tag, BackendTag::Postgres);
+        assert_eq!(decoded.payload, p);
+    }
+
+    /// Regression guard: an opaque buffer produced by the pre-Wave-1c
+    /// Valkey-only codec (leading byte = 0x01, no magic, no embedded
+    /// backend tag) must still decode cleanly as `BackendTag::Valkey`.
+    /// Non-negotiable per Wave 1c spec.
+    #[test]
+    fn old_v1_format_decodes_as_valkey() {
+        let p = sample_payload();
+        // Synthesise a v1 buffer byte-for-byte identical to what the
+        // pre-Wave-1c `encode_handle` in ff-backend-valkey produced.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(V1_VERSION_TAG); // single version byte, no magic, no tag
+        write_fields(&mut buf, &p);
+        let opaque = HandleOpaque::new(buf.into_boxed_slice());
+        let decoded = decode(&opaque).expect("v1 compat decode");
+        assert_eq!(decoded.tag, BackendTag::Valkey);
+        assert_eq!(decoded.payload, p);
+    }
+
+    #[test]
+    fn truncated_handle_rejected() {
+        // Only the magic byte — read_u8 for wire_version will fail.
+        let opaque = HandleOpaque::new(Box::new([V2_MAGIC]));
+        let err = decode(&opaque).unwrap_err();
+        assert!(matches!(err, HandleDecodeError::Truncated { .. }));
+    }
+
+    #[test]
+    fn bad_v2_wire_version_rejected() {
+        // v2 magic, unknown wire version.
+        let opaque = HandleOpaque::new(Box::new([V2_MAGIC, 0xFF, 0x01]));
+        let err = decode(&opaque).unwrap_err();
+        assert!(matches!(err, HandleDecodeError::BadWireVersion { got: 0xFF }));
+    }
+
+    #[test]
+    fn bad_backend_tag_rejected() {
+        // v2 magic + valid wire version + bogus tag byte.
+        let opaque = HandleOpaque::new(Box::new([V2_MAGIC, V2_WIRE_VERSION, 0xFE]));
+        let err = decode(&opaque).unwrap_err();
+        assert!(matches!(err, HandleDecodeError::BadBackendTag { got: 0xFE }));
+    }
+
+    #[test]
+    fn bad_leading_byte_rejected() {
+        // Neither v2 magic nor v1 version tag.
+        let opaque = HandleOpaque::new(Box::new([0xAB]));
+        let err = decode(&opaque).unwrap_err();
+        assert!(matches!(err, HandleDecodeError::BadV1Version { got: 0xAB }));
+    }
+
+    #[test]
+    fn decode_error_maps_to_validation_corruption() {
+        let err: EngineError = HandleDecodeError::Truncated {
+            needed: 4,
+            at: 1,
+            have: 1,
+        }
+        .into();
+        match err {
+            EngineError::Validation { kind, detail } => {
+                assert_eq!(kind, ValidationKind::Corruption);
+                assert!(detail.contains("handle_codec"));
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+}

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod contracts;
 pub mod engine_backend;
 pub mod engine_error;
 pub mod error;
+pub mod handle_codec;
 pub mod hash;
 pub mod keys;
 pub mod partition;


### PR DESCRIPTION
## Summary

RFC-v0.7 Wave 1c (Worker-B §4.1 + Part 3 hotspot list). Moves the
`Handle.opaque` codec from `ff-backend-valkey` into `ff-core` so the
future `ff-backend-postgres` decodes the same wire shape, and upgrades
the encoded form to self-identify its backend via an embedded
`BackendTag` byte.

- **Wire format v2:** `[0x02 magic, wire_version, BackendTag, ...fields]`.
  Backward-compat: pre-Wave-1c Valkey handles (leading byte `0x01`)
  still decode cleanly under `BackendTag::Valkey` through a v1-compat
  branch in `decode()`. The `old_v1_format_decodes_as_valkey` test
  pins this — a v1 byte-for-byte synthesised buffer round-trips.
- **New ff-core surface:** `handle_codec::{HandlePayload,
  DecodedHandle, encode, decode, HandleDecodeError}`, plus
  `BackendTag::Postgres` and `ValidationKind::HandleFromOtherBackend`.
- **Backends:** `ff-backend-valkey::handle_codec` is now a thin
  wrapper that delegates to the core codec, preserves the internal
  `HandleFields` alias so the rest of the crate sees no churn, and
  enforces the backend-tag invariant. `ff-backend-postgres` gains a
  mirror stub ready for Wave 4+ ops.
- Cites master spec `rfcs/drafts/v0.7-migration-master.md` Part 3
  hotspot list + Worker-B §4.1.

## Non-goals / safety

- HMAC path is unchanged. The existing Valkey codec carried no HMAC
  — fence-triple / lease validation lives server-side via
  `lease_epoch` — and that behavior is preserved byte-for-byte
  modulo the leading bytes.
- No call-site churn in `ff-backend-valkey/src/lib.rs` beyond the
  one `HandleFields { .. }` struct-literal → `HandleFields::new(..)`
  adaptation forced by the cross-crate `#[non_exhaustive]`.

## Test plan

- [x] `cargo check --workspace --all-features` clean.
- [x] `cargo clippy -p ff-core -p ff-backend-valkey -p ff-backend-postgres -p ff-sdk -- -D warnings` clean.
- [x] `cargo test -p ff-core --lib handle_codec` — 8/8 green
      (round-trip Valkey v2, round-trip Postgres v2, v1 regression,
      truncated, bad wire version, bad backend tag, bad leading byte,
      decode-error → Validation{Corruption} mapping).
- [x] `cargo test -p ff-backend-valkey --lib` — 12/12 green
      (round-trip Fresh/Resumed + cross-backend reject).
- [x] `cargo test -p ff-backend-postgres --lib` — 2/2 green
      (round-trip + Valkey-handle-rejected-as-other-backend).
- [x] `cargo test --workspace --all-features --lib` — all green.
- [x] Old v1 handle regression guard synthesised from the pre-Wave-1c
      layout passes — wire backward-compat preserved.

Do NOT merge — owner/parallel-Wave coordination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the wire encoding/decoding of `HandleOpaque` and centralizes it in `ff-core`, which can break in-flight handles or cross-version interoperability if the compat path is wrong. Also introduces new backend-tag validation errors that may surface in unexpected call paths during migrations.
> 
> **Overview**
> Moves Valkey’s `HandleOpaque` byte codec into new public `ff_core::handle_codec` and upgrades the encoding to a self-identifying v2 format (`0x02` magic + wire version + embedded `BackendTag`), while preserving decode compatibility for legacy v1 Valkey handles.
> 
> Adds `BackendTag::Postgres` plus stable tag wire-byte helpers, introduces `ValidationKind::HandleFromOtherBackend`, and updates `ff-backend-valkey` to delegate encode/decode to the core codec while rejecting handles tagged for other backends.
> 
> Adds a Postgres backend `handle_codec` wrapper (Wave 1c scaffold) that uses the core codec and enforces the same backend-tag invariant, plus associated tests and changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561ec4786131397557e5e6bf2857e877d15085d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->