### PR TITLE
feat(pg-wave4h): Postgres CompletionBackend via LISTEN/NOTIFY + outbox replay (Q1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "ff-core",
  "ff-observability",
  "ff-script",
+ "futures-core",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -45,6 +45,7 @@ sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls", "macr
 async-trait = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+futures-core = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ff-backend-postgres/src/completion.rs
+++ b/crates/ff-backend-postgres/src/completion.rs
@@ -1,0 +1,356 @@
+//! `CompletionBackend` implementation for Postgres (Wave 4h / Q1).
+//!
+//! Transport design (per RFC-v0.7 Q1 adjudication):
+//!
+//! * Durable source of truth is the `ff_completion_event` outbox
+//!   table — a `bigserial` event_id column sequenced across all 256
+//!   hash partitions gives a single total order.
+//! * `pg_notify('ff_completion', event_id::text)` fires from the
+//!   `ff_completion_event_notify_trg` trigger (see
+//!   `migrations/0001_initial.sql` §Section 8). NOTIFY is the wake
+//!   signal only — the payload carries only the event_id cursor so
+//!   we sidestep Postgres's 8 KB NOTIFY payload cap and the natural
+//!   coalescing (`pg` collapses duplicate payloads on the same
+//!   channel within a transaction).
+//! * Each subscriber owns a long-lived tokio task holding a
+//!   [`PgListener`] (one dedicated pg connection) + issues
+//!   `SELECT ... WHERE event_id > $last_seen` on every wake to
+//!   catch bursts NOTIFY coalesced.
+//! * On LISTEN-connection loss (pg restart, PgBouncer eviction,
+//!   network drop), `PgListener::recv()` surfaces an error; we
+//!   re-establish LISTEN + replay from `last_seen_event_id`.
+//! * Subscriber drop ends the task via `tx.closed()`.
+//!
+//! Missed NOTIFY between commit and LISTEN start is covered by
+//! `dependency_reconciler`'s scan — out of scope here.
+//!
+//! Coordination with Wave 4e (stream LISTEN/NOTIFY via
+//! [`super::listener::StreamNotifier`]): completion subscribers own
+//! their own `PgListener` instance; they do NOT share the
+//! `StreamNotifier` task. Completion fanout is low cardinality
+//! (engines subscribe, not every execution) so a per-subscriber
+//! connection is cheap — reuse is a future optimisation once Wave 4e
+//! stabilises.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ff_core::backend::{CompletionPayload, ScannerFilter};
+use ff_core::completion_backend::{CompletionBackend, CompletionStream};
+use ff_core::engine_error::EngineError;
+use ff_core::types::{ExecutionId, FlowId, Namespace, TimestampMs};
+use futures_core::Stream;
+use sqlx::postgres::{PgListener, PgPool};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+use crate::PostgresBackend;
+
+/// Channel name fired by `ff_notify_completion_event()` after every
+/// `ff_completion_event` INSERT.
+pub const COMPLETION_CHANNEL: &str = "ff_completion";
+
+/// Bounded fan-out capacity. Matches the Valkey backend's
+/// [`ff_backend_valkey::completion::STREAM_CAPACITY`] so consumer
+/// code sees equivalent backpressure behaviour across backends.
+const STREAM_CAPACITY: usize = 1024;
+
+/// Max rows pulled per wake; caps catch-up query cost.
+const REPLAY_BATCH: i64 = 256;
+
+/// Reconnect backoff when the LISTEN connection drops.
+const RECONNECT_BACKOFF: Duration = Duration::from_millis(200);
+
+/// Stream adapter returned to callers. Holds the `mpsc::Receiver`
+/// plus the task handle that feeds it; dropping the stream drops the
+/// receiver, `tx.closed()` fires in the task, and the task exits —
+/// which aborts the owned `JoinHandle` cleanly on drop.
+pub struct PostgresCompletionStream {
+    rx: mpsc::Receiver<CompletionPayload>,
+    /// Task handle kept alive for the stream's lifetime. Aborted on
+    /// drop (no need to `.await` — the task also exits when the
+    /// receiver is dropped via `tx.closed()`).
+    handle: JoinHandle<()>,
+}
+
+impl Drop for PostgresCompletionStream {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl Stream for PostgresCompletionStream {
+    type Item = CompletionPayload;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+/// Decoded outbox row. Mirrors the `ff_completion_event` columns we
+/// need to build a [`CompletionPayload`] + apply [`ScannerFilter`].
+struct CompletionEventRow {
+    event_id: i64,
+    execution_id: Uuid,
+    flow_id: Option<Uuid>,
+    outcome: String,
+    namespace: Option<String>,
+    instance_tag: Option<String>,
+    occurred_at_ms: i64,
+    partition_key: i16,
+}
+
+impl CompletionEventRow {
+    /// Build a [`CompletionPayload`] from the outbox row.
+    ///
+    /// The stored `execution_id` is a bare UUID; we re-attach the
+    /// `{fp:N}:<uuid>` hash-tag using the row's `partition_key` so
+    /// downstream consumers see the same execution-id shape they
+    /// would get from the Valkey backend.
+    fn into_payload(self) -> CompletionPayload {
+        let eid_string = format!("{{fp:{}}}:{}", self.partition_key, self.execution_id);
+        // Parse goes through the canonical shape check; on a
+        // well-formed Wave-3 row this is infallible.
+        let execution_id = ExecutionId::parse(&eid_string)
+            .expect("ff_completion_event row produced malformed ExecutionId");
+        let mut payload = CompletionPayload::new(
+            execution_id,
+            self.outcome,
+            None, // payload_bytes — not persisted in Wave 3 outbox
+            TimestampMs(self.occurred_at_ms),
+        );
+        if let Some(fid) = self.flow_id {
+            payload = payload.with_flow_id(FlowId::from_uuid(fid));
+        }
+        payload
+    }
+
+    /// Apply a [`ScannerFilter`]. The filter's `namespace` dimension
+    /// is checked against the row's `namespace` column; the
+    /// `instance_tag` dimension is checked against the row's
+    /// `instance_tag` column, which the Wave-3 schema stores as the
+    /// denormalised `"key=value"` pair written by the completion
+    /// emitter. When the filter specifies a tag the row must carry a
+    /// matching exact pair; missing `instance_tag` never matches.
+    fn passes(&self, filter: &ScannerFilter) -> bool {
+        if let Some(ref want_ns) = filter.namespace {
+            let have: Option<Namespace> = self.namespace.as_deref().map(Namespace::from);
+            if have.as_ref() != Some(want_ns) {
+                return false;
+            }
+        }
+        if let Some((ref k, ref v)) = filter.instance_tag {
+            let want = format!("{k}={v}");
+            match self.instance_tag {
+                Some(ref have) if have == &want => {}
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+/// Public entrypoint — subscribe to completions with an optional
+/// [`ScannerFilter`].
+///
+/// Starting cursor is `max(event_id)` at subscribe time: we tail new
+/// events only. Replay from an older cursor is a future feature and
+/// is deliberately out of scope for v0.7.
+pub(crate) async fn subscribe(
+    pool: &PgPool,
+    filter: Option<ScannerFilter>,
+) -> Result<CompletionStream, EngineError> {
+    let filter = filter.unwrap_or(ScannerFilter::NOOP);
+
+    // Resolve the starting cursor BEFORE we spawn the listen task so
+    // synchronous-setup errors (pool exhausted, schema missing) bubble
+    // back to the caller as `EngineError` per the trait contract.
+    let start: i64 = sqlx::query_scalar("SELECT COALESCE(MAX(event_id), 0) FROM ff_completion_event")
+        .fetch_one(pool)
+        .await
+        .map_err(|e| EngineError::Unavailable {
+            op: match &e {
+                sqlx::Error::Database(_) => "pg.subscribe_completions (max(event_id))",
+                _ => "pg.subscribe_completions (connect)",
+            },
+        })?;
+
+    let (tx, rx) = mpsc::channel::<CompletionPayload>(STREAM_CAPACITY);
+    let pool_clone = pool.clone();
+    let handle = tokio::spawn(subscriber_loop(pool_clone, tx, filter, start));
+
+    let stream = PostgresCompletionStream { rx, handle };
+    Ok(Box::pin(stream))
+}
+
+/// Long-lived LISTEN + replay loop. Ends when `tx.closed()` fires
+/// (consumer dropped the stream) or an unrecoverable setup error
+/// occurs — logged at `tracing::error!` and leaves the receiver to
+/// observe end-of-stream.
+async fn subscriber_loop(
+    pool: PgPool,
+    tx: mpsc::Sender<CompletionPayload>,
+    filter: ScannerFilter,
+    mut last_seen: i64,
+) {
+    loop {
+        // (Re)establish the dedicated LISTEN connection.
+        let mut listener = match PgListener::connect_with(&pool).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "pg.completion.subscribe: PgListener::connect_with failed; retrying"
+                );
+                if wait_or_exit(&tx, RECONNECT_BACKOFF).await {
+                    return;
+                }
+                continue;
+            }
+        };
+        if let Err(e) = listener.listen(COMPLETION_CHANNEL).await {
+            tracing::warn!(
+                error = %e,
+                "pg.completion.subscribe: LISTEN ff_completion failed; retrying"
+            );
+            if wait_or_exit(&tx, RECONNECT_BACKOFF).await {
+                return;
+            }
+            continue;
+        }
+
+        // Catch-up replay immediately after (re)subscribe — covers
+        // any events committed between last_seen and the LISTEN
+        // registration that NOTIFY missed for us.
+        if !replay(&pool, &tx, &filter, &mut last_seen).await {
+            return; // tx closed
+        }
+
+        // Steady-state: recv one NOTIFY, drain all events above the
+        // cursor, repeat. `recv()` also surfaces connection drops as
+        // Err; on error we break to the outer reconnect loop.
+        loop {
+            tokio::select! {
+                _ = tx.closed() => return,
+                res = listener.recv() => {
+                    match res {
+                        Ok(_notification) => {
+                            if !replay(&pool, &tx, &filter, &mut last_seen).await {
+                                return;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "pg.completion.subscribe: listener.recv() error; reconnecting"
+                            );
+                            break; // outer loop rebuilds the listener
+                        }
+                    }
+                }
+            }
+        }
+
+        if wait_or_exit(&tx, RECONNECT_BACKOFF).await {
+            return;
+        }
+    }
+}
+
+/// Sleep for `d` OR return `true` if the subscriber dropped during
+/// the wait (caller should exit).
+async fn wait_or_exit(tx: &mpsc::Sender<CompletionPayload>, d: Duration) -> bool {
+    tokio::select! {
+        _ = tx.closed() => true,
+        _ = tokio::time::sleep(d) => false,
+    }
+}
+
+/// Drain all events above `last_seen`, filter, forward. Returns
+/// `false` iff the consumer has dropped the stream (caller must
+/// exit).
+async fn replay(
+    pool: &PgPool,
+    tx: &mpsc::Sender<CompletionPayload>,
+    filter: &ScannerFilter,
+    last_seen: &mut i64,
+) -> bool {
+    loop {
+        let rows: Vec<CompletionEventRow> = match sqlx::query_as::<_, (i64, Uuid, Option<Uuid>, String, Option<String>, Option<String>, i64, i16)>(
+            "SELECT event_id, execution_id, flow_id, outcome, namespace, instance_tag, occurred_at_ms, partition_key \
+             FROM ff_completion_event \
+             WHERE event_id > $1 \
+             ORDER BY event_id ASC \
+             LIMIT $2"
+        )
+        .bind(*last_seen)
+        .bind(REPLAY_BATCH)
+        .fetch_all(pool)
+        .await
+        {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(event_id, execution_id, flow_id, outcome, namespace, instance_tag, occurred_at_ms, partition_key)| CompletionEventRow {
+                    event_id,
+                    execution_id,
+                    flow_id,
+                    outcome,
+                    namespace,
+                    instance_tag,
+                    occurred_at_ms,
+                    partition_key,
+                })
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "pg.completion.replay: query failed");
+                return !tx.is_closed();
+            }
+        };
+
+        if rows.is_empty() {
+            return !tx.is_closed();
+        }
+
+        for row in rows {
+            *last_seen = row.event_id;
+            let passes = row.passes(filter);
+            if !passes {
+                continue;
+            }
+            let payload = row.into_payload();
+            if tx.send(payload).await.is_err() {
+                return false; // consumer dropped
+            }
+        }
+        // Loop: there may be more rows than REPLAY_BATCH. Keep
+        // draining until we hit an empty page.
+    }
+}
+
+/// Compile-time proof that `PostgresBackend` stays dyn-compatible
+/// under the `CompletionBackend` trait. Mirrors the sibling guard in
+/// `ff_core::completion_backend::_assert_dyn_compatible`.
+#[allow(dead_code)]
+fn _assert_pg_dyn_completion(b: std::sync::Arc<PostgresBackend>) -> std::sync::Arc<dyn CompletionBackend> {
+    b
+}
+
+#[async_trait]
+impl CompletionBackend for PostgresBackend {
+    async fn subscribe_completions(&self) -> Result<CompletionStream, EngineError> {
+        subscribe(&self.pool, None).await
+    }
+
+    async fn subscribe_completions_filtered(
+        &self,
+        filter: &ScannerFilter,
+    ) -> Result<CompletionStream, EngineError> {
+        if filter.is_noop() {
+            return self.subscribe_completions().await;
+        }
+        subscribe(&self.pool, Some(filter.clone())).await
+    }
+}

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -58,6 +58,7 @@ use sqlx::PgPool;
 mod admin;
 pub mod attempt;
 pub mod budget;
+pub mod completion;
 pub mod error;
 pub mod exec_core;
 pub mod handle_codec;
@@ -66,6 +67,7 @@ pub mod migrate;
 pub mod pool;
 pub mod version;
 
+pub use completion::{PostgresCompletionStream, COMPLETION_CHANNEL};
 pub use error::{map_sqlx_error, PostgresTransportError};
 pub use listener::StreamNotifier;
 pub use migrate::{apply_migrations, MigrationError};

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -54,8 +54,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 futures = { workspace = true }
 # Issue #154 — tracing span capture in the observability wiring test.
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
-# Wave 4f/4g: live Postgres integration tests for budget + admin/list
-# surfaces. Gated on `FF_PG_TEST_URL` at runtime (tests are `#[ignore]`
-# by default).
+# Wave 4f/4g/4h: live Postgres integration tests for budget + admin/list
+# + CompletionBackend surfaces. Gated on `FF_PG_TEST_URL` at runtime
+# (tests are `#[ignore]` by default).
 ff-backend-postgres = { workspace = true }
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls", "uuid", "macros", "migrate"] }

--- a/crates/ff-test/tests/pg_completion_backend.rs
+++ b/crates/ff-test/tests/pg_completion_backend.rs
@@ -1,0 +1,240 @@
+//! Wave 4h — Postgres `CompletionBackend` integration test.
+//!
+//! Covers the Q1-adjudicated LISTEN/NOTIFY + outbox-replay transport:
+//!
+//! 1. Happy path — subscribe, INSERT into `ff_completion_event`,
+//!    receive the payload.
+//! 2. Filter — a namespace-scoped subscriber sees only matching rows.
+//! 3. Replay — INSERTs that happen between two wakes are drained in
+//!    order (validates the "NOTIFY coalesces, replay catches bursts"
+//!    invariant).
+//! 4. Subscriber drop — dropping the stream ends the background task
+//!    cleanly.
+//!
+//! The reconnect-on-connection-drop scenario is covered by the
+//! backend's internal reconnect loop (tested by fault injection in a
+//! follow-up — it would require a second PgPool pointed at a
+//! connection-terminating proxy, out of scope for Wave 4h).
+//!
+//! # Running
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://user:pw@localhost/ff_wave4h_test \
+//!   cargo test -p ff-test --test pg_completion_backend -- --ignored --test-threads=1
+//! ```
+//!
+//! `--test-threads=1` because the tests share the `ff_completion_event`
+//! outbox table and observe absolute row counts.
+
+use std::time::Duration;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::backend::ScannerFilter;
+use ff_core::completion_backend::CompletionBackend;
+use ff_core::partition::PartitionConfig;
+use futures::StreamExt;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(8) // subscribers each take a dedicated LISTEN conn
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+/// Insert one row into `ff_completion_event`. Returns the
+/// partition_key used so tests can reconstruct the expected
+/// ExecutionId hash-tag.
+async fn insert_completion(
+    pool: &PgPool,
+    execution_id: Uuid,
+    flow_id: Option<Uuid>,
+    outcome: &str,
+    namespace: Option<&str>,
+    instance_tag: Option<&str>,
+) -> i16 {
+    // Pick partition_key = 0 for tests; the trigger fires the same
+    // way on any partition. Using a fixed key keeps the expected
+    // ExecutionId shape predictable.
+    let partition_key: i16 = 0;
+    sqlx::query(
+        "INSERT INTO ff_completion_event \
+         (partition_key, execution_id, flow_id, outcome, namespace, instance_tag, occurred_at_ms) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(partition_key)
+    .bind(execution_id)
+    .bind(flow_id)
+    .bind(outcome)
+    .bind(namespace)
+    .bind(instance_tag)
+    .bind(1_700_000_000_000_i64)
+    .execute(pool)
+    .await
+    .expect("insert ff_completion_event");
+    partition_key
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn subscribe_receives_inserted_completion() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let mut stream = backend
+        .subscribe_completions()
+        .await
+        .expect("subscribe_completions");
+
+    let eid = Uuid::new_v4();
+    let fid = Uuid::new_v4();
+    insert_completion(&pool, eid, Some(fid), "complete", None, None).await;
+
+    let got = tokio::time::timeout(Duration::from_secs(3), stream.next())
+        .await
+        .expect("completion arrives within 3s")
+        .expect("stream yields Some");
+
+    assert_eq!(got.outcome, "complete");
+    assert_eq!(got.flow_id.map(|f| f.0), Some(fid));
+    assert!(got.execution_id.as_str().contains(&eid.to_string()));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn filter_drops_non_matching_namespace() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let filter = ScannerFilter::new().with_namespace("tenant-a");
+    let mut stream = backend
+        .subscribe_completions_filtered(&filter)
+        .await
+        .expect("subscribe_completions_filtered");
+
+    // Mismatched namespace — must NOT be delivered.
+    insert_completion(
+        &pool,
+        Uuid::new_v4(),
+        Some(Uuid::new_v4()),
+        "complete",
+        Some("tenant-b"),
+        None,
+    )
+    .await;
+    // Matching namespace — must be delivered.
+    let eid_match = Uuid::new_v4();
+    insert_completion(
+        &pool,
+        eid_match,
+        Some(Uuid::new_v4()),
+        "complete",
+        Some("tenant-a"),
+        None,
+    )
+    .await;
+
+    let got = tokio::time::timeout(Duration::from_secs(3), stream.next())
+        .await
+        .expect("filtered completion arrives")
+        .expect("stream yields Some");
+    assert!(got.execution_id.as_str().contains(&eid_match.to_string()));
+
+    // Drain briefly to confirm the filtered-out row never arrives.
+    let drained = tokio::time::timeout(Duration::from_millis(300), stream.next()).await;
+    assert!(drained.is_err(), "no further events should arrive");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn replay_drains_burst_after_single_notify() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let mut stream = backend
+        .subscribe_completions()
+        .await
+        .expect("subscribe_completions");
+
+    // Burst-insert 5 rows inside a single transaction. NOTIFY
+    // delivers at COMMIT; pg may coalesce identical-payload NOTIFYs
+    // and the first wake will see all 5 via the cursor-driven
+    // replay.
+    let mut tx = pool.begin().await.expect("begin");
+    let mut fids = Vec::new();
+    for _ in 0..5 {
+        let fid = Uuid::new_v4();
+        fids.push(fid);
+        sqlx::query(
+            "INSERT INTO ff_completion_event \
+             (partition_key, execution_id, flow_id, outcome, occurred_at_ms) \
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(0_i16)
+        .bind(Uuid::new_v4())
+        .bind(fid)
+        .bind("complete")
+        .bind(1_700_000_000_000_i64)
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    }
+    tx.commit().await.expect("commit");
+
+    let mut received = Vec::new();
+    for _ in 0..5 {
+        let got = tokio::time::timeout(Duration::from_secs(3), stream.next())
+            .await
+            .expect("all 5 completions arrive")
+            .expect("stream yields Some");
+        received.push(got.flow_id.unwrap().0);
+    }
+    // Monotonic event_id ordering ⇒ same insertion order.
+    assert_eq!(received, fids);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn dropping_stream_exits_subscriber_task() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let stream = backend
+        .subscribe_completions()
+        .await
+        .expect("subscribe_completions");
+
+    // Drop the stream. The subscriber task's `tx.closed()` should
+    // fire; dropping the stream also aborts the JoinHandle.
+    drop(stream);
+
+    // Subsequent inserts must not block or panic anything.
+    insert_completion(
+        &pool,
+        Uuid::new_v4(),
+        Some(Uuid::new_v4()),
+        "complete",
+        None,
+        None,
+    )
+    .await;
+
+    // Give the reactor a tick to observe the shutdown cleanly.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}


### PR DESCRIPTION
## Summary

Wave 4h — Postgres backend's `CompletionBackend` impl per Q1 adjudication (LISTEN/NOTIFY + outbox replay).

- New `crates/ff-backend-postgres/src/completion.rs`: `PostgresCompletionStream` + per-subscriber tokio task holding a dedicated `sqlx::postgres::PgListener`. NOTIFY on `ff_completion` is the wake signal only; every wake replays `SELECT ... WHERE event_id > last_seen FROM ff_completion_event ORDER BY event_id LIMIT 256` (catches bursts that NOTIFY coalesces). On LISTEN-connection drop the task rebuilds the listener + replays from the same cursor.
- `ScannerFilter` applied Rust-side on the decoded row — `namespace` checks the row column; `instance_tag` checks `"key=value"` against the row column.
- `impl CompletionBackend for PostgresBackend` in `lib.rs`. Starting cursor = `max(event_id)` at subscribe time (tail-only; older-cursor replay is future work).
- Does NOT touch `listener.rs` (Wave 4e owns `StreamNotifier`). Completion subscribers own their own `PgListener` per subscriber — coordination is by isolation, not shared state.
- `dependency_reconciler` covers any NOTIFY-lost-between-commit-and-LISTEN window (consistent with Q1's safety-net contract; out of scope here).

## Test plan

`crates/ff-test/tests/pg_completion_backend.rs` gated on `FF_PG_TEST_URL` (Wave-3 schema_0001 pattern):

- [ ] `subscribe_receives_inserted_completion` — happy path.
- [ ] `filter_drops_non_matching_namespace` — `ScannerFilter::with_namespace` path.
- [ ] `replay_drains_burst_after_single_notify` — 5 inserts in one tx, all arrive in order.
- [ ] `dropping_stream_exits_subscriber_task` — `tx.closed()` + `JoinHandle::abort()`.

Local verification without live Postgres:
- `cargo check -p ff-backend-postgres` — clean.
- `cargo check -p ff-test --tests` — clean.
- `cargo test -p ff-test --test pg_completion_backend` — 4 tests enumerate + properly `--ignored` without `FF_PG_TEST_URL`.
- `cargo clippy -p ff-backend-postgres --all-targets` — no new warnings.
- Compile-time `_assert_pg_dyn_completion` proves `Arc<dyn CompletionBackend>` for `PostgresBackend`.

Live-Postgres run was attempted but the local pg instance required a password and no container runtime was available in the sandbox; CI + manual verification against a real pg expected to cover the `--ignored` tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new async completion subscription path backed by Postgres `LISTEN/NOTIFY` and cursor-based replay, which can impact delivery semantics and DB load/connection usage if misconfigured. Includes reconnect logic and filtering that should be validated under production-like failure modes.
> 
> **Overview**
> Adds a Postgres `CompletionBackend` implementation that tails `ff_completion_event` using `LISTEN ff_completion` as a wake signal and a cursor-based replay query (`event_id > last_seen`, batched) to drain bursts and recover after reconnects.
> 
> Introduces `PostgresCompletionStream` (bounded `mpsc` + background task) with Rust-side `ScannerFilter` support (`namespace` and `instance_tag`) and exports `COMPLETION_CHANNEL`; updates dependencies accordingly.
> 
> Adds ignored integration tests (gated by `FF_PG_TEST_URL`) to validate delivery, filtering, burst replay ordering, and clean shutdown on stream drop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3bfecd8cd6b221033b210c87c2260732f11943a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->