### PR TITLE
feat(pg-smoke): unblock flow_anyof + claim_lifecycle + fanout_slo on Postgres (all prereqs landed)

### DIFF
--- a/benches/smoke/src/scenarios/claim_lifecycle.rs
+++ b/benches/smoke/src/scenarios/claim_lifecycle.rs
@@ -8,15 +8,23 @@
 //! * `EngineBackend::progress`
 //! * `EngineBackend::complete`
 //!
-//! If any of these fail or return `Unavailable`, the scenario fails.
+//! On Postgres we also exercise [`PostgresScheduler::claim_for_worker`]
+//! (Wave 5b PR #246) on a separate seeded execution so the signed-grant
+//! issuance path is reachability-probed too.
+//!
+//! The submit→runnable promoter is deliberately out-of-scope on Postgres
+//! (see Wave 5b docs + `pg_scheduler_claim.rs::promote_to_runnable`), so
+//! the smoke replicates the documented test pattern: manual UPDATE to
+//! `lifecycle_phase='runnable'` after create_execution.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-// `Duration` is used below for the post-create settle.
-
-use ff_backend_postgres::PostgresBackend;
+use ff_backend_postgres::{PgPool, PostgresBackend};
+use ff_backend_postgres::scheduler::PostgresScheduler;
 use ff_core::engine_backend::EngineBackend;
+use ff_core::types::{WorkerId, WorkerInstanceId};
 
 use crate::ScenarioReport;
 use crate::SmokeCtx;
@@ -58,40 +66,83 @@ pub async fn run_postgres(
     ctx: Arc<SmokeCtx>,
     pg: Arc<PostgresBackend>,
     backend: Arc<dyn EngineBackend>,
+    pool: PgPool,
 ) -> ScenarioReport {
     let started = scenarios::start();
-    let (_eid, args) = build_create_args(&ctx.partition_config);
-    if let Err(e) = pg.create_execution(args).await {
-        return ScenarioReport::fail(NAME, "postgres", started, format!("create: {e}"));
+
+    // ── Exec A: exercise the scheduler.claim_for_worker grant-issuance
+    //           path (Wave 5b PR #246).
+    let (eid_a, args_a) = build_create_args(&ctx.partition_config);
+    if let Err(e) = pg.create_execution(args_a).await {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("create A: {e}"));
+    }
+    if let Err(e) = promote_to_runnable(&pool, &eid_a).await {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("promote A: {e}"));
+    }
+    // Seed a single HMAC secret so the scheduler can sign. The
+    // v0.7 release gate script exports FF_WAITPOINT_HMAC_SECRET;
+    // ensure a row exists in `ff_waitpoint_hmac` regardless so the
+    // smoke is self-sufficient. Upsert-by-hash keeps concurrent
+    // scenarios from duplicating the row.
+    if let Err(e) = ensure_hmac_secret(&pool).await {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("hmac seed: {e}"));
     }
 
