### PR TITLE
feat(pg-wave2): Valkey claim + claim_from_reclaim + ClaimPolicy extension (v0.7 critical path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **RFC-v0.7 Wave 2: Valkey `EngineBackend::claim` +
+  `claim_from_reclaim` implementations.** `ValkeyBackend::claim` now
+  performs a fresh-find scan across execution partitions — ZRANGEBYSCORE
+  the lane's eligible set, capability-subset filter via
+  `ff_core::caps::matches`, issue `ff_issue_claim_grant`, and claim via
+  `ff_claim_execution` — and returns a `HandleKind::Fresh` handle.
+  `claim_from_reclaim` unwraps the `ReclaimGrant` carried by
+  `ReclaimToken` and routes through `ff_claim_resumed_execution`,
+  returning a `HandleKind::Resumed` handle with a bumped lease epoch.
+  Both replace the prior `EngineError::Unavailable` stubs.
+
+### Changed
+
+- **Pre-1.0 BREAKING — `ClaimPolicy` extended with worker identity.**
+  `ClaimPolicy` now carries `worker_id: WorkerId`,
+  `worker_instance_id: WorkerInstanceId`, and `lease_ttl_ms: u32` so the
+  backend's `claim(&self, lane, caps, policy)` can invoke
+  `ff_claim_execution` without a side-channel identity lookup (Wave 2
+  design-gap adjudication). The prior `ClaimPolicy::immediate()` and
+  `ClaimPolicy::with_max_wait(..)` constructors are replaced by a single
+  `ClaimPolicy::new(worker_id, worker_instance_id, lease_ttl_ms,
+  max_wait)`. Call-sites migrated: `ff-core::backend` tests,
+  `ff-sdk::layer::tracing_layer` test. Generic forwarders
+  (`ff-sdk::layer::hooks`, `ff-sdk::layer::test_support`,
+  `ff-backend-postgres::claim` stub) pass `ClaimPolicy` through
+  unchanged.
+- **Pre-1.0 BREAKING — `ReclaimToken` extended with worker identity.**
+  Mirrors the `ClaimPolicy` shape so `claim_from_reclaim` (which does
+  not take a `ClaimPolicy`) has the identity it needs to invoke
+  `ff_claim_resumed_execution`. New constructor:
+  `ReclaimToken::new(grant, worker_id, worker_instance_id, lease_ttl_ms)`.
+
 - **RFC-v0.7 Wave 1b: `EngineBackend::rotate_waitpoint_hmac_secret_all`
   (migration-master Q4).** New additive trait method for cluster-wide
   waitpoint HMAC kid rotation. Valkey impl fans out one

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -38,14 +38,14 @@ use ff_core::contracts::decode::{
     build_edge_snapshot, build_execution_snapshot, build_flow_snapshot,
 };
 use ff_core::contracts::{
-    AdditionalWaitpointBinding, CancelFlowArgs, CancelFlowResult, ClaimResumedExecutionArgs,
-    ClaimResumedExecutionResult, CompositeBody, CountKind, DeliverSignalArgs, DeliverSignalResult,
-    EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, FlowStatus, FlowSummary,
-    ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage, ReportUsageResult,
-    ResumeCondition, ResumePolicy, ResumeTarget, RotateWaitpointHmacSecretAllArgs,
-    RotateWaitpointHmacSecretAllEntry, RotateWaitpointHmacSecretAllResult,
-    RotateWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs, SuspendOutcome,
-    SuspendOutcomeDetails, SuspendedExecutionEntry, WaitpointBinding,
+    AdditionalWaitpointBinding, CancelFlowArgs, CancelFlowResult, ClaimExecutionArgs,
+    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, CompositeBody,
+    CountKind, DeliverSignalArgs, DeliverSignalResult, EdgeDirection, EdgeSnapshot,
+    ExecutionSnapshot, FlowSnapshot, FlowStatus, FlowSummary, ListExecutionsPage, ListFlowsPage,
+    ListLanesPage, ListSuspendedPage, ReportUsageResult, ResumeCondition, ResumePolicy,
+    ResumeTarget, RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllEntry,
+    RotateWaitpointHmacSecretAllResult, RotateWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs,
+    SuspendOutcome, SuspendOutcomeDetails, SuspendedExecutionEntry, WaitpointBinding,
 };
 use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::engine_error::{StateKind, ValidationKind};
@@ -60,7 +60,9 @@ use ff_core::types::{
 };
 use ff_script::engine_error_ext::transport_script;
 use ff_script::error::ScriptError;
-use ff_script::functions::execution::ExecOpKeys;
+use ff_script::functions::execution::{
+    ClaimExecutionResultPartial, ExecOpKeys, ff_claim_execution,
+};
 use ff_script::functions::flow::{FlowStructOpKeys, ff_cancel_flow};
 use ff_script::functions::signal::{SignalOpKeys, ff_claim_resumed_execution, ff_deliver_signal};
 use ff_script::result::FcallResult;
@@ -3392,6 +3394,303 @@ async fn deliver_signal_impl(
         .map_err(EngineError::from)
 }
 
+/// Fresh-find claim implementation (Wave 2, v0.7).
+///
+/// Scans the lane's eligible ZSET across every execution partition,
+/// filters by capability subset-match on each candidate's
+/// `required_capabilities`, and on the first match issues a claim
+/// grant + invokes `ff_claim_execution`. Returns `Ok(None)` when no
+/// partition has an eligible execution the worker can serve.
+///
+/// Returns the encoded Valkey `Handle` on success.
+#[tracing::instrument(
+    name = "ff.claim",
+    skip_all,
+    fields(
+        backend = "valkey",
+        lane = %lane,
+        worker_id = %policy.worker_id,
+        worker_instance_id = %policy.worker_instance_id,
+    )
+)]
+async fn claim_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    lane: &LaneId,
+    capabilities: &CapabilitySet,
+    policy: &ClaimPolicy,
+) -> Result<Option<Handle>, EngineError> {
+    use ff_core::caps::CapabilityRequirement;
+
+    let num_partitions = partition_config.num_flow_partitions;
+    if num_partitions == 0 {
+        return Ok(None);
+    }
+
+    // Build the caps CSV (sorted, deterministic) for the grant FCALL.
+    let mut sorted_caps: Vec<String> = capabilities.tokens.clone();
+    sorted_caps.sort();
+    sorted_caps.dedup();
+    let caps_csv = sorted_caps.join(",");
+
+    for p_idx in 0..num_partitions {
+        let partition = Partition {
+            family: PartitionFamily::Execution,
+            index: p_idx,
+        };
+        let idx = IndexKeys::new(&partition);
+        let eligible_key = idx.lane_eligible(lane);
+
+        // Pick the highest-priority eligible candidate on this partition.
+        let candidates: Vec<String> = client
+            .cmd("ZRANGEBYSCORE")
+            .arg(&eligible_key)
+            .arg("-inf")
+            .arg("+inf")
+            .arg("LIMIT")
+            .arg("0")
+            .arg("1")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+
+        let eid_str = match candidates.first() {
+            Some(s) => s.clone(),
+            None => continue,
+        };
+
+        let execution_id = ExecutionId::parse(&eid_str).map_err(|e| {
+            transport_script(ScriptError::Parse {
+                fcall: "ff_claim_execution".into(),
+                execution_id: None,
+                message: format!("bad execution_id in eligible set: {e}"),
+            })
+        })?;
+
+        let ctx = ExecKeyContext::new(&partition, &execution_id);
+
+        // Capability pre-check: if the execution declares required caps
+        // that aren't a subset of the worker's CapabilitySet, skip.
+        let required_csv: Option<String> = client
+            .cmd("HGET")
+            .arg(ctx.core())
+            .arg("required_capabilities")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        if let Some(req) = required_csv.as_deref()
+            && !req.is_empty()
+        {
+            let required = CapabilityRequirement::from_csv(req);
+            if !ff_core::caps::matches(&required, capabilities) {
+                continue;
+            }
+        }
+
+        // Step 1 — issue the claim grant.
+        let grant_keys_owned: [String; 3] =
+            [ctx.core(), ctx.claim_grant(), eligible_key.clone()];
+        let grant_keys_ref: [&str; 3] = [
+            grant_keys_owned[0].as_str(),
+            grant_keys_owned[1].as_str(),
+            grant_keys_owned[2].as_str(),
+        ];
+        let eid_s = execution_id.to_string();
+        let worker_id_s = policy.worker_id.to_string();
+        let worker_instance_s = policy.worker_instance_id.to_string();
+        let lane_s = lane.to_string();
+        let grant_argv: [&str; 9] = [
+            &eid_s,
+            &worker_id_s,
+            &worker_instance_s,
+            &lane_s,
+            "",            // capability_hash
+            "5000",        // grant_ttl_ms (5s)
+            "",            // route_snapshot_json
+            "",            // admission_summary
+            &caps_csv,     // worker_capabilities_csv (sorted)
+        ];
+        let raw: ferriskey::Value = client
+            .fcall("ff_issue_claim_grant", &grant_keys_ref, &grant_argv)
+            .await
+            .map_err(transport_fk)?;
+        // Parse grant result: {1, "OK", ...}
+        let ok = match &raw {
+            ferriskey::Value::Array(arr) => {
+                matches!(arr.first(), Some(Ok(ferriskey::Value::Int(1))))
+            }
+            _ => false,
+        };
+        if !ok {
+            // Non-OK grant (capability mismatch mid-race, already granted, etc.).
+            // Surface as a script error so the caller sees a typed error; callers
+            // that want to continue polling will loop on their own.
+            let code = match &raw {
+                ferriskey::Value::Array(arr) => arr
+                    .get(1)
+                    .and_then(|v| match v {
+                        Ok(ferriskey::Value::BulkString(b)) => {
+                            Some(String::from_utf8_lossy(b).into_owned())
+                        }
+                        Ok(ferriskey::Value::SimpleString(s)) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_default(),
+                _ => String::new(),
+            };
+            if let Some(err) = ScriptError::from_code_with_detail(&code, "") {
+                // Retryable errors (capability_mismatch, grant_already_issued,
+                // exec_not_eligible) → skip this partition, keep scanning.
+                use ff_core::error::ErrorClass;
+                let engine_err = EngineError::from(err);
+                if matches!(
+                    ff_script::engine_error_ext::class(&engine_err),
+                    ErrorClass::Retryable | ErrorClass::Informational
+                ) {
+                    continue;
+                }
+                return Err(engine_err);
+            }
+            continue;
+        }
+
+        // Step 2 — claim the execution via ff_claim_execution.
+        let att_idx_str: Option<String> = client
+            .cmd("HGET")
+            .arg(ctx.core())
+            .arg("total_attempt_count")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        let next_idx = att_idx_str
+            .as_deref()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(0);
+        let att_idx = AttemptIndex::new(next_idx);
+
+        let lease_id = LeaseId::new();
+        let attempt_id = AttemptId::new();
+
+        let args = ClaimExecutionArgs {
+            execution_id: execution_id.clone(),
+            worker_id: policy.worker_id.clone(),
+            worker_instance_id: policy.worker_instance_id.clone(),
+            lane_id: lane.clone(),
+            lease_id: lease_id.clone(),
+            lease_ttl_ms: u64::from(policy.lease_ttl_ms),
+            attempt_id: attempt_id.clone(),
+            expected_attempt_index: att_idx,
+            attempt_policy_json: "{}".to_owned(),
+            attempt_timeout_ms: None,
+            execution_deadline_at: None,
+            now: TimestampMs::now(),
+        };
+
+        let exec_keys = ExecOpKeys {
+            ctx: &ctx,
+            idx: &idx,
+            lane_id: lane,
+            worker_instance_id: &policy.worker_instance_id,
+        };
+
+        let partial = match ff_claim_execution(client, &exec_keys, &args).await {
+            Ok(p) => p,
+            Err(err) => {
+                use ff_core::error::ErrorClass;
+                let engine_err = EngineError::from(err);
+                if matches!(
+                    ff_script::engine_error_ext::class(&engine_err),
+                    ErrorClass::Retryable | ErrorClass::Informational
+                ) {
+                    continue;
+                }
+                return Err(engine_err);
+            }
+        };
+        let ClaimExecutionResultPartial::Claimed(claimed) = partial;
+
+        let fields = handle_codec::HandleFields::new(
+            execution_id,
+            claimed.attempt_index,
+            claimed.attempt_id,
+            claimed.lease_id,
+            claimed.lease_epoch,
+            u64::from(policy.lease_ttl_ms),
+            lane.clone(),
+            policy.worker_instance_id.clone(),
+        );
+        return Ok(Some(handle_codec::encode_handle(&fields, HandleKind::Fresh)));
+    }
+
+    Ok(None)
+}
+
+/// Resume-claim implementation — consumes a `ReclaimToken` and routes
+/// through `ff_claim_resumed_execution`. Worker identity + lease TTL
+/// ride on the token (Wave 2 additive extension).
+#[tracing::instrument(
+    name = "ff.claim_from_reclaim",
+    skip_all,
+    fields(
+        backend = "valkey",
+        execution_id = %token.grant.execution_id,
+        worker_instance_id = %token.worker_instance_id,
+    )
+)]
+async fn claim_from_reclaim_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    token: ReclaimToken,
+) -> Result<Option<Handle>, EngineError> {
+    let execution_id = token.grant.execution_id.clone();
+    let lane_id = token.grant.lane_id.clone();
+    let partition = execution_partition(&execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &execution_id);
+
+    // Pre-read current_attempt_index for the existing attempt hash KEY.
+    let att_idx_str: Option<String> = client
+        .cmd("HGET")
+        .arg(ctx.core())
+        .arg("current_attempt_index")
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    let att_idx = AttemptIndex::new(
+        att_idx_str
+            .as_deref()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(0),
+    );
+
+    let lease_id = LeaseId::new();
+    let args = ClaimResumedExecutionArgs {
+        execution_id: execution_id.clone(),
+        worker_id: token.worker_id.clone(),
+        worker_instance_id: token.worker_instance_id.clone(),
+        lane_id: lane_id.clone(),
+        lease_id: lease_id.clone(),
+        lease_ttl_ms: u64::from(token.lease_ttl_ms),
+        current_attempt_index: att_idx,
+        remaining_attempt_timeout_ms: None,
+        now: TimestampMs::now(),
+    };
+
+    let ClaimResumedExecutionResult::Claimed(claimed) =
+        claim_resumed_execution_impl(client, partition_config, args).await?;
+
+    let fields = handle_codec::HandleFields::new(
+        execution_id,
+        claimed.attempt_index,
+        claimed.attempt_id,
+        claimed.lease_id,
+        claimed.lease_epoch,
+        u64::from(token.lease_ttl_ms),
+        lane_id,
+        token.worker_instance_id,
+    );
+    Ok(Some(handle_codec::encode_handle(&fields, HandleKind::Resumed)))
+}
+
 /// Thin forwarder to
 /// `ff_script::functions::signal::ff_claim_resumed_execution`. The Lua
 /// returns a partial result (omits `execution_id`, which the caller
