### PR TITLE
feat(pg-wave3b): schema 0002 budget tables (unblocks Wave 4f)

### DIFF
--- a/crates/ff-backend-postgres/migrations/0002_budget.sql
+++ b/crates/ff-backend-postgres/migrations/0002_budget.sql
@@ -1,0 +1,108 @@
+-- no-transaction
+-- RFC-v0.7 Wave 3b — budget schema (RFC-008).
+--
+-- Wave 3's `0001_initial.sql` deliberately omitted budget tables;
+-- Wave 4f (budget proc impls) is blocked without them. This
+-- migration lands the three budget parent tables + their 256-way
+-- hash partition children, and annotates itself as
+-- `backward_compatible=true` (additive — existing Wave 4 impls
+-- ignore these tables).
+--
+-- Authority:
+--   * rfcs/RFC-008-budget.md — budget semantics.
+--   * rfcs/drafts/v0.7-migration-master.md §Q5 (HASH 256
+--     partitioning, partition_key sole hash input),
+--     §Q11 (budget ops run at READ COMMITTED + row-level
+--     `FOR UPDATE`, not SERIALIZABLE — relevant for Wave 4f procs,
+--     not this DDL), §Q12 (backward_compatible annotation).
+--
+-- Schema conventions (mirrors 0001_initial.sql §Schema conventions):
+--   * PARTITION BY HASH (partition_key) with 256 children; same
+--     hash input + count as Wave 3 for uniformity.
+--   * Timestamps stored as `*_ms bigint`.
+--   * JSONB for policy / outcome snapshot shapes that Wave 4f owns.
+--   * PKs on partitioned tables include partition_key.
+--
+-- Partition-child creation uses one `DO` block per parent with
+-- explicit COMMIT boundaries to stay under
+-- `max_locks_per_transaction` on stock Postgres — identical pattern
+-- to 0001's §Section 7. The leading `-- no-transaction` directive
+-- opts sqlx out of wrapping this file in one txn.
+
+-- ============================================================
+-- Section 1 — Budget parent tables (partitioned)
+-- ============================================================
+
+-- ff_budget_policy — definitional rows (one per budget_id). The
+-- `policy_json` blob holds hard_limit / soft_limit / reset_policy /
+-- etc; Wave 4f procs own the shape.
+CREATE TABLE ff_budget_policy (
+    partition_key  smallint NOT NULL,
+    budget_id      text     NOT NULL,
+    policy_json    jsonb    NOT NULL,
+    created_at_ms  bigint   NOT NULL,
+    updated_at_ms  bigint   NOT NULL,
+    PRIMARY KEY (partition_key, budget_id)
+) PARTITION BY HASH (partition_key);
+
+-- ff_budget_usage — running totals, one row per
+-- (budget_id, dimensions_key). `dimensions_key` is the canonical-
+-- sorted stringification of `UsageDimensions` (same key shape used
+-- by Valkey's per-dimension Hash) so the Wave 4f check/report procs
+-- can key lookups without unpacking the full JSON.
+CREATE TABLE ff_budget_usage (
+    partition_key     smallint NOT NULL,
+    budget_id         text     NOT NULL,
+    dimensions_key    text     NOT NULL,
+    current_value     bigint   NOT NULL DEFAULT 0,
+    last_reset_at_ms  bigint,
+    updated_at_ms     bigint   NOT NULL,
+    PRIMARY KEY (partition_key, budget_id, dimensions_key)
+) PARTITION BY HASH (partition_key);
+
+-- ff_budget_usage_dedup — idempotency cache for `report_usage`
+-- (RFC-012 §R7.2.3). `dedup_key` is caller-supplied; when a
+-- duplicate call arrives the cached `outcome_json` is replayed
+-- verbatim. `expires_at_ms` bounds retention; a future TTL sweeper
+-- (separate migration) walks the index below to evict expired rows.
+CREATE TABLE ff_budget_usage_dedup (
+    partition_key  smallint NOT NULL,
+    dedup_key      text     NOT NULL,
+    outcome_json   jsonb    NOT NULL,
+    applied_at_ms  bigint   NOT NULL,
+    expires_at_ms  bigint   NOT NULL,
+    PRIMARY KEY (partition_key, dedup_key)
+) PARTITION BY HASH (partition_key);
+
+-- TTL-sweeper scan index.
+CREATE INDEX ff_budget_usage_dedup_expires_idx
+    ON ff_budget_usage_dedup (partition_key, expires_at_ms);
+
+-- ============================================================
+-- Section 2 — 256-way HASH partition children
+-- ============================================================
+-- 3 parents × 256 children = 768 partitions. One `DO` block per
+-- parent with explicit COMMIT boundaries between blocks — same
+-- lock-budget discipline as 0001 §Section 7.
+
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_budget_policy FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_budget_policy_p' || i, i); END LOOP; END $$;
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_budget_usage FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_budget_usage_p' || i, i); END LOOP; END $$;
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_budget_usage_dedup FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_budget_usage_dedup_p' || i, i); END LOOP; END $$;
+COMMIT;
+
+-- ============================================================
+-- Section 3 — Migration annotation (Q12)
+-- ============================================================
+-- backward_compatible=true: this migration is purely additive;
+-- existing Wave 4 impls can ignore these tables.
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    2,
+    '0002_budget',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/tests/schema_0002.rs
+++ b/crates/ff-backend-postgres/tests/schema_0002.rs
@@ -1,0 +1,166 @@
+//! Wave 3b schema-0002 smoke test.
+//!
+//! Applies `migrations/0002_budget.sql` (on top of `0001_initial.sql`)
+//! and asserts the budget-schema invariants:
+//!
+//! * the three new parent tables exist,
+//! * each parent has exactly 256 child partitions (Q5),
+//! * `ff_migration_annotation` records the row
+//!   `(2, '0002_budget', _, true)` (Q12),
+//! * the PK constraints are present on every parent.
+//!
+//! Runs under the same `FF_PG_TEST_URL` harness as `schema_0001`;
+//! see that file for rationale.
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://user:pw@localhost/ff_wave3b_test \
+//!   cargo test -p ff-backend-postgres --test schema_0002 -- --ignored
+//! ```
+//!
+//! Note: `apply_migrations` is idempotent (sqlx tracks applied
+//! versions), so this test implicitly re-exercises 0001 as well.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+const BUDGET_PARENTS: &[&str] = &[
+    "ff_budget_policy",
+    "ff_budget_usage",
+    "ff_budget_usage_dedup",
+];
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_parent_tables_exist() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    for parent in BUDGET_PARENTS {
+        let row = sqlx::query(
+            "SELECT COUNT(*)::bigint AS n FROM pg_class c \
+             JOIN pg_namespace n ON c.relnamespace = n.oid \
+             WHERE n.nspname = 'public' AND c.relname = $1",
+        )
+        .bind(parent)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let n: i64 = row.get("n");
+        assert_eq!(n, 1, "parent table {parent} must exist");
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_partition_children_are_256() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+
+    for parent in BUDGET_PARENTS {
+        let row = sqlx::query(
+            "SELECT COUNT(*)::bigint AS n FROM pg_inherits \
+             WHERE inhparent = ($1 || '')::regclass",
+        )
+        .bind(parent)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let n: i64 = row.get("n");
+        assert_eq!(n, 256, "{parent} must have exactly 256 child partitions");
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_migration_annotation_row() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+
+    let row = sqlx::query(
+        "SELECT version, name, backward_compatible FROM ff_migration_annotation WHERE version = 2",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let v: i32 = row.get("version");
+    let n: String = row.get("name");
+    let bc: bool = row.get("backward_compatible");
+    assert_eq!(v, 2);
+    assert_eq!(n, "0002_budget");
+    assert!(bc, "0002 must be backward_compatible=true (additive)");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_primary_keys_present() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+
+    // Expected PK column lists, in order.
+    let expected: &[(&str, &[&str])] = &[
+        ("ff_budget_policy", &["partition_key", "budget_id"]),
+        (
+            "ff_budget_usage",
+            &["partition_key", "budget_id", "dimensions_key"],
+        ),
+        (
+            "ff_budget_usage_dedup",
+            &["partition_key", "dedup_key"],
+        ),
+    ];
+
+    for (table, cols) in expected {
+        let row = sqlx::query(
+            "SELECT a.attname AS col, array_position(i.indkey::int[], a.attnum::int) AS ord \
+             FROM pg_index i \
+             JOIN pg_class c ON c.oid = i.indrelid \
+             JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey) \
+             WHERE c.relname = $1 AND i.indisprimary \
+             ORDER BY ord",
+        )
+        .bind(table)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        let got: Vec<String> = row.iter().map(|r| r.get::<String, _>("col")).collect();
+        let expect: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
+        assert_eq!(got, expect, "PK columns mismatch on {table}");
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_dedup_expires_index_exists() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+
+    let row = sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM pg_indexes \
+         WHERE schemaname='public' AND indexname = 'ff_budget_usage_dedup_expires_idx'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let n: i64 = row.get("n");
+    assert_eq!(n, 1, "ff_budget_usage_dedup_expires_idx must exist");
+}


### PR DESCRIPTION
## Summary

- Wave 3's `0001_initial.sql` omitted budget tables; **Wave 4f is blocked** without them. This PR lands `0002_budget.sql` so Wave 4f proc impls can proceed.
- Three partitioned parents (`ff_budget_policy`, `ff_budget_usage`, `ff_budget_usage_dedup`) — each HASH(partition_key) × 256 children = **768 child partitions**. Same hash input + count as Wave 3 for uniformity.
- Annotated `backward_compatible=true` per master-spec Q12 — purely additive, existing Wave 4 impls can ignore these tables.

## Design notes

- **`dimensions_key` canonicalization.** `ff_budget_usage` keys usage rows on `(partition_key, budget_id, dimensions_key)` where `dimensions_key` is the canonical-sorted stringification of `UsageDimensions` — matches Valkey's per-dimension Hash shape, so Wave 4f check/report procs can key lookups without unpacking the full JSON.
- **Dedup TTL.** `ff_budget_usage_dedup` carries `expires_at_ms` + an index on `(partition_key, expires_at_ms)` so a future sweeper can evict expired rows. Dedup key is caller-supplied per RFC-012 §R7.2.3.
- **Lock-budget discipline.** `-- no-transaction` directive at the top; one `DO` block per parent with explicit `COMMIT` boundaries between blocks. Mirrors 0001_initial.sql §Section 7 (three parents * 256 = 768 locks split into three 256-lock chunks).
- **No stored procs, no triggers.** Tables + one index + annotation only. Budget ops don't need NOTIFY (Q11 says budgets run at RC + `FOR UPDATE`, no push wake-ups required).

## References

- `rfcs/RFC-008-budget.md` — budget semantics (policy / usage / dedup split).
- `rfcs/drafts/v0.7-migration-master.md` §Q5 (partitioning), §Q11 (isolation), §Q12 (annotation).
- Wave 3 PR #235 — pattern this PR mirrors.

## Test plan

- [x] Applied `0001_initial.sql` + `0002_budget.sql` against live Postgres 16.
- [x] `cargo test -p ff-backend-postgres --test schema_0001 --test schema_0002 -- --ignored` — 10/10 green.
- [x] New tests (`schema_0002.rs`, 5 tests):
  - [x] parent tables exist
  - [x] 256 child partitions per parent (768 total verified)
  - [x] `ff_migration_annotation` contains `(2, '0002_budget', _, true)`
  - [x] PK columns match spec on all three parents
  - [x] `ff_budget_usage_dedup_expires_idx` exists
- [x] Existing `schema_0001.rs` still green (idempotent reapply).
- [x] `cargo check --workspace --all-features` clean.

Do NOT merge — owner admin-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive Postgres DDL, but it creates 768 partitions and uses non-transactional migration steps, which can be operationally risky if applied on constrained/managed databases.
> 
> **Overview**
> Adds a new Postgres migration `0002_budget.sql` that introduces the budget schema: three new hash-partitioned tables (`ff_budget_policy`, `ff_budget_usage`, `ff_budget_usage_dedup`) plus a TTL-scan index on the dedup table, and records `(2, '0002_budget', backward_compatible=true)` in `ff_migration_annotation`.
> 
> The migration creates **256 hash partitions per table (768 total)** using explicit `COMMIT` boundaries and `-- no-transaction` to stay within Postgres lock limits. A new ignored integration test `schema_0002.rs` applies migrations and asserts table existence, partition counts, PK columns, the annotation row, and the dedup expiry index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d01b81efd78765b7f6cf7af041fc4064c45563d5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->