### PR TITLE
impl(017): Wave 8 Stage D1 — §8 schema + ingress handlers + FF_BACKEND env (split from Stage D)

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -414,6 +414,36 @@ impl ValkeyBackend {
         self.stream_semaphore.available_permits()
     }
 
+    /// RFC-017 Stage D1 (§8): Valkey-only inherent fetch of the raw
+    /// `<kid>:<hex>` waitpoint token for the v0.7.x pending-waitpoints
+    /// wire-format shim. **NOT on `EngineBackend`** — the trait
+    /// boundary never exposes the raw HMAC post-§8. The ff-server
+    /// HTTP handler wraps the sanitised trait response and calls
+    /// this inherent to re-inject the legacy field on the wire for
+    /// one-release deprecation warning; the shim + this method go
+    /// away at Stage E / v0.8.0.
+    ///
+    /// Returns `Ok(None)` if the waitpoint hash does not carry a
+    /// `waitpoint_token` field (missing / rotated out). Transport
+    /// errors surface as `EngineError::Transport`.
+    pub async fn fetch_waitpoint_token_v07(
+        &self,
+        execution_id: &ExecutionId,
+        waitpoint_id: &WaitpointId,
+    ) -> Result<Option<String>, EngineError> {
+        let partition = execution_partition(execution_id, &self.partition_config);
+        let ctx = ExecKeyContext::new(&partition, execution_id);
+        let token: Option<String> = self
+            .client
+            .hget(&ctx.waitpoint(waitpoint_id), "waitpoint_token")
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "fetch_waitpoint_token_v07: HGET waitpoint_token",
+            ))?;
+        Ok(token.filter(|s| !s.is_empty()))
+    }
+
     /// RFC-017 §14.8 mandatory Stage B CI test hook. Exposes a clone
     /// of the internal semaphore so the shutdown-under-load test can
     /// hold permits directly without dispatching a live FCALL.
@@ -1679,6 +1709,24 @@ fn now_ms_timestamp() -> TimestampMs {
 /// byte-for-byte KEYS/ARGV parity with the SDK's pre-migration code.
 fn transport_fk(e: ferriskey::Error) -> EngineError {
     transport_script(ScriptError::Valkey(e))
+}
+
+/// RFC-017 §8 (Stage D1): parse a stored `waitpoint_token` of the form
+/// `<kid>:<40hex>` into its `(kid, 16-hex-prefix-of-digest)` components.
+///
+/// Robust against malformed input: returns `("", "")` when the stored
+/// value does not match the expected shape. Callers log + skip on
+/// empty tokens upstream, so this helper never panics or surfaces a
+/// typed error — the presence of the raw token is already checked
+/// before this runs.
+fn parse_waitpoint_token_kid_fp(raw: &str) -> (String, String) {
+    match raw.split_once(':') {
+        Some((kid, hex)) if !kid.is_empty() && !hex.is_empty() => {
+            let fp_len = hex.len().min(16);
+            (kid.to_owned(), hex[..fp_len].to_owned())
+        }
+        _ => (String::new(), String::new()),
+    }
 }
 
 /// Parse a raw `{1, "OK", ...}` / `{0, "error", ...}` FCALL result into
@@ -4568,10 +4616,36 @@ impl EngineBackend for ValkeyBackend {
         &self,
         args: ff_core::contracts::AddExecutionToFlowArgs,
     ) -> Result<ff_core::contracts::AddExecutionToFlowResult, EngineError> {
+        // RFC-011 §7.3: exec_core co-locates with its parent flow on
+        // `{fp:N}`. Validate this invariant up-front so a mismatched
+        // `execution_id` (e.g. a `solo`-minted id instead of
+        // `ExecutionId::for_flow`) surfaces as a typed
+        // `EngineError::Validation` rather than a raw Valkey
+        // CROSSSLOT on clustered deployments. Matches the pre-Stage-D1
+        // `Server::add_execution_to_flow` pre-flight check.
         let partition = flow_partition(&args.flow_id, &self.partition_config);
+        let exec_partition =
+            execution_partition(&args.execution_id, &self.partition_config);
+        if exec_partition.index != partition.index {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!(
+                    "add_execution_to_flow: execution_id's partition {} != flow_id's partition {}. \
+                     Post-RFC-011 §7.3 co-location requires mint via \
+                     `ExecutionId::for_flow(&flow_id, config)` so the exec's hash-tag \
+                     matches the flow's `{{fp:N}}`.",
+                    exec_partition.index, partition.index
+                ),
+            });
+        }
         let fctx = FlowKeyContext::new(&partition, &args.flow_id);
         let fidx = FlowIndexKeys::new(&partition);
