### PR TITLE
feat(pg-wave4i): Postgres flow-staging methods (create_flow, add_execution_to_flow, stage/apply_dependency_edge)

### DIFF
--- a/crates/ff-backend-postgres/src/flow_staging.rs
+++ b/crates/ff-backend-postgres/src/flow_staging.rs
@@ -1,0 +1,564 @@
+//! Postgres flow-staging inherent methods (Wave 4i).
+//!
+//! Mirrors the ingress-layer Lua FCALLs that the Valkey backend ships
+//! under `ff-server::Server` — these are **not** `EngineBackend` trait
+//! methods. The Valkey shape is:
+//!
+//!   * `ff_create_flow`                — INSERT flow_core
+//!   * `ff_add_execution_to_flow`      — stamp exec.flow_id + bump counters
+//!   * `ff_stage_dependency_edge`      — CAS graph_revision + INSERT edge
+//!   * `ff_apply_dependency_to_child`  — mark edge applied + bump edge_group
+//!
+//! Wave 4c already covers the read surface and `cancel_flow`. This
+//! module adds the mutating ingress operations so flow-DAG construction
+//! works on Postgres end-to-end. Wave 5a owns the completion-cascade
+//! dispatch that consumes what `apply_dependency_to_child` writes.
+//!
+//! # Storage convention
+//!
+//! Matches Wave 4c's decoder in `flow.rs`:
+//!
+//!   * Flow-level extras (`flow_kind`, `namespace`, `node_count`,
+//!     `edge_count`, `last_mutation_at_ms`) live in
+//!     `ff_flow_core.raw_fields` jsonb.
+//!   * Edge-level extras (`dependency_kind`, `data_passing_ref`,
+//!     `staged_at_ms`, `applied_at_ms`, `edge_state`, `created_at_ms`,
+//!     `created_by`, `satisfaction_condition`) live in
+//!     `ff_edge.policy` jsonb (the only jsonb slot on that row).
+//!
+//! No schema migration is required — every new field fits in the
+//! existing jsonb columns. This keeps Wave 4c's decoder and the
+//! dispatch queries (which select on typed columns only) unchanged.
+//!
+//! # Membership
+//!
+//! `ff_add_execution_to_flow` / `ff_stage_dependency_edge` treat
+//! membership as `ff_exec_core.flow_id = flow_id` — the same back-
+//! pointer that Wave 4c's `cancel_flow` already queries. No separate
+//! member table is introduced; RFC-011 flow/exec co-location makes the
+//! back-pointer authoritative on the flow's partition.
+
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
+    ApplyDependencyToChildResult, CreateFlowArgs, CreateFlowResult, StageDependencyEdgeArgs,
+    StageDependencyEdgeResult,
+};
+use ff_core::engine_error::{ConflictKind, ContentionKind, EngineError, ValidationKind};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{ExecutionId, FlowId};
+use serde_json::json;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::error::map_sqlx_error;
+
+/// Compute the flow partition byte (0..=255). Matches Wave 4c's helper.
+fn flow_partition_byte(flow_id: &FlowId, pc: &PartitionConfig) -> i16 {
+    ff_core::partition::flow_partition(flow_id, pc).index as i16
+}
+
+/// Parse the UUID suffix from a `{fp:N}:<uuid>` exec id.
+fn parse_exec_uuid(eid: &ExecutionId) -> Result<Uuid, EngineError> {
+    let s = eid.as_str();
+    let Some(colon) = s.rfind("}:") else {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("execution_id missing '}}:' delimiter: {s}"),
+        });
+    };
+    Uuid::parse_str(&s[colon + 2..]).map_err(|e| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id uuid suffix: {e}"),
+    })
+}
+
+/// `ff_create_flow` — idempotent INSERT into `ff_flow_core`.
+///
+/// Mirrors `lua/flow.lua :: ff_create_flow`. Graph_revision starts at 0;
+/// `public_flow_state` starts at `'open'`. Typed columns carry what the
+/// engine filters on; `flow_kind`, `namespace`, `node_count`,
+/// `edge_count`, `last_mutation_at_ms` ride in `raw_fields` so Wave 4c's
+/// decoder picks them up.
+pub async fn create_flow(
+    pool: &PgPool,
+    pc: &PartitionConfig,
+    args: &CreateFlowArgs,
+) -> Result<CreateFlowResult, EngineError> {
+    let part = flow_partition_byte(&args.flow_id, pc);
+    let flow_uuid: Uuid = args.flow_id.0;
+    let now_ms = args.now.0;
+
+    let raw_fields = json!({
+        "flow_kind": args.flow_kind,
+        "namespace": args.namespace.as_str(),
+        "node_count": 0,
+        "edge_count": 0,
+        "last_mutation_at_ms": now_ms,
+    });
+
+    // ON CONFLICT DO NOTHING makes the insert idempotent. `RETURNING`
+    // fires only on the insert path; a conflict returns zero rows, so
+    // we can branch on the row count.
+    let inserted = sqlx::query(
+        r#"
+        INSERT INTO ff_flow_core
+            (partition_key, flow_id, graph_revision, public_flow_state,
+             created_at_ms, raw_fields)
+        VALUES ($1, $2, 0, 'open', $3, $4)
+        ON CONFLICT (partition_key, flow_id) DO NOTHING
+        RETURNING flow_id
+        "#,
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(now_ms)
+    .bind(&raw_fields)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if inserted.is_some() {
+        Ok(CreateFlowResult::Created {
+            flow_id: args.flow_id.clone(),
+        })
+    } else {
+        Ok(CreateFlowResult::AlreadySatisfied {
+            flow_id: args.flow_id.clone(),
+        })
+    }
+}
+
+/// `ff_add_execution_to_flow` — stamp `exec.flow_id` + bump flow counters.
+///
+/// Single transaction:
+///   1. Validate flow exists and is not terminal.
+///   2. Validate exec exists.
+///   3. If exec already on this flow → idempotent `AlreadyMember`.
+///   4. If exec on a different flow → `Validation(InvalidInput)`
+///      (RFC-007: an exec belongs to at most one flow).
+///   5. Stamp `exec_core.flow_id` + bump `graph_revision` and
+///      `raw_fields.node_count` on `flow_core`.
+pub async fn add_execution_to_flow(
+    pool: &PgPool,
+    pc: &PartitionConfig,
+    args: &AddExecutionToFlowArgs,
+) -> Result<AddExecutionToFlowResult, EngineError> {
+    let part = flow_partition_byte(&args.flow_id, pc);
+    let flow_uuid: Uuid = args.flow_id.0;
+    let exec_uuid = parse_exec_uuid(&args.execution_id)?;
+    let now_ms = args.now.0;
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // 1. Flow must exist + not be terminal.
+    let flow_row = sqlx::query(
+        "SELECT public_flow_state, raw_fields FROM ff_flow_core \
+         WHERE partition_key = $1 AND flow_id = $2 FOR UPDATE",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(flow_row) = flow_row else {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "flow_not_found".to_string(),
+        });
+    };
+    let public_flow_state: String = flow_row.get("public_flow_state");
+    if matches!(
+        public_flow_state.as_str(),
+        "cancelled" | "completed" | "failed"
+    ) {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "flow_already_terminal".to_string(),
+        });
+    }
+
+    // 2. Exec must exist. The partition co-location invariant
+    //    (RFC-011 §7.3) guarantees the exec row, if any, lives on the
+    //    flow's partition; use the flow partition_key directly.
+    let exec_row = sqlx::query(
+        "SELECT flow_id FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2 FOR UPDATE",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(exec_row) = exec_row else {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "execution_not_found".to_string(),
+        });
+    };
+    let existing_flow_id: Option<Uuid> = exec_row.get("flow_id");
+
+    // 3. Idempotent: already on this flow.
+    if existing_flow_id == Some(flow_uuid) {
+        let raw: serde_json::Value = flow_row.get("raw_fields");
+        let nc = raw
+            .get("node_count")
+            .and_then(|v| v.as_u64())
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(0);
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(AddExecutionToFlowResult::AlreadyMember {
+            execution_id: args.execution_id.clone(),
+            node_count: nc,
+        });
+    }
+
+    // 4. Cross-flow refusal.
+    if let Some(other) = existing_flow_id
+        && other != flow_uuid
+    {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("already_member_of_different_flow:{other}"),
+        });
+    }
+
+    // 5. Stamp exec.flow_id + bump flow counters.
+    sqlx::query(
+        "UPDATE ff_exec_core SET flow_id = $3 \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(flow_uuid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let bumped = sqlx::query(
+        r#"
+        UPDATE ff_flow_core
+           SET graph_revision = graph_revision + 1,
+               raw_fields = raw_fields
+                   || jsonb_build_object(
+                       'node_count',
+                       COALESCE((raw_fields->>'node_count')::int, 0) + 1,
+                       'last_mutation_at_ms', $3::bigint
+                   )
+         WHERE partition_key = $1 AND flow_id = $2
+         RETURNING (raw_fields->>'node_count')::int AS node_count
+        "#,
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(now_ms)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let new_nc: i32 = bumped.get("node_count");
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(AddExecutionToFlowResult::Added {
+        execution_id: args.execution_id.clone(),
+        new_node_count: u32::try_from(new_nc.max(0)).unwrap_or(0),
+    })
+}
+
+/// `ff_stage_dependency_edge` — CAS on graph_revision + INSERT into
+/// `ff_edge`.
+///
+/// Parity with `lua/flow.lua :: ff_stage_dependency_edge`:
+///
+///   * Rejects self-edges, cross-flow membership, terminal flows.
+///   * Mismatching `expected_graph_revision` →
+///     `Contention(StaleGraphRevision)`.
+///   * Duplicate edge_id → `Conflict(DependencyAlreadyExists { .. })`.
+///   * Cycle detection: not implemented here (deferred to a future
+///     Wave; the Valkey path's `detect_cycle` uses BFS over adjacency
+///     SETs that Postgres models as SELECTs — can land in Wave 4j /
+///     Wave 5b without re-opening the contract).
+///
+/// On success: writes `staged_at_ms = now`, `applied_at_ms = null`,
+/// `edge_state = 'pending'` into `policy` jsonb; bumps
+/// `graph_revision` and `raw_fields.edge_count` on `flow_core`.
+pub async fn stage_dependency_edge(
+    pool: &PgPool,
+    pc: &PartitionConfig,
+    args: &StageDependencyEdgeArgs,
+) -> Result<StageDependencyEdgeResult, EngineError> {
+    if args.upstream_execution_id == args.downstream_execution_id {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "self_referencing_edge".to_string(),
+        });
+    }
+
+    let part = flow_partition_byte(&args.flow_id, pc);
+    let flow_uuid: Uuid = args.flow_id.0;
+    let edge_uuid: Uuid = args.edge_id.0;
+    let upstream_uuid = parse_exec_uuid(&args.upstream_execution_id)?;
+    let downstream_uuid = parse_exec_uuid(&args.downstream_execution_id)?;
+    let now_ms = args.now.0;
+    let expected_rev = i64::try_from(args.expected_graph_revision).unwrap_or(i64::MAX);
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // 1. Flow must exist + not terminal + graph_revision matches. CAS
+    //    in one UPDATE: the WHERE clause pins the expected rev, and
+    //    the RETURNING tells us whether we won the race.
+    let bumped = sqlx::query(
+        r#"
+        UPDATE ff_flow_core
+           SET graph_revision = graph_revision + 1,
+               raw_fields = raw_fields
+                   || jsonb_build_object(
+                       'edge_count',
+                       COALESCE((raw_fields->>'edge_count')::int, 0) + 1,
+                       'last_mutation_at_ms', $4::bigint
+                   )
+         WHERE partition_key = $1
+           AND flow_id = $2
+           AND graph_revision = $3
+           AND public_flow_state = 'open'
+         RETURNING graph_revision
+        "#,
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(expected_rev)
+    .bind(now_ms)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(bumped_row) = bumped else {
+        // Distinguish "flow missing" / "terminal" / "stale rev".
+        let probe = sqlx::query(
+            "SELECT graph_revision, public_flow_state FROM ff_flow_core \
+             WHERE partition_key = $1 AND flow_id = $2",
+        )
+        .bind(part)
+        .bind(flow_uuid)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        let _ = tx.rollback().await;
+        return match probe {
+            None => Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "flow_not_found".to_string(),
+            }),
+            Some(r) => {
+                let state: String = r.get("public_flow_state");
+                if matches!(state.as_str(), "cancelled" | "completed" | "failed") {
+                    Err(EngineError::Validation {
+                        kind: ValidationKind::InvalidInput,
+                        detail: "flow_already_terminal".to_string(),
+                    })
+                } else {
+                    Err(EngineError::Contention(ContentionKind::StaleGraphRevision))
+                }
+            }
+        };
+    };
+    let new_rev: i64 = bumped_row.get("graph_revision");
+
+    // 2. Membership — both execs must be on this flow.
+    let members: Vec<Uuid> = sqlx::query_scalar(
+        "SELECT execution_id FROM ff_exec_core \
+         WHERE partition_key = $1 AND flow_id = $2 \
+           AND execution_id = ANY($3)",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(&[upstream_uuid, downstream_uuid][..])
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    if !members.contains(&upstream_uuid) || !members.contains(&downstream_uuid) {
+        let _ = tx.rollback().await;
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "execution_not_in_flow".to_string(),
+        });
+    }
+
+    // 3. Insert edge. `policy jsonb` carries the immutable edge record
+    //    (dependency_kind, data_passing_ref, staged_at_ms, etc.) so
+    //    Wave 4c's `decode_edge_row` picks it up unchanged.
+    let policy = json!({
+        "dependency_kind": args.dependency_kind,
+        "satisfaction_condition": "all_required",
+        "data_passing_ref": args.data_passing_ref.clone().unwrap_or_default(),
+        "edge_state": "pending",
+        "created_at_ms": now_ms,
+        "created_by": "engine",
+        "staged_at_ms": now_ms,
+        "applied_at_ms": serde_json::Value::Null,
+    });
+
+    let insert = sqlx::query(
+        r#"
+        INSERT INTO ff_edge
+            (partition_key, flow_id, edge_id, upstream_eid, downstream_eid,
+             policy, policy_version)
+        VALUES ($1, $2, $3, $4, $5, $6, 0)
+        ON CONFLICT (partition_key, flow_id, edge_id) DO NOTHING
+        RETURNING edge_id
+        "#,
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(edge_uuid)
+    .bind(upstream_uuid)
+    .bind(downstream_uuid)
+    .bind(&policy)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if insert.is_none() {
+        // Edge already exists — surface the existing snapshot for
+        // `ConflictKind::DependencyAlreadyExists` parity. We need to
+        // commit the rev bump rollback since the CAS succeeded but the
+        // downstream write failed.
+        let _ = tx.rollback().await;
+        // Read back for the error payload.
+        let existing = crate::flow::describe_edge(pool, pc, &args.flow_id, &args.edge_id)
+            .await?
+            .ok_or_else(|| EngineError::Validation {
+                kind: ValidationKind::Corruption,
+                detail: "edge vanished between insert and describe".to_string(),
+            })?;
+        return Err(EngineError::Conflict(
+            ConflictKind::DependencyAlreadyExists { existing },
+        ));
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(StageDependencyEdgeResult::Staged {
+        edge_id: args.edge_id.clone(),
+        new_graph_revision: u64::try_from(new_rev).unwrap_or(0),
+    })
+}
+
+/// `ff_apply_dependency_to_child` — mark an edge applied + bump the
+/// downstream's edge-group aggregate.
+///
+/// Parity with `lua/flow.lua :: ff_apply_dependency_to_child`:
+///
+///   * Idempotent on already-applied (`policy.applied_at_ms` already
+///     non-null) → returns `AlreadyApplied`.
+///   * Bumps `ff_edge_group.running_count` (the Stage-A "unsatisfied
+///     required count" equivalent). Creates an `ff_edge_group` row
+///     with a default `AllOf` policy when none exists — matches the
+///     Lua path's inline `SET policy_variant='all_of'` fallback.
+///
+/// The cascade (downstream eligibility flip + sibling cancellation) is
+/// driven by Wave 5a's `dispatch::dispatch_completion` → this function
+/// only writes the per-edge state the cascade reads.
+pub async fn apply_dependency_to_child(
+    pool: &PgPool,
+    pc: &PartitionConfig,
+    args: &ApplyDependencyToChildArgs,
+) -> Result<ApplyDependencyToChildResult, EngineError> {
+    let part = flow_partition_byte(&args.flow_id, pc);
+    let flow_uuid: Uuid = args.flow_id.0;
+    let edge_uuid: Uuid = args.edge_id.0;
+    let downstream_uuid = parse_exec_uuid(&args.downstream_execution_id)?;
+    let now_ms = args.now.0;
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // 1. Load + lock the edge row.
+    let edge_row = sqlx::query(
+        "SELECT policy FROM ff_edge \
+         WHERE partition_key = $1 AND flow_id = $2 AND edge_id = $3 \
+         FOR UPDATE",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(edge_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(edge_row) = edge_row else {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "edge_not_found".to_string(),
+        });
+    };
+    let mut policy: serde_json::Value = edge_row.get("policy");
+
+    // 2. Idempotency: already applied? Count this edge in the running
+    //    group state if we have to create the edge_group row (fresh
+    //    flows), but do NOT double-bump `running_count`.
+    let already_applied = policy
+        .get("applied_at_ms")
+        .and_then(|v| v.as_i64())
+        .is_some();
+    if already_applied {
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(ApplyDependencyToChildResult::AlreadyApplied);
+    }
+
+    // 3. Mark edge applied in the policy jsonb.
+    if let Some(obj) = policy.as_object_mut() {
+        obj.insert("applied_at_ms".to_string(), json!(now_ms));
+        obj.insert("edge_state".to_string(), json!("applied"));
+    }
+    sqlx::query(
+        "UPDATE ff_edge SET policy = $4 \
+         WHERE partition_key = $1 AND flow_id = $2 AND edge_id = $3",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(edge_uuid)
+    .bind(&policy)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 4. Upsert the edge_group row — create with default AllOf when
+    //    missing, bump `running_count` when present. `running_count`
+    //    is the "unsatisfied required" bucket the dispatch cascade
+    //    decrements on each completion.
+    sqlx::query(
+        r#"
+        INSERT INTO ff_edge_group
+            (partition_key, flow_id, downstream_eid, policy, running_count)
+        VALUES ($1, $2, $3, $4, 1)
+        ON CONFLICT (partition_key, flow_id, downstream_eid) DO UPDATE
+           SET running_count = ff_edge_group.running_count + 1
+        "#,
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(downstream_uuid)
+    .bind(json!({ "kind": "all_of" }))
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Read back the post-update running_count for the result.
+    let unsatisfied: i32 = sqlx::query_scalar(
+        "SELECT running_count FROM ff_edge_group \
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(downstream_uuid)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(ApplyDependencyToChildResult::Applied {
+        unsatisfied_count: u32::try_from(unsatisfied.max(0)).unwrap_or(0),
+    })
+}

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -31,9 +31,12 @@ use ff_core::backend::{
 };
 #[cfg(feature = "core")]
 use ff_core::contracts::{
-    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, CreateExecutionArgs, DeliverSignalArgs,
-    DeliverSignalResult, EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot, ListExecutionsPage,
-    ListFlowsPage, ListLanesPage, ListSuspendedPage, SetEdgeGroupPolicyResult,
+    AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
+    ApplyDependencyToChildResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
+    CreateExecutionArgs, CreateFlowArgs, CreateFlowResult, DeliverSignalArgs, DeliverSignalResult,
+    EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot, ListExecutionsPage, ListFlowsPage,
+    ListLanesPage, ListSuspendedPage, SetEdgeGroupPolicyResult, StageDependencyEdgeArgs,
+    StageDependencyEdgeResult,
 };
 use ff_core::contracts::{
     CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
@@ -67,6 +70,8 @@ pub mod dispatch;
 pub mod error;
 pub mod exec_core;
 pub mod flow;
+#[cfg(feature = "core")]
+pub mod flow_staging;
 pub mod handle_codec;
 pub mod listener;
 pub mod migrate;
@@ -180,6 +185,55 @@ impl PostgresBackend {
         args: CreateExecutionArgs,
     ) -> Result<ExecutionId, EngineError> {
         exec_core::create_execution_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    // ── RFC-v0.7 Wave 4i: flow-staging ingress methods ──
+    //
+    // Inherent methods (not on `EngineBackend`) matching the Valkey
+    // side's `ff-server::Server` shape — see `flow_staging` module
+    // docs. Called by ff-server request handlers and the integration
+    // test harness.
+
+    /// Create a flow. Idempotent on `(partition_key, flow_id)`.
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.create_flow", skip_all)]
+    pub async fn create_flow(
+        &self,
+        args: &CreateFlowArgs,
+    ) -> Result<CreateFlowResult, EngineError> {
+        flow_staging::create_flow(&self.pool, &self.partition_config, args).await
+    }
+
+    /// Add an execution to a flow. Idempotent on re-add.
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.add_execution_to_flow", skip_all)]
+    pub async fn add_execution_to_flow(
+        &self,
+        args: &AddExecutionToFlowArgs,
+    ) -> Result<AddExecutionToFlowResult, EngineError> {
+        flow_staging::add_execution_to_flow(&self.pool, &self.partition_config, args).await
+    }
+
+    /// Stage a dependency edge. CAS on `graph_revision`; stale rev →
+    /// `Contention(StaleGraphRevision)`.
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.stage_dependency_edge", skip_all)]
+    pub async fn stage_dependency_edge(
+        &self,
+        args: &StageDependencyEdgeArgs,
+    ) -> Result<StageDependencyEdgeResult, EngineError> {
+        flow_staging::stage_dependency_edge(&self.pool, &self.partition_config, args).await
+    }
+
+    /// Apply a staged dependency to its downstream child — marks the
+    /// edge applied and bumps the downstream's edge-group aggregate.
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.apply_dependency_to_child", skip_all)]
+    pub async fn apply_dependency_to_child(
+        &self,
+        args: &ApplyDependencyToChildArgs,
+    ) -> Result<ApplyDependencyToChildResult, EngineError> {
+        flow_staging::apply_dependency_to_child(&self.pool, &self.partition_config, args).await
     }
 }
 

--- a/crates/ff-test/tests/pg_flow_staging.rs
+++ b/crates/ff-test/tests/pg_flow_staging.rs
@@ -1,0 +1,485 @@
+//! Wave 4i — Postgres flow-staging integration tests.
+//!
+//! Exercises the four inherent methods landed on [`PostgresBackend`]:
+//!
+//!   * `create_flow`
+//!   * `add_execution_to_flow`
+//!   * `stage_dependency_edge`  (including stale-graph-revision CAS)
+//!   * `apply_dependency_to_child`
+//!
+//! Plus the end-to-end scenario Wave 7b's unskip agent hit a wall on:
+//! create flow + 1 downstream + 3 upstream members + Stage-A policy
+//! `AnyOf{CancelRemaining}` + stage 3 edges + apply 3 deps + drive one
+//! upstream to completion + `dispatch::dispatch_completion` + assert
+//! downstream eligible + `ff_pending_cancel_groups` enqueued + the
+//! `cancel_siblings_pending_flag` raised on the edge_group.
+//!
+//! # Known Wave 5a gap surfaced by this test
+//!
+//! The dispatcher's `advance_edge_group` flips
+//! `cancel_siblings_pending_flag=true` but does NOT populate
+//! `cancel_siblings_pending_members` — the reconciler / dispatcher then
+//! has no exec ids to cancel. Captured as a TODO on the end-to-end
+//! test; the four methods covered by this PR are the prerequisite for
+//! closing that gap.
+//!
+//! # Running
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://user:pw@localhost/ff_wave4i_test \
+//!   cargo test -p ff-test --test pg_flow_staging -- --ignored --test-threads=1
+//! ```
+
+use std::collections::HashMap;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
+    ApplyDependencyToChildResult, CreateExecutionArgs, CreateFlowArgs, CreateFlowResult,
+    EdgeDependencyPolicy, OnSatisfied, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{EdgeId, ExecutionId, FlowId, LaneId, Namespace, TimestampMs};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations");
+    Some(pool)
+}
+
+fn now() -> TimestampMs {
+    TimestampMs(1_700_000_000_000)
+}
+
+fn sample_exec_args(eid: &ExecutionId, lane: &LaneId) -> CreateExecutionArgs {
+    CreateExecutionArgs {
+        execution_id: eid.clone(),
+        namespace: Namespace::new("tenant-wave4i"),
+        lane_id: lane.clone(),
+        execution_kind: "task".to_owned(),
+        input_payload: b"{}".to_vec(),
+        payload_encoding: Some("application/json".to_owned()),
+        priority: 0,
+        creator_identity: "pg-wave4i-test".to_owned(),
+        idempotency_key: None,
+        tags: HashMap::new(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: eid.partition(),
+        now: now(),
+    }
+}
+
+fn new_flow() -> FlowId {
+    FlowId::from_uuid(Uuid::new_v4())
+}
+
+async fn make_flow_and_exec(
+    backend: &PostgresBackend,
+    pc: &PartitionConfig,
+    lane: &LaneId,
+) -> (FlowId, ExecutionId) {
+    let flow = new_flow();
+    backend
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow.clone(),
+            flow_kind: "graph".to_owned(),
+            namespace: Namespace::new("tenant-wave4i"),
+            now: now(),
+        })
+        .await
+        .expect("create_flow");
+
+    let eid = ExecutionId::for_flow(&flow, pc);
+    backend
+        .create_execution(sample_exec_args(&eid, lane))
+        .await
+        .expect("create_execution");
+    backend
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow.clone(),
+            execution_id: eid.clone(),
+            now: now(),
+        })
+        .await
+        .expect("add_execution_to_flow");
+    (flow, eid)
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn create_flow_happy_and_idempotent() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = PostgresBackend::from_pool(pool, PartitionConfig::default());
+    let flow = new_flow();
+
+    let r1 = backend
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow.clone(),
+            flow_kind: "graph".to_owned(),
+            namespace: Namespace::new("tenant-wave4i"),
+            now: now(),
+        })
+        .await
+        .expect("create_flow #1");
+    assert!(matches!(r1, CreateFlowResult::Created { .. }));
+
+    let r2 = backend
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow,
+            flow_kind: "graph".to_owned(),
+            namespace: Namespace::new("tenant-wave4i"),
+            now: now(),
+        })
+        .await
+        .expect("create_flow #2");
+    assert!(matches!(r2, CreateFlowResult::AlreadySatisfied { .. }));
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn add_execution_bumps_graph_revision_and_node_count() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let pc = PartitionConfig::default();
+    let backend = PostgresBackend::from_pool(pool, pc.clone());
+    let lane = LaneId::new("wave4i-add");
+
+    let (flow, eid) = make_flow_and_exec(&backend, &pc, &lane).await;
+
+    let snap = backend
+        .describe_flow(&flow)
+        .await
+        .expect("describe_flow")
+        .expect("flow present");
+    assert_eq!(snap.graph_revision, 1);
+    assert_eq!(snap.node_count, 1);
+
+    let again = backend
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow.clone(),
+            execution_id: eid,
+            now: now(),
+        })
+        .await
+        .expect("add #2");
+    assert!(matches!(
+        again,
+        AddExecutionToFlowResult::AlreadyMember { .. }
+    ));
+    let snap2 = backend.describe_flow(&flow).await.unwrap().unwrap();
+    assert_eq!(snap2.graph_revision, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn stage_and_apply_edge_happy_path() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let pc = PartitionConfig::default();
+    let backend = PostgresBackend::from_pool(pool, pc.clone());
+    let lane = LaneId::new("wave4i-stage");
+
+    let (flow, upstream) = make_flow_and_exec(&backend, &pc, &lane).await;
+    let downstream = ExecutionId::for_flow(&flow, &pc);
+    backend
+        .create_execution(sample_exec_args(&downstream, &lane))
+        .await
+        .unwrap();
+    backend
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow.clone(),
+            execution_id: downstream.clone(),
+            now: now(),
+        })
+        .await
+        .unwrap();
+
+    let edge_id = EdgeId::from_uuid(Uuid::new_v4());
+    let staged = backend
+        .stage_dependency_edge(&StageDependencyEdgeArgs {
+            flow_id: flow.clone(),
+            edge_id: edge_id.clone(),
+            upstream_execution_id: upstream.clone(),
+            downstream_execution_id: downstream.clone(),
+            dependency_kind: "success_only".to_owned(),
+            data_passing_ref: None,
+            expected_graph_revision: 2,
+            now: now(),
+        })
+        .await
+        .expect("stage_dependency_edge");
+    let StageDependencyEdgeResult::Staged { new_graph_revision, .. } = staged;
+    assert_eq!(new_graph_revision, 3);
+
+    let applied = backend
+        .apply_dependency_to_child(&ApplyDependencyToChildArgs {
+            flow_id: flow.clone(),
+            edge_id: edge_id.clone(),
+            downstream_execution_id: downstream.clone(),
+            upstream_execution_id: upstream.clone(),
+            graph_revision: 3,
+            dependency_kind: "success_only".to_owned(),
+            data_passing_ref: None,
+            now: now(),
+        })
+        .await
+        .expect("apply_dependency_to_child");
+    assert!(matches!(
+        applied,
+        ApplyDependencyToChildResult::Applied { unsatisfied_count: 1 }
+    ));
+
+    let applied_again = backend
+        .apply_dependency_to_child(&ApplyDependencyToChildArgs {
+            flow_id: flow.clone(),
+            edge_id: edge_id.clone(),
+            downstream_execution_id: downstream.clone(),
+            upstream_execution_id: upstream.clone(),
+            graph_revision: 3,
+            dependency_kind: "success_only".to_owned(),
+            data_passing_ref: None,
+            now: now(),
+        })
+        .await
+        .expect("apply #2");
+    assert!(matches!(
+        applied_again,
+        ApplyDependencyToChildResult::AlreadyApplied
+    ));
+
+    let edge = backend
+        .describe_edge(&flow, &edge_id)
+        .await
+        .expect("describe_edge")
+        .expect("edge present");
+    assert_eq!(edge.edge_state, "applied");
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn stage_rejects_stale_graph_revision() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let pc = PartitionConfig::default();
+    let backend = PostgresBackend::from_pool(pool, pc.clone());
+    let lane = LaneId::new("wave4i-stale");
+
+    let (flow, upstream) = make_flow_and_exec(&backend, &pc, &lane).await;
+    let downstream = ExecutionId::for_flow(&flow, &pc);
+    backend
+        .create_execution(sample_exec_args(&downstream, &lane))
+        .await
+        .unwrap();
+    backend
+        .add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow.clone(),
+            execution_id: downstream.clone(),
+            now: now(),
+        })
+        .await
+        .unwrap();
+
+    let err = backend
+        .stage_dependency_edge(&StageDependencyEdgeArgs {
+            flow_id: flow.clone(),
+            edge_id: EdgeId::from_uuid(Uuid::new_v4()),
+            upstream_execution_id: upstream,
+            downstream_execution_id: downstream,
+            dependency_kind: "success_only".to_owned(),
+            data_passing_ref: None,
+            expected_graph_revision: 99,
+            now: now(),
+        })
+        .await
+        .expect_err("should reject stale rev");
+    assert!(matches!(
+        err,
+        EngineError::Contention(ContentionKind::StaleGraphRevision)
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres; set FF_PG_TEST_URL"]
+async fn e2e_any_of_cancel_remaining_cascade() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let pc = PartitionConfig::default();
+    let backend = PostgresBackend::from_pool(pool.clone(), pc.clone());
+    let lane = LaneId::new("wave4i-e2e");
+
+    let flow = new_flow();
+    backend
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow.clone(),
+            flow_kind: "graph".to_owned(),
+            namespace: Namespace::new("tenant-wave4i"),
+            now: now(),
+        })
+        .await
+        .expect("create_flow");
+
+    let upstreams: Vec<ExecutionId> =
+        (0..3).map(|_| ExecutionId::for_flow(&flow, &pc)).collect();
+    let downstream = ExecutionId::for_flow(&flow, &pc);
+
+    for eid in upstreams.iter().chain(std::iter::once(&downstream)) {
+        backend
+            .create_execution(sample_exec_args(eid, &lane))
+            .await
+            .expect("create_execution");
+        backend
+            .add_execution_to_flow(&AddExecutionToFlowArgs {
+                flow_id: flow.clone(),
+                execution_id: eid.clone(),
+                now: now(),
+            })
+            .await
+            .expect("add_execution_to_flow");
+    }
+
+    backend
+        .set_edge_group_policy(
+            &flow,
+            &downstream,
+            EdgeDependencyPolicy::AnyOf {
+                on_satisfied: OnSatisfied::CancelRemaining,
+            },
+        )
+        .await
+        .expect("set_edge_group_policy");
+
+    let mut rev: u64 = 4;
+    let mut edges = Vec::new();
+    for up in &upstreams {
+        let edge_id = EdgeId::from_uuid(Uuid::new_v4());
+        backend
+            .stage_dependency_edge(&StageDependencyEdgeArgs {
+                flow_id: flow.clone(),
+                edge_id: edge_id.clone(),
+                upstream_execution_id: up.clone(),
+                downstream_execution_id: downstream.clone(),
+                dependency_kind: "success_only".to_owned(),
+                data_passing_ref: None,
+                expected_graph_revision: rev,
+                now: now(),
+            })
+            .await
+            .expect("stage_dependency_edge");
+        rev += 1;
+        backend
+            .apply_dependency_to_child(&ApplyDependencyToChildArgs {
+                flow_id: flow.clone(),
+                edge_id: edge_id.clone(),
+                downstream_execution_id: downstream.clone(),
+                upstream_execution_id: up.clone(),
+                graph_revision: rev,
+                dependency_kind: "success_only".to_owned(),
+                data_passing_ref: None,
+                now: now(),
+            })
+            .await
+            .expect("apply_dependency_to_child");
+        edges.push(edge_id);
+    }
+
+    let part_i16 = ff_core::partition::flow_partition(&flow, &pc).index as i16;
+    let first_up_uuid = parse_exec_uuid(&upstreams[0]);
+
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal', \
+            public_state = 'completed', terminal_at_ms = $3 \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part_i16)
+    .bind(first_up_uuid)
+    .bind(now().0)
+    .execute(&pool)
+    .await
+    .expect("UPDATE upstream");
+
+    let event_id: i64 = sqlx::query_scalar(
+        "INSERT INTO ff_completion_event \
+            (partition_key, execution_id, flow_id, outcome, occurred_at_ms) \
+         VALUES ($1, $2, $3, 'success', $4) RETURNING event_id",
+    )
+    .bind(part_i16)
+    .bind(first_up_uuid)
+    .bind(flow.0)
+    .bind(now().0)
+    .fetch_one(&pool)
+    .await
+    .expect("INSERT completion");
+
+    let outcome = ff_backend_postgres::dispatch::dispatch_completion(&pool, event_id)
+        .await
+        .expect("dispatch_completion");
+    assert!(matches!(
+        outcome,
+        ff_backend_postgres::dispatch::DispatchOutcome::Advanced(n) if n >= 1
+    ));
+
+    let down_uuid = parse_exec_uuid(&downstream);
+    let elig: String = sqlx::query_scalar(
+        "SELECT eligibility_state FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part_i16)
+    .bind(down_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("SELECT downstream");
+    assert_eq!(elig, "eligible_now");
+
+    let flag: bool = sqlx::query_scalar(
+        "SELECT cancel_siblings_pending_flag FROM ff_edge_group \
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+    )
+    .bind(part_i16)
+    .bind(flow.0)
+    .bind(down_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("SELECT edge_group flag");
+    assert!(flag);
+
+    let pending_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_pending_cancel_groups \
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+    )
+    .bind(part_i16)
+    .bind(flow.0)
+    .bind(down_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("SELECT pending_cancel_groups");
+    assert_eq!(pending_count, 1);
+    // TODO(wave-5a): once `dispatch::advance_edge_group` populates
+    // `cancel_siblings_pending_members`, extend this test to assert the
+    // two remaining upstream siblings flip to `cancelled`.
+}
+
+fn parse_exec_uuid(eid: &ExecutionId) -> Uuid {
+    let s = eid.as_str();
+    let colon = s.rfind("}:").expect("hash-tag delimiter");
+    Uuid::parse_str(&s[colon + 2..]).expect("uuid suffix")
+}


### PR DESCRIPTION
## Summary

Wave 4c landed the flow-read + cancel_flow trait methods but skipped the four ingress-layer ops that live as inherent methods on the Valkey side (`ff-server::Server`). Without them, flow DAG construction cannot happen on Postgres, which is what Wave 7b's unskip agent hit a wall on when trying to exercise RFC-016 `AnyOf{CancelRemaining}`.

This PR adds all four as inherent methods on `PostgresBackend` (NOT on the `EngineBackend` trait), matching the Valkey ingress shape so the smoke harness can call both paths uniformly.

- `create_flow` — idempotent INSERT into `ff_flow_core`.
- `add_execution_to_flow` — stamps `exec.flow_id`, bumps `graph_revision` + `raw_fields.node_count`. Idempotent + RFC-007 cross-flow refusal.
- `stage_dependency_edge` — CAS on `graph_revision` (stale rev surfaces as `Contention(StaleGraphRevision)`), membership check, INSERT edge with `staged_at_ms`. Duplicate edge surfaces as `Conflict(DependencyAlreadyExists{..})` with an enriched snapshot.
- `apply_dependency_to_child` — marks edge applied (`applied_at_ms` set), upserts `ff_edge_group` with `running_count+=1`. Idempotent.

## Structural choice

- Extended `flow_staging.rs` (new module) rather than `flow.rs` — keeps the 6 existing Wave-4c trait-method impls separate from the 4 new inherent ingress ops, so readers can tell at a glance which calls belong to the worker trait vs the server ingress path.
- **No schema migration.** Every new field (`dependency_kind`, `data_passing_ref`, `staged_at_ms`, `applied_at_ms`, `edge_state`, etc.) fits inside the existing `ff_edge.policy` jsonb / `ff_flow_core.raw_fields` jsonb columns that Wave 4c's decoder already reads from. Keeps the 0001 schema stable; no `0006_flow_staging.sql`.
- Membership model = `ff_exec_core.flow_id = flow_id` (the back-pointer Wave 4c's `cancel_flow` already queries). No separate `ff_flow_member` table introduced; RFC-011 flow/exec co-location makes the back-pointer authoritative on the flow's partition.

## End-to-end cascade evidence

5/5 integration tests green against a live Postgres (ff_wave4i_test on the default local pg):

```
test add_execution_bumps_graph_revision_and_node_count ... ok
test create_flow_happy_and_idempotent ... ok
test e2e_any_of_cancel_remaining_cascade ... ok
test stage_and_apply_edge_happy_path ... ok
test stage_rejects_stale_graph_revision ... ok
```

The `e2e_any_of_cancel_remaining_cascade` test is the scenario Wave 7b's unskip agent hit a wall on: 4 members (3 upstream + 1 downstream), `AnyOf{CancelRemaining}` policy, 3 staged + applied edges, one upstream driven to `success`, `dispatch_completion` invoked, and we assert:

- downstream `eligibility_state = 'eligible_now'`
- `ff_edge_group.cancel_siblings_pending_flag = true`
- one row enqueued into `ff_pending_cancel_groups`

## Known Wave 5a gap (NOT fixed here — not my lane)

`dispatch::advance_edge_group` flips the flag but does NOT populate `cancel_siblings_pending_members`, so the edge-cancel-dispatcher currently has no exec ids to cancel. The e2e test asserts up to the flag + enqueue and leaves a `TODO(wave-5a)` for the dispatcher lane to populate the members array. This PR's 4 methods are the prerequisite for closing that loop.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-backend-postgres --all-features -- -D warnings` clean
- [x] `cargo test -p ff-test --test pg_flow_staging -- --ignored --test-threads=1` 5/5 green on live Postgres
- [ ] Downstream: Wave 5a to populate `cancel_siblings_pending_members` so the e2e test's TODO can be filled in to assert sibling cancellation.

Do NOT merge — landing this ahead of Wave 5a's dispatcher members-array fix leaves the `AnyOf{CancelRemaining}` fixture partially exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new transactional Postgres write paths that mutate `ff_flow_core`, `ff_exec_core`, `ff_edge`, and `ff_edge_group`, including CAS on `graph_revision`; bugs here could cause flow membership/edge state inconsistencies under concurrency. No schema changes, but correctness depends on JSONB field conventions and conflict/idempotency handling.
> 
> **Overview**
> Enables end-to-end flow DAG construction on Postgres by adding a new `flow_staging` module with four ingress-style write operations: `create_flow`, `add_execution_to_flow`, `stage_dependency_edge` (CAS on `graph_revision` + edge insert), and `apply_dependency_to_child` (mark edge applied + increment downstream `ff_edge_group.running_count`).
> 
> `PostgresBackend` now exposes these as **inherent methods** (not `EngineBackend` trait methods) to mirror the Valkey/ff-server ingress API, using existing `raw_fields`/`policy` JSONB storage (no migrations). Adds ignored live-Postgres integration tests covering idempotency, stale-revision contention, edge apply behavior, and an `AnyOf{CancelRemaining}` dispatch cascade scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4da153b38817797a811c0b3675a15a76045296. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->