### PR TITLE
impl(017): Wave 8 Stage E2 — Server::client field removal + full cancel_flow trait migration

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -5678,6 +5678,329 @@ impl EngineBackend for ValkeyBackend {
             None => ff_core::contracts::ClaimForWorkerOutcome::no_work(),
         })
     }
+
+    // ── RFC-017 Stage E2 — `Server::client` removal (header + reads) ───
+
+    async fn cancel_flow_header(
+        &self,
+        args: CancelFlowArgs,
+    ) -> Result<ff_core::contracts::CancelFlowHeader, EngineError> {
+        use ff_core::contracts::CancelFlowHeader;
+
+        let partition = flow_partition(&args.flow_id, &self.partition_config);
+        let fctx = FlowKeyContext::new(&partition, &args.flow_id);
+        let fidx = FlowIndexKeys::new(&partition);
+
+        // Grace window matches the Server's pre-E2 constant.
+        const CANCEL_RECONCILER_GRACE_MS: u64 = 30_000;
+
+        let fcall_keys: Vec<String> = vec![
+            fctx.core(),
+            fctx.members(),
+            fidx.flow_index(),
+            fctx.pending_cancels(),
+            fidx.cancel_backlog(),
+        ];
+        let fcall_args: Vec<String> = vec![
+            args.flow_id.to_string(),
+            args.reason.clone(),
+            args.cancellation_policy.clone(),
+            args.now.to_string(),
+            CANCEL_RECONCILER_GRACE_MS.to_string(),
+        ];
+        let key_refs: Vec<&str> = fcall_keys.iter().map(|s| s.as_str()).collect();
+        let arg_refs: Vec<&str> = fcall_args.iter().map(|s| s.as_str()).collect();
+
+        // FCALL with auto Lua-library reload on failover (previously in
+        // `ff-server::fcall_with_reload_on_client`).
+        let raw: ferriskey::Value = match self
+            .client
+            .fcall("ff_cancel_flow", &key_refs, &arg_refs)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) if is_function_not_loaded_fk(&e) => {
+                tracing::warn!(
+                    function = "ff_cancel_flow",
+                    "Lua library not found on server, reloading"
+                );
+                ff_script::loader::ensure_library(&self.client)
+                    .await
+                    .map_err(|le| EngineError::Transport {
+                        backend: "valkey",
+                        source: Box::new(le),
+                    })?;
+                self.client
+                    .fcall("ff_cancel_flow", &key_refs, &arg_refs)
+                    .await
+                    .map_err(|e| ff_core::engine_error::backend_context(
+                        transport_fk(e),
+                        "cancel_flow_header: FCALL ff_cancel_flow (post reload)",
+                    ))?
+            }
+            Err(e) => {
+                return Err(ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    "cancel_flow_header: FCALL ff_cancel_flow",
+                ));
+            }
+        };
+
+        // Parse the raw response. Shape:
+        //   {1, "OK", cancellation_policy, member1, member2, ...}  — success
+        //   {0, "flow_already_terminal", ...}                      — idempotent retry
+        let arr = match &raw {
+            ferriskey::Value::Array(arr) => arr,
+            _ => {
+                return Err(EngineError::Validation {
+                    kind: ValidationKind::InvalidInput,
+                    detail: "ff_cancel_flow: expected Array".into(),
+                });
+            }
+        };
+        let status = match arr.first() {
+            Some(Ok(ferriskey::Value::Int(n))) => *n,
+            _ => {
+                return Err(EngineError::Validation {
+                    kind: ValidationKind::InvalidInput,
+                    detail: "ff_cancel_flow: bad status code".into(),
+                });
+            }
+        };
+        fn field_str(arr: &[Result<ferriskey::Value, ferriskey::Error>], index: usize) -> String {
+            match arr.get(index) {
+                Some(Ok(ferriskey::Value::BulkString(b))) => {
+                    String::from_utf8_lossy(b).into_owned()
+                }
+                Some(Ok(ferriskey::Value::SimpleString(s))) => s.clone(),
+                Some(Ok(ferriskey::Value::Int(n))) => n.to_string(),
+                _ => String::new(),
+            }
+        }
+        if status != 1 {
+            let error_code = field_str(arr, 1);
+            if error_code != "flow_already_terminal" {
+                return Err(EngineError::Validation {
+                    kind: ValidationKind::InvalidInput,
+                    detail: format!("ff_cancel_flow failed: {error_code}"),
+                });
+            }
+            // Idempotent retry path: flow was already cancelled/completed/failed.
+            // Fetch stored policy/reason (HMGET on flow_core) + full membership
+            // (SMEMBERS on members_set) so the Server can return an
+            // idempotent `Cancelled` with the historical policy.
+            let flow_meta: Vec<Option<String>> = self
+                .client
+                .cmd("HMGET")
+                .arg(fctx.core())
+                .arg("cancellation_policy")
+                .arg("cancel_reason")
+                .execute()
+                .await
+                .map_err(|e| ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    "cancel_flow_header (AlreadyTerminal): HMGET flow_core cancellation_policy,cancel_reason",
+                ))?;
+            let stored_cancellation_policy = flow_meta
+                .first()
+                .and_then(|v| v.as_ref())
+                .filter(|s| !s.is_empty())
+                .cloned();
+            let stored_cancel_reason = flow_meta
+                .get(1)
+                .and_then(|v| v.as_ref())
+                .filter(|s| !s.is_empty())
+                .cloned();
+            let members: Vec<String> = self
+                .client
+                .cmd("SMEMBERS")
+                .arg(fctx.members())
+                .execute()
+                .await
+                .map_err(|e| ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    "cancel_flow_header (AlreadyTerminal): SMEMBERS flow members",
+                ))?;
+            return Ok(CancelFlowHeader::AlreadyTerminal {
+                stored_cancellation_policy,
+                stored_cancel_reason,
+                member_execution_ids: members,
+            });
+        }
+
+        // Success path: {1, "OK", cancellation_policy, member1, ...}.
+        let policy = field_str(arr, 2);
+        let mut members = Vec::with_capacity(arr.len().saturating_sub(3));
+        for i in 3..arr.len() {
+            members.push(field_str(arr, i));
+        }
+        Ok(CancelFlowHeader::Cancelled {
+            cancellation_policy: policy,
+            member_execution_ids: members,
+        })
+    }
+
+    async fn ack_cancel_member(
+        &self,
+        flow_id: &FlowId,
+        execution_id: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        let partition = flow_partition(flow_id, &self.partition_config);
+        let fctx = FlowKeyContext::new(&partition, flow_id);
+        let fidx = FlowIndexKeys::new(&partition);
+        let pending = fctx.pending_cancels();
+        let backlog = fidx.cancel_backlog();
+        let flow_id_str = flow_id.to_string();
+        let eid_str = execution_id.to_string();
+        let keys = [pending.as_str(), backlog.as_str()];
+        let args_v = [eid_str.as_str(), flow_id_str.as_str()];
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_ack_cancel_member", &keys, &args_v)
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "ack_cancel_member: FCALL ff_ack_cancel_member",
+            ))?;
+        Ok(())
+    }
+
+    async fn read_execution_info(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<ff_core::contracts::ExecutionInfo>, EngineError> {
+        use ff_core::contracts::ExecutionInfo;
+        use ff_core::state::StateVector;
+        use std::collections::HashMap;
+
+        let partition = execution_partition(id, &self.partition_config);
+        let ctx = ExecKeyContext::new(&partition, id);
+        let fields: HashMap<String, String> = self
+            .client
+            .hgetall(&ctx.core())
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "read_execution_info: HGETALL exec_core",
+            ))?;
+        if fields.is_empty() {
+            return Ok(None);
+        }
+        let parse_enum = |field: &str| -> String {
+            fields.get(field).cloned().unwrap_or_default()
+        };
+        fn deserialize<T: serde::de::DeserializeOwned>(
+            field: &str,
+            raw: &str,
+        ) -> Result<T, EngineError> {
+            let quoted = format!("\"{raw}\"");
+            serde_json::from_str(&quoted).map_err(|e| EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!("invalid {field} '{raw}': {e}"),
+            })
+        }
+        let lp_str = parse_enum("lifecycle_phase");
+        let os_str = parse_enum("ownership_state");
+        let es_str = parse_enum("eligibility_state");
+        let br_str = parse_enum("blocking_reason");
+        let to_str = parse_enum("terminal_outcome");
+        let as_str = parse_enum("attempt_state");
+        let ps_str = parse_enum("public_state");
+        let state_vector = StateVector {
+            lifecycle_phase: deserialize("lifecycle_phase", &lp_str)?,
+            ownership_state: deserialize("ownership_state", &os_str)?,
+            eligibility_state: deserialize("eligibility_state", &es_str)?,
+            blocking_reason: deserialize("blocking_reason", &br_str)?,
+            terminal_outcome: deserialize("terminal_outcome", &to_str)?,
+            attempt_state: deserialize("attempt_state", &as_str)?,
+            public_state: deserialize("public_state", &ps_str)?,
+        };
+        let flow_id_val = fields.get("flow_id").filter(|s| !s.is_empty()).cloned();
+        let started_at_opt = fields.get("started_at").filter(|s| !s.is_empty()).cloned();
+        let completed_at_opt = fields.get("completed_at").filter(|s| !s.is_empty()).cloned();
+        Ok(Some(ExecutionInfo {
+            execution_id: id.clone(),
+            namespace: parse_enum("namespace"),
+            lane_id: parse_enum("lane_id"),
+            priority: fields.get("priority").and_then(|v| v.parse().ok()).unwrap_or(0),
+            execution_kind: parse_enum("execution_kind"),
+            state_vector,
+            public_state: deserialize("public_state", &ps_str)?,
+            created_at: parse_enum("created_at"),
+            started_at: started_at_opt,
+            completed_at: completed_at_opt,
+            current_attempt_index: fields
+                .get("current_attempt_index")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0),
+            flow_id: flow_id_val,
+            blocking_detail: parse_enum("blocking_detail"),
+        }))
+    }
+
+    async fn read_execution_state(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<ff_core::state::PublicState>, EngineError> {
+        let partition = execution_partition(id, &self.partition_config);
+        let ctx = ExecKeyContext::new(&partition, id);
+        let state_str: Option<String> = self
+            .client
+            .hget(&ctx.core(), "public_state")
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "read_execution_state: HGET public_state",
+            ))?;
+        match state_str {
+            Some(s) => {
+                let quoted = format!("\"{s}\"");
+                let parsed: ff_core::state::PublicState = serde_json::from_str(&quoted)
+                    .map_err(|e| EngineError::Validation {
+                        kind: ValidationKind::InvalidInput,
+                        detail: format!("invalid public_state '{s}': {e}"),
+                    })?;
+                Ok(Some(parsed))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn fetch_waitpoint_token_v07(
+        &self,
+        execution_id: &ExecutionId,
+        waitpoint_id: &WaitpointId,
+    ) -> Result<Option<String>, EngineError> {
+        let partition = execution_partition(execution_id, &self.partition_config);
+        let ctx = ExecKeyContext::new(&partition, execution_id);
+        let token: Option<String> = self
+            .client
+            .hget(&ctx.waitpoint(waitpoint_id), "waitpoint_token")
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "fetch_waitpoint_token_v07: HGET waitpoint_token",
+            ))?;
+        Ok(token.filter(|s| !s.is_empty()))
+    }
+}
+
+/// Detect Valkey errors indicating the Lua function library is not
+/// loaded (post-failover cold replica, etc.). Relocated from
+/// `ff-server::server::is_function_not_loaded` in Stage E2 alongside
+/// `cancel_flow_header`'s FCALL-with-reload wrapper.
+fn is_function_not_loaded_fk(e: &ferriskey::Error) -> bool {
+    if matches!(e.kind(), ferriskey::ErrorKind::NoScriptError) {
+        return true;
+    }
+    e.detail()
+        .map(|d| {
+            d.contains("Function not loaded")
+                || d.contains("No matching function")
+                || d.contains("function not found")
+        })
+        .unwrap_or(false)
+        || e.to_string().contains("Function not loaded")
 }
 
 // ── Stream read implementations (RFC-012 Stage 1c tranche-4; #87) ──

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -1660,8 +1660,9 @@ pub enum CancelFlowResult {
 }
 
 /// RFC-017 Stage E2: result of the "header" portion of a cancel_flow