@@ -3432,11 +3731,13 @@ async fn claim_resumed_execution_impl(
 impl EngineBackend for ValkeyBackend {
     async fn claim(
         &self,
-        _lane: &LaneId,
-        _capabilities: &CapabilitySet,
-        _policy: ClaimPolicy,
+        lane: &LaneId,
+        capabilities: &CapabilitySet,
+        policy: ClaimPolicy,
     ) -> Result<Option<Handle>, EngineError> {
-        Err(EngineError::Unavailable { op: "claim" })
+        claim_impl(&self.client, &self.partition_config, lane, capabilities, &policy)
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(e, "claim: FCALL ff_claim_execution"))
     }
 
     async fn renew(&self, handle: &Handle) -> Result<LeaseRenewal, EngineError> {
@@ -3620,11 +3921,16 @@ impl EngineBackend for ValkeyBackend {
 
     async fn claim_from_reclaim(
         &self,
-        _token: ReclaimToken,
+        token: ReclaimToken,
     ) -> Result<Option<Handle>, EngineError> {
-        Err(EngineError::Unavailable {
-            op: "claim_from_reclaim",
-        })
+        claim_from_reclaim_impl(&self.client, &self.partition_config, token)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "claim_from_reclaim: FCALL ff_claim_resumed_execution",
+                )
+            })
     }
 
     async fn delay(&self, handle: &Handle, delay_until: TimestampMs) -> Result<(), EngineError> {

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -21,7 +21,7 @@
 //! type inventory and §4.1-§4.2 for the `Handle` / `EngineError` shapes.
 
 use crate::contracts::ReclaimGrant;
-use crate::types::{TimestampMs, WaitpointToken};
+use crate::types::{TimestampMs, WaitpointToken, WorkerId, WorkerInstanceId};
 
 // DX (HHH v0.3.4 re-smoke): `Namespace` lives in `ff_core::types` but
 // is used on `BackendConfig` + `ScannerFilter` (both defined in this
@@ -185,27 +185,44 @@ impl CapabilitySet {
     }
 }
 
