### PR TITLE
feat(flowfabric): umbrella crate re-exporting the 7-crate family (#279)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,14 @@
 #     `publish-new` + `publish-update`.
 #   - GITHUB_TOKEN is auto-provided by GHA; `gh release create` uses it.
 #
-# Publish set (11 crates, topologically ordered):
+# Publish set (12 crates, topologically ordered):
 #   ferriskey -> ff-core -> ff-script -> ff-observability
 #     -> ff-observability-http
 #     -> ff-backend-valkey -> ff-backend-postgres
 #     -> ff-engine -> ff-scheduler
-#     -> ff-sdk -> ff-server
+#     -> ff-sdk -> ff-server -> flowfabric
+# flowfabric is the umbrella re-export crate (issue #279) and MUST
+# publish last — it depends on every other publishable crate.
 # ff-test is dev-only (publish = false) and not in the set.
 # The former telemetrylib sub-crate was inlined into ferriskey
 # during the Tier 1 envelope collapse (PR #18).
@@ -376,6 +378,23 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-sdk"
+            exit 1
+          }
+      - run: sleep 30
+      # `flowfabric` umbrella (issue #279) depends on every other
+      # publishable ff-* crate + ferriskey, so it MUST publish last.
+      # If this step fails, the consumer-visible umbrella is missing
+      # for the release — yank every previously-published crate and
+      # re-tag as the next patch (crates.io refuses re-publish of a
+      # yanked version).
+      - name: publish flowfabric
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          VER="${TAG_VERSION#v}"
+          cargo publish -p flowfabric --no-verify || {
+            echo "::error::cargo publish flowfabric failed — yank every previously-published crate before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey ff-core ff-script ff-observability ff-observability-http ff-scheduler ff-backend-valkey ff-backend-postgres ff-engine ff-sdk ff-server"
             exit 1
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`flowfabric` umbrella crate** — re-exports the ff-* family
+  (`ff_core`, `ff_sdk`, and optionally `ff_backend_valkey`,
+  `ff_backend_postgres`, `ff_engine`, `ff_scheduler`, `ff_script`)
+  behind feature flags. Consumers can pin one crate + feature-flag
+  the backend instead of tracking 7–8 separate pins in lockstep.
+  Default `features = ["valkey"]` preserves the v0.7–v0.8 stability
+  posture; `default-features = false, features = ["postgres"]` opts
+  into the Postgres backend. See
+  [`docs/CONSUMER_MIGRATION_v0.8.md`](docs/CONSUMER_MIGRATION_v0.8.md)
+  § "Umbrella crate (flowfabric)" for before/after. Closes #279.
+
 ## [0.8.1] - 2026-04-25
 
 Release-infrastructure fix for v0.8.0 partial-publish.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flowfabric"
+version = "0.8.1"
+dependencies = [
+ "ff-backend-postgres",
+ "ff-backend-valkey",
+ "ff-core",
+ "ff-engine",
+ "ff-scheduler",
+ "ff-script",
+ "ff-sdk",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/ff-backend-postgres",
     "crates/ff-observability",
     "crates/ff-observability-http",
+    "crates/flowfabric",
 ]
 
 [workspace.package]
@@ -47,6 +48,10 @@ ff-backend-postgres = { version = "0.8.1", path = "crates/ff-backend-postgres" }
 ff-observability = { version = "0.8.1", path = "crates/ff-observability" }
 ff-observability-http = { version = "0.8.1", path = "crates/ff-observability-http" }
 ferriskey = { version = "0.8.1", path = "ferriskey" }
+# Umbrella crate re-exporting the ff-* family (issue #279). Declared
+# at workspace scope so internal doc examples / dev-deps can name it
+# via `{ workspace = true }`.
+flowfabric = { version = "0.8.1", path = "crates/flowfabric" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/flowfabric/Cargo.toml
+++ b/crates/flowfabric/Cargo.toml
@@ -1,0 +1,77 @@
+[package]
+name = "flowfabric"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "FlowFabric — Valkey/Postgres-native execution engine. Umbrella crate re-exporting the published FlowFabric family."
+
+# Closes #279 — cairn (and future consumers) can pin a single crate
+# instead of the 7–8 ff-* crates and have Cargo resolve a
+# version-coherent set. See `docs/CONSUMER_MIGRATION_v0.8.md` §
+# "Umbrella crate (flowfabric)" for the before/after.
+
+[features]
+# Valkey backend is the default (matches v0.7–v0.8 stability posture).
+# `valkey` activates ff-sdk's `valkey-default` so the worker/task/admin
+# surface and the ferriskey transport re-export stay available. The
+# `postgres` feature does NOT activate valkey-default, matching the
+# `--no-default-features` agnosticism contract proven by RFC-012.
+default = ["valkey"]
+
+valkey = [
+    "dep:ff-backend-valkey",
+    "dep:ff-script",
+    "ff-sdk/valkey-default",
+    "ff-script/valkey-client",
+]
+
+postgres = [
+    "dep:ff-backend-postgres",
+]
+
+# Advanced consumers may want direct scheduler / engine access but most
+# don't. Gate via feature flags so the default umbrella stays minimal.
+engine = ["dep:ff-engine"]
+scheduler-internals = ["dep:ff-scheduler"]
+script-internals = ["dep:ff-script"]
+
+# Re-export of ferriskey's `iam` flag for consumers that pin the
+# umbrella but still need the AWS IAM auth path (parity with
+# `ff-sdk/iam`). Off by default — the ~40-crate AWS dep graph does not
+# land in umbrella builds that don't need it.
+iam = ["ff-sdk/iam"]
+
+[dependencies]
+ff-core = { workspace = true }
+# Direct path-dep (not `workspace = true`) because we need
+# `default-features = false` — Cargo forbids overriding a workspace
+# dep's default-features at the consumer site. Pinning version +
+# path here matches the workspace.dependencies entry; `cargo release`
+# keeps both in lockstep via `shared-version = true`.
+ff-sdk = { version = "0.8.1", path = "../ff-sdk", default-features = false }
+
+ff-backend-valkey = { workspace = true, optional = true }
+ff-backend-postgres = { workspace = true, optional = true }
+ff-engine = { workspace = true, optional = true }
+ff-scheduler = { workspace = true, optional = true }
+# Optional because activating `valkey` also needs `ff-script/valkey-client`
+# (see #171 — the ferriskey transitive edge is ff-script-owned). The
+# `script-internals` feature exposes the crate as `flowfabric::script`.
+ff-script = { workspace = true, optional = true }
+
+[package.metadata.docs.rs]
+# Build rustdoc with every consumer-visible feature so the re-export
+# shape is discoverable on docs.rs — umbrella is the canonical
+# entry point, its docs page must show the full surface.
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.release]
+# Umbrella participates in the workspace-wide `cargo release` bump
+# (shared-version = true in release.toml). Publish is driven by the
+# tag-triggered workflow, not cargo-release itself.

--- a/crates/flowfabric/src/lib.rs
+++ b/crates/flowfabric/src/lib.rs
@@ -1,0 +1,90 @@
+//! FlowFabric — umbrella crate re-exporting the published crate family.
+//!
+//! Pin one crate; let Cargo resolve the rest. Closes #279 — prior to
+//! v0.8.2 consumers (cairn-fabric, downstream integrations) had to
+//! pin all 7–8 `ff-*` crates + `ferriskey` in lockstep and version-
+//! skew drift was only caught at `cargo update` time. This crate is
+//! the single-line import surface; feature flags gate which backend
+//! and which optional internals get pulled in.
+//!
+//! # Quick start
+//!
+//! ```toml
+//! # Valkey backend (default):
+//! flowfabric = "0.8"
+//!
+//! # Postgres backend (explicit, no valkey):
+//! flowfabric = { version = "0.8", default-features = false, features = ["postgres"] }
+//!
+//! # Advanced — direct engine/scheduler access:
+//! flowfabric = { version = "0.8", features = ["engine", "scheduler-internals"] }
+//! ```
+//!
+//! See `docs/CONSUMER_MIGRATION_v0.8.md` § "Umbrella crate
+//! (flowfabric)" for mapping from the 7-crate import shape to the
+//! umbrella shape.
+//!
+//! # Re-export map
+//!
+//! | Umbrella path | Underlying crate | Feature gate |
+//! |---|---|---|
+//! | `flowfabric::core`      | `ff_core`              | always |
+//! | `flowfabric::sdk`       | `ff_sdk`               | always |
+//! | `flowfabric::valkey`    | `ff_backend_valkey`    | `valkey` (default) |
+//! | `flowfabric::postgres`  | `ff_backend_postgres`  | `postgres` |
+//! | `flowfabric::engine`    | `ff_engine`            | `engine` |
+//! | `flowfabric::scheduler` | `ff_scheduler`         | `scheduler-internals` |
+//! | `flowfabric::script`    | `ff_script`            | `script-internals` or `valkey` |
+//!
+//! The [`prelude`] module glob-re-exports the 80% path
+//! (`flowfabric::sdk::*`), which already flattens the most-used
+//! `ff_core::contracts` and `ff_core::backend` types via `ff-sdk`'s
+//! own `pub use`. Consumers needing scheduler/engine types should
+//! enable the respective feature flag and reach through
+//! `flowfabric::engine::…` / `flowfabric::scheduler::…` explicitly.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub use ff_core as core;
+pub use ff_sdk as sdk;
+
+#[cfg(feature = "valkey")]
+#[cfg_attr(docsrs, doc(cfg(feature = "valkey")))]
+pub use ff_backend_valkey as valkey;
+
+#[cfg(feature = "postgres")]
+#[cfg_attr(docsrs, doc(cfg(feature = "postgres")))]
+pub use ff_backend_postgres as postgres;
+
+#[cfg(feature = "engine")]
+#[cfg_attr(docsrs, doc(cfg(feature = "engine")))]
+pub use ff_engine as engine;
+
+#[cfg(feature = "scheduler-internals")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scheduler-internals")))]
+pub use ff_scheduler as scheduler;
+
+// `ff_script` is pulled in by either the `script-internals` opt-in or
+// transitively by the default `valkey` feature (valkey-default's
+// FCALL path depends on it). Either way, re-expose it at
+// `flowfabric::script` so consumers don't have to guess which flag
+// to toggle.
+#[cfg(any(feature = "script-internals", feature = "valkey"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "script-internals", feature = "valkey"))))]
+pub use ff_script as script;
+
+/// Prelude — convenience glob re-export of the most-used SDK surface.
+///
+/// `ff_sdk` already re-exports the common `ff_core::contracts` and
+/// `ff_core::backend` types (e.g. `ClaimGrant`, `FailOutcome`,
+/// `ResumeSignal`, `SummaryDocument`), so a single
+/// `use flowfabric::prelude::*;` covers the 80% consumer code path.
+///
+/// Scheduler/engine/backend types are intentionally NOT flattened
+/// here — consumers that need them enable the feature flag and
+/// reach through the qualified path (`flowfabric::engine::…`,
+/// `flowfabric::scheduler::…`, `flowfabric::valkey::…`). This keeps
+/// prelude imports stable across feature-flag configurations.
+pub mod prelude {
+    pub use crate::sdk::*;
+}

--- a/docs/CONSUMER_MIGRATION_v0.8.md
+++ b/docs/CONSUMER_MIGRATION_v0.8.md
@@ -210,3 +210,102 @@ the reference for what a "complete" impl looks like.
 7. Re-run your integration smoke. File issues against
    [`rfcs/RFC-017-ff-server-backend-abstraction.md`](../rfcs/RFC-017-ff-server-backend-abstraction.md)
    for any migration-guide gap you hit.
+
+## 8. Umbrella crate (`flowfabric`)
+
+Added in v0.8.2 per issue [#279](https://github.com/avifenesh/FlowFabric/issues/279).
+Consumers who were pinning the 7-crate ff-* family in lockstep can
+switch to a single `flowfabric` pin and let Cargo resolve a coherent
+set.
+
+### Before
+
+```toml
+[dependencies]
+ff-core             = "0.8"
+ff-sdk              = "0.8"
+ff-engine           = "0.8"
+ff-scheduler        = "0.8"
+ff-script           = "0.8"
+ff-backend-valkey   = "0.8"   # or ff-backend-postgres
+ferriskey           = "0.8"   # direct dep for raw client types
+```
+
+```rust
+use ff_core::types::FlowId;
+use ff_core::contracts::ClaimGrant;
+use ff_sdk::{FlowFabricWorker, WorkerConfig};
+use ff_scheduler::Scheduler;
+```
+
+### After (Valkey, default)
+
+```toml
+[dependencies]
+flowfabric = "0.8"    # pulls ff-core + ff-sdk + ff-backend-valkey + ff-script
+```
+
+```rust
+use flowfabric::core::types::FlowId;
+use flowfabric::core::contracts::ClaimGrant;
+use flowfabric::sdk::{FlowFabricWorker, WorkerConfig};
+// or the prelude glob:
+use flowfabric::prelude::*;  // re-exports ff_sdk::* (contracts + backend types)
+```
+
+### After (Postgres backend)
+
+```toml
+[dependencies]
+flowfabric = { version = "0.8", default-features = false, features = ["postgres"] }
+```
+
+Dropping `default-features` turns off the Valkey backend — `ferriskey`
+and `ff-backend-valkey` no longer appear in the transitive graph, and
+`flowfabric::postgres` becomes the only backend re-export.
+
+### Opting into scheduler / engine / script internals
+
+Most consumers never touch these directly. If you do (benchmark
+harness, custom scanner, alternative worker runtime), opt in per-
+crate:
+
+```toml
+flowfabric = {
+    version = "0.8",
+    features = ["valkey", "engine", "scheduler-internals", "script-internals"],
+}
+```
+
+Reach through the qualified paths: `flowfabric::engine::…`,
+`flowfabric::scheduler::…`, `flowfabric::script::…`. These are NOT
+flattened into `prelude` — they're rare enough that explicit paths
+keep import sites self-documenting.
+
+### Feature matrix
+
+| Feature | Default? | Pulls in |
+|---|---|---|
+| `valkey`              | yes | `ff-backend-valkey`, `ff-script/valkey-client`, `ff-sdk/valkey-default` |
+| `postgres`            | no  | `ff-backend-postgres` |
+| `engine`              | no  | `ff-engine` |
+| `scheduler-internals` | no  | `ff-scheduler` |
+| `script-internals`    | no  | `ff-script` (pure Lua-loader, no ferriskey edge) |
+| `iam`                 | no  | propagates `ff-sdk/iam` → `ferriskey/iam` (AWS IAM auth) |
+
+`ff-server` and `ferriskey` are intentionally NOT re-exported by the
+umbrella — `ff-server` is a binary/HTTP-server concern (library-mode
+consumers almost never need it), and direct `ferriskey` consumption
+against FF's public contract is a smell the RFC process prefers to
+resolve by expanding `EngineBackend` rather than re-exposing raw
+client types. Consumers with a demonstrated need can still pin
+`ff-server` or `ferriskey` directly alongside `flowfabric`.
+
+### Version coherence
+
+`flowfabric`'s `Cargo.toml` pins each ff-* sub-crate at the same
+workspace version (via `[workspace.package] version`), so
+`cargo update -p flowfabric` moves them together. This closes the
+class of version-skew bug that hit v0.3.0 and v0.8.0 partial-publishes
+at the consumer side.
+

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,7 @@ This doc covers the operator workflow for cutting a release. Tooling lives in
 
 ## What gets published
 
-Eleven crates, all pinned to the same version, published in topological order:
+Twelve crates, all pinned to the same version, published in topological order:
 
 1. `ferriskey`       — Valkey client (reparented fork of glide-core;
    the former `telemetrylib` sub-crate was inlined during the Tier 1
@@ -47,6 +47,13 @@ Eleven crates, all pinned to the same version, published in topological order:
     off by default; production deployments use the scheduler-routed
     HTTP path via `FlowFabricWorker::claim_via_server`
 11. `ff-server`      — HTTP server library + binary
+12. `flowfabric`     — umbrella re-export of the ff-* family
+    (issue #279). Depends on every other publishable crate; MUST
+    publish LAST. Lets consumers pin one crate + feature-flag the
+    backend (`flowfabric = { version = "0.8", features = ["valkey"] }`
+    or `features = ["postgres"]`) instead of tracking 7–8 separate
+    pins in lockstep. Default-features=["valkey"] preserves v0.7–
+    v0.8 stability posture.
 
 Excluded from publish:
 

--- a/release.toml
+++ b/release.toml
@@ -4,7 +4,10 @@
 # workspace-wide version bump across the publishable crates:
 #   ferriskey, ff-core, ff-script, ff-observability,
 #   ff-observability-http, ff-scheduler, ff-backend-valkey,
-#   ff-backend-postgres, ff-engine, ff-sdk, ff-server
+#   ff-backend-postgres, ff-engine, ff-sdk, ff-server, flowfabric
+# (flowfabric is the umbrella re-export crate added in v0.8.2 per
+# issue #279 — it depends on every other publishable crate and
+# publishes LAST in .github/workflows/release.yml.)
 # (ff-scheduler must publish BEFORE ff-backend-valkey per RFC-017
 # Stage C — ff-backend-valkey owns Arc<ff_scheduler::Scheduler>.)
 # The former telemetrylib sub-crate was inlined into ferriskey in


### PR DESCRIPTION
## Summary

Closes #279 (cairn's third ask for an umbrella crate). Adds
`flowfabric` — a new workspace crate that re-exports the ff-* family
behind feature flags, so consumers can pin one crate and feature-flag
the backend instead of tracking 7–8 separate pins in lockstep.

## Consumer before/after

Before (today's cairn-fabric shape):

```toml
[dependencies]
ff-core             = "0.8"
ff-sdk              = "0.8"
ff-engine           = "0.8"
ff-scheduler        = "0.8"
ff-script           = "0.8"
ff-backend-valkey   = "0.8"
ferriskey           = "0.8"
```

After (Valkey, default):

```toml
flowfabric = "0.8"
```

After (Postgres):

```toml
flowfabric = { version = "0.8", default-features = false, features = ["postgres"] }
```

## Feature matrix

| Feature               | Default? | Pulls in |
|---                    |---       |--- |
| `valkey`              | yes      | `ff-backend-valkey`, `ff-script/valkey-client`, `ff-sdk/valkey-default` |
| `postgres`            | no       | `ff-backend-postgres` |
| `engine`              | no       | `ff-engine` |
| `scheduler-internals` | no       | `ff-scheduler` |
| `script-internals`    | no       | `ff-script` (pure Lua-loader, no ferriskey) |
| `iam`                 | no       | propagates `ff-sdk/iam` → `ferriskey/iam` |

`ff-server` and `ferriskey` are intentionally NOT re-exported — see
the migration doc for rationale (RFC-process prefers to expand
`EngineBackend` over re-exposing raw client types).

## Release-infra updates

- Workspace `members` + `workspace.dependencies` both updated.
- `.github/workflows/release.yml`: added `cargo publish -p flowfabric`
  as the LAST step (depends on every other publishable crate);
  header comment updated (11→12 crates).
- `docs/RELEASING.md`: 12-crate publish set with entry #12 describing
  the umbrella.
- `release.toml`: comment updated.
- **publish-list-drift check passes locally.** Ran the drift job's
  exact jq/grep/diff pipeline — zero delta between cargo metadata and
  release.yml.

## Verification

All green on this branch (pre-existing `ff-sdk` dead_code warning is
not introduced here):

```
cargo build --workspace
cargo build -p flowfabric --no-default-features --features valkey
cargo build -p flowfabric --no-default-features --features postgres
cargo build -p flowfabric --features "engine scheduler-internals script-internals"
cargo clippy -p flowfabric --no-deps --all-targets -- -D warnings
cargo doc -p flowfabric --no-deps
```

## Out of scope (peer-team boundary)

Cairn's `Cargo.toml` is NOT edited — the migration doc is the
hand-off artifact, per `feedback_peer_team_boundaries`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo build -p flowfabric --no-default-features --features valkey`
- [x] `cargo build -p flowfabric --no-default-features --features postgres`
- [x] `cargo build -p flowfabric --features "engine scheduler-internals script-internals"`
- [x] `cargo clippy -p flowfabric --no-deps --all-targets -- -D warnings`
- [x] `cargo doc -p flowfabric --no-deps`
- [x] publish-list drift check (local jq/grep/diff)
- [ ] CI: matrix + security-and-quality green (in-flight)

Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new published crate and modifies the crates.io release workflow/publish ordering; main risk is release/publish failure or feature-flag dependency graph issues rather than runtime behavior changes.
> 
> **Overview**
> Introduces a new `flowfabric` *umbrella crate* that re-exports the `ff-*` family behind feature flags (defaulting to the Valkey backend) and provides a `prelude` for the common SDK surface.
> 
> Wires the new crate into the workspace (`Cargo.toml`, `Cargo.lock`) and updates release infrastructure/docs so `flowfabric` is included in the topologically-ordered publish set and published **last** (`.github/workflows/release.yml`, `docs/RELEASING.md`, `release.toml`), with migration guidance added to `docs/CONSUMER_MIGRATION_v0.8.md` and noted in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1bcf644f9bfd6e570586587770d22081ac946b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->