### PR TITLE
feat(pg-wave6a): Postgres dependency_reconciler with transitive-descendant sweep

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -72,6 +72,8 @@ pub mod listener;
 pub mod migrate;
 pub mod pool;
 #[cfg(feature = "core")]
+pub mod reconcilers;
+#[cfg(feature = "core")]
 pub mod scheduler;
 pub mod signal;
 #[cfg(feature = "streaming")]

--- a/crates/ff-backend-postgres/src/reconcilers/dependency.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/dependency.rs
@@ -1,0 +1,196 @@
+//! Dependency-resolution reconciler (RFC-v0.7 Wave 6a).
+//!
+//! Backstop for the per-hop-tx cascade implemented in
+//! [`crate::dispatch::dispatch_completion`] (Wave 5a). The cascade
+//! is deliberately NOT wrapped in a single transaction spanning
+//! transitive descendants — a mid-cascade failure (crash, lock
+//! timeout, SERIALIZABLE retry exhaustion) leaves downstream
+//! `ff_completion_event` rows with `dispatched_at_ms IS NULL`. This
+//! reconciler sweeps those rows on its interval and re-invokes
+//! `dispatch_completion`, which is idempotent via the
+//! `UPDATE ... RETURNING` claim on `dispatched_at_ms`.
+//!
+//! # Transitive-descendant sweep (K-2 round-2)
+//!
+//! The reconciler query covers the **entire transitive descendant
+//! set** of any interrupted cascade, not just 1-hop children of the
+//! original trigger. Proof by construction:
+//!
+//! 1. Every `PolicyDecision::Satisfied` / `::Impossible` that
+//!    transitions a downstream to `completed` / `skipped` INSERTs a
+//!    new row into `ff_completion_event` inside the same per-hop tx
+//!    ([`crate::dispatch::advance_edge_group`] line ~430).
+//! 2. If the per-hop tx for hop N commits but hop N+1 crashes, the
+//!    hop-N event lands durably with `dispatched_at_ms = NULL`.
+//! 3. The reconciler finds that row via the partial index
+//!    `ff_completion_event_pending_dispatch_idx` and fires
+//!    `dispatch_completion(event_id)`, which kicks the cascade at
+//!    hop N+1.
+//! 4. Hop N+1's successful execution emits hop N+2's event, and so
+//!    on — the reconciler's next tick (or the in-process cascade
+//!    inside `dispatch_completion` itself) carries the chain
+//!    forward.
+//!
+//! So a single crashed cascade of depth D eventually drains in at
+//! most D reconciler ticks regardless of where the interruption
+//! happened in the chain.
+//!
+//! # Interval + threshold
+//!
+//! `stale_threshold_ms` (default 1 000 ms) keeps the reconciler out
+//! of the hot path: the normal in-process dispatcher flips
+//! `dispatched_at_ms` within sub-millisecond of the commit that
+//! inserted the row, so rows younger than the threshold are left
+//! for the primary dispatcher.
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::EngineError;
+use sqlx::{PgPool, Row};
+
+use crate::dispatch::{dispatch_completion, DispatchOutcome};
+use crate::error::map_sqlx_error;
+
+/// Per-tick work report. Returned so the driving scanner task can
+/// emit metrics + logs at cycle boundary without re-querying.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ReconcileReport {
+    /// Rows matched by the scan query before filter application.
+    pub scanned: u64,
+    /// Events that produced `DispatchOutcome::Advanced(_)`.
+    pub reconciled: u64,
+    /// Events that produced `DispatchOutcome::NoOp` (concurrent
+    /// dispatcher won the claim race between our SELECT and our
+    /// re-dispatch — legal, logged at trace).
+    pub noop: u64,
+    /// Events skipped by the `ScannerFilter`.
+    pub filtered: u64,
+    /// Re-dispatch invocations that returned `EngineError`. The
+    /// event row stays `dispatched_at_ms IS NULL` and the next tick
+    /// will retry.
+    pub errors: u64,
+}
+
+/// Max rows per tick. Bounds the per-tick pool + transaction budget.
+const BATCH_LIMIT: i64 = 1_000;
+
+/// Default minimum age of a `ff_completion_event` row before the
+/// reconciler will claim it. Keeps this off the hot path — the
+/// primary dispatcher has this long to flip `dispatched_at_ms` from
+/// NULL before the reconciler takes over.
+pub const DEFAULT_STALE_THRESHOLD_MS: i64 = 1_000;
+
+/// Run one reconciler tick. See module docs for semantics.
+///
+/// The query uses the `ff_completion_event_pending_dispatch_idx`
+/// partial index from migration 0003 for partition-local index
+/// scans. `ScannerFilter` is applied inline via optional SQL
+/// predicates (namespace + instance_tag both live on the event row
+/// — issue #122 column additions) so we do not pay an extra RTT per
+/// candidate like the Valkey reconciler does.
+#[tracing::instrument(name = "pg.dep_reconciler.tick", skip(pool, filter))]
+pub async fn reconcile_tick(
+    pool: &PgPool,
+    filter: &ScannerFilter,
+    stale_threshold_ms: i64,
+) -> Result<ReconcileReport, EngineError> {
+    let now_ms = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+    let cutoff_ms = now_ms.saturating_sub(stale_threshold_ms);
+
+    // We bind both filter dimensions as NULLABLE parameters and let
+    // `($N IS NULL OR column = $N)` short-circuit in the planner.
+    // That keeps one prepared statement for every filter shape.
+    let ns_param: Option<String> = filter.namespace.as_ref().map(|ns| ns.as_str().to_owned());
+    let tag_param: Option<String> = filter
+        .instance_tag
+        .as_ref()
+        .map(|(_, v)| v.clone());
+
+    let rows = sqlx::query(
+        r#"
+        SELECT event_id, namespace, instance_tag
+          FROM ff_completion_event
+         WHERE dispatched_at_ms IS NULL
+           AND committed_at_ms < $1
+           AND ($2::text IS NULL OR namespace = $2)
+           AND ($3::text IS NULL OR instance_tag = $3)
+         ORDER BY event_id ASC
+         LIMIT $4
+        "#,
+    )
+    .bind(cutoff_ms)
+    .bind(&ns_param)
+    .bind(&tag_param)
+    .bind(BATCH_LIMIT)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = ReconcileReport {
+        scanned: rows.len() as u64,
+        ..ReconcileReport::default()
+    };
+
+    for row in rows {
+        let event_id: i64 = row.get("event_id");
+        match dispatch_completion(pool, event_id).await {
+            Ok(DispatchOutcome::Advanced(n)) => {
+                report.reconciled += 1;
+                tracing::debug!(
+                    event_id,
+                    advanced = n,
+                    "dep_reconciler: re-dispatched stale completion event"
+                );
+            }
+            Ok(DispatchOutcome::NoOp) => {
+                report.noop += 1;
+                tracing::trace!(
+                    event_id,
+                    "dep_reconciler: concurrent dispatcher won claim race"
+                );
+            }
+            Err(e) => {
+                report.errors += 1;
+                tracing::warn!(
+                    event_id,
+                    error = %e,
+                    "dep_reconciler: dispatch_completion failed — will retry next tick"
+                );
+            }
+        }
+    }
+
+    // `filtered` is always zero here: filter pushdown is SQL-side.
+    // The field is retained in the report so a future filter
+    // dimension that can't be pushed down stays additive-compatible.
+    let _ = &mut report.filtered;
+
+    Ok(report)
+}
+
+// ── unit tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_default_is_zero() {
+        let r = ReconcileReport::default();
+        assert_eq!(r.scanned, 0);
+        assert_eq!(r.reconciled, 0);
+        assert_eq!(r.noop, 0);
+        assert_eq!(r.filtered, 0);
+        assert_eq!(r.errors, 0);
+    }
+
+    #[test]
+    fn default_threshold_is_one_second() {
+        assert_eq!(DEFAULT_STALE_THRESHOLD_MS, 1_000);
+    }
+}