-/// Policy hints for `claim`. Minimal at Stage 0 per RFC-012 §3.3.0
-/// ("Bikeshed-prone; keep minimal at Stage 0"). Future fields (retry
-/// count, fairness hints) land additively.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+/// Policy hints for `claim`. Carries the worker identity the backend
+/// needs to invoke `ff_claim_execution` (v0.7 Wave 2) plus the
+/// blocking-wait bound.
+///
+/// **Wave 2 extension:** `worker_id` + `worker_instance_id` +
+/// `lease_ttl_ms` are now required so the Valkey backend's `claim`
+/// impl can issue the claim FCALL without a side-channel identity
+/// lookup. The constructor change is a pre-1.0 breaking change,
+/// tracked in the CHANGELOG.
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ClaimPolicy {
     /// Maximum blocking wait. `None` means backend-default (today:
     /// non-blocking / immediate return).
     pub max_wait: Option<Duration>,
+    /// Worker identity (stable across process restarts).
+    pub worker_id: WorkerId,
+    /// Worker instance identity (unique per process).
+    pub worker_instance_id: WorkerInstanceId,
+    /// Lease TTL in milliseconds for the claim about to be minted.
+    pub lease_ttl_ms: u32,
 }
 
 impl ClaimPolicy {
-    /// Zero-timeout claim (non-blocking). Matches today's SDK default.
-    pub fn immediate() -> Self {
-        Self { max_wait: None }
-    }
-
-    /// Claim with an explicit blocking bound.
-    pub fn with_max_wait(max_wait: Duration) -> Self {
+    /// Build a claim policy. `max_wait = None` means non-blocking /
+    /// immediate return. `lease_ttl_ms` is the TTL the backend
+    /// installs on the minted lease.
+    pub fn new(
+        worker_id: WorkerId,
+        worker_instance_id: WorkerInstanceId,
+        lease_ttl_ms: u32,
+        max_wait: Option<Duration>,
+    ) -> Self {
         Self {
-            max_wait: Some(max_wait),
+            max_wait,
+            worker_id,
+            worker_instance_id,
+            lease_ttl_ms,
         }
     }
 }
@@ -817,11 +834,29 @@ impl UsageDimensions {
 #[non_exhaustive]
 pub struct ReclaimToken {
     pub grant: ReclaimGrant,
+    /// Worker identity that will claim the resumed execution.
+    /// Wave 2 additive extension — mirrors the `ClaimPolicy`
+    /// shape since `claim_from_reclaim` does not take a `ClaimPolicy`.
+    pub worker_id: WorkerId,
+    /// Worker instance identity.
+    pub worker_instance_id: WorkerInstanceId,
+    /// Lease TTL (ms) for the resumed attempt's fresh lease.
+    pub lease_ttl_ms: u32,
 }
 
 impl ReclaimToken {
-    pub fn new(grant: ReclaimGrant) -> Self {
-        Self { grant }
+    pub fn new(
+        grant: ReclaimGrant,
+        worker_id: WorkerId,
+        worker_instance_id: WorkerInstanceId,
+        lease_ttl_ms: u32,
+    ) -> Self {
+        Self {
+            grant,
+            worker_id,
+            worker_instance_id,
+            lease_ttl_ms,
+        }
     }
 }
 
@@ -1406,10 +1441,24 @@ mod tests {
 
     #[test]
     fn claim_policy_derives() {
-        let p = ClaimPolicy::with_max_wait(Duration::from_millis(500));
+        let p = ClaimPolicy::new(
+            WorkerId::new("w"),
+            WorkerInstanceId::new("w-1"),
+            30_000,
+            Some(Duration::from_millis(500)),
+        );
         assert_eq!(p.max_wait, Some(Duration::from_millis(500)));
+        assert_eq!(p.lease_ttl_ms, 30_000);
+        assert_eq!(p.worker_id.as_str(), "w");
+        assert_eq!(p.worker_instance_id.as_str(), "w-1");
         assert_eq!(p.clone(), p);
-        assert_eq!(ClaimPolicy::immediate(), ClaimPolicy::default());
+        let immediate = ClaimPolicy::new(
+            WorkerId::new("w"),
+            WorkerInstanceId::new("w-1"),
+            30_000,
+            None,
+        );
+        assert_eq!(immediate.max_wait, None);
     }
 
     #[test]
@@ -1512,8 +1561,16 @@ mod tests {
             expires_at_ms: 123,
             lane_id: LaneId::new("default"),
         };
-        let t = ReclaimToken::new(grant.clone());
+        let t = ReclaimToken::new(
+            grant.clone(),
+            WorkerId::new("w"),
+            WorkerInstanceId::new("w-1"),
+            30_000,
+        );
         assert_eq!(t.grant, grant);
+        assert_eq!(t.worker_id.as_str(), "w");
+        assert_eq!(t.worker_instance_id.as_str(), "w-1");
+        assert_eq!(t.lease_ttl_ms, 30_000);
         assert_eq!(t.clone(), t);
     }
 

--- a/crates/ff-sdk/src/layer/tracing_layer.rs
+++ b/crates/ff-sdk/src/layer/tracing_layer.rs
@@ -154,7 +154,7 @@ mod tests {
     use super::*;
     use crate::layer::{EngineBackendLayerExt, test_support::PassthroughBackend};
     use ff_core::backend::{CapabilitySet, ClaimPolicy};
-    use ff_core::types::LaneId;
+    use ff_core::types::{LaneId, WorkerId, WorkerInstanceId};
 
     #[tokio::test]
     async fn delegates_and_counts_call() {
@@ -165,7 +165,13 @@ mod tests {
 
         let lane = LaneId::new("main");
         let caps = CapabilitySet::new::<_, String>(Vec::<String>::new());
-        let _ = layered.claim(&lane, &caps, ClaimPolicy::immediate()).await;
+        let policy = ClaimPolicy::new(
+            WorkerId::new("w"),
+            WorkerInstanceId::new("w-1"),
+            30_000,
+            None,
+        );
+        let _ = layered.claim(&lane, &caps, policy).await;
 
         assert_eq!(raw_clone.calls("claim"), 1);
     }

--- a/crates/ff-test/tests/engine_backend_claim.rs
+++ b/crates/ff-test/tests/engine_backend_claim.rs
@@ -1,0 +1,493 @@
+//! Integration coverage for
+//! [`ff_core::engine_backend::EngineBackend::claim`] and
+//! [`ff_core::engine_backend::EngineBackend::claim_from_reclaim`] on
+//! the Valkey-backed impl (v0.7 Wave 2).
+//!
+//! Covers:
+//!   * Fresh-claim happy path — scan lands on the seeded partition,
+//!     issues a grant, claims via `ff_claim_execution`, returns a
+//!     `HandleKind::Fresh` handle.
+//!   * Capability-subset mismatch — eligible candidate exists but the
+//!     worker's CapabilitySet doesn't cover required_capabilities, so
+//!     `claim` returns `Ok(None)`.
+//!   * Empty eligible set — nothing to claim, `Ok(None)`.
+//!   * claim_from_reclaim happy path — consumes a `ReclaimToken`
+//!     (Wave 2 extended shape with worker identity) and mints a
+//!     `HandleKind::Resumed` handle with a bumped lease_epoch.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test engine_backend_claim -- --test-threads=1
+
+use std::sync::Arc;
+
+use ferriskey::Value;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::{
+    BackendTag, CapabilitySet, ClaimPolicy, HandleKind, ReclaimToken,
+};
+use ff_core::contracts::{DeliverSignalArgs, ReclaimGrant};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, PartitionConfig, PartitionKey};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+const LANE: &str = "ebc-lane";
+const NS: &str = "ebc-ns";
+const WORKER: &str = "ebc-worker";
+const WORKER_INST: &str = "ebc-worker-1";
+
+fn config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+async fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    ValkeyBackend::from_client_and_partitions(tc.client().clone(), config())
+}
+
+/// Create an execution and return its id. If `required_caps_csv` is
+/// non-empty, the exec's `policy_json.routing_requirements.required_capabilities`
+/// is populated.
+async fn create_execution(
+    tc: &TestCluster,
+    eid: &ExecutionId,
+    required_caps_csv: &str,
+) {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let policy_json = if required_caps_csv.is_empty() {
+        "{}".to_owned()
+    } else {
+        let caps: Vec<&str> = required_caps_csv.split(',').collect();
+        serde_json::json!({
+            "routing_requirements": { "required_capabilities": caps }
+        })
+        .to_string()
+    };
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "ebc".to_owned(),
+        "0".to_owned(),
+        "ebc-runner".to_owned(),
+        policy_json,
+        r#"{"test":true}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("ff_create_execution");
+}
+
+async fn issue_grant(tc: &TestCluster, eid: &ExecutionId, caps_csv: &str) {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let grant_keys: Vec<String> =
+        vec![ctx.core(), ctx.claim_grant(), idx.lane_eligible(&lane_id)];
+    let grant_args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        WORKER_INST.to_owned(),
+        LANE.to_owned(),
+        String::new(),
+        "5000".to_owned(),
+        String::new(),
+        String::new(),
+        caps_csv.to_owned(),
+    ];
+    let kr: Vec<&str> = grant_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = grant_args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_issue_claim_grant", &kr, &ar)
+        .await
+        .expect("ff_issue_claim_grant");
+}
+
+fn base_policy(lease_ttl_ms: u32) -> ClaimPolicy {
+    ClaimPolicy::new(
+        WorkerId::new(WORKER),
+        WorkerInstanceId::new(WORKER_INST),
+        lease_ttl_ms,
+        None,
+    )
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn claim_happy_path_returns_fresh_handle() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    create_execution(&tc, &eid, "").await;
+
+    let backend = build_backend(&tc).await;
+    let lane = LaneId::new(LANE);
+    let caps = CapabilitySet::new::<_, String>(Vec::<String>::new());
+    let policy = base_policy(30_000);
+
+    let handle = backend
+        .claim(&lane, &caps, policy)
+        .await
+        .expect("claim should succeed on a seeded eligible exec")
+        .expect("claim should return Some on a matching exec");
+
+    assert_eq!(handle.backend, BackendTag::Valkey);
+    assert_eq!(handle.kind, HandleKind::Fresh);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn claim_empty_eligible_returns_none() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let backend = build_backend(&tc).await;
+    let lane = LaneId::new(LANE);
+    let caps = CapabilitySet::new::<_, String>(Vec::<String>::new());
+    let policy = base_policy(30_000);
+
+    let out = backend
+        .claim(&lane, &caps, policy)
+        .await
+        .expect("claim on empty lane should be Ok(None)");
+    assert!(out.is_none(), "expected Ok(None), got {out:?}");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn claim_capability_mismatch_returns_none() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    create_execution(&tc, &eid, "gpu").await;
+
+    let backend = build_backend(&tc).await;
+    let lane = LaneId::new(LANE);
+    // Worker advertises no caps; exec requires "gpu" — must skip.
+    let caps = CapabilitySet::new::<_, String>(Vec::<String>::new());
+    let policy = base_policy(30_000);
+
+    let out = backend
+        .claim(&lane, &caps, policy)
+        .await
+        .expect("claim with mismatched caps should be Ok(None)");
+    assert!(out.is_none(), "expected Ok(None), got {out:?}");
+}
+
+// ───────────────────────── claim_from_reclaim ─────────────────────────
+
+/// Seed an execution, claim it, suspend it, deliver a resuming signal,
+/// and leave the exec ready for `claim_from_reclaim`. Returns
+/// `(exec_id, lease_epoch_before_reclaim)`.
+async fn seed_resumable(tc: &TestCluster, eid: &ExecutionId) -> u64 {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+    let wid = WorkerInstanceId::new(WORKER_INST);
+
+    create_execution(tc, eid, "").await;
+    issue_grant(tc, eid, "").await;
+
+    // Claim via raw FCALL so we keep the lease_id + attempt_id for the
+    // suspend ARGV below.
+    let lease_id = uuid::Uuid::new_v4().to_string();
+    let attempt_id = uuid::Uuid::new_v4().to_string();
+    let att_idx = AttemptIndex::new(0);
+    let lease_ttl_ms: u64 = 30_000;
+    let renew_before = lease_ttl_ms * 2 / 3;
+    let claim_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.claim_grant(),
+        idx.lane_eligible(&lane_id),
+        idx.lease_expiry(),
+        idx.worker_leases(&wid),
+        ctx.attempt_hash(att_idx),
+        ctx.attempt_usage(att_idx),
+        ctx.attempt_policy(att_idx),
+        ctx.attempts(),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lane_active(&lane_id),
+        idx.attempt_timeout(),
+        idx.execution_deadline(),
+    ];
+    let claim_args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        WORKER_INST.to_owned(),
+        LANE.to_owned(),
+        String::new(),
+        lease_id.clone(),
+        lease_ttl_ms.to_string(),
+        renew_before.to_string(),
+        attempt_id.clone(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+    ];
+    let kr: Vec<&str> = claim_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = claim_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_claim_execution", &kr, &ar)
+        .await
+        .expect("ff_claim_execution");
+    let arr = match &raw {
+        Value::Array(a) => a,
+        _ => panic!("claim: expected Array"),
+    };
+    let epoch_str = match arr.get(3) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::Int(n))) => n.to_string(),
+        _ => panic!("claim: no epoch"),
+    };
+    let epoch_before: u64 = epoch_str.parse().expect("epoch parse");
+
+    // Suspend and collect a waitpoint token.
+    let wp_uuid = uuid::Uuid::new_v4();
+    let wp_id_str = wp_uuid.to_string();
+    let wp_id = WaitpointId::from_uuid(wp_uuid);
+    let wp_key = format!("wpk:{wp_id_str}");
+
+    let suspend_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.attempt_hash(AttemptIndex::new(0)),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lease_expiry(),
+        idx.worker_leases(&wid),
+        ctx.suspension_current(),
+        ctx.waitpoint(&wp_id),
+        ctx.waitpoint_signals(&wp_id),
+        idx.suspension_timeout(),
+        idx.pending_waitpoint_expiry(),
+        idx.lane_active(&lane_id),
+        idx.lane_suspended(&lane_id),
+        ctx.waitpoints(),
+        ctx.waitpoint_condition(&wp_id),
+        idx.attempt_timeout(),
+        idx.waitpoint_hmac_secrets(),
+    ];
+    let resume_condition_json = serde_json::json!({
+        "condition_type": "signal_set",
+        "required_signal_names": ["ebc_signal"],
+        "signal_match_mode": "any",
+        "minimum_signal_count": 1,
+        "timeout_behavior": "fail",
+        "allow_operator_override": true,
+    })
+    .to_string();
+    let resume_policy_json = serde_json::json!({
+        "resume_target": "runnable",
+        "close_waitpoint_on_resume": true,
+        "consume_matched_signals": true,
+        "retain_signal_buffer_until_closed": true,
+    })
+    .to_string();
+    let suspend_args: Vec<String> = vec![
+        eid.to_string(),
+        "0".to_owned(),
+        attempt_id.clone(),
+        lease_id.clone(),
+        epoch_str.clone(),
+        uuid::Uuid::new_v4().to_string(),
+        wp_id_str.clone(),
+        wp_key,
+        "waiting_for_signal".to_owned(),
+        "worker".to_owned(),
+        String::new(),
+        resume_condition_json,
+        resume_policy_json,
+        String::new(),
+        "0".to_owned(),
+        "fail".to_owned(),
+        "1000".to_owned(),
+    ];
+    let kr: Vec<&str> = suspend_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = suspend_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_suspend_execution", &kr, &ar)
+        .await
+        .expect("ff_suspend_execution");
+    let arr = match &raw {
+        Value::Array(a) => a,
+        _ => panic!("suspend: expected Array"),
+    };
+    let token = match arr.get(5) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::SimpleString(s))) => s.clone(),
+        _ => panic!("suspend: missing token"),
+    };
+
+    // Deliver the resuming signal via the backend (flips the execution
+    // to `runnable + attempt_interrupted`).
+    let backend = build_backend(tc).await;
+    let sig_args = DeliverSignalArgs {
+        execution_id: eid.clone(),
+        waitpoint_id: wp_id,
+        signal_id: SignalId::new(),
+        signal_name: "ebc_signal".to_owned(),
+        signal_category: "test".to_owned(),
+        source_type: "external".to_owned(),
+        source_identity: "ebc".to_owned(),
+        payload: None,
+        payload_encoding: Some("json".to_owned()),
+        correlation_id: None,
+        idempotency_key: None,
+        target_scope: "waitpoint".to_owned(),
+        created_at: Some(TimestampMs::now()),
+        dedup_ttl_ms: None,
+        resume_delay_ms: None,
+        max_signals_per_execution: None,
+        signal_maxlen: None,
+        waitpoint_token: WaitpointToken::new(token),
+        now: TimestampMs::now(),
+    };
+    backend
+        .deliver_signal(sig_args)
+        .await
+        .expect("deliver_signal should resume");
+
+    // A fresh grant is required before claim_from_reclaim consumes it.
+    issue_grant(tc, eid, "").await;
+
+    epoch_before
+}
+
+fn synthetic_reclaim_grant(eid: &ExecutionId) -> ReclaimGrant {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    ReclaimGrant {
+        execution_id: eid.clone(),
+        partition_key: PartitionKey::from(&partition),
+        grant_key: ctx.claim_grant(),
+        expires_at_ms: 0, // unused by the Valkey resume path
+        lane_id: LaneId::new(LANE),
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn claim_from_reclaim_happy_path_bumps_epoch() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    let epoch_before = seed_resumable(&tc, &eid).await;
+
+    let grant = synthetic_reclaim_grant(&eid);
+    let token = ReclaimToken::new(
+        grant,
+        WorkerId::new(WORKER),
+        WorkerInstanceId::new(WORKER_INST),
+        30_000,
+    );
+
+    let backend = build_backend(&tc).await;
+    let handle = backend
+        .claim_from_reclaim(token)
+        .await
+        .expect("claim_from_reclaim should succeed")
+        .expect("claim_from_reclaim should return Some on resumed exec");
+
+    assert_eq!(handle.backend, BackendTag::Valkey);
+    assert_eq!(handle.kind, HandleKind::Resumed);
+
+    // Lease epoch must have advanced (RFC-003 — each lease transition
+    // monotonically bumps the epoch).
+    let partition = execution_partition(&eid, &config());
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let epoch_after_str: Option<String> = tc
+        .client()
+        .cmd("HGET")
+        .arg(ctx.lease_current())
+        .arg("lease_epoch")
+        .execute()
+        .await
+        .expect("HGET lease_epoch");
+    let epoch_after: u64 = epoch_after_str
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .expect("lease_epoch must be present after resume claim");
+    assert!(
+        epoch_after > epoch_before,
+        "expected bumped lease_epoch, before={epoch_before} after={epoch_after}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn claim_from_reclaim_double_consume_surfaces_typed_error() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    let _ = seed_resumable(&tc, &eid).await;
+
+    let grant = synthetic_reclaim_grant(&eid);
+    let token = ReclaimToken::new(
+        grant,
+        WorkerId::new(WORKER),
+        WorkerInstanceId::new(WORKER_INST),
+        30_000,
+    );
+
+    let backend = build_backend(&tc).await;
+    let _first = backend
+        .claim_from_reclaim(token.clone())
+        .await
+        .expect("first claim_from_reclaim should succeed")
+        .expect("first claim_from_reclaim should return Some");
+
+    // Second consume on the same grant: the grant key was consumed by
+    // the first FCALL and the lease is now held by the first claim, so
+    // the FCALL surfaces a typed ScriptError (invalid_claim_grant /
+    // claim_grant_consumed / lease_conflict depending on wire state).
+    let err = backend
+        .claim_from_reclaim(token)
+        .await
+        .expect_err("second claim_from_reclaim should fail");
+    let s = err.to_string();
+    assert!(
+        s.contains("invalid_claim_grant")
+            || s.contains("claim_grant")
+            || s.contains("lease_conflict")
+            || s.contains("LeaseConflict")
+            || s.contains("not_a_resumed_execution")
+            || s.contains("stale_lease")
+            || s.contains("ExecutionNotLeaseable")
+            || s.contains("execution_not_leaseable"),
+        "expected typed conflict error, got: {s}"
+    );
+}


### PR DESCRIPTION
## Summary

- Lands v0.7 Wave 2 critical-path #5: Valkey-backed `EngineBackend::claim` (fresh-find scan → grant → `ff_claim_execution`) and `EngineBackend::claim_from_reclaim` (unwrap `ReclaimGrant` → `ff_claim_resumed_execution`). Both replace `EngineError::Unavailable` stubs.
- Adjudicated design gap (owner adjudication — extend additively, do not mint a new trait method): `ClaimPolicy` now carries `worker_id` + `worker_instance_id` + `lease_ttl_ms` so the backend has the identity it needs for `ff_claim_execution` without a side-channel lookup. `ReclaimToken` got the same treatment because `claim_from_reclaim` doesn't take a `ClaimPolicy`. Pre-1.0 breaking change on both constructors; documented in CHANGELOG.
- Untouched: `ff-backend-postgres` stubs (per task constraint). No new trait methods. No second `ValkeyBackend` constructor.

## Call-site migration

`ClaimPolicy` construction call-sites migrated: 2 (one in `ff-core::backend` unit tests, one in `ff-sdk::layer::tracing_layer` test). Every other path — `hooks.rs`, `test_support.rs`, `ff-backend-postgres` stub — threads `ClaimPolicy` generically and needed no change. `ReclaimToken::new` construction call-sites: 1 (ff-core unit test).

## FCALLs wired

- `claim` → `ff_issue_claim_grant` (grant key) + `ff_claim_execution` (claim).
- `claim_from_reclaim` → `ff_claim_resumed_execution` (via existing `claim_resumed_execution_impl`).

Capability-subset filter uses `ff_core::caps::matches` (Wave 1a). Errors flow through `ff_core::engine_error::backend_context` per the RFC-012 pattern.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings` clean
- [x] New `engine_backend_claim` integration test (5 cases: claim happy, empty eligible, capability mismatch, claim_from_reclaim happy w/ epoch bump, claim_from_reclaim double-consume) passes against live Valkey
- [x] `cargo test -p ff-test -- --test-threads=1` full workspace integration suite green
- [x] `cargo test -p ff-scheduler` green
- [ ] CI run on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Implements core scheduling/lease acquisition paths (`claim`/`claim_from_reclaim`) and changes public constructors for `ClaimPolicy`/`ReclaimToken`, so regressions could impact task pickup and lease correctness across workers.
> 
> **Overview**
> Implements Valkey `EngineBackend::claim` and `claim_from_reclaim`, replacing previous `EngineError::Unavailable` stubs. `claim` now scans each execution partition’s eligible set, filters candidates by capability subset, issues `ff_issue_claim_grant`, and finalizes the lease via `ff_claim_execution` to return a `HandleKind::Fresh`; `claim_from_reclaim` consumes a `ReclaimToken` and routes through `ff_claim_resumed_execution` to return a `HandleKind::Resumed` with a bumped lease epoch.
> 
> Introduces a **pre-1.0 breaking** API change: `ClaimPolicy` now includes `worker_id`, `worker_instance_id`, and `lease_ttl_ms` (new `ClaimPolicy::new(...)` constructor replaces `immediate()`/`with_max_wait()`), and `ReclaimToken` is extended similarly with a new constructor. Adds a new Valkey integration test suite covering fresh-claim, empty/mismatched-capability cases, and reclaim-claim behavior including double-consume error surfacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c1a6c529a16b3b844dc789d37156e49389260f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->