### PR TITLE
feat(pg-wave6d): Postgres completion_listener drains outbox via dispatch_completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,8 +1051,10 @@ dependencies = [
  "ff-observability",
  "futures",
  "serde_json",
+ "sqlx",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -17,8 +17,10 @@ description = "FlowFabric cross-partition dispatch and background scanners"
 observability = ["ff-observability/enabled"]
 # Wave 5a: enable the Postgres dispatch branch in `partition_router`.
 # Pulls `ff-backend-postgres` as a direct dep. OFF by default; the
-# Valkey-only build stays lean.
-postgres = ["dep:ff-backend-postgres"]
+# Valkey-only build stays lean. Wave 6d extends this feature to gate
+# the Postgres completion_listener drain loop, which adds `sqlx` +
+# `uuid` for the outbox event_id resolution query.
+postgres = ["dep:ff-backend-postgres", "dep:sqlx", "dep:uuid"]
 
 [dependencies]
 ff-core = { workspace = true }
@@ -31,3 +33,8 @@ tracing = { workspace = true }
 # Wave 5a: Postgres dispatch delegate. Activated by `postgres`
 # feature only; stays out of the Valkey-only dep graph.
 ff-backend-postgres = { workspace = true, optional = true }
+# Wave 6d: Postgres completion_listener outbox drain. `sqlx` for the
+# event_id resolution query; `uuid` to decode the ExecutionId suffix.
+# Both flip on with the `postgres` feature only.
+sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls"], optional = true }
+uuid = { workspace = true, optional = true }

--- a/crates/ff-engine/src/completion_listener.rs
+++ b/crates/ff-engine/src/completion_listener.rs
@@ -124,3 +124,161 @@ async fn handle_completion(
     )
     .await;
 }