--- a/crates/ff-backend-postgres/src/reconcilers/mod.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/mod.rs
@@ -1,0 +1,11 @@
+//! Postgres-backend scanner reconcilers (RFC-v0.7 Wave 6).
+//!
+//! These modules implement the Postgres twins of the Valkey scanners
+//! in `ff-engine::scanner::*`. Each reconciler is a single
+//! `reconcile_tick(pool, filter, ...)` function the engine's scanner
+//! task drives on a fixed interval.
+//!
+//! Wave 6a ships the dependency reconciler — the backstop for the
+//! per-hop-tx dispatch cascade from Wave 5a.
+
+pub mod dependency;

--- a/crates/ff-engine/src/scanner/dependency_reconciler.rs
+++ b/crates/ff-engine/src/scanner/dependency_reconciler.rs
@@ -364,3 +364,32 @@ async fn get_upstream_outcome(
     cache.insert(upstream_id.to_owned(), result.clone());
     result
 }
+
+// ── Postgres branch (Wave 6a, RFC-v0.7) ─────────────────────────────────
+
+/// Postgres parity for [`DependencyReconciler`].
+///
+/// Delegates to [`ff_backend_postgres::reconcilers::dependency::reconcile_tick`]
+/// — the cascade backstop for the per-hop-tx dispatch chain in
+/// Wave 5a. See that module's docs for the transitive-descendant
+/// sweep proof.
+///
+/// The engine's Postgres scanner task drives this on a fixed
+/// interval (mirrors the Valkey `ScannerRunner` contract), passing
+/// its configured `ScannerFilter` and the `stale_threshold_ms`
+/// from `BackendConfig`. A `None` threshold folds to
+/// [`ff_backend_postgres::reconcilers::dependency::DEFAULT_STALE_THRESHOLD_MS`].
+#[cfg(feature = "postgres")]
+pub async fn reconcile_via_postgres(
+    pool: &ff_backend_postgres::PgPool,
+    filter: &ScannerFilter,
+    stale_threshold_ms: Option<i64>,
+) -> Result<
+    ff_backend_postgres::reconcilers::dependency::ReconcileReport,
+    ff_core::engine_error::EngineError,
+> {
+    let threshold = stale_threshold_ms.unwrap_or(
+        ff_backend_postgres::reconcilers::dependency::DEFAULT_STALE_THRESHOLD_MS,
+    );
+    ff_backend_postgres::reconcilers::dependency::reconcile_tick(pool, filter, threshold).await
+}

