### PR TITLE
fix(pre-v0.7): populate cancel_siblings_pending_members + max_locks warning + PublicState::Resumable

### DIFF
--- a/crates/ff-backend-postgres/src/dispatch.rs
+++ b/crates/ff-backend-postgres/src/dispatch.rs
@@ -257,8 +257,6 @@ async fn advance_edge_group(
     downstream_eid: Uuid,
     outcome: OutcomeKind,
 ) -> Result<(), EngineError> {
-    let _ = upstream_eid; // retained for tracing; no per-hop predicate yet.
-
     let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
 
     sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
@@ -367,8 +365,39 @@ async fn advance_edge_group(
             if cancel_siblings && !already_flagged {
                 // Stage-C bookkeeping: add one row to
                 // `ff_pending_cancel_groups` per still-running sibling
-                // group and flip the flag so a replay doesn't
-                // double-enqueue.
+                // group, compute the sibling-members set, and flip the
+                // flag so a replay doesn't double-enqueue. The
+                // reconciler (Wave 6b) consumes `members` to drive
+                // per-sibling cancel; the set excludes the winner.
+                let sibling_rows = sqlx::query(
+                    r#"
+                    SELECT ff_exec_core.execution_id
+                      FROM ff_exec_core
+                      JOIN ff_edge ON ff_edge.upstream_eid = ff_exec_core.execution_id
+                     WHERE ff_exec_core.partition_key = $1
+                       AND ff_edge.partition_key      = $1
+                       AND ff_edge.flow_id            = $2
+                       AND ff_edge.downstream_eid     = $3
+                       AND ff_exec_core.lifecycle_phase NOT IN ('terminal','cancelled')
+                       AND ff_exec_core.public_state  <> 'skipped'
+                       AND ff_exec_core.execution_id <> $4
+                    "#,
+                )
+                .bind(partition_key)
+                .bind(flow_id)
+                .bind(downstream_eid)
+                .bind(upstream_eid)
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(map_sqlx_error)?;
+                let members: Vec<String> = sibling_rows
+                    .iter()
+                    .map(|r| {
+                        let u: Uuid = r.get("execution_id");
+                        u.to_string()
+                    })
+                    .collect();
+
                 sqlx::query(
                     r#"
                     INSERT INTO ff_pending_cancel_groups
@@ -388,13 +417,15 @@ async fn advance_edge_group(
                 sqlx::query(
                     r#"
                     UPDATE ff_edge_group
-                       SET cancel_siblings_pending_flag = TRUE
+                       SET cancel_siblings_pending_flag    = TRUE,
+                           cancel_siblings_pending_members = $4
                      WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3
                     "#,
                 )
                 .bind(partition_key)
                 .bind(flow_id)
                 .bind(downstream_eid)
+                .bind(&members)
                 .execute(&mut *tx)
                 .await
                 .map_err(map_sqlx_error)?;

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -134,6 +134,7 @@ impl PostgresBackend {
     /// connection arm is not Postgres.
     pub async fn connect(config: BackendConfig) -> Result<Arc<dyn EngineBackend>, EngineError> {
         let pool = pool::build_pool(&config).await?;
+        warn_if_max_locks_low(&pool).await;
         let stream_notifier = Some(StreamNotifier::spawn(pool.clone()));
         let backend = Self {
             pool,
@@ -549,5 +550,89 @@ impl EngineBackend for PostgresBackend {
         attempt_index: AttemptIndex,
     ) -> Result<Option<SummaryDocument>, EngineError> {
         stream::read_summary(&self.pool, execution_id, attempt_index).await
+    }
+}
+
+/// Minimum recommended `max_locks_per_transaction`. Partition-heavy
+/// schemas (256 hash partitions per logical table) can exceed the
+/// Postgres default of `64` per tx under modest concurrent bench
+/// load — the Wave 7c bench hit `out of shared memory` at 16 workers
+/// × 10k tasks with the default and unblocked at `512`. We warn at
+/// boot rather than hard-fail because operators may legitimately
+/// run with a tuned value that still exceeds 64 but sits below our
+/// threshold.
+const MIN_MAX_LOCKS_PER_TRANSACTION: i64 = 256;
+
+/// Probe `max_locks_per_transaction` at connect time + log a warning
+/// when the current value is below the production-safe threshold.
+/// Never fails the connect — probe errors are logged at debug and
+/// swallowed (pg_show may be restricted on exotic deploys).
+async fn warn_if_max_locks_low(pool: &PgPool) {
+    let row: Result<(String,), sqlx::Error> =
+        sqlx::query_as("SHOW max_locks_per_transaction")
+            .fetch_one(pool)
+            .await;
+    match row {
+        Ok((raw,)) => emit_max_locks_decision(&raw),
+        Err(e) => {
+            tracing::debug!("failed to probe max_locks_per_transaction: {e}");
+        }
+    }
+}
+
+/// Pure decision surface for the max-locks probe — extracted for
+/// unit-testability (the live probe is gated by a running Postgres).
+/// Returns the integer value when a warning SHOULD fire, `None`
+/// otherwise (either the raw is valid + at/above threshold, or the
+/// raw is unparseable — the latter is debug-only).
+fn max_locks_warn_value(raw: &str) -> Option<i64> {
+    match raw.parse::<i64>() {
+        Ok(v) if v < MIN_MAX_LOCKS_PER_TRANSACTION => Some(v),
+        Ok(_) => None,
+        Err(e) => {
+            tracing::debug!(raw, "failed to parse max_locks_per_transaction: {e}");
+            None
+        }
+    }
+}
+
+fn emit_max_locks_decision(raw: &str) {
+    if let Some(v) = max_locks_warn_value(raw) {
+        tracing::warn!(
+            current = v,
+            recommended = MIN_MAX_LOCKS_PER_TRANSACTION,
+            "postgres max_locks_per_transaction={v} is below the recommended \
+             minimum ({MIN_MAX_LOCKS_PER_TRANSACTION}); partition-heavy workloads \
+             may hit 'out of shared memory' under concurrent load. \
+             See docs/operator-guide-postgres.md."
+        );
+    }
+}
+
+#[cfg(test)]
+mod max_locks_tests {
+    use super::{max_locks_warn_value, MIN_MAX_LOCKS_PER_TRANSACTION};
+
+    #[test]
+    fn warns_when_below_threshold() {
+        assert_eq!(max_locks_warn_value("64"), Some(64));
+        assert_eq!(
+            max_locks_warn_value(&(MIN_MAX_LOCKS_PER_TRANSACTION - 1).to_string()),
+            Some(MIN_MAX_LOCKS_PER_TRANSACTION - 1)
+        );
+    }
+
+    #[test]
+    fn silent_at_or_above_threshold() {
+        assert_eq!(
+            max_locks_warn_value(&MIN_MAX_LOCKS_PER_TRANSACTION.to_string()),
+            None
+        );
+        assert_eq!(max_locks_warn_value("1024"), None);
+    }
+
+    #[test]
+    fn silent_for_unparseable_raw() {
+        assert_eq!(max_locks_warn_value("not-a-number"), None);
     }
 }

--- a/crates/ff-core/src/state.rs
+++ b/crates/ff-core/src/state.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 // ── Dimension A — Lifecycle Phase ──
@@ -149,6 +151,7 @@ pub enum AttemptState {
 /// Engine-computed user-facing label. Derived from the state vector.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum PublicState {
     /// Eligible and waiting for a worker to claim.
     Waiting,
@@ -162,6 +165,12 @@ pub enum PublicState {
     Active,
     /// Intentionally paused, waiting for signal/approval/callback.
     Suspended,
+    /// Suspension signal satisfied — awaiting `claim_resumed` to start
+    /// the next attempt. Transient state between `Suspended` and
+    /// `Active`; emitted by the Postgres suspend_signal path (and the
+    /// Valkey equivalent via `ff_deliver_signal` when the waitpoint
+    /// fires). See `ff-backend-postgres::suspend_ops`.
+    Resumable,
     /// Terminal: finished successfully.
     Completed,
     /// Terminal: finished unsuccessfully.
@@ -172,6 +181,34 @@ pub enum PublicState {
     Expired,
     /// Terminal: impossible to run because required dependency failed.
     Skipped,
+}
+
+impl PublicState {
+    /// Snake-case string form. Round-trips with
+    /// `ff_script::functions::suspension::parse_public_state` and the
+    /// raw strings Postgres stores in `ff_exec_core.public_state`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Waiting => "waiting",
+            Self::Delayed => "delayed",
+            Self::RateLimited => "rate_limited",
+            Self::WaitingChildren => "waiting_children",
+            Self::Active => "active",
+            Self::Suspended => "suspended",
+            Self::Resumable => "resumable",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Expired => "expired",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+impl fmt::Display for PublicState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 // ── State Vector ──
@@ -464,6 +501,19 @@ mod tests {
         assert!(!AttemptLifecycle::Created.is_terminal());
         assert!(!AttemptLifecycle::Started.is_terminal());
         assert!(!AttemptLifecycle::Suspended.is_terminal());
+    }
+
+    #[test]
+    fn public_state_resumable_roundtrip_display_and_serde() {
+        // Display ↔ snake_case form
+        assert_eq!(PublicState::Resumable.to_string(), "resumable");
+        assert_eq!(PublicState::Resumable.as_str(), "resumable");
+
+        // serde round-trip using the snake_case form
+        let json = serde_json::to_string(&PublicState::Resumable).unwrap();
+        assert_eq!(json, "\"resumable\"");
+        let parsed: PublicState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, PublicState::Resumable);
     }
 
     #[test]

--- a/crates/ff-script/src/functions/execution.rs
+++ b/crates/ff-script/src/functions/execution.rs
@@ -769,6 +769,7 @@ fn parse_public_state(s: &str) -> Result<PublicState, ScriptError> {
         "waiting_children" => Ok(PublicState::WaitingChildren),
         "active" => Ok(PublicState::Active),
         "suspended" => Ok(PublicState::Suspended),
+        "resumable" => Ok(PublicState::Resumable),
         "completed" => Ok(PublicState::Completed),
         "failed" => Ok(PublicState::Failed),
         "cancelled" => Ok(PublicState::Cancelled),

--- a/crates/ff-script/src/functions/suspension.rs
+++ b/crates/ff-script/src/functions/suspension.rs
@@ -449,6 +449,7 @@ fn parse_public_state(s: &str) -> Result<PublicState, ScriptError> {
         "waiting_children" => Ok(PublicState::WaitingChildren),
         "active" => Ok(PublicState::Active),
         "suspended" => Ok(PublicState::Suspended),
+        "resumable" => Ok(PublicState::Resumable),
         "completed" => Ok(PublicState::Completed),
         "failed" => Ok(PublicState::Failed),
         "cancelled" => Ok(PublicState::Cancelled),

--- a/crates/ff-test/tests/pg_dispatch_dependency.rs
+++ b/crates/ff-test/tests/pg_dispatch_dependency.rs
@@ -462,3 +462,59 @@ async fn large_fanout_per_hop_tx_releases_locks() {
         "per-hop-tx invariant broken: peak_holds={peak_holds}"
     );
 }
+
+// ── Test 8: AnyOf + CancelRemaining populates pending_members ────────
+
+/// Regression for the Wave 4i + Wave 6b finding: when the policy flips
+/// `cancel_siblings_pending_flag = true`, `advance_edge_group` MUST
+/// also write the list of sibling upstream execution_ids into
+/// `cancel_siblings_pending_members` — the Wave 6b dispatcher reads
+/// that column to drive the actual per-sibling cancel. Prior to the
+/// fix the flag was set but members stayed `'{}'::text[]`.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn advance_edge_group_any_of_populates_cancel_members() {
+    let Some(pool) = setup_or_skip().await else { return };
+    let (flow, downstream, upstreams) = seed_flow(
+        &pool,
+        3,
+        serde_json::json!({"kind": "any_of", "on_satisfied": "cancel_remaining"}),
+        1,
+    )
+    .await;
+
+    // Winner = upstreams[0]; siblings[1..] should still be active
+    // (we only emit the winner's completion event).
+    let ev = emit(&pool, upstreams[0], flow, "success").await;
+    dispatch::dispatch_completion(&pool, ev)
+        .await
+        .expect("dispatch ok");
+
+    // Downstream flips eligible.
+    assert_eq!(exec_eligibility(&pool, downstream).await, "eligible_now");
+    // Pending-cancel bookkeeping row inserted.
+    assert_eq!(pending_cancel_rows(&pool, flow).await, 1);
+
+    // The flag is set + members list contains exactly the 2 non-winner
+    // upstream execution_ids.
+    let row = sqlx::query(
+        "SELECT cancel_siblings_pending_flag, cancel_siblings_pending_members \
+         FROM ff_edge_group \
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+    )
+    .bind(P)
+    .bind(flow)
+    .bind(downstream)
+    .fetch_one(&pool)
+    .await
+    .expect("read edge_group");
+    let flag: bool = row.get("cancel_siblings_pending_flag");
+    let members: Vec<String> = row.get("cancel_siblings_pending_members");
+    assert!(flag, "pending flag not set");
+    assert_eq!(members.len(), 2, "expected 2 siblings; got {members:?}");
+    let mut got: Vec<String> = members;
+    got.sort();
+    let mut want: Vec<String> = upstreams[1..].iter().map(|u| u.to_string()).collect();
+    want.sort();
+    assert_eq!(got, want, "sibling members mismatch");
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,6 +63,12 @@ Before cutting a release, verify:
 - [ ] Valkey minimum is 8.0+. The server refuses to start against
       Valkey < 8.0 (RFC-011 §13). Ensure all production + CI targets
       are on 8.x before cutting.
+- [ ] Postgres `max_locks_per_transaction >= 512` on all target
+      deployments (default `64` is insufficient under concurrent
+      bench/partition load — see
+      [`operator-guide-postgres.md`](operator-guide-postgres.md)).
+      `PostgresBackend::connect` emits a `tracing::warn` at boot when
+      the value is below `256`.
 - [ ] RESP3 is required for the engine's completion listener.
       `FlowFabricWorker::connect` defaults to RESP3; servers fronted
       by protocol-downgrading proxies must be verified against.

--- a/docs/operator-guide-postgres.md
+++ b/docs/operator-guide-postgres.md
@@ -1,0 +1,58 @@
+# Postgres operator guide
+
+Tuning notes for running FlowFabric's Postgres backend
+(`ff-backend-postgres`) under production load.
+
+## `max_locks_per_transaction`
+
+**Recommended:** `512` (minimum `256`).
+**Postgres default:** `64`.
+
+### Why
+
+The RFC-v0.7 Postgres schema hash-partitions every hot table into
+256 child partitions (`ff_exec_core_pNN`, `ff_edge_group_pNN`, etc.).
+A single transaction that touches rows across many partitions —
+common in the dispatch cascade, flow cancellation, and reconciler
+scans — acquires one lock per partition it touches, plus its
+index partitions. A fanout transaction can easily demand well
+beyond 64 locks.
+
+Under modest concurrent load the shared lock table fills and
+transactions abort with:
+
+```
+ERROR: out of shared memory
+HINT:  You might need to increase "max_locks_per_transaction"
+```
+
+Wave 7c's Phase 0 benchmark hit this at 16 workers × 10k tasks
+against a Postgres 16 with default settings. Raising the setting
+to `512` cleared the failure without further tuning.
+
+### How
+
+In `postgresql.conf`:
+
+```
+max_locks_per_transaction = 512
+```
+
+Requires a server restart. On managed providers (RDS, Cloud SQL,
+etc.) this is a parameter-group setting followed by a reboot.
+
+### Boot-time warning
+
+`PostgresBackend::connect` runs `SHOW max_locks_per_transaction`
+at dial time and logs a `tracing::warn` when the value is below
+`256`. The warning is informational — the backend does not refuse
+to start, since operators may have platform reasons to run with a
+non-default-but-still-below-256 value. The warning surfaces as:
+
+```
+postgres max_locks_per_transaction=64 is below the recommended minimum (256);
+partition-heavy workloads may hit 'out of shared memory' under concurrent load.
+```
+
+If the probe itself fails (`SHOW` denied on exotic deploys) the
+error is logged at `debug` and swallowed.


### PR DESCRIPTION
## Summary

Three genuine bugs surfaced during Waves 4i / 7b / 7c, batched for the v0.7 pre-tag cleanup. Based off `origin/main` at `a1c2322`; PRs #252–#255 will rebase on top at chain-merge.

- **Bug 1 (Wave 4i + 6b):** `dispatch::advance_edge_group` flipped `cancel_siblings_pending_flag=true` under `AnyOf` / `Quorum` + `CancelRemaining` but never populated the companion `cancel_siblings_pending_members` column. The Wave 6b dispatcher reads that column to drive per-sibling cancel, so the flag was set with nothing to act on. Fix: at the flag-flip moment, query the set of sibling upstream `execution_id`s still in a non-terminal lifecycle phase (excluding the winner) and write them into the `text[]` column in the same per-hop tx.
- **Bug 2 (Wave 7c):** Postgres default `max_locks_per_transaction=64` is insufficient under partition-heavy concurrent load (256 hash partitions × fanout tx). Wave 7c bench hit `ERROR: out of shared memory` at 16 workers × 10k tasks; `512` unblocked. Fix: boot-time `SHOW max_locks_per_transaction` probe in `PostgresBackend::connect` that `tracing::warn`s when below `256`. Not a hard fail — operators may have platform reasons. New `docs/operator-guide-postgres.md` + `docs/RELEASING.md` pre-flight checklist entry document the recommended `512`.
- **Bug 3 (Wave 7b):** Postgres `suspend_signal` writes `public_state='resumable'` as a raw string, but `PublicState` enum lacked a `Resumable` variant. Any consumer decoding the state (e.g. `describe_execution` → `parse_public_state`) errored on round-trip. Fix: additive `Resumable` variant + `#[non_exhaustive]` on the enum for forward-compat; `as_str()` + `Display` impl; `parse_public_state` updated in both ff-script arms (`suspension.rs`, `execution.rs`). Grep confirmed no Valkey Lua currently emits `resumable`.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-core -p ff-backend-postgres --tests -- -D warnings` clean
- [x] ff-core lib tests: 196/196 green (includes new `public_state_resumable_roundtrip_display_and_serde`)
- [x] ff-backend-postgres lib tests: 24/24 green (includes 3 new `max_locks_tests::*`)
- [x] `pg_dispatch_dependency` live-Postgres suite: 8/8 green (includes new `advance_edge_group_any_of_populates_cancel_members`, which asserts both the 2 sibling UUIDs land in `cancel_siblings_pending_members` and the flag is set)
- [ ] Runtime smoke against a deployment with `max_locks_per_transaction=64` to capture the warn line (not run locally; the bench node is already at `512`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Postgres dispatch/cancellation bookkeeping and execution public-state decoding, which can affect flow progression and suspend/resume behavior; also adds a boot-time configuration probe that should be low impact but could be noisy in logs.
> 
> **Overview**
> Fixes Postgres dependency dispatch so `AnyOf`/`Quorum` with `CancelRemaining` now records the actual sibling execution IDs in `ff_edge_group.cancel_siblings_pending_members` when setting `cancel_siblings_pending_flag`, enabling downstream per-sibling cancellation to run correctly.
> 
> Adds a connect-time probe in `PostgresBackend::connect` that `SHOW`s `max_locks_per_transaction` and logs a warning when below `256`, with new operator/releasing docs describing the recommended `512` setting.
> 
> Extends `ff-core`’s `PublicState` with a new `Resumable` variant (plus `as_str`/`Display` and tests) and updates ff-script `parse_public_state` helpers to accept the `"resumable"` string, preventing parse errors when Postgres writes this state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efaf7c20b28117ab06c1dcd2fecece560a90034f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->