### PR TITLE
feat(ff-sdk): re-export ClaimGrant + claim types so consumers drop ff-scheduler direct pin (#283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `ff-sdk` re-exports `ClaimGrant`, `ReclaimGrant`, `ClaimPolicy`, and
+  `ReclaimToken`; consumers typing `claim_from_grant` /
+  `claim_from_reclaim_grant` signatures can drop their direct
+  `ff-scheduler` dep pin (closes #283). `Scheduler` itself is
+  intentionally not re-exported — implementing a scheduler stays
+  behind the explicit `ff-scheduler` dep.
+
 ## [0.8.1] - 2026-04-25
 
 Release-infrastructure fix for v0.8.0 partial-publish.

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -41,7 +41,7 @@
 //!     // In a real deployment `grant` is obtained from the
 //!     // scheduler's `claim_for_worker` RPC/helper; it carries the
 //!     // execution id, capability match, and admission result.
-//!     # let grant: ff_core::contracts::ClaimGrant = unimplemented!();
+//!     # let grant: ff_sdk::ClaimGrant = unimplemented!();
 //!     let task = worker.claim_from_grant(lane, grant).await?;
 //!     println!("claimed: {}", task.execution_id());
 //!     // Process task...
@@ -67,8 +67,13 @@
 //! grant-based path does not. See each method's rustdoc for the
 //! exact migration recipe.
 //!
-//! [`ClaimGrant`]: ff_core::contracts::ClaimGrant
-//! [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
+//! `ClaimGrant` / `ReclaimGrant` (and the `ClaimPolicy` /
+//! `ReclaimToken` wire types on the scheduler-owner side) are
+//! re-exported from `ff-sdk` (#283) so consumers do not need a
+//! direct `ff-scheduler` dep just to type these signatures.
+//!
+//! [`ClaimGrant`]: crate::ClaimGrant
+//! [`ReclaimGrant`]: crate::ReclaimGrant
 
 #[cfg(feature = "valkey-default")]
 pub mod admin;
@@ -137,7 +142,7 @@ pub use ff_core::contracts::{
 // `EngineBackend::claim_for_worker`) can name these as
 // `ff_sdk::ClaimGrant` etc. without pinning `ff-scheduler` directly.
 // `Scheduler` itself is intentionally not re-exported: implementing a
-// scheduler is specialised and stays behind the `ff-scheduler` dep.
+// scheduler is specialized and stays behind the `ff-scheduler` dep.
 pub use ff_core::backend::{ClaimPolicy, ReclaimToken};
 pub use ff_core::contracts::{ClaimGrant, ReclaimGrant};
 #[cfg(feature = "valkey-default")]

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -132,6 +132,14 @@ pub use ff_core::contracts::{
     SignalMatcher, SuspendArgs, SuspendOutcome, SuspendOutcomeDetails, SuspensionReasonCode,
     SuspensionRequester, TimeoutBehavior, WaitpointBinding,
 };
+// #283 — Claim-flow wire types. Consumers typing `claim_from_grant` /
+// `claim_from_reclaim_grant` signatures (or wrapping
+// `EngineBackend::claim_for_worker`) can name these as
+// `ff_sdk::ClaimGrant` etc. without pinning `ff-scheduler` directly.
+// `Scheduler` itself is intentionally not re-exported: implementing a
+// scheduler is specialised and stays behind the `ff-scheduler` dep.
+pub use ff_core::backend::{ClaimPolicy, ReclaimToken};
+pub use ff_core::contracts::{ClaimGrant, ReclaimGrant};
 #[cfg(feature = "valkey-default")]
 pub use worker::FlowFabricWorker;
 


### PR DESCRIPTION
## Summary

Re-export claim-flow wire types from `ff-sdk` so consumers typing `claim_from_grant` / `claim_from_reclaim_grant` signatures (or wrapping `EngineBackend::claim_for_worker`) can drop their direct `ff-scheduler` dep pin.

## Re-exports added

In `crates/ff-sdk/src/lib.rs` (both unconditional — the source modules have no feature gate):

```rust
pub use ff_core::backend::{ClaimPolicy, ReclaimToken};
pub use ff_core::contracts::{ClaimGrant, ReclaimGrant};
```

`Scheduler` itself is intentionally NOT re-exported — implementing a scheduler is specialised and stays behind the explicit `ff-scheduler` dep, per the issue's non-goal.

## Verification

```
cargo build -p ff-sdk   # green
cargo check -p ff-sdk   # green
cargo doc -p ff-sdk --no-deps   # green, re-exports documentable
```

## Test plan

- [x] `cargo build -p ff-sdk` passes
- [x] `cargo check -p ff-sdk` passes
- [x] `cargo doc -p ff-sdk --no-deps` renders re-exports
- [ ] CI matrix green
- [ ] cargo-semver-checks stays green (purely additive re-exports from deps already in public API)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a purely additive public API change (new `pub use` re-exports) plus changelog updates, with no behavior or data-path logic modified.
> 
> **Overview**
> `ff-sdk` now re-exports claim-flow types (`ClaimGrant`, `ReclaimGrant`, `ClaimPolicy`, `ReclaimToken`) so consumers can type `claim_from_grant`/`claim_from_reclaim_grant` flows without directly pinning `ff-scheduler`.
> 
> The changelog documents the new re-exports and explicitly notes that `Scheduler` is **not** re-exported to keep scheduler implementation behind an explicit `ff-scheduler` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc408729cbb6c3c06333e5bb946597accdd2035. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->