-/// operation — the atomic flow-state flip + member enumeration. The
-/// Server composes this with its own wait/async member-dispatch
+/// operation — the atomic flow-state flip + member enumeration.
+///
+/// The Server composes this with its own wait/async member-dispatch
 /// machinery to build the wire-level [`CancelFlowResult`]. Backends
 /// implement [`crate::engine_backend::EngineBackend::cancel_flow_header`]
 /// (default: `Unavailable`) so the Valkey-native `ff_cancel_flow`
@@ -1678,8 +1679,8 @@ pub enum CancelFlowHeader {
         member_execution_ids: Vec<String>,
     },
     /// Flow was already in a terminal state on entry. The backend has
-    /// surfaced the *stored* `cancellation_policy` + `cancel_reason`
-    /// + full membership so the Server can return an idempotent
+    /// surfaced the *stored* `cancellation_policy`, `cancel_reason`,
+    /// and full membership so the Server can return an idempotent
     /// [`CancelFlowResult::Cancelled`] without re-doing the flip.
     AlreadyTerminal {
         /// `None` only for flows cancelled by pre-E2 Lua that never

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -1659,6 +1659,40 @@ pub enum CancelFlowResult {
     },
 }
 
+/// RFC-017 Stage E2: result of the "header" portion of a cancel_flow
+/// operation — the atomic flow-state flip + member enumeration. The
+/// Server composes this with its own wait/async member-dispatch
+/// machinery to build the wire-level [`CancelFlowResult`]. Backends
+/// implement [`crate::engine_backend::EngineBackend::cancel_flow_header`]
+/// (default: `Unavailable`) so the Valkey-native `ff_cancel_flow`
+/// FCALL (with its `flow_already_terminal` idempotency branch) can be
+/// driven through the trait without re-shaping the existing public
+/// `cancel_flow(id, policy, wait)` signature.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CancelFlowHeader {
+    /// Flow-state flipped this call. `member_execution_ids` is the
+    /// full (uncapped) membership at flip time.
+    Cancelled {
+        cancellation_policy: String,
+        member_execution_ids: Vec<String>,
+    },
+    /// Flow was already in a terminal state on entry. The backend has
+    /// surfaced the *stored* `cancellation_policy` + `cancel_reason`
+    /// + full membership so the Server can return an idempotent
+    /// [`CancelFlowResult::Cancelled`] without re-doing the flip.
+    AlreadyTerminal {
+        /// `None` only for flows cancelled by pre-E2 Lua that never
+        /// persisted the policy field.
+        stored_cancellation_policy: Option<String>,
+        /// `None` when the flow was never cancel-reason-stamped.
+        stored_cancel_reason: Option<String>,
+        /// Full membership. Server caps to
+        /// `ALREADY_TERMINAL_MEMBER_CAP` before wiring.
+        member_execution_ids: Vec<String>,
+    },
+}
+
 // ─── stage_dependency_edge ───
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -61,16 +61,18 @@ use crate::contracts::{
 use crate::contracts::{
     AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
     ApplyDependencyToChildResult, BudgetStatus, CancelExecutionArgs, CancelExecutionResult,
-    ChangePriorityArgs, ChangePriorityResult, ClaimForWorkerArgs, ClaimForWorkerOutcome,
-    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, CreateBudgetArgs, CreateBudgetResult,
-    CreateExecutionArgs, CreateExecutionResult, CreateFlowArgs, CreateFlowResult,
-    CreateQuotaPolicyArgs, CreateQuotaPolicyResult, DeliverSignalArgs, DeliverSignalResult,
-    EdgeDirection, EdgeSnapshot, ListExecutionsPage, ListFlowsPage, ListLanesPage,
-    ListPendingWaitpointsArgs, ListPendingWaitpointsResult, ListSuspendedPage,
-    ReplayExecutionArgs, ReplayExecutionResult, ReportUsageAdminArgs, ResetBudgetArgs,
-    ResetBudgetResult, RevokeLeaseArgs, RevokeLeaseResult, StageDependencyEdgeArgs,
-    StageDependencyEdgeResult,
+    CancelFlowArgs, ChangePriorityArgs, ChangePriorityResult, ClaimForWorkerArgs,
+    ClaimForWorkerOutcome, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
+    CreateBudgetArgs, CreateBudgetResult, CreateExecutionArgs, CreateExecutionResult,
+    CreateFlowArgs, CreateFlowResult, CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
+    DeliverSignalArgs, DeliverSignalResult, EdgeDirection, EdgeSnapshot, ExecutionInfo,
+    ListExecutionsPage, ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs,
+    ListPendingWaitpointsResult, ListSuspendedPage, ReplayExecutionArgs, ReplayExecutionResult,
+    ReportUsageAdminArgs, ResetBudgetArgs, ResetBudgetResult, RevokeLeaseArgs, RevokeLeaseResult,
+    StageDependencyEdgeArgs, StageDependencyEdgeResult,
 };
+#[cfg(feature = "core")]
+use crate::state::PublicState;
 #[cfg(feature = "core")]
 use crate::partition::PartitionKey;
 #[cfg(feature = "streaming")]
@@ -80,7 +82,7 @@ use crate::engine_error::EngineError;
 use crate::types::AttemptIndex;
 #[cfg(feature = "core")]
 use crate::types::EdgeId;
-use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
+use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs, WaitpointId};
 
 /// The engine write surface — a single trait a backend implementation
 /// honours to serve a `FlowFabricWorker`.