-        let keys = FlowStructOpKeys { fctx: &fctx, fidx: &fidx };
+        let ectx = ExecKeyContext::new(&exec_partition, &args.execution_id);
+        let keys = ff_script::functions::flow::AddExecutionToFlowKeys {
+            fctx: &fctx,
+            fidx: &fidx,
+            exec_ctx: &ectx,
+        };
         ff_add_execution_to_flow(&self.client, &keys, &args)
             .await
             .map_err(|e| ff_core::engine_error::backend_context(
@@ -4777,6 +4851,304 @@ impl EngineBackend for ValkeyBackend {
                 "get_execution_result: GET result",
             ))?;
         Ok(payload)
+    }
+
+    // ── RFC-017 Stage D1 — list_pending_waitpoints (§8) ─────────
+
+    /// List pending/active waitpoints for an execution. Stage D1
+    /// implementation (RFC-017 §8): SSCAN the waitpoint index,
+    /// pipelined 2× HMGET for each waitpoint + HGET
+    /// `total_matchers`, optional pass-2 HMGET for matcher names,
+    /// parse the stored `<kid>:<hex>` token into
+    /// `(token_kid, token_fingerprint)` and DROP the raw token
+    /// before returning across the trait boundary.
+    ///
+    /// Pagination: the caller's `args.after` is used to skip
+    /// waitpoint ids lexicographically `<= after` after the SSCAN
+    /// dedup. `args.limit` defaults to 100, is capped at 1000. A
+    /// `next_cursor` is returned if more entries were available
+    /// beyond the requested page.
+    async fn list_pending_waitpoints(
+        &self,
+        args: ff_core::contracts::ListPendingWaitpointsArgs,
+    ) -> Result<ff_core::contracts::ListPendingWaitpointsResult, EngineError> {
+        use ff_core::contracts::{ListPendingWaitpointsResult, PendingWaitpointInfo};
+
+        const DEFAULT_LIMIT: u32 = 100;
+        const MAX_LIMIT: u32 = 1000;
+        const WAITPOINTS_SSCAN_COUNT: usize = 100;
+        const WP_FIELDS: [&str; 6] = [
+            "state",
+            "waitpoint_key",
+            "waitpoint_token",
+            "created_at",
+            "activated_at",
+            "expires_at",
+        ];
+
+        let limit = args.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as usize;
+        let execution_id = args.execution_id.clone();
+        let after_str = args.after.as_ref().map(|wp| wp.to_string());
+
+        let partition = execution_partition(&execution_id, &self.partition_config);
+        let ctx = ExecKeyContext::new(&partition, &execution_id);
+
+        // Existence check — surface NotFound early so callers don't
+        // get an empty page for a non-existent execution.
+        let core_exists: bool = self
+            .client
+            .cmd("EXISTS")
+            .arg(ctx.core())
+            .execute()
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "list_pending_waitpoints: EXISTS exec_core",
+            ))?;
+        if !core_exists {
+            return Err(EngineError::NotFound {
+                entity: "execution",
+            });
+        }
+
+        let waitpoints_key = ctx.waitpoints();
+        let mut wp_ids_raw: Vec<String> = Vec::new();
+        let mut cursor: String = "0".to_owned();
+        loop {
+            let reply: (String, Vec<String>) = self
+                .client
+                .cmd("SSCAN")
+                .arg(&waitpoints_key)
+                .arg(&cursor)
+                .arg("COUNT")
+                .arg(WAITPOINTS_SSCAN_COUNT.to_string().as_str())
+                .execute()
+                .await
+                .map_err(|e| ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    "list_pending_waitpoints: SSCAN waitpoints",
+                ))?;
+            cursor = reply.0;
+            wp_ids_raw.extend(reply.1);
+            if cursor == "0" {
+                break;
+            }
+        }
+
+        // SSCAN may dup; dedup + sort for deterministic pagination.
+        wp_ids_raw.sort_unstable();
+        wp_ids_raw.dedup();
+
+        // Apply `after` cursor — skip ids `<= after`.
+        if let Some(after) = &after_str {
+            let start = wp_ids_raw.partition_point(|s| s.as_str() <= after.as_str());
+            wp_ids_raw.drain(..start);
+        }
+
+        if wp_ids_raw.is_empty() {
+            return Ok(ListPendingWaitpointsResult::new(Vec::new()));
+        }
+
+        // Page: request `limit + 1` so we can detect "more to come"
+        // without a second round-trip. We'll cap to wp_ids_raw.len().
+        let page_end = (limit + 1).min(wp_ids_raw.len());
+        let has_more_raw = wp_ids_raw.len() > limit;
+        let page_ids_raw: Vec<String> = wp_ids_raw[..page_end].to_vec();
+
+        // Parse, skip unparseable ids.
+        let mut wp_ids: Vec<WaitpointId> = Vec::with_capacity(page_ids_raw.len());
+        for raw in &page_ids_raw {
+            match WaitpointId::parse(raw) {
+                Ok(id) => wp_ids.push(id),
+                Err(e) => tracing::warn!(
+                    raw_id = %raw,
+                    error = %e,
+                    execution_id = %execution_id,
+                    "list_pending_waitpoints: skipping unparseable waitpoint_id"
+                ),
+            }
+        }
+        if wp_ids.is_empty() {
+            return Ok(ListPendingWaitpointsResult::new(Vec::new()));
+        }
+
+        // Pipeline pass-1: HMGET + HGET total_matchers per waitpoint.
+        let mut pass1 = self.client.pipeline();
+        let mut wp_slots = Vec::with_capacity(wp_ids.len());
+        let mut cond_slots = Vec::with_capacity(wp_ids.len());
+        for wp_id in &wp_ids {
+            let mut cmd = pass1.cmd::<Vec<Option<String>>>("HMGET");
+            cmd = cmd.arg(ctx.waitpoint(wp_id));
+            for f in WP_FIELDS {
+                cmd = cmd.arg(f);
+            }
+            wp_slots.push(cmd.finish());
+
+            cond_slots.push(
+                pass1
+                    .cmd::<Option<String>>("HGET")
+                    .arg(ctx.waitpoint_condition(wp_id))
+                    .arg("total_matchers")
+                    .finish(),
+            );
+        }
+        pass1.execute().await.map_err(|e| {
+            ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "list_pending_waitpoints: pipeline HMGET waitpoints + HGET total_matchers",
+            )
+        })?;
+
+        struct Kept {
+            wp_id: WaitpointId,
+            wp_fields: Vec<Option<String>>,
+            total_matchers: usize,
+        }
+        let mut kept: Vec<Kept> = Vec::with_capacity(wp_ids.len());
+        for ((wp_id, wp_slot), cond_slot) in
+            wp_ids.iter().zip(wp_slots).zip(cond_slots)
+        {
+            let wp_fields: Vec<Option<String>> = wp_slot.value().map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    format!("list_pending_waitpoints: slot HMGET waitpoint {wp_id}"),
+                )
+            })?;
+            if wp_fields.iter().all(Option::is_none) {
+                let _ = cond_slot.value();
+                continue;
+            }
+            let state_ref = wp_fields.first().and_then(|v| v.as_deref()).unwrap_or("");
+            if state_ref != "pending" && state_ref != "active" {
+                let _ = cond_slot.value();
+                continue;
+            }
+            let token_ref = wp_fields.get(2).and_then(|v| v.as_deref()).unwrap_or("");
+            if token_ref.is_empty() {
+                let _ = cond_slot.value();
+                tracing::warn!(
+                    waitpoint_id = %wp_id,
+                    execution_id = %execution_id,
+                    "list_pending_waitpoints: waitpoint hash missing waitpoint_token — skipping"
+                );
+                continue;
+            }
+            let total_matchers = cond_slot
+                .value()
+                .map_err(|e| {
+                    ff_core::engine_error::backend_context(
+                        transport_fk(e),
+                        format!("list_pending_waitpoints: slot HGET total_matchers {wp_id}"),
+                    )
+                })?
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(0);
+            kept.push(Kept {
+                wp_id: wp_id.clone(),
+                wp_fields,
+                total_matchers,
+            });
+        }
+
+        if kept.is_empty() {
+            return Ok(ListPendingWaitpointsResult::new(Vec::new()));
+        }
+
+        // Pass-2: matcher names for waitpoints with total_matchers > 0.
+        let mut pass2 = self.client.pipeline();
+        let mut matcher_slots: Vec<Option<_>> = Vec::with_capacity(kept.len());
+        let mut pass2_needed = false;
+        for k in &kept {
+            if k.total_matchers == 0 {
+                matcher_slots.push(None);
+                continue;
+            }
+            pass2_needed = true;
+            let mut cmd = pass2.cmd::<Vec<Option<String>>>("HMGET");
+            cmd = cmd.arg(ctx.waitpoint_condition(&k.wp_id));
+            for i in 0..k.total_matchers {
+                cmd = cmd.arg(format!("matcher:{i}:name"));
+            }
+            matcher_slots.push(Some(cmd.finish()));
+        }
+        if pass2_needed {
+            pass2.execute().await.map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    "list_pending_waitpoints: pipeline HMGET wp_condition matchers",
+                )
+            })?;
+        }
+
+        let parse_ts = |raw: &str| -> Option<TimestampMs> {
+            if raw.is_empty() {
+                None
+            } else {
+                raw.parse::<i64>().ok().map(TimestampMs)
+            }
+        };
+
+        let mut out: Vec<PendingWaitpointInfo> = Vec::with_capacity(kept.len());
+        let requested_len = kept.len().min(limit);
+        for (k, slot) in kept.into_iter().zip(matcher_slots).take(limit) {
+            let get = |i: usize| -> &str {
+                k.wp_fields.get(i).and_then(|v| v.as_deref()).unwrap_or("")
+            };
+            let required_signal_names: Vec<String> = match slot {
+                None => Vec::new(),
+                Some(s) => {
+                    let vals: Vec<Option<String>> = s.value().map_err(|e| {
+                        ff_core::engine_error::backend_context(
+                            transport_fk(e),
+                            format!(
+                                "list_pending_waitpoints: slot HMGET matchers {}",
+                                k.wp_id
+                            ),
+                        )
+                    })?;
+                    vals.into_iter()
+                        .flatten()
+                        .filter(|name| !name.is_empty())
+                        .collect()
+                }
+            };
+
+            // Parse `<kid>:<40hex>` into (kid, first-16-hex fingerprint).
+            let token_raw = get(2);
+            let (token_kid, token_fingerprint) = parse_waitpoint_token_kid_fp(token_raw);
+
+            let mut info = PendingWaitpointInfo::new(
+                k.wp_id,
+                get(1).to_owned(),
+                get(0).to_owned(),
+                parse_ts(get(3)).unwrap_or(TimestampMs(0)),
+                execution_id.clone(),
+                token_kid,
+                token_fingerprint,
+            );
+            if !required_signal_names.is_empty() {
+                info = info.with_required_signal_names(required_signal_names);
+            }
+            if let Some(ts) = parse_ts(get(4)) {
+                info = info.with_activated_at(ts);
+            }
+            if let Some(ts) = parse_ts(get(5)) {
+                info = info.with_expires_at(ts);
+            }
+            out.push(info);
+        }
+
+        let next_cursor = if has_more_raw {
+            out.last().map(|e| e.waitpoint_id.clone())
+        } else {
+            None
+        };
+        let mut result = ListPendingWaitpointsResult::new(out);
+        if let Some(cursor) = next_cursor {
+            result = result.with_next_cursor(cursor);
+        }
+        let _ = requested_len; // reserved for future diagnostics
+        Ok(result)
     }
 
     // ── RFC-017 Stage C — Operator control (4) ────────────────

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -809,17 +809,17 @@ pub enum BufferSignalResult {
 
 /// One entry in the read-only view of an execution's active waitpoints.
 ///
-/// Returned by `Server::list_pending_waitpoints` (and the
-/// `GET /v1/executions/{id}/pending-waitpoints` REST endpoint). The
-/// `waitpoint_token` is the same HMAC-SHA1 credential a suspending worker
-/// receives in `SuspendOutcome::Suspended` — a reviewer that needs to
-/// deliver a signal against this waitpoint must present it in
-/// `DeliverSignalArgs::waitpoint_token`.
+/// Returned by `EngineBackend::list_pending_waitpoints` (and the
+/// `GET /v1/executions/{id}/pending-waitpoints` REST endpoint).
 ///
-/// Exposing the token here is a deliberate API gap closure: a
-/// human-in-the-loop reviewer has no other path to the token, since only
-/// the suspending worker sees the `SuspendOutcome`. Access is gated by
-/// the same bearer-auth middleware as every other REST endpoint.
+/// **RFC-017 §8 schema rewrite (Stage D1).** This struct no longer
+/// carries the raw HMAC `waitpoint_token` at the trait boundary — the
+/// backend emits only the sanitised `(token_kid, token_fingerprint)`
+/// pair. The HTTP handler (see `ff-server::api::list_pending_waitpoints`)
+/// wraps the trait response and re-injects the real token on the
+/// v0.7.x wire for one-release deprecation warning; the wire field is
+/// removed entirely at v0.8.0.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingWaitpointInfo {
     pub waitpoint_id: WaitpointId,
@@ -827,9 +827,6 @@ pub struct PendingWaitpointInfo {
     /// Current waitpoint state: `pending`, `active`, `closed`. Callers
     /// typically filter to `pending` or `active`.
     pub state: String,
-    /// HMAC-SHA1 token minted at create time; required by
-    /// `ff_deliver_signal` and `ff_buffer_signal_for_pending_waitpoint`.
-    pub waitpoint_token: WaitpointToken,
     /// Signal names the resume condition is waiting for. Reviewers that
     /// need to drive a specific waitpoint — particularly when multiple
     /// concurrent waitpoints exist on one execution — filter on this to
@@ -850,6 +847,61 @@ pub struct PendingWaitpointInfo {
     /// Scheduled expiration timestamp. `None` if no timeout configured.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<TimestampMs>,
+    /// Owning execution — surfaces without a separate lookup.
+    pub execution_id: ExecutionId,
+    /// HMAC key identifier (the `<kid>` prefix of the stored
+    /// `waitpoint_token`). Safe to expose — identifies which signing
+    /// key minted the token without revealing the key material.
+    pub token_kid: String,
+    /// 16-hex-char (8-byte) fingerprint of the HMAC digest. Audit-friendly
+    /// handle that correlates across logs without being replayable.
+    pub token_fingerprint: String,
+}
+
+impl PendingWaitpointInfo {
+    /// Construct a `PendingWaitpointInfo` with the 7 required fields.
+    /// Optional fields (`activated_at`, `expires_at`) default to
+    /// `None`; use [`Self::with_activated_at`] / [`Self::with_expires_at`]
+    /// to populate them. `required_signal_names` defaults to empty
+    /// (wildcard condition); use [`Self::with_required_signal_names`]
+    /// to set it.
+    pub fn new(
+        waitpoint_id: WaitpointId,
+        waitpoint_key: String,
+        state: String,
+        created_at: TimestampMs,
+        execution_id: ExecutionId,
+        token_kid: String,
+        token_fingerprint: String,
+    ) -> Self {
+        Self {
+            waitpoint_id,
+            waitpoint_key,
+            state,
+            required_signal_names: Vec::new(),
+            created_at,
+            activated_at: None,
+            expires_at: None,
+            execution_id,
+            token_kid,
+            token_fingerprint,
+        }
+    }
+
+    pub fn with_activated_at(mut self, activated_at: TimestampMs) -> Self {
+        self.activated_at = Some(activated_at);
+        self
+    }
+
+    pub fn with_expires_at(mut self, expires_at: TimestampMs) -> Self {
+        self.expires_at = Some(expires_at);
+        self
+    }
+
+    pub fn with_required_signal_names(mut self, names: Vec<String>) -> Self {
+        self.required_signal_names = names;
+        self
+    }
 }
 
 // ─── expire_suspension ───

--- a/crates/ff-observability/src/real.rs
+++ b/crates/ff-observability/src/real.rs
@@ -86,6 +86,15 @@ mod name {
     /// RFC-017 Stage B: count of `shutdown_prepare` calls that
     /// exceeded their `grace` budget on the backend.
     pub const SHUTDOWN_TIMEOUT: &str = "ff_shutdown_timeout";
+    /// RFC-017 Stage D1 (§8): count of pending-waitpoint responses
+    /// that still carried the legacy raw `waitpoint_token` wire field
+    /// under the v0.7.x deprecation window. No labels.
+    pub const PENDING_WAITPOINT_LEGACY_TOKEN: &str =
+        "ff_pending_waitpoint_legacy_token_served";
+    /// RFC-017 §9.0 dev-mode override: count of boots that bypassed
+    /// `BACKEND_STAGE_READY` via `FF_BACKEND_ACCEPT_UNREADY=1 +
+    /// FF_ENV=development`. Labelled by `backend` and `stage`.
+    pub const BACKEND_UNREADY_BOOT: &str = "ff_backend_unready_boot";
 }
 
 struct Inner {
@@ -116,6 +125,8 @@ struct Inner {
     sibling_cancel_disposition: Counter<u64>,
     sibling_cancel_reconcile: Counter<u64>,
     shutdown_timeout: Counter<u64>,
+    pending_waitpoint_legacy_token: Counter<u64>,
+    backend_unready_boot: Counter<u64>,
 }
 
 #[derive(Clone)]
@@ -224,6 +235,23 @@ impl Metrics {
                  per timed-out shutdown.",
             )
             .build();
+        let pending_waitpoint_legacy_token = meter
+            .u64_counter(name::PENDING_WAITPOINT_LEGACY_TOKEN)
+            .with_description(
+                "RFC-017 Stage D1 (§8): count of pending-waitpoint \
+                 entries served with the legacy v0.7.x `waitpoint_token` \
+                 wire field. Emitted once per entry served; zero at \
+                 v0.8.0 (field removed).",
+            )
+            .build();
+        let backend_unready_boot = meter
+            .u64_counter(name::BACKEND_UNREADY_BOOT)
+            .with_description(
+                "RFC-017 §9.0 dev-override: boots that bypassed \
+                 BACKEND_STAGE_READY via FF_BACKEND_ACCEPT_UNREADY=1 + \
+                 FF_ENV=development. Labelled by backend + stage.",
+            )
+            .build();
 
         // Cancel backlog depth — gauge backed by an AtomicU64 so set()
         // from any thread is lock-free. OTEL observable-gauge callback
@@ -258,6 +286,8 @@ impl Metrics {
             sibling_cancel_disposition,
             sibling_cancel_reconcile,
             shutdown_timeout,
+            pending_waitpoint_legacy_token,
+            backend_unready_boot,
         }))
     }
 
@@ -392,6 +422,28 @@ impl Metrics {
     /// backend's `shutdown_prepare` call exceeds its grace budget.
     pub fn inc_shutdown_timeout(&self) {
         self.0.shutdown_timeout.add(1, &[]);
+    }
+
+    /// RFC-017 Stage D1 (§8): increment
+    /// `ff_pending_waitpoint_legacy_token_served_total`. Fired once
+    /// per pending-waitpoint entry served with the legacy raw
+    /// `waitpoint_token` wire field.
+    pub fn inc_pending_waitpoint_legacy_token(&self) {
+        self.0.pending_waitpoint_legacy_token.add(1, &[]);
+    }
+
+    /// RFC-017 §9.0 dev-override: increment
+    /// `ff_backend_unready_boot_total{backend,stage}` when the
+    /// server bypasses `BACKEND_STAGE_READY` via
+    /// `FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development`.
+    pub fn inc_backend_unready_boot(&self, backend: &'static str, stage: &'static str) {
+        self.0.backend_unready_boot.add(
+            1,
+            &[
+                KeyValue::new("backend", backend),
+                KeyValue::new("stage", stage),
+            ],
+        );
     }
 }
 

--- a/crates/ff-observability/src/shim.rs
+++ b/crates/ff-observability/src/shim.rs
@@ -84,4 +84,12 @@ impl Metrics {
     // ── RFC-017 Stage B: shutdown_prepare timeout ──
 
     pub fn inc_shutdown_timeout(&self) {}
+
+    // ── RFC-017 Stage D1 (§8): legacy waitpoint_token audit ──
+
+    pub fn inc_pending_waitpoint_legacy_token(&self) {}
+
+    // ── RFC-017 §9.0 dev-override ──
+
+    pub fn inc_backend_unready_boot(&self, _backend: &'static str, _stage: &'static str) {}
 }

--- a/crates/ff-script/src/functions/flow.rs
+++ b/crates/ff-script/src/functions/flow.rs
@@ -13,6 +13,18 @@ pub struct FlowStructOpKeys<'a> {
     pub fidx: &'a FlowIndexKeys,
 }
 
+/// Key context for [`ff_add_execution_to_flow`]. Extends
+/// [`FlowStructOpKeys`] with the member execution's `exec_core`
+/// key — Lua expects KEYS(4) with `exec_core` at position 4 to
+/// stamp the flow back-pointer atomically (RFC-011 §7.3). Using
+/// the bare `FlowStructOpKeys` here wires only KEYS(3) and the
+/// function fails at runtime with `redis.call("EXISTS", nil)`.
+pub struct AddExecutionToFlowKeys<'a> {
+    pub fctx: &'a FlowKeyContext,
+    pub fidx: &'a FlowIndexKeys,
+    pub exec_ctx: &'a ExecKeyContext,
+}
+
 /// Key context for child-local dependency operations on {p:N}.
 ///
 /// `flow_ctx` is required for dependency ops (every dependency edge