--- a/crates/ff-test/tests/pg_reconciler_dependency.rs
+++ b/crates/ff-test/tests/pg_reconciler_dependency.rs
@@ -1,0 +1,362 @@
+//! Wave 6a — Postgres dependency reconciler integration tests.
+//!
+//! The reconciler is the backstop for the per-hop-tx cascade in
+//! `dispatch::dispatch_completion`. It scans `ff_completion_event`
+//! for rows whose `dispatched_at_ms IS NULL` and whose
+//! `committed_at_ms` is older than the stale threshold, and
+//! re-invokes the dispatcher (idempotent via the claim UPDATE).
+//!
+//! Tests:
+//!
+//! 1. `normal_sweep_reconciles_stale_event`
+//! 2. `crash_mid_cascade_two_hops`
+//! 3. `reconciler_idempotent_on_second_tick`
+//! 4. `scanner_filter_excludes_nonmatching_namespace`
+//! 5. `transitive_three_hop_sweep`
+//!
+//! # Running
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://postgres:postgres@localhost/ff_wave6a_test \
+//!   cargo test -p ff-test --test pg_reconciler_dependency -- --ignored --test-threads=1
+//! ```
+
+use ff_backend_postgres::reconcilers::dependency::{reconcile_tick, ReconcileReport};
+use ff_backend_postgres::{apply_migrations, dispatch};
+use ff_core::backend::ScannerFilter;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+const P: i16 = 0;
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(16)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    apply_migrations(&pool).await.expect("apply_migrations");
+    for stmt in [
+        "DELETE FROM ff_pending_cancel_groups",
+        "DELETE FROM ff_completion_event",
+        "DELETE FROM ff_edge_group",
+        "DELETE FROM ff_edge",
+        "DELETE FROM ff_exec_core",
+        "DELETE FROM ff_flow_core",
+    ] {
+        sqlx::query(stmt).execute(&pool).await.expect("reset");
+    }
+    Some(pool)
+}
+
+async fn insert_flow(pool: &PgPool) -> Uuid {
+    let flow_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_flow_core (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms) \
+         VALUES ($1, $2, 0, 'running', 0)",
+    )
+    .bind(P)
+    .bind(flow_id)
+    .execute(pool)
+    .await
+    .expect("flow");
+    flow_id
+}
+
+async fn insert_exec_with_id(
+    pool: &PgPool,
+    eid: Uuid,
+    flow_id: Uuid,
+    lifecycle: &str,
+    eligibility: &str,
+    public: &str,
+    attempt: &str,
+) {
+    sqlx::query(
+        "INSERT INTO ff_exec_core (partition_key, execution_id, flow_id, lane_id, \
+         lifecycle_phase, ownership_state, eligibility_state, public_state, attempt_state, \
+         created_at_ms) \
+         VALUES ($1, $2, $3, 'default', $4, 'unowned', $5, $6, $7, 0)",
+    )
+    .bind(P)
+    .bind(eid)
+    .bind(flow_id)
+    .bind(lifecycle)
+    .bind(eligibility)
+    .bind(public)
+    .bind(attempt)
+    .execute(pool)
+    .await
+    .expect("exec");
+}
+
+async fn insert_edge(pool: &PgPool, flow_id: Uuid, upstream: Uuid, downstream: Uuid) {
+    sqlx::query(
+        "INSERT INTO ff_edge (partition_key, flow_id, edge_id, upstream_eid, downstream_eid, policy) \
+         VALUES ($1, $2, $3, $4, $5, '{}'::jsonb)",
+    )
+    .bind(P)
+    .bind(flow_id)
+    .bind(Uuid::new_v4())
+    .bind(upstream)
+    .bind(downstream)
+    .execute(pool)
+    .await
+    .expect("edge");
+}
+
+async fn insert_edge_group(
+    pool: &PgPool,
+    flow_id: Uuid,
+    downstream: Uuid,
+    fanout: i32,
+    policy: serde_json::Value,
+    k_target: i32,
+) {
+    sqlx::query(
+        "INSERT INTO ff_edge_group (partition_key, flow_id, downstream_eid, policy, k_target, \
+         success_count, fail_count, skip_count, running_count) \
+         VALUES ($1, $2, $3, $4, $5, 0, 0, 0, $6)",
+    )
+    .bind(P)
+    .bind(flow_id)
+    .bind(downstream)
+    .bind(&policy)
+    .bind(k_target)
+    .bind(fanout)
+    .execute(pool)
+    .await
+    .expect("edge_group");
+}
+
+async fn emit_stale(
+    pool: &PgPool,
+    upstream: Uuid,
+    flow_id: Option<Uuid>,
+    outcome: &str,
+    committed_at_ms: i64,
+    namespace: Option<&str>,
+) -> i64 {
+    let row = sqlx::query(
+        "INSERT INTO ff_completion_event \
+             (partition_key, execution_id, flow_id, outcome, namespace, \
+              occurred_at_ms, committed_at_ms) \
+         VALUES ($1, $2, $3, $4, $5, 0, $6) RETURNING event_id",
+    )
+    .bind(P)
+    .bind(upstream)
+    .bind(flow_id)
+    .bind(outcome)
+    .bind(namespace)
+    .bind(committed_at_ms)
+    .fetch_one(pool)
+    .await
+    .expect("emit");
+    row.get("event_id")
+}
+
+async fn dispatched_at(pool: &PgPool, event_id: i64) -> Option<i64> {
+    let row = sqlx::query("SELECT dispatched_at_ms FROM ff_completion_event WHERE event_id = $1")
+        .bind(event_id)
+        .fetch_one(pool)
+        .await
+        .expect("read");
+    row.get("dispatched_at_ms")
+}
+
+async fn exec_eligibility(pool: &PgPool, eid: Uuid) -> String {
+    let row = sqlx::query("SELECT eligibility_state FROM ff_exec_core WHERE execution_id = $1")
+        .bind(eid)
+        .fetch_one(pool)
+        .await
+        .expect("read");
+    row.get("eligibility_state")
+}
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX)
+}
+
+// ── Test 1: Normal sweep ────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn normal_sweep_reconciles_stale_event() {
+    let Some(pool) = setup_or_skip().await else { return };
+
+    let flow = insert_flow(&pool).await;
+    let upstream = Uuid::new_v4();
+    let downstream = Uuid::new_v4();
+    insert_exec_with_id(&pool, upstream, flow, "active", "not_applicable", "running", "running").await;
+    insert_exec_with_id(&pool, downstream, flow, "blocked", "blocked", "pending", "pending").await;
+    insert_edge(&pool, flow, upstream, downstream).await;
+    insert_edge_group(&pool, flow, downstream, 1, serde_json::json!({"kind": "all_of"}), 1).await;
+
+    let tstart = now_ms();
+    let ev = emit_stale(&pool, upstream, Some(flow), "success", tstart - 5_000, None).await;
+    assert!(dispatched_at(&pool, ev).await.is_none(), "event starts undispatched");
+
+    let report: ReconcileReport = reconcile_tick(&pool, &ScannerFilter::NOOP, 1_000)
+        .await
+        .expect("reconcile");
+    assert_eq!(report.scanned, 1);
+    assert_eq!(report.reconciled, 1);
+    assert_eq!(report.errors, 0);
+
+    assert!(dispatched_at(&pool, ev).await.is_some(), "claim flipped");
+    assert_eq!(exec_eligibility(&pool, downstream).await, "eligible_now");
+}
+
+// ── Test 2: Crash mid-cascade (2 hops) ──────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn crash_mid_cascade_two_hops() {
+    let Some(pool) = setup_or_skip().await else { return };
+
+    let flow = insert_flow(&pool).await;
+    let upstream = Uuid::new_v4();
+    let mid = Uuid::new_v4();
+    let leaf = Uuid::new_v4();
+    insert_exec_with_id(&pool, upstream, flow, "active", "not_applicable", "running", "running").await;
+    insert_exec_with_id(&pool, mid, flow, "blocked", "blocked", "pending", "pending").await;
+    insert_exec_with_id(&pool, leaf, flow, "blocked", "blocked", "pending", "pending").await;
+    insert_edge(&pool, flow, upstream, mid).await;
+    insert_edge(&pool, flow, mid, leaf).await;
+    insert_edge_group(&pool, flow, mid, 1, serde_json::json!({"kind": "all_of"}), 1).await;
+    insert_edge_group(&pool, flow, leaf, 1, serde_json::json!({"kind": "all_of"}), 1).await;
+
+    let tstart = now_ms();
+    let ev1 = emit_stale(&pool, upstream, Some(flow), "success", tstart - 5_000, None).await;
+    dispatch::dispatch_completion(&pool, ev1).await.expect("hop1");
+    assert_eq!(exec_eligibility(&pool, mid).await, "eligible_now");
+
+    // Simulated crash: `mid` completed, its event landed, but the
+    // dispatcher never claimed it.
+    let ev2 = emit_stale(&pool, mid, Some(flow), "success", tstart - 5_000, None).await;
+    assert!(dispatched_at(&pool, ev2).await.is_none());
+
+    let report = reconcile_tick(&pool, &ScannerFilter::NOOP, 1_000)
+        .await
+        .expect("reconcile");
+    assert_eq!(report.reconciled, 1, "reconciler dispatched hop 2");
+    assert_eq!(exec_eligibility(&pool, leaf).await, "eligible_now");
+}
+
+// ── Test 3: Idempotency ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn reconciler_idempotent_on_second_tick() {
+    let Some(pool) = setup_or_skip().await else { return };
+
+    let flow = insert_flow(&pool).await;
+    let upstream = Uuid::new_v4();
+    let downstream = Uuid::new_v4();
+    insert_exec_with_id(&pool, upstream, flow, "active", "not_applicable", "running", "running").await;
+    insert_exec_with_id(&pool, downstream, flow, "blocked", "blocked", "pending", "pending").await;
+    insert_edge(&pool, flow, upstream, downstream).await;
+    insert_edge_group(&pool, flow, downstream, 1, serde_json::json!({"kind": "all_of"}), 1).await;
+
+    let tstart = now_ms();
+    let _ev = emit_stale(&pool, upstream, Some(flow), "success", tstart - 5_000, None).await;
+
+    let first = reconcile_tick(&pool, &ScannerFilter::NOOP, 1_000).await.expect("t1");
+    let second = reconcile_tick(&pool, &ScannerFilter::NOOP, 1_000).await.expect("t2");
+
+    assert_eq!(first.scanned, 1);
+    assert_eq!(first.reconciled, 1);
+    assert_eq!(second.scanned, 0, "second tick sees nothing to sweep");
+    assert_eq!(second.reconciled, 0);
+    assert_eq!(second.errors, 0);
+}
+
+// ── Test 4: Namespace filter ────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn scanner_filter_excludes_nonmatching_namespace() {
+    let Some(pool) = setup_or_skip().await else { return };
+
+    let flow = insert_flow(&pool).await;
+    let up_a = Uuid::new_v4();
+    let down_a = Uuid::new_v4();
+    let up_b = Uuid::new_v4();
+    let down_b = Uuid::new_v4();
+    for (u, d) in [(up_a, down_a), (up_b, down_b)] {
+        insert_exec_with_id(&pool, u, flow, "active", "not_applicable", "running", "running").await;
+        insert_exec_with_id(&pool, d, flow, "blocked", "blocked", "pending", "pending").await;
+        insert_edge(&pool, flow, u, d).await;
+        insert_edge_group(&pool, flow, d, 1, serde_json::json!({"kind": "all_of"}), 1).await;
+    }
+
+    let tstart = now_ms();
+    let ev_a = emit_stale(&pool, up_a, Some(flow), "success", tstart - 5_000, Some("tenant-a")).await;
+    let ev_b = emit_stale(&pool, up_b, Some(flow), "success", tstart - 5_000, Some("tenant-b")).await;
+
+    let filter = ScannerFilter::new().with_namespace("tenant-a");
+    let report = reconcile_tick(&pool, &filter, 1_000).await.expect("reconcile");
+
+    assert_eq!(report.scanned, 1);
+    assert_eq!(report.reconciled, 1);
+    assert!(dispatched_at(&pool, ev_a).await.is_some(), "tenant-a dispatched");
+    assert!(dispatched_at(&pool, ev_b).await.is_none(), "tenant-b untouched");
+    assert_eq!(exec_eligibility(&pool, down_a).await, "eligible_now");
+    assert_eq!(exec_eligibility(&pool, down_b).await, "blocked");
+}
+
+// ── Test 5: Transitive 3-hop sweep ──────────────────────────────────────
+//
+// Linear 3-hop: root → a → b → c. We simulate the scheduler
+// completing each middle hop between reconciler ticks; the test
+// asserts the reconciler walks the entire transitive set (not just
+// 1-hop children of root), consistent with the K-2 round-2 contract.
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn transitive_three_hop_sweep() {
+    let Some(pool) = setup_or_skip().await else { return };
+
+    let flow = insert_flow(&pool).await;
+    let root = Uuid::new_v4();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    insert_exec_with_id(&pool, root, flow, "active", "not_applicable", "running", "running").await;
+    for d in [a, b, c] {
+        insert_exec_with_id(&pool, d, flow, "blocked", "blocked", "pending", "pending").await;
+    }
+    insert_edge(&pool, flow, root, a).await;
+    insert_edge(&pool, flow, a, b).await;
+    insert_edge(&pool, flow, b, c).await;
+    for d in [a, b, c] {
+        insert_edge_group(&pool, flow, d, 1, serde_json::json!({"kind": "all_of"}), 1).await;
+    }
+
+    let tstart = now_ms();
+    let _ev_root = emit_stale(&pool, root, Some(flow), "success", tstart - 5_000, None).await;
+
+    // Threshold=0: any past `committed_at_ms` qualifies. Lets us
+    // deterministically test without waiting real wall-clock time.
+    let r1 = reconcile_tick(&pool, &ScannerFilter::NOOP, 0).await.expect("t1");
+    assert!(r1.reconciled >= 1, "tick 1 reconciled root");
+    assert_eq!(exec_eligibility(&pool, a).await, "eligible_now");
+
+    let _ev_a = emit_stale(&pool, a, Some(flow), "success", tstart - 4_000, None).await;
+    let r2 = reconcile_tick(&pool, &ScannerFilter::NOOP, 0).await.expect("t2");
+    assert!(r2.reconciled >= 1, "tick 2 reconciled a");
+    assert_eq!(exec_eligibility(&pool, b).await, "eligible_now");
+
+    let _ev_b = emit_stale(&pool, b, Some(flow), "success", tstart - 3_000, None).await;
+    let r3 = reconcile_tick(&pool, &ScannerFilter::NOOP, 0).await.expect("t3");
+    assert!(r3.reconciled >= 1, "tick 3 reconciled b");
+    assert_eq!(exec_eligibility(&pool, c).await, "eligible_now");
+}


