### PR TITLE
test(pg-wave7a): backend-matrix fixture + parameterize 3 integration tests

### DIFF
--- a/crates/ff-test/src/backend_matrix.rs
+++ b/crates/ff-test/src/backend_matrix.rs
@@ -1,0 +1,453 @@
+//! Backend matrix fixture harness — **RFC-v0.7 Wave 7a**.
+//!
+//! Lets the same integration-test body run against **both** the
+//! Valkey-backed and Postgres-backed [`EngineBackend`] impls. Each
+//! test that opts into the matrix writes its body once, takes a
+//! [`BackendFixture`] parameter, and the harness loops over the
+//! requested backends.
+//!
+//! # Environment
+//!
+//! * `FF_TEST_BACKEND` — selects which backends the matrix exercises.
+//!   Accepts `valkey` (default), `postgres`, or `both`.
+//! * `FF_PG_TEST_URL` — Postgres connection URL. If unset, any
+//!   `postgres` slot is skipped with a log message (matching the
+//!   existing `#[ignore]`-by-default Postgres test pattern in
+//!   `ff-test/tests/pg_*.rs`).
+//! * Valkey connection config is read by
+//!   [`crate::fixtures::TestCluster::connect`].
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use ff_test::backend_matrix::{run_matrix, BackendFixture};
+//!
+//! #[tokio::test]
+//! async fn list_lanes_sorted() {
+//!     run_matrix(|fx| async move {
+//!         fx.seed_lanes(&["alpha", "bravo"]).await;
+//!         let page = fx.backend().list_lanes(None, 10).await.unwrap();
+//!         assert_eq!(page.lanes.len(), 2);
+//!     }).await;
+//! }
+//! ```
+//!
+//! Tests that exercise Valkey-specific seeding (direct FCALL) should
+//! stay non-matrix for now and live in their existing files.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::CreateExecutionArgs;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::ExecutionId;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use tokio::sync::OnceCell;
+
+use crate::fixtures::TestCluster;
+
+/// Which backend an integration test body is running against.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BackendKind {
+    Valkey,
+    Postgres,
+}
+
+impl BackendKind {
+    /// Human-readable label for assertion messages + log lines.
+    pub fn label(self) -> &'static str {
+        match self {
+            BackendKind::Valkey => "valkey",
+            BackendKind::Postgres => "postgres",
+        }
+    }
+}
+
+/// Backend-agnostic integration-test fixture. One instance is built
+/// per backend per test invocation by [`run_matrix`].
+///
+/// The Valkey arm holds a [`TestCluster`]; the Postgres arm holds a
+/// [`PgPool`]. Both arms expose the same surface:
+/// [`Self::backend`] (an `Arc<dyn EngineBackend>`), plus backend-
+/// agnostic seed helpers ([`Self::seed_lanes`],
+/// [`Self::seed_execution`]) so tests don't reach for FCALL / raw SQL
+/// directly.
+pub struct BackendFixture {
+    kind: BackendKind,
+    partition_config: PartitionConfig,
+    inner: Inner,
+}
+
+enum Inner {
+    Valkey {
+        tc: TestCluster,
+        backend: Arc<dyn EngineBackend>,
+    },
+    Postgres {
+        pool: PgPool,
+        backend: Arc<PostgresBackend>,
+    },
+}
+
+impl BackendFixture {
+    /// Backend tag for this fixture instance.
+    pub fn kind(&self) -> BackendKind {
+        self.kind
+    }
+
+    /// Partition config the fixture is wired to. Tests should use
+    /// this value (not the compile-time constant) when minting ids.
+    pub fn partition_config(&self) -> &PartitionConfig {
+        &self.partition_config
+    }
+
+    /// Trait-object backend handle.
+    pub fn backend(&self) -> Arc<dyn EngineBackend> {
+        match &self.inner {
+            Inner::Valkey { backend, .. } => backend.clone(),
+            Inner::Postgres { backend, .. } => backend.clone() as Arc<dyn EngineBackend>,
+        }
+    }
+
+    /// Valkey-only accessor. Panics on the Postgres arm; use sparingly
+    /// from tests that need direct cluster access (e.g. FCALL setup
+    /// that hasn't yet been lifted into the fixture surface).
+    pub fn as_valkey(&self) -> &TestCluster {
+        match &self.inner {
+            Inner::Valkey { tc, .. } => tc,
+            Inner::Postgres { .. } => panic!("BackendFixture::as_valkey called on Postgres arm"),
+        }
+    }
+
+    /// Postgres-only accessor. Panics on the Valkey arm.
+    pub fn as_postgres(&self) -> &PgPool {
+        match &self.inner {
+            Inner::Postgres { pool, .. } => pool,
+            Inner::Valkey { .. } => panic!("BackendFixture::as_postgres called on Valkey arm"),
+        }
+    }
+
+    /// Seed the lane registry with the given ids. Backend-agnostic.
+    ///
+    /// * Valkey: `SADD ff:idx:lanes <lanes...>` — matches the shape
+    ///   tests were already driving via ad-hoc `SADD` calls.
+    /// * Postgres: bulk `INSERT ... ON CONFLICT DO NOTHING` into
+    ///   `ff_lane_registry`.
+    pub async fn seed_lanes(&self, lanes: &[&str]) {
+        if lanes.is_empty() {
+            return;
+        }
+        match &self.inner {
+            Inner::Valkey { tc, .. } => {
+                let members: Vec<String> =
+                    lanes.iter().map(|s| (*s).to_owned()).collect();
+                let _: i64 = tc
+                    .client()
+                    .cmd("SADD")
+                    .arg("ff:idx:lanes")
+                    .arg(members)
+                    .execute()
+                    .await
+                    .expect("SADD ff:idx:lanes");
+            }
+            Inner::Postgres { pool, .. } => {
+                let now_ms: i64 = ff_core::types::TimestampMs::now().0;
+                for lane in lanes {
+                    sqlx::query(
+                        "INSERT INTO ff_lane_registry \
+                         (lane_id, registered_at_ms, registered_by) \
+                         VALUES ($1, $2, $3) \
+                         ON CONFLICT (lane_id) DO NOTHING",
+                    )
+                    .bind(*lane)
+                    .bind(now_ms)
+                    .bind("ff-test-matrix")
+                    .execute(pool)
+                    .await
+                    .expect("INSERT ff_lane_registry");
+                }
+            }
+        }
+    }
+
+    /// Seed a single execution. Backend-agnostic: lands the row via
+    /// the Valkey `ff_create_execution` FCALL or the Postgres
+    /// [`PostgresBackend::create_execution`] inherent.
+    pub async fn seed_execution(&self, args: CreateExecutionArgs) -> ExecutionId {
+        match &self.inner {
+            Inner::Valkey { tc, .. } => seed_execution_valkey(tc, args).await,
+            Inner::Postgres { backend, .. } => backend
+                .create_execution(args)
+                .await
+                .expect("PostgresBackend::create_execution"),
+        }
+    }
+
+    /// Drop every row / key the fixture can reach. Called implicitly
+    /// at fixture construction so each `run_matrix` invocation starts
+    /// from a clean slate.
+    pub async fn cleanup(&self) {
+        match &self.inner {
+            Inner::Valkey { tc, .. } => tc.cleanup().await,
+            Inner::Postgres { pool, .. } => truncate_postgres(pool).await,
+        }
+    }
+}
+
+/// Build a fixture for the given backend. Panics on connection
+/// failure — matches [`TestCluster::connect`]'s existing contract.
+pub async fn fixture(kind: BackendKind) -> BackendFixture {
+    match kind {
+        BackendKind::Valkey => {
+            let tc = TestCluster::connect().await;
+            tc.cleanup().await;
+            let partition_config = *tc.partition_config();
+            let backend = tc.backend();
+            BackendFixture {
+                kind,
+                partition_config,
+                inner: Inner::Valkey { tc, backend },
+            }
+        }
+        BackendKind::Postgres => {
+            let url = std::env::var("FF_PG_TEST_URL").unwrap_or_else(|_| {
+                panic!(
+                    "FF_PG_TEST_URL must be set to build a Postgres BackendFixture; \
+                     `requested_backends()` should have filtered this out"
+                )
+            });
+            let pool = pg_pool().await.unwrap_or_else(|| {
+                panic!("failed to build Postgres pool at {url}")
+            });
+            truncate_postgres(&pool).await;
+            // Match the Valkey arm's partition config so execution ids
+            // route to the same `partition_key` values on both backends.
+            let partition_config = crate::fixtures::TEST_PARTITION_CONFIG;
+            let backend = PostgresBackend::from_pool(pool.clone(), partition_config);
+            BackendFixture {
+                kind,
+                partition_config,
+                inner: Inner::Postgres { pool, backend },
+            }
+        }
+    }
+}
+
+/// Parse the `FF_TEST_BACKEND` env var + filter by availability.
+///
+/// * `valkey` (or unset) — `[Valkey]`
+/// * `postgres` — `[Postgres]`
+/// * `both` — `[Valkey, Postgres]`
+/// * anything else — panics with a readable error.
+///
+/// When the list would include `Postgres` but `FF_PG_TEST_URL` is
+/// unset, the Postgres entry is dropped with a log message. If that
+/// leaves the list empty, returns `[Valkey]` so CI that sets
+/// `FF_TEST_BACKEND=postgres` without a URL still exercises
+/// *something* (matches the soft-skip behaviour of the existing
+/// `pg_*.rs` tests, which return early when `FF_PG_TEST_URL` is unset
+/// rather than hard-failing).
+pub fn requested_backends() -> Vec<BackendKind> {
+    let raw = std::env::var("FF_TEST_BACKEND").unwrap_or_else(|_| "valkey".to_owned());
+    let mut requested: Vec<BackendKind> = match raw.as_str() {
+        "valkey" => vec![BackendKind::Valkey],
+        "postgres" => vec![BackendKind::Postgres],
+        "both" => vec![BackendKind::Valkey, BackendKind::Postgres],
+        other => panic!(
+            "FF_TEST_BACKEND must be one of valkey|postgres|both (got {other:?})"
+        ),
+    };
+    if requested.contains(&BackendKind::Postgres) && std::env::var("FF_PG_TEST_URL").is_err() {
+        eprintln!(
+            "ff-test backend-matrix: FF_PG_TEST_URL unset — skipping Postgres slot"
+        );
+        requested.retain(|k| *k != BackendKind::Postgres);
+    }
+    if requested.is_empty() {
+        requested.push(BackendKind::Valkey);
+    }
+    requested
+}
+
+/// Run the async test body once per requested backend.
+///
+/// Each iteration builds a fresh [`BackendFixture`] (with cleanup on
+/// construction), runs the body, and drops the fixture. Panics in
+/// the body propagate with a backend label attached so failures say
+/// which backend tripped.
+pub async fn run_matrix<F, Fut>(body: F)
+where
+    F: Fn(BackendFixture) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    for kind in requested_backends() {
+        eprintln!("ff-test backend-matrix: running against {}", kind.label());
+        let fx = fixture(kind).await;
+        body(fx).await;
+    }
+}
+
+// ─── Internal helpers ───
+
+/// Shared Postgres pool guarded by `OnceCell` so all matrix-based
+/// tests reuse one set of connections per process (matches the
+/// `LIBRARY_LOADED` pattern in `fixtures.rs`).
+static PG_POOL: OnceCell<PgPool> = OnceCell::const_new();
+
+async fn pg_pool() -> Option<PgPool> {
+    let cell = PG_POOL
+        .get_or_try_init(|| async {
+            let url = std::env::var("FF_PG_TEST_URL")
+                .map_err(|_| "FF_PG_TEST_URL not set".to_owned())?;
+            // Bump max_connections: each `PostgresBackend::from_pool`
+            // call spawns a `StreamNotifier` task that holds a
+            // dedicated LISTEN connection for that backend's lifetime.
+            // Matrix tests rebuild the backend per test, and tokio's
+            // per-test runtime teardown doesn't always reclaim the
+            // connection promptly — a higher cap avoids the pool
+            // running dry across a test file's worth of fixtures.
+            let pool = PgPoolOptions::new()
+                .max_connections(32)
+                .connect(&url)
+                .await
+                .map_err(|e| format!("connect {url}: {e}"))?;
+            ff_backend_postgres::apply_migrations(&pool)
+                .await
+                .map_err(|e| format!("apply_migrations: {e}"))?;
+            Ok::<PgPool, String>(pool)
+        })
+        .await
+        .ok()?;
+    Some(cell.clone())
+}
+
+/// Truncate every Wave-4+ table the matrix fixture can write. Run
+/// between fixture instances so tests don't see each other's rows.
+///
+/// Uses `TRUNCATE ... RESTART IDENTITY CASCADE` so foreign-key
+/// dependents are cleared automatically. Limited to tables the
+/// current matrix tests seed or assert against — new Wave-n tables
+/// can be appended here as they come online without breaking older
+/// callers.
+async fn truncate_postgres(pool: &PgPool) {
+    let tables = [
+        "ff_exec_core",
+        "ff_attempt_current",
+        "ff_attempt_history",
+        "ff_suspension_current",
+        "ff_flow_core",
+        "ff_flow_members",
+        "ff_flow_edges",
+        "ff_lane_registry",
+        "ff_budget_current",
+        "ff_stream_frames",
+        "ff_pending_cancel_groups",
+        "ff_completion_outbox",
+    ];
+    // Per-table truncate gated by `to_regclass` so a table a future
+    // migration hasn't landed yet is skipped rather than aborting the
+    // reset. A bulk `TRUNCATE a, b, c` would be faster but fails
+    // atomically on the first missing relation.
+    for t in &tables {
+        let exists: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+            .bind(*t)
+            .fetch_one(pool)
+            .await
+            .unwrap_or(None);
+        if exists.is_some() {
+            let _ = sqlx::query(&format!("TRUNCATE {t} RESTART IDENTITY CASCADE"))
+                .execute(pool)
+                .await;
+        }
+    }
+}
+
+/// Valkey arm of `seed_execution`: drive the same `ff_create_execution`
+/// FCALL that production traffic (ff-server → ValkeyBackend) uses.
+async fn seed_execution_valkey(
+    tc: &TestCluster,
+    args: CreateExecutionArgs,
+) -> ExecutionId {
+    use ff_core::keys::{ExecKeyContext, IndexKeys};
+    use ff_core::partition::execution_partition;
+
+    let config = *tc.partition_config();
+    let partition = execution_partition(&args.execution_id, &config);
+    let ctx = ExecKeyContext::new(&partition, &args.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let tags_json = serde_json::to_string(&args.tags).unwrap_or_else(|_| "{}".to_owned());
+    let policy_json = args
+        .policy
+        .as_ref()
+        .map(|p| serde_json::to_string(p).unwrap_or_else(|_| "{}".to_owned()))
+        .unwrap_or_else(|| "{}".to_owned());
+    let delay_str = args
+        .delay_until
+        .map(|d| d.0.to_string())
+        .unwrap_or_default();
+    let is_delayed = !delay_str.is_empty();
+    let scheduling_zset = if is_delayed {
+        idx.lane_delayed(&args.lane_id)
+    } else {
+        idx.lane_eligible(&args.lane_id)
+    };
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        scheduling_zset,
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let argv: Vec<String> = vec![
+        args.execution_id.to_string(),
+        args.namespace.to_string(),
+        args.lane_id.to_string(),
+        args.execution_kind,
+        args.priority.to_string(),
+        args.creator_identity,
+        policy_json,
+        String::from_utf8_lossy(&args.input_payload).into_owned(),
+        delay_str,
+        String::new(),
+        tags_json,
+        args.execution_deadline_at
+            .map(|d| d.to_string())
+            .unwrap_or_default(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let _: ferriskey::Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("FCALL ff_create_execution (matrix seed, Valkey arm)");
+    args.execution_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_labels_are_stable() {
+        assert_eq!(BackendKind::Valkey.label(), "valkey");
+        assert_eq!(BackendKind::Postgres.label(), "postgres");
+    }
+
+    #[test]
+    fn requested_backends_default_is_valkey() {
+        // Don't mutate env inside concurrent tests — only read-path.
+        if std::env::var("FF_TEST_BACKEND").is_err() {
+            assert_eq!(requested_backends(), vec![BackendKind::Valkey]);
+        }
+    }
+}

--- a/crates/ff-test/src/lib.rs
+++ b/crates/ff-test/src/lib.rs
@@ -29,6 +29,7 @@
 //! ```
 
 pub mod assertions;
+pub mod backend_matrix;
 pub mod fixtures;
 pub mod helpers;
 

--- a/crates/ff-test/tests/matrix_describe_execution.rs
+++ b/crates/ff-test/tests/matrix_describe_execution.rs
@@ -1,0 +1,92 @@
+//! Backend-matrix variant of `engine_backend_describe.rs`
+//! (execution-side only) — RFC-v0.7 Wave 7a.
+//!
+//! `describe_flow` stays Valkey-only for now: the Valkey path seeds
+//! flows through `ff_create_flow` FCALL; the Postgres equivalent
+//! (`ff_flow_core` row insertion) is still being shaped by
+//! Waves 4c/4f and not yet exposed via a backend-agnostic fixture
+//! surface.
+
+use std::collections::HashMap;
+
+use ff_core::contracts::CreateExecutionArgs;
+use ff_core::partition::execution_partition;
+use ff_core::state::PublicState;
+use ff_core::types::{ExecutionId, FlowId, LaneId, Namespace, TimestampMs};
+use ff_test::backend_matrix::run_matrix;
+
+const LANE: &str = "matrix-desc-lane";
+const NS: &str = "matrix-desc-ns";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn describe_execution_returns_snapshot_for_fresh_row() {
+    run_matrix(|fx| async move {
+        let cfg = *fx.partition_config();
+        let lane = LaneId::new(LANE);
+        let eid = ExecutionId::for_flow(&FlowId::new(), &cfg);
+        let partition = execution_partition(&eid, &cfg);
+
+        let mut tags = HashMap::new();
+        tags.insert("cairn.task_id".to_owned(), "t-www".to_owned());
+        tags.insert("cairn.project".to_owned(), "ff".to_owned());
+
+        let args = CreateExecutionArgs {
+            execution_id: eid.clone(),
+            namespace: Namespace::new(NS),
+            lane_id: lane.clone(),
+            execution_kind: "matrix_desc_kind".to_owned(),
+            input_payload: b"{}".to_vec(),
+            payload_encoding: Some("application/json".to_owned()),
+            priority: 0,
+            creator_identity: "matrix-desc-test".to_owned(),
+            idempotency_key: None,
+            tags: tags.clone(),
+            policy: None,
+            delay_until: None,
+            execution_deadline_at: None,
+            partition_id: partition.index,
+            now: TimestampMs::now(),
+        };
+        fx.seed_execution(args).await;
+
+        let snap = fx
+            .backend()
+            .describe_execution(&eid)
+            .await
+            .expect("describe_execution OK")
+            .expect("snapshot present");
+
+        assert_eq!(snap.execution_id, eid, "[{}]", fx.kind().label());
+        assert_eq!(snap.lane_id, lane);
+        assert_eq!(snap.namespace.as_str(), NS);
+        assert_eq!(snap.public_state, PublicState::Waiting);
+        assert_eq!(
+            snap.tags.get("cairn.task_id").map(String::as_str),
+            Some("t-www")
+        );
+        assert_eq!(
+            snap.tags.get("cairn.project").map(String::as_str),
+            Some("ff")
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn describe_execution_on_unknown_returns_none() {
+    run_matrix(|fx| async move {
+        let cfg = *fx.partition_config();
+        let eid = ExecutionId::for_flow(&FlowId::new(), &cfg);
+        let snap = fx
+            .backend()
+            .describe_execution(&eid)
+            .await
+            .expect("describe_execution OK");
+        assert!(
+            snap.is_none(),
+            "[{}] describe on unseeded id must be None",
+            fx.kind().label()
+        );
+    })
+    .await;
+}

--- a/crates/ff-test/tests/matrix_list_executions.rs
+++ b/crates/ff-test/tests/matrix_list_executions.rs
@@ -1,0 +1,152 @@
+//! Backend-matrix variant of the cursor-pagination half of
+//! `engine_backend_list_executions.rs` — RFC-v0.7 Wave 7a.
+//!
+//! Exercises [`EngineBackend::list_executions`] with keyset cursors
+//! on both Valkey + Postgres backends. The HTTP half (which boots
+//! `ff-server`) stays in the Valkey-only file — ff-server's
+//! Postgres path is a sibling wave's scope.
+
+use std::collections::HashMap;
+
+use ff_core::contracts::CreateExecutionArgs;
+use ff_core::partition::{execution_partition, PartitionKey};
+use ff_core::types::{ExecutionId, FlowId, LaneId, Namespace, TimestampMs};
+use ff_test::backend_matrix::{run_matrix, BackendFixture};
+
+const LANE: &str = "matrix-list-execs-lane";
+const NS: &str = "matrix-list-execs-ns";
+
+fn sample_args(
+    eid: &ExecutionId,
+    lane: &LaneId,
+    partition_id: u16,
+) -> CreateExecutionArgs {
+    CreateExecutionArgs {
+        execution_id: eid.clone(),
+        namespace: Namespace::new(NS),
+        lane_id: lane.clone(),
+        execution_kind: "matrix_list_kind".to_owned(),
+        input_payload: b"{}".to_vec(),
+        payload_encoding: Some("application/json".to_owned()),
+        priority: 0,
+        creator_identity: "matrix-list-test".to_owned(),
+        idempotency_key: None,
+        tags: HashMap::new(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id,
+        now: TimestampMs::now(),
+    }
+}
+
+/// Seed `n` executions all co-located to the same flow partition so
+/// they land in a single partition, and return the sorted id list.
+async fn seed_n(fx: &BackendFixture, flow: &FlowId, n: usize) -> Vec<ExecutionId> {
+    let cfg = *fx.partition_config();
+    let lane = LaneId::new(LANE);
+    let mut ids: Vec<ExecutionId> = Vec::with_capacity(n);
+    for _ in 0..n {
+        let eid = ExecutionId::for_flow(flow, &cfg);
+        let partition = execution_partition(&eid, &cfg);
+        let args = sample_args(&eid, &lane, partition.index);
+        fx.seed_execution(args).await;
+        ids.push(eid);
+    }
+    ids.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    ids
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_executions_threads_cursor_across_pages() {
+    run_matrix(|fx| async move {
+        let flow = FlowId::new();
+        let seeded = seed_n(&fx, &flow, 15).await;
+        let cfg = *fx.partition_config();
+        let partition: PartitionKey =
+            (&ff_core::partition::flow_partition(&flow, &cfg)).into();
+
+        // Page 1 — limit 5 → 5 ids + next_cursor=Some.
+        let p1 = fx
+            .backend()
+            .list_executions(partition.clone(), None, 5)
+            .await
+            .expect("list_executions p1");
+        assert_eq!(
+            p1.executions.len(),
+            5,
+            "[{}] p1 should hold 5 ids",
+            fx.kind().label()
+        );
+        assert!(
+            p1.next_cursor.is_some(),
+            "[{}] p1 should carry a next_cursor",
+            fx.kind().label()
+        );
+
+        // Page 2 — resume.
+        let p2 = fx
+            .backend()
+            .list_executions(partition.clone(), p1.next_cursor.clone(), 5)
+            .await
+            .expect("list_executions p2");
+        assert_eq!(p2.executions.len(), 5);
+        assert!(p2.next_cursor.is_some());
+
+        // Page 3 — tail.
+        let p3 = fx
+            .backend()
+            .list_executions(partition.clone(), p2.next_cursor.clone(), 5)
+            .await
+            .expect("list_executions p3");
+        assert_eq!(p3.executions.len(), 5);
+        assert_eq!(
+            p3.next_cursor,
+            None,
+            "[{}] p3 is tail page, next_cursor must be None",
+            fx.kind().label()
+        );
+
+        // Union of all pages = seeded set (partition has nothing else:
+        // fixture truncates / FLUSHDBs before each run).
+        let mut seen: Vec<ExecutionId> = p1.executions;
+        seen.extend(p2.executions);
+        seen.extend(p3.executions);
+        seen.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(
+            seen, seeded,
+            "[{}] page union must equal seeded set",
+            fx.kind().label()
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_executions_short_partition_has_no_cursor() {
+    run_matrix(|fx| async move {
+        let flow = FlowId::new();
+        let seeded = seed_n(&fx, &flow, 3).await;
+        let cfg = *fx.partition_config();
+        let partition: PartitionKey =
+            (&ff_core::partition::flow_partition(&flow, &cfg)).into();
+
+        let page = fx
+            .backend()
+            .list_executions(partition, None, 10)
+            .await
+            .expect("list_executions");
+        assert_eq!(page.executions.len(), 3);
+        assert_eq!(
+            page.next_cursor,
+            None,
+            "[{}] partition smaller than limit ⇒ next_cursor=None",
+            fx.kind().label()
+        );
+
+        let mut got = page.executions;
+        got.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(got, seeded);
+    })
+    .await;
+}

--- a/crates/ff-test/tests/matrix_list_lanes.rs
+++ b/crates/ff-test/tests/matrix_list_lanes.rs
@@ -1,0 +1,105 @@
+//! Backend-matrix variant of `engine_backend_list_lanes.rs` —
+//! RFC-v0.7 Wave 7a.
+//!
+//! The same bodies exercise `ValkeyBackend` and `PostgresBackend` via
+//! the [`run_matrix`] harness. Driven by `FF_TEST_BACKEND`:
+//!
+//! ```bash
+//! # default — Valkey only
+//! cargo test -p ff-test --test matrix_list_lanes -- --test-threads=1
+//!
+//! # Postgres only (requires FF_PG_TEST_URL)
+//! FF_TEST_BACKEND=postgres FF_PG_TEST_URL=postgres://… \
+//!     cargo test -p ff-test --test matrix_list_lanes -- --test-threads=1
+//!
+//! # Both — proves trait parity
+//! FF_TEST_BACKEND=both FF_PG_TEST_URL=postgres://… \
+//!     cargo test -p ff-test --test matrix_list_lanes -- --test-threads=1
+//! ```
+
+use ff_core::types::LaneId;
+use ff_test::backend_matrix::run_matrix;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_lanes_paginates_sorted_registry() {
+    run_matrix(|fx| async move {
+        // Seed 5 lanes in non-sorted order. Expected sort:
+        //   ["alpha", "bravo", "charlie", "delta", "echo"]
+        fx.seed_lanes(&["charlie", "alpha", "echo", "bravo", "delta"])
+            .await;
+
+        let backend = fx.backend();
+
+        let p1 = backend.list_lanes(None, 2).await.expect("list_lanes p1");
+        assert_eq!(
+            p1.lanes,
+            vec![LaneId::new("alpha"), LaneId::new("bravo")],
+            "[{}] page 1 sort order wrong",
+            fx.kind().label()
+        );
+        assert_eq!(p1.next_cursor, Some(LaneId::new("bravo")));
+
+        let p2 = backend
+            .list_lanes(p1.next_cursor.clone(), 2)
+            .await
+            .expect("list_lanes p2");
+        assert_eq!(
+            p2.lanes,
+            vec![LaneId::new("charlie"), LaneId::new("delta")]
+        );
+        assert_eq!(p2.next_cursor, Some(LaneId::new("delta")));
+
+        let p3 = backend
+            .list_lanes(p2.next_cursor.clone(), 2)
+            .await
+            .expect("list_lanes p3");
+        assert_eq!(p3.lanes, vec![LaneId::new("echo")]);
+        assert_eq!(
+            p3.next_cursor,
+            None,
+            "[{}] last page must have no next_cursor",
+            fx.kind().label()
+        );
+
+        // Over-limit returns the full sorted set with no next_cursor.
+        let full = backend
+            .list_lanes(None, 100)
+            .await
+            .expect("list_lanes full");
+        assert_eq!(full.lanes.len(), 5);
+        assert_eq!(full.next_cursor, None);
+        let mut expected = full.lanes.clone();
+        expected.sort();
+        assert_eq!(full.lanes, expected);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_lanes_empty_registry_returns_empty_page() {
+    run_matrix(|fx| async move {
+        let page = fx
+            .backend()
+            .list_lanes(None, 10)
+            .await
+            .expect("list_lanes empty");
+        assert!(page.lanes.is_empty());
+        assert_eq!(page.next_cursor, None);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_lanes_limit_zero_short_circuits() {
+    run_matrix(|fx| async move {
+        fx.seed_lanes(&["alpha", "bravo"]).await;
+        let page = fx
+            .backend()
+            .list_lanes(None, 0)
+            .await
+            .expect("list_lanes zero");
+        assert!(page.lanes.is_empty());
+        assert_eq!(page.next_cursor, None);
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary

Wave 7a adds a backend-matrix fixture harness so the same integration-test bodies exercise both the Valkey and Postgres `EngineBackend` impls, plus three parameterised test files that use it.

- `crates/ff-test/src/backend_matrix.rs` — new `BackendKind` / `BackendFixture` / `run_matrix` harness. Driven by `FF_TEST_BACKEND` (`valkey` default, `postgres`, `both`). Silently skips the Postgres slot when `FF_PG_TEST_URL` is unset so default `cargo test` stays Valkey-only.
- Backend-agnostic seed helpers: `fx.seed_lanes(&[...])` and `fx.seed_execution(args)`. Valkey arm drives the existing `ff_create_execution` FCALL; Postgres arm calls `PostgresBackend::create_execution`.
- Cleanup: `FLUSHDB` on Valkey; per-table `TRUNCATE ... CASCADE` gated by `to_regclass` on Postgres so tables that haven't shipped yet are skipped rather than aborting the fixture.

## Tests parameterised (3 files, 7 test cases)

Every case **passes on both Valkey and Postgres** (verified with `FF_TEST_BACKEND=both`).

1. `matrix_list_lanes.rs` — 3 cases: sorted-pagination across pages, empty-registry empty-page, `limit=0` short-circuit.
2. `matrix_list_executions.rs` — 2 cases: cursor threading across 3 pages, short-partition has `next_cursor=None`.
3. `matrix_describe_execution.rs` — 2 cases: fresh-row snapshot (tags round-trip, `PublicState::Waiting`), unknown id returns `None`.

## Tests NOT parameterised (and why)

The brief named ten candidates. The remaining seven stay Valkey-only in their existing files:

- `engine_backend_claim` — claim path requires lane-eligibility scheduler wiring that the Postgres `PostgresBackend::claim` entry covers via its own `pg_scheduler_claim.rs` suite. Parity would need the matrix fixture to drive the scheduler, out of Wave 7a scope.
- `engine_backend_resume_composite` — seeds suspensions via RFC-014 count/allof FCALLs that have no shared fixture entry yet.
- `engine_backend_stream_modes` — RFC-015 streaming seed path uses `XADD` directly; Postgres `ff_stream_frames` ingest uses `append_frame`, but the existing assertions inspect Valkey-specific tail shapes.
- `engine_backend_suspend` — drives the SDK `try_suspend`, which currently pins to the Valkey scheduler.
- `flow_edge_policies_stage_c` — cancel dispatcher is Valkey-first; the Postgres sibling (`pg_reconciler_edge_cancel.rs`) already has parallel coverage.
- `engine_backend_list_suspended` — list is parameterisable in principle, but seeding suspensions via the trait is not yet exposed from the fixture surface.
- `e2e_lifecycle::test_flow_happy_path` — full flow requires dispatcher + scheduler, out of a read-surface matrix scope.

Subsequent waves can ratchet more of these into the matrix as Postgres parity on the underlying ops lands.

## Matrix mode invocation

```bash
# Default — Valkey only (matches today's CI).
cargo test -p ff-test --test matrix_list_lanes \
    --test matrix_list_executions \
    --test matrix_describe_execution -- --test-threads=1

# Postgres only.
FF_TEST_BACKEND=postgres \
FF_PG_TEST_URL=postgres://user:pw@host/db \
    cargo test -p ff-test --test matrix_list_lanes \
        --test matrix_list_executions \
        --test matrix_describe_execution -- --test-threads=1

# Both — proves trait parity in one run.
FF_TEST_BACKEND=both FF_PG_TEST_URL=postgres://user:pw@host/db \
    cargo test -p ff-test --test matrix_list_lanes \
        --test matrix_list_executions \
        --test matrix_describe_execution -- --test-threads=1
```

## Test plan

- [x] `cargo build -p ff-test --tests` clean.
- [x] `cargo test -p ff-test --lib` (includes `backend_matrix::tests`) passes.
- [x] Matrix tests pass with `FF_TEST_BACKEND` unset (Valkey default).
- [x] Matrix tests pass with `FF_TEST_BACKEND=postgres FF_PG_TEST_URL=...`.
- [x] Matrix tests pass with `FF_TEST_BACKEND=both`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to `ff-test` and add new test infrastructure and test cases without affecting production code paths.
> 
> **Overview**
> Adds a new `ff_test::backend_matrix` harness (`BackendFixture` + `run_matrix`) to run the same integration-test body against **Valkey**, **Postgres**, or **both** backends based on `FF_TEST_BACKEND`, with Postgres softly skipped when `FF_PG_TEST_URL` is unset.
> 
> The fixture includes backend-agnostic seeding helpers (`seed_lanes`, `seed_execution`) and per-run cleanup (Valkey `cleanup` / Postgres table truncation with migrations + a shared `PgPool`).
> 
> Introduces three new matrix integration test files that validate backend parity for `list_lanes`, `list_executions` pagination, and `describe_execution` behavior across both backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e3f1fbbede8a379a8db32a27dcd4f2c855e973. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->