### PR TITLE
feat(pg-wave6c): Postgres timeout scanners (attempt + lease + suspension)

### DIFF
--- a/crates/ff-backend-postgres/migrations/0005_timeout_scanners.sql
+++ b/crates/ff-backend-postgres/migrations/0005_timeout_scanners.sql
@@ -1,0 +1,31 @@
+-- RFC-v0.7 Wave 6c — timeout scanner support columns.
+--
+-- Additive (`backward_compatible = true`). The Wave 6c timeout
+-- reconcilers (`attempt_timeout`, `lease_expiry`, `suspension_timeout`)
+-- mirror the Valkey-side `ff:idx:...` ZSET scans against the
+-- Postgres schema. One schema extension is needed:
+--
+--   * `ff_suspension_current.timeout_behavior` — the wire-string
+--     encoding of `TimeoutBehavior` (`fail | cancel | expire |
+--     auto_resume_with_timeout_signal | escalate`), recorded at
+--     suspend time so the `suspension_timeout` reconciler can
+--     apply the configured behavior without a second round-trip
+--     to rehydrate policy. Nullable + NULL-treated-as-`fail` so
+--     rows created by the pre-migration `suspend_impl` body keep
+--     a safe default.
+--
+-- The attempt_timeout + lease_expiry reconcilers need no schema
+-- extension — `ff_attempt.lease_expires_at_ms` already carries
+-- the scan key and the partial index
+-- `ff_attempt_lease_expiry_idx` already exists.
+
+ALTER TABLE ff_suspension_current
+    ADD COLUMN timeout_behavior text;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    5,
+    '0005_timeout_scanners',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/src/reconcilers/attempt_timeout.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/attempt_timeout.rs
@@ -1,0 +1,294 @@
+//! Postgres `attempt_timeout` reconciler (wave 6c).
+//!
+//! Mirrors [`ff_engine::scanner::attempt_timeout`] against the Postgres
+//! schema. The Valkey side scans `ff:idx:{p:N}:attempt_timeout` ZSET
+//! for attempts whose lease timeout has lapsed and fires
+//! `FCALL ff_expire_execution`. On Postgres the authority is the
+//! `ff_attempt.lease_expires_at_ms` column (partial index
+//! `ff_attempt_lease_expiry_idx`); an attempt is "timed out" iff its
+//! lease has expired AND the `ff_exec_core.lifecycle_phase = 'active'`
+//! (a released lease — `lease_expires_at_ms IS NULL` — is not a
+//! timeout; a terminal attempt is also not a timeout).
+//!
+//! Per-row tx: each timeout action (mark attempt interrupted + transition
+//! exec_core to either `runnable` (retries remain) or `terminal`
+//! (exhausted) + emit completion event on terminal) is its own
+//! `BEGIN/COMMIT`, per spec §Constraints.
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::EngineError;
+use serde_json::Value as JsonValue;
+use sqlx::{PgPool, Row};
+
+use crate::error::map_sqlx_error;
+use crate::reconcilers::ScanReport;
+
+/// Max rows pulled per scan tick.
+const BATCH_SIZE: i64 = 1000;
+
+/// Grace period (ms). 0 by default.
+const GRACE_MS: i64 = 0;
+
+/// Scan one partition for timed-out attempt leases.
+pub async fn scan_tick(
+    pool: &PgPool,
+    partition_key: i16,
+    filter: &ScannerFilter,
+) -> Result<ScanReport, EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+    let cutoff = now_ms.saturating_sub(GRACE_MS);
+
+    let rows = sqlx::query(
+        r#"
+        SELECT a.execution_id, a.attempt_index
+          FROM ff_attempt a
+          JOIN ff_exec_core c
+            ON c.partition_key = a.partition_key
+           AND c.execution_id = a.execution_id
+         WHERE a.partition_key = $1
+           AND a.lease_expires_at_ms IS NOT NULL
+           AND a.lease_expires_at_ms < $2
+           AND c.lifecycle_phase = 'active'
+         ORDER BY a.lease_expires_at_ms ASC
+         LIMIT $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(cutoff)
+    .bind(BATCH_SIZE)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = ScanReport::default();
+    for row in rows {
+        let exec_uuid: uuid::Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
+        let attempt_index: i32 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+        if skip_by_filter(pool, partition_key, exec_uuid, filter).await {
+            continue;
+        }
+        match expire_one(pool, partition_key, exec_uuid, attempt_index, now_ms).await {
+            Ok(()) => report.processed += 1,
+            Err(e) => {
+                tracing::warn!(
+                    partition = partition_key,
+                    execution = %exec_uuid,
+                    attempt_index,
+                    error = %e,
+                    "attempt_timeout reconciler: row expiry failed",
+                );
+                report.errors += 1;
+            }
+        }
+    }
+    Ok(report)
+}
+
+async fn expire_one(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+    attempt_index: i32,
+    now_ms: i64,
+) -> Result<(), EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let att_row = sqlx::query(
+        r#"
+        SELECT lease_expires_at_ms
+          FROM ff_attempt
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(att) = att_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    let expires_at: Option<i64> = att
+        .try_get::<Option<i64>, _>("lease_expires_at_ms")
+        .map_err(map_sqlx_error)?;
+    if !matches!(expires_at, Some(e) if e < now_ms) {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+
+    let core_row = sqlx::query(
+        r#"
+        SELECT attempt_index, lifecycle_phase, policy
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(core) = core_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    let phase: String = core.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    if phase != "active" {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+    let cur_attempt: i32 = core.try_get("attempt_index").map_err(map_sqlx_error)?;
+    let policy: Option<JsonValue> = core.try_get("policy").map_err(map_sqlx_error)?;
+    let max_retries = extract_max_retries(policy.as_ref());
+    let retries_remain = (cur_attempt as i64) < (max_retries as i64);
+
+    sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET outcome = 'interrupted',
+               lease_expires_at_ms = NULL,
+               terminal_at_ms = $1
+         WHERE partition_key = $2 AND execution_id = $3 AND attempt_index = $4
+        "#,
+    )
+    .bind(now_ms)
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if retries_remain {
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase = 'runnable',
+                   ownership_state = 'unowned',
+                   eligibility_state = 'eligible_now',
+                   attempt_state = 'pending_retry_attempt',
+                   attempt_index = attempt_index + 1,
+                   raw_fields = raw_fields || jsonb_build_object(
+                       'last_failure_message', 'attempt_timeout'
+                   )
+             WHERE partition_key = $1 AND execution_id = $2
+            "#,
+        )
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    } else {
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase = 'terminal',
+                   ownership_state = 'unowned',
+                   eligibility_state = 'not_applicable',
+                   attempt_state = 'attempt_terminal',
+                   terminal_at_ms = $1,
+                   raw_fields = raw_fields || jsonb_build_object(
+                       'last_failure_message', 'attempt_timeout'
+                   )
+             WHERE partition_key = $2 AND execution_id = $3
+            "#,
+        )
+        .bind(now_ms)
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO ff_completion_event (
+                partition_key, execution_id, flow_id, outcome,
+                namespace, instance_tag, occurred_at_ms
+            )
+            SELECT partition_key, execution_id, flow_id, 'expired',
+                   NULL, NULL, $3
+              FROM ff_exec_core
+             WHERE partition_key = $1 AND execution_id = $2
+            "#,
+        )
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .bind(now_ms)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+/// Read `policy.retry_policy.max_retries` out of exec_core `policy`
+/// jsonb. Defaults to 0 (no retries) when absent.
+fn extract_max_retries(policy: Option<&JsonValue>) -> u32 {
+    policy
+        .and_then(|v| v.get("retry_policy"))
+        .and_then(|rp| rp.get("max_retries"))
+        .and_then(|m| m.as_u64())
+        .and_then(|n| u32::try_from(n).ok())
+        .unwrap_or(0)
+}
+
+/// Apply [`ScannerFilter`] dimensions against `ff_exec_core.raw_fields`.
+/// Returns `true` when the candidate should be skipped.
+pub(crate) async fn skip_by_filter(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+    filter: &ScannerFilter,
+) -> bool {
+    if filter.is_noop() {
+        return false;
+    }
+    let row = sqlx::query(
+        r#"
+        SELECT raw_fields->>'namespace' AS ns,
+               raw_fields->'tags'       AS tags
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await;
+    let Ok(Some(row)) = row else {
+        return true;
+    };
+    if let Some(ref want_ns) = filter.namespace {
+        let got: Option<String> = row.try_get("ns").ok().flatten();
+        if got.as_deref() != Some(want_ns.as_str()) {
+            return true;
+        }
+    }
+    if let Some((ref k, ref v)) = filter.instance_tag {
+        let tags: Option<JsonValue> = row.try_get("tags").ok();
+        let got = tags
+            .as_ref()
+            .and_then(|t| t.get(k))
+            .and_then(|t| t.as_str());
+        if got != Some(v.as_str()) {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/ff-backend-postgres/src/reconcilers/lease_expiry.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/lease_expiry.rs
@@ -1,0 +1,177 @@
+//! Postgres `lease_expiry` reconciler (wave 6c).
+//!
+//! Mirrors [`ff_engine::scanner::lease_expiry`] — scans for attempts
+//! whose lease has lapsed and marks them reclaimable so another worker
+//! can redeem the execution via [`crate::attempt::claim_from_reclaim`].
+//!
+//! Action per row (in its own tx):
+//!   * NULL out `ff_attempt.lease_expires_at_ms` (the fence-triple
+//!     release — `claim_from_reclaim` requires either
+//!     `lease_expires_at_ms <= now` OR `NULL` to succeed).
+//!   * Set `ff_attempt.outcome = 'lease_expired_reclaimable'`.
+//!   * Flip `ff_exec_core` to `ownership_state = 'unowned'` +
+//!     `lifecycle_phase = 'runnable'` + `eligibility_state =
+//!     'eligible_now'` + `attempt_state = 'attempt_interrupted'` so
+//!     the normal claim path picks it back up (or a targeted
+//!     `claim_from_reclaim` redeems the specific attempt).
+//!
+//! Distinction from `attempt_timeout`: `attempt_timeout` terminates
+//! or retries the whole execution (worker vanished AND retry budget
+//! is the authority). `lease_expiry` is the gentler reclaim path —
+//! keeps the same attempt_index, just releases the lease so a new
+//! worker can take over. The Valkey side runs these as two separate
+//! scanners for the same reason; whichever fires first on a given
+//! execution wins.
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::EngineError;
+use sqlx::{PgPool, Row};
+
+use crate::error::map_sqlx_error;
+use crate::reconcilers::ScanReport;
+use crate::reconcilers::attempt_timeout::skip_by_filter;
+
+const BATCH_SIZE: i64 = 1000;
+
+/// Scan one partition for expired-lease attempts and emit reclaimable
+/// markers.
+pub async fn scan_tick(
+    pool: &PgPool,
+    partition_key: i16,
+    filter: &ScannerFilter,
+) -> Result<ScanReport, EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    // Candidate rows: any attempt with a lapsed lease, regardless of
+    // lifecycle phase. Unlike `attempt_timeout` we DO NOT join on
+    // `lifecycle_phase = 'active'` — a crashed worker that left the
+    // lease behind may have already been flipped by a different scanner
+    // or by cancel_flow; we still want to zero out the stale lease
+    // column so `claim_from_reclaim` cleanly sees a released slot.
+    let rows = sqlx::query(
+        r#"
+        SELECT execution_id, attempt_index
+          FROM ff_attempt
+         WHERE partition_key = $1
+           AND lease_expires_at_ms IS NOT NULL
+           AND lease_expires_at_ms < $2
+         ORDER BY lease_expires_at_ms ASC
+         LIMIT $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(now_ms)
+    .bind(BATCH_SIZE)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = ScanReport::default();
+    for row in rows {
+        let exec_uuid: uuid::Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
+        let attempt_index: i32 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+        if skip_by_filter(pool, partition_key, exec_uuid, filter).await {
+            continue;
+        }
+        match release_one(pool, partition_key, exec_uuid, attempt_index, now_ms).await {
+            Ok(()) => report.processed += 1,
+            Err(e) => {
+                tracing::warn!(
+                    partition = partition_key,
+                    execution = %exec_uuid,
+                    attempt_index,
+                    error = %e,
+                    "lease_expiry reconciler: row release failed",
+                );
+                report.errors += 1;
+            }
+        }
+    }
+    Ok(report)
+}
+
+async fn release_one(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+    attempt_index: i32,
+    now_ms: i64,
+) -> Result<(), EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // Re-read under lock — defensive against a worker that renewed
+    // its lease between scan and action.
+    let att_row = sqlx::query(
+        r#"
+        SELECT lease_expires_at_ms
+          FROM ff_attempt
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(att) = att_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    let expires_at: Option<i64> = att
+        .try_get::<Option<i64>, _>("lease_expires_at_ms")
+        .map_err(map_sqlx_error)?;
+    if !matches!(expires_at, Some(e) if e < now_ms) {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+
+    sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET lease_expires_at_ms = NULL,
+               outcome = 'lease_expired_reclaimable'
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Flip exec_core to reclaimable-runnable. Only touch rows still
+    // in `active` — a terminal/cancelled exec should be left alone.
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET lifecycle_phase = 'runnable',
+               ownership_state = 'unowned',
+               eligibility_state = 'eligible_now',
+               attempt_state = 'attempt_interrupted',
+               raw_fields = raw_fields || jsonb_build_object(
+                   'lease_expired_at_ms', $3::bigint
+               )
+         WHERE partition_key = $1 AND execution_id = $2
+           AND lifecycle_phase = 'active'
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(now_ms)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}

--- a/crates/ff-backend-postgres/src/reconcilers/mod.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/mod.rs
@@ -8,6 +8,21 @@
 //! Wave 6a ships the dependency reconciler — the backstop for the
 //! per-hop-tx dispatch cascade from Wave 5a.
 
+pub mod attempt_timeout;
 pub mod dependency;
 pub mod edge_cancel_dispatcher;
 pub mod edge_cancel_reconciler;
+pub mod lease_expiry;
+pub mod suspension_timeout;
+
+/// Result of scanning one partition. Mirrors
+/// [`ff_engine::scanner::ScanResult`] so engine-side aggregation code
+/// stays identical across backends; kept here (not re-exported from
+/// ff-engine) so `ff-backend-postgres` does not take a dep on the
+/// engine crate. The engine's `scan_tick_pg` wrapper maps one to the
+/// other.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScanReport {
+    pub processed: u32,
+    pub errors: u32,
+}

--- a/crates/ff-backend-postgres/src/reconcilers/suspension_timeout.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/suspension_timeout.rs
@@ -1,0 +1,243 @@
+//! Postgres `suspension_timeout` reconciler (wave 6c).
+//!
+//! Mirrors [`ff_engine::scanner::suspension_timeout`] — scans
+//! `ff_suspension_current` for active suspensions whose `timeout_at_ms`
+//! has lapsed and applies the configured [`TimeoutBehavior`] recorded
+//! at suspend-time (migration 0005 added the column).
+//!
+//! Per-row tx. Behaviors honored today:
+//!   * `Fail` (default when column is NULL) — exec terminal-failed +
+//!     completion event emitted.
+//!   * `AutoResumeWithTimeoutSignal` — append a synthetic "timeout"
+//!     signal into `ff_suspension_current.member_map` under key
+//!     `__timeout__` + clear `timeout_at_ms`, keeping the exec in its
+//!     suspended state so a subsequent `deliver_signal` /
+//!     `claim_resumed_execution` drains it. (The RFC-004 full
+//!     semantics also re-evaluate the composite condition; that
+//!     plumbing is Valkey-parity work for a later wave.)
+//!   * `Cancel` / `Expire` / `Escalate` — treated as terminal-cancel
+//!     with distinct `cancellation_reason`; no further fan-out.
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::EngineError;
+use serde_json::{Value as JsonValue, json};
+use sqlx::{PgPool, Row};
+
+use crate::error::map_sqlx_error;
+use crate::reconcilers::ScanReport;
+use crate::reconcilers::attempt_timeout::skip_by_filter;
+
+const BATCH_SIZE: i64 = 1000;
+
+/// Scan one partition for expired suspensions.
+pub async fn scan_tick(
+    pool: &PgPool,
+    partition_key: i16,
+    filter: &ScannerFilter,
+) -> Result<ScanReport, EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    let rows = sqlx::query(
+        r#"
+        SELECT execution_id, timeout_behavior
+          FROM ff_suspension_current
+         WHERE partition_key = $1
+           AND timeout_at_ms IS NOT NULL
+           AND timeout_at_ms < $2
+         ORDER BY timeout_at_ms ASC
+         LIMIT $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(now_ms)
+    .bind(BATCH_SIZE)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = ScanReport::default();
+    for row in rows {
+        let exec_uuid: uuid::Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
+        let behavior: Option<String> = row
+            .try_get::<Option<String>, _>("timeout_behavior")
+            .map_err(map_sqlx_error)?;
+        if skip_by_filter(pool, partition_key, exec_uuid, filter).await {
+            continue;
+        }
+        let b = behavior.as_deref().unwrap_or("fail");
+        match expire_one(pool, partition_key, exec_uuid, b, now_ms).await {
+            Ok(()) => report.processed += 1,
+            Err(e) => {
+                tracing::warn!(
+                    partition = partition_key,
+                    execution = %exec_uuid,
+                    behavior = b,
+                    error = %e,
+                    "suspension_timeout reconciler: expire failed",
+                );
+                report.errors += 1;
+            }
+        }
+    }
+    Ok(report)
+}
+
+async fn expire_one(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+    behavior: &str,
+    now_ms: i64,
+) -> Result<(), EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // Lock the suspension row and re-check the deadline. If another
+    // path (deliver_signal → resume) resolved the suspension between
+    // scan and action, timeout_at_ms will be NULL or the row gone.
+    let row = sqlx::query(
+        r#"
+        SELECT timeout_at_ms, member_map
+          FROM ff_suspension_current
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(row) = row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    let timeout_at: Option<i64> = row
+        .try_get::<Option<i64>, _>("timeout_at_ms")
+        .map_err(map_sqlx_error)?;
+    if !matches!(timeout_at, Some(t) if t < now_ms) {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+
+    match behavior {
+        "auto_resume_with_timeout_signal" => {
+            // Append synthetic timeout signal into member_map[__timeout__]
+            // and clear timeout_at_ms so the scanner doesn't re-fire.
+            // The signal_name is fixed to "timeout" — consumers that
+            // want a custom name thread it through the composite
+            // condition's `on_timeout` branch (future wave).
+            let member_map: JsonValue = row.try_get("member_map").map_err(map_sqlx_error)?;
+            let mut map = match member_map {
+                JsonValue::Object(m) => m,
+                _ => serde_json::Map::new(),
+            };
+            let entry = map
+                .entry("__timeout__".to_string())
+                .or_insert_with(|| JsonValue::Array(Vec::new()));
+            if let JsonValue::Array(a) = entry {
+                a.push(json!({
+                    "signal_name": "timeout",
+                    "payload": null,
+                    "delivered_at_ms": now_ms,
+                    "source": "suspension_timeout",
+                }));
+            }
+            sqlx::query(
+                r#"
+                UPDATE ff_suspension_current
+                   SET member_map    = $1,
+                       timeout_at_ms = NULL
+                 WHERE partition_key = $2 AND execution_id = $3
+                "#,
+            )
+            .bind(JsonValue::Object(map))
+            .bind(partition_key)
+            .bind(exec_uuid)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        }
+        // "fail" (default), "cancel", "expire", "escalate": all
+        // collapse to terminal in the PG port. Differentiate the
+        // `cancellation_reason` so downstream audit can tell them
+        // apart.
+        other => {
+            let reason = match other {
+                "cancel" => "suspension_timeout_cancel",
+                "expire" => "suspension_timeout_expire",
+                "escalate" => "suspension_timeout_escalate",
+                _ => "suspension_timeout_fail",
+            };
+            sqlx::query(
+                r#"
+                UPDATE ff_exec_core
+                   SET lifecycle_phase = 'terminal',
+                       ownership_state = 'unowned',
+                       eligibility_state = 'not_applicable',
+                       attempt_state = 'attempt_terminal',
+                       terminal_at_ms = $1,
+                       cancellation_reason = $2,
+                       raw_fields = raw_fields || jsonb_build_object(
+                           'last_failure_message', 'suspension_timeout'
+                       )
+                 WHERE partition_key = $3 AND execution_id = $4
+                "#,
+            )
+            .bind(now_ms)
+            .bind(reason)
+            .bind(partition_key)
+            .bind(exec_uuid)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            // Clear the suspension row — no longer pending.
+            sqlx::query(
+                r#"
+                DELETE FROM ff_suspension_current
+                 WHERE partition_key = $1 AND execution_id = $2
+                "#,
+            )
+            .bind(partition_key)
+            .bind(exec_uuid)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            // Outbox: emit completion event.
+            let outcome = if other == "cancel" {
+                "cancelled"
+            } else {
+                "expired"
+            };
+            sqlx::query(
+                r#"
+                INSERT INTO ff_completion_event (
+                    partition_key, execution_id, flow_id, outcome,
+                    namespace, instance_tag, occurred_at_ms
+                )
+                SELECT partition_key, execution_id, flow_id, $3,
+                       NULL, NULL, $4
+                  FROM ff_exec_core
+                 WHERE partition_key = $1 AND execution_id = $2
+                "#,
+            )
+            .bind(partition_key)
+            .bind(exec_uuid)
+            .bind(outcome)
+            .bind(now_ms)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        }
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -388,8 +388,9 @@ pub(crate) async fn suspend_impl(
             sqlx::query(
                 "INSERT INTO ff_suspension_current \
                    (partition_key, execution_id, suspension_id, suspended_at_ms, \
-                    timeout_at_ms, reason_code, condition, satisfied_set, member_map) \
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, '[]'::jsonb, '{}'::jsonb) \
+                    timeout_at_ms, reason_code, condition, satisfied_set, member_map, \
+                    timeout_behavior) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, '[]'::jsonb, '{}'::jsonb, $8) \
                  ON CONFLICT (partition_key, execution_id) DO UPDATE SET \
                    suspension_id = EXCLUDED.suspension_id, \
                    suspended_at_ms = EXCLUDED.suspended_at_ms, \
@@ -397,7 +398,8 @@ pub(crate) async fn suspend_impl(
                    reason_code = EXCLUDED.reason_code, \
                    condition = EXCLUDED.condition, \
                    satisfied_set = '[]'::jsonb, \
-                   member_map = '{}'::jsonb",
+                   member_map = '{}'::jsonb, \
+                   timeout_behavior = EXCLUDED.timeout_behavior",
             )
             .bind(part)
             .bind(exec_uuid)
@@ -406,6 +408,7 @@ pub(crate) async fn suspend_impl(
             .bind(args.timeout_at.map(|t| t.0))
             .bind(args.reason_code.as_wire_str())
             .bind(&condition_json)
+            .bind(args.timeout_behavior.as_wire_str())
             .execute(&mut **tx)
             .await
             .map_err(map_sqlx_error)?;

--- a/crates/ff-engine/src/scanner/attempt_timeout.rs
+++ b/crates/ff-engine/src/scanner/attempt_timeout.rs
@@ -18,6 +18,22 @@ use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
 const BATCH_SIZE: u32 = 50;
 
+// ─── Postgres branch (wave 6c) ──────────────────────────────────────────
+//
+// Parallel entry point for deployments running the Postgres backend.
+// Delegates to `ff_backend_postgres::reconcilers::attempt_timeout`. The
+// Valkey scan path above is untouched. The engine's driver picks this
+// branch when the configured backend is Postgres; same shape as
+// `dispatch_via_postgres` (partition_router.rs).
+#[cfg(feature = "postgres")]
+pub async fn scan_tick_pg(
+    pool: &ff_backend_postgres::PgPool,
+    partition_key: i16,
+    filter: &ff_core::backend::ScannerFilter,
+) -> Result<ff_backend_postgres::reconcilers::ScanReport, ff_core::engine_error::EngineError> {
+    ff_backend_postgres::reconcilers::attempt_timeout::scan_tick(pool, partition_key, filter).await
+}
+
 pub struct AttemptTimeoutScanner {
     interval: Duration,
     failures: FailureTracker,

--- a/crates/ff-engine/src/scanner/lease_expiry.rs
+++ b/crates/ff-engine/src/scanner/lease_expiry.rs
@@ -18,6 +18,16 @@ use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 /// Batch size per ZRANGEBYSCORE call.
 const BATCH_SIZE: u32 = 50;
 
+// ─── Postgres branch (wave 6c) ──────────────────────────────────────────
+#[cfg(feature = "postgres")]
+pub async fn scan_tick_pg(
+    pool: &ff_backend_postgres::PgPool,
+    partition_key: i16,
+    filter: &ff_core::backend::ScannerFilter,
+) -> Result<ff_backend_postgres::reconcilers::ScanReport, ff_core::engine_error::EngineError> {
+    ff_backend_postgres::reconcilers::lease_expiry::scan_tick(pool, partition_key, filter).await
+}
+
 pub struct LeaseExpiryScanner {
     interval: Duration,
     failures: FailureTracker,

--- a/crates/ff-engine/src/scanner/suspension_timeout.rs
+++ b/crates/ff-engine/src/scanner/suspension_timeout.rs
@@ -17,6 +17,17 @@ use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
 const BATCH_SIZE: u32 = 50;
 
+// ─── Postgres branch (wave 6c) ──────────────────────────────────────────
+#[cfg(feature = "postgres")]
+pub async fn scan_tick_pg(
+    pool: &ff_backend_postgres::PgPool,
+    partition_key: i16,
+    filter: &ff_core::backend::ScannerFilter,
+) -> Result<ff_backend_postgres::reconcilers::ScanReport, ff_core::engine_error::EngineError> {
+    ff_backend_postgres::reconcilers::suspension_timeout::scan_tick(pool, partition_key, filter)
+        .await
+}
+
 pub struct SuspensionTimeoutScanner {
     interval: Duration,
     failures: FailureTracker,

--- a/crates/ff-test/tests/pg_reconciler_timeouts.rs
+++ b/crates/ff-test/tests/pg_reconciler_timeouts.rs
@@ -1,0 +1,445 @@
+//! Postgres timeout-reconciler integration tests (RFC-v0.7 Wave 6c).
+//!
+//! Covers the three scanner ports landed in wave 6c:
+//!
+//!   * `attempt_timeout` — expired lease with retries remaining →
+//!     attempt interrupted + execution re-eligible. Same with retries
+//!     exhausted → terminal + completion event emitted.
+//!   * `lease_expiry` — orphaned lease → reclaim becomes redeemable
+//!     via `claim_from_reclaim`.
+//!   * `suspension_timeout` — `Fail` behavior → terminal; `Signal`
+//!     behavior → synthetic timeout entry in member_map + timeout
+//!     cleared so the scanner doesn't re-fire.
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://user:pw@localhost/ff_wave6c_test \
+//!   cargo test -p ff-test --test pg_reconciler_timeouts -- --ignored
+//! ```
+
+use std::collections::HashMap;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_backend_postgres::reconcilers::{
+    attempt_timeout as rt_attempt, lease_expiry as rt_lease, suspension_timeout as rt_susp,
+};
+use ff_core::backend::{CapabilitySet, ClaimPolicy, ScannerFilter};
+use ff_core::contracts::CreateExecutionArgs;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::policy::{ExecutionPolicy, RetryPolicy};
+use ff_core::types::{ExecutionId, LaneId, Namespace, TimestampMs, WorkerId, WorkerInstanceId};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+
+// ── fixture helpers ─────────────────────────────────────────────────
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+fn now() -> TimestampMs {
+    TimestampMs(1_700_000_000_000)
+}
+
+fn exec_uuid(eid: &ExecutionId) -> uuid::Uuid {
+    uuid::Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap()
+}
+
+fn part_key(eid: &ExecutionId) -> i16 {
+    eid.partition() as i16
+}
+
+fn policy_with_max_retries(n: u32) -> ExecutionPolicy {
+    let rp = RetryPolicy {
+        max_retries: n,
+        ..RetryPolicy::default()
+    };
+    ExecutionPolicy {
+        retry_policy: Some(rp),
+        ..ExecutionPolicy::default()
+    }
+}
+
+async fn seed_exec_with_policy(
+    backend: &std::sync::Arc<PostgresBackend>,
+    lane: &LaneId,
+    policy: Option<ExecutionPolicy>,
+) -> ExecutionId {
+    let eid = ExecutionId::solo(lane, &PartitionConfig::default());
+    backend
+        .create_execution(CreateExecutionArgs {
+            execution_id: eid.clone(),
+            namespace: Namespace::new("wave6c-test"),
+            lane_id: lane.clone(),
+            execution_kind: "task".into(),
+            input_payload: b"{}".to_vec(),
+            payload_encoding: Some("application/json".into()),
+            priority: 0,
+            creator_identity: "pg-wave6c".into(),
+            idempotency_key: None,
+            tags: HashMap::new(),
+            policy,
+            delay_until: None,
+            execution_deadline_at: None,
+            partition_id: eid.partition(),
+            now: now(),
+        })
+        .await
+        .expect("create_execution OK");
+    eid
+}
+
+/// Place the execution in `active` phase with a live lease on
+/// `attempt_index = 0`, owned by `wid`/`wiid`, expiring at `expires_ms`.
+async fn install_active_lease(
+    pool: &PgPool,
+    eid: &ExecutionId,
+    wid: &WorkerId,
+    wiid: &WorkerInstanceId,
+    expires_ms: i64,
+) {
+    let part = part_key(eid);
+    let uuid = exec_uuid(eid);
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='active', ownership_state='leased', \
+         eligibility_state='not_applicable', attempt_state='running_attempt' \
+         WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ff_attempt (partition_key, execution_id, attempt_index, worker_id, \
+            worker_instance_id, lease_epoch, lease_expires_at_ms, started_at_ms) \
+         VALUES ($1, $2, 0, $3, $4, 1, $5, $6) \
+         ON CONFLICT (partition_key, execution_id, attempt_index) DO UPDATE SET \
+             worker_id=EXCLUDED.worker_id, worker_instance_id=EXCLUDED.worker_instance_id, \
+             lease_epoch=1, lease_expires_at_ms=EXCLUDED.lease_expires_at_ms, \
+             outcome=NULL, terminal_at_ms=NULL",
+    )
+    .bind(part)
+    .bind(uuid)
+    .bind(wid.as_str())
+    .bind(wiid.as_str())
+    .bind(expires_ms)
+    .bind(expires_ms - 10_000)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+// ── attempt_timeout ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn attempt_timeout_retries_remain_makes_execution_eligible_again() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let lane = LaneId::new(format!("wave6c-at-retry-{}", uuid::Uuid::new_v4()));
+    let eid = seed_exec_with_policy(&backend, &lane, Some(policy_with_max_retries(3))).await;
+    let part = part_key(&eid);
+    let wid = WorkerId::new("w-wave6c-at");
+    let wiid = WorkerInstanceId::new("wi-wave6c-at");
+
+    // Expired 1h ago.
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    install_active_lease(&pool, &eid, &wid, &wiid, now_ms - 3_600_000).await;
+
+    let report = rt_attempt::scan_tick(&pool, part, &ScannerFilter::NOOP)
+        .await
+        .expect("scan_tick OK");
+    assert_eq!(report.processed, 1, "exactly one timed-out attempt");
+    assert_eq!(report.errors, 0);
+
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, eligibility_state, attempt_state, attempt_index \
+           FROM ff_exec_core WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let phase: String = row.get("lifecycle_phase");
+    let elig: String = row.get("eligibility_state");
+    let astate: String = row.get("attempt_state");
+    let attempt_index: i32 = row.get("attempt_index");
+    assert_eq!(phase, "runnable", "retries remain → runnable");
+    assert_eq!(elig, "eligible_now");
+    assert_eq!(astate, "pending_retry_attempt");
+    assert_eq!(attempt_index, 1, "attempt_index bumped");
+
+    let outcome: Option<String> = sqlx::query_scalar(
+        "SELECT outcome FROM ff_attempt WHERE partition_key=$1 AND execution_id=$2 AND attempt_index=0",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(outcome.as_deref(), Some("interrupted"));
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn attempt_timeout_retries_exhausted_terminalizes_and_emits_event() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let lane = LaneId::new(format!("wave6c-at-exhaust-{}", uuid::Uuid::new_v4()));
+    let eid = seed_exec_with_policy(&backend, &lane, Some(policy_with_max_retries(0))).await;
+    let part = part_key(&eid);
+    let wid = WorkerId::new("w-wave6c-at2");
+    let wiid = WorkerInstanceId::new("wi-wave6c-at2");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    install_active_lease(&pool, &eid, &wid, &wiid, now_ms - 60_000).await;
+
+    let report = rt_attempt::scan_tick(&pool, part, &ScannerFilter::NOOP)
+        .await
+        .expect("scan_tick OK");
+    assert_eq!(report.processed, 1);
+
+    let phase: String = sqlx::query_scalar(
+        "SELECT lifecycle_phase FROM ff_exec_core WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(phase, "terminal");
+
+    let outcomes: Vec<String> = sqlx::query_scalar(
+        "SELECT outcome FROM ff_completion_event WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert!(
+        outcomes.contains(&"expired".to_string()),
+        "expected completion event with outcome=expired, got {outcomes:?}"
+    );
+}
+
+// ── lease_expiry ────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn lease_expiry_releases_orphaned_lease_and_claim_from_reclaim_succeeds() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let lane = LaneId::new(format!("wave6c-le-{}", uuid::Uuid::new_v4()));
+    let eid = seed_exec_with_policy(&backend, &lane, None).await;
+    let part = part_key(&eid);
+    let wid_old = WorkerId::new("w-gone");
+    let wiid_old = WorkerInstanceId::new("wi-gone");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    install_active_lease(&pool, &eid, &wid_old, &wiid_old, now_ms - 300_000).await;
+
+    let report = rt_lease::scan_tick(&pool, part, &ScannerFilter::NOOP)
+        .await
+        .expect("lease scan_tick OK");
+    assert_eq!(report.processed, 1, "one expired lease released");
+    assert_eq!(report.errors, 0);
+
+    // Lease column nulled + exec flipped back to runnable.
+    let row = sqlx::query(
+        "SELECT a.lease_expires_at_ms, a.outcome, c.lifecycle_phase, c.eligibility_state \
+           FROM ff_attempt a JOIN ff_exec_core c \
+             ON c.partition_key=a.partition_key AND c.execution_id=a.execution_id \
+          WHERE a.partition_key=$1 AND a.execution_id=$2 AND a.attempt_index=0",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let lease_at: Option<i64> = row.get("lease_expires_at_ms");
+    let outcome: Option<String> = row.get("outcome");
+    let phase: String = row.get("lifecycle_phase");
+    let elig: String = row.get("eligibility_state");
+    assert!(lease_at.is_none(), "lease column cleared");
+    assert_eq!(outcome.as_deref(), Some("lease_expired_reclaimable"));
+    assert_eq!(phase, "runnable");
+    assert_eq!(elig, "eligible_now");
+
+    // A fresh worker can now claim the lane — the released lease means
+    // the standard claim path picks the exec back up.
+    let caps: CapabilitySet = CapabilitySet::new(std::iter::empty::<&str>());
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w-fresh"),
+        WorkerInstanceId::new("wi-fresh"),
+        30_000,
+        None,
+    );
+    let h = backend.claim(&lane, &caps, policy).await.expect("claim OK");
+    assert!(h.is_some(), "fresh worker claims the reclaimed exec");
+}
+
+// ── suspension_timeout ──────────────────────────────────────────────
+
+async fn install_suspension(pool: &PgPool, eid: &ExecutionId, timeout_at_ms: i64, behavior: &str) {
+    let part = part_key(eid);
+    let uuid = exec_uuid(eid);
+    // Flip exec_core into a `suspended` lifecycle phase so the
+    // terminal branch has a visible source state to transition from.
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='suspended', ownership_state='unowned', \
+         eligibility_state='blocked_by_dependencies', attempt_state='attempt_interrupted' \
+         WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ff_suspension_current \
+           (partition_key, execution_id, suspension_id, suspended_at_ms, timeout_at_ms, \
+            reason_code, condition, satisfied_set, member_map, timeout_behavior) \
+         VALUES ($1, $2, $3, $4, $5, 'waiting_for_signal', '{}'::jsonb, '[]'::jsonb, \
+                 '{}'::jsonb, $6)",
+    )
+    .bind(part)
+    .bind(uuid)
+    .bind(uuid::Uuid::new_v4())
+    .bind(timeout_at_ms - 60_000)
+    .bind(timeout_at_ms)
+    .bind(behavior)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn suspension_timeout_signal_behavior_appends_timeout_member() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let lane = LaneId::new(format!("wave6c-st-sig-{}", uuid::Uuid::new_v4()));
+    let eid = seed_exec_with_policy(&backend, &lane, None).await;
+    let part = part_key(&eid);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    install_suspension(
+        &pool,
+        &eid,
+        now_ms - 1_000,
+        "auto_resume_with_timeout_signal",
+    )
+    .await;
+
+    let report = rt_susp::scan_tick(&pool, part, &ScannerFilter::NOOP)
+        .await
+        .expect("susp scan_tick OK");
+    assert_eq!(report.processed, 1);
+    assert_eq!(report.errors, 0);
+
+    let row = sqlx::query(
+        "SELECT member_map, timeout_at_ms FROM ff_suspension_current \
+         WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let mm: serde_json::Value = row.get("member_map");
+    let to_at: Option<i64> = row.get("timeout_at_ms");
+    assert!(to_at.is_none(), "timeout_at cleared after signal fan-out");
+    let timeout_bucket = mm
+        .get("__timeout__")
+        .and_then(|v| v.as_array())
+        .expect("__timeout__ bucket present");
+    assert_eq!(timeout_bucket.len(), 1);
+    assert_eq!(
+        timeout_bucket[0]
+            .get("signal_name")
+            .and_then(|v| v.as_str()),
+        Some("timeout")
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn suspension_timeout_fail_behavior_terminalizes_and_clears_suspension() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let lane = LaneId::new(format!("wave6c-st-fail-{}", uuid::Uuid::new_v4()));
+    let eid = seed_exec_with_policy(&backend, &lane, None).await;
+    let part = part_key(&eid);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    install_suspension(&pool, &eid, now_ms - 1_000, "fail").await;
+
+    let report = rt_susp::scan_tick(&pool, part, &ScannerFilter::NOOP)
+        .await
+        .expect("susp scan_tick OK");
+    assert_eq!(report.processed, 1);
+
+    let phase: String = sqlx::query_scalar(
+        "SELECT lifecycle_phase FROM ff_exec_core WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(phase, "terminal");
+
+    let n: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_suspension_current \
+         WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(n, 0, "suspension row cleared");
+
+    let outcomes: Vec<String> = sqlx::query_scalar(
+        "SELECT outcome FROM ff_completion_event WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid(&eid))
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert!(outcomes.iter().any(|o| o == "expired"));
+}


### PR DESCRIPTION
## Summary

Wave 6 Agent C — ports three Valkey ZSET-scan timeout scanners to Postgres and wires engine-side dispatch branches.

- `ff_backend_postgres::reconcilers::attempt_timeout` — expired lease on active exec → attempt interrupted; re-eligible (retries remain) or terminal + completion event (exhausted). Retry budget read from `policy.retry_policy.max_retries` on `ff_exec_core`.
- `ff_backend_postgres::reconcilers::lease_expiry` — orphaned lease → NULL `lease_expires_at_ms` + mark `lease_expired_reclaimable` so `claim_from_reclaim` (or a fresh `claim`) redeems.
- `ff_backend_postgres::reconcilers::suspension_timeout` — `Fail/Cancel/Expire/Escalate` → terminal-cancel + completion event; `AutoResumeWithTimeoutSignal` → synthetic `__timeout__` signal appended to `member_map` + `timeout_at_ms` cleared.

Migration `0005_timeout_scanners.sql` (backward-compatible) adds `ff_suspension_current.timeout_behavior text`; `suspend_ops::suspend_impl` now binds `args.timeout_behavior.as_wire_str()` on INSERT.

Engine: each of the three `ff-engine/src/scanner/{attempt_timeout,lease_expiry,suspension_timeout}.rs` files adds a `#[cfg(feature = \"postgres\")] pub async fn scan_tick_pg` that delegates to the new reconciler. Valkey paths are untouched.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo check -p ff-engine --features postgres` clean
- [x] `cargo clippy -p ff-backend-postgres -p ff-test` clean on new files
- [ ] With live Postgres: `FF_PG_TEST_URL=... cargo test -p ff-test --test pg_reconciler_timeouts -- --ignored` — 5 scenarios covering retries-remain retry path, retries-exhausted terminal path, lease-expiry reclaim path, suspension Signal behavior, suspension Fail behavior.

## Constraints honored

- Per-row transactions (not per-batch); each row expiry is atomic.
- `ScannerFilter` namespace + `instance_tag` applied via `ff_exec_core.raw_fields`.
- Partial indexes `ff_attempt_lease_expiry_idx` + `ff_suspension_current_timeout_idx` cover the scans.

## Parallel siblings

Wave 6a (dep-reconciler), 6b (edge-cancel), 6d (completion-outbox-drain) are independent lanes; this PR only touches `reconcilers/mod.rs` additively (own `pub mod` lines under the shared `ScanReport`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Postgres reconcilers that mutate execution lifecycle state and emit completion events based on timeouts; correctness depends on SQL predicates/locking and the new `timeout_behavior` column being populated consistently.
> 
> **Overview**
> Ports the Wave 6c timeout scanners to the Postgres backend by adding new reconcilers for `attempt_timeout`, `lease_expiry`, and `suspension_timeout`, each scanning by timestamp columns and applying per-row transactional state transitions.
> 
> Adds a backward-compatible migration to persist `ff_suspension_current.timeout_behavior`, updates `suspend_impl` to write it, and updates the engine scanners to expose `scan_tick_pg` entry points (behind `postgres` feature) that delegate to the new Postgres reconcilers. An ignored integration test suite is included to validate the three reconciler behaviors against a live Postgres instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7375e5c96bd7a416dd80c42ca7fe58b60f169188. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->