+    let scheduler = PostgresScheduler::new(pool.clone());
+    let lane = ff_core::types::LaneId::new(scenarios::SMOKE_LANE);
+    let caps: BTreeSet<String> = BTreeSet::new();
+    let wid = WorkerId::new(format!("smoke-{}", uuid::Uuid::new_v4()));
+    let wiid = WorkerInstanceId::new(format!("smoke-inst-{}", uuid::Uuid::new_v4()));
+    match scheduler
+        .claim_for_worker(&lane, &wid, &wiid, &caps, 30_000)
+        .await
+    {
+        Ok(Some(_grant)) => {}
+        Ok(None) => {
+            return ScenarioReport::fail(
+                NAME,
+                "postgres",
+                started,
+                "scheduler.claim_for_worker returned None for a freshly-runnable row",
+            );
+        }
+        Err(e) => {
+            return ScenarioReport::fail(
+                NAME,
+                "postgres",
+                started,
+                format!("scheduler.claim_for_worker: {e}"),
+            );
+        }
+    }
+
+    // ── Exec B: exercise the claim → progress → complete lifecycle
+    //           through the `EngineBackend` trait.
+    let (eid_b, args_b) = build_create_args(&ctx.partition_config);
+    if let Err(e) = pg.create_execution(args_b).await {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("create B: {e}"));
+    }
+    if let Err(e) = promote_to_runnable(&pool, &eid_b).await {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("promote B: {e}"));
+    }
     // Small settle to let any indexes/rows commit before claim.
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    // Try to claim the freshly seeded execution via the trait.
-    // `claim` may legitimately return Ok(None) if the Postgres
-    // scheduler's admission pipeline hasn't admitted the row yet.
-    // Treat Ok(None) as Skip (surface exists, just didn't hand back
-    // a handle in the smoke window) and Ok(Some(_)) as Pass.
     let handle = match claim_one(&backend).await {
         Ok(Some(h)) => h,
         Ok(None) => {
-            return ScenarioReport::skip(
+            return ScenarioReport::fail(
                 NAME,
                 "postgres",
-                "claim returned Ok(None) (scheduler had no eligible handle in window)",
+                started,
+                "backend.claim returned None for a freshly-runnable row",
             );
-        }
-        Err(ff_core::engine_error::EngineError::Unavailable { op }) => {
-            return ScenarioReport::skip(NAME, "postgres", format!("Unavailable: {op}"));
         }
         Err(e) => {
             return ScenarioReport::fail(NAME, "postgres", started, format!("claim: {e}"));
         }
     };
 
-    // progress heartbeat (optional-ish — if Unavailable we still want
-    // the scenario to pass, since it is a single trait method).
     if let Err(e) = backend
         .progress(&handle, Some(50), Some("smoke-halfway".to_string()))
         .await
@@ -100,13 +151,80 @@ pub async fn run_postgres(
         return ScenarioReport::fail(NAME, "postgres", started, format!("progress: {e}"));
     }
 
-    // Terminal — complete.
     match backend.complete(&handle, Some(b"smoke-ok".to_vec())).await {
-        Ok(()) => ScenarioReport::pass(NAME, "postgres", started),
-        Err(ff_core::engine_error::EngineError::Unavailable { op }) => {
-            ScenarioReport::skip(NAME, "postgres", format!("complete Unavailable: {op}"))
+        Ok(()) => {}
+        Err(e) => {
+            return ScenarioReport::fail(NAME, "postgres", started, format!("complete: {e}"));
         }
-        Err(e) => ScenarioReport::fail(NAME, "postgres", started, format!("complete: {e}")),
+    }
+
+    // Verify terminal state committed.
+    match verify_terminal(&pool, &eid_b).await {
+        Ok(true) => ScenarioReport::pass(NAME, "postgres", started),
+        Ok(false) => ScenarioReport::fail(
+            NAME,
+            "postgres",
+            started,
+            "exec B did not reach lifecycle_phase='terminal' after complete",
+        ),
+        Err(e) => ScenarioReport::fail(NAME, "postgres", started, format!("verify: {e}")),
     }
 }
 
+/// Flip a freshly-created execution from `submitted` → `runnable` so
+/// the `claim` / scheduler pipelines can pick it up. Mirrors the
+/// documented test pattern in `crates/ff-test/tests/pg_scheduler_claim.rs`.
+async fn promote_to_runnable(
+    pool: &PgPool,
+    eid: &ff_core::types::ExecutionId,
+) -> Result<(), sqlx::Error> {
+    let part_i16 = eid.partition() as i16;
+    let uuid = parse_exec_uuid(eid);
+    sqlx::query(
+        "UPDATE ff_exec_core \
+            SET lifecycle_phase = 'runnable' \
+          WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part_i16)
+    .bind(uuid)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Seed a single active HMAC secret if none exists. The scheduler
+/// refuses to issue grants against an empty keystore; smoke is
+/// responsible for having a baseline row.
+async fn ensure_hmac_secret(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO ff_waitpoint_hmac (kid, secret, rotated_at_ms) \
+         VALUES ('smoke-kid', decode('0000000000000000000000000000000000000000000000000000000000000000', 'hex'), 0) \
+         ON CONFLICT (kid) DO NOTHING",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn verify_terminal(
+    pool: &PgPool,
+    eid: &ff_core::types::ExecutionId,
+) -> Result<bool, sqlx::Error> {
+    let part_i16 = eid.partition() as i16;
+    let uuid = parse_exec_uuid(eid);
+    let phase: Option<String> = sqlx::query_scalar(
+        "SELECT lifecycle_phase FROM ff_exec_core \
+          WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part_i16)
+    .bind(uuid)
+    .fetch_optional(pool)
+    .await?;
+    Ok(phase.as_deref() == Some("terminal"))
+}
+
+fn parse_exec_uuid(eid: &ff_core::types::ExecutionId) -> uuid::Uuid {
+    let s = eid.as_str();
+    let colon = s.rfind("}:").expect("hash-tag delimiter");
+    uuid::Uuid::parse_str(&s[colon + 2..]).expect("uuid suffix")
+}

--- a/benches/smoke/src/scenarios/fanout_slo.rs
+++ b/benches/smoke/src/scenarios/fanout_slo.rs
@@ -1,33 +1,54 @@
-//! Scenario 7 — 50-way quorum fanout.
+//! Scenario 7 — 100-way Quorum(1)+CancelRemaining fanout SLO.
 //!
-//! The master-spec Phase 0 SLO calls for p99 ≤ 500ms at 50-way
-//! fanout. Measuring p99 latency is the perf harness's job
-//! (`benches/harness/benches/quorum_cancel_fanout.rs`, kept separate
-//! per the Wave 7c sibling). This smoke leg is a *reachability*
-//! probe only — it seeds 50 executions through the ingress path
-//! and confirms the claim pump can observe all 50 within a bounded
-//! window. A Pass here rules out "fanout-ingress is broken" / "claim
-//! cannot observe post-create visibility"; it does NOT prove p99.
+//! Master spec §4.2: p99 end-to-end dispatch latency MUST stay within
+//! 500ms at n=100. Wave 7c measured 313ms on Postgres; this smoke
+//! asserts the same gate as a release check.
+//!
+//! Shape (per sample): create flow with 100 upstream members + 1
+//! downstream, stage 100 AnyOf/Quorum(1)+CancelRemaining edges, apply
+//! them, drive upstream[0] to `terminal`, call `dispatch_completion`
+//! (this flips `cancel_siblings_pending_flag=TRUE` — the "flag-set
+//! moment" for latency measurement), then call `dispatcher_tick`
+//! repeatedly until all 99 siblings reach `public_state='cancelled'`.
+//! Record wall time from flag-set to last-sibling-observed.
+//!
+//! 10 samples minimum, p99 ≤ 500 ms.
+//!
+//! The Valkey leg stays as a reachability probe (see v0.7 smoke Wave
+//! 7b) — the SLO measurement is Postgres-specific in this pass.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use ff_backend_postgres::PostgresBackend;
+use ff_backend_postgres::{PgPool, PostgresBackend};
+use ff_backend_postgres::reconcilers::edge_cancel_dispatcher;
+use ff_core::backend::ScannerFilter;
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, ApplyDependencyToChildArgs, CreateExecutionArgs, CreateFlowArgs,
+    EdgeDependencyPolicy, OnSatisfied, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+};
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
+use ff_core::types::{EdgeId, ExecutionId, FlowId, LaneId, Namespace, TimestampMs};
 
 use crate::ScenarioReport;
 use crate::SmokeCtx;
 use crate::scenarios;
 
 const NAME: &str = "fanout_slo";
-const FANOUT: usize = 50;
-const DEADLINE_SECS: u64 = 30;
+const VALKEY_FANOUT: usize = 50;
+const VALKEY_DEADLINE_SECS: u64 = 30;
+
+// Postgres SLO measurement knobs (master spec §4.2).
+const PG_FANIN: usize = 100;
+const PG_SAMPLES: usize = 10;
+const PG_P99_SLO_MS: u128 = 500;
+const PG_DISPATCH_DEADLINE: Duration = Duration::from_secs(30);
 
 pub async fn run_valkey(ctx: Arc<SmokeCtx>) -> ScenarioReport {
     let started = scenarios::start();
-    let mut seeded: Vec<ff_core::types::ExecutionId> = Vec::with_capacity(FANOUT);
-    for _ in 0..FANOUT {
+    let mut seeded: Vec<ff_core::types::ExecutionId> = Vec::with_capacity(VALKEY_FANOUT);
+    for _ in 0..VALKEY_FANOUT {
         let (_fid, eid) = scenarios::mint_fresh_exec_id(&ctx.partition_config);
         if let Err(e) = scenarios::http_create_execution(&ctx, &eid, b"fanout".to_vec()).await {
             return ScenarioReport::fail(
@@ -39,9 +60,7 @@ pub async fn run_valkey(ctx: Arc<SmokeCtx>) -> ScenarioReport {
         }
         seeded.push(eid);
     }
-    // All 50 seeded — confirm a sample of their state endpoints
-    // answer. We don't poll to terminal (no worker pump running in
-    // the smoke); just assert visibility.
+    // All seeded — confirm a sample of their state endpoints answer.
     for eid in seeded.iter().take(5) {
         let url = format!("{}/v1/executions/{}/state", ctx.http_server, eid);
         match ctx.http.get(&url).send().await {
@@ -59,6 +78,7 @@ pub async fn run_valkey(ctx: Arc<SmokeCtx>) -> ScenarioReport {
             }
         }
     }
+    let _ = VALKEY_DEADLINE_SECS;
     ScenarioReport::pass(NAME, "valkey", started)
 }
 
@@ -66,52 +86,233 @@ pub async fn run_postgres(
     ctx: Arc<SmokeCtx>,
     pg: Arc<PostgresBackend>,
     backend: Arc<dyn EngineBackend>,
+    pool: PgPool,
 ) -> ScenarioReport {
+    let _ = backend;
     let started = scenarios::start();
-    for i in 0..FANOUT {
-        let (_eid, args) = scenarios::build_create_args(&ctx.partition_config);
-        if let Err(e) = pg.create_execution(args).await {
-            return ScenarioReport::fail(NAME, "postgres", started, format!("create[{i}]: {e}"));
-        }
-    }
-    // Drive the claim pump and count observations until we've seen
-    // FANOUT (success) or the deadline elapses (fail).
-    let deadline = std::time::Instant::now() + Duration::from_secs(DEADLINE_SECS);
-    let mut observed = 0usize;
-    while observed < FANOUT && std::time::Instant::now() < deadline {
-        match scenarios::claim_one(&backend).await {
-            Ok(Some(h)) => {
-                observed += 1;
-                // Release the lease so subsequent claims can flow.
-                let _ = backend.cancel(&h, "smoke-fanout-release").await;
-            }
-            Ok(None) => {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-            Err(EngineError::Unavailable { op }) => {
+    let mut samples_ms: Vec<u128> = Vec::with_capacity(PG_SAMPLES);
+
+    for sample in 0..PG_SAMPLES {
+        match run_one_sample(&ctx, &pg, &pool, sample).await {
+            Ok(ms) => samples_ms.push(ms),
+            Err(SampleErr::Unavailable(op)) => {
                 return ScenarioReport::skip(
                     NAME,
                     "postgres",
-                    format!("claim Unavailable: {op}"),
+                    format!("Unavailable at sample {sample}: {op}"),
                 );
             }
-            Err(e) => {
-                return ScenarioReport::fail(NAME, "postgres", started, format!("claim: {e}"));
+            Err(SampleErr::Other(msg)) => {
+                return ScenarioReport::fail(NAME, "postgres", started, msg);
             }
         }
     }
-    if observed < FANOUT {
-        // Partial fanout is honest — not every wave has the claim
-        // pump wired in strict enough to see all 50 inside 30s.
-        // Flag as Skip rather than Fail so the release doesn't
-        // block on it; `--strict` still catches.
-        return ScenarioReport::skip(
+
+    samples_ms.sort_unstable();
+    let p50 = samples_ms[samples_ms.len() / 2];
+    let p99_idx = ((samples_ms.len() as f64) * 0.99).ceil() as usize - 1;
+    let p99 = samples_ms[p99_idx.min(samples_ms.len() - 1)];
+    let max = *samples_ms.last().unwrap_or(&0);
+    tracing::info!(
+        scenario = NAME,
+        backend = "postgres",
+        samples = samples_ms.len(),
+        p50_ms = p50,
+        p99_ms = p99,
+        max_ms = max,
+        slo_p99_ms = PG_P99_SLO_MS,
+        "fanout_slo postgres latencies"
+    );
+
+    if p99 > PG_P99_SLO_MS {
+        return ScenarioReport::fail(
             NAME,
             "postgres",
+            started,
             format!(
-                "observed {observed}/{FANOUT} within {DEADLINE_SECS}s (partial fanout)"
+                "p99={p99}ms exceeds SLO {PG_P99_SLO_MS}ms (p50={p50}, max={max}, n={fanin}, samples={samples})",
+                fanin = PG_FANIN,
+                samples = samples_ms.len(),
             ),
         );
     }
     ScenarioReport::pass(NAME, "postgres", started)
+}
+
+enum SampleErr {
+    Unavailable(&'static str),
+    Other(String),
+}
+
+impl From<sqlx::Error> for SampleErr {
+    fn from(e: sqlx::Error) -> Self {
+        SampleErr::Other(format!("sqlx: {e}"))
+    }
+}
+
+impl From<EngineError> for SampleErr {
+    fn from(e: EngineError) -> Self {
+        match e {
+            EngineError::Unavailable { op } => SampleErr::Unavailable(op),
+            other => SampleErr::Other(format!("engine: {other}")),
+        }
+    }
+}
+
+async fn run_one_sample(
+    ctx: &Arc<SmokeCtx>,
+    pg: &Arc<PostgresBackend>,
+    pool: &PgPool,
+    sample_idx: usize,
+) -> Result<u128, SampleErr> {
+    let pc = ctx.partition_config;
+    let lane = LaneId::new(scenarios::SMOKE_LANE);
+    let namespace = Namespace::new(scenarios::SMOKE_NAMESPACE);
+    let now = TimestampMs::from_millis(scenarios::now_ms());
+
+    let flow = FlowId::new();
+    pg.create_flow(&CreateFlowArgs {
+        flow_id: flow.clone(),
+        flow_kind: "smoke-fanout".to_owned(),
+        namespace: namespace.clone(),
+        now,
+    })
+    .await?;
+
+    let upstreams: Vec<ExecutionId> =
+        (0..PG_FANIN).map(|_| ExecutionId::for_flow(&flow, &pc)).collect();
+    let downstream = ExecutionId::for_flow(&flow, &pc);
+
+    for eid in upstreams.iter().chain(std::iter::once(&downstream)) {
+        let args = CreateExecutionArgs {
+            execution_id: eid.clone(),
+            namespace: namespace.clone(),
+            lane_id: lane.clone(),
+            execution_kind: scenarios::SMOKE_KIND.to_string(),
+            input_payload: Vec::new(),
+            payload_encoding: Some("binary".to_string()),
+            priority: 100,
+            creator_identity: "ff-smoke-v0.7".to_string(),
+            idempotency_key: None,
+            tags: std::collections::HashMap::new(),
+            policy: None,
+            delay_until: None,
+            execution_deadline_at: None,
+            partition_id: eid.partition(),
+            now,
+        };
+        pg.create_execution(args).await?;
+        pg.add_execution_to_flow(&AddExecutionToFlowArgs {
+            flow_id: flow.clone(),
+            execution_id: eid.clone(),
+            now,
+        })
+        .await?;
+    }
+
+    pg.set_edge_group_policy(
+        &flow,
+        &downstream,
+        EdgeDependencyPolicy::quorum(1, OnSatisfied::cancel_remaining()),
+    )
+    .await?;
+
+    // graph_revision: create_flow seeds rev=0; each fresh
+    // add_execution_to_flow bumps by 1. PG_FANIN upstreams +
+    // 1 downstream = PG_FANIN+1 adds.
+    let mut rev: u64 = (PG_FANIN as u64) + 1;
+    for up in &upstreams {
+        let edge_id = EdgeId::new();
+        let staged = pg
+            .stage_dependency_edge(&StageDependencyEdgeArgs {
+                flow_id: flow.clone(),
+                edge_id: edge_id.clone(),
+                upstream_execution_id: up.clone(),
+                downstream_execution_id: downstream.clone(),
+                dependency_kind: "success_only".to_string(),
+                data_passing_ref: None,
+                expected_graph_revision: rev,
+                now,
+            })
+            .await?;
+        let StageDependencyEdgeResult::Staged { new_graph_revision, .. } = staged;
+        rev = new_graph_revision;
+        pg.apply_dependency_to_child(&ApplyDependencyToChildArgs {
+            flow_id: flow.clone(),
+            edge_id,
+            downstream_execution_id: downstream.clone(),
+            upstream_execution_id: up.clone(),
+            graph_revision: rev,
+            dependency_kind: "success_only".to_string(),
+            data_passing_ref: None,
+            now,
+        })
+        .await?;
+    }
+
+    // Drive upstream[0] → terminal.
+    let part_i16 = ff_core::partition::flow_partition(&flow, &pc).index as i16;
+    let first_up_uuid = parse_exec_uuid(&upstreams[0]);
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal', \
+            public_state = 'completed', terminal_at_ms = $3 \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part_i16)
+    .bind(first_up_uuid)
+    .bind(now.0)
+    .execute(pool)
+    .await?;
+
+    let event_id: i64 = sqlx::query_scalar(
+        "INSERT INTO ff_completion_event \
+            (partition_key, execution_id, flow_id, outcome, occurred_at_ms) \
+         VALUES ($1, $2, $3, 'success', $4) RETURNING event_id",
+    )
+    .bind(part_i16)
+    .bind(first_up_uuid)
+    .bind(flow.0)
+    .bind(now.0)
+    .fetch_one(pool)
+    .await?;
+
+    // ── Flag-set moment: dispatch_completion flips the cancel flag.
+    let flag_set_at = Instant::now();
+    ff_backend_postgres::dispatch::dispatch_completion(pool, event_id).await?;
+
+    // Drain until all 99 siblings are cancelled (or deadline).
+    let expected_cancelled = (PG_FANIN - 1) as i64;
+    let down_uuid = parse_exec_uuid(&downstream);
+    let deadline = Instant::now() + PG_DISPATCH_DEADLINE;
+    loop {
+        edge_cancel_dispatcher::dispatcher_tick(pool, &ScannerFilter::new()).await?;
+        let cancelled: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM ff_exec_core \
+             WHERE partition_key = $1 AND flow_id = $2 \
+               AND public_state = 'cancelled' \
+               AND execution_id <> $3",
+        )
+        .bind(part_i16)
+        .bind(flow.0)
+        .bind(down_uuid)
+        .fetch_one(pool)
+        .await?;
+        if cancelled >= expected_cancelled {
+            break;
+        }
+        if Instant::now() > deadline {
+            return Err(SampleErr::Other(format!(
+                "sample {sample_idx}: only {cancelled}/{expected_cancelled} siblings cancelled within {}s",
+                PG_DISPATCH_DEADLINE.as_secs()
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    Ok(flag_set_at.elapsed().as_millis())
+}
+
+fn parse_exec_uuid(eid: &ExecutionId) -> uuid::Uuid {
+    let s = eid.as_str();
+    let colon = s.rfind("}:").expect("hash-tag delimiter");
+    uuid::Uuid::parse_str(&s[colon + 2..]).expect("uuid suffix")
 }

--- a/benches/smoke/src/scenarios/flow_anyof.rs
+++ b/benches/smoke/src/scenarios/flow_anyof.rs
@@ -1,16 +1,32 @@
 //! Scenario 2 — AnyOf{CancelRemaining} flow DAG.
 //!
 //! On Valkey this drives the flow-family HTTP surface — POST the DAG
-//! spec then assert the admin list endpoint sees it. On Postgres the
-//! flow-family entries are not yet wave-landed (wave 4c only filled
-//! six flow methods; the AnyOf dispatch path is still tracked under
-//! RFC-016 Stage C/D); the scenario Skips with the surface name so
-//! `--strict` catches it.
+//! spec then assert the admin list endpoint sees it.
+//!
+//! On Postgres we mirror the Wave 4i `pg_flow_staging.rs::e2e_any_of_
+//! cancel_remaining_cascade` shape + the Wave 7b/cleanup-PR-#256
+//! closure (members populated, dispatcher drain): create a flow with
+//! 3 upstream members + 1 downstream, stage 3 AnyOf+CancelRemaining
+//! edges, apply them, drive upstream[0] to `terminal`, fire
+//! `dispatch::dispatch_completion`, then run
+//! `edge_cancel_dispatcher::dispatcher_tick` to drain the pending-
+//! cancel group. Finally assert:
+//!
+//! * downstream is `eligible_now` (AnyOf satisfied on first success)
+//! * the other 2 siblings are `lifecycle_phase='terminal'` +
+//!   `public_state='cancelled'` + `cancellation_reason='sibling_quorum_satisfied'`
 
 use std::sync::Arc;
 
-use ff_backend_postgres::PostgresBackend;
+use ff_backend_postgres::{PgPool, PostgresBackend};
+use ff_backend_postgres::reconcilers::edge_cancel_dispatcher;
+use ff_core::backend::ScannerFilter;
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, ApplyDependencyToChildArgs, CreateExecutionArgs, CreateFlowArgs,
+    EdgeDependencyPolicy, OnSatisfied, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+};
 use ff_core::engine_backend::EngineBackend;
+use ff_core::types::{EdgeId, ExecutionId, FlowId, LaneId, Namespace, TimestampMs};
 
 use crate::ScenarioReport;
 use crate::SmokeCtx;
@@ -20,24 +36,15 @@ const NAME: &str = "flow_anyof";
 
 pub async fn run_valkey(ctx: Arc<SmokeCtx>) -> ScenarioReport {
     let started = scenarios::start();
-    // Minimum: POST a trivial 2-node AnyOf flow and verify /v1/flows
-    // surfaces it. Full DAG-drain assertions belong in ff-test.
+    // Minimum: POST a well-formed [`CreateFlowArgs`] to /v1/flows and
+    // verify the server accepts it (2xx). Full DAG-drain assertions
+    // belong in ff-test; here we just confirm the flow HTTP surface
+    // is reachable, matching the Valkey scenario intent from Wave 7b.
     let flow_id = ff_core::types::FlowId::new();
     let body = serde_json::json!({
         "flow_id": flow_id.to_string(),
+        "flow_kind": "smoke",
         "namespace": scenarios::SMOKE_NAMESPACE,
-        "execution_kind": scenarios::SMOKE_KIND,
-        "lane_id": scenarios::SMOKE_LANE,
-        "partition_id": 0u16,
-        "nodes": [
-            {"node_id": "a"},
-            {"node_id": "b"},
-            {"node_id": "c"},
-        ],
-        "edges": [
-            {"from": "a", "to": "c", "policy": {"any_of": {"on_first": "cancel_remaining"}}},
-            {"from": "b", "to": "c", "policy": {"any_of": {"on_first": "cancel_remaining"}}},
-        ],
         "now": scenarios::now_ms(),
     });
     let url = format!("{}/v1/flows", ctx.http_server);
@@ -45,32 +52,270 @@ pub async fn run_valkey(ctx: Arc<SmokeCtx>) -> ScenarioReport {
         Ok(r) => r,
         Err(e) => return ScenarioReport::fail(NAME, "valkey", started, format!("POST: {e}")),
     };
-    // If the server rejects our simplified payload, skip — this
-    // scenario's value is "the flow HTTP surface is reachable"; the
-    // Valkey AnyOf behavior is covered by ff-test's flow e2e suite.
     if !resp.status().is_success() {
-        return ScenarioReport::skip(
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return ScenarioReport::fail(
             NAME,
             "valkey",
-            format!("POST /v1/flows rejected ({})", resp.status()),
+            started,
+            format!("POST /v1/flows failed ({status}): {text}"),
         );
     }
     ScenarioReport::pass(NAME, "valkey", started)
 }
 
 pub async fn run_postgres(
-    _ctx: Arc<SmokeCtx>,
-    _pg: Arc<PostgresBackend>,
-    _backend: Arc<dyn EngineBackend>,
+    ctx: Arc<SmokeCtx>,
+    pg: Arc<PostgresBackend>,
+    backend: Arc<dyn EngineBackend>,
+    pool: PgPool,
 ) -> ScenarioReport {
-    ScenarioReport::skip(
-        NAME,
-        "postgres",
-        "flow_anyof on Postgres requires stage_dependency_edge + apply_dependency_to_child \
-         Postgres impls (tracked as Wave 4i follow-up). Wave 4c landed the 6 flow trait \
-         methods; the staging methods live on ff-server's inherent Valkey surface and \
-         haven't been ported. Prerequisites: INSERT paths into ff_edge + \
-         ff_edge_group_counter. Dispatch cascade (Wave 5a) + Stage C+D reconcilers \
-         (Wave 6b) are ready; only the writer side is missing.",
+    let _ = backend;
+    let started = scenarios::start();
+    let pc = ctx.partition_config;
+    let lane = LaneId::new(scenarios::SMOKE_LANE);
+    let namespace = Namespace::new(scenarios::SMOKE_NAMESPACE);
+    let now = TimestampMs::from_millis(scenarios::now_ms());
+
+    // ── Seed flow + 3 upstream members + 1 downstream ──
+    let flow = FlowId::new();
+    if let Err(e) = pg
+        .create_flow(&CreateFlowArgs {
+            flow_id: flow.clone(),
+            flow_kind: "smoke".to_owned(),
+            namespace: namespace.clone(),
+            now,
+        })
+        .await
+    {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("create_flow: {e}"));
+    }
+
+    let upstreams: Vec<ExecutionId> = (0..3).map(|_| ExecutionId::for_flow(&flow, &pc)).collect();
+    let downstream = ExecutionId::for_flow(&flow, &pc);
+    for eid in upstreams.iter().chain(std::iter::once(&downstream)) {
+        let args = CreateExecutionArgs {
+            execution_id: eid.clone(),
+            namespace: namespace.clone(),
+            lane_id: lane.clone(),
+            execution_kind: scenarios::SMOKE_KIND.to_string(),
+            input_payload: Vec::new(),
+            payload_encoding: Some("binary".to_string()),
+            priority: 100,
+            creator_identity: "ff-smoke-v0.7".to_string(),
+            idempotency_key: None,
+            tags: std::collections::HashMap::new(),
+            policy: None,
+            delay_until: None,
+            execution_deadline_at: None,
+            partition_id: eid.partition(),
+            now,
+        };
+        if let Err(e) = pg.create_execution(args).await {
+            return ScenarioReport::fail(NAME, "postgres", started, format!("create exec: {e}"));
+        }
+        if let Err(e) = pg
+            .add_execution_to_flow(&AddExecutionToFlowArgs {
+                flow_id: flow.clone(),
+                execution_id: eid.clone(),
+                now,
+            })
+            .await
+        {
+            return ScenarioReport::fail(NAME, "postgres", started, format!("add_to_flow: {e}"));
+        }
+    }
+
+    // ── Policy + 3 edges ──
+    if let Err(e) = pg
+        .set_edge_group_policy(
+            &flow,
+            &downstream,
+            EdgeDependencyPolicy::any_of(OnSatisfied::cancel_remaining()),
+        )
+        .await
+    {
+        return ScenarioReport::fail(
+            NAME,
+            "postgres",
+            started,
+            format!("set_edge_group_policy: {e}"),
+        );
+    }
+
+    // graph_revision after create_flow + 4 add_execution_to_flow = 4.
+    let mut rev: u64 = 4;
+    for up in &upstreams {
+        let edge_id = EdgeId::new();
+        let staged = match pg
+            .stage_dependency_edge(&StageDependencyEdgeArgs {
+                flow_id: flow.clone(),
+                edge_id: edge_id.clone(),
+                upstream_execution_id: up.clone(),
+                downstream_execution_id: downstream.clone(),
+                dependency_kind: "success_only".to_string(),
+                data_passing_ref: None,
+                expected_graph_revision: rev,
+                now,
+            })
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return ScenarioReport::fail(NAME, "postgres", started, format!("stage: {e}"));
+            }
+        };
+        let StageDependencyEdgeResult::Staged {
+            new_graph_revision, ..
+        } = staged;
+        rev = new_graph_revision;
+        if let Err(e) = pg
+            .apply_dependency_to_child(&ApplyDependencyToChildArgs {
+                flow_id: flow.clone(),
+                edge_id,
+                downstream_execution_id: downstream.clone(),
+                upstream_execution_id: up.clone(),
+                graph_revision: rev,
+                dependency_kind: "success_only".to_string(),
+                data_passing_ref: None,
+                now,
+            })
+            .await
+        {
+            return ScenarioReport::fail(NAME, "postgres", started, format!("apply: {e}"));
+        }
+    }
+
+    // ── Drive upstream[0] to terminal + fire completion event ──
+    let part_i16 = ff_core::partition::flow_partition(&flow, &pc).index as i16;
+    let first_up_uuid = parse_exec_uuid(&upstreams[0]);
+
+    if let Err(e) = sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal', \
+            public_state = 'completed', terminal_at_ms = $3 \
+         WHERE partition_key = $1 AND execution_id = $2",
     )
+    .bind(part_i16)
+    .bind(first_up_uuid)
+    .bind(now.0)
+    .execute(&pool)
+    .await
+    {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("upstream terminal: {e}"));
+    }
+
+    let event_id: i64 = match sqlx::query_scalar(
+        "INSERT INTO ff_completion_event \
+            (partition_key, execution_id, flow_id, outcome, occurred_at_ms) \
+         VALUES ($1, $2, $3, 'success', $4) RETURNING event_id",
+    )
+    .bind(part_i16)
+    .bind(first_up_uuid)
+    .bind(flow.0)
+    .bind(now.0)
+    .fetch_one(&pool)
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            return ScenarioReport::fail(NAME, "postgres", started, format!("completion event: {e}"));
+        }
+    };
+
+    if let Err(e) = ff_backend_postgres::dispatch::dispatch_completion(&pool, event_id).await {
+        return ScenarioReport::fail(
+            NAME,
+            "postgres",
+            started,
+            format!("dispatch_completion: {e}"),
+        );
+    }
+
+    // ── Drain pending-cancel groups ──
+    if let Err(e) =
+        edge_cancel_dispatcher::dispatcher_tick(&pool, &ScannerFilter::new()).await
+    {
+        return ScenarioReport::fail(NAME, "postgres", started, format!("dispatcher_tick: {e}"));
+    }
+
+    // ── Assertions ──
+    let down_uuid = parse_exec_uuid(&downstream);
+    let elig: String = match sqlx::query_scalar(
+        "SELECT eligibility_state FROM ff_exec_core \
+          WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part_i16)
+    .bind(down_uuid)
+    .fetch_one(&pool)
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            return ScenarioReport::fail(
+                NAME,
+                "postgres",
+                started,
+                format!("downstream select: {e}"),
+            );
+        }
+    };
+    if elig != "eligible_now" {
+        return ScenarioReport::fail(
+            NAME,
+            "postgres",
+            started,
+            format!("downstream eligibility_state={elig} (want eligible_now)"),
+        );
+    }
+
+    for (i, sib) in upstreams.iter().enumerate().skip(1) {
+        let sib_uuid = parse_exec_uuid(sib);
+        let row: (String, String, Option<String>) = match sqlx::query_as(
+            "SELECT lifecycle_phase, public_state, cancellation_reason FROM ff_exec_core \
+              WHERE partition_key = $1 AND execution_id = $2",
+        )
+        .bind(part_i16)
+        .bind(sib_uuid)
+        .fetch_one(&pool)
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return ScenarioReport::fail(
+                    NAME,
+                    "postgres",
+                    started,
+                    format!("sibling[{i}] select: {e}"),
+                );
+            }
+        };
+        if row.0 != "terminal" || row.1 != "cancelled" {
+            return ScenarioReport::fail(
+                NAME,
+                "postgres",
+                started,
+                format!(
+                    "sibling[{i}] not cancelled: phase={} public={}",
+                    row.0, row.1
+                ),
+            );
+        }
+        if row.2.as_deref() != Some("sibling_quorum_satisfied") {
+            return ScenarioReport::fail(
+                NAME,
+                "postgres",
+                started,
+                format!("sibling[{i}] cancellation_reason={:?}", row.2),
+            );
+        }
+    }
+
+    ScenarioReport::pass(NAME, "postgres", started)
+}
+
+fn parse_exec_uuid(eid: &ExecutionId) -> uuid::Uuid {
+    let s = eid.as_str();
+    let colon = s.rfind("}:").expect("hash-tag delimiter");
+    uuid::Uuid::parse_str(&s[colon + 2..]).expect("uuid suffix")
 }

--- a/benches/smoke/src/scenarios/mod.rs
+++ b/benches/smoke/src/scenarios/mod.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 
-use ff_backend_postgres::PostgresBackend;
+use ff_backend_postgres::{PgPool, PostgresBackend};
 use ff_core::engine_backend::EngineBackend;
 use ff_core::backend::BackendConfig;
 
@@ -52,7 +52,7 @@ pub const NAMES: &[&str] = &[
 /// path to `create_execution` without modifying the trait.
 pub async fn postgres_connect(
     url: &str,
-) -> Result<(Arc<dyn EngineBackend>, Arc<PostgresBackend>)> {
+) -> Result<(Arc<dyn EngineBackend>, Arc<PostgresBackend>, PgPool)> {
     use ff_core::backend::PostgresConnection;
     use sqlx::postgres::PgPoolOptions;
 
@@ -77,9 +77,9 @@ pub async fn postgres_connect(
         .acquire_timeout(conn.acquire_timeout)
         .connect(&conn.url)
         .await?;
-    let pg = PostgresBackend::from_pool(pool, ff_core::partition::PartitionConfig::default());
+    let pg = PostgresBackend::from_pool(pool.clone(), ff_core::partition::PartitionConfig::default());
 
-    Ok((trait_backend, pg))
+    Ok((trait_backend, pg, pool))
 }
 
 pub async fn run_all_valkey(ctx: Arc<SmokeCtx>) -> Vec<ScenarioReport> {
@@ -115,9 +115,9 @@ pub async fn run_all_valkey(ctx: Arc<SmokeCtx>) -> Vec<ScenarioReport> {
 
 pub async fn run_all_postgres(
     ctx: Arc<SmokeCtx>,
-    handles: Option<(Arc<dyn EngineBackend>, Arc<PostgresBackend>)>,
+    handles: Option<(Arc<dyn EngineBackend>, Arc<PostgresBackend>, PgPool)>,
 ) -> Vec<ScenarioReport> {
-    let Some((trait_backend, pg)) = handles else {
+    let Some((trait_backend, pg, pool)) = handles else {
         let started = Instant::now();
         return NAMES
             .iter()
@@ -133,13 +133,13 @@ pub async fn run_all_postgres(
     };
 
     vec![
-        claim_lifecycle::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone()).await,
-        flow_anyof::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone()).await,
+        claim_lifecycle::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone(), pool.clone()).await,
+        flow_anyof::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone(), pool.clone()).await,
         suspend_signal::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone()).await,
         stream_durable_summary::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone()).await,
         stream_best_effort::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone()).await,
         cancel_cascade::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone()).await,
-        fanout_slo::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone()).await,
+        fanout_slo::run_postgres(ctx.clone(), pg.clone(), trait_backend.clone(), pool.clone()).await,
     ]
 }
 


### PR DESCRIPTION
## Summary
- Unblocks the three remaining pre-v0.7 smoke Postgres Skips now that prereqs are in: Wave 4i flow-staging (#255), Wave 5b PostgresScheduler::claim_for_worker (#246), and cleanup PR #256 (cancel_siblings_pending_members populated).
- `flow_anyof::run_postgres` mirrors the `pg_flow_staging` e2e shape (create_flow + 3 upstream + 1 downstream, AnyOf/CancelRemaining, dispatch_completion, dispatcher_tick drain); asserts downstream `eligible_now` + siblings `terminal/cancelled/sibling_quorum_satisfied`.
- `claim_lifecycle::run_postgres` exercises both Wave 5b `PostgresScheduler::claim_for_worker` (grant issuance) and the `EngineBackend` claim→progress→complete trait lifecycle. Replicates the documented `pg_scheduler_claim` pattern of a manual submitted→runnable UPDATE (admission promoter out-of-scope on Postgres).
- `fanout_slo::run_postgres` measures p99 dispatch latency across 10 samples × 100-way Quorum(1)+CancelRemaining fanout from flag-set-moment to last-sibling-terminal-observed; asserts master-spec §4.2 p99 ≤ 500 ms. Local run p50=58ms / p99=233ms (Wave 7c characterized 313ms).
- `flow_anyof::run_valkey` now posts a well-formed `CreateFlowArgs` instead of the stub DAG payload that always 422'd; the scenario was Skip-on-parity before and now Passes, preserving the "flow HTTP surface reachable" intent.
- Harness plumbing: `postgres_connect` returns the raw `PgPool` alongside the backend handles so scenarios can fire completion events + run the dispatcher directly (matches the production pattern used by `ff-engine::dispatch_via_postgres`).

References:
- Master spec §4.2 fanout SLO
- Wave 4i PR #255 (flow-staging inherent methods)
- Wave 5b PR #246 (PostgresScheduler::claim_for_worker)
- Cleanup PR #256 (cancel_siblings_pending_members populated + PublicState::Resumable)

## Test plan
- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-smoke-v07 -- -D warnings` clean
- [x] `bash scripts/smoke-v0.7.sh` in `--strict` mode — 14/14 Pass, 0 Skip, 0 Fail, no parity violations (see commit message for per-scenario table)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Postgres smoke logic with direct SQL updates/inserts and adds a p99 latency gate, which could introduce flakiness or false failures if timing/DB state differs across environments.
> 
> **Overview**
> Unblocks previously skipped Postgres smoke coverage by adding end-to-end checks for flow staging/cancel cascades (`flow_anyof`), scheduler grant issuance plus trait lifecycle (`claim_lifecycle`), and a **100-way Quorum(1)+CancelRemaining** dispatch **p99 ≤ 500ms** SLO measurement (`fanout_slo`).
> 
> Plumbs a raw `PgPool` through `postgres_connect`/`run_all_postgres` so scenarios can seed prerequisites (HMAC secret), perform targeted DB updates, emit completion events, run `dispatch_completion`, and tick the cancel dispatcher; Valkey `flow_anyof` is updated to POST a valid `CreateFlowArgs` payload and fail with response details on rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 022e1f6809f5308828775d11f0178cac4d62cc07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->