+
+// ── Postgres completion listener (Wave 6d) ───────────────────────────
+//
+// Drains the `ff_completion_event` outbox via the Postgres
+// `CompletionBackend` stream (Wave 4h) and invokes
+// `ff_backend_postgres::dispatch::dispatch_completion(pool, event_id)`
+// (Wave 5a) per event to cascade DAG promotion.
+//
+// ## event_id plumbing
+//
+// `CompletionPayload` (ff-core) does NOT carry `event_id`. The Wave 4h
+// stream emits payloads in strict `event_id ASC` order but drops the
+// cursor on the way out. Rather than extend the ff-core type (which
+// would leak a Postgres-specific field into the Valkey backend), we
+// resolve each payload to its event_id by looking up the smallest
+// `event_id > last_seen` that matches the payload's
+// `(execution_id_uuid, occurred_at_ms)`. `last_seen` is a monotonic
+// cursor seeded from `max(event_id)` at startup — matching the Wave 4h
+// stream's own starting cursor, so we never dispatch an event that
+// existed before we subscribed (the dependency_reconciler is the
+// backstop for those).
+//
+// ## Failure handling
+//
+// Per Wave 6a contract, `dispatch_completion` failures are logged and
+// the listener continues — the Wave 6a reconciler claims any event
+// whose `dispatched_at_ms` stays NULL past its grace window.
+
+#[cfg(feature = "postgres")]
+pub use postgres_listener::run_completion_listener_postgres;
+
+#[cfg(feature = "postgres")]
+mod postgres_listener {
+    use super::*;
+    use ff_core::backend::ScannerFilter;
+    use ff_core::completion_backend::CompletionBackend;
+    use ff_core::engine_error::EngineError;
+    use sqlx::PgPool;
+
+    /// Shutdown signal for the Postgres completion listener.
+    ///
+    /// Accepts the same `watch::Receiver<bool>` that the Valkey
+    /// dispatch loop uses (set to `true` to shut down) so the engine's
+    /// existing shutdown plumbing drives both branches.
+    pub type ShutdownRx = watch::Receiver<bool>;
+
+    /// Run the Postgres completion-listener drain loop. Returns when
+    /// `shutdown` fires or the stream ends.
+    ///
+    /// `backend` is a `CompletionBackend` (typically a
+    /// `PostgresBackend`) whose `subscribe_completions` yields
+    /// `ff_completion_event` rows; `pool` is the dispatch pool used by
+    /// `dispatch_completion` to run the cascade tx.
+    pub async fn run_completion_listener_postgres(
+        backend: Arc<dyn CompletionBackend>,
+        pool: PgPool,
+        shutdown: ShutdownRx,
+    ) -> Result<(), EngineError> {
+        let stream = backend.subscribe_completions().await?;
+        run_with_stream(stream, pool, shutdown).await
+    }
+
+    /// Same contract with a pre-built `ScannerFilter` for multi-tenant
+    /// deployments (issue #122).
+    #[allow(dead_code)]
+    pub async fn run_completion_listener_postgres_filtered(
+        backend: Arc<dyn CompletionBackend>,
+        pool: PgPool,
+        filter: ScannerFilter,
+        shutdown: ShutdownRx,
+    ) -> Result<(), EngineError> {
+        let stream = backend.subscribe_completions_filtered(&filter).await?;
+        run_with_stream(stream, pool, shutdown).await
+    }
+
+    async fn run_with_stream(
+        mut stream: CompletionStream,
+        pool: PgPool,
+        mut shutdown: ShutdownRx,
+    ) -> Result<(), EngineError> {
+        // `last_seen` starts at the outbox's current max so we never
+        // bind to a pre-subscribe event_id. The Wave 4h stream uses the
+        // same starting cursor internally; this keeps the two cursors
+        // aligned so the `event_id > last_seen` lookup always finds the
+        // row the stream just emitted.
+        let mut last_seen: i64 =
+            sqlx::query_scalar("SELECT COALESCE(MAX(event_id), 0) FROM ff_completion_event")
+                .fetch_one(&pool)
+                .await
+                .map_err(|_| EngineError::Unavailable {
+                    op: "pg.completion_listener (max(event_id))",
+                })?;
+
+        loop {
+            tokio::select! {
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() {
+                        return Ok(());
+                    }
+                }
+                maybe_payload = next_payload(&mut stream) => {
+                    let Some(payload) = maybe_payload else {
+                        tracing::warn!(
+                            "pg.completion_listener: stream ended, loop exiting"
+                        );
+                        return Ok(());
+                    };
+                    if let Some(event_id) = resolve_event_id(&pool, &payload, last_seen).await {
+                        last_seen = event_id;
+                        if let Err(e) = ff_backend_postgres::dispatch::dispatch_completion(
+                            &pool, event_id,
+                        ).await {
+                            tracing::warn!(
+                                event_id,
+                                error = %e,
+                                "pg.completion_listener: dispatch failed, reconciler will retry"
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            execution_id = %payload.execution_id,
+                            occurred_at_ms = payload.produced_at_ms.0,
+                            "pg.completion_listener: could not resolve event_id; \
+                             reconciler will claim"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Look up the next unseen `event_id` for this payload's
+    /// `(execution_id_uuid, occurred_at_ms)`. Returns `None` if the
+    /// outbox lookup fails or no matching row exists above the cursor.
+    async fn resolve_event_id(
+        pool: &PgPool,
+        payload: &CompletionPayload,
+        last_seen: i64,
+    ) -> Option<i64> {
+        // Extract the bare uuid from the `{fp:N}:<uuid>` form.
+        let eid_str = payload.execution_id.as_str();
+        let uuid_str = eid_str.rsplit_once(':').map(|(_, u)| u)?;
+        let uuid = uuid::Uuid::parse_str(uuid_str).ok()?;
+
+        sqlx::query_scalar::<_, i64>(
+            "SELECT event_id FROM ff_completion_event \
+             WHERE event_id > $1 AND execution_id = $2 AND occurred_at_ms = $3 \
+             ORDER BY event_id ASC LIMIT 1",
+        )
+        .bind(last_seen)
+        .bind(uuid)
+        .bind(payload.produced_at_ms.0)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+    }
+}

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -17,7 +17,7 @@ release = false
 
 [dependencies]
 ff-core = { workspace = true }
-ff-engine = { workspace = true }
+ff-engine = { workspace = true, features = ["postgres"] }
 ff-scheduler = { workspace = true }
 # Issue #171: test fixtures use FCALL helpers + ferriskey::Value parsers.
 ff-script = { workspace = true, features = ["valkey-client"] }

--- a/crates/ff-test/tests/pg_completion_listener.rs
+++ b/crates/ff-test/tests/pg_completion_listener.rs
@@ -1,0 +1,256 @@
+//! Wave 6d — Postgres completion listener outbox drain.
+//!
+//! The listener subscribes to the Wave 4h `CompletionBackend` stream,
+//! resolves each payload to its `event_id` via the
+//! `(execution_id, occurred_at_ms)` index on `ff_completion_event`,
+//! and invokes Wave 5a's `dispatch_completion` to run the per-hop-tx
+//! cascade.
+//!
+//! Coverage:
+//!
+//! 1. Happy path — emit a completion event with a downstream edge,
+//!    the listener picks it up, dispatches, downstream flips from
+//!    `blocked` to `eligible_now`, and the outbox row is marked
+//!    `dispatched_at_ms IS NOT NULL`.
+//! 2. Subscriber drop — cancelling the watch fires a clean shutdown
+//!    (JoinHandle resolves within 2s).
+//! 3. Burst — emit 10 completions in quick succession, listener
+//!    dispatches all 10 exactly once (each `dispatched_at_ms` is
+//!    stamped; a follow-up call to `dispatch_completion` on the same
+//!    event returns `NoOp`).
+//!
+//! # Running
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://postgres:postgres@localhost/ff_wave6d_test \
+//!   cargo test -p ff-test --test pg_completion_listener -- --ignored --test-threads=1
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ff_backend_postgres::{apply_migrations, dispatch, PostgresBackend};
+use ff_core::completion_backend::CompletionBackend;
+use ff_core::partition::PartitionConfig;
+use ff_engine::completion_listener::run_completion_listener_postgres;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use tokio::sync::watch;
+use uuid::Uuid;
+
+const P: i16 = 0;
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(16)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    apply_migrations(&pool).await.expect("apply_migrations");
+    for stmt in [
+        "DELETE FROM ff_pending_cancel_groups",
+        "DELETE FROM ff_completion_event",
+        "DELETE FROM ff_edge_group",
+        "DELETE FROM ff_edge",
+        "DELETE FROM ff_exec_core",
+        "DELETE FROM ff_flow_core",
+    ] {
+        sqlx::query(stmt).execute(&pool).await.expect("reset");
+    }
+    Some(pool)
+}
+
+/// Seed a minimal AllOf(1) cascade: one flow, one downstream blocked
+/// on one upstream edge. Returns (flow_id, downstream_eid, upstream_eid).
+async fn seed_simple_flow(pool: &PgPool) -> (Uuid, Uuid, Uuid) {
+    let flow_id = Uuid::new_v4();
+    let downstream = Uuid::new_v4();
+    let upstream = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_flow_core (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms) \
+         VALUES ($1, $2, 0, 'running', 0)",
+    )
+    .bind(P).bind(flow_id).execute(pool).await.unwrap();
+    sqlx::query(
+        "INSERT INTO ff_exec_core (partition_key, execution_id, flow_id, lane_id, \
+         lifecycle_phase, ownership_state, eligibility_state, public_state, attempt_state, \
+         created_at_ms) VALUES ($1, $2, $3, 'default', 'blocked', 'unowned', 'blocked', 'pending', 'pending', 0)",
+    )
+    .bind(P).bind(downstream).bind(flow_id).execute(pool).await.unwrap();
+    sqlx::query(
+        "INSERT INTO ff_exec_core (partition_key, execution_id, flow_id, lane_id, \
+         lifecycle_phase, ownership_state, eligibility_state, public_state, attempt_state, \
+         created_at_ms) VALUES ($1, $2, $3, 'default', 'active', 'leased', 'not_applicable', 'running', 'running', 0)",
+    )
+    .bind(P).bind(upstream).bind(flow_id).execute(pool).await.unwrap();
+    sqlx::query(
+        "INSERT INTO ff_edge (partition_key, flow_id, edge_id, upstream_eid, downstream_eid, policy) \
+         VALUES ($1, $2, $3, $4, $5, '{}'::jsonb)",
+    )
+    .bind(P).bind(flow_id).bind(Uuid::new_v4()).bind(upstream).bind(downstream)
+    .execute(pool).await.unwrap();
+    sqlx::query(
+        "INSERT INTO ff_edge_group (partition_key, flow_id, downstream_eid, policy, k_target, \
+         success_count, fail_count, skip_count, running_count) \
+         VALUES ($1, $2, $3, $4, 1, 0, 0, 0, 1)",
+    )
+    .bind(P).bind(flow_id).bind(downstream).bind(serde_json::json!({"kind": "all_of"}))
+    .execute(pool).await.unwrap();
+    (flow_id, downstream, upstream)
+}
+
+/// Emit a completion event; the trigger fires NOTIFY on commit.
+async fn emit(pool: &PgPool, exec: Uuid, flow: Uuid, outcome: &str, occurred_at_ms: i64) -> i64 {
+    let row = sqlx::query(
+        "INSERT INTO ff_completion_event (partition_key, execution_id, flow_id, outcome, occurred_at_ms) \
+         VALUES ($1, $2, $3, $4, $5) RETURNING event_id",
+    )
+    .bind(P).bind(exec).bind(flow).bind(outcome).bind(occurred_at_ms)
+    .fetch_one(pool).await.expect("emit");
+    row.get::<i64, _>("event_id")
+}
+
+async fn eligibility(pool: &PgPool, exec: Uuid) -> String {
+    let row = sqlx::query("SELECT eligibility_state FROM ff_exec_core WHERE execution_id = $1")
+        .bind(exec).fetch_one(pool).await.expect("read");
+    row.get("eligibility_state")
+}
+
+async fn dispatched_count(pool: &PgPool) -> i64 {
+    let row = sqlx::query("SELECT COUNT(*)::bigint AS c FROM ff_completion_event WHERE dispatched_at_ms IS NOT NULL")
+        .fetch_one(pool).await.expect("count dispatched");
+    row.get("c")
+}
+
+// ── Test 1: Happy path ───────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn listener_dispatches_single_completion() {
+    let Some(pool) = setup_or_skip().await else { return };
+    let (flow, downstream, upstream) = seed_simple_flow(&pool).await;
+
+    let backend: Arc<dyn CompletionBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let pool_clone = pool.clone();
+    let handle = tokio::spawn(async move {
+        run_completion_listener_postgres(backend, pool_clone, shutdown_rx).await
+    });
+
+    // Give the subscriber task time to LISTEN before we emit.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    emit(&pool, upstream, flow, "success", 1_700_000_000_000).await;
+
+    // Poll for the downstream flip — cascade should run within a second
+    // over loopback Postgres.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if eligibility(&pool, downstream).await == "eligible_now" {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("downstream did not flip within 5s");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    assert_eq!(dispatched_count(&pool).await, 1);
+
+    let _ = shutdown_tx.send(true);
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await
+        .expect("listener shuts down within 2s");
+}
+
+// ── Test 2: Subscriber drop / clean shutdown ─────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn listener_shuts_down_on_watch_signal() {
+    let Some(pool) = setup_or_skip().await else { return };
+    let backend: Arc<dyn CompletionBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let pool_clone = pool.clone();
+    let handle = tokio::spawn(async move {
+        run_completion_listener_postgres(backend, pool_clone, shutdown_rx).await
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _ = shutdown_tx.send(true);
+
+    let res = tokio::time::timeout(Duration::from_secs(2), handle).await
+        .expect("listener joins within 2s")
+        .expect("task not cancelled");
+    assert!(res.is_ok(), "listener returned Ok on clean shutdown");
+}
+
+// ── Test 3: Burst — 10 completions dispatched exactly once ───────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn listener_dispatches_burst_exactly_once() {
+    let Some(pool) = setup_or_skip().await else { return };
+
+    // Seed 10 independent no-flow completions. `dispatch_completion`
+    // on a flow_id=None row short-circuits to Advanced(0) after flipping
+    // `dispatched_at_ms` — perfect for asserting "dispatched exactly
+    // once" via the outbox row count without needing 10 flow-graphs.
+    let mut execs = Vec::new();
+    for _ in 0..10 {
+        execs.push(Uuid::new_v4());
+    }
+
+    let backend: Arc<dyn CompletionBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let pool_clone = pool.clone();
+    let handle = tokio::spawn(async move {
+        run_completion_listener_postgres(backend, pool_clone, shutdown_rx).await
+    });
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Burst-insert 10 completions in a single tx; NOTIFY fires once on
+    // commit and the stream drains all 10 via cursor replay.
+    let mut tx = pool.begin().await.unwrap();
+    let mut event_ids = Vec::new();
+    for (i, exec) in execs.iter().enumerate() {
+        let row = sqlx::query(
+            "INSERT INTO ff_completion_event (partition_key, execution_id, outcome, occurred_at_ms) \
+             VALUES ($1, $2, 'success', $3) RETURNING event_id",
+        )
+        .bind(P).bind(exec).bind(1_700_000_000_000_i64 + i as i64)
+        .fetch_one(&mut *tx).await.unwrap();
+        event_ids.push(row.get::<i64, _>("event_id"));
+    }
+    tx.commit().await.unwrap();
+
+    // Wait for all 10 to be dispatched.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if dispatched_count(&pool).await >= 10 {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("only {} / 10 dispatched within 10s", dispatched_count(&pool).await);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Exactly-once: re-dispatching any of the claimed event_ids yields
+    // NoOp (the `dispatched_at_ms IS NULL` guard holds).
+    for ev in &event_ids {
+        let out = dispatch::dispatch_completion(&pool, *ev).await.expect("replay");
+        assert!(
+            matches!(out, dispatch::DispatchOutcome::NoOp),
+            "event {ev} should be NoOp on replay, got {:?}", out
+        );
+    }
+
+    let _ = shutdown_tx.send(true);
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await
+        .expect("listener shuts down within 2s");
+}


### PR DESCRIPTION
## Summary

- Wave 6d adds `run_completion_listener_postgres` in ff-engine (behind the `postgres` feature) that drains the Wave 4h `CompletionBackend` stream and invokes Wave 5a's `dispatch_completion(pool, event_id)` per event to cascade DAG promotion.
- event_id plumbing: `CompletionPayload` (ff-core) does not carry `event_id`. Rather than leak a Postgres-specific field into the Valkey-shared type, the listener resolves each payload to its `event_id` by looking up the smallest `event_id > last_seen` matching `(execution_id_uuid, occurred_at_ms)` on the outbox, with a monotonic `last_seen` cursor seeded from `max(event_id)` at startup — aligned with the Wave 4h stream's own starting cursor.
- Dispatch failures are logged at `warn!` with the `event_id` and the loop continues; the Wave 6a reconciler is the backstop for any outbox row whose `dispatched_at_ms` stays NULL.
- Shutdown via `watch::Receiver<bool>`, matching the existing Valkey dispatch loop's pattern (avoids a new `tokio-util` dep).

## Lane discipline

- Stayed in ff-engine + ff-test; no edits to `ff-backend-postgres/src/**` (parallel siblings 6a/6b/6c own those).

## Test plan

- [x] `cargo check --workspace --all-features` green.
- [x] `cargo test -p ff-engine --all-features` green (4 existing unit tests pass).
- [x] Test file compiles under `cargo test -p ff-test --test pg_completion_listener --no-run`.
- [ ] Run `FF_PG_TEST_URL=... cargo test -p ff-test --test pg_completion_listener -- --ignored --test-threads=1` against a live Postgres in CI (3 cases: single-dispatch happy path, clean shutdown, 10-event burst with exactly-once assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres-only completion drain loop that queries the outbox and triggers `dispatch_completion`, which could affect DAG promotion behavior and database load when the `postgres` feature is enabled. Changes are feature-gated and include ignored integration tests, reducing default impact but still touching core dispatch flow for Postgres deployments.
> 
> **Overview**
> Adds a **Postgres-gated** completion listener in `ff-engine` (`run_completion_listener_postgres`) that drains the Postgres `CompletionBackend` stream and calls `ff_backend_postgres::dispatch::dispatch_completion` per completion to drive DAG promotion.
> 
> Because `CompletionPayload` lacks `event_id`, the listener resolves `event_id` via a monotonic `last_seen` cursor plus an outbox lookup on `(execution_id_uuid, occurred_at_ms)`, logs and continues on dispatch/lookup failures, and supports shutdown via `watch::Receiver<bool>`.
> 
> Updates feature/dependency wiring (`ff-engine` `postgres` feature now pulls in `sqlx` + `uuid`) and adds ignored `ff-test` integration coverage for happy-path dispatch, clean shutdown, and burst/"exactly once" outbox claiming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24fb7e6f8699c807c198c7b37b17f77889637583. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->