### PR DESCRIPTION
## Summary

- Ships the Wave 6a Postgres `dependency_reconciler` — the backstop for the per-hop-tx cascade from Wave 5a (`dispatch_completion`).
- Scans `ff_completion_event` WHERE `dispatched_at_ms IS NULL AND committed_at_ms < now_ms - threshold` (default 1 000 ms) and re-invokes `dispatch_completion`, idempotent via the existing claim UPDATE.
- `ScannerFilter` pushed down to SQL via `namespace` + `instance_tag` columns on the event row — no per-candidate RTT.

## Transitive-descendant sweep (K-2 round-2)

Structural: every `PolicyDecision::{Satisfied,Impossible}` that terminates a downstream INSERTs a new `ff_completion_event` inside the same per-hop tx (`dispatch.rs` ~L430). A crash between hop N's commit and hop N+1's claim leaves hop N's event durable + unclaimed; the reconciler catches it via the `ff_completion_event_pending_dispatch_idx` partial index and cascades forward. A depth-D chain drains in at most D reconciler ticks.

## Changes

- `crates/ff-backend-postgres/src/reconcilers/{mod,dependency}.rs` — new
- `crates/ff-backend-postgres/src/lib.rs` — `mod reconcilers;` (core-gated)
- `crates/ff-engine/src/scanner/dependency_reconciler.rs` — `reconcile_via_postgres` under `#[cfg(feature = "postgres")]`
- `crates/ff-test/tests/pg_reconciler_dependency.rs` — new, 5 tests

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-backend-postgres -p ff-engine --all-features -- -D warnings` clean
- [x] 5/5 tests pass against live Postgres (`FF_PG_TEST_URL=postgres://postgres:postgres@localhost/ff_wave6a_test`):
  - `normal_sweep_reconciles_stale_event`
  - `crash_mid_cascade_two_hops`
  - `reconciler_idempotent_on_second_tick`
  - `scanner_filter_excludes_nonmatching_namespace`
  - `transitive_three_hop_sweep`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres scanner logic that re-dispatches stale `ff_completion_event` rows and can advance dependency cascades; incorrect query/filtering or threshold tuning could cause missed dispatches or extra load.
> 
> **Overview**
> Adds a **Postgres dependency reconciler** (`reconcile_tick`) that periodically scans `ff_completion_event` for *stale, undispatched* rows (`dispatched_at_ms IS NULL` older than a threshold) and re-invokes `dispatch_completion` as a backstop for interrupted per-hop dispatch cascades.
> 
> Integrates this into the engine via `reconcile_via_postgres` (feature-gated), exposes the new `reconcilers` module from `ff-backend-postgres`, and adds live-Postgres integration tests covering normal sweeps, mid-cascade recovery, idempotency, namespace filtering, and transitive multi-hop draining.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60607703f2d5830b69e26e89220e86074fe48dda. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->