### PR TITLE
fix(ci): wait for full cluster convergence across all 6 nodes (#275)

### DIFF
--- a/.github/cluster/bootstrap.sh
+++ b/.github/cluster/bootstrap.sh
@@ -57,18 +57,66 @@ done
 echo "forming cluster across: ${addrs[*]}"
 "$CLI" --cluster create "${addrs[@]}" --cluster-replicas 1 --cluster-yes
 
-# 4. Poll up to 30s for cluster_state:ok so the test step doesn't race
-# the gossip convergence.
-deadline=$(( $(date +%s) + 30 ))
+# 4. Poll up to 60s for cluster convergence across ALL 6 nodes. The
+# previous implementation polled only node[0]; `cluster_state:ok` flips
+# true on a single node as soon as its local slot table is allocated,
+# which can happen before nodes[3..5] have completed the REPLICAOF
+# handshake with their masters. A client that dials into the partial
+# cluster at that moment and issues a write-routed command (e.g.
+# `FUNCTION LOAD`, which routes `AllPrimaries`) can hit a node whose
+# topology view still has it as a primary even though it's already a
+# replica, getting a `READONLY` error.
+#
+# Convergence criteria (ALL must hold from EVERY node's perspective):
+#   * `cluster_state:ok`
+#   * exactly 3 masters + 3 slaves in `CLUSTER NODES`
+#   * no `fail?` or `handshake` flags in `CLUSTER NODES`
+#
+# See github.com/avifenesh/FlowFabric/issues/275 for the race this
+# guards against.
+deadline=$(( $(date +%s) + 60 ))
 while :; do
-    state="$("$CLI" -h "$HOST" -p "${NODES[0]}" cluster info 2>/dev/null | tr -d '\r' | grep '^cluster_state:' | cut -d: -f2 || true)"
-    if [ "$state" = "ok" ]; then
-        echo "cluster ready (cluster_state:ok)"
+    converged=1
+    for port in "${NODES[@]}"; do
+        info="$("$CLI" -h "$HOST" -p "$port" cluster info 2>/dev/null | tr -d '\r' || true)"
+        state="$(printf '%s\n' "$info" | grep '^cluster_state:' | cut -d: -f2 || true)"
+        if [ "$state" != "ok" ]; then
+            converged=0
+            last_fail="node $port: cluster_state=${state:-unknown}"
+            break
+        fi
+        nodes_out="$("$CLI" -h "$HOST" -p "$port" cluster nodes 2>/dev/null || true)"
+        # Count masters + slaves; reject if either count != 3 or any
+        # handshake/fail flag is present.
+        masters=$(printf '%s\n' "$nodes_out" | grep -c ' master ' || true)
+        slaves=$(printf '%s\n' "$nodes_out" | grep -c ' slave ' || true)
+        # `myself,master` and `myself,slave` are hyphenated in nodes flags,
+        # but `grep -c ' master '` misses `myself,master` because of the comma.
+        # Re-count using a broader match (master anywhere in the flag field,
+        # same for slave):
+        masters=$(printf '%s\n' "$nodes_out" | awk '{print $3}' | grep -c 'master' || true)
+        slaves=$(printf '%s\n' "$nodes_out" | awk '{print $3}' | grep -c 'slave' || true)
+        if [ "$masters" -ne 3 ] || [ "$slaves" -ne 3 ]; then
+            converged=0
+            last_fail="node $port: masters=$masters slaves=$slaves (expected 3/3)"
+            break
+        fi
+        if printf '%s\n' "$nodes_out" | grep -qE 'handshake|fail\?|fail,' ; then
+            converged=0
+            last_fail="node $port: handshake/fail flags still present"
+            break
+        fi
+    done
+    if [ "$converged" = "1" ]; then
+        echo "cluster fully converged across all 6 nodes (3 masters + 3 slaves, no handshake flags)"
         exit 0
     fi
     if [ "$(date +%s)" -ge "$deadline" ]; then
-        echo "timeout: cluster_state never reached ok (last: ${state:-unknown})" >&2
-        "$CLI" -h "$HOST" -p "${NODES[0]}" cluster info >&2 || true
+        echo "timeout: cluster never fully converged (last: $last_fail)" >&2
+        for port in "${NODES[@]}"; do
+            echo "=== cluster nodes @ $port ===" >&2
+            "$CLI" -h "$HOST" -p "$port" cluster nodes >&2 || true
+        done
         exit 1
     fi
     sleep 0.5


### PR DESCRIPTION
## Summary

Closes the race tracked in #275. Previous bootstrap polled only node[0]'s `cluster_state:ok`, which flips true before the full 6-node cluster has fully gossip-converged. Tests that dial the cluster in that window and issue write-routed commands (`FUNCTION LOAD`, which routes `AllPrimaries`) can hit a node whose topology view still has it as a primary even though it's actually a replica — surfaces as `READONLY: You can't write against a read only replica.` at `ff-server` boot.

Observed on both `ubuntu-latest · valkey 8 · cluster` and `ubuntu-24.04-arm · valkey 8 · cluster` cells (rules out arm-specific causes; both are KVM-virtualized on GHA).

## Change

`.github/cluster/bootstrap.sh` post-create poll now checks ALL 6 nodes. Every node must report:
- `cluster_state:ok`
- exactly 3 masters + 3 slaves in `CLUSTER NODES`
- no `handshake` / `fail?` / `fail,` flags

Deadline 30s → 60s for margin.

## Verification plan

This PR itself + the next 10 consecutive main-branch Matrix-CI runs. If the cluster cells stay green, close #275.

## Not done here (follow-up candidates)

- ferriskey still uses `SystemTime::now()` in slot-refresh throttling. Not the cause of this specific race (ruled out via local repro + root-cause analysis in issue comment), but a real robustness concern for NTP-step scenarios — worth a future ferriskey PR swapping to `Instant::now()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to CI bootstrap timing/validation, with the main impact being slightly longer waits and stricter failure conditions if the cluster doesn’t fully converge.
> 
> **Overview**
> Makes the Valkey cluster bootstrap in `.github/cluster/bootstrap.sh` wait for **full 6-node convergence** after `--cluster create`, addressing a race where polling only one node could return ready before replicas finish handshaking.
> 
> The convergence check now validates from *each node’s* perspective that `cluster_state:ok` is set, `CLUSTER NODES` reports exactly **3 masters + 3 slaves**, and no `handshake`/`fail*` flags remain; the timeout is increased from **30s to 60s** and timeout diagnostics now dump `CLUSTER NODES` for all ports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3886db0a1e50b33262fd3ce1f0ecc4cd7708465. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->