### PR TITLE
release(v0.8.0): Wave 8 Stage E4a — BACKEND_STAGE_READY flip + cleanup + v0.8.0 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,88 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-24
+
+RFC-017 Wave 8 — Postgres backend ships first-class. The `EngineBackend`
+trait expanded by ~17 methods across Waves 0–8, `ServerConfig` flattened
+into a sum-typed `BackendConfig`, and the v0.7 `/v1/pending-waitpoints`
+compatibility shim was retired. See
+[`docs/CONSUMER_MIGRATION_v0.8.md`](docs/CONSUMER_MIGRATION_v0.8.md) for
+the full migration guide and
+[`docs/POSTGRES_PARITY_MATRIX.md`](docs/POSTGRES_PARITY_MATRIX.md) for
+the v0.8.0 Postgres parity audit.
+
+### Breaking
+
+- **RFC-017 `EngineBackend` trait expansion.** ~17 methods added over
+  Waves 4–8 to cover the flow/attempt/budget/admin/completion families
+  on Postgres. Custom `EngineBackend` implementations must add the new
+  methods; `HookedBackend` / `PassthroughBackend` / `ValkeyBackend` /
+  `PostgresBackend` all carry in-tree impls.
+- **`ServerConfig` flat Valkey fields removed.** The deprecated
+  `host` / `port` / `tls` / `cluster` / `skip_library_load` fields on
+  `ServerConfig` are gone. Replaced by nested
+  `ServerConfig::valkey: ValkeyServerConfig` mirroring the existing
+  `ServerConfig::postgres: PostgresServerConfig` shape.
+- **`PendingWaitpointInfo` wire-shape change.** The
+  `/v1/executions/{id}/pending-waitpoints` response no longer carries a
+  raw `waitpoint_token` HMAC. Clients correlate via `(token_kid,
+  token_fingerprint)` alongside the other sanitised fields. The
+  `Deprecation: ff-017` response header was also removed.
+- **`ServerError` variant additions.** Additive variants landed across
+  Stages D1–E3 for Postgres-path error classification; `ServerError` is
+  `#[non_exhaustive]`, so consumers matching it must add a catch-all
+  arm if they haven't already.
+- **`ClaimPolicy::immediate()` removed / `ClaimPolicy::new` signature
+  change** (from the v0.7 cycle, published here). `ClaimPolicy` now
+  carries `worker_id`, `worker_instance_id`, `lease_ttl_ms`.
+  `ReclaimToken::new` gained the matching identity args.
+
 ### Added
+
+- **RFC-017 Stage E4: Postgres backend first-class over HTTP.**
+  `FF_BACKEND=postgres` boots natively — the v0.7-era
+  `FF_BACKEND_ACCEPT_UNREADY=1` / `FF_ENV=development` dev-override is
+  gone and `BACKEND_STAGE_READY` now lists both `valkey` and
+  `postgres`.
+- **`PostgresScheduler` + 6 reconcilers.** Stage E3 landed the
+  Postgres execution-dispatch scheduler plus the sibling-cancel,
+  lease-timeout, completion-listener, cancel-backlog, flow-staging,
+  and edge-group-policy reconcilers on top of the Wave 3 schema.
+- **`Server::start_with_backend`** — test-injection entry point that
+  accepts a constructed `EngineBackend` trait object, used by
+  `crates/ff-test/tests/http_postgres_smoke.rs` for the integration
+  smoke without a full env-var dance.
+- **`http_postgres_smoke` integration test** — end-to-end POST/GET
+  coverage of the HTTP API against a `PostgresBackend`, gated by the
+  `postgres-e2e` feature.
+- **New `docs/CONSUMER_MIGRATION_v0.8.md`** — upgrade guide for
+  `ServerConfig`, `PendingWaitpointInfo`, `FF_BACKEND=postgres`
+  setup, and the `EngineBackend` trait expansion.
+
+### Removed
+
+- `Server::client()` accessor / `Server::client` field.
+- `Server::fcall_with_reload` inherent.
+- `Server::scheduler` field (replaced by trait-routed dispatch).
+- Legacy `waitpoint_token` wire field on
+  `/v1/executions/{id}/pending-waitpoints`; the `Deprecation: ff-017`
+  response header; and the `ValkeyBackend::fetch_waitpoint_token_v07`
+  inherent + trait method. The
+  `ff_pending_waitpoint_legacy_token_served_total` and
+  `ff_backend_unready_boot_total` counters remain declared in
+  `ff-observability` for historical continuity but are no longer
+  emitted by the server.
+- Deprecated `ServerConfig` flat Valkey fields (see Breaking above).
+- `FF_BACKEND_ACCEPT_UNREADY` + `FF_ENV` dev-mode escape hatches on
+  the server boot path.
+
+### v0.7-cycle changes (shipped in 0.8.0)
+
+The following items landed during the v0.7 RFC cycle but did not get a
+point release of their own; they ship here.
+
+#### Added
 
 - **RFC-v0.7 Wave 4c: Postgres flow family (`EngineBackend`).**
   `PostgresBackend` now implements six flow-scoped trait methods over

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "crc16",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "axum",
  "ff-observability",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "axum",
  "ferriskey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -35,18 +35,18 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.6.1", path = "crates/ff-core" }
-ff-script = { version = "0.6.1", path = "crates/ff-script" }
-ff-engine = { version = "0.6.1", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.6.1", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.6.1", path = "crates/ff-sdk" }
-ff-server = { version = "0.6.1", path = "crates/ff-server" }
+ff-core = { version = "0.8.0", path = "crates/ff-core" }
+ff-script = { version = "0.8.0", path = "crates/ff-script" }
+ff-engine = { version = "0.8.0", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.8.0", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.8.0", path = "crates/ff-sdk" }
+ff-server = { version = "0.8.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.6.1", path = "crates/ff-backend-valkey" }
-ff-backend-postgres = { version = "0.6.1", path = "crates/ff-backend-postgres" }
-ff-observability = { version = "0.6.1", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.6.1", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.6.1", path = "ferriskey" }
+ff-backend-valkey = { version = "0.8.0", path = "crates/ff-backend-valkey" }
+ff-backend-postgres = { version = "0.8.0", path = "crates/ff-backend-postgres" }
+ff-observability = { version = "0.8.0", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.8.0", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.8.0", path = "ferriskey" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/benches/harness/benches/quorum_cancel_fanout.rs
+++ b/benches/harness/benches/quorum_cancel_fanout.rs
@@ -267,11 +267,12 @@ async fn start_server(tc: &TestCluster) -> std::sync::Arc<ff_server::server::Ser
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
+
+
+
+
+
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -281,14 +282,15 @@ async fn start_server(tc: &TestCluster) -> std::sync::Arc<ff_server::server::Ser
             edge_cancel_dispatcher_interval: Duration::from_millis(250),
             ..Default::default()
         },
-        skip_library_load: false,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:
             "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
         waitpoint_hmac_grace_ms: 86_400_000,
         max_concurrent_stream_ops: 64,
-    };
+    
+};
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -28,7 +28,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.8.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.8.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -467,35 +467,6 @@ impl ValkeyBackend {
     }
 
     /// RFC-017 Stage D1 (§8): Valkey-only inherent fetch of the raw
-    /// `<kid>:<hex>` waitpoint token for the v0.7.x pending-waitpoints
-    /// wire-format shim. **NOT on `EngineBackend`** — the trait
-    /// boundary never exposes the raw HMAC post-§8. The ff-server
-    /// HTTP handler wraps the sanitised trait response and calls
-    /// this inherent to re-inject the legacy field on the wire for
-    /// one-release deprecation warning; the shim + this method go
-    /// away at Stage E / v0.8.0.
-    ///
-    /// Returns `Ok(None)` if the waitpoint hash does not carry a
-    /// `waitpoint_token` field (missing / rotated out). Transport
-    /// errors surface as `EngineError::Transport`.
-    pub async fn fetch_waitpoint_token_v07(
-        &self,
-        execution_id: &ExecutionId,
-        waitpoint_id: &WaitpointId,
-    ) -> Result<Option<String>, EngineError> {
-        let partition = execution_partition(execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, execution_id);
-        let token: Option<String> = self
-            .client
-            .hget(&ctx.waitpoint(waitpoint_id), "waitpoint_token")
-            .await
-            .map_err(|e| ff_core::engine_error::backend_context(
-                transport_fk(e),
-                "fetch_waitpoint_token_v07: HGET waitpoint_token",
-            ))?;
-        Ok(token.filter(|s| !s.is_empty()))
-    }
-
     /// RFC-017 §14.8 mandatory Stage B CI test hook. Exposes a clone
     /// of the internal semaphore so the shutdown-under-load test can
     /// hold permits directly without dispatching a live FCALL.
@@ -5966,23 +5937,6 @@ impl EngineBackend for ValkeyBackend {
         }
     }
 
-    async fn fetch_waitpoint_token_v07(
-        &self,
-        execution_id: &ExecutionId,
-        waitpoint_id: &WaitpointId,
-    ) -> Result<Option<String>, EngineError> {
-        let partition = execution_partition(execution_id, &self.partition_config);
-        let ctx = ExecKeyContext::new(&partition, execution_id);
-        let token: Option<String> = self
-            .client
-            .hget(&ctx.waitpoint(waitpoint_id), "waitpoint_token")
-            .await
-            .map_err(|e| ff_core::engine_error::backend_context(
-                transport_fk(e),
-                "fetch_waitpoint_token_v07: HGET waitpoint_token",
-            ))?;
-        Ok(token.filter(|s| !s.is_empty()))
-    }
 }
 
 /// Detect Valkey errors indicating the Lua function library is not

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -82,7 +82,7 @@ use crate::engine_error::EngineError;
 use crate::types::AttemptIndex;
 #[cfg(feature = "core")]
 use crate::types::EdgeId;
-use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs, WaitpointId};
+use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 
 /// The engine write surface — a single trait a backend implementation
 /// honours to serve a `FlowFabricWorker`.
@@ -989,24 +989,6 @@ pub trait EngineBackend: Send + Sync + 'static {
         })
     }
 