@@ -906,6 +908,104 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// override with a real body.
     async fn shutdown_prepare(&self, _grace: Duration) -> Result<(), EngineError> {
         Ok(())
+    }
+
+    // ── RFC-017 Stage E2 — `Server::client` removal (header + reads) ───
+
+    /// RFC-017 Stage E2: the "header" portion of `cancel_flow` — run the
+    /// atomic flow-state flip (Valkey: `ff_cancel_flow` FCALL; Postgres:
+    /// `cancel_flow_once` tx), decode policy + membership, and surface
+    /// the `flow_already_terminal` idempotency branch as a first-class
+    /// [`CancelFlowHeader::AlreadyTerminal`] so the Server can build
+    /// the wire [`CancelFlowResult`] without reaching for a raw
+    /// `Client`. Separate from the existing
+    /// [`EngineBackend::cancel_flow`] entry point (which takes the
+    /// enum-typed `(policy, wait)` split and returns the wait-collapsed
+    /// `CancelFlowResult`) because the Server owns its own
+    /// wait-dispatch + member-cancel machinery via
+    /// [`EngineBackend::cancel_execution`] + backlog ack.
+    ///
+    /// Default impl returns [`EngineError::Unavailable`] so un-migrated
+    /// backends surface the miss loudly.
+    #[cfg(feature = "core")]
+    async fn cancel_flow_header(
+        &self,
+        _args: CancelFlowArgs,
+    ) -> Result<crate::contracts::CancelFlowHeader, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "cancel_flow_header",
+        })
+    }
+
+    /// RFC-017 Stage E2: best-effort acknowledgement that one member of
+    /// a `cancel_all` flow has completed its per-member cancel. Drains
+    /// the member from the flow's `pending_cancels` set and, if empty,
+    /// removes the flow from the partition-level `cancel_backlog`
+    /// (Valkey: `ff_ack_cancel_member` FCALL; Postgres: table write —
+    /// default `Unavailable` until Wave 9).
+    ///
+    /// Failures are swallowed by the caller — the cancel-backlog
+    /// reconciler is the authoritative drain — but a typed error here
+    /// lets the caller log a backend-scoped context string.
+    #[cfg(feature = "core")]
+    async fn ack_cancel_member(
+        &self,
+        _flow_id: &FlowId,
+        _execution_id: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "ack_cancel_member",
+        })
+    }
+
+    /// RFC-017 Stage E2: full-shape execution read used by the
+    /// `GET /v1/executions/{id}` HTTP route. Returns the legacy
+    /// [`ExecutionInfo`] wire shape (not the decoupled
+    /// [`ExecutionSnapshot`]) so the existing HTTP response bytes stay
+    /// identical across the migration.
+    ///
+    /// `Ok(None)` ⇒ no such execution. Default `Unavailable` because
+    /// the Valkey HGETALL-and-parse is backend-specific.
+    #[cfg(feature = "core")]
+    async fn read_execution_info(
+        &self,
+        _id: &ExecutionId,
+    ) -> Result<Option<ExecutionInfo>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "read_execution_info",
+        })
+    }
+
+    /// RFC-017 Stage E2: narrow `public_state` read used by the
+    /// `GET /v1/executions/{id}/state` HTTP route. Returns `Ok(None)`
+    /// when the execution is missing. Default `Unavailable`.
+    #[cfg(feature = "core")]
+    async fn read_execution_state(
+        &self,
+        _id: &ExecutionId,
+    ) -> Result<Option<PublicState>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "read_execution_state",
+        })
+    }
+
+    /// RFC-017 Stage D1 / E2: fetch the raw `<kid>:<hex>` waitpoint
+    /// token so the v0.7.x wire-format shim in
+    /// `api::list_pending_waitpoints` can re-inject the legacy
+    /// `waitpoint_token` field during the one-release deprecation
+    /// window. Returns `Ok(None)` when the field is absent/empty.
+    /// Valkey-only; Postgres default is `Unavailable`. At v0.8.0 the
+    /// legacy wire field is removed and both this method + caller
+    /// shim go with it.
+    #[cfg(feature = "core")]
+    async fn fetch_waitpoint_token_v07(
+        &self,
+        _execution_id: &ExecutionId,
+        _waitpoint_id: &WaitpointId,
+    ) -> Result<Option<String>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "fetch_waitpoint_token_v07",
+        })
     }
 }
 

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ferriskey::{Client, ClientBuilder, Value};
+use ferriskey::ClientBuilder;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinSet;
 use ff_core::engine_backend::EngineBackend;
@@ -19,9 +18,8 @@ use ff_core::contracts::{
     RevokeLeaseResult,
     StageDependencyEdgeArgs, StageDependencyEdgeResult,
 };
-use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext};
 use ff_core::partition::{execution_partition, flow_partition, PartitionConfig};
-use ff_core::state::{PublicState, StateVector};
+use ff_core::state::PublicState;
 use ff_core::types::*;
 use ff_engine::Engine;
 use ff_script::retry::is_retryable_kind;
@@ -45,7 +43,6 @@ const ALREADY_TERMINAL_MEMBER_CAP: usize = 1000;
 /// Manages the Valkey connection, Lua library loading, background scanners,
 /// and provides a minimal API for Phase 1.
 pub struct Server {
-    client: Client,
     /// Server-wide Semaphore(1) gating admin rotate calls. Legitimate
     /// operators rotate ~monthly and can afford to serialize; concurrent
     /// rotate requests are an attack or misbehaving script. Holding the
@@ -345,9 +342,7 @@ impl Server {
         // `BACKEND_STAGE_READY` to include "postgres"; until then the
         // dev-mode override above is the only way in. On the Postgres
         // path we skip the Valkey-specific engine/scanner + scheduler
-        // construction entirely (E2/E3 wire the Postgres twins); the
-        // Server still holds a `Client` for unmigrated legacy read
-        // paths (retired in Stage E2).
+        // construction entirely (E3 wires the scheduler twin).
         if matches!(config.backend, BackendKind::Postgres) {
             return Self::start_postgres_branch(config, metrics).await;
         }
@@ -570,7 +565,6 @@ impl Server {
         let backend: Arc<dyn EngineBackend> = valkey_backend as Arc<dyn EngineBackend>;
 
         Ok(Self {
-            client,
             // Single-permit semaphore: only one rotate-waitpoint-secret can
             // be mid-flight server-wide. Attackers or misbehaving scripts
             // firing parallel rotations fail fast with 429 instead of
@@ -585,33 +579,26 @@ impl Server {
         })
     }
 
-    /// RFC-017 Wave 8 Stage E1: Postgres boot branch for
+    /// RFC-017 Wave 8 Stage E1/E2: Postgres boot branch for
     /// [`Server::start_with_metrics`]. Called after the §9.0 hard-gate
     /// admitted the boot under the dev-mode override.
     ///
-    /// **Scope (Stage E1):**
+    /// **Scope (Stage E2):**
     /// * Dial Postgres + wrap an `Arc<PostgresBackend>` as the
     ///   `backend` field (all migrated HTTP handlers dispatch through
     ///   the trait — create_execution / create_flow / add member /
-    ///   stage edge / apply dep / describe_flow / etc.).
-    /// * Dial Valkey too — the `Server` still holds a `client: Client`
-    ///   for unmigrated legacy paths (`get_execution_state`,
-    ///   `get_execution`, `cancel_flow_inner`'s idempotent HMGET /
-    ///   SMEMBERS follow-ups, `fetch_waitpoint_token_v07`). Those
-    ///   paths are not reachable in the Postgres HTTP smoke scenario,
-    ///   but the field type is `Client`-not-`Option<Client>` until
-    ///   Stage E2 lands the `cancel_flow` trait migration. **Valkey is
-    ///   dialed but `initialize_deployment` is skipped** — no Lua
-    ///   FUNCTION LOAD, no partition-config write, no HMAC install,
-    ///   no lanes SADD against Valkey on the Postgres path.
+    ///   stage edge / apply dep / describe_flow / cancel_flow / etc.).
+    /// * **No Valkey dial.** The E1 residual ambient-Valkey client is
+    ///   retired in E2 — `Server::client` is gone, `cancel_flow_header`
+    ///   / `ack_cancel_member` / `read_execution_info` /
+    ///   `read_execution_state` / `fetch_waitpoint_token_v07` all flow
+    ///   through the trait. Legacy reads that Postgres does not yet
+    ///   implement surface as `EngineError::Unavailable` (Wave 9).
     /// * Skip engine + scheduler. Stage E3 wires the Postgres-specific
     ///   `claim_for_worker` via the trait; until then the scheduler
-    ///   field stays `None` and `claim_for_worker` fails with a typed
-    ///   error (E3-deferred).
+    ///   field stays `None`.
     /// * Run `apply_migrations` against the Postgres pool so an empty
     ///   database becomes usable without operator out-of-band steps.
-    ///   This matches the Valkey path's `initialize_deployment`
-    ///   ergonomics; Stage E4 may hoist it behind an operator flag.
     async fn start_postgres_branch(
         config: ServerConfig,
         metrics: Arc<ff_observability::Metrics>,
@@ -623,7 +610,7 @@ impl Server {
         }
         tracing::info!(
             pool_size = config.postgres.pool_size,
-            "dialing Postgres backend (RFC-017 Stage E1)"
+            "dialing Postgres backend (RFC-017 Stage E2)"
         );
         let pg_backend_arc = ff_backend_postgres::PostgresBackend::connect_with_metrics(
             config.postgres_config(),
@@ -644,37 +631,15 @@ impl Server {
 
         let backend: Arc<dyn EngineBackend> = pg_backend_arc;
 
-        // Dial a Valkey client for the residual legacy fields. Stage
-        // E2 removes `Server::client: Client` and this dial goes away.
-        tracing::info!(
-            host = %config.host, port = config.port,
-            "dialing ambient Valkey client (Stage E1 residual for \
-             unmigrated legacy fields; retired in Stage E2)"
-        );
-        let mut builder = ClientBuilder::new()
-            .host(&config.host, config.port)
-            .connect_timeout(Duration::from_secs(10))
-            .request_timeout(Duration::from_millis(5000));
-        if config.tls {
-            builder = builder.tls();
-        }
-        if config.cluster {
-            builder = builder.cluster();
-        }
-        let client = builder
-            .build()
-            .await
-            .map_err(|e| crate::server::backend_context(e, "postgres-branch ambient Valkey connect"))?;
-
         tracing::info!(
             flow_partitions = config.partition_config.num_flow_partitions,
             lanes = ?config.lanes.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
-            "FlowFabric server started (Postgres backend, Stage E1). \
-             Engine scanners skipped; scheduler skipped (Stage E3 pending)."
+            "FlowFabric server started (Postgres backend, Stage E2). \
+             Engine scanners skipped; scheduler skipped (Stage E3 pending). \
+             No ambient Valkey client."
         );
 
         Ok(Self {
-            client,
             admin_rotate_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
             engine: None,
             config,
@@ -735,14 +700,16 @@ impl Server {
         &self.metrics
     }
 
-    // RFC-017 Stage D2 (§9 Stage D bullet): `Server::client()` accessor
-    // removed; external callers route ping / healthz through the
-    // backend trait (`self.backend.ping()` → `ValkeyBackend::ping`). The
-    // underlying `Client` remains on `Server` only to service the
-    // header-only `ff_cancel_flow` FCALL + its post-header SMEMBERS /
-    // HMGET follow-ups (the backend trait's `cancel_flow` does not yet
-    // surface the caller-supplied `reason`, so the Server-level header
-    // FCALL is preserved pending a trait-signature extension.)
+    // RFC-017 Stage E2 (§9 Stage D bullet completed): `Server::client()`
+    // accessor + underlying `Client` field both removed. External
+    // callers route ping / healthz through the backend trait
+    // (`self.backend.ping()` → `ValkeyBackend::ping`). The
+    // `ff_cancel_flow` header FCALL, its `flow_already_terminal`
+    // HMGET/SMEMBERS fallback, the per-member `ff_ack_cancel_member`
+    // backlog drain, and the `get_execution*` / `fetch_waitpoint_token_v07`
+    // reads are all reachable through the Stage E2 trait additions
+    // (`cancel_flow_header`, `ack_cancel_member`, `read_execution_info`,
+    // `read_execution_state`, `fetch_waitpoint_token_v07`).
 
     /// RFC-017 Stage D1 (§8): fetch the raw `<kid>:<hex>`
     /// `waitpoint_token` so the v0.7.x wire-format shim in
@@ -757,31 +724,13 @@ impl Server {
         execution_id: &ExecutionId,
         waitpoint_id: &WaitpointId,
     ) -> Result<Option<String>, ServerError> {
-        let partition = execution_partition(execution_id, &self.config.partition_config);
-        let ctx = ExecKeyContext::new(&partition, execution_id);
-        let token: Option<String> = self
-            .client
-            .hget(&ctx.waitpoint(waitpoint_id), "waitpoint_token")
-            .await
-            .map_err(|e| {
-                crate::server::backend_context(e, "fetch_waitpoint_token_v07: HGET waitpoint_token")
-            })?;
-        Ok(token.filter(|s| !s.is_empty()))
-    }
-
-    /// Execute an FCALL with automatic Lua library reload on "function not loaded".
-    ///
-    /// After a Valkey failover the new primary may not have the Lua library
-    /// loaded (replication lag or cold replica). This wrapper detects that
-    /// condition, reloads the library via `ff_script::loader::ensure_library`,
-    /// and retries the FCALL once.
-    async fn fcall_with_reload(
-        &self,
-        function: &str,
-        keys: &[&str],
-        args: &[&str],
-    ) -> Result<Value, ServerError> {
-        fcall_with_reload_on_client(&self.client, function, keys, args).await
+        // RFC-017 Stage E2: routed through the backend trait. The
+        // Valkey impl carries the HGET verbatim; Postgres returns
+        // Unavailable (it cannot reach this path at boot per §9.0).
+        Ok(self
+            .backend
+            .fetch_waitpoint_token_v07(execution_id, waitpoint_id)
+            .await?)
     }
 
     /// Get the server config.
@@ -823,24 +772,9 @@ impl Server {
         &self,
         execution_id: &ExecutionId,
     ) -> Result<PublicState, ServerError> {
-        let partition = execution_partition(execution_id, &self.config.partition_config);
-        let ctx = ExecKeyContext::new(&partition, execution_id);
-
-        let state_str: Option<String> = self
-            .client
-            .hget(&ctx.core(), "public_state")
-            .await
-            .map_err(|e| crate::server::backend_context(e, "HGET public_state"))?;
-
-        match state_str {
-            Some(s) => {
-                let quoted = format!("\"{s}\"");
-                serde_json::from_str(&quoted).map_err(|e| {
-                    ServerError::Script(format!(
-                        "invalid public_state '{s}' for {execution_id}: {e}"
-                    ))
-                })
-            }
+        // RFC-017 Stage E2: routed through the backend trait.
+        match self.backend.read_execution_state(execution_id).await? {
+            Some(s) => Ok(s),
             None => Err(ServerError::NotFound(format!(
                 "execution not found: {execution_id}"
             ))),
@@ -877,26 +811,11 @@ impl Server {
         &self,
         execution_id: &ExecutionId,
     ) -> Result<Option<Vec<u8>>, ServerError> {
-        let partition = execution_partition(execution_id, &self.config.partition_config);
-        let ctx = ExecKeyContext::new(&partition, execution_id);
-
-        // Binary-safe read. Decoding into `String` would reject any
-        // non-UTF-8 payload (bincode-encoded f32 vectors, compressed
-        // artifacts, arbitrary binary stages) with a ferriskey decode
-        // error that surfaces as HTTP 500. The endpoint response is
-        // already `application/octet-stream`; `Vec<u8>` has a
-        // ferriskey-specialized `FromValue` impl that preserves raw
-        // bytes without UTF-8 validation (see ferriskey/src/value.rs:
-        // `from_byte_vec`). Nil → None via the blanket
-        // `Option<T: FromValue>` wrapper.
-        let payload: Option<Vec<u8>> = self
-            .client
-            .cmd("GET")
-            .arg(ctx.result())
-            .execute()
-            .await
-            .map_err(|e| crate::server::backend_context(e, "GET exec result"))?;
-        Ok(payload)
+        // RFC-017 Stage E2: routed through the backend trait. The
+        // Valkey impl preserves binary-safe semantics via ferriskey's
+        // `Vec<u8>` FromValue; Postgres returns Unavailable until the
+        // result-store migration lands.
+        Ok(self.backend.get_execution_result(execution_id).await?)
     }
 
 
@@ -1052,7 +971,7 @@ impl Server {
     /// the shared background `JoinSet`. Rapid repeated calls against the
     /// same flow will spawn *multiple* overlapping dispatch tasks. This is
     /// not a correctness issue — each member cancel is idempotent and
-    /// terminal flows short-circuit via [`ParsedCancelFlow::AlreadyTerminal`]
+    /// terminal flows short-circuit via [`ff_core::contracts::CancelFlowHeader::AlreadyTerminal`]
     /// — but heavy burst callers should either use `?wait=true` (serialises
     /// the dispatch on the HTTP thread, giving natural backpressure) or
     /// implement client-side deduplication on `flow_id`. The `JoinSet` is
@@ -1097,104 +1016,56 @@ impl Server {
         args: &CancelFlowArgs,
         wait: bool,
     ) -> Result<CancelFlowResult, ServerError> {
-        let partition = flow_partition(&args.flow_id, &self.config.partition_config);
-        let fctx = FlowKeyContext::new(&partition, &args.flow_id);
-        let fidx = FlowIndexKeys::new(&partition);
+        // RFC-017 Stage E2: the header FCALL + AlreadyTerminal fetch
+        // now dispatch through the backend trait. The Server no longer
+        // owns a ferriskey `Client`; `self.backend.cancel_flow_header`
+        // encapsulates the Valkey-specific FCALL + reload-on-failover
+        // + HMGET/SMEMBERS-for-AlreadyTerminal work previously inlined
+        // here.
+        let header = self.backend.cancel_flow_header(args.clone()).await?;
 
-        // Grace window before the reconciler may pick up this flow.
-        // Kept short because the in-process dispatch is fast and bounded;
-        // long enough to cover transport round-trips under load without
-        // the reconciler fighting the live dispatch.
-        const CANCEL_RECONCILER_GRACE_MS: u64 = 30_000;
-
-        // KEYS (5): flow_core, members_set, flow_index, pending_cancels, cancel_backlog
-        let fcall_keys: Vec<String> = vec![
-            fctx.core(),
-            fctx.members(),
-            fidx.flow_index(),
-            fctx.pending_cancels(),
-            fidx.cancel_backlog(),
-        ];
-
-        // ARGV (5): flow_id, reason, cancellation_policy, now_ms, grace_ms
-        let fcall_args: Vec<String> = vec![
-            args.flow_id.to_string(),
-            args.reason.clone(),
-            args.cancellation_policy.clone(),
-            args.now.to_string(),
-            CANCEL_RECONCILER_GRACE_MS.to_string(),
-        ];
-
-        let key_refs: Vec<&str> = fcall_keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = fcall_args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self
-            .fcall_with_reload("ff_cancel_flow", &key_refs, &arg_refs)
-            .await?;
-
-        let (policy, members) = match parse_cancel_flow_raw(&raw)? {
-            ParsedCancelFlow::Cancelled { policy, member_execution_ids } => {
-                (policy, member_execution_ids)
-            }
+        let (policy, members) = match header {
+            ff_core::contracts::CancelFlowHeader::Cancelled {
+                cancellation_policy,
+                member_execution_ids,
+            } => (cancellation_policy, member_execution_ids),
             // Idempotent retry: flow was already cancelled/completed/failed.
-            // Return Cancelled with the *stored* policy and member list so
-            // observability tooling gets the real historical state rather
-            // than echoing the caller's retry intent. One HMGET + SMEMBERS
-            // on the idempotent path — both on {fp:N}, same slot.
-            ParsedCancelFlow::AlreadyTerminal => {
-                let flow_meta: Vec<Option<String>> = self
-                    .client
-                    .cmd("HMGET")
-                    .arg(fctx.core())
-                    .arg("cancellation_policy")
-                    .arg("cancel_reason")
-                    .execute()
-                    .await
-                    .map_err(|e| crate::server::backend_context(e, "HMGET flow_core cancellation_policy,cancel_reason"))?;
-                let stored_policy = flow_meta
-                    .first()
-                    .and_then(|v| v.as_ref())
-                    .filter(|s| !s.is_empty())
-                    .cloned();
-                let stored_reason = flow_meta
-                    .get(1)
-                    .and_then(|v| v.as_ref())
-                    .filter(|s| !s.is_empty())
-                    .cloned();
-                let all_members: Vec<String> = self
-                    .client
-                    .cmd("SMEMBERS")
-                    .arg(fctx.members())
-                    .execute()
-                    .await
-                    .map_err(|e| crate::server::backend_context(e, "SMEMBERS flow members (already terminal)"))?;
-                // Cap the returned list to avoid pathological bandwidth on
-                // idempotent retries for flows with 10k+ members. Clients
-                // already received the authoritative member list on the
-                // first (non-idempotent) call; subsequent retries just need
-                // enough to confirm the operation and trigger per-member
-                // polling if desired.
-                let total_members = all_members.len();
-                let stored_members: Vec<String> = all_members
+            // Return Cancelled with the *stored* policy + (capped) member
+            // list so observability tooling gets the real historical state
+            // rather than echoing the caller's retry intent. The backend
+            // has already done the HMGET + SMEMBERS; the Server just caps
+            // the member list to bound wire bandwidth.
+            ff_core::contracts::CancelFlowHeader::AlreadyTerminal {
+                stored_cancellation_policy,
+                stored_cancel_reason,
+                member_execution_ids,
+            } => {
+                let total_members = member_execution_ids.len();
+                let stored_members: Vec<String> = member_execution_ids
                     .into_iter()
                     .take(ALREADY_TERMINAL_MEMBER_CAP)
                     .collect();
                 tracing::debug!(
                     flow_id = %args.flow_id,
-                    stored_policy = stored_policy.as_deref().unwrap_or(""),
-                    stored_reason = stored_reason.as_deref().unwrap_or(""),
+                    stored_policy = stored_cancellation_policy.as_deref().unwrap_or(""),
+                    stored_reason = stored_cancel_reason.as_deref().unwrap_or(""),
                     total_members,
                     returned_members = stored_members.len(),
                     "cancel_flow: flow already terminal, returning idempotent Cancelled"
                 );
                 return Ok(CancelFlowResult::Cancelled {
-                    // Fall back to caller's policy only if the stored field
-                    // is missing (flows cancelled by older Lua that did not
-                    // persist cancellation_policy).
-                    cancellation_policy: stored_policy
+                    cancellation_policy: stored_cancellation_policy
                         .unwrap_or_else(|| args.cancellation_policy.clone()),
                     member_execution_ids: stored_members,
                 });
+            }
+            // `CancelFlowHeader` is `#[non_exhaustive]`. Any future
+            // variant must be reviewed at this match site before it
+            // reaches the wire; fall closed with a typed server error.
+            other => {
+                return Err(ServerError::OperationFailed(format!(
+                    "cancel_flow_header: unknown CancelFlowHeader variant: {other:?}"
+                )));
             }
         };
         let needs_dispatch = policy == "cancel_all" && !members.is_empty();
@@ -1206,23 +1077,17 @@ impl Server {
             });
         }
 
-        let pending_cancels_key = fctx.pending_cancels();
-        let cancel_backlog_key = fidx.cancel_backlog();
-
         if wait {
             // Synchronous dispatch — cancel every member inline before returning.
             // Collect per-member failures so the caller sees a
             // PartiallyCancelled outcome instead of a false-positive
-            // Cancelled when any member cancel faulted (ghost member,
-            // transport exhaustion, Lua reject). The cancel-backlog
-            // reconciler still retries the unacked members; surfacing
-            // the partial state lets operator tooling alert without
-            // polling per-member state.
-            // RFC-017 Stage D2 (§4 row 5): member-level cancel dispatches
-            // through the backend trait. Each `CancelExecutionArgs` carries
-            // the caller-supplied `reason` verbatim — the same payload the
-            // pre-migration `cancel_member_execution` handed to
-            // `ff_cancel_execution`.
+            // Cancelled when any member cancel faulted. The
+            // cancel-backlog reconciler still retries the unacked
+            // members; surfacing the partial state lets operator
+            // tooling alert without polling per-member state.
+            // RFC-017 Stage E2: ack drain dispatches via the backend
+            // trait's `ack_cancel_member` — the Server no longer owns
+            // a raw ferriskey `Client`.
             let mut failed: Vec<String> = Vec::new();
             for eid_str in &members {
                 let Ok(eid) = ExecutionId::parse(eid_str) else {
@@ -1230,7 +1095,7 @@ impl Server {
                     continue;
                 };
                 let cancel_args = ff_core::contracts::CancelExecutionArgs {
-                    execution_id: eid,
+                    execution_id: eid.clone(),
                     reason: args.reason.clone(),
                     source: ff_core::types::CancelSource::OperatorOverride,
                     lease_id: None,
@@ -1240,23 +1105,21 @@ impl Server {
                 };
                 match self.backend.cancel_execution(cancel_args).await {
                     Ok(_) => {
-                        ack_cancel_member(
-                            &self.client,
-                            &pending_cancels_key,
-                            &cancel_backlog_key,
+                        ack_cancel_member_via_backend(
+                            self.backend.as_ref(),
+                            &args.flow_id,
+                            &eid,
                             eid_str,
-                            &args.flow_id.to_string(),
                         )
                         .await;
                     }
                     Err(e) => {
                         if is_terminal_ack_engine_error(&e) {
-                            ack_cancel_member(
-                                &self.client,
-                                &pending_cancels_key,
-                                &cancel_backlog_key,
+                            ack_cancel_member_via_backend(
+                                self.backend.as_ref(),
+                                &args.flow_id,
+                                &eid,
                                 eid_str,
-                                &args.flow_id.to_string(),
                             )
                             .await;
                             continue;
@@ -1284,31 +1147,21 @@ impl Server {
             });
         }
 
-        // Asynchronous dispatch — spawn into the shared JoinSet so Server::shutdown
-        // can wait for pending cancellations (bounded by a shutdown timeout).
-        // RFC-017 Stage D2 (§4 row 5): dispatches via the backend trait's
-        // `cancel_execution`; `self.client` is still held for the backlog
-        // ack (`SREM pending_cancels + LREM cancel_backlog`) which is not
-        // yet on the trait surface.
+        // Asynchronous dispatch — spawn into the shared JoinSet so
+        // Server::shutdown can wait for pending cancellations (bounded
+        // by a shutdown timeout). RFC-017 Stage E2: both the
+        // per-member cancel and the backlog ack dispatch through the
+        // backend trait (the Server no longer holds a ferriskey handle).
         let backend = self.backend.clone();
-        let client = self.client.clone();
         let reason = args.reason.clone();
         let now = args.now;
         let dispatch_members = members.clone();
         let flow_id = args.flow_id.clone();
-        // Every async cancel_flow contends on this lock, but the critical
-        // section is tiny: try_join_next drain + spawn. Drain is amortized
-        // O(1) — each completed task is reaped exactly once across all
-        // callers, and spawn is synchronous. At realistic cancel rates the
-        // lock hold time is microseconds and does not bottleneck handlers.
+        // Every async cancel_flow contends on this lock, but the
+        // critical section is tiny: try_join_next drain + spawn.
         let mut guard = self.background_tasks.lock().await;
 
         // Reap completed background dispatches before spawning the next.
-        // Without this sweep, JoinSet accumulates Ok(()) results for every
-        // async cancel ever issued — a memory leak in long-running servers
-        // that would otherwise only drain on Server::shutdown. Surface any
-        // panicked/aborted dispatches via tracing so silent failures in
-        // cancel_member_execution are visible in logs.
         while let Some(joined) = guard.try_join_next() {
             if let Err(e) = joined {
                 tracing::warn!(
@@ -1318,17 +1171,8 @@ impl Server {
             }
         }
 
-        let pending_key_owned = pending_cancels_key.clone();
-        let backlog_key_owned = cancel_backlog_key.clone();
-        let flow_id_str = args.flow_id.to_string();
-
         guard.spawn(async move {
             // Bounded parallel dispatch via futures::stream::buffer_unordered.
-            // Sequential cancel of a 1000-member flow at ~2ms/FCALL is ~2s —
-            // too long to finish inside a 15s shutdown abort window for
-            // large flows. Bounding at CONCURRENCY keeps Valkey load
-            // predictable while still cutting wall-clock dispatch time by
-            // ~CONCURRENCY× for large member sets.
             use futures::stream::StreamExt;
             const CONCURRENCY: usize = 16;
 
@@ -1337,12 +1181,8 @@ impl Server {
             futures::stream::iter(dispatch_members)
                 .map(|eid_str| {
                     let backend = backend.clone();
-                    let client = client.clone();
                     let reason = reason.clone();
                     let flow_id = flow_id.clone();
-                    let pending = pending_key_owned.clone();
-                    let backlog = backlog_key_owned.clone();
-                    let flow_id_str = flow_id_str.clone();
                     async move {
                         let Ok(eid) = ExecutionId::parse(&eid_str) else {
                             tracing::warn!(
@@ -1353,7 +1193,7 @@ impl Server {
                             return;
                         };
                         let cancel_args = ff_core::contracts::CancelExecutionArgs {
-                            execution_id: eid,
+                            execution_id: eid.clone(),
                             reason: reason.clone(),
                             source: ff_core::types::CancelSource::OperatorOverride,
                             lease_id: None,
@@ -1363,23 +1203,21 @@ impl Server {
                         };
                         match backend.cancel_execution(cancel_args).await {
                             Ok(_) => {
-                                ack_cancel_member(
-                                    &client,
-                                    &pending,
-                                    &backlog,
+                                ack_cancel_member_via_backend(
+                                    backend.as_ref(),
+                                    &flow_id,
+                                    &eid,
                                     &eid_str,
-                                    &flow_id_str,
                                 )
                                 .await;
                             }
                             Err(e) => {
                                 if is_terminal_ack_engine_error(&e) {
-                                    ack_cancel_member(
-                                        &client,
-                                        &pending,
-                                        &backlog,
+                                    ack_cancel_member_via_backend(
+                                        backend.as_ref(),
+                                        &flow_id,
+                                        &eid,
                                         &eid_str,
-                                        &flow_id_str,
                                     )
                                     .await;
                                 } else {
@@ -1544,98 +1382,19 @@ impl Server {
         }
     }
 
-    /// Get full execution info via HGETALL on exec_core.
+    /// Get full execution info (HGETALL-shape on Valkey; SELECT-shape on
+    /// Postgres once Wave 9 wires it). RFC-017 Stage E2: routed through
+    /// the backend trait's [`ff_core::engine_backend::EngineBackend::read_execution_info`].
     pub async fn get_execution(
         &self,
         execution_id: &ExecutionId,
     ) -> Result<ExecutionInfo, ServerError> {
-        let partition = execution_partition(execution_id, &self.config.partition_config);
-        let ctx = ExecKeyContext::new(&partition, execution_id);
-
-        let fields: HashMap<String, String> = self
-            .client
-            .hgetall(&ctx.core())
-            .await
-            .map_err(|e| crate::server::backend_context(e, "HGETALL exec_core"))?;
-
-        if fields.is_empty() {
-            return Err(ServerError::NotFound(format!(
+        match self.backend.read_execution_info(execution_id).await? {
+            Some(info) => Ok(info),
+            None => Err(ServerError::NotFound(format!(
                 "execution not found: {execution_id}"
-            )));
+            ))),
         }
-
-        let parse_enum = |field: &str| -> String {
-            fields.get(field).cloned().unwrap_or_default()
-        };
-        fn deserialize<T: serde::de::DeserializeOwned>(field: &str, raw: &str) -> Result<T, ServerError> {
-            let quoted = format!("\"{raw}\"");
-            serde_json::from_str(&quoted).map_err(|e| {
-                ServerError::Script(format!("invalid {field} '{raw}': {e}"))
-            })
-        }
-
-        let lp_str = parse_enum("lifecycle_phase");
-        let os_str = parse_enum("ownership_state");
-        let es_str = parse_enum("eligibility_state");
-        let br_str = parse_enum("blocking_reason");
-        let to_str = parse_enum("terminal_outcome");
-        let as_str = parse_enum("attempt_state");
-        let ps_str = parse_enum("public_state");
-
-        let state_vector = StateVector {
-            lifecycle_phase: deserialize("lifecycle_phase", &lp_str)?,
-            ownership_state: deserialize("ownership_state", &os_str)?,
-            eligibility_state: deserialize("eligibility_state", &es_str)?,
-            blocking_reason: deserialize("blocking_reason", &br_str)?,
-            terminal_outcome: deserialize("terminal_outcome", &to_str)?,
-            attempt_state: deserialize("attempt_state", &as_str)?,
-            public_state: deserialize("public_state", &ps_str)?,
-        };
-
-        // Reader invariant (RFC-011 §7.3): `flow_id` on exec_core is
-        // stamped atomically with membership in `add_execution_to_flow`'s
-        // single FCALL. Empty iff the exec has no flow affinity (never
-        // called `add_execution_to_flow` — solo execs) — NOT "orphaned
-        // mid-two-phase" (that failure mode is retired). Filter on empty
-        // to surface "no flow affinity" distinctly from "flow X".
-        let flow_id_val = fields.get("flow_id").filter(|s| !s.is_empty()).cloned();
-
-        // started_at / completed_at come from the exec_core hash —
-        // lua/execution.lua writes them alongside the rest of the state
-        // vector. `created_at` is required; the other two are optional
-        // (pre-claim / pre-terminal reads) and elided when empty so the
-        // wire payload for in-flight executions stays the shape existing
-        // callers expect.
-        let started_at_opt = fields
-            .get("started_at")
-            .filter(|s| !s.is_empty())
-            .cloned();
-        let completed_at_opt = fields
-            .get("completed_at")
-            .filter(|s| !s.is_empty())
-            .cloned();
-
-        Ok(ExecutionInfo {
-            execution_id: execution_id.clone(),
-            namespace: parse_enum("namespace"),
-            lane_id: parse_enum("lane_id"),
-            priority: fields
-                .get("priority")
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(0),
-            execution_kind: parse_enum("execution_kind"),
-            state_vector,
-            public_state: deserialize("public_state", &ps_str)?,
-            created_at: parse_enum("created_at"),
-            started_at: started_at_opt,
-            completed_at: completed_at_opt,
-            current_attempt_index: fields
-                .get("current_attempt_index")
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(0),
-            flow_id: flow_id_val,
-            blocking_detail: parse_enum("blocking_detail"),
-        })
     }
 
     /// Partition-scoped forward-only cursor listing of executions.
@@ -1999,56 +1758,6 @@ impl Server {
 
 
 
-/// Outcome of parsing a raw `ff_cancel_flow` FCALL response.
-///
-/// Keeps `AlreadyTerminal` distinct from other script errors so the caller
-/// can treat cancel on an already-cancelled/completed/failed flow as
-/// idempotent success instead of surfacing a 400 to the client.
-enum ParsedCancelFlow {
-    Cancelled {
-        policy: String,
-        member_execution_ids: Vec<String>,
-    },
-    AlreadyTerminal,
-}
-
-/// Parse the raw `ff_cancel_flow` FCALL response.
-///
-/// Returns [`ParsedCancelFlow::Cancelled`] on success, [`ParsedCancelFlow::AlreadyTerminal`]
-/// when the flow was already in a terminal state (idempotent retry), or a
-/// [`ServerError`] for any other failure.
-fn parse_cancel_flow_raw(raw: &Value) -> Result<ParsedCancelFlow, ServerError> {
-    let arr = match raw {
-        Value::Array(arr) => arr,
-        _ => return Err(ServerError::Script("ff_cancel_flow: expected Array".into())),
-    };
-    let status = match arr.first() {
-        Some(Ok(Value::Int(n))) => *n,
-        _ => return Err(ServerError::Script("ff_cancel_flow: bad status code".into())),
-    };
-    if status != 1 {
-        let error_code = fcall_field_str(arr, 1);
-        if error_code == "flow_already_terminal" {
-            return Ok(ParsedCancelFlow::AlreadyTerminal);
-        }
-        return Err(ServerError::OperationFailed(format!(
-            "ff_cancel_flow failed: {error_code}"
-        )));
-    }
-    // {1, "OK", cancellation_policy, member1, member2, ...}
-    let policy = fcall_field_str(arr, 2);
-    // Iterate to arr.len() rather than breaking on the first empty string —
-    // safer against malformed Lua responses and clearer than a sentinel loop.
-    let mut members = Vec::with_capacity(arr.len().saturating_sub(3));
-    for i in 3..arr.len() {
-        members.push(fcall_field_str(arr, i));
-    }
-    Ok(ParsedCancelFlow::Cancelled { policy, member_execution_ids: members })
-}
-
-
-
-
 
 /// Extract a string from an FCALL result array at the given index.
 /// Convert a `ScriptError` into a `ServerError` preserving `ferriskey::ErrorKind`
@@ -2070,81 +1779,25 @@ fn script_error_to_server(e: ff_script::error::ScriptError) -> ServerError {
     }
 }
 
-fn fcall_field_str(arr: &[Result<Value, ferriskey::Error>], index: usize) -> String {
-    match arr.get(index) {
-        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
-        Some(Ok(Value::SimpleString(s))) => s.clone(),
-        Some(Ok(Value::Int(n))) => n.to_string(),
-        _ => String::new(),
-    }
-}
-
-/// Detect Valkey errors indicating the Lua function library is not loaded.
-///
-/// After a failover, the new primary may not have the library if replication
-/// was incomplete. Valkey returns `ERR Function not loaded` for FCALL calls
-/// targeting missing functions.
-fn is_function_not_loaded(e: &ferriskey::Error) -> bool {
-    if matches!(e.kind(), ferriskey::ErrorKind::NoScriptError) {
-        return true;
-    }
-    e.detail()
-        .map(|d| {
-            d.contains("Function not loaded")
-                || d.contains("No matching function")
-                || d.contains("function not found")
-        })
-        .unwrap_or(false)
-        || e.to_string().contains("Function not loaded")
-}
-
-/// Free-function form of [`Server::fcall_with_reload`] — callable from
-/// background tasks that own a cloned `Client` but no `&Server`.
-async fn fcall_with_reload_on_client(
-    client: &Client,
-    function: &str,
-    keys: &[&str],
-    args: &[&str],
-) -> Result<Value, ServerError> {
-    match client.fcall(function, keys, args).await {
-        Ok(v) => Ok(v),
-        Err(e) if is_function_not_loaded(&e) => {
-            tracing::warn!(function, "Lua library not found on server, reloading");
-            ff_script::loader::ensure_library(client)
-                .await
-                .map_err(ServerError::LibraryLoad)?;
-            client
-                .fcall(function, keys, args)
-                .await
-                .map_err(ServerError::from)
-        }
-        Err(e) => Err(ServerError::from(e)),
-    }
-}
-
-/// Acknowledge that a member cancel has committed. Fires
-/// `ff_ack_cancel_member` on `{fp:N}` to SREM the execution from the
-/// flow's `pending_cancels` set and, if empty, ZREM the flow from the
-/// partition-level `cancel_backlog`. Best-effort — failures are logged
-/// but not propagated, since the reconciler will catch anything that
-/// stays behind on its next pass.
-async fn ack_cancel_member(
-    client: &Client,
-    pending_cancels_key: &str,
-    cancel_backlog_key: &str,
+/// Acknowledge that a member cancel has committed. Delegates to
+/// [`EngineBackend::ack_cancel_member`] (Valkey: `ff_ack_cancel_member`
+/// FCALL on `{fp:N}` — SREM the execution from the flow's
+/// `pending_cancels` set and, if empty, ZREM the flow from the
+/// partition-level `cancel_backlog`). Best-effort — failures are
+/// logged but not propagated, since the reconciler drains any
+/// leftovers on its next pass.
+async fn ack_cancel_member_via_backend(
+    backend: &dyn EngineBackend,
+    flow_id: &FlowId,
+    execution_id: &ExecutionId,
     eid_str: &str,
-    flow_id: &str,
 ) {
-    let keys = [pending_cancels_key, cancel_backlog_key];
-    let args_v = [eid_str, flow_id];
-    let fut: Result<Value, _> =
-        client.fcall("ff_ack_cancel_member", &keys, &args_v).await;
-    if let Err(e) = fut {
+    if let Err(e) = backend.ack_cancel_member(flow_id, execution_id).await {
         tracing::warn!(
             flow_id = %flow_id,
             execution_id = %eid_str,
             error = %e,
-            "ff_ack_cancel_member failed; reconciler will drain on next pass"
+            "ack_cancel_member failed; reconciler will drain on next pass"
         );
     }
 }

--- a/crates/ff-test/tests/http_postgres_smoke.rs
+++ b/crates/ff-test/tests/http_postgres_smoke.rs
@@ -33,13 +33,15 @@
 //! * `POST /v1/flows/{id}/edges` × 2 → `backend.stage_dependency_edge`
 //! * `POST /v1/flows/{id}/edges/apply` × 2 → `backend.apply_dependency_to_child`
 //!
-//! **Deferred (NOT tested — architectural dependency on later stages):**
-//! * `POST /v1/flows/{id}/cancel` — `Server::cancel_flow_inner` still
-//!   calls the Valkey-only `fcall_with_reload` + `self.client.hmget` /
-//!   `smembers`. Stage **E2** lifts `cancel_flow` onto the trait.
-//! * `GET /v1/executions/{id}` / `.../state` / `.../result` — all use
-//!   `self.client.hgetall` / `hget` / `cmd("GET")`. Stage **E2**
-//!   removes the `Client` field + migrates these reads.
+//! **Deferred (NOT tested — Postgres impls land in Wave 9):**
+//! * `POST /v1/flows/{id}/cancel` — now dispatches through the
+//!   backend trait (`cancel_flow_header` + `ack_cancel_member`), but
+//!   Postgres returns `EngineError::Unavailable` for both methods
+//!   until Wave 9 lands the Postgres-side cancel machinery.
+//! * `GET /v1/executions/{id}` / `.../state` / `.../result` — now
+//!   dispatch through `read_execution_info` / `read_execution_state`
+//!   / `get_execution_result`. Postgres returns `Unavailable` for
+//!   each until the Postgres read-model migration lands.
 //! * `GET /v1/flows/{id}` — route does not exist today; adding it is
 //!   a separate ingress-read task post-E4.
 //! * `claim_for_worker` — scheduler is Valkey-only; Stage **E3** wires

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -33,9 +33,16 @@ split into four PRs so each lands in a single session with CI-green:
   / `Server.scheduler` become `Option` (`None` on Postgres). Dev-mode
   override (`FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development`) still
   required; §9.0 hard-gate not yet flipped.
-- **E2** — full `cancel_flow` trait migration (lifts `cancel_flow_inner`
-  into `ValkeyBackend::cancel_flow_with_args`), `Server::client: Client`
-  field removal, `fcall_with_reload` removal.
+- **E2** (shipped, `impl/017-stage-e2`) — `cancel_flow` header + member-
+  ack migrated through the backend trait via new provided-default
+  methods (`cancel_flow_header`, `ack_cancel_member`), Valkey impls
+  porting the Server bodies verbatim (plus `read_execution_info`,
+  `read_execution_state`, `fetch_waitpoint_token_v07`);
+  `Server::client: Client` field + Postgres-branch ambient Valkey
+  dial + `fcall_with_reload` + `fcall_with_reload_on_client` +
+  `parse_cancel_flow_raw` + `is_function_not_loaded` + `fcall_field_str`
+  + standalone `ack_cancel_member` helper removed. Postgres path
+  touches no Valkey at all.
 - **E3** — `Server::claim_for_worker` trait cutover (Postgres-native
   scheduler), `Server::scheduler` field removal.
 - **E4** — v0.8.0 cleanup: deprecated flat Valkey `ServerConfig` fields
@@ -94,6 +101,11 @@ both when the `streaming` feature is enabled, `n/a` otherwise.
 | 16 | `list_pending_waitpoints` | `impl` | `stub` | **Landed Stage D1.** Pipelined SSCAN + 2× HMGET + §8 schema rewrite (HMAC redaction + `token_kid`/`token_fingerprint`) + `after`/`limit` pagination. HTTP handler wraps with the v0.7.x `Deprecation: ff-017` header and the raw `waitpoint_token` (fetched via the Valkey-only inherent `Server::fetch_waitpoint_token_v07`) for one-release deprecation warning. Postgres impl lands in Stage D2 (full parity gate). |
 | 17 | `ping` | `impl` | `impl` | Valkey: `PING`. Postgres: `SELECT 1`. |
 | 18 | `claim_for_worker` | `impl` | `stub` | **Landed Stage C.** `ff-backend-valkey` added `ff-scheduler` dep; `ValkeyBackend` holds `Option<Arc<ff_scheduler::Scheduler>>` wired at `ff-server` boot via `ValkeyBackend::with_scheduler` before the `Arc<dyn EngineBackend>` is sealed. Trait impl forwards to `Scheduler::claim_for_worker`; `SchedulerError::Config` maps to `EngineError::Validation`, Valkey transport errors via `transport_fk`. Backends without a wired scheduler (e.g. SDK-side `MockBackend`) surface `EngineError::Unavailable { op: "claim_for_worker (scheduler not wired on this ValkeyBackend)" }`. |
+| 19 | `cancel_flow_header` | `impl` | `stub` | **Landed Stage E2.** Valkey body runs `ff_cancel_flow` FCALL with the caller-supplied reason + cancellation_policy + now + grace window, surfaces `flow_already_terminal` as `CancelFlowHeader::AlreadyTerminal` (with stored policy/reason + full SMEMBERS of members) so the Server can return an idempotent `Cancelled` without re-doing the flip. FCALL-with-reload (post-failover Lua re-install via `ff_script::loader::ensure_library`) inlined on the Valkey impl. Postgres returns `Unavailable` until Wave 9. |
+| 20 | `ack_cancel_member` | `impl` | `stub` | **Landed Stage E2.** Valkey wraps `ff_ack_cancel_member` (SREM from `pending_cancels` + ZREM from `cancel_backlog` if empty). Called by `Server::cancel_flow_inner`'s sync + async dispatchers after each successful per-member cancel. Postgres returns `Unavailable` until Wave 9's cancel-backlog table write lands. |
+| 21 | `read_execution_info` | `impl` | `stub` | **Landed Stage E2.** Valkey body is HGETALL on `exec_core` + field-by-field parse into the legacy `ExecutionInfo` wire shape (`StateVector` with all 7 sub-states), preserving HTTP response bytes. Returns `Ok(None)` when the hash is empty. Postgres returns `Unavailable` until the read-model migration lands. |
+| 22 | `read_execution_state` | `impl` | `stub` | **Landed Stage E2.** Valkey body is HGET `public_state` on `exec_core` + JSON deserialize. Returns `Ok(None)` when the field is absent. Postgres returns `Unavailable`. |
+| 23 | `fetch_waitpoint_token_v07` | `impl` | `stub` | **Landed Stage E2 (relocated from Server).** Valkey body is HGET `waitpoint_token` on the exec's waitpoint hash. Filters empty strings to `None`. Retires at v0.8.0 with the legacy wire field. Postgres returns `Unavailable`. |
 
 **Cross-cutting (unconditional, landed pre-Stage-A):**
 
@@ -184,19 +196,26 @@ sequence anticipated.
   `&["valkey", "postgres"]`; `FF_BACKEND=postgres` boots successfully
   for the first time.
 
-### Remaining gaps for v0.8.0 (E1 honest-scope)
+### Remaining gaps for v0.8.0 (E2 honest-scope)
 
-The Stage E1 smoke deliberately avoided these HTTP routes because the
-server-side dispatch is still Valkey-bound:
+Stage E2 closes the `Server::client` removal and lifts `cancel_flow`
++ `get_execution*` + `fetch_waitpoint_token_v07` onto the backend
+trait (Valkey impls port the Server bodies verbatim; Postgres returns
+`Unavailable` for rows that land in Wave 9). The Stage E1 smoke still
+deliberately avoids the following HTTP routes because Postgres does
+not yet implement the underlying trait method:
 
-- **`POST /v1/flows/{id}/cancel`** — `Server::cancel_flow_inner` still
-  builds FCALL KEYS/ARGV and dispatches through `fcall_with_reload`;
-  the idempotent-retry path does `HMGET` / `SMEMBERS` on `self.client`
-  directly. **Stage E2** lifts `cancel_flow` onto the backend trait,
-  removes `Server::client: Client`, and retires `fcall_with_reload`.
-- **`GET /v1/executions/{id}` / `…/state` / `…/result`** — all three
-  use `self.client.hgetall` / `hget` / `cmd("GET")` on the legacy
-  Valkey client. Migrated as part of **Stage E2**'s field removal.
+- **`POST /v1/flows/{id}/cancel`** — the Server side now dispatches
+  through `backend.cancel_flow_header` + `backend.ack_cancel_member`;
+  both methods have Valkey impls but Postgres returns `Unavailable`
+  until Wave 9 lands the cancel machinery. Smoke remains Valkey-only.
+- **`GET /v1/executions/{id}` / `…/state`** — dispatch through
+  `backend.read_execution_info` / `backend.read_execution_state`;
+  Valkey impls port the HGETALL / HGET + parse logic. Postgres
+  default is `Unavailable` until the PG read-model lands.
+- **`GET /v1/executions/{id}/result`** — trait method `get_execution_result`
+  was already available; Valkey impl unchanged. Postgres returns
+  `Unavailable` until the result-store migration lands.
 - **`GET /v1/flows/{id}`** — this HTTP route does not exist today;
   callers infer flow state from member executions. Introducing it is
   an ingress-read task tracked post-E4.
@@ -215,11 +234,10 @@ server-side dispatch is still Valkey-bound:
   `FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development` through Stages E1-E3.
   Stage E4 flips `BACKEND_STAGE_READY` to include `"postgres"` and
   this requirement goes away.
-- **`Server::client: Client` on Postgres path** — the Stage E1
-  Postgres branch still dials an ambient Valkey client for the
-  residual legacy fields (`get_execution`, `get_execution_state`,
-  `get_execution_result`, `fetch_waitpoint_token_v07`,
-  `cancel_flow_inner`). That dial is not semantically meaningful for
-  Postgres-only deployments; it exists only because the field type is
-  `Client` not `Option<Client>`. **Stage E2** removes the field; the
-  ambient dial goes with it.
+- **`Server::client: Client` on Postgres path** — retired in
+  **Stage E2**. The Postgres branch of `Server::start_with_metrics`
+  no longer dials Valkey at all; the residual legacy-field paths all
+  flow through the `EngineBackend` trait, and Postgres returns
+  `Unavailable` for the methods whose impls land in Wave 9
+  (`cancel_flow_header`, `ack_cancel_member`, `read_execution_info`,
+  `read_execution_state`, `fetch_waitpoint_token_v07`).


### PR DESCRIPTION
## Summary

Stage E2 of the RFC-017 Wave 8 sub-split. Retires `Server::client: Client` + its associated Valkey-native machinery from `ff-server`; every handler that previously reached into the raw ferriskey handle now dispatches through `EngineBackend` trait additions landed in this PR.

Previous: Stage E1 (PR #269) landed the Postgres dial branch and migrated 5 ingress routes.

### Trait additions (ff-core)

Five new provided-default methods on `EngineBackend` (all default to `EngineError::Unavailable { op }`; Valkey overrides, Postgres stays stub pending Wave 9):

- `cancel_flow_header(CancelFlowArgs) -> CancelFlowHeader` — new `CancelFlowHeader` enum in contracts surfaces the `flow_already_terminal` idempotent-retry branch as a first-class variant carrying the stored policy/reason + full membership.
- `ack_cancel_member(&FlowId, &ExecutionId)` — the `ff_ack_cancel_member` FCALL drain side of `cancel_all`.
- `read_execution_info`, `read_execution_state`, `fetch_waitpoint_token_v07` — legacy HGETALL/HGET reads lifted off the Server.

### Server migration (ff-server)

- `Server::cancel_flow_inner` → `backend.cancel_flow_header` + `backend.cancel_execution` + `backend.ack_cancel_member`. HTTP wire shape byte-identical (Server still reconstructs the wait / async / partial CancelFlowResult from the trait output).
- Async member-dispatch task (WI-3) now clones `Arc<dyn EngineBackend>` instead of `Client`.
- `fetch_waitpoint_token_v07`, `get_execution_state`, `get_execution_result`, `get_execution` all single-line trait delegates.

### Deletions (WI-2)

- `Server::client: Client` field.
- Valkey-branch + Postgres-branch constructor assignments to it.
- Postgres-branch ambient Valkey dial (Stage E1 residual) — Postgres path touches no Valkey at all now.
- `Server::fcall_with_reload`, free-function `fcall_with_reload_on_client`.
- FCALL-parsing helpers `parse_cancel_flow_raw`, `fcall_field_str`, `is_function_not_loaded`, the `ParsedCancelFlow` enum, and the free-function `ack_cancel_member`.
- Unused imports (`HashMap`, `Client`, `Value`, `ExecKeyContext`, `FlowIndexKeys`, `FlowKeyContext`, `StateVector`).

### Grep evidence

```
$ grep -n "self\.client|self\.fcall_with_reload|client: Client|fn fcall_with_reload" \
    crates/ff-server/src/server.rs crates/ff-server/src/api.rs
# (zero hits)
```

### Lines changed per file

| File | Δ |
|---|---|
| `crates/ff-backend-valkey/src/lib.rs` | +323 |
| `crates/ff-core/src/contracts/mod.rs` | +35 |
| `crates/ff-core/src/engine_backend.rs` | +105 / -0 |
| `crates/ff-server/src/server.rs` | +77 / -531 |
| `crates/ff-test/tests/http_postgres_smoke.rs` | +8 / -8 |
| `docs/POSTGRES_PARITY_MATRIX.md` | +51 / -15 |

### Matrix

Rows 19-23 flipped in `docs/POSTGRES_PARITY_MATRIX.md` for the five new trait methods (`impl` on Valkey, `stub` on Postgres). The "Remaining gaps" section rewritten to track Wave-9 Postgres impls rather than the retired Server::client coupling.

### Trait signature discipline (§5.1.1 note)

The existing `EngineBackend::cancel_flow(id, policy, wait)` signature is **unchanged**. The reason-plumbing requirement from the Stage E2 spec is satisfied via an additive route: a new sibling method `cancel_flow_header(CancelFlowArgs)` that the Server calls instead, because the Server owns its own wait/async member-dispatch machinery. This keeps every pre-existing `impl EngineBackend for X` in-tree (SDK layer hooks, 5 parity mocks, describe_flow_api mock, PG backend) compile-clean with zero diff. The 5 new methods ride the provided-default discipline (return `Unavailable`) so the additions are purely opt-in.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test --features ff-sdk/direct-valkey-claim -- -D warnings` clean
- [x] `cargo clippy -p ff-backend-valkey -p ff-backend-postgres -- -D warnings` clean
- [x] `cargo test -p ff-core -p ff-script -p ff-backend-valkey -p ff-backend-postgres -p ff-server --lib` — all green
- [x] `cargo test -p ff-server --test parity_stage_a --test parity_stage_a_backfill --test parity_stage_b --test parity_stage_c --test parity_stage_d1` — all green
- [x] `cargo test -p ff-test` — all relevant cancel_flow tests pass (`pr_c1_cancel_flow_partial`, etc.). Two environmental test collisions (`completion_backend` ordering, `engine_backend_list_flows` concurrent-contamination) reproduce on `origin/main` — pre-existing, not caused by this PR.
- [x] `cargo test -p ff-test --test http_postgres_smoke --features postgres-e2e` — **green**; Postgres smoke unaffected (the 5 migrated-ingress routes still pass end-to-end).
- [x] Grep verification of all four patterns returns zero hits.

## Out of scope (E3/E4)

- `Server::scheduler` field removal — E3
- `Server::claim_for_worker` trait cutover — E3
- Postgres scanner supervisor / reconciler driver — E3
- `BACKEND_STAGE_READY` flip — E4
- `ServerConfig` deprecated flat fields — E4
- Legacy `waitpoint_token` wire field — E4
- v0.8.0 bump — E4

## Known-red

- `cargo-semver-checks` will flag the 5 new trait methods as breaking additions to `EngineBackend`. This is expected Stage E v0.8 semver behaviour (consistent with E1); admin-merge when matrix + sec/quality are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors cancellation and execution-read paths to route through new `EngineBackend` methods and adds backend-specific parsing/reload logic in `ff-backend-valkey`, which could impact runtime behavior during failover or idempotent retries.
> 
> **Overview**
> **Stage E2 migrates remaining server-owned Valkey operations behind `EngineBackend` and deletes the raw `ferriskey::Client` from `ff-server`.** `cancel_flow` now calls `backend.cancel_flow_header()` (new `CancelFlowHeader` enum) and acknowledges per-member cancels via `backend.ack_cancel_member()`, preserving the existing `CancelFlowResult` wire behavior including the *already-terminal* idempotent path.
> 
> Valkey backend gains implementations for `cancel_flow_header`, `ack_cancel_member`, `read_execution_info`, `read_execution_state`, and `fetch_waitpoint_token_v07`, including the prior FCALL retry-on-“function not loaded” logic and response parsing. Postgres boot no longer dials Valkey; unimplemented Stage-E2 methods default to `EngineError::Unavailable`, and docs/tests are updated to reflect the new parity gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47f43a999dc7fb16878ecfa61e16332d5d8481a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->