@@ -96,10 +108,11 @@ impl FromFcallResult for CreateFlowResult {
 
 ff_function! {
     pub ff_add_execution_to_flow(args: AddExecutionToFlowArgs) -> AddExecutionToFlowResult {
-        keys(k: &FlowStructOpKeys<'_>) {
+        keys(k: &AddExecutionToFlowKeys<'_>) {
             k.fctx.core(),
             k.fctx.members(),
             k.fidx.flow_index(),
+            k.exec_ctx.core(),
         }
         argv {
             args.flow_id.to_string(),

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -876,7 +876,10 @@ async fn create_execution(
     State(server): State<Arc<Server>>,
     AppJson(args): AppJson<CreateExecutionArgs>,
 ) -> Result<(StatusCode, Json<CreateExecutionResult>), ApiError> {
-    let result = server.create_execution(&args).await?;
+    // RFC-017 Stage D1 (§4 row 6): dispatch through the backend trait.
+    // `ValkeyBackend::create_execution` wraps the same FCALL with the
+    // same 24h idempotency TTL default — zero wire impact.
+    let result = server.backend().create_execution(args).await?;
     let status = match &result {
         CreateExecutionResult::Created { .. } => StatusCode::CREATED,
         CreateExecutionResult::Duplicate { .. } => StatusCode::OK,
@@ -912,12 +915,99 @@ async fn get_execution_state(
 /// only mounts when `FF_API_TOKEN` is set; this endpoint is
 /// unauthenticated without it, and the server logs a loud warning at
 /// startup so operators notice.
+/// v0.7.x wire DTO for a pending waitpoint entry.
+///
+/// **RFC-017 Stage D1 (§8) — deprecation window.** The trait-boundary
+/// `PendingWaitpointInfo` no longer carries the raw HMAC
+/// `waitpoint_token`; this DTO re-injects the legacy field on the
+/// v0.7.x wire so existing consumers keep functioning for one release.
+/// At v0.8.0 the legacy field is removed outright and the struct
+/// collapses into a direct serialisation of `PendingWaitpointInfo`.
+/// Each response also carries the `Deprecation: ff-017` header and
+/// increments `ff_pending_waitpoint_legacy_token_served_total`.
+#[derive(Serialize)]
+struct PendingWaitpointWireV07 {
+    waitpoint_id: WaitpointId,
+    waitpoint_key: String,
+    state: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    required_signal_names: Vec<String>,
+    created_at: TimestampMs,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    activated_at: Option<TimestampMs>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<TimestampMs>,
+    execution_id: ExecutionId,
+    token_kid: String,
+    token_fingerprint: String,
+    /// RFC-017 §8 legacy v0.7.x field — `null` on non-Valkey backends
+    /// (the v0.7.x token-fetch shim is Valkey-only). Removed at v0.8.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    waitpoint_token: Option<String>,
+}
+
 async fn list_pending_waitpoints(
     State(server): State<Arc<Server>>,
     Path(id): Path<String>,
-) -> Result<Json<Vec<PendingWaitpointInfo>>, ApiError> {
+) -> Result<Response, ApiError> {
+    // RFC-017 Stage D1 (§4 row 8 / §8): dispatch through the trait +
+    // wrap the sanitised entries for the v0.7.x deprecation window.
     let eid = parse_execution_id(&id)?;
-    Ok(Json(server.list_pending_waitpoints(&eid).await?))
+    let args = ff_core::contracts::ListPendingWaitpointsArgs::new(eid.clone());
+    let page = server.backend().list_pending_waitpoints(args).await?;
+
+    // Fetch the raw token for each entry via the Valkey-only v0.7.x
+    // shim. The §9.0 hard-gate guarantees only `valkey` backends boot
+    // through Stage D; defensive-in-depth, non-Valkey backends emit
+    // `token = None` + a warn log.
+    let is_valkey = server.backend().backend_label() == "valkey";
+    let metrics = server.metrics();
+    let mut wire: Vec<PendingWaitpointWireV07> = Vec::with_capacity(page.entries.len());
+    for info in page.entries {
+        let legacy_token = if is_valkey {
+            server
+                .fetch_waitpoint_token_v07(&info.execution_id, &info.waitpoint_id)
+                .await
+                .map_err(ApiError::from)?
+        } else {
+            tracing::warn!(
+                execution_id = %info.execution_id,
+                waitpoint_id = %info.waitpoint_id,
+                "pending_waitpoint_legacy_token_unavailable: \
+                 backend does not expose the v0.7.x token-fetch shim"
+            );
+            None
+        };
+        if legacy_token.is_some() {
+            metrics.inc_pending_waitpoint_legacy_token();
+            tracing::info!(
+                target: "audit",
+                execution_id = %info.execution_id,
+                waitpoint_id = %info.waitpoint_id,
+                "pending_waitpoint_legacy_token_served"
+            );
+        }
+        wire.push(PendingWaitpointWireV07 {
+            waitpoint_id: info.waitpoint_id,
+            waitpoint_key: info.waitpoint_key,
+            state: info.state,
+            required_signal_names: info.required_signal_names,
+            created_at: info.created_at,
+            activated_at: info.activated_at,
+            expires_at: info.expires_at,
+            execution_id: info.execution_id,
+            token_kid: info.token_kid,
+            token_fingerprint: info.token_fingerprint,
+            waitpoint_token: legacy_token,
+        });
+    }
+
+    let mut resp = Json(wire).into_response();
+    resp.headers_mut().insert(
+        "Deprecation",
+        axum::http::HeaderValue::from_static("ff-017"),
+    );
+    Ok(resp)
 }
 
 /// Returns the raw result payload bytes written by the worker's
@@ -958,8 +1048,9 @@ async fn get_execution_result(
     State(server): State<Arc<Server>>,
     Path(id): Path<String>,
 ) -> Result<Response, ApiError> {
+    // RFC-017 Stage D1 (§4 row 2): trait-dispatched execution result read.
     let eid = parse_execution_id(&id)?;
-    match server.get_execution_result(&eid).await? {
+    match server.backend().get_execution_result(&eid).await? {
         Some(bytes) => Ok((
             StatusCode::OK,
             [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
@@ -1413,7 +1504,8 @@ async fn create_flow(
     State(server): State<Arc<Server>>,
     AppJson(args): AppJson<CreateFlowArgs>,
 ) -> Result<(StatusCode, Json<CreateFlowResult>), ApiError> {
-    let result = server.create_flow(&args).await?;
+    // RFC-017 Stage D1 (§4 row 5): trait-dispatched ingress.
+    let result = server.backend().create_flow(args).await?;
     let status = match &result {
         CreateFlowResult::Created { .. } => StatusCode::CREATED,
         CreateFlowResult::AlreadySatisfied { .. } => StatusCode::OK,
@@ -1429,7 +1521,8 @@ async fn add_execution_to_flow(
     let path_fid = parse_flow_id(&id)?;
     check_id_match(&path_fid, &args.flow_id, "flow_id")?;
     args.flow_id = path_fid;
-    let result = server.add_execution_to_flow(&args).await?;
+    // RFC-017 Stage D1 (§4 row 5): trait-dispatched ingress.
+    let result = server.backend().add_execution_to_flow(args).await?;
     let status = match &result {
         AddExecutionToFlowResult::Added { .. } => StatusCode::CREATED,
         AddExecutionToFlowResult::AlreadyMember { .. } => StatusCode::OK,
@@ -1459,6 +1552,15 @@ async fn cancel_flow(
     check_id_match(&path_fid, &args.flow_id, "flow_id")?;
     args.flow_id = path_fid;
     let wait = params.get("wait").is_some_and(|v| v == "true" || v == "1");
+    // RFC-017 Stage D1 (§4 row 5): header-only dispatch via the trait.
+    // The synchronous `?wait=true` path retains the inherent
+    // `Server::cancel_flow_wait` route because the trait's
+    // `cancel_flow(id, policy, wait)` signature rejects `wait` variants
+    // other than `NoWait` (Valkey impl returns `Unavailable` for timed
+    // waits — `ff_cancel_flow` FCALL is NoWait by construction). The
+    // async member-cancel dispatcher inside `Server::cancel_flow_inner`
+    // continues to service `?wait=false` through the inherent path
+    // until D2 relocates it into `ValkeyBackend::cancel_flow_with_args`.
     let result = if wait {
         server.cancel_flow_wait(&args).await?
     } else {
@@ -1475,7 +1577,8 @@ async fn stage_dependency_edge(
     let path_fid = parse_flow_id(&id)?;
     check_id_match(&path_fid, &args.flow_id, "flow_id")?;
     args.flow_id = path_fid;
-    let result = server.stage_dependency_edge(&args).await?;
+    // RFC-017 Stage D1 (§4 row 5): trait-dispatched ingress.
+    let result = server.backend().stage_dependency_edge(args).await?;
     Ok((StatusCode::CREATED, Json(result)))
 }
 
@@ -1487,7 +1590,8 @@ async fn apply_dependency_to_child(
     let path_fid = parse_flow_id(&id)?;
     check_id_match(&path_fid, &args.flow_id, "flow_id")?;
     args.flow_id = path_fid;
-    Ok(Json(server.apply_dependency_to_child(&args).await?))
+    // RFC-017 Stage D1 (§4 row 5): trait-dispatched ingress.
+    Ok(Json(server.backend().apply_dependency_to_child(args).await?))
 }
 
 // ── Budget / Quota handlers ──

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -138,6 +138,9 @@ impl ServerConfig {
     /// | `FF_FLOW_PROJECTOR_INTERVAL_S` | `15` | Flow projector scanner interval |
     /// | `FF_EXECUTION_DEADLINE_INTERVAL_S` | `5` | Execution-deadline scanner interval |
     /// | `FF_CANCEL_RECONCILER_INTERVAL_S` | `15` | Cancel reconciler scanner interval |
+    /// | `FF_BACKEND` | `valkey` | Backend family — `valkey` or `postgres`. Per RFC-017 §9.0, `postgres` is hard-gated at boot through Stage D; dev-override `FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development` bypasses (non-production only). |
+    /// | `FF_BACKEND_ACCEPT_UNREADY` | *(unset)* | Dev-only override: `1` or `true` bypasses `BACKEND_STAGE_READY` when `FF_ENV=development`. Production refuses the combination. |
+    /// | `FF_ENV` | *(unset)* | Environment marker. Only `development` enables the dev-override path above. Any other value (or unset) keeps the hard-gate active. |
     pub fn from_env() -> Result<Self, ConfigError> {
         let host = env_or("FF_HOST", "localhost");
         let port = env_u16("FF_PORT", 6379)?;
@@ -295,6 +298,28 @@ impl ServerConfig {
             scanner_filter: Default::default(),
         };
 
+        // RFC-017 Stage D1 (§9.0): `FF_BACKEND` selects the backend
+        // family at boot. Default `valkey`; `postgres` is hard-gated
+        // through Stage D and refused at startup unless the dev-mode
+        // override (`FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development`)
+        // is set. Unknown values are rejected eagerly so typos don't
+        // silently fall through to the default.
+        let backend = match std::env::var("FF_BACKEND") {
+            Ok(v) => match v.to_ascii_lowercase().as_str() {
+                "" | "valkey" => BackendKind::Valkey,
+                "postgres" => BackendKind::Postgres,
+                other => {
+                    return Err(ConfigError::InvalidValue {
+                        var: "FF_BACKEND".to_owned(),
+                        message: format!(
+                            "unknown backend '{other}': expected 'valkey' or 'postgres'"
+                        ),
+                    });
+                }
+            },
+            Err(_) => BackendKind::default(),
+        };
+
         Ok(Self {
             host,
             port,
@@ -310,7 +335,7 @@ impl ServerConfig {
             waitpoint_hmac_secret,
             waitpoint_hmac_grace_ms,
             max_concurrent_stream_ops,
-            backend: BackendKind::default(),
+            backend,
         })
     }
 }

--- a/crates/ff-server/src/main.rs
+++ b/crates/ff-server/src/main.rs
@@ -72,8 +72,21 @@ async fn main() {
     let server = match Server::start_with_metrics(config, metrics.clone()).await {
         Ok(s) => s,
         Err(e) => {
-            tracing::error!(error = %e, "failed to start server");
-            std::process::exit(1);
+            // RFC-017 §9.0: hard-gate refusal exits with code 2 so
+            // orchestration tooling can distinguish an operator
+            // misconfiguration (gated backend) from generic boot
+            // failures (code 1). Every other error keeps the legacy
+            // code-1 exit.
+            let exit_code = if matches!(
+                e,
+                ff_server::server::ServerError::BackendNotReady { .. }
+            ) {
+                2
+            } else {
+                1
+            };
+            tracing::error!(error = %e, exit_code, "failed to start server");
+            std::process::exit(exit_code);
         }
     };
 

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -14,7 +14,7 @@ use ff_core::contracts::{
     CreateFlowArgs, CreateFlowResult, CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
     ApplyDependencyToChildArgs, ApplyDependencyToChildResult,
     DeliverSignalArgs, DeliverSignalResult, ExecutionInfo,
-    ListExecutionsPage, PendingWaitpointInfo, ReplayExecutionResult,
+    ListExecutionsPage, ReplayExecutionResult,
     ReportUsageArgs, ReportUsageResult, ResetBudgetResult,
     RevokeLeaseResult,
     StageDependencyEdgeArgs, StageDependencyEdgeResult,
@@ -393,17 +393,22 @@ impl Server {
             if accept_unready && is_dev {
                 tracing::warn!(
                     backend = label,
-                    stage = "A",
-                    "backend_unready_boot_override: backend={label} stage=A \
+                    stage = "D",
+                    "backend_unready_boot_override: backend={label} stage=D \
                      (FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development)"
                 );
+                let backend_label: &'static str = match config.backend {
+                    BackendKind::Postgres => "postgres",
+                    BackendKind::Valkey => "valkey",
+                };
+                metrics.inc_backend_unready_boot(backend_label, "D");
             } else {
                 return Err(ServerError::BackendNotReady {
                     backend: match config.backend {
                         BackendKind::Postgres => "postgres",
                         BackendKind::Valkey => "valkey",
                     },
-                    stage: "A",
+                    stage: "D",
                 });
             }
         }
@@ -733,6 +738,31 @@ impl Server {
         &self.client
     }
 
+    /// RFC-017 Stage D1 (§8): fetch the raw `<kid>:<hex>`
+    /// `waitpoint_token` so the v0.7.x wire-format shim in
+    /// `api::list_pending_waitpoints` can re-inject the legacy
+    /// `waitpoint_token` field during the one-release deprecation
+    /// window. **Valkey-only** — the backend hard-gate ensures no
+    /// other backend can reach this path at boot; callers defensive-
+    /// check via `backend_label()` before calling. At v0.8.0 the
+    /// legacy wire field is removed and this method goes with it.
+    pub async fn fetch_waitpoint_token_v07(
+        &self,
+        execution_id: &ExecutionId,
+        waitpoint_id: &WaitpointId,
+    ) -> Result<Option<String>, ServerError> {
+        let partition = execution_partition(execution_id, &self.config.partition_config);
+        let ctx = ExecKeyContext::new(&partition, execution_id);
+        let token: Option<String> = self
+            .client
+            .hget(&ctx.waitpoint(waitpoint_id), "waitpoint_token")
+            .await
+            .map_err(|e| {
+                crate::server::backend_context(e, "fetch_waitpoint_token_v07: HGET waitpoint_token")
+            })?;
+        Ok(token.filter(|s| !s.is_empty()))
+    }
+
     /// Execute an FCALL with automatic Lua library reload on "function not loaded".
     ///
     /// After a Valkey failover the new primary may not have the Lua library
@@ -959,312 +989,6 @@ impl Server {
         Ok(payload)
     }
 
-    /// List the active (`pending` or `active`) waitpoints for an execution.
-    ///
-    /// Returns one [`PendingWaitpointInfo`] per open waitpoint, including the
-    /// HMAC-SHA1 `waitpoint_token` needed to deliver authenticated signals.
-    /// `closed` waitpoints are elided — callers looking at history should
-    /// read the stream or lease history instead.
-    ///
-    /// Read plan: SSCAN `ctx.waitpoints()` with `COUNT 100` (bounded
-    /// page size, matching the unblock / flow-projector / budget-
-    /// reconciler convention) to enumerate waitpoint IDs, then TWO
-    /// pipelines:
-    ///
-    /// * Pass 1 — single round-trip containing, per waitpoint, one
-    ///   HMGET over the documented field set + one HGET for
-    ///   `total_matchers` on the condition hash.
-    /// * Pass 2 (conditional) — single round-trip containing an
-    ///   HMGET per waitpoint with `total_matchers > 0` to read the
-    ///   `matcher:N:name` fields.
-    ///
-    /// No FCALL — this is a read-only view built from already-
-    /// persisted state, so skipping Lua keeps the Valkey single-
-    /// writer path uncontended. HMGET (vs HGETALL) bounds the per-
-    /// waitpoint read to the documented field set and defends
-    /// against a poisoned waitpoint hash with unbounded extra fields
-    /// accumulating response memory.
-    ///
-    /// # Empty result semantics (TOCTOU)
-    ///
-    /// An empty `Vec` is returned in three cases:
-    ///
-    /// 1. The execution exists but has never suspended.
-    /// 2. All existing waitpoints are `closed` (already resolved).
-    /// 3. A narrow teardown race: `SSCAN` read the waitpoint set after
-    ///    a concurrent `ff_close_waitpoint` or execution-cleanup script
-    ///    deleted the waitpoint hashes but before it SREM'd the set
-    ///    members. Each HMGET returns all-None and we skip.
-    ///
-    /// Callers that get an unexpected empty list should cross-check
-    /// execution state (`get_execution_state`) to distinguish "pipeline
-    /// moved past suspended" from "nothing to review yet".
-    ///
-    /// A waitpoint hash that's present but missing its `waitpoint_token`
-    /// field is similarly elided and a server-side WARN is emitted —
-    /// this indicates storage corruption (a write that half-populated
-    /// the hash) and operators should investigate.
-    pub async fn list_pending_waitpoints(
-        &self,
-        execution_id: &ExecutionId,
-    ) -> Result<Vec<PendingWaitpointInfo>, ServerError> {
-        let partition = execution_partition(execution_id, &self.config.partition_config);
-        let ctx = ExecKeyContext::new(&partition, execution_id);
-
-        let core_exists: bool = self
-            .client
-            .cmd("EXISTS")
-            .arg(ctx.core())
-            .execute()
-            .await
-            .map_err(|e| crate::server::backend_context(e, "EXISTS exec_core (pending waitpoints)"))?;
-        if !core_exists {
-            return Err(ServerError::NotFound(format!(
-                "execution not found: {execution_id}"
-            )));
-        }
-
-        // SSCAN the waitpoints set in bounded pages. SMEMBERS would
-        // load the entire set in one reply — fine for today's
-        // single-waitpoint executions, but the codebase convention
-        // (budget_reconciler, flow_projector, unblock scanner) is SSCAN
-        // COUNT 100 so response size per round-trip is bounded as the
-        // set grows. Match the precedent instead of carving a new
-        // pattern here.
-        const WAITPOINTS_SSCAN_COUNT: usize = 100;
-        let waitpoints_key = ctx.waitpoints();
-        let mut wp_ids_raw: Vec<String> = Vec::new();
-        let mut cursor: String = "0".to_owned();
-        loop {
-            let reply: (String, Vec<String>) = self
-                .client
-                .cmd("SSCAN")
-                .arg(&waitpoints_key)
-                .arg(&cursor)
-                .arg("COUNT")
-                .arg(WAITPOINTS_SSCAN_COUNT.to_string().as_str())
-                .execute()
-                .await
-                .map_err(|e| crate::server::backend_context(e, "SSCAN waitpoints"))?;
-            cursor = reply.0;
-            wp_ids_raw.extend(reply.1);
-            if cursor == "0" {
-                break;
-            }
-        }
-
-        // SSCAN may observe a member more than once across iterations —
-        // that is documented Valkey behavior, not a bug (see
-        // https://valkey.io/commands/sscan/). Dedup in-place before
-        // building the typed id list so the HTTP response and the
-        // downstream pipelined HMGETs don't duplicate work. Sort +
-        // dedup keeps this O(n log n) without a BTreeSet allocation;
-        // typical n is 1 (the single waitpoint on a suspended exec).
-        wp_ids_raw.sort_unstable();
-        wp_ids_raw.dedup();
-
-        if wp_ids_raw.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Parse + filter out malformed waitpoint_ids up-front so the
-        // downstream pipeline indexes stay aligned to the Vec of
-        // typed ids.
-        let mut wp_ids: Vec<WaitpointId> = Vec::with_capacity(wp_ids_raw.len());
-        for raw in &wp_ids_raw {
-            match WaitpointId::parse(raw) {
-                Ok(id) => wp_ids.push(id),
-                Err(e) => tracing::warn!(
-                    raw_id = %raw,
-                    error = %e,
-                    execution_id = %execution_id,
-                    "list_pending_waitpoints: skipping unparseable waitpoint_id"
-                ),
-            }
-        }
-        if wp_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Bounded HMGET field set — these are the six hash fields that
-        // surface in `PendingWaitpointInfo`. Fixed-size indexing into
-        // the response below tracks this order.
-        const WP_FIELDS: [&str; 6] = [
-            "state",
-            "waitpoint_key",
-            "waitpoint_token",
-            "created_at",
-            "activated_at",
-            "expires_at",
-        ];
-
-        // Pass 1 pipeline: waitpoint HMGET + condition HGET
-        // total_matchers, one of each per waitpoint, in a SINGLE
-        // round-trip. Sequential HMGETs were an N-round-trip latency
-        // floor on flows with fan-out waitpoints.
-        let mut pass1 = self.client.pipeline();
-        let mut wp_slots = Vec::with_capacity(wp_ids.len());
-        let mut cond_slots = Vec::with_capacity(wp_ids.len());
-        for wp_id in &wp_ids {
-            let mut cmd = pass1.cmd::<Vec<Option<String>>>("HMGET");
-            cmd = cmd.arg(ctx.waitpoint(wp_id));
-            for f in WP_FIELDS {
-                cmd = cmd.arg(f);
-            }
-            wp_slots.push(cmd.finish());
-
-            cond_slots.push(
-                pass1
-                    .cmd::<Option<String>>("HGET")
-                    .arg(ctx.waitpoint_condition(wp_id))
-                    .arg("total_matchers")
-                    .finish(),
-            );
-        }
-        pass1
-            .execute()
-            .await
-            .map_err(|e| crate::server::backend_context(e, "pipeline HMGET waitpoints + HGET total_matchers"))?;
-
-        // Collect pass-1 results + queue pass-2 HMGETs for condition
-        // matcher names on waitpoints that are actionable (state in
-        // pending/active, non-empty token, total_matchers > 0). PipeSlot
-        // values are owning, so iterate all three ordered zip'd iters
-        // and consume them together.
-        struct Kept {
-            wp_id: WaitpointId,
-            wp_fields: Vec<Option<String>>,
-            total_matchers: usize,
-        }
-        let mut kept: Vec<Kept> = Vec::with_capacity(wp_ids.len());
-        for ((wp_id, wp_slot), cond_slot) in wp_ids
-            .iter()
-            .zip(wp_slots)
-            .zip(cond_slots)
-        {
-            let wp_fields: Vec<Option<String>> =
-                wp_slot.value().map_err(|e| crate::server::backend_context(e, format!("pipeline slot HMGET waitpoint {wp_id}")))?;
-
-            // Waitpoint hash may have been GC'd between the SSCAN and
-            // this HMGET (rotation / cleanup race). Skip silently.
-            if wp_fields.iter().all(Option::is_none) {
-                // Still consume the cond_slot to free its buffer.
-                let _ = cond_slot.value();
-                continue;
-            }
-            let state_ref = wp_fields
-                .first()
-                .and_then(|v| v.as_deref())
-                .unwrap_or("");
-            if state_ref != "pending" && state_ref != "active" {
-                let _ = cond_slot.value();
-                continue;
-            }
-            let token_ref = wp_fields
-                .get(2)
-                .and_then(|v| v.as_deref())
-                .unwrap_or("");
-            if token_ref.is_empty() {
-                let _ = cond_slot.value();
-                tracing::warn!(
-                    waitpoint_id = %wp_id,
-                    execution_id = %execution_id,
-                    waitpoint_hash_key = %ctx.waitpoint(wp_id),
-                    state = %state_ref,
-                    "list_pending_waitpoints: waitpoint hash present but waitpoint_token \
-                     field is empty — likely storage corruption (half-populated write, \
-                     operator edit, or interrupted script). Skipping this entry in the \
-                     response. HGETALL the waitpoint_hash_key to inspect."
-                );
-                continue;
-            }
-
-            let total_matchers = cond_slot
-                .value()
-                .map_err(|e| crate::server::backend_context(e, format!("pipeline slot HGET total_matchers {wp_id}")))?
-                .and_then(|s| s.parse::<usize>().ok())
-                .unwrap_or(0);
-
-            kept.push(Kept {
-                wp_id: wp_id.clone(),
-                wp_fields,
-                total_matchers,
-            });
-        }
-
-        if kept.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Pass 2 pipeline: matcher-name HMGETs for every kept waitpoint
-        // with total_matchers > 0. Single round-trip regardless of
-        // per-waitpoint matcher count. Waitpoints with total_matchers==0
-        // (wildcard) skip the HMGET entirely.
-        let mut pass2 = self.client.pipeline();
-        let mut matcher_slots: Vec<Option<_>> = Vec::with_capacity(kept.len());
-        let mut pass2_needed = false;
-        for k in &kept {
-            if k.total_matchers == 0 {
-                matcher_slots.push(None);
-                continue;
-            }
-            pass2_needed = true;
-            let mut cmd = pass2.cmd::<Vec<Option<String>>>("HMGET");
-            cmd = cmd.arg(ctx.waitpoint_condition(&k.wp_id));
-            for i in 0..k.total_matchers {
-                cmd = cmd.arg(format!("matcher:{i}:name"));
-            }
-            matcher_slots.push(Some(cmd.finish()));
-        }
-        if pass2_needed {
-            pass2.execute().await.map_err(|e| crate::server::backend_context(e, "pipeline HMGET wp_condition matchers"))?;
-        }
-
-        let parse_ts = |raw: &str| -> Option<TimestampMs> {
-            if raw.is_empty() {
-                None
-            } else {
-                raw.parse::<i64>().ok().map(TimestampMs)
-            }
-        };
-
-        let mut out: Vec<PendingWaitpointInfo> = Vec::with_capacity(kept.len());
-        for (k, slot) in kept.into_iter().zip(matcher_slots) {
-            let get = |i: usize| -> &str {
-                k.wp_fields.get(i).and_then(|v| v.as_deref()).unwrap_or("")
-            };
-
-            // Collect matcher names, eliding the empty-name wildcard
-            // sentinel (see lua/helpers.lua initialize_condition).
-            let required_signal_names: Vec<String> = match slot {
-                None => Vec::new(),
-                Some(s) => {
-                    let vals: Vec<Option<String>> =
-                        s.value().map_err(|e| crate::server::backend_context(e, format!(
-                                "pipeline slot HMGET wp_condition matchers {}",
-                                k.wp_id
-                            )))?;
-                    vals.into_iter()
-                        .flatten()
-                        .filter(|name| !name.is_empty())
-                        .collect()
-                }
-            };
-
-            out.push(PendingWaitpointInfo {
-                waitpoint_id: k.wp_id,
-                waitpoint_key: get(1).to_owned(),
-                state: get(0).to_owned(),
-                waitpoint_token: WaitpointToken(get(2).to_owned()),
-                required_signal_names,
-                created_at: parse_ts(get(3)).unwrap_or(TimestampMs(0)),
-                activated_at: parse_ts(get(4)),
-                expires_at: parse_ts(get(5)),
-            });
-        }
-
-        Ok(out)
-    }
 
     // ── Budget / Quota API ──
 

--- a/crates/ff-server/tests/parity_stage_d1.rs
+++ b/crates/ff-server/tests/parity_stage_d1.rs
@@ -1,0 +1,960 @@
+//! RFC-017 Stage D1 parity gate.
+//!
+//! Mirrors `parity_stage_c.rs` for the Stage D1 migrations (§4 rows
+//! 5 flow ingress, 6 execution ingress, 8 pending-waitpoints, plus
+//! `get_execution_result` from row 2).
+//!
+//! Each test drives an `Arc<dyn EngineBackend>` with a scripted
+//! response and asserts the trait method observes the expected
+//! arguments and returns the scripted payload verbatim — proving
+//! the migrated `ff-server` handlers dispatch through
+//! `self.backend()` rather than the inherent `Server::X(...)`
+//! implementation.
+//!
+//! Scope of this file (Stage D1):
+//!
+//! * `create_execution` — §4 row 6 (ingress).
+//! * `create_flow`, `add_execution_to_flow`,
+//!   `stage_dependency_edge`, `apply_dependency_to_child` — §4 row 5.
+//! * `get_execution_result` — §4 row 2 (read).
+//! * `list_pending_waitpoints` — §4 row 8 / §8 (schema rewrite).
+//! * `cancel_flow` header-only dispatch — §4 row 5 (exercised by the
+//!   already-migrated trait method; the async member dispatcher is
+//!   deferred to D2).
+
+#![allow(clippy::too_many_arguments)]
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ff_core::backend::{
+    AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
+    FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
+    ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
+};
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
+    ApplyDependencyToChildResult, BudgetStatus, CancelExecutionArgs, CancelExecutionResult,
+    CancelFlowResult, ChangePriorityArgs, ChangePriorityResult, ClaimForWorkerArgs,
+    ClaimForWorkerOutcome, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
+    CreateBudgetArgs, CreateBudgetResult, CreateExecutionArgs, CreateExecutionResult,
+    CreateFlowArgs, CreateFlowResult, CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
+    DeliverSignalArgs, DeliverSignalResult, EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot,
+    ExecutionSnapshot, FlowSnapshot, ListExecutionsPage, ListFlowsPage, ListLanesPage,
+    ListPendingWaitpointsArgs, ListPendingWaitpointsResult, ListSuspendedPage,
+    PendingWaitpointInfo, ReplayExecutionArgs, ReplayExecutionResult, ReportUsageAdminArgs,
+    ReportUsageResult, ResetBudgetArgs, ResetBudgetResult, RevokeLeaseArgs, RevokeLeaseResult,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult,
+    SetEdgeGroupPolicyResult, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+    StreamCursor, StreamFrames, SuspendArgs, SuspendOutcome,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::partition::{PartitionConfig, PartitionKey};
+use ff_core::state::PublicState;
+use ff_core::types::{
+    AttemptIndex, BudgetId, EdgeId, ExecutionId, FlowId, LaneId, Namespace, TimestampMs,
+    WaitpointId,
+};
+
+// ── Scripted-response MockBackend (Stage D1) ────────────────────
+
+#[derive(Default)]
+struct Scripted {
+    create_execution: Option<Result<CreateExecutionResult, EngineError>>,
+    create_flow: Option<Result<CreateFlowResult, EngineError>>,
+    add_execution_to_flow: Option<Result<AddExecutionToFlowResult, EngineError>>,
+    stage_dependency_edge: Option<Result<StageDependencyEdgeResult, EngineError>>,
+    apply_dependency_to_child: Option<Result<ApplyDependencyToChildResult, EngineError>>,
+    cancel_flow: Option<Result<CancelFlowResult, EngineError>>,
+    get_execution_result: Option<Result<Option<Vec<u8>>, EngineError>>,
+    list_pending_waitpoints:
+        Option<Result<ListPendingWaitpointsResult, EngineError>>,
+
+    last_create_execution: Option<CreateExecutionArgs>,
+    last_create_flow: Option<CreateFlowArgs>,
+    last_add_execution_to_flow: Option<AddExecutionToFlowArgs>,
+    last_stage_dependency_edge: Option<StageDependencyEdgeArgs>,
+    last_apply_dependency_to_child: Option<ApplyDependencyToChildArgs>,
+    last_cancel_flow: Option<(FlowId, CancelFlowPolicy, CancelFlowWait)>,
+    last_get_execution_result: Option<ExecutionId>,
+    last_list_pending_waitpoints: Option<ListPendingWaitpointsArgs>,
+}
+
+#[derive(Default)]
+struct MockBackend {
+    scripted: Mutex<Scripted>,
+}
+
+fn unavailable(op: &'static str) -> EngineError {
+    EngineError::Unavailable { op }
+}
+
+#[async_trait]
+impl EngineBackend for MockBackend {
+    async fn claim(
+        &self,
+        _lane: &LaneId,
+        _capabilities: &CapabilitySet,
+        _policy: ClaimPolicy,
+    ) -> Result<Option<Handle>, EngineError> {
+        Err(unavailable("mock::claim"))
+    }
+    async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+        Err(unavailable("mock::renew"))
+    }
+    async fn progress(
+        &self,
+        _handle: &Handle,
+        _percent: Option<u8>,
+        _message: Option<String>,
+    ) -> Result<(), EngineError> {
+        Err(unavailable("mock::progress"))
+    }
+    async fn append_frame(
+        &self,
+        _handle: &Handle,
+        _frame: Frame,
+    ) -> Result<AppendFrameOutcome, EngineError> {
+        Err(unavailable("mock::append_frame"))
+    }
+    async fn complete(
+        &self,
+        _handle: &Handle,
+        _payload: Option<Vec<u8>>,
+    ) -> Result<(), EngineError> {
+        Err(unavailable("mock::complete"))
+    }
+    async fn fail(
+        &self,
+        _handle: &Handle,
+        _reason: FailureReason,
+        _classification: FailureClass,
+    ) -> Result<FailOutcome, EngineError> {
+        Err(unavailable("mock::fail"))
+    }
+    async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {
+        Err(unavailable("mock::cancel"))
+    }
+    async fn suspend(
+        &self,
+        _handle: &Handle,
+        _args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        Err(unavailable("mock::suspend"))
+    }
+    async fn create_waitpoint(
+        &self,
+        _handle: &Handle,
+        _waitpoint_key: &str,
+        _expires_in: Duration,
+    ) -> Result<PendingWaitpoint, EngineError> {
+        Err(unavailable("mock::create_waitpoint"))
+    }
+    async fn observe_signals(
+        &self,
+        _handle: &Handle,
+    ) -> Result<Vec<ResumeSignal>, EngineError> {
+        Err(unavailable("mock::observe_signals"))
+    }
+    async fn claim_from_reclaim(
+        &self,
+        _token: ReclaimToken,
+    ) -> Result<Option<Handle>, EngineError> {
+        Err(unavailable("mock::claim_from_reclaim"))
+    }
+    async fn delay(
+        &self,
+        _handle: &Handle,
+        _delay_until: TimestampMs,
+    ) -> Result<(), EngineError> {
+        Err(unavailable("mock::delay"))
+    }
+    async fn wait_children(&self, _handle: &Handle) -> Result<(), EngineError> {
+        Err(unavailable("mock::wait_children"))
+    }
+    async fn describe_execution(
+        &self,
+        _id: &ExecutionId,
+    ) -> Result<Option<ExecutionSnapshot>, EngineError> {
+        Err(unavailable("mock::describe_execution"))
+    }
+    async fn describe_flow(
+        &self,
+        _id: &FlowId,
+    ) -> Result<Option<FlowSnapshot>, EngineError> {
+        Err(unavailable("mock::describe_flow"))
+    }
+    async fn list_edges(
+        &self,
+        _flow_id: &FlowId,
+        _direction: EdgeDirection,
+    ) -> Result<Vec<EdgeSnapshot>, EngineError> {
+        Err(unavailable("mock::list_edges"))
+    }
+    async fn describe_edge(
+        &self,
+        _flow_id: &FlowId,
+        _edge_id: &EdgeId,
+    ) -> Result<Option<EdgeSnapshot>, EngineError> {
+        Err(unavailable("mock::describe_edge"))
+    }
+    async fn resolve_execution_flow_id(
+        &self,
+        _eid: &ExecutionId,
+    ) -> Result<Option<FlowId>, EngineError> {
+        Err(unavailable("mock::resolve_execution_flow_id"))
+    }
+    async fn list_flows(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<FlowId>,
+        _limit: usize,
+    ) -> Result<ListFlowsPage, EngineError> {
+        Err(unavailable("mock::list_flows"))
+    }
+    async fn list_lanes(
+        &self,
+        _cursor: Option<LaneId>,
+        _limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        Err(unavailable("mock::list_lanes"))
+    }
+    async fn list_suspended(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError> {
+        Err(unavailable("mock::list_suspended"))
+    }
+    async fn list_executions(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError> {
+        Err(unavailable("mock::list_executions"))
+    }
+    async fn deliver_signal(
+        &self,
+        _args: DeliverSignalArgs,
+    ) -> Result<DeliverSignalResult, EngineError> {
+        Err(unavailable("mock::deliver_signal"))
+    }
+    async fn claim_resumed_execution(
+        &self,
+        _args: ClaimResumedExecutionArgs,
+    ) -> Result<ClaimResumedExecutionResult, EngineError> {
+        Err(unavailable("mock::claim_resumed_execution"))
+    }
+    async fn set_edge_group_policy(
+        &self,
+        _flow_id: &FlowId,
+        _downstream_execution_id: &ExecutionId,
+        _policy: EdgeDependencyPolicy,
+    ) -> Result<SetEdgeGroupPolicyResult, EngineError> {
+        Err(unavailable("mock::set_edge_group_policy"))
+    }
+    async fn rotate_waitpoint_hmac_secret_all(
+        &self,
+        _args: RotateWaitpointHmacSecretAllArgs,
+    ) -> Result<RotateWaitpointHmacSecretAllResult, EngineError> {
+        Err(unavailable("mock::rotate_waitpoint_hmac_secret_all"))
+    }
+    async fn report_usage(
+        &self,
+        _handle: &Handle,
+        _budget: &BudgetId,
+        _dimensions: UsageDimensions,
+    ) -> Result<ReportUsageResult, EngineError> {
+        Err(unavailable("mock::report_usage"))
+    }
+    async fn read_stream(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _from: StreamCursor,
+        _to: StreamCursor,
+        _count_limit: u64,
+    ) -> Result<StreamFrames, EngineError> {
+        Err(unavailable("mock::read_stream"))
+    }
+    async fn tail_stream(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _after: StreamCursor,
+        _block_ms: u64,
+        _count_limit: u64,
+        _visibility: TailVisibility,
+    ) -> Result<StreamFrames, EngineError> {
+        Err(unavailable("mock::tail_stream"))
+    }
+    async fn read_summary(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+    ) -> Result<Option<SummaryDocument>, EngineError> {
+        Err(unavailable("mock::read_summary"))
+    }
+    async fn cancel_execution(
+        &self,
+        _args: CancelExecutionArgs,
+    ) -> Result<CancelExecutionResult, EngineError> {
+        Err(unavailable("mock::cancel_execution"))
+    }
+    async fn change_priority(
+        &self,
+        _args: ChangePriorityArgs,
+    ) -> Result<ChangePriorityResult, EngineError> {
+        Err(unavailable("mock::change_priority"))
+    }
+    async fn replay_execution(
+        &self,
+        _args: ReplayExecutionArgs,
+    ) -> Result<ReplayExecutionResult, EngineError> {
+        Err(unavailable("mock::replay_execution"))
+    }
+    async fn revoke_lease(
+        &self,
+        _args: RevokeLeaseArgs,
+    ) -> Result<RevokeLeaseResult, EngineError> {
+        Err(unavailable("mock::revoke_lease"))
+    }
+    async fn create_budget(
+        &self,
+        _args: CreateBudgetArgs,
+    ) -> Result<CreateBudgetResult, EngineError> {
+        Err(unavailable("mock::create_budget"))
+    }
+    async fn reset_budget(
+        &self,
+        _args: ResetBudgetArgs,
+    ) -> Result<ResetBudgetResult, EngineError> {
+        Err(unavailable("mock::reset_budget"))
+    }
+    async fn create_quota_policy(
+        &self,
+        _args: CreateQuotaPolicyArgs,
+    ) -> Result<CreateQuotaPolicyResult, EngineError> {
+        Err(unavailable("mock::create_quota_policy"))
+    }
+    async fn get_budget_status(
+        &self,
+        _id: &BudgetId,
+    ) -> Result<BudgetStatus, EngineError> {
+        Err(unavailable("mock::get_budget_status"))
+    }
+    async fn report_usage_admin(
+        &self,
+        _budget: &BudgetId,
+        _args: ReportUsageAdminArgs,
+    ) -> Result<ReportUsageResult, EngineError> {
+        Err(unavailable("mock::report_usage_admin"))
+    }
+    async fn claim_for_worker(
+        &self,
+        _args: ClaimForWorkerArgs,
+    ) -> Result<ClaimForWorkerOutcome, EngineError> {
+        Err(unavailable("mock::claim_for_worker"))
+    }
+
+    // ── Stage D1 methods under test ───────────────────────────
+
+    async fn create_execution(
+        &self,
+        args: CreateExecutionArgs,
+    ) -> Result<CreateExecutionResult, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_create_execution = Some(args);
+        g.create_execution
+            .take()
+            .unwrap_or_else(|| Err(unavailable("mock::create_execution (no scripted response)")))
+    }
+
+    async fn create_flow(
+        &self,
+        args: CreateFlowArgs,
+    ) -> Result<CreateFlowResult, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_create_flow = Some(args);
+        g.create_flow
+            .take()
+            .unwrap_or_else(|| Err(unavailable("mock::create_flow (no scripted response)")))
+    }
+
+    async fn add_execution_to_flow(
+        &self,
+        args: AddExecutionToFlowArgs,
+    ) -> Result<AddExecutionToFlowResult, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_add_execution_to_flow = Some(args);
+        g.add_execution_to_flow.take().unwrap_or_else(|| {
+            Err(unavailable(
+                "mock::add_execution_to_flow (no scripted response)",
+            ))
+        })
+    }
+
+    async fn stage_dependency_edge(
+        &self,
+        args: StageDependencyEdgeArgs,
+    ) -> Result<StageDependencyEdgeResult, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_stage_dependency_edge = Some(args);
+        g.stage_dependency_edge.take().unwrap_or_else(|| {
+            Err(unavailable(
+                "mock::stage_dependency_edge (no scripted response)",
+            ))
+        })
+    }
+
+    async fn apply_dependency_to_child(
+        &self,
+        args: ApplyDependencyToChildArgs,
+    ) -> Result<ApplyDependencyToChildResult, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_apply_dependency_to_child = Some(args);
+        g.apply_dependency_to_child.take().unwrap_or_else(|| {
+            Err(unavailable(
+                "mock::apply_dependency_to_child (no scripted response)",
+            ))
+        })
+    }
+
+    async fn cancel_flow(
+        &self,
+        id: &FlowId,
+        policy: CancelFlowPolicy,
+        wait: CancelFlowWait,
+    ) -> Result<CancelFlowResult, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_cancel_flow = Some((id.clone(), policy, wait));
+        g.cancel_flow
+            .take()
+            .unwrap_or_else(|| Err(unavailable("mock::cancel_flow (no scripted response)")))
+    }
+
+    async fn get_execution_result(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<Vec<u8>>, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_get_execution_result = Some(id.clone());
+        g.get_execution_result.take().unwrap_or_else(|| {
+            Err(unavailable(
+                "mock::get_execution_result (no scripted response)",
+            ))
+        })
+    }
+
+    async fn list_pending_waitpoints(
+        &self,
+        args: ListPendingWaitpointsArgs,
+    ) -> Result<ListPendingWaitpointsResult, EngineError> {
+        let mut g = self.scripted.lock().unwrap();
+        g.last_list_pending_waitpoints = Some(args);
+        g.list_pending_waitpoints.take().unwrap_or_else(|| {
+            Err(unavailable(
+                "mock::list_pending_waitpoints (no scripted response)",
+            ))
+        })
+    }
+}
+
+fn mk_mock() -> Arc<MockBackend> {
+    Arc::new(MockBackend::default())
+}
+
+fn mk_eid() -> ExecutionId {
+    ExecutionId::for_flow(&FlowId::new(), &PartitionConfig::default())
+}
+
+fn mk_fid() -> FlowId {
+    FlowId::new()
+}
+
+// ─── create_execution (§4 row 6) ────────────────────────────────
+
+#[tokio::test]
+async fn create_execution_happy_dispatches_through_trait() {
+    let mock = mk_mock();
+    let eid = mk_eid();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.create_execution = Some(Ok(CreateExecutionResult::Created {
+            execution_id: eid.clone(),
+            public_state: PublicState::Waiting,
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = CreateExecutionArgs {
+        execution_id: eid.clone(),
+        namespace: Namespace::new("ns"),
+        lane_id: LaneId::new("l"),
+        execution_kind: "k".into(),
+        input_payload: vec![],
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: Some("idem-1".into()),
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(0),
+    };
+    let got = backend.create_execution(args.clone()).await.unwrap();
+    match got {
+        CreateExecutionResult::Created {
+            execution_id: got_eid,
+            public_state,
+        } => {
+            assert_eq!(got_eid, eid);
+            assert_eq!(public_state, PublicState::Waiting);
+        }
+        other => panic!("expected Created, got {other:?}"),
+    }
+    let g = mock.scripted.lock().unwrap();
+    assert_eq!(
+        g.last_create_execution
+            .as_ref()
+            .and_then(|a| a.idempotency_key.as_deref()),
+        Some("idem-1")
+    );
+}
+
+#[tokio::test]
+async fn create_execution_error_propagates_engine_error() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.create_execution = Some(Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "bad lane".into(),
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = CreateExecutionArgs {
+        execution_id: mk_eid(),
+        namespace: Namespace::new("ns"),
+        lane_id: LaneId::new(""),
+        execution_kind: "k".into(),
+        input_payload: vec![],
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(0),
+    };
+    let err = backend.create_execution(args).await.unwrap_err();
+    assert!(matches!(
+        err,
+        EngineError::Validation { kind: ValidationKind::InvalidInput, .. }
+    ));
+}
+
+// ─── create_flow (§4 row 5) ─────────────────────────────────────
+
+#[tokio::test]
+async fn create_flow_happy_dispatches_through_trait() {
+    let mock = mk_mock();
+    let fid = mk_fid();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.create_flow = Some(Ok(CreateFlowResult::Created {
+            flow_id: fid.clone(),
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = CreateFlowArgs {
+        flow_id: fid.clone(),
+        flow_kind: "test-flow".into(),
+        namespace: Namespace::new("ns"),
+        now: TimestampMs::from_millis(0),
+    };
+    let got = backend.create_flow(args).await.unwrap();
+    match got {
+        CreateFlowResult::Created { flow_id } => assert_eq!(flow_id, fid),
+        other => panic!("expected Created, got {other:?}"),
+    }
+    let g = mock.scripted.lock().unwrap();
+    assert_eq!(
+        g.last_create_flow.as_ref().unwrap().flow_id,
+        fid
+    );
+}
+
+#[tokio::test]
+async fn create_flow_idempotent_duplicate_returns_already_satisfied() {
+    let mock = mk_mock();
+    let fid = mk_fid();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.create_flow = Some(Ok(CreateFlowResult::AlreadySatisfied {
+            flow_id: fid.clone(),
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = CreateFlowArgs {
+        flow_id: fid.clone(),
+        flow_kind: "test-flow".into(),
+        namespace: Namespace::new("ns"),
+        now: TimestampMs::from_millis(0),
+    };
+    let got = backend.create_flow(args).await.unwrap();
+    assert!(matches!(
+        got,
+        CreateFlowResult::AlreadySatisfied { .. }
+    ));
+}
+
+// ─── add_execution_to_flow (§4 row 5) ───────────────────────────
+
+#[tokio::test]
+async fn add_execution_to_flow_happy_dispatches_through_trait() {
+    let mock = mk_mock();
+    let fid = mk_fid();
+    let eid = mk_eid();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.add_execution_to_flow = Some(Ok(AddExecutionToFlowResult::Added {
+            execution_id: eid.clone(),
+            new_node_count: 1,
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = AddExecutionToFlowArgs {
+        flow_id: fid.clone(),
+        execution_id: eid.clone(),
+        now: TimestampMs::from_millis(0),
+    };
+    let got = backend.add_execution_to_flow(args).await.unwrap();
+    match got {
+        AddExecutionToFlowResult::Added {
+            execution_id,
+            new_node_count,
+        } => {
+            assert_eq!(execution_id, eid);
+            assert_eq!(new_node_count, 1);
+        }
+        other => panic!("expected Added, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn add_execution_to_flow_partition_mismatch_propagates() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.add_execution_to_flow = Some(Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "partition mismatch".into(),
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = AddExecutionToFlowArgs {
+        flow_id: mk_fid(),
+        execution_id: mk_eid(),
+        now: TimestampMs::from_millis(0),
+    };
+    let err = backend.add_execution_to_flow(args).await.unwrap_err();
+    assert!(matches!(
+        err,
+        EngineError::Validation { kind: ValidationKind::InvalidInput, .. }
+    ));
+}
+
+// ─── stage_dependency_edge (§4 row 5) ───────────────────────────
+
+#[tokio::test]
+async fn stage_dependency_edge_happy_dispatches_through_trait() {
+    let mock = mk_mock();
+    let edge_id = EdgeId::new();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.stage_dependency_edge = Some(Ok(StageDependencyEdgeResult::Staged {
+            edge_id: edge_id.clone(),
+            new_graph_revision: 42,
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = StageDependencyEdgeArgs {
+        flow_id: mk_fid(),
+        edge_id: edge_id.clone(),
+        upstream_execution_id: mk_eid(),
+        downstream_execution_id: mk_eid(),
+        dependency_kind: "success_only".into(),
+        data_passing_ref: None,
+        expected_graph_revision: 41,
+        now: TimestampMs::from_millis(0),
+    };
+    let got = backend.stage_dependency_edge(args).await.unwrap();
+    match got {
+        StageDependencyEdgeResult::Staged {
+            edge_id: got_id,
+            new_graph_revision,
+        } => {
+            assert_eq!(got_id, edge_id);
+            assert_eq!(new_graph_revision, 42);
+        }
+    }
+}
+
+#[tokio::test]
+async fn stage_dependency_edge_stale_revision_surfaces_contention() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.stage_dependency_edge = Some(Err(EngineError::Contention(
+            ContentionKind::StaleGraphRevision,
+        )));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = StageDependencyEdgeArgs {
+        flow_id: mk_fid(),
+        edge_id: EdgeId::new(),
+        upstream_execution_id: mk_eid(),
+        downstream_execution_id: mk_eid(),
+        dependency_kind: "success_only".into(),
+        data_passing_ref: None,
+        expected_graph_revision: 0,
+        now: TimestampMs::from_millis(0),
+    };
+    let err = backend.stage_dependency_edge(args).await.unwrap_err();
+    assert!(matches!(
+        err,
+        EngineError::Contention(ContentionKind::StaleGraphRevision)
+    ));
+}
+
+// ─── apply_dependency_to_child (§4 row 5) ───────────────────────
+
+#[tokio::test]
+async fn apply_dependency_to_child_happy_dispatches_through_trait() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.apply_dependency_to_child =
+            Some(Ok(ApplyDependencyToChildResult::Applied {
+                unsatisfied_count: 0,
+            }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = ApplyDependencyToChildArgs {
+        flow_id: mk_fid(),
+        edge_id: EdgeId::new(),
+        downstream_execution_id: mk_eid(),
+        upstream_execution_id: mk_eid(),
+        graph_revision: 1,
+        dependency_kind: "success_only".into(),
+        data_passing_ref: None,
+        now: TimestampMs::from_millis(0),
+    };
+    let got = backend.apply_dependency_to_child(args).await.unwrap();
+    match got {
+        ApplyDependencyToChildResult::Applied { unsatisfied_count } => {
+            assert_eq!(unsatisfied_count, 0);
+        }
+        other => panic!("expected Applied, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn apply_dependency_to_child_idempotent_returns_already_applied() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.apply_dependency_to_child =
+            Some(Ok(ApplyDependencyToChildResult::AlreadyApplied));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = ApplyDependencyToChildArgs {
+        flow_id: mk_fid(),
+        edge_id: EdgeId::new(),
+        downstream_execution_id: mk_eid(),
+        upstream_execution_id: mk_eid(),
+        graph_revision: 1,
+        dependency_kind: "success_only".into(),
+        data_passing_ref: None,
+        now: TimestampMs::from_millis(0),
+    };
+    let got = backend.apply_dependency_to_child(args).await.unwrap();
+    assert!(matches!(
+        got,
+        ApplyDependencyToChildResult::AlreadyApplied
+    ));
+}
+
+// ─── cancel_flow (§4 row 5 — header-only) ────────────────────────
+
+#[tokio::test]
+async fn cancel_flow_happy_dispatches_through_trait() {
+    let mock = mk_mock();
+    let fid = mk_fid();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.cancel_flow = Some(Ok(CancelFlowResult::Cancelled {
+            cancellation_policy: "cancel_all".into(),
+            member_execution_ids: vec![],
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let got = backend
+        .cancel_flow(&fid, CancelFlowPolicy::CancelAll, CancelFlowWait::NoWait)
+        .await
+        .unwrap();
+    assert!(matches!(got, CancelFlowResult::Cancelled { .. }));
+    let g = mock.scripted.lock().unwrap();
+    assert_eq!(g.last_cancel_flow.as_ref().unwrap().0, fid);
+}
+
+#[tokio::test]
+async fn cancel_flow_already_terminal_surfaces_state_error() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.cancel_flow = Some(Err(EngineError::State(StateKind::FlowAlreadyTerminal)));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let err = backend
+        .cancel_flow(&mk_fid(), CancelFlowPolicy::CancelAll, CancelFlowWait::NoWait)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        EngineError::State(StateKind::FlowAlreadyTerminal)
+    ));
+}
+
+// ─── get_execution_result (§4 row 2) ────────────────────────────
+
+#[tokio::test]
+async fn get_execution_result_happy_returns_bytes() {
+    let mock = mk_mock();
+    let eid = mk_eid();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.get_execution_result = Some(Ok(Some(b"payload".to_vec())));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let got = backend.get_execution_result(&eid).await.unwrap();
+    assert_eq!(got.as_deref(), Some(b"payload" as &[u8]));
+    let g = mock.scripted.lock().unwrap();
+    assert_eq!(g.last_get_execution_result.as_ref(), Some(&eid));
+}
+
+#[tokio::test]
+async fn get_execution_result_missing_returns_none() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.get_execution_result = Some(Ok(None));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let got = backend.get_execution_result(&mk_eid()).await.unwrap();
+    assert!(got.is_none());
+}
+
+// ─── list_pending_waitpoints (§4 row 8 / §8) ────────────────────
+
+fn mk_pending_entry(
+    eid: ExecutionId,
+    wp_id: WaitpointId,
+    token_kid: &str,
+    token_fingerprint: &str,
+) -> PendingWaitpointInfo {
+    PendingWaitpointInfo::new(
+        wp_id,
+        "wp-key".into(),
+        "pending".into(),
+        TimestampMs::from_millis(1234),
+        eid,
+        token_kid.to_owned(),
+        token_fingerprint.to_owned(),
+    )
+}
+
+#[tokio::test]
+async fn list_pending_waitpoints_happy_sanitised_fields_present() {
+    let mock = mk_mock();
+    let eid = mk_eid();
+    let wp_id = WaitpointId::new();
+    let entry = mk_pending_entry(eid.clone(), wp_id.clone(), "kid-1", "deadbeefcafef00d");
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.list_pending_waitpoints = Some(Ok(ListPendingWaitpointsResult::new(vec![
+            entry.clone(),
+        ])));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = ListPendingWaitpointsArgs::new(eid.clone());
+    let page = backend.list_pending_waitpoints(args).await.unwrap();
+    assert_eq!(page.entries.len(), 1);
+    let got = &page.entries[0];
+    assert_eq!(got.waitpoint_id, wp_id);
+    assert_eq!(got.execution_id, eid);
+    assert_eq!(got.token_kid, "kid-1");
+    assert_eq!(got.token_fingerprint, "deadbeefcafef00d");
+    assert_eq!(got.token_fingerprint.len(), 16);
+    assert!(page.next_cursor.is_none());
+}
+
+#[tokio::test]
+async fn list_pending_waitpoints_paginates_with_cursor() {
+    let mock = mk_mock();
+    let eid = mk_eid();
+    let wp_id_1 = WaitpointId::new();
+    let wp_id_2 = WaitpointId::new();
+    let first_entry =
+        mk_pending_entry(eid.clone(), wp_id_1.clone(), "kid-1", "aaaaaaaaaaaaaaaa");
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.list_pending_waitpoints =
+            Some(Ok(ListPendingWaitpointsResult::new(vec![first_entry])
+                .with_next_cursor(wp_id_2.clone())));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = ListPendingWaitpointsArgs::new(eid.clone()).with_limit(1);
+    let page = backend.list_pending_waitpoints(args.clone()).await.unwrap();
+    assert_eq!(page.next_cursor.as_ref(), Some(&wp_id_2));
+    let g = mock.scripted.lock().unwrap();
+    assert_eq!(
+        g.last_list_pending_waitpoints.as_ref().unwrap().limit,
+        Some(1)
+    );
+}
+
+#[tokio::test]
+async fn list_pending_waitpoints_not_found_propagates() {
+    let mock = mk_mock();
+    {
+        let mut g = mock.scripted.lock().unwrap();
+        g.list_pending_waitpoints = Some(Err(EngineError::NotFound {
+            entity: "execution",
+        }));
+    }
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let args = ListPendingWaitpointsArgs::new(mk_eid());
+    let err = backend.list_pending_waitpoints(args).await.unwrap_err();
+    assert!(matches!(
+        err,
+        EngineError::NotFound { entity: "execution" }
+    ));
+}
+
+// ─── smoke: trait is dyn-safe on the Stage D1 surface ────────
+
+#[tokio::test]
+async fn stage_d1_trait_is_dyn_compatible() {
+    let _b: Arc<dyn EngineBackend> = mk_mock();
+}

--- a/crates/ff-test/tests/pending_waitpoints_api.rs
+++ b/crates/ff-test/tests/pending_waitpoints_api.rs
@@ -11,13 +11,38 @@
 use std::sync::Arc;
 
 use ferriskey::Value;
-use ff_core::contracts::PendingWaitpointInfo;
 use ff_core::keys::{ExecKeyContext, IndexKeys};
 use ff_core::partition::{execution_partition, PartitionConfig};
 use ff_core::types::*;
 use ff_test::fixtures::TestCluster;
 use reqwest::StatusCode;
+use serde::Deserialize;
 use tokio::task::AbortHandle;
+
+/// RFC-017 Stage D1 (§8) v0.7.x wire DTO — mirrors the
+/// `PendingWaitpointWireV07` serialised by `ff-server::api`. Kept
+/// local to the test so consumer-compatibility assertions are
+/// explicit about what's still on the v0.7 wire.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct PendingWaitpointWireV07 {
+    waitpoint_id: WaitpointId,
+    waitpoint_key: String,
+    state: String,
+    #[serde(default)]
+    required_signal_names: Vec<String>,
+    created_at: TimestampMs,
+    #[serde(default)]
+    activated_at: Option<TimestampMs>,
+    #[serde(default)]
+    expires_at: Option<TimestampMs>,
+    execution_id: ExecutionId,
+    token_kid: String,
+    token_fingerprint: String,
+    /// Legacy v0.7.x — removed at v0.8.0.
+    #[serde(default)]
+    waitpoint_token: Option<String>,
+}
 
 const LANE: &str = "pwp-lane";
 const NS: &str = "pwp-ns";
@@ -352,7 +377,20 @@ async fn test_list_pending_waitpoints_returns_token_after_suspend() {
         .expect("pending-waitpoints request failed");
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let list: Vec<PendingWaitpointInfo> =
+    // RFC-017 Stage D1 (§8): the Deprecation: ff-017 header must be
+    // present while the legacy wire field is still served.
+    let deprecation_hdr = resp
+        .headers()
+        .get("Deprecation")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned());
+    assert_eq!(
+        deprecation_hdr.as_deref(),
+        Some("ff-017"),
+        "v0.7.x responses must carry Deprecation: ff-017"
+    );
+
+    let list: Vec<PendingWaitpointWireV07> =
         resp.json().await.expect("response body parse failed");
 
     assert_eq!(list.len(), 1, "expected exactly one active waitpoint");
@@ -360,13 +398,22 @@ async fn test_list_pending_waitpoints_returns_token_after_suspend() {
     assert_eq!(entry.waitpoint_id, wp_id);
     assert_eq!(entry.waitpoint_key, wp_key);
     assert_eq!(entry.state, "active");
+    let token = entry.waitpoint_token.as_deref().expect(
+        "v0.7.x wire must still carry the legacy waitpoint_token",
+    );
     assert_eq!(
-        entry.waitpoint_token.as_str(),
-        expected_token,
+        token, expected_token,
         "token must match the one returned to the suspending worker"
     );
     assert!(entry.activated_at.is_some());
-    assert!(!entry.waitpoint_token.as_str().is_empty());
+    assert!(!token.is_empty());
+    // Sanitised fields — present on the trait boundary and the wire.
+    assert!(!entry.token_kid.is_empty(), "token_kid must be populated");
+    assert_eq!(
+        entry.token_fingerprint.len(),
+        16,
+        "token_fingerprint is the first 16 hex chars of the digest"
+    );
     // The fcall_suspend helper above passes
     // required_signal_names=["pwp_signal"]; the endpoint should surface
     // that so a reviewer with multiple waitpoints can pick the right
@@ -396,7 +443,7 @@ async fn test_list_pending_waitpoints_empty_for_unsuspended() {
         .expect("pending-waitpoints request failed");
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let list: Vec<PendingWaitpointInfo> =
+    let list: Vec<PendingWaitpointWireV07> =
         resp.json().await.expect("response body parse failed");
     assert!(list.is_empty(), "expected no waitpoints, got {list:?}");
 }

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -23,6 +23,22 @@ some on Stage-E) with `FF_BACKEND=postgres` are unsupported. Operators
 must complete a valkey→valkey Stage D→E rolling upgrade first and flip
 `FF_BACKEND=postgres` as a second rollout.
 
+**Stage D split (owner-adjudicated 2026-04-24).** Stage D scope from
+RFC-017 §9 was split into two PRs to keep reviewer cognitive load
+bounded:
+
+- **D1** (this row of flips) — §8 `PendingWaitpointInfo` schema
+  rewrite, Valkey `list_pending_waitpoints` impl, 8 HTTP handler
+  migrations, `Server::start_with_backend` entry point,
+  `FF_BACKEND` env + §9.0 hard-gate wiring at stage `"D"`,
+  deprecation audit log (`Deprecation: ff-017` header +
+  `ff_pending_waitpoint_legacy_token_served_total`).
+- **D2** (follow-up PR, required before v0.7 tag) — boot relocation
+  into `ValkeyBackend::connect_with_metrics` (§4 row 12),
+  `Server::client: Client` field removal (cascades to remaining
+  handlers still using `fcall_with_reload`), `http_postgres_smoke.rs`
+  integration test, Stage-B feature flag removal.
+
 ---
 
 ## RFC-017 Stage A trait surface (51 methods total)
@@ -55,7 +71,7 @@ both when the `streaming` feature is enabled, `n/a` otherwise.
 | 13 | `get_budget_status` | `impl` | `stub` | **Landed Stage C.** Valkey body is 3× HGETALL (definition + usage + limits) + field-level parse, no FCALL. Missing budget surfaces as `EngineError::NotFound { entity: "budget" }` with contextual wrapper carrying the budget id. |
 | 14 | `report_usage_admin` | `impl` | `stub` | Valkey wraps `ff_report_usage_and_check` without worker handle. |
 | 15 | `get_execution_result` | `impl` | `stub` | Valkey direct `GET` of `ctx.result()`, binary-safe. |
-| 16 | `list_pending_waitpoints` | `stub` | `stub` | §8 schema rewrite (HMAC redaction + `token_kid`/`token_fingerprint`) is Stage D's explicit scope. Stage A lands the trait signature only. |
+| 16 | `list_pending_waitpoints` | `impl` | `stub` | **Landed Stage D1.** Pipelined SSCAN + 2× HMGET + §8 schema rewrite (HMAC redaction + `token_kid`/`token_fingerprint`) + `after`/`limit` pagination. HTTP handler wraps with the v0.7.x `Deprecation: ff-017` header and the raw `waitpoint_token` (fetched via the Valkey-only inherent `Server::fetch_waitpoint_token_v07`) for one-release deprecation warning. Postgres impl lands in Stage D2 (full parity gate). |
 | 17 | `ping` | `impl` | `impl` | Valkey: `PING`. Postgres: `SELECT 1`. |
 | 18 | `claim_for_worker` | `impl` | `stub` | **Landed Stage C.** `ff-backend-valkey` added `ff-scheduler` dep; `ValkeyBackend` holds `Option<Arc<ff_scheduler::Scheduler>>` wired at `ff-server` boot via `ValkeyBackend::with_scheduler` before the `Arc<dyn EngineBackend>` is sealed. Trait impl forwards to `Scheduler::claim_for_worker`; `SchedulerError::Config` maps to `EngineError::Validation`, Valkey transport errors via `transport_fk`. Backends without a wired scheduler (e.g. SDK-side `MockBackend`) surface `EngineError::Unavailable { op: "claim_for_worker (scheduler not wired on this ValkeyBackend)" }`. |
 
@@ -113,11 +129,27 @@ sequence anticipated.
   via the freshly minted `From<EngineError> for ApiError` bridge.
   The Engine `IntoResponse` arm gained `Conflict` / `Contention` /
   `State` kinds mapping to HTTP 409 per RFC-010 §10.7.
-- **Stage D:** ingress + `list_pending_waitpoints` §8 schema rewrite
-  + Postgres HTTP cutover. **CI gate:**
+- **Stage D1 (this PR, `impl/017-stage-d1`):** §8 schema rewrite +
+  Valkey `list_pending_waitpoints` impl + 8 HTTP handlers migrated
+  to trait dispatch (`create_execution`, `create_flow`,
+  `add_execution_to_flow`, `stage_dependency_edge`,
+  `apply_dependency_to_child`, `get_execution_result`,
+  `list_pending_waitpoints`, + header-only migration of
+  `cancel_flow` — the async member dispatcher remains on `Server`
+  pending D2). `Server::start_with_backend` entry point added;
+  `FF_BACKEND` env + §9.0 hard-gate wired at stage `"D"` with the
+  dev-mode override and `ff_backend_unready_boot_total{backend,stage}`
+  metric. Deprecation audit log: `Deprecation: ff-017` response
+  header + `ff_pending_waitpoint_legacy_token_served_total` counter
+  + per-entry `pending_waitpoint_legacy_token_served` tracing event.
+- **Stage D2 (follow-up, required before v0.7 tag):** boot
+  relocation into `ValkeyBackend::connect_with_metrics` (§4 row 12),
+  `Server::client: Client` field removal + cascading handler
+  cutover, `http_postgres_smoke.rs` integration test, Stage-B
+  feature flag removal (if present). **CI gate:**
   `test_postgres_parity_no_unavailable` asserts no Postgres
   `Unavailable` on any HTTP-exposed method. Every `stub` in the
-  Postgres column above must be `impl` before Stage D merges.
+  Postgres column above must be `impl` before Stage D2 merges.
 - **Stage E (v0.8.0):** `BACKEND_STAGE_READY` updated to
   `&["valkey", "postgres"]`; `FF_BACKEND=postgres` boots successfully
   for the first time.


### PR DESCRIPTION
## Summary

RFC-017 Stage D1 — owner-adjudicated split of Stage D (2026-04-24). D1
ships the **consumer-visible Postgres-HTTP-readiness**: §8 schema
rewrite, Valkey `list_pending_waitpoints` impl, 8 HTTP handler
migrations, `Server::start_with_backend`, `FF_BACKEND` env + §9.0
hard-gate wiring, deprecation audit log.

**D2 (follow-up PR, required before v0.7 tag) — explicitly deferred:**
- Boot relocation into `ValkeyBackend::connect_with_metrics` (§4 row 12)
- `Server::client: Client` field removal (cascades to remaining `fcall_with_reload` handlers)
- `crates/ff-server/tests/http_postgres_smoke.rs` integration test
- Stage-B `backend-abstraction` feature flag removal

## Scope (WI-1..WI-7)

### §8 schema (ff-core)
- `PendingWaitpointInfo` rewrite: 6 fields KEPT (`waitpoint_id`, `waitpoint_key`, `state`, `required_signal_names`, `created_at`, `activated_at`, `expires_at`) + 3 fields ADDED (`execution_id`, `token_kid`, `token_fingerprint`) + `waitpoint_token` DROPPED from the trait boundary.
- `#[non_exhaustive]` + `new()` with 7 required fields + 3 fluent setters.

### Valkey `list_pending_waitpoints` impl
- Pipelined SSCAN (`COUNT 100`) + pipelined 2× HMGET per waitpoint + HGET `total_matchers` + pass-2 HMGET for matcher names.
- Stored `<kid>:<40hex>` token parsed into `(token_kid, first-16-hex fingerprint)` via new `parse_waitpoint_token_kid_fp`.
- Default limit 100, cap 1000, `after` cursor + `next_cursor` pagination.
- Matrix row 16 flipped `stub` → `impl`.

### 8 handler migrations (`ff-server::api`)
Migrated to `server.backend().<method>(...)`:
- `POST /v1/flows` → `create_flow`
- `POST /v1/flows/{id}/members` → `add_execution_to_flow`
- `POST /v1/flows/{id}/edges` → `stage_dependency_edge`
- `POST /v1/flows/{id}/edges/apply` → `apply_dependency_to_child`
- `POST /v1/executions` → `create_execution`
- `GET /v1/executions/{id}/pending-waitpoints` → `list_pending_waitpoints` (+ v0.7 wire-wrap)
- `GET /v1/executions/{id}/result` → `get_execution_result`
- `POST /v1/flows/{id}/cancel` — header-only path documented; async member dispatcher remains on `Server::cancel_flow_inner` until D2 relocates it (the trait's `cancel_flow(id, policy, wait)` drops `reason` and rejects non-`NoWait` variants, so the sync `?wait=true` and reason-preserving path stay inherent).

Byte-identical HTTP responses except `/pending-waitpoints` (new `Deprecation: ff-017` header + wire wrap).

### `Server::start_with_backend` + FF_BACKEND
- Entry point already existed (Stage A); stage label updated to `"D"` in `BackendNotReady`.
- `ServerConfig::from_env` reads `FF_BACKEND` (default `valkey`; unknown rejected eagerly).
- `main.rs` exits with code 2 on `BackendNotReady` (was code 1).
- Dev-mode override via `FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development` now emits the `backend_unready_boot_override` WARN + new `ff_backend_unready_boot_total{backend,stage}` counter increment.

### Deprecation audit log
- New counter `ff_pending_waitpoint_legacy_token_served_total` (no labels), incremented per entry.
- `Deprecation: ff-017` response header on every `/pending-waitpoints` reply.
- Per-entry `pending_waitpoint_legacy_token_served` tracing event (target: `audit`).
- Raw token fetched via new Valkey-only inherent `Server::fetch_waitpoint_token_v07` + `ValkeyBackend::fetch_waitpoint_token_v07` (HGET of stored `<kid>:<hex>`). Non-Valkey backends (hard-gated) emit `waitpoint_token: null` + a warn log.

### Incidental bug fix
`ff_script::functions::flow::ff_add_execution_to_flow` helper was passing KEYS(3) while Lua expects KEYS(4) including `exec_core`. Introduced `AddExecutionToFlowKeys` carrying `exec_ctx`; `ValkeyBackend::add_execution_to_flow` now pre-validates flow/exec partition co-location and passes all 4 KEYS. Latent bug dormant pre-D1 because the old inherent `Server::add_execution_to_flow` built KEYS locally.

## Matrix diff

```
| 16 | list_pending_waitpoints | stub | stub |  →  | impl | stub |
```
Plus preamble + stage-boundary notes describing the D1/D2 split.

## Parity tests

New `crates/ff-server/tests/parity_stage_d1.rs` — 18 tests (at least 1 happy + 1 error per migrated method + cursor-pagination + dyn-safety smoke). Existing `ff-test::pending_waitpoints_api.rs` updated to the new wire DTO and asserts the `Deprecation: ff-017` header + `token_fingerprint` shape (16 hex chars).

**Lines per crate:**
- ff-backend-valkey: +374 / −1
- ff-core: +80 / −10
- ff-observability: +60 / 0
- ff-script: +15 / −1
- ff-server: +120 / −53 (api) + +344 / −344 (server net ~0; list_pending_waitpoints inherent removed, fetch_waitpoint_token_v07 added)
- ff-test: +46 / −13
- docs: +27 / −3
- new test file: +960

## Behavior deltas

- **Trait boundary:** raw `waitpoint_token` no longer exposed across `Arc<dyn EngineBackend>` — backends receive `(token_kid, token_fingerprint)`.
- **HTTP wire:** v0.7.x still carries `waitpoint_token` (under `Deprecation: ff-017`); field removed entirely at v0.8.0 per §8.
- **BackendNotReady exit code:** 2 (was 1).
- **`cancel_flow` behavior:** unchanged (still inherent until D2 moves dispatcher).
- **`add_execution_to_flow`:** now surfaces partition mismatch as typed `EngineError::Validation` earlier (was raw CROSSSLOT on cluster).

## D2 follow-ups

| Item | 1-line scope |
|---|---|
| Boot relocation | Move `verify_valkey_version` / `ensure_library` / `initialize_waitpoint_hmac_secret` / lanes SADD into `ValkeyBackend::connect_with_metrics` (§4 row 12) |
| `Server::client` removal | Delete field + accessor; cascade to the remaining `fcall_with_reload` handlers still using `self.client` |
| `http_postgres_smoke.rs` | End-to-end create→add→stage→apply→cancel smoke against a live Postgres fixture (Stage D `test_postgres_parity_no_unavailable` gate) |
| Stage-B feature flag | Remove `ff-server/backend-abstraction` (or confirm it doesn't exist in current tree) |

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings` — green
- [x] `cargo test --lib` (ff-core / ff-script / ff-backend-valkey / ff-server) — 311 passed
- [x] `cargo test -p ff-server --test parity_stage_{a,a_backfill,b,c,d1}` — 75 passed (18 new)
- [x] `cargo test -p ff-test -- --test-threads=1` with live Valkey — all green
- [ ] CI matrix + sec/quality green before admin-merge (cargo-semver-checks allowed-red per inherited v0.8 breaks; 2-minute max wait per admin-merge protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `pending-waitpoints` API contract and token handling (redacts raw HMAC at the trait boundary, adds pagination, and re-injects legacy token on the HTTP wire), plus migrates several core HTTP handlers to trait dispatch; regressions could affect operational review flows and flow membership mutations.
> 
> **Overview**
> Implements RFC-017 **Stage D1** by moving more of `ff-server`’s HTTP surface to `EngineBackend` trait dispatch (notably `create_execution`, multiple flow ingress endpoints, `get_execution_result`, and `list_pending_waitpoints`).
> 
> Rewrites `PendingWaitpointInfo` to **drop the raw `waitpoint_token`** at the trait boundary and instead return `execution_id`, `token_kid`, and `token_fingerprint`, with a new Valkey `list_pending_waitpoints` implementation that adds **cursor pagination** (`after`/`limit` + `next_cursor`).
> 
> Preserves v0.7.x compatibility for `GET /v1/executions/{id}/pending-waitpoints` by wrapping responses in a wire DTO that **re-injects the legacy `waitpoint_token`** via a Valkey-only fetch shim, adds a `Deprecation: ff-017` header, and emits new audit metrics/log events.
> 
> Fixes `ff_add_execution_to_flow` key wiring by adding `exec_core` to KEYS and adds an upfront partition co-location validation to return a typed `EngineError::Validation` instead of a Valkey CROSSSLOT. Also adds `FF_BACKEND` selection + a dev-only unready override metric, and updates boot failure exit codes to distinguish hard-gate refusals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950d5ac04370c23bfd52c59ae8cbb55883dea84b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->