-    /// RFC-017 Stage D1 / E2: fetch the raw `<kid>:<hex>` waitpoint
-    /// token so the v0.7.x wire-format shim in
-    /// `api::list_pending_waitpoints` can re-inject the legacy
-    /// `waitpoint_token` field during the one-release deprecation
-    /// window. Returns `Ok(None)` when the field is absent/empty.
-    /// Valkey-only; Postgres default is `Unavailable`. At v0.8.0 the
-    /// legacy wire field is removed and both this method + caller
-    /// shim go with it.
-    #[cfg(feature = "core")]
-    async fn fetch_waitpoint_token_v07(
-        &self,
-        _execution_id: &ExecutionId,
-        _waitpoint_id: &WaitpointId,
-    ) -> Result<Option<String>, EngineError> {
-        Err(EngineError::Unavailable {
-            op: "fetch_waitpoint_token_v07",
-        })
-    }
 }
 
 /// Object-safety assertion: `dyn EngineBackend` compiles iff every

--- a/crates/ff-readiness-tests/src/server.rs
+++ b/crates/ff-readiness-tests/src/server.rs
@@ -75,11 +75,12 @@ impl InProcessServer {
         let tls = crate::valkey::env_flag("FF_TLS");
         let cluster = crate::valkey::env_flag("FF_CLUSTER");
 
-        let config = ServerConfig {
-            host,
-            port,
-            tls,
-            cluster,
+        let config = ServerConfig {            valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: tls, cluster: cluster, skip_library_load: true },
+
+
+
+
+
             partition_config: TEST_PARTITION_CONFIG,
             lanes: vec![LaneId::new(lane)],
             listen_addr: "127.0.0.1:0".into(),
@@ -88,7 +89,7 @@ impl InProcessServer {
                 lanes: vec![LaneId::new(lane)],
                 ..Default::default()
             },
-            skip_library_load: true,
+
             cors_origins: vec!["*".to_owned()],
             api_token: None,
             waitpoint_hmac_secret: secret.to_owned(),
@@ -96,7 +97,8 @@ impl InProcessServer {
             max_concurrent_stream_ops: 64,
             backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-        };
+        
+};
 
         let server = Arc::new(Server::start(config).await.expect("Server::start"));
         let app = ff_server::api::router(server.clone(), &["*".to_owned()], None)

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -49,7 +49,7 @@ valkey-client = ["dep:ferriskey"]
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.8.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: optional so `--no-default-features` drops the transport edge.
 ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -75,7 +75,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.6.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.8.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-script's defaults are empty — the `valkey-client`
 # feature (which owns the `ferriskey` dep edge) is activated below by
 # the `valkey-default` feature, NOT here. This keeps

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -904,110 +904,28 @@ async fn get_execution_state(
 }
 
 /// Returns the actionable (`pending`/`active`) waitpoints for an
-/// execution, including the HMAC `waitpoint_token` required to deliver
-/// signals. Human reviewers use this to look up the token originally
-/// returned only to the suspending worker's `SuspendOutcome`.
+/// execution as the sanitised `PendingWaitpointInfo` shape
+/// (6 original fields + `token_kid` + `token_fingerprint` +
+/// `execution_id`). The raw HMAC `waitpoint_token` is NOT returned —
+/// callers correlate waitpoints via `(token_kid, token_fingerprint)`
+/// and obtain the delivery credential through the worker's
+/// `SuspendOutcome` at suspend time.
 ///
-/// SECURITY: `waitpoint_token` is a bearer credential for signal
-/// delivery; leaking it lets a third party forge authority to resume or
-/// influence the execution. Gate the endpoint behind `FF_API_TOKEN` in
-/// any deployment reachable from untrusted networks. The auth middleware
-/// only mounts when `FF_API_TOKEN` is set; this endpoint is
-/// unauthenticated without it, and the server logs a loud warning at
-/// startup so operators notice.
-/// v0.7.x wire DTO for a pending waitpoint entry.
-///
-/// **RFC-017 Stage D1 (§8) — deprecation window.** The trait-boundary
-/// `PendingWaitpointInfo` no longer carries the raw HMAC
-/// `waitpoint_token`; this DTO re-injects the legacy field on the
-/// v0.7.x wire so existing consumers keep functioning for one release.
-/// At v0.8.0 the legacy field is removed outright and the struct
-/// collapses into a direct serialisation of `PendingWaitpointInfo`.
-/// Each response also carries the `Deprecation: ff-017` header and
-/// increments `ff_pending_waitpoint_legacy_token_served_total`.
-#[derive(Serialize)]
-struct PendingWaitpointWireV07 {
-    waitpoint_id: WaitpointId,
-    waitpoint_key: String,
-    state: String,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    required_signal_names: Vec<String>,
-    created_at: TimestampMs,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    activated_at: Option<TimestampMs>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    expires_at: Option<TimestampMs>,
-    execution_id: ExecutionId,
-    token_kid: String,
-    token_fingerprint: String,
-    /// RFC-017 §8 legacy v0.7.x field — `null` on non-Valkey backends
-    /// (the v0.7.x token-fetch shim is Valkey-only). Removed at v0.8.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    waitpoint_token: Option<String>,
-}
-
+/// (RFC-017 Stage E4 / v0.8.0 §8: the legacy `waitpoint_token` wire
+/// field was removed; the one-release deprecation window closed with
+/// this release.)
 async fn list_pending_waitpoints(
     State(server): State<Arc<Server>>,
     Path(id): Path<String>,
 ) -> Result<Response, ApiError> {
-    // RFC-017 Stage D1 (§4 row 8 / §8): dispatch through the trait +
-    // wrap the sanitised entries for the v0.7.x deprecation window.
+    // RFC-017 Stage E4 (v0.8.0 §8): wire response serializes the
+    // sanitised `PendingWaitpointInfo` directly — no raw HMAC
+    // `waitpoint_token`, no `Deprecation: ff-017` header. Consumers
+    // correlate via `(token_kid, token_fingerprint)`.
     let eid = parse_execution_id(&id)?;
-    let args = ff_core::contracts::ListPendingWaitpointsArgs::new(eid.clone());
+    let args = ff_core::contracts::ListPendingWaitpointsArgs::new(eid);
     let page = server.backend().list_pending_waitpoints(args).await?;
-
-    // Fetch the raw token for each entry via the Valkey-only v0.7.x
-    // shim. The §9.0 hard-gate guarantees only `valkey` backends boot
-    // through Stage D; defensive-in-depth, non-Valkey backends emit
-    // `token = None` + a warn log.
-    let is_valkey = server.backend().backend_label() == "valkey";
-    let metrics = server.metrics();
-    let mut wire: Vec<PendingWaitpointWireV07> = Vec::with_capacity(page.entries.len());
-    for info in page.entries {
-        let legacy_token = if is_valkey {
-            server
-                .fetch_waitpoint_token_v07(&info.execution_id, &info.waitpoint_id)
-                .await
-                .map_err(ApiError::from)?
-        } else {
-            tracing::warn!(
-                execution_id = %info.execution_id,
-                waitpoint_id = %info.waitpoint_id,
-                "pending_waitpoint_legacy_token_unavailable: \
-                 backend does not expose the v0.7.x token-fetch shim"
-            );
-            None
-        };
-        if legacy_token.is_some() {
-            metrics.inc_pending_waitpoint_legacy_token();
-            tracing::info!(
-                target: "audit",
-                execution_id = %info.execution_id,
-                waitpoint_id = %info.waitpoint_id,
-                "pending_waitpoint_legacy_token_served"
-            );
-        }
-        wire.push(PendingWaitpointWireV07 {
-            waitpoint_id: info.waitpoint_id,
-            waitpoint_key: info.waitpoint_key,
-            state: info.state,
-            required_signal_names: info.required_signal_names,
-            created_at: info.created_at,
-            activated_at: info.activated_at,
-            expires_at: info.expires_at,
-            execution_id: info.execution_id,
-            token_kid: info.token_kid,
-            token_fingerprint: info.token_fingerprint,
-            waitpoint_token: legacy_token,
-        });
-    }
-
-    let mut resp = Json(wire).into_response();
-    resp.headers_mut().insert(
-        "Deprecation",
-        axum::http::HeaderValue::from_static("ff-017"),
-    );
-    Ok(resp)
+    Ok(Json(page.entries).into_response())
 }
 
 /// Returns the raw result payload bytes written by the worker's

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -3,23 +3,18 @@ use ff_core::types::LaneId;
 use ff_engine::EngineConfig;
 use std::time::Duration;
 
-/// RFC-017 Stage A: backend family selector. Default `Valkey`; the
-/// `Postgres` variant is hard-gated at boot during Stages A-D per
-/// RFC-017 §9.0 (`BACKEND_STAGE_READY`). The gate lifts in Stage E
-/// alongside v0.8.0.
-///
-/// Stage A adds the selector only so `Server::start` can refuse
-/// unready backends cleanly; no `FF_BACKEND` env var is wired yet
-/// (Stage D lands the env plumbing + the `BackendConfig` sum type
-/// per RFC §11).
+/// RFC-017 Stage A: backend family selector. Default `Valkey`. At
+/// Stage E4 (v0.8.0) both `Valkey` and `Postgres` are first-class and
+/// boot without a dev-override; `BACKEND_STAGE_READY` remains in
+/// `ff-server::server` as defence-in-depth for future backend
+/// additions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum BackendKind {
     /// Valkey / FCALL backend (production path through v0.7.x).
     #[default]
     Valkey,
-    /// Postgres backend. **Refuses to boot** until Stage E — see
-    /// [`crate::server::ServerError::BackendNotReady`].
+    /// Postgres backend. First-class since v0.8.0 (RFC-017 Stage E4).
     Postgres,
 }
 
@@ -185,9 +180,7 @@ impl ServerConfig {
     /// | `FF_FLOW_PROJECTOR_INTERVAL_S` | `15` | Flow projector scanner interval |
     /// | `FF_EXECUTION_DEADLINE_INTERVAL_S` | `5` | Execution-deadline scanner interval |
     /// | `FF_CANCEL_RECONCILER_INTERVAL_S` | `15` | Cancel reconciler scanner interval |
-    /// | `FF_BACKEND` | `valkey` | Backend family — `valkey` or `postgres`. Per RFC-017 §9.0, `postgres` is hard-gated at boot through Stage D; dev-override `FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development` bypasses (non-production only). |
-    /// | `FF_BACKEND_ACCEPT_UNREADY` | *(unset)* | Dev-only override: `1` or `true` bypasses `BACKEND_STAGE_READY` when `FF_ENV=development`. Production refuses the combination. |
-    /// | `FF_ENV` | *(unset)* | Environment marker. Only `development` enables the dev-override path above. Any other value (or unset) keeps the hard-gate active. |
+    /// | `FF_BACKEND` | `valkey` | Backend family — `valkey` or `postgres`. Both are first-class at v0.8.0 (RFC-017 Stage E4 flipped `BACKEND_STAGE_READY` to `&["valkey", "postgres"]`). |
     /// | `FF_POSTGRES_URL` | *(empty)* | Postgres connection URL (libpq/sqlx shape, e.g. `postgres://user:pass@host:port/db`). Required when `FF_BACKEND=postgres`; ignored otherwise. |
     /// | `FF_POSTGRES_POOL_SIZE` | `10` | Max Postgres pool connections; ignored on the Valkey path. |
     pub fn from_env() -> Result<Self, ConfigError> {
@@ -347,17 +340,13 @@ impl ServerConfig {
             scanner_filter: Default::default(),
         };
 
-        // RFC-017 Stage D1 (§9.0): `FF_BACKEND` selects the backend
-        // family at boot. Default `valkey`; `postgres` is hard-gated
-        // through Stage D and refused at startup unless the dev-mode
-        // override (`FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development`)
-        // is set. Unknown values are rejected eagerly so typos don't
-        // silently fall through to the default.
-        // RFC-017 Wave 8 Stage E1: FF_POSTGRES_URL + FF_POSTGRES_POOL_SIZE
-        // populate `postgres` when FF_BACKEND=postgres. Read regardless of
-        // backend selector so operators can preset the values; the Valkey
-        // path ignores them. Empty URL is a hard error only when
-        // FF_BACKEND=postgres (checked during boot).
+        // RFC-017 Stage E4 (v0.8.0): `FF_BACKEND` selects the backend
+        // family at boot. Default `valkey`; both `valkey` and `postgres`
+        // are first-class. Unknown values are rejected eagerly so typos
+        // don't silently fall through to the default. FF_POSTGRES_URL +
+        // FF_POSTGRES_POOL_SIZE populate `postgres` when FF_BACKEND=postgres.
+        // Read regardless of backend selector so operators can preset the
+        // values; the Valkey path ignores them.
         let postgres = PostgresServerConfig {
             url: std::env::var("FF_POSTGRES_URL").unwrap_or_default(),
             pool_size: env_u32_positive("FF_POSTGRES_POOL_SIZE", 10)?,

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -58,8 +58,19 @@ impl Default for PostgresServerConfig {
     }
 }
 
-/// Server configuration, loaded from environment variables.
-pub struct ServerConfig {
+/// RFC-017 Wave 8 Stage E4 (v0.8.0): Valkey connection parameters
+/// carried on [`ServerConfig`] when `backend == BackendKind::Valkey`.
+///
+/// Mirrors the pre-existing [`PostgresServerConfig`] shape. Replaces
+/// the flat `host` / `port` / `tls` / `cluster` / `skip_library_load`
+/// fields removed at v0.8.0 in favour of sum-typed nesting.
+///
+/// **Not `#[non_exhaustive]`** so downstream tests and consumers can
+/// construct the struct literal directly. Adding fields here is a
+/// v0.y.0 breaking bump; call sites that want to remain insulated can
+/// use `..ValkeyServerConfig::default()` in their literal.
+#[derive(Debug, Clone)]
+pub struct ValkeyServerConfig {
     /// Valkey host. Default: `"localhost"`.
     pub host: String,
     /// Valkey port. Default: `6379`.
@@ -68,6 +79,28 @@ pub struct ServerConfig {
     pub tls: bool,
     /// Enable Valkey cluster mode.
     pub cluster: bool,
+    /// Skip library loading (for tests where TestCluster already loaded it).
+    pub skip_library_load: bool,
+}
+
+impl Default for ValkeyServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "localhost".into(),
+            port: 6379,
+            tls: false,
+            cluster: false,
+            skip_library_load: false,
+        }
+    }
+}
+
+/// Server configuration, loaded from environment variables.
+///
+/// **RFC-017 Stage E4 (v0.8.0):** the flat Valkey fields (`host`,
+/// `port`, `tls`, `cluster`, `skip_library_load`) were removed. Use
+/// [`ValkeyServerConfig`] on the `valkey` field instead.
+pub struct ServerConfig {
     /// Partition counts (execution/flow/budget/quota).
     pub partition_config: PartitionConfig,
     /// Lanes to manage. Default: `["default"]`.
@@ -76,8 +109,6 @@ pub struct ServerConfig {
     pub listen_addr: String,
     /// Scanner intervals and engine config.
     pub engine_config: EngineConfig,
-    /// Skip library loading (for tests where TestCluster already loaded it).
-    pub skip_library_load: bool,
     /// Allowed CORS origins. `["*"]` means permissive (all origins).
     pub cors_origins: Vec<String>,
     /// Shared-secret API token. If set, all requests except GET /healthz must
@@ -112,6 +143,10 @@ pub struct ServerConfig {
     /// [`BackendKind::Valkey`]. `BackendKind::Postgres` is rejected
     /// at startup through Stage D per RFC-017 §9.0.
     pub backend: BackendKind,
+    /// RFC-017 Stage E4 (v0.8.0): Valkey connection parameters.
+    /// Meaningful only when `backend == BackendKind::Valkey`; the
+    /// Postgres path ignores these fields.
+    pub valkey: ValkeyServerConfig,
     /// RFC-017 Wave 8 Stage E1: Postgres connection parameters.
     /// Meaningful only when `backend == BackendKind::Postgres`; the
     /// Valkey path ignores these fields.
@@ -184,10 +219,13 @@ impl ServerConfig {
     /// | `FF_POSTGRES_URL` | *(empty)* | Postgres connection URL (libpq/sqlx shape, e.g. `postgres://user:pass@host:port/db`). Required when `FF_BACKEND=postgres`; ignored otherwise. |
     /// | `FF_POSTGRES_POOL_SIZE` | `10` | Max Postgres pool connections; ignored on the Valkey path. |
     pub fn from_env() -> Result<Self, ConfigError> {
-        let host = env_or("FF_HOST", "localhost");
-        let port = env_u16("FF_PORT", 6379)?;
-        let tls = env_bool("FF_TLS");
-        let cluster = env_bool("FF_CLUSTER");
+        let valkey = ValkeyServerConfig {
+            host: env_or("FF_HOST", "localhost"),
+            port: env_u16("FF_PORT", 6379)?,
+            tls: env_bool("FF_TLS"),
+            cluster: env_bool("FF_CLUSTER"),
+            skip_library_load: false,
+        };
         let listen_addr = env_or("FF_LISTEN_ADDR", "0.0.0.0:9090");
         // FF_CORS_ORIGINS contract:
         //   unset      → default "*" (permissive)
@@ -369,21 +407,17 @@ impl ServerConfig {
         };
 
         Ok(Self {
-            host,
-            port,
-            tls,
-            cluster,
             partition_config,
             lanes,
             listen_addr,
             engine_config,
-            skip_library_load: false,
             cors_origins,
             api_token,
             waitpoint_hmac_secret,
             waitpoint_hmac_grace_ms,
             max_concurrent_stream_ops,
             backend,
+            valkey,
             postgres,
         })
     }
@@ -394,10 +428,6 @@ impl Default for ServerConfig {
         let lanes = vec![LaneId::new("default")];
         let partition_config = PartitionConfig::default();
         Self {
-            host: "localhost".into(),
-            port: 6379,
-            tls: false,
-            cluster: false,
             partition_config,
             lanes: lanes.clone(),
             listen_addr: "0.0.0.0:9090".into(),
@@ -406,7 +436,6 @@ impl Default for ServerConfig {
                 lanes,
                 ..Default::default()
             },
-            skip_library_load: false,
             cors_origins: vec!["*".to_owned()],
             api_token: None,
             // Deterministic dev/test secret. Production deployments MUST
@@ -419,6 +448,7 @@ impl Default for ServerConfig {
             waitpoint_hmac_grace_ms: 86_400_000,
             max_concurrent_stream_ops: 64,
             backend: BackendKind::default(),
+            valkey: ValkeyServerConfig::default(),
             postgres: PostgresServerConfig::default(),
         }
     }

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -712,28 +712,6 @@ impl Server {
     // (`cancel_flow_header`, `ack_cancel_member`, `read_execution_info`,
     // `read_execution_state`, `fetch_waitpoint_token_v07`).
 
-    /// RFC-017 Stage D1 (§8): fetch the raw `<kid>:<hex>`
-    /// `waitpoint_token` so the v0.7.x wire-format shim in
-    /// `api::list_pending_waitpoints` can re-inject the legacy
-    /// `waitpoint_token` field during the one-release deprecation
-    /// window. **Valkey-only** — the backend hard-gate ensures no
-    /// other backend can reach this path at boot; callers defensive-
-    /// check via `backend_label()` before calling. At v0.8.0 the
-    /// legacy wire field is removed and this method goes with it.
-    pub async fn fetch_waitpoint_token_v07(
-        &self,
-        execution_id: &ExecutionId,
-        waitpoint_id: &WaitpointId,
-    ) -> Result<Option<String>, ServerError> {
-        // RFC-017 Stage E2: routed through the backend trait. The
-        // Valkey impl carries the HGET verbatim; Postgres returns
-        // Unavailable (it cannot reach this path at boot per §9.0).
-        Ok(self
-            .backend
-            .fetch_waitpoint_token_v07(execution_id, waitpoint_id)
-            .await?)
-    }
-
     /// Get the server config.
     pub fn config(&self) -> &ServerConfig {
         &self.config

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -30,7 +30,7 @@ use crate::config::{BackendKind, ServerConfig};
 /// joins at Stage E (v0.8.0). Compiled into the binary by design —
 /// see RFC-017 §9.0 "Fleet-wide cutover requirement" for the
 /// rolling-upgrade implication.
-const BACKEND_STAGE_READY: &[&str] = &["valkey"];
+const BACKEND_STAGE_READY: &[&str] = &["valkey", "postgres"];
 
 /// Upper bound on `member_execution_ids` returned in the
 /// [`CancelFlowResult::Cancelled`] response when the flow was already in a
@@ -147,9 +147,8 @@ pub enum ServerError {
     /// `stage` names the current stage ("A"/"B"/"C"/"D") so operator
     /// tooling can correlate the refusal with the migration plan.
     #[error(
-        "backend not ready: {backend} (staged for Stage E; current binary at Stage {stage}). \
-         Set FF_BACKEND=valkey, or set both FF_BACKEND_ACCEPT_UNREADY=1 and FF_ENV=development to \
-         override in dev."
+        "backend not ready: {backend} (not in BACKEND_STAGE_READY; current stage {stage}). \
+         Set FF_BACKEND=valkey or FF_BACKEND=postgres."
     )]
     BackendNotReady {
         backend: &'static str,
@@ -301,39 +300,21 @@ impl Server {
         config: ServerConfig,
         metrics: Arc<ff_observability::Metrics>,
     ) -> Result<Self, ServerError> {
-        // RFC-017 §9.0 hard-gate. Refuse to boot unready backends
-        // unless the dev-mode override combo (FF_BACKEND_ACCEPT_UNREADY=1
-        // AND FF_ENV=development) is set. Production refuses the
-        // override; see the env-var check inline.
+        // RFC-017 §9.0 hard-gate. At v0.8.0 (Stage E4) both `valkey` and
+        // `postgres` are ready; this check remains as defence-in-depth
+        // so future backend additions must explicitly opt into the list.
+        // The `FF_BACKEND_ACCEPT_UNREADY` / `FF_ENV=development` dev-mode
+        // override was retired at Stage E4 because it is no longer
+        // needed — both supported backends now boot without override.
         let label = config.backend.as_str();
         if !BACKEND_STAGE_READY.contains(&label) {
-            let accept_unready = std::env::var("FF_BACKEND_ACCEPT_UNREADY")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
-            let is_dev = std::env::var("FF_ENV")
-                .map(|v| v.eq_ignore_ascii_case("development"))
-                .unwrap_or(false);
-            if accept_unready && is_dev {
-                tracing::warn!(
-                    backend = label,
-                    stage = "E1",
-                    "backend_unready_boot_override: backend={label} stage=E1 \
-                     (FF_BACKEND_ACCEPT_UNREADY=1 + FF_ENV=development)"
-                );
-                let backend_label: &'static str = match config.backend {
+            return Err(ServerError::BackendNotReady {
+                backend: match config.backend {
                     BackendKind::Postgres => "postgres",
                     BackendKind::Valkey => "valkey",
-                };
-                metrics.inc_backend_unready_boot(backend_label, "E1");
-            } else {
-                return Err(ServerError::BackendNotReady {
-                    backend: match config.backend {
-                        BackendKind::Postgres => "postgres",
-                        BackendKind::Valkey => "valkey",
-                    },
-                    stage: "E1",
-                });
-            }
+                },
+                stage: "E4",
+            });
         }
 
         // RFC-017 Wave 8 Stage E1: Postgres dial branch. Stage E4 flips

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -327,18 +327,18 @@ impl Server {
         }
         // Step 1: Connect to Valkey via ClientBuilder
         tracing::info!(
-            host = %config.host, port = config.port,
-            tls = config.tls, cluster = config.cluster,
+            host = %config.valkey.host, port = config.valkey.port,
+            tls = config.valkey.tls, cluster = config.valkey.cluster,
             "connecting to Valkey"
         );
         let mut builder = ClientBuilder::new()
-            .host(&config.host, config.port)
+            .host(&config.valkey.host, config.valkey.port)
             .connect_timeout(Duration::from_secs(10))
             .request_timeout(Duration::from_millis(5000));
-        if config.tls {
+        if config.valkey.tls {
             builder = builder.tls();
         }
-        if config.cluster {
+        if config.valkey.cluster {
             builder = builder.cluster();
         }
         let client = builder
@@ -375,7 +375,7 @@ impl Server {
             .initialize_deployment(
                 &config.waitpoint_hmac_secret,
                 &config.lanes,
-                config.skip_library_load,
+                config.valkey.skip_library_load,
             )
             .await
             .map_err(|e| ServerError::Engine(Box::new(e)))?;
@@ -415,11 +415,11 @@ impl Server {
         // the wire subscription now lives in ff-backend-valkey, the
         // engine just consumes the resulting stream.
         let mut valkey_conn = ff_core::backend::ValkeyConnection::new(
-            config.host.clone(),
-            config.port,
+            config.valkey.host.clone(),
+            config.valkey.port,
         );
-        valkey_conn.tls = config.tls;
-        valkey_conn.cluster = config.cluster;
+        valkey_conn.tls = config.valkey.tls;
+        valkey_conn.cluster = config.valkey.cluster;
         let completion_backend = ff_backend_valkey::ValkeyBackend::from_client_partitions_and_connection(
             client.clone(),
             config.partition_config,
@@ -515,11 +515,11 @@ impl Server {
             config.partition_config,
             {
                 let mut c = ff_core::backend::ValkeyConnection::new(
-                    config.host.clone(),
-                    config.port,
+                    config.valkey.host.clone(),
+                    config.valkey.port,
                 );
-                c.tls = config.tls;
-                c.cluster = config.cluster;
+                c.tls = config.valkey.tls;
+                c.cluster = config.valkey.cluster;
                 c
             },
         );

--- a/crates/ff-test/tests/admin_rotate_api.rs
+++ b/crates/ff-test/tests/admin_rotate_api.rs
@@ -116,10 +116,13 @@ fn test_server_config(api_token: Option<String>) -> ff_server::config::ServerCon
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls: ff_test::fixtures::env_flag("FF_TLS"),
+            cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+            skip_library_load: true,
+        },
         partition_config: pc,
         lanes: vec![ff_core::types::LaneId::new("admin-rotate-lane")],
         listen_addr: "127.0.0.1:0".into(),
@@ -128,7 +131,7 @@ fn test_server_config(api_token: Option<String>) -> ff_server::config::ServerCon
             lanes: vec![ff_core::types::LaneId::new("admin-rotate-lane")],
             ..Default::default()
         },
-        skip_library_load: true,
+
         cors_origins: vec!["*".to_owned()],
         api_token,
         // Known-weak all-zeros secret — fine for tests, documented

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -91,6 +91,7 @@ impl TestApi {
 }
 
 fn test_server_config() -> ff_server::config::ServerConfig {
+
     let config = ff_test::fixtures::TEST_PARTITION_CONFIG;
     let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
     let port: u16 = std::env::var("FF_PORT")
@@ -100,10 +101,13 @@ fn test_server_config() -> ff_server::config::ServerConfig {
     let tls = ff_test::fixtures::env_flag("FF_TLS");
     let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
     ff_server::config::ServerConfig {
-        host,
-        port,
-        tls,
-        cluster,
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls: ff_test::fixtures::env_flag("FF_TLS"),
+            cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+            skip_library_load: true,
+        },
         partition_config: config,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -112,7 +116,7 @@ fn test_server_config() -> ff_server::config::ServerConfig {
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: true,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -98,8 +98,6 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    let tls = ff_test::fixtures::env_flag("FF_TLS");
-    let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
     ff_server::config::ServerConfig {
         valkey: ff_server::config::ValkeyServerConfig {
             host,

--- a/crates/ff-test/tests/e2e_flow_atomicity.rs
+++ b/crates/ff-test/tests/e2e_flow_atomicity.rs
@@ -32,11 +32,12 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: true },
+
+
+
+
+
         partition_config: pc,
         lanes: vec![LaneId::new("atomicity-lane")],
         listen_addr: "127.0.0.1:0".into(),
@@ -45,7 +46,7 @@ async fn start_server(
             lanes: vec![LaneId::new("atomicity-lane")],
             ..Default::default()
         },
-        skip_library_load: true,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:
@@ -54,7 +55,8 @@ async fn start_server(
         max_concurrent_stream_ops: 64,
         backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-    };
+    
+};
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -6253,11 +6253,12 @@ async fn test_server() -> ff_server::server::Server {
     let cluster = std::env::var("FF_CLUSTER")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-    let server_config = ServerConfig {
-        host,
-        port,
-        tls,
-        cluster,
+    let server_config = ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: tls, cluster: cluster },
+
+
+
+
+
         partition_config: config,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "0.0.0.0:0".into(),
@@ -7303,11 +7304,12 @@ async fn test_system_engine_with_concurrent_scanners() {
         let cluster = std::env::var("FF_CLUSTER")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        ServerConfig {
-            host,
-            port,
-            tls,
-            cluster,
+        ServerConfig {            valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: tls, cluster: cluster, skip_library_load: true },
+
+
+
+
+
             partition_config: config,
             lanes: vec![LaneId::new(LANE)],
             listen_addr: "0.0.0.0:0".into(),
@@ -7319,7 +7321,7 @@ async fn test_system_engine_with_concurrent_scanners() {
                 lease_expiry_interval: std::time::Duration::from_millis(500),
                 ..Default::default()
             },
-            skip_library_load: true,
+
             cors_origins: vec!["*".to_owned()],
             api_token: None,
             waitpoint_hmac_secret:
@@ -7328,7 +7330,8 @@ async fn test_system_engine_with_concurrent_scanners() {
             max_concurrent_stream_ops: 64,
         backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-        }
+        
+}
     };
     let server = ff_server::server::Server::start(server_config)
         .await

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -6253,11 +6253,14 @@ async fn test_server() -> ff_server::server::Server {
     let cluster = std::env::var("FF_CLUSTER")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-    let server_config = ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: tls, cluster: cluster },
-
-
-
-
+    let server_config = ServerConfig {
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls,
+            cluster,
+            skip_library_load: true, // TestCluster::connect() already loaded it
+        },
 
         partition_config: config,
         lanes: vec![LaneId::new(LANE)],
@@ -6267,7 +6270,6 @@ async fn test_server() -> ff_server::server::Server {
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: true, // TestCluster::connect() already loaded it
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:

--- a/crates/ff-test/tests/engine_backend_list_executions.rs
+++ b/crates/ff-test/tests/engine_backend_list_executions.rs
@@ -250,8 +250,6 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    let tls = ff_test::fixtures::env_flag("FF_TLS");
-    let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
     ff_server::config::ServerConfig {
         valkey: ff_server::config::ValkeyServerConfig {
             host,

--- a/crates/ff-test/tests/engine_backend_list_executions.rs
+++ b/crates/ff-test/tests/engine_backend_list_executions.rs
@@ -243,6 +243,7 @@ impl Drop for TestApi {
 }
 
 fn test_server_config() -> ff_server::config::ServerConfig {
+
     let config = ff_test::fixtures::TEST_PARTITION_CONFIG;
     let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
     let port: u16 = std::env::var("FF_PORT")
@@ -252,10 +253,13 @@ fn test_server_config() -> ff_server::config::ServerConfig {
     let tls = ff_test::fixtures::env_flag("FF_TLS");
     let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
     ff_server::config::ServerConfig {
-        host,
-        port,
-        tls,
-        cluster,
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls: ff_test::fixtures::env_flag("FF_TLS"),
+            cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+            skip_library_load: true,
+        },
         partition_config: config,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -264,7 +268,7 @@ fn test_server_config() -> ff_server::config::ServerConfig {
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: true,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:

--- a/crates/ff-test/tests/flow_edge_policies_stage_a.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_a.rs
@@ -50,11 +50,12 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
+
+
+
+
+
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -63,7 +64,7 @@ async fn start_server(
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: false,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:
@@ -72,7 +73,8 @@ async fn start_server(
         max_concurrent_stream_ops: 64,
         backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-    };
+    
+};
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_b.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_b.rs
@@ -49,11 +49,12 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
+
+
+
+
+
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -62,7 +63,7 @@ async fn start_server(
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: false,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:
@@ -71,7 +72,8 @@ async fn start_server(
         max_concurrent_stream_ops: 64,
         backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-    };
+    
+};
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_c.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_c.rs
@@ -53,11 +53,12 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
+
+
+
+
+
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -67,7 +68,7 @@ async fn start_server(
             edge_cancel_dispatcher_interval: Duration::from_millis(250),
             ..Default::default()
         },
-        skip_library_load: false,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:
@@ -76,7 +77,8 @@ async fn start_server(
         max_concurrent_stream_ops: 64,
         backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-    };
+    
+};
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_d.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_d.rs
@@ -65,11 +65,12 @@ async fn start_server(
     } else {
         Duration::from_secs(3600)
     };
-    let config = ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
+
+
+
+
+
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -80,7 +81,7 @@ async fn start_server(
             edge_cancel_reconciler_interval: Duration::from_millis(500),
             ..Default::default()
         },
-        skip_library_load: false,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:
@@ -89,7 +90,8 @@ async fn start_server(
         max_concurrent_stream_ops: 64,
         backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-    };
+    
+};
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_e.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_e.rs
@@ -89,11 +89,12 @@ async fn start_server_with_metrics(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
+
+
+
+
+
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -105,7 +106,7 @@ async fn start_server_with_metrics(
             edge_cancel_reconciler_interval: Duration::from_millis(500),
             ..Default::default()
         },
-        skip_library_load: false,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:
@@ -114,7 +115,8 @@ async fn start_server_with_metrics(
         max_concurrent_stream_ops: 64,
         backend: ff_server::config::BackendKind::default(),
         postgres: Default::default(),
-    };
+    
+};
     let server = ff_server::server::Server::start_with_metrics(config, metrics)
         .await
         .expect("Server::start_with_metrics");

--- a/crates/ff-test/tests/http_postgres_smoke.rs
+++ b/crates/ff-test/tests/http_postgres_smoke.rs
@@ -99,11 +99,12 @@ impl PgHttpSmoke {
         cleanup_postgres().await;
 
         let partition_config = PartitionConfig::default();
-        let config = ff_server::config::ServerConfig {
-            host: "localhost".into(),
-            port: 6379,
-            tls: false,
-            cluster: false,
+        let config = ff_server::config::ServerConfig {            valkey: ff_server::config::ValkeyServerConfig { host: "localhost".into(), port: 6379, tls: false, cluster: false, skip_library_load: true },
+
+
+
+
+
             partition_config,
             lanes: vec![LaneId::new(LANE)],
             listen_addr: "127.0.0.1:0".into(),
@@ -112,7 +113,7 @@ impl PgHttpSmoke {
                 lanes: vec![LaneId::new(LANE)],
                 ..Default::default()
             },
-            skip_library_load: true,
+
             cors_origins: vec!["*".to_owned()],
             api_token: None,
             waitpoint_hmac_secret:
@@ -126,7 +127,8 @@ impl PgHttpSmoke {
                 p.pool_size = 10;
                 p
             },
-        };
+        
+};
 
         let server = ff_server::server::Server::start(config)
             .await

--- a/crates/ff-test/tests/http_postgres_smoke.rs
+++ b/crates/ff-test/tests/http_postgres_smoke.rs
@@ -94,18 +94,8 @@ struct PgHttpSmoke {
 
 impl PgHttpSmoke {
     async fn setup() -> Self {
-        // CI / dev-override combo required for the §9.0 hard-gate;
-        // Stage E4 flips `BACKEND_STAGE_READY` and this override goes
-        // away.
-        // SAFETY: set_var is unsafe in Rust 2024 because env-vars are
-        // process-global and concurrent reads in other threads are
-        // racy. This test is the sole writer at boot time and the
-        // server reads the values synchronously during `start`.
-        unsafe {
-            std::env::set_var("FF_BACKEND_ACCEPT_UNREADY", "1");
-            std::env::set_var("FF_ENV", "development");
-        }
-
+        // RFC-017 Stage E4 (v0.8.0): `postgres` is in `BACKEND_STAGE_READY`
+        // and boots without the dev-override that Stages D1-E3 required.
         cleanup_postgres().await;
 
         let partition_config = PartitionConfig::default();

--- a/crates/ff-test/tests/list_lanes_population.rs
+++ b/crates/ff-test/tests/list_lanes_population.rs
@@ -51,8 +51,6 @@ fn server_config_with_lanes(lanes: Vec<LaneId>) -> ff_server::config::ServerConf
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    let tls = ff_test::fixtures::env_flag("FF_TLS");
-    let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
     ff_server::config::ServerConfig {
         valkey: ff_server::config::ValkeyServerConfig {
             host,

--- a/crates/ff-test/tests/list_lanes_population.rs
+++ b/crates/ff-test/tests/list_lanes_population.rs
@@ -44,6 +44,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 }
 
 fn server_config_with_lanes(lanes: Vec<LaneId>) -> ff_server::config::ServerConfig {
+
     let config = test_config();
     let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
     let port: u16 = std::env::var("FF_PORT")
@@ -53,10 +54,13 @@ fn server_config_with_lanes(lanes: Vec<LaneId>) -> ff_server::config::ServerConf
     let tls = ff_test::fixtures::env_flag("FF_TLS");
     let cluster = ff_test::fixtures::env_flag("FF_CLUSTER");
     ff_server::config::ServerConfig {
-        host,
-        port,
-        tls,
-        cluster,
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls: ff_test::fixtures::env_flag("FF_TLS"),
+            cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+            skip_library_load: true,
+        },
         partition_config: config,
         lanes: lanes.clone(),
         listen_addr: "127.0.0.1:0".into(),
@@ -69,7 +73,7 @@ fn server_config_with_lanes(lanes: Vec<LaneId>) -> ff_server::config::ServerConf
         // TestCluster fixture pre-loads the library. The lanes-index seed
         // runs unconditionally regardless of this flag (it does not depend
         // on the Lua library).
-        skip_library_load: true,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:

--- a/crates/ff-test/tests/pending_waitpoints_api.rs
+++ b/crates/ff-test/tests/pending_waitpoints_api.rs
@@ -100,6 +100,7 @@ impl TestApi {
 }
 
 fn test_server_config() -> ff_server::config::ServerConfig {
+
     let pc = ff_test::fixtures::TEST_PARTITION_CONFIG;
     let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
     let port: u16 = std::env::var("FF_PORT")
@@ -107,10 +108,13 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls: ff_test::fixtures::env_flag("FF_TLS"),
+            cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+            skip_library_load: true,
+        },
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -119,7 +123,7 @@ fn test_server_config() -> ff_server::config::ServerConfig {
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: true,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:

--- a/crates/ff-test/tests/pending_waitpoints_api.rs
+++ b/crates/ff-test/tests/pending_waitpoints_api.rs
@@ -19,13 +19,13 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use tokio::task::AbortHandle;
 
-/// RFC-017 Stage D1 (§8) v0.7.x wire DTO — mirrors the
-/// `PendingWaitpointWireV07` serialised by `ff-server::api`. Kept
-/// local to the test so consumer-compatibility assertions are
-/// explicit about what's still on the v0.7 wire.
+/// RFC-017 Stage E4 (v0.8.0 §8) wire DTO — direct serialisation of
+/// `PendingWaitpointInfo`, no raw HMAC. Consumers correlate via
+/// `(token_kid, token_fingerprint)`. Kept local to the test so
+/// consumer-compatibility assertions are explicit about the wire.
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
-struct PendingWaitpointWireV07 {
+struct PendingWaitpointWire {
     waitpoint_id: WaitpointId,
     waitpoint_key: String,
     state: String,
@@ -39,9 +39,6 @@ struct PendingWaitpointWireV07 {
     execution_id: ExecutionId,
     token_kid: String,
     token_fingerprint: String,
-    /// Legacy v0.7.x — removed at v0.8.0.
-    #[serde(default)]
-    waitpoint_token: Option<String>,
 }
 
 const LANE: &str = "pwp-lane";
@@ -358,7 +355,9 @@ async fn fcall_suspend(
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
-/// Suspend an execution and verify the endpoint returns the minted token.
+/// Suspend an execution and verify the endpoint returns the sanitised
+/// `(token_kid, token_fingerprint)` pair — the raw `waitpoint_token`
+/// and `Deprecation: ff-017` header were both removed at v0.8.0.
 #[tokio::test]
 #[serial_test::serial]
 async fn test_list_pending_waitpoints_returns_token_after_suspend() {
@@ -367,7 +366,7 @@ async fn test_list_pending_waitpoints_returns_token_after_suspend() {
 
     let eid = tc.new_execution_id();
     let (lease_id, epoch, attempt_id) = fcall_create_and_claim(&tc, &eid).await;
-    let (wp_id, wp_key, expected_token) =
+    let (wp_id, wp_key, _token) =
         fcall_suspend(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
 
     let resp = api
@@ -378,36 +377,39 @@ async fn test_list_pending_waitpoints_returns_token_after_suspend() {
         .expect("pending-waitpoints request failed");
     assert_eq!(resp.status(), StatusCode::OK);
 
-    // RFC-017 Stage D1 (§8): the Deprecation: ff-017 header must be
-    // present while the legacy wire field is still served.
-    let deprecation_hdr = resp
-        .headers()
-        .get("Deprecation")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_owned());
-    assert_eq!(
-        deprecation_hdr.as_deref(),
-        Some("ff-017"),
-        "v0.7.x responses must carry Deprecation: ff-017"
+    // RFC-017 Stage E4 (v0.8.0 §8): no more `Deprecation: ff-017`
+    // header — the legacy wire field is gone, so the deprecation
+    // signal is gone too.
+    assert!(
+        resp.headers().get("Deprecation").is_none(),
+        "v0.8.0 responses must not carry Deprecation: ff-017"
     );
 
-    let list: Vec<PendingWaitpointWireV07> =
-        resp.json().await.expect("response body parse failed");
+    // Parse as raw JSON first so we can assert on both the *absence*
+    // of `waitpoint_token` and the *presence* of the sanitised fields.
+    let body: serde_json::Value = resp.json().await.expect("response body parse failed");
+    let arr = body.as_array().expect("response is an array");
+    assert_eq!(arr.len(), 1, "expected exactly one active waitpoint");
+    assert!(
+        arr[0].get("waitpoint_token").is_none(),
+        "v0.8.0 wire must not carry `waitpoint_token`; got {arr:?}"
+    );
+    assert!(
+        arr[0].get("token_kid").and_then(|v| v.as_str()).is_some(),
+        "v0.8.0 wire must carry `token_kid`"
+    );
+    assert!(
+        arr[0].get("token_fingerprint").and_then(|v| v.as_str()).is_some(),
+        "v0.8.0 wire must carry `token_fingerprint`"
+    );
 
-    assert_eq!(list.len(), 1, "expected exactly one active waitpoint");
+    let list: Vec<PendingWaitpointWire> =
+        serde_json::from_value(body).expect("wire DTO parse failed");
     let entry = &list[0];
     assert_eq!(entry.waitpoint_id, wp_id);
     assert_eq!(entry.waitpoint_key, wp_key);
     assert_eq!(entry.state, "active");
-    let token = entry.waitpoint_token.as_deref().expect(
-        "v0.7.x wire must still carry the legacy waitpoint_token",
-    );
-    assert_eq!(
-        token, expected_token,
-        "token must match the one returned to the suspending worker"
-    );
     assert!(entry.activated_at.is_some());
-    assert!(!token.is_empty());
     // Sanitised fields — present on the trait boundary and the wire.
     assert!(!entry.token_kid.is_empty(), "token_kid must be populated");
     assert_eq!(
@@ -444,7 +446,7 @@ async fn test_list_pending_waitpoints_empty_for_unsuspended() {
         .expect("pending-waitpoints request failed");
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let list: Vec<PendingWaitpointWireV07> =
+    let list: Vec<PendingWaitpointWire> =
         resp.json().await.expect("response body parse failed");
     assert!(list.is_empty(), "expected no waitpoints, got {list:?}");
 }

--- a/crates/ff-test/tests/pr_c1_cancel_flow_partial.rs
+++ b/crates/ff-test/tests/pr_c1_cancel_flow_partial.rs
@@ -60,10 +60,13 @@ async fn start_test_server() -> Server {
         .unwrap_or(false);
 
     let server_config = ServerConfig {
-        host,
-        port,
-        tls,
-        cluster,
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls,
+            cluster,
+            skip_library_load: true, // TestCluster::connect() already loaded
+        },
         partition_config: config,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "0.0.0.0:0".into(),
@@ -72,7 +75,6 @@ async fn start_test_server() -> Server {
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: true, // TestCluster::connect() already loaded
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:

--- a/crates/ff-test/tests/result_api.rs
+++ b/crates/ff-test/tests/result_api.rs
@@ -84,6 +84,7 @@ impl TestApi {
 }
 
 fn test_server_config() -> ff_server::config::ServerConfig {
+
     let pc = ff_test::fixtures::TEST_PARTITION_CONFIG;
     let host = std::env::var("FF_HOST").unwrap_or_else(|_| "localhost".into());
     let port: u16 = std::env::var("FF_PORT")
@@ -91,10 +92,13 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     ff_server::config::ServerConfig {
-        host,
-        port,
-        tls: ff_test::fixtures::env_flag("FF_TLS"),
-        cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+        valkey: ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls: ff_test::fixtures::env_flag("FF_TLS"),
+            cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
+            skip_library_load: true,
+        },
         partition_config: pc,
         lanes: vec![LaneId::new(LANE)],
         listen_addr: "127.0.0.1:0".into(),
@@ -103,7 +107,7 @@ fn test_server_config() -> ff_server::config::ServerConfig {
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
         },
-        skip_library_load: true,
+
         cors_origins: vec!["*".to_owned()],
         api_token: None,
         waitpoint_hmac_secret:

--- a/docs/CONSUMER_MIGRATION_v0.8.md
+++ b/docs/CONSUMER_MIGRATION_v0.8.md
@@ -1,0 +1,212 @@
+# Consumer Migration Guide — FlowFabric v0.8.0
+
+RFC-017 Wave 8 ships the Postgres backend as a first-class
+`EngineBackend` over the full HTTP surface and retires the v0.7-era
+compatibility shims. This guide covers the breaking changes a
+library-mode consumer (cairn-fabric or any out-of-tree embedder) must
+adapt to.
+
+> Audience: crates that depend on `ff-sdk`, `ff-server`, `ff-core`,
+> or `ff-engine` directly. Pure HTTP API consumers only need the
+> `PendingWaitpointInfo` section.
+
+## 1. `ServerConfig` flat Valkey fields removed
+
+**Before (v0.7.x):**
+
+```rust
+use ff_server::config::ServerConfig;
+
+let cfg = ServerConfig {
+    host: "valkey-0.internal".into(),
+    port: 6379,
+    tls: true,
+    cluster: true,
+    skip_library_load: false,
+    // ... other fields ...
+    ..ServerConfig::default()
+};
+```
+
+**After (v0.8.0):**
+
+```rust
+use ff_server::config::{ServerConfig, ValkeyServerConfig, BackendKind};
+
+let cfg = ServerConfig {
+    backend: BackendKind::Valkey,
+    valkey: ValkeyServerConfig {
+        host: "valkey-0.internal".into(),
+        port: 6379,
+        tls: true,
+        cluster: true,
+        skip_library_load: false,
+    },
+    // ... other fields ...
+    ..ServerConfig::default()
+};
+```
+
+The `valkey: ValkeyServerConfig` field mirrors the pre-existing
+`postgres: PostgresServerConfig` and is ignored when
+`backend == BackendKind::Postgres`. Env-var loading via
+`ServerConfig::from_env()` is unchanged (`FF_HOST` / `FF_PORT` / etc.
+still read into `cfg.valkey.*`).
+
+`ValkeyServerConfig` is **not** `#[non_exhaustive]` — you can
+construct the struct literal directly. Adding a field is a v0.y.0
+breaking bump; insulate with `..ValkeyServerConfig::default()` if you
+prefer.
+
+## 2. `PendingWaitpointInfo` wire-format break
+
+`GET /v1/executions/{id}/pending-waitpoints` no longer includes a raw
+`waitpoint_token` HMAC in each entry. Clients must correlate
+waitpoints by `(token_kid, token_fingerprint)`.
+
+**Before (v0.7.x):**
+
+```json
+{
+  "entries": [
+    {
+      "execution_id": "...",
+      "waitpoint_id": "...",
+      "token_kid": "v1",
+      "token_fingerprint": "sha256:...",
+      "waitpoint_token": "v1.eyJhbGciOi...",
+      "...": "..."
+    }
+  ]
+}
+```
+
+Response also carried a `Deprecation: ff-017` header and bumped the
+`ff_pending_waitpoint_legacy_token_served_total` counter.
+
+**After (v0.8.0):**
+
+```json
+[
+  {
+    "execution_id": "...",
+    "waitpoint_id": "...",
+    "token_kid": "v1",
+    "token_fingerprint": "sha256:...",
+    "...": "..."
+  }
+]
+```
+
+The top-level response is now the sanitised `PendingWaitpointInfo`
+array directly (no `{"entries": [...]}` wrapper — note this was the
+v0.7-era shape; v0.8.0 confirms the unwrapped list). The
+`Deprecation` header is gone. If your code was re-signing or
+verifying the `waitpoint_token` client-side, switch to deriving the
+same logical identity from `(token_kid, token_fingerprint)`.
+
+The Rust type `ff_core::PendingWaitpointInfo` no longer carries a
+`waitpoint_token` field. The Valkey-only inherent
+`Server::fetch_waitpoint_token_v07` + `EngineBackend` trait method of
+the same name are removed.
+
+## 3. `FF_BACKEND=postgres` setup
+
+Postgres boots natively at v0.8.0 — no `FF_BACKEND_ACCEPT_UNREADY=1` /
+`FF_ENV=development` escape hatch required.
+
+### Required env vars
+
+| Env var | Default | Notes |
+|---|---|---|
+| `FF_BACKEND` | `valkey` | Set to `postgres` to boot the Postgres path. |
+| `FF_POSTGRES_URL` | *(empty)* | Required on the Postgres path. `postgres://user:pass@host:port/db` shape (libpq / sqlx). |
+| `FF_POSTGRES_POOL_SIZE` | `10` | Max pool connections; ignored on Valkey path. |
+| `FF_WAITPOINT_HMAC_SECRET` | *(empty)* | Required on both paths. |
+
+### Migrations
+
+`ff-server` auto-runs `apply_migrations` at boot against
+`FF_POSTGRES_URL`. The initial schema (Waves 3 + 3b) seeds the full
+execution / flow / attempt / budget tableset. Re-runs are idempotent.
+
+### Parity
+
+See [`docs/POSTGRES_PARITY_MATRIX.md`](POSTGRES_PARITY_MATRIX.md) for
+the per-method status at v0.8.0. At release time, the Postgres path
+ships:
+
+- Full create/read-ingress parity (create_flow, create_execution,
+  add_execution_to_flow, stage_dependency_edge,
+  apply_dependency_to_child).
+- Full flow family (describe_flow, list_flows, list_edges,
+  describe_edge, cancel_flow, set_edge_group_policy).
+- Scheduler + `claim_for_worker` + 6 reconcilers.
+- `ping`, `backend_label`, `shutdown_prepare`.
+
+Rows marked `stub` on the Postgres column return
+`EngineError::Unavailable { op }` → HTTP 503 with a structured body:
+
+- operator control (`cancel_execution`, `change_priority`,
+  `replay_execution`, `revoke_lease`)
+- read model (`read_execution_info`, `read_execution_state`,
+  `get_execution_result`)
+- budget / quota admin
+- `list_pending_waitpoints`
+- `rotate_waitpoint_hmac_secret_all`
+
+These land in Wave 9. If your consumer needs any of them against
+Postgres before Wave 9 ships, stay on the Valkey backend for now.
+
+## 4. `EngineBackend` trait expansion (custom backend impls)
+
+If you implement `EngineBackend` for a bespoke backend (test doubles,
+alternate storage), the trait grew by ~17 methods between Wave 4 and
+Wave 8. All new methods carry sensible defaults:
+
+- Most return `Err(EngineError::Unavailable { op: "<name>" })`.
+- `backend_label` returns `"custom"` if unset.
+- `ping` returns `Ok(())` if unset.
+- `shutdown_prepare` returns `Ok(())` if unset.
+
+The `HookedBackend`, `PassthroughBackend`, `ValkeyBackend`, and
+`PostgresBackend` impls in-tree cover every method concretely and are
+the reference for what a "complete" impl looks like.
+
+## 5. Other v0.8.0 breakage (v0.7-cycle rollups)
+
+- **`ClaimPolicy`** — `ClaimPolicy::immediate()` removed. Constructor
+  is now `ClaimPolicy::new(worker_id, worker_instance_id,
+  lease_ttl_ms, max_wait)`.
+- **`ReclaimToken`** — `ReclaimToken::new` gained `worker_id`,
+  `worker_instance_id`, `lease_ttl_ms` args to match.
+- **`ContentionKind::RetryExhausted`** — additive variant on the
+  `#[non_exhaustive]` enum. Consumer match-arms on `Contention(_)`
+  keep working; specific-variant matches may need an update.
+- **`ServerError`** — additive `#[non_exhaustive]` variants across
+  Stages D1–E3. Catch-all arm required.
+
+## 6. Removed server API
+
+- `Server::client()` accessor / `Server::client` field — the Server
+  no longer exposes an ambient Valkey `Client`. Consumers that need
+  Valkey connectivity should build their own `ferriskey::ClientBuilder`
+  using the same `ServerConfig::valkey` parameters, or go through the
+  `EngineBackend` trait.
+- `Server::fcall_with_reload` — inlined into the Valkey backend impl.
+- `Server::scheduler` field — replaced by trait-routed dispatch on
+  `backend.claim_for_worker`.
+
+## 7. Upgrading
+
+1. Bump `ff-*` deps to `0.8.0`.
+2. Update `ServerConfig` construction sites (section 1).
+3. Drop `waitpoint_token` from your `/v1/pending-waitpoints`
+   deserialiser (section 2).
+4. If you match on `ClaimPolicy::immediate()`, adjust (section 5).
+5. Add a catch-all arm to any `match` on `ServerError`.
+6. If migrating to Postgres, set `FF_BACKEND=postgres` +
+   `FF_POSTGRES_URL` + `FF_WAITPOINT_HMAC_SECRET` (section 3).
+7. Re-run your integration smoke. File issues against
+   [`rfcs/RFC-017-ff-server-backend-abstraction.md`](../rfcs/RFC-017-ff-server-backend-abstraction.md)
+   for any migration-guide gap you hit.

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -241,3 +241,56 @@ not yet implement the underlying trait method:
   `Unavailable` for the methods whose impls land in Wave 9
   (`cancel_flow_header`, `ack_cancel_member`, `read_execution_info`,
   `read_execution_state`, `fetch_waitpoint_token_v07`).
+
+---
+
+## Release: v0.8.0 (Stage E4, 2026-04-24)
+
+**Gate status:** `BACKEND_STAGE_READY = &["valkey", "postgres"]`.
+`FF_BACKEND=postgres` boots natively; no `FF_BACKEND_ACCEPT_UNREADY`
+dev-override. The §9.0 hard-gate still exists in `ff-server` as
+defence-in-depth for future backend additions (e.g. SQLite, DynamoDB)
+but no longer trips on Postgres.
+
+### Parity summary at v0.8.0
+
+| Family | Valkey | Postgres | Notes |
+|---|---|---|---|
+| Ingress (create_flow, create_execution, add_execution_to_flow, stage_dependency_edge, apply_dependency_to_child) | `impl` | `impl` | Full HTTP parity. `http_postgres_smoke` exercises all 5 end-to-end. |
+| Flow family (`describe_flow`, `list_flows`, `list_edges`, `describe_edge`, `cancel_flow`, `set_edge_group_policy`) | `impl` | `impl` | RFC-v0.7 Wave 4c. |
+| Flow cancel (`cancel_flow_header`, `ack_cancel_member`) | `impl` | `stub` | Wave 9 follow-up; Postgres `cancel_flow` covers the bulk path, the header/ack split lands with cancel-backlog machinery. |
+| Read model (`read_execution_info`, `read_execution_state`, `get_execution_result`) | `impl` | `stub` | Wave 9 PG read-model migration. |
+| Operator control (`cancel_execution`, `change_priority`, `replay_execution`, `revoke_lease`) | `impl` | `stub` | Wave 9. |
+| Budget / quota (`create_budget`, `reset_budget`, `create_quota_policy`, `get_budget_status`, `report_usage_admin`) | `impl` | `stub` | Wave 9. |
+| Scheduler (`claim_for_worker`) | `impl` | `impl` | Stage E3 `PostgresScheduler` + `claim_for_worker` trait impl + 6 reconcilers. |
+| Waitpoints (`list_pending_waitpoints`) | `impl` | `stub` | Wave 9. |
+| Admin rotation (`rotate_waitpoint_hmac_secret_all`) | `impl` | `stub` | Wave 9 (single-INSERT on the global HMAC table). |
+| Cross-cutting (`backend_label`, `shutdown_prepare`, `ping`) | `impl` | `impl` | — |
+
+### v0.8.0 shipped
+
+- Stage E1 — Postgres HTTP ingress branch + `http_postgres_smoke`.
+- Stage E2 — `Server::client` field retired on Postgres path;
+  `cancel_flow_header` / `ack_cancel_member` / `read_execution_info` /
+  `read_execution_state` / `fetch_waitpoint_token_v07` moved onto the
+  trait (Valkey bodies ported verbatim; Postgres returns `Unavailable`
+  for the Wave-9 rows).
+- Stage E3 — `PostgresScheduler` + `claim_for_worker` trait impl +
+  sibling-cancel, lease-timeout, completion-listener, cancel-backlog,
+  flow-staging, edge-group-policy reconcilers.
+- Stage E4a (this release) — `BACKEND_STAGE_READY` flip,
+  `ServerConfig` flat-field removal, legacy `waitpoint_token` wire
+  field removal, v0.8.0 version bump, CHANGELOG, migration doc.
+
+### Deferred to v0.9 / post-0.8
+
+Every Postgres column row still marked `stub` in the Stage A table
+above lands in Wave 9 (RFC-018, scope TBD). No `stub` row is an
+HTTP-exposed dispatch blocker at v0.8.0 because the corresponding
+HTTP handlers return a structured `503 Unavailable` with an
+`EngineError::Unavailable { op }` body — operators upgrading to
+`FF_BACKEND=postgres` at v0.8.0 get a functional create/read/dispatch
++ scheduler loop and structured-error visibility on the missing
+rows. The consumer migration guide (`docs/CONSUMER_MIGRATION_v0.8.md`)
+lists the current Postgres `Unavailable` surface so consumers know
+what to expect.

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.6.1"
+version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

RFC-017 Wave 8 **Stage E4a** — v0.8.0 cleanup PR. This lands the
code-level cleanup + version bump + CHANGELOG + migration doc +
pre-release smoke. **It does NOT tag or publish**; tag+publish
happens in the follow-up E4b session.

E3 landed in PR #271; E4a builds on top of that.

## Per-WI diff summary

**WI-1 — `BACKEND_STAGE_READY` flip.** (commit `62d88bc`)
- `crates/ff-server/src/server.rs`: `BACKEND_STAGE_READY = &["valkey", "postgres"]`.
- Removed the `FF_BACKEND_ACCEPT_UNREADY=1` / `FF_ENV=development`
  dev-override branch from `Server::start_with_metrics`.
- The `ff_backend_unready_boot_total` counter stays declared in
  `ff-observability` for historical continuity (no longer emitted).
- `config.rs` docs updated: env-var table drops `FF_BACKEND_ACCEPT_UNREADY`
  / `FF_ENV` rows, `BackendKind::Postgres` rustdoc flagged first-class
  since v0.8.0.
- `http_postgres_smoke.rs`: `unsafe { set_var("FF_BACKEND_ACCEPT_UNREADY"…) }`
  + `"FF_ENV"` block gone. Test still passes (see smoke below).

**WI-2 — Remove deprecated `ServerConfig` flat Valkey fields.** (commits
`3332183` + `dfd6182`)
- New `ValkeyServerConfig` (host, port, tls, cluster, skip_library_load)
  mirroring `PostgresServerConfig`.
- `ServerConfig::valkey: ValkeyServerConfig` replaces the flat fields.
- All call sites (Server, bench harness, ff-readiness-tests, every
  `ff-test` fixture) rewired to `config.valkey.*`.
- Follow-up commit `dfd6182` fixed a residual flat-field in
  `e2e_lifecycle.rs` and dropped dead `tls`/`cluster` locals from 3
  other test files.

**WI-3 — Remove legacy `waitpoint_token` wire field.** (commit `bc97df8`)
- `Server::fetch_waitpoint_token_v07` (inherent) + the same-named
  `EngineBackend` trait method + the `ValkeyBackend` inherent/trait
  HGET helpers: all deleted.
- `/v1/executions/{id}/pending-waitpoints` now returns
  `Json(page.entries)` directly — no `PendingWaitpointWireV07` wrap,
  no `Deprecation: ff-017` header, no
  `ff_pending_waitpoint_legacy_token_served_total` increment (counter
  stays defined).
- `pending_waitpoints_api.rs` parity test updated: asserts
  `arr[0].get("waitpoint_token").is_none()`, `token_kid` present,
  `token_fingerprint` present.

**WI-4 — Version bump to 0.8.0.** (commit `792df11`)
- Root `Cargo.toml` workspace `package.version = "0.8.0"`.
- Internal `workspace.dependencies` pins bumped to `0.8.0`.
- Per-crate `ff-core = "0.6.1"` overrides in ff-sdk / ff-script /
  ff-backend-valkey / ff-backend-postgres bumped to `0.8.0`.
- `ferriskey/Cargo.toml` bumped to `0.8.0`.
- `lua/version.lua` still at `'26'` — not changed since v0.6.0 bump,
  `flowfabric_lua_version` blob matches. No regen needed.
- CHANGELOG: `[Unreleased]` renamed to `[0.8.0] - 2026-04-24` with
  Breaking / Added / Removed sections covering the RFC-017 Stage E
  cleanup; v0.7-cycle items nested under
  "v0.7-cycle changes (shipped in 0.8.0)".

**WI-5 — Publish-list drift.** No changes required.
- `release.toml` already lists all 11 publishable crates including
  `ff-backend-postgres` (added during v0.7 cycle).
- `.github/workflows/release.yml` has a `publish ff-backend-postgres`
  step at the right place in the topological order (ferriskey →
  ff-core → ff-script → ff-observability → ff-observability-http →
  ff-backend-valkey → ff-backend-postgres → ff-engine → ff-scheduler
  → ff-sdk → ff-server).
- `docs/RELEASING.md` describes the same order.

**WI-6 — Parity matrix + consumer migration doc.** (commit `04db1d1`)
- `docs/POSTGRES_PARITY_MATRIX.md`: appended "Release: v0.8.0"
  section — gate status, family-level parity table, v0.8.0 shipped
  stages, Wave-9 deferred list.
- New `docs/CONSUMER_MIGRATION_v0.8.md`: before/after for
  `ServerConfig`, `PendingWaitpointInfo` wire break,
  `FF_BACKEND=postgres` setup, `EngineBackend` trait expansion,
  v0.7-cycle rollups, removed server API surface.

## Pre-release smoke (WI-7)

```
$ cargo build --workspace
    Finished `dev` profile in 16.81s

$ cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler \
    -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey \
    -p ff-backend-postgres --features ff-sdk/direct-valkey-claim \
    -- -D warnings
    Finished `dev` profile in 12.07s      # clean

$ cargo test -p ff-core -p ff-script -p ff-backend-valkey \
    -p ff-backend-postgres -p ff-server --lib
  # 24 + 32 + 196 + 58 + 23 lib tests — all pass

$ FF_WAITPOINT_HMAC_SECRET=<hex> cargo test -p ff-test
  # All suites pass except `completion_backend::two_streams_both_receive`
  # and `completion_backend::subscribe_yields_published_completion`:
  # known pre-existing environmental flake from concurrent publish
  # ordering; both tests pass standalone (`--test-threads=1` green).

$ cargo test -p ff-server --test parity_stage_a --test parity_stage_a_backfill \
    --test parity_stage_b --test parity_stage_c --test parity_stage_d1
  # 18 tests across D1, prior stages — all green

$ FF_WAITPOINT_HMAC_SECRET=<hex> FF_BACKEND=postgres \
    FF_POSTGRES_URL=postgres://postgres:postgres@localhost/ff_e2e_http_smoke \
    cargo test -p ff-test --test http_postgres_smoke \
    --features postgres-e2e -- --nocapture
  [e1-smoke] GET /healthz → 200 OK
  [e1-smoke] POST /v1/flows → e287a09b-…
  [e1-smoke] POST /v1/executions[0/1/2] / members / edges / apply …
  [e1-smoke] PASS — flow=1 execs=3 edges=2 (all committed to Postgres)
  test http_postgres_smoke ... ok
```

**WI-1 gate-flip proof:** the `http_postgres_smoke` test ran
**without** `FF_BACKEND_ACCEPT_UNREADY=1` or `FF_ENV=development` in
its env. It passes. `BACKEND_STAGE_READY` now includes `"postgres"`
and the dev-override is gone.

## Out-of-scope / carried to E4b

- `git tag v0.8.0` + push.
- `.github/workflows/release.yml` tag-triggered `cargo publish`
  workflow execution.
- Scratch-project smoke against the published crates.io artifacts.

## Known flakes

- `ff-test::completion_backend` two streams test — concurrent publish
  ordering; green standalone, red in parallel. Pre-existing from
  RFC-010 era; not regressed by this PR. Admin-merge through it.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy … -D warnings`
- [x] `cargo test … --lib` (full workspace lib)
- [x] `cargo test -p ff-test` (all but the known flake)
- [x] `cargo test -p ff-server` (parity stages A/B/C/D1 + A-backfill)
- [x] `http_postgres_smoke` (Postgres path, no dev-override)
- [x] CHANGELOG `[0.8.0] - 2026-04-24` heading finalised
- [x] `docs/CONSUMER_MIGRATION_v0.8.md` published
- [x] `docs/POSTGRES_PARITY_MATRIX.md` v0.8.0 section appended

### E4b HAND-OFF

For the E4b release agent picking this up after merge to main:

- **Merge commit SHA**: to be populated after admin-merge (check the
  merge commit on `main` after this PR is squashed or rebased in).
- **CHANGELOG 0.8.0 entry**: finalised — see `CHANGELOG.md` §
  `[0.8.0] - 2026-04-24`, Breaking + Added + Removed groups, with
  v0.7-cycle rollup nested below. **Do not edit it** — tag against
  the merge commit as-is.
- **Publish order** (from `.github/workflows/release.yml` +
  `docs/RELEASING.md`):
  1. `ferriskey`
  2. `ff-core`
  3. `ff-script`
  4. `ff-observability`
  5. `ff-observability-http`
  6. `ff-backend-valkey`
  7. `ff-backend-postgres`
  8. `ff-engine`
  9. `ff-scheduler`
  10. `ff-sdk`
  11. `ff-server`
- **In-session concerns to watch**:
  - `ff-test::completion_backend` two-stream flake — known
    pre-existing, ignore if it trips CI; retry once before yanking
    anything.
  - `cargo semver-checks --baseline-rev v0.7.0` is **not a valid
    baseline** (no `v0.7.0` tag exists in this repo — we went 0.6.1
    → 0.8.0 directly). Skip that step or use `v0.6.1` as baseline
    knowing it will flag the expected breaking changes.
  - Pre-release smoke already ran (this PR body); E4b should run
    the **published-artifact** smoke per `feedback_smoke_before_release.md`
    using a scratch project pulling from crates.io.
  - Secrets: ensure `CARGO_REGISTRY_TOKEN` in Actions has
    publish-update rights for all 11 crates; `ferriskey` and
    `ff-observability-http` were added late in the v0.3.x cycle, so
    verify the token scope before firing the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to multiple breaking surface changes (server config shape, readiness gating, and pending-waitpoints HTTP wire format) that can break consumers and boot paths if any call site or client isn’t updated.
> 
> **Overview**
> **Prepares the v0.8.0 release by promoting Postgres to a first-class backend**: `BACKEND_STAGE_READY` now includes `postgres`, and the `FF_BACKEND_ACCEPT_UNREADY` / `FF_ENV=development` dev override path is removed.
> 
> **Breaks and cleans up public/server surfaces** by nesting Valkey connection settings under a new `ServerConfig::valkey: ValkeyServerConfig` (removing the prior flat Valkey fields), and by removing the v0.7 pending-waitpoints compatibility shim: `GET /v1/executions/{id}/pending-waitpoints` now returns sanitised `PendingWaitpointInfo` entries only (no `waitpoint_token` and no `Deprecation: ff-017` header), with the related `fetch_waitpoint_token_v07` hooks deleted.
> 
> Bumps all workspace crate versions (and `ferriskey`) to `0.8.0`, updates tests/bench harnesses accordingly, and adds/updates release docs (`docs/CONSUMER_MIGRATION_v0.8.md`, `docs/POSTGRES_PARITY_MATRIX.md`, CHANGELOG).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd6182bab58f1d7c2604bbbe52e85228af754a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->