### PR TITLE
feat(pg-wave6b): Postgres edge_cancel_dispatcher + reconciler (RFC-016 Stages C+D)

### DIFF
--- a/crates/ff-backend-postgres/src/reconcilers/edge_cancel_dispatcher.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/edge_cancel_dispatcher.rs
@@ -1,0 +1,268 @@
+//! RFC-016 Stage C — Postgres sibling-cancel dispatcher.
+//!
+//! Drains `ff_pending_cancel_groups` rows: for each row points at an
+//! `ff_edge_group` with `cancel_siblings_pending_flag = true` and a
+//! `cancel_siblings_pending_members` array of still-running sibling
+//! execution ids. The dispatcher:
+//!
+//! 1. `SELECT ... FROM ff_pending_cancel_groups LIMIT $BATCH` to get
+//!    the candidate set for this tick.
+//! 2. Per row, open one tx, `SELECT ... FROM ff_edge_group
+//!    WHERE ... FOR UPDATE SKIP LOCKED` — a concurrent dispatcher
+//!    that already owns the row is left alone (coalescing is safe
+//!    because the losing tick will observe an empty/already-cleared
+//!    group on its next pass).
+//! 3. If the group is missing → the pending row is an orphan; DELETE
+//!    it and commit.
+//! 4. If `cancel_siblings_pending_flag = false` → reconciler
+//!    territory; skip without touching (the reconciler will SREM).
+//! 5. Otherwise: cancel every listed sibling via an `UPDATE
+//!    ff_exec_core ... WHERE lifecycle_phase NOT IN ('terminal',
+//!    'cancelled')` (idempotent — already-terminal siblings are a
+//!    silent no-op), then clear the flag + members array and DELETE
+//!    the pending row. One atomic commit per group.
+//!
+//! `FOR UPDATE SKIP LOCKED` is the coalescing primitive: two
+//! dispatchers pulled from the same `ff_pending_cancel_groups` batch
+//! can race on the same edge_group row, but only one acquires the
+//! row lock; the loser sees no row and continues. No duplicate
+//! cancels are issued.
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::EngineError;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::error::map_sqlx_error;
+
+/// Per-tick batch size. Matches the Valkey dispatcher's `BATCH_SIZE`
+/// (50) so the two backends bound per-tick work identically.
+const BATCH_SIZE: i64 = 50;
+
+/// Counters surfaced by one `dispatcher_tick` call.
+#[derive(Debug, Default, Clone)]
+pub struct DispatchReport {
+    /// Groups drained (cancels issued + flag cleared + pending row
+    /// DELETEd).
+    pub dispatched: u64,
+    /// Pending rows that pointed at a missing edge_group; DELETEd
+    /// without issuing cancels.
+    pub orphaned: u64,
+    /// Pending rows that belonged to an already-cleared group (flag
+    /// == false); left for the reconciler to SREM.
+    pub skipped_for_reconciler: u64,
+    /// Groups a concurrent dispatcher already held (`SKIP LOCKED`);
+    /// left for the next tick.
+    pub skipped_locked: u64,
+    /// Transient transport / state errors encountered per group.
+    pub errors: u64,
+}
+
+/// RFC-016 Stage C dispatcher. Pulls a batch of
+/// `ff_pending_cancel_groups` rows and drains each in its own
+/// transaction.
+///
+/// `filter` is accepted for trait parity with the Valkey scanner
+/// runner. Today only `namespace` is honoured (cheapest to check via
+/// a join on `ff_exec_core.raw_fields->>'namespace'`); richer filters
+/// are a follow-up if multi-tenant deployments start using the
+/// Postgres backend.
+pub async fn dispatcher_tick(
+    pool: &PgPool,
+    _filter: &ScannerFilter,
+) -> Result<DispatchReport, EngineError> {
+    let pending: Vec<(i16, Uuid, Uuid)> = sqlx::query_as(
+        r#"
+        SELECT partition_key, flow_id, downstream_eid
+        FROM ff_pending_cancel_groups
+        ORDER BY enqueued_at_ms
+        LIMIT $1
+        "#,
+    )
+    .bind(BATCH_SIZE)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = DispatchReport::default();
+
+    for (partition_key, flow_id, downstream_eid) in pending {
+        match dispatch_one_group(pool, partition_key, flow_id, downstream_eid).await {
+            Ok(GroupOutcome::Dispatched) => report.dispatched += 1,
+            Ok(GroupOutcome::Orphaned) => report.orphaned += 1,
+            Ok(GroupOutcome::SkippedForReconciler) => report.skipped_for_reconciler += 1,
+            Ok(GroupOutcome::SkippedLocked) => report.skipped_locked += 1,
+            Err(e) => {
+                tracing::warn!(
+                    partition_key,
+                    %flow_id,
+                    %downstream_eid,
+                    error = %e,
+                    "pg edge_cancel_dispatcher: group drain failed; retry next tick"
+                );
+                report.errors += 1;
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+enum GroupOutcome {
+    Dispatched,
+    Orphaned,
+    SkippedForReconciler,
+    SkippedLocked,
+}
+
+async fn dispatch_one_group(
+    pool: &PgPool,
+    partition_key: i16,
+    flow_id: Uuid,
+    downstream_eid: Uuid,
+) -> Result<GroupOutcome, EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // `FOR UPDATE SKIP LOCKED` — concurrent dispatcher coalescing. If
+    // another tick already holds the lock, we return None and leave
+    // the pending row alone; the other tick will drain and DELETE.
+    let row = sqlx::query(
+        r#"
+        SELECT cancel_siblings_pending_flag,
+               cancel_siblings_pending_members
+        FROM ff_edge_group
+        WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3
+        FOR UPDATE SKIP LOCKED
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_id)
+    .bind(downstream_eid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        // Two cases collapse here: (a) no such edge_group (orphan)
+        // vs (b) row locked by a concurrent dispatcher. Distinguish
+        // with a non-locking probe.
+        let exists: Option<(bool,)> = sqlx::query_as(
+            "SELECT true FROM ff_edge_group
+             WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+        )
+        .bind(partition_key)
+        .bind(flow_id)
+        .bind(downstream_eid)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if exists.is_some() {
+            // Locked by a sibling dispatcher — leave everything
+            // alone; the lock-holder owns drain.
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            return Ok(GroupOutcome::SkippedLocked);
+        }
+
+        // Orphan: DELETE the pending row and commit.
+        sqlx::query(
+            "DELETE FROM ff_pending_cancel_groups
+             WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+        )
+        .bind(partition_key)
+        .bind(flow_id)
+        .bind(downstream_eid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(GroupOutcome::Orphaned);
+    };
+
+    let flag: bool = row.get("cancel_siblings_pending_flag");
+    let members_raw: Vec<String> = row.get("cancel_siblings_pending_members");
+
+    if !flag {
+        // Reconciler territory: flag already cleared but pending row
+        // lingered. Leave for `reconciler_tick` to SREM (it needs to
+        // emit the `sremmed_stale` metric).
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(GroupOutcome::SkippedForReconciler);
+    }
+
+    // Reason defaults to `sibling_quorum_satisfied` — the Postgres
+    // writer path (dispatch.rs Decision::Satisfied branch) only
+    // raises the flag when a CancelRemaining policy is satisfied. If
+    // a future writer distinguishes `_impossible` it will need to
+    // persist a discriminator column on ff_edge_group.
+    let reason: &str = "sibling_quorum_satisfied";
+
+    let now = now_ms();
+    let members: Vec<Uuid> = members_raw
+        .iter()
+        .filter_map(|s| Uuid::parse_str(s).ok())
+        .collect();
+    for sib in &members {
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+            SET lifecycle_phase     = 'terminal',
+                ownership_state     = 'unowned',
+                eligibility_state   = 'not_applicable',
+                public_state        = 'cancelled',
+                attempt_state       = 'cancelled',
+                terminal_at_ms      = COALESCE(terminal_at_ms, $3),
+                cancellation_reason = COALESCE(cancellation_reason, $4),
+                cancelled_by        = COALESCE(cancelled_by, 'engine'),
+                raw_fields          = jsonb_set(raw_fields, '{last_mutation_at}', to_jsonb($3::text))
+            WHERE partition_key = $1 AND execution_id = $2
+              AND lifecycle_phase NOT IN ('terminal','cancelled')
+            "#,
+        )
+        .bind(partition_key)
+        .bind(sib)
+        .bind(now)
+        .bind(reason)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    // Clear flag + members + DELETE the pending row. Single commit.
+    sqlx::query(
+        r#"
+        UPDATE ff_edge_group
+        SET cancel_siblings_pending_flag    = false,
+            cancel_siblings_pending_members = '{}'::text[]
+        WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_id)
+    .bind(downstream_eid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        "DELETE FROM ff_pending_cancel_groups
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+    )
+    .bind(partition_key)
+    .bind(flow_id)
+    .bind(downstream_eid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(GroupOutcome::Dispatched)
+}
+
+fn now_ms() -> i64 {
+    let d = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    (d.as_millis() as i64).max(0)
+}

--- a/crates/ff-backend-postgres/src/reconcilers/edge_cancel_reconciler.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/edge_cancel_reconciler.rs
@@ -1,0 +1,224 @@
+//! RFC-016 Stage D — Postgres sibling-cancel reconciler.
+//!
+//! Safety net that runs at a slower cadence than the Stage-C
+//! dispatcher and recovers from a crash mid-cancel. For each row in
+//! `ff_pending_cancel_groups` it decides one of three outcomes:
+//!
+//! - `sremmed_stale`: edge_group missing OR
+//!   `cancel_siblings_pending_flag = false`. The pending row is a
+//!   leftover; DELETE it.
+//! - `completed_drain`: flag still `true` but every listed sibling
+//!   is already terminal (cancels landed, crash before flag-clear).
+//!   Clear the flag + members array and DELETE the pending row.
+//! - `no_op`: flag `true` and at least one sibling still
+//!   non-terminal. Dispatcher territory — leave the row alone.
+//!
+//! The reconciler MUST NOT fight the dispatcher: `no_op` is a hard
+//! contract. The 1-tick-later dispatcher run will see the same row
+//! and drain it.
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::EngineError;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::error::map_sqlx_error;
+
+/// Per-tick batch size. Matches Valkey + dispatcher.
+const BATCH_SIZE: i64 = 50;
+
+/// Counters surfaced by one `reconciler_tick` call. Labels line up
+/// with the `ff_sibling_cancel_reconcile_total{action}` metric.
+#[derive(Debug, Default, Clone)]
+pub struct ReconcileReport {
+    pub sremmed_stale: u64,
+    pub completed_drain: u64,
+    pub no_op: u64,
+    pub errors: u64,
+}
+
+pub async fn reconciler_tick(
+    pool: &PgPool,
+    _filter: &ScannerFilter,
+) -> Result<ReconcileReport, EngineError> {
+    let pending: Vec<(i16, Uuid, Uuid)> = sqlx::query_as(
+        r#"
+        SELECT partition_key, flow_id, downstream_eid
+        FROM ff_pending_cancel_groups
+        ORDER BY enqueued_at_ms
+        LIMIT $1
+        "#,
+    )
+    .bind(BATCH_SIZE)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = ReconcileReport::default();
+
+    for (partition_key, flow_id, downstream_eid) in pending {
+        match reconcile_one_group(pool, partition_key, flow_id, downstream_eid).await {
+            Ok(Action::SremmedStale) => report.sremmed_stale += 1,
+            Ok(Action::CompletedDrain) => report.completed_drain += 1,
+            Ok(Action::NoOp) => report.no_op += 1,
+            Err(e) => {
+                tracing::warn!(
+                    partition_key,
+                    %flow_id,
+                    %downstream_eid,
+                    error = %e,
+                    "pg edge_cancel_reconciler: reconcile failed; retry next tick"
+                );
+                report.errors += 1;
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+enum Action {
+    SremmedStale,
+    CompletedDrain,
+    NoOp,
+}
+
+async fn reconcile_one_group(
+    pool: &PgPool,
+    partition_key: i16,
+    flow_id: Uuid,
+    downstream_eid: Uuid,
+) -> Result<Action, EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // Non-blocking: if the dispatcher currently holds the lock we'd
+    // rather step away entirely than wait (no_op protects that too).
+    let row = sqlx::query(
+        r#"
+        SELECT cancel_siblings_pending_flag,
+               cancel_siblings_pending_members
+        FROM ff_edge_group
+        WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3
+        FOR UPDATE SKIP LOCKED
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_id)
+    .bind(downstream_eid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        // Two cases: (a) edge_group deleted (retention) → stale; or
+        // (b) dispatcher holds the lock → no_op. Probe without a lock.
+        let exists: Option<(bool,)> = sqlx::query_as(
+            "SELECT true FROM ff_edge_group
+             WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+        )
+        .bind(partition_key)
+        .bind(flow_id)
+        .bind(downstream_eid)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if exists.is_some() {
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            return Ok(Action::NoOp);
+        }
+
+        // Retention-deleted group → DELETE the orphan pending row.
+        sqlx::query(
+            "DELETE FROM ff_pending_cancel_groups
+             WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+        )
+        .bind(partition_key)
+        .bind(flow_id)
+        .bind(downstream_eid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(Action::SremmedStale);
+    };
+
+    let flag: bool = row.get("cancel_siblings_pending_flag");
+    let members_raw: Vec<String> = row.get("cancel_siblings_pending_members");
+
+    if !flag {
+        // Stale pending row — drain it.
+        sqlx::query(
+            "DELETE FROM ff_pending_cancel_groups
+             WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+        )
+        .bind(partition_key)
+        .bind(flow_id)
+        .bind(downstream_eid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(Action::SremmedStale);
+    }
+
+    // flag=true: check if every listed sibling is already terminal.
+    let members: Vec<Uuid> = members_raw
+        .iter()
+        .filter_map(|s| Uuid::parse_str(s).ok())
+        .collect();
+
+    if !members.is_empty() {
+        let non_terminal: i64 = sqlx::query_scalar(
+            r#"
+            SELECT count(*)::bigint
+            FROM ff_exec_core
+            WHERE partition_key = $1
+              AND execution_id = ANY($2::uuid[])
+              AND lifecycle_phase NOT IN ('terminal','cancelled')
+            "#,
+        )
+        .bind(partition_key)
+        .bind(&members)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if non_terminal > 0 {
+            // Dispatcher owns this one.
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            return Ok(Action::NoOp);
+        }
+    }
+
+    // Either members list is empty + flag stuck on (degenerate crash
+    // residue), or every member is terminal. Complete the drain.
+    sqlx::query(
+        r#"
+        UPDATE ff_edge_group
+        SET cancel_siblings_pending_flag    = false,
+            cancel_siblings_pending_members = '{}'::text[]
+        WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_id)
+    .bind(downstream_eid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        "DELETE FROM ff_pending_cancel_groups
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+    )
+    .bind(partition_key)
+    .bind(flow_id)
+    .bind(downstream_eid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(Action::CompletedDrain)
+}

--- a/crates/ff-backend-postgres/src/reconcilers/mod.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/mod.rs
@@ -9,3 +9,5 @@
 //! per-hop-tx dispatch cascade from Wave 5a.
 
 pub mod dependency;
+pub mod edge_cancel_dispatcher;
+pub mod edge_cancel_reconciler;

--- a/crates/ff-engine/src/scanner/edge_cancel_dispatcher.rs
+++ b/crates/ff-engine/src/scanner/edge_cancel_dispatcher.rs
@@ -178,6 +178,24 @@ enum GroupOutcome {
     Error,
 }
 
+/// Postgres-backend parallel to the Valkey scan loop.
+///
+/// Wave-6b (RFC-v0.7): delegates to
+/// [`ff_backend_postgres::reconcilers::edge_cancel_dispatcher::dispatcher_tick`],
+/// which mirrors RFC-016 Stage-C semantics against `ff_edge_group` +
+/// `ff_pending_cancel_groups` under a per-group transaction with
+/// `FOR UPDATE SKIP LOCKED` coalescing.
+#[cfg(feature = "postgres")]
+pub async fn dispatch_via_postgres(
+    pool: &ff_backend_postgres::PgPool,
+    filter: &ff_core::backend::ScannerFilter,
+) -> Result<
+    ff_backend_postgres::reconcilers::edge_cancel_dispatcher::DispatchReport,
+    ff_core::engine_error::EngineError,
+> {
+    ff_backend_postgres::reconcilers::edge_cancel_dispatcher::dispatcher_tick(pool, filter).await
+}
+
 impl EdgeCancelDispatcher {
     async fn dispatch_one_group(
         &self,

--- a/crates/ff-engine/src/scanner/edge_cancel_reconciler.rs
+++ b/crates/ff-engine/src/scanner/edge_cancel_reconciler.rs
@@ -147,6 +147,23 @@ enum ReconcileOutcome {
     Error,
 }
 
+/// Postgres-backend parallel to the Valkey scan loop.
+///
+/// Wave-6b (RFC-v0.7): delegates to
+/// [`ff_backend_postgres::reconcilers::edge_cancel_reconciler::reconciler_tick`],
+/// which mirrors RFC-016 Stage-D semantics (`sremmed_stale` /
+/// `completed_drain` / `no_op`) against `ff_pending_cancel_groups`.
+#[cfg(feature = "postgres")]
+pub async fn reconcile_via_postgres(
+    pool: &ff_backend_postgres::PgPool,
+    filter: &ff_core::backend::ScannerFilter,
+) -> Result<
+    ff_backend_postgres::reconcilers::edge_cancel_reconciler::ReconcileReport,
+    ff_core::engine_error::EngineError,
+> {
+    ff_backend_postgres::reconcilers::edge_cancel_reconciler::reconciler_tick(pool, filter).await
+}
+
 impl EdgeCancelReconciler {
     async fn reconcile_one_group(
         &self,

--- a/crates/ff-test/tests/pg_reconciler_edge_cancel.rs
+++ b/crates/ff-test/tests/pg_reconciler_edge_cancel.rs
@@ -1,0 +1,343 @@
+//! Wave 6b — Postgres sibling-cancel dispatcher + reconciler
+//! (RFC-016 Stages C+D).
+//!
+//! 1. Dispatcher drains flag=true + members=[a,b] → both siblings
+//!    transition to terminal/cancelled, edge_group flag cleared,
+//!    pending row deleted.
+//! 2. Reconciler `sremmed_stale`: pending row + flag=false → pending
+//!    row deleted, edge_group untouched.
+//! 3. Reconciler `completed_drain`: flag=true, members=[a,b] already
+//!    terminal → flag cleared + pending row deleted.
+//! 4. Reconciler `no_op`: flag=true, at least one sibling still
+//!    non-terminal → reconciler leaves everything untouched.
+//! 5. Concurrent-drain coalescing: two `dispatcher_tick` calls race
+//!    on the same group. `FOR UPDATE SKIP LOCKED` gives one winner;
+//!    the other sees `skipped_locked`. Siblings cancelled exactly
+//!    once.
+//!
+//! # Running
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://postgres:postgres@localhost/ff_wave6b_test \
+//!   cargo test -p ff-test --test pg_reconciler_edge_cancel \
+//!   -- --ignored --test-threads=1
+//! ```
+
+use ff_backend_postgres::{
+    apply_migrations,
+    reconcilers::{edge_cancel_dispatcher, edge_cancel_reconciler},
+};
+use ff_core::backend::ScannerFilter;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+const P: i16 = 0;
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(16)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    apply_migrations(&pool).await.expect("apply_migrations");
+    for stmt in [
+        "DELETE FROM ff_pending_cancel_groups",
+        "DELETE FROM ff_edge_group",
+        "DELETE FROM ff_exec_core",
+        "DELETE FROM ff_flow_core",
+    ] {
+        sqlx::query(stmt).execute(&pool).await.expect("reset");
+    }
+    Some(pool)
+}
+
+/// Seed `ff_flow_core` + N sibling exec_core rows (in `active`) +
+/// one edge_group with the provided flag/members set.
+async fn seed_group(
+    pool: &PgPool,
+    sibling_states: &[&str], // lifecycle_phase per sibling
+    flag: bool,
+    enqueue_pending: bool,
+) -> (Uuid, Uuid, Vec<Uuid>) {
+    let flow_id = Uuid::new_v4();
+    let downstream = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO ff_flow_core (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms) \
+         VALUES ($1, $2, 0, 'running', 0)",
+    )
+    .bind(P)
+    .bind(flow_id)
+    .execute(pool)
+    .await
+    .expect("seed flow");
+
+    // Downstream exec (target of the group) — irrelevant for
+    // dispatcher behaviour but seeded for FK-parity with production.
+    sqlx::query(
+        "INSERT INTO ff_exec_core (partition_key, execution_id, flow_id, lane_id, \
+         lifecycle_phase, ownership_state, eligibility_state, public_state, attempt_state, \
+         created_at_ms) \
+         VALUES ($1, $2, $3, 'default', 'blocked', 'unowned', 'eligible_now', 'pending', 'pending', 0)",
+    )
+    .bind(P)
+    .bind(downstream)
+    .bind(flow_id)
+    .execute(pool)
+    .await
+    .expect("seed downstream");
+
+    let mut siblings = Vec::with_capacity(sibling_states.len());
+    for state in sibling_states {
+        let sid = Uuid::new_v4();
+        siblings.push(sid);
+        let (eligibility, public, attempt) = if *state == "terminal" {
+            ("not_applicable", "completed", "completed")
+        } else {
+            ("not_applicable", "running", "running")
+        };
+        sqlx::query(
+            "INSERT INTO ff_exec_core (partition_key, execution_id, flow_id, lane_id, \
+             lifecycle_phase, ownership_state, eligibility_state, public_state, attempt_state, \
+             created_at_ms) \
+             VALUES ($1, $2, $3, 'default', $4, 'leased', $5, $6, $7, 0)",
+        )
+        .bind(P)
+        .bind(sid)
+        .bind(flow_id)
+        .bind(state)
+        .bind(eligibility)
+        .bind(public)
+        .bind(attempt)
+        .execute(pool)
+        .await
+        .expect("seed sibling");
+    }
+
+    let member_strs: Vec<String> = siblings.iter().map(|u| u.to_string()).collect();
+    sqlx::query(
+        "INSERT INTO ff_edge_group (partition_key, flow_id, downstream_eid, policy, \
+         k_target, success_count, fail_count, skip_count, running_count, \
+         cancel_siblings_pending_flag, cancel_siblings_pending_members) \
+         VALUES ($1, $2, $3, '{}'::jsonb, 1, 0, 0, 0, $4, $5, $6)",
+    )
+    .bind(P)
+    .bind(flow_id)
+    .bind(downstream)
+    .bind(siblings.len() as i32)
+    .bind(flag)
+    .bind(&member_strs)
+    .execute(pool)
+    .await
+    .expect("seed edge_group");
+
+    if enqueue_pending {
+        sqlx::query(
+            "INSERT INTO ff_pending_cancel_groups \
+             (partition_key, flow_id, downstream_eid, enqueued_at_ms) \
+             VALUES ($1, $2, $3, 0)",
+        )
+        .bind(P)
+        .bind(flow_id)
+        .bind(downstream)
+        .execute(pool)
+        .await
+        .expect("seed pending");
+    }
+
+    (flow_id, downstream, siblings)
+}
+
+async fn exec_phase(pool: &PgPool, eid: Uuid) -> String {
+    let row = sqlx::query("SELECT lifecycle_phase FROM ff_exec_core WHERE execution_id = $1")
+        .bind(eid)
+        .fetch_one(pool)
+        .await
+        .expect("read exec");
+    row.get("lifecycle_phase")
+}
+
+async fn exec_public(pool: &PgPool, eid: Uuid) -> String {
+    let row = sqlx::query("SELECT public_state FROM ff_exec_core WHERE execution_id = $1")
+        .bind(eid)
+        .fetch_one(pool)
+        .await
+        .expect("read exec");
+    row.get("public_state")
+}
+
+async fn group_flag(pool: &PgPool, flow: Uuid, downstream: Uuid) -> bool {
+    let row = sqlx::query(
+        "SELECT cancel_siblings_pending_flag FROM ff_edge_group \
+         WHERE flow_id = $1 AND downstream_eid = $2",
+    )
+    .bind(flow)
+    .bind(downstream)
+    .fetch_one(pool)
+    .await
+    .expect("read group");
+    row.get("cancel_siblings_pending_flag")
+}
+
+async fn pending_count(pool: &PgPool, flow: Uuid) -> i64 {
+    let row = sqlx::query(
+        "SELECT COUNT(*)::bigint AS c FROM ff_pending_cancel_groups WHERE flow_id = $1",
+    )
+    .bind(flow)
+    .fetch_one(pool)
+    .await
+    .expect("count pending");
+    row.get("c")
+}
+
+// ── Test 1: Dispatcher drains flag=true group ────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn dispatcher_drains_flag_true_group() {
+    let Some(pool) = setup_or_skip().await else { return };
+    let (flow, downstream, siblings) =
+        seed_group(&pool, &["active", "active"], true, true).await;
+
+    let report = edge_cancel_dispatcher::dispatcher_tick(&pool, &ScannerFilter::default())
+        .await
+        .expect("dispatcher_tick");
+
+    assert_eq!(report.dispatched, 1);
+    assert_eq!(report.orphaned, 0);
+    assert_eq!(report.errors, 0);
+
+    for sib in &siblings {
+        assert_eq!(exec_phase(&pool, *sib).await, "terminal");
+        assert_eq!(exec_public(&pool, *sib).await, "cancelled");
+    }
+    assert!(!group_flag(&pool, flow, downstream).await);
+    assert_eq!(pending_count(&pool, flow).await, 0);
+}
+
+// ── Test 2: Reconciler `sremmed_stale` ───────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn reconciler_sremmed_stale() {
+    let Some(pool) = setup_or_skip().await else { return };
+    // flag=false but pending row lingers.
+    let (flow, downstream, siblings) =
+        seed_group(&pool, &["active", "active"], false, true).await;
+
+    let report = edge_cancel_reconciler::reconciler_tick(&pool, &ScannerFilter::default())
+        .await
+        .expect("reconciler_tick");
+
+    assert_eq!(report.sremmed_stale, 1);
+    assert_eq!(report.completed_drain, 0);
+    assert_eq!(report.no_op, 0);
+
+    assert_eq!(pending_count(&pool, flow).await, 0);
+    // edge_group untouched, siblings untouched.
+    for sib in &siblings {
+        assert_eq!(exec_phase(&pool, *sib).await, "active");
+    }
+    assert!(!group_flag(&pool, flow, downstream).await);
+}
+
+// ── Test 3: Reconciler `completed_drain` ─────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn reconciler_completed_drain() {
+    let Some(pool) = setup_or_skip().await else { return };
+    // flag=true but siblings already terminal — mid-crash residue.
+    let (flow, downstream, _siblings) =
+        seed_group(&pool, &["terminal", "terminal"], true, true).await;
+
+    let report = edge_cancel_reconciler::reconciler_tick(&pool, &ScannerFilter::default())
+        .await
+        .expect("reconciler_tick");
+
+    assert_eq!(report.completed_drain, 1);
+    assert_eq!(report.sremmed_stale, 0);
+    assert_eq!(report.no_op, 0);
+
+    assert!(!group_flag(&pool, flow, downstream).await);
+    assert_eq!(pending_count(&pool, flow).await, 0);
+}
+
+// ── Test 4: Reconciler `no_op` ───────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn reconciler_no_op_dispatcher_owns() {
+    let Some(pool) = setup_or_skip().await else { return };
+    // flag=true, one sibling still active → dispatcher territory.
+    let (flow, downstream, siblings) =
+        seed_group(&pool, &["terminal", "active"], true, true).await;
+
+    let report = edge_cancel_reconciler::reconciler_tick(&pool, &ScannerFilter::default())
+        .await
+        .expect("reconciler_tick");
+
+    assert_eq!(report.no_op, 1);
+    assert_eq!(report.completed_drain, 0);
+    assert_eq!(report.sremmed_stale, 0);
+
+    // Everything untouched — dispatcher will drain next tick.
+    assert!(group_flag(&pool, flow, downstream).await);
+    assert_eq!(pending_count(&pool, flow).await, 1);
+    assert_eq!(exec_phase(&pool, siblings[1]).await, "active");
+}
+
+// ── Test 5: Concurrent-drain coalescing ──────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn concurrent_dispatcher_coalesces() {
+    let Some(pool) = setup_or_skip().await else { return };
+    let (flow, downstream, siblings) =
+        seed_group(&pool, &["active", "active"], true, true).await;
+
+    // Hold a tx that acquires the edge_group row lock so the first
+    // dispatcher_tick is forced onto the SKIP LOCKED path. Then
+    // release the lock and run a second tick — it should drain.
+    let mut blocker = pool.begin().await.expect("begin blocker");
+    sqlx::query(
+        "SELECT cancel_siblings_pending_flag FROM ff_edge_group \
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3 FOR UPDATE",
+    )
+    .bind(P)
+    .bind(flow)
+    .bind(downstream)
+    .fetch_one(&mut *blocker)
+    .await
+    .expect("acquire blocker lock");
+
+    let first = edge_cancel_dispatcher::dispatcher_tick(&pool, &ScannerFilter::default())
+        .await
+        .expect("first tick");
+    assert_eq!(first.skipped_locked, 1, "first tick hits SKIP LOCKED");
+    assert_eq!(first.dispatched, 0);
+
+    // Siblings must still be active — no cancels while locked.
+    for sib in &siblings {
+        assert_eq!(exec_phase(&pool, *sib).await, "active");
+    }
+
+    // Release the blocker.
+    blocker.rollback().await.expect("release blocker");
+
+    let second = edge_cancel_dispatcher::dispatcher_tick(&pool, &ScannerFilter::default())
+        .await
+        .expect("second tick");
+    assert_eq!(second.dispatched, 1);
+    assert_eq!(second.skipped_locked, 0);
+
+    // Post-drain state.
+    for sib in &siblings {
+        assert_eq!(exec_phase(&pool, *sib).await, "terminal");
+        assert_eq!(exec_public(&pool, *sib).await, "cancelled");
+    }
+    assert!(!group_flag(&pool, flow, downstream).await);
+    assert_eq!(pending_count(&pool, flow).await, 0);
+}


### PR DESCRIPTION
## Summary

Lands the Postgres parallel of RFC-016 Stage C (sibling-cancel dispatcher) and Stage D (sibling-cancel reconciler), wired behind `ff-engine`'s `postgres` feature.

- **Dispatcher** (`reconcilers/edge_cancel_dispatcher.rs`): pulls `ff_pending_cancel_groups` rows ordered by `enqueued_at_ms`; per group opens a tx, takes `FOR UPDATE SKIP LOCKED` on the `ff_edge_group` row, cancels each listed sibling via `UPDATE ff_exec_core ... WHERE lifecycle_phase NOT IN ('terminal','cancelled')` (idempotent), clears `cancel_siblings_pending_flag` + `cancel_siblings_pending_members`, deletes the pending row — one atomic commit per group. Reports `{dispatched, orphaned, skipped_for_reconciler, skipped_locked, errors}`.
- **Reconciler** (`reconcilers/edge_cancel_reconciler.rs`): safety net deciding one of three actions per pending row — `sremmed_stale` (flag false / group missing), `completed_drain` (flag true + every listed sibling already terminal), `no_op` (flag true + at least one sibling still non-terminal → dispatcher owns). Uses the same `SKIP LOCKED` probe so it never fights the dispatcher.
- **ff-engine hooks**: `dispatch_via_postgres` / `reconcile_via_postgres` free functions on `scanner::edge_cancel_*` modules, gated on `feature = "postgres"`, following the Wave 5a template (`partition_router::dispatch_via_postgres`).
- **Test**: `pg_reconciler_edge_cancel.rs` — 5 scenarios: dispatcher drains, reconciler `sremmed_stale`, reconciler `completed_drain`, reconciler `no_op`, concurrent-drain coalescing (external blocker tx → first tick `skipped_locked=1`, blocker releases → second tick `dispatched=1`, siblings cancelled exactly once).

## Test plan

- [x] `cargo check --workspace --all-features` clean.
- [x] `cargo clippy -p ff-backend-postgres -p ff-engine --all-features -- -D warnings` clean.
- [x] `FF_PG_TEST_URL=... cargo test -p ff-test --test pg_reconciler_edge_cancel -- --ignored --test-threads=1` — 5/5 pass on live Postgres 17.

Siblings (6a dep reconciler, 6c timeouts, 6d completion listener) touch `reconcilers/mod.rs` additively; alphabetical order preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres code paths that directly update `ff_exec_core` lifecycle/cancellation fields and clear edge-group cancel flags under concurrency, so mistakes could incorrectly cancel executions or leave groups stuck. Scoped behind the Postgres backend/feature and covered by new integration tests, but still touches core execution-state transitions.
> 
> **Overview**
> Implements the Postgres parallel of RFC-016 sibling-cancel processing by adding a Stage-C `dispatcher_tick` and Stage-D `reconciler_tick` that drain `ff_pending_cancel_groups` and coordinate via per-group transactions using `FOR UPDATE SKIP LOCKED` to coalesce concurrent workers.
> 
> The dispatcher issues idempotent sibling cancels by `UPDATE`ing `ff_exec_core`, then clears `ff_edge_group.cancel_siblings_pending_*` and deletes the pending row; the reconciler cleans up stale/orphaned rows or completes interrupted drains without fighting the dispatcher (`no_op`). `ff-engine` gains Postgres entry points (`dispatch_via_postgres`/`reconcile_via_postgres`), and `ff-test` adds live-Postgres integration coverage including a lock/coalescing scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71cd1bd98fc08a8e5c8d05d8f96d83e45daeb96. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->