### PR TITLE
feat(EngineBackend): seed_waitpoint_hmac_secret trait method (#280)

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -42,8 +42,8 @@ use ff_core::contracts::{
 use ff_core::state::PublicState;
 use ff_core::contracts::{
     CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
-    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SuspendArgs,
-    SuspendOutcome,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SeedOutcome,
+    SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome,
 };
 #[cfg(feature = "streaming")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
@@ -739,6 +739,21 @@ impl EngineBackend for PostgresBackend {
             .map(|d| d.as_millis() as i64)
             .unwrap_or(0);
         signal::rotate_waitpoint_hmac_secret_all_impl(&self.pool, args, now_ms).await
+    }
+
+    #[tracing::instrument(name = "pg.seed_waitpoint_hmac_secret", skip_all)]
+    async fn seed_waitpoint_hmac_secret(
+        &self,
+        args: SeedWaitpointHmacSecretArgs,
+    ) -> Result<SeedOutcome, EngineError> {
+        // Issue #280: install-only boot-time seed against the global
+        // `ff_waitpoint_hmac` table. Idempotent — cairn calls this on
+        // every boot and the backend decides whether to INSERT.
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        signal::seed_waitpoint_hmac_secret_impl(&self.pool, args, now_ms).await
     }
 
     // ── Stream reads (streaming feature) ──

--- a/crates/ff-backend-postgres/src/signal.rs
+++ b/crates/ff-backend-postgres/src/signal.rs
@@ -252,6 +252,93 @@ pub async fn rotate_waitpoint_hmac_secret_all_impl(
     ]))
 }
 
+/// Implementation of `EngineBackend::seed_waitpoint_hmac_secret` (issue #280).
+///
+/// Semantics against the global `ff_waitpoint_hmac` table:
+///
+/// * No active row exists and no row for the supplied kid → INSERT
+///   the new kid as the active signing kid. Returns
+///   `SeedOutcome::Seeded { kid }`.
+/// * Row for the supplied kid exists (regardless of `active`) →
+///   `SeedOutcome::AlreadySeeded { kid, same_secret }` where
+///   `same_secret` reports whether the stored bytes match.
+/// * Different kid is currently `active=TRUE` → `Validation(InvalidInput)`;
+///   operators must rotate rather than re-seed under a conflicting
+///   kid. Mirrors the Valkey backend's behaviour when the per-partition
+///   `current_kid` differs from the supplied one.
+pub async fn seed_waitpoint_hmac_secret_impl(
+    pool: &PgPool,
+    args: ff_core::contracts::SeedWaitpointHmacSecretArgs,
+    now_ms: i64,
+) -> Result<ff_core::contracts::SeedOutcome, EngineError> {
+    use ff_core::contracts::SeedOutcome;
+
+    if args.secret_hex.len() != 64 || !args.secret_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::InvalidInput,
+            detail: "secret_hex must be 64 hex characters (256-bit secret)".into(),
+        });
+    }
+    if args.kid.is_empty() {
+        return Err(EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::InvalidInput,
+            detail: "kid must be non-empty".into(),
+        });
+    }
+    let secret_bytes = hex::decode(&args.secret_hex).map_err(|_| EngineError::Validation {
+        kind: ff_core::engine_error::ValidationKind::InvalidInput,
+        detail: "secret_hex is not valid hex".into(),
+    })?;
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let existing: Option<(Vec<u8>,)> =
+        sqlx::query_as("SELECT secret FROM ff_waitpoint_hmac WHERE kid = $1")
+            .bind(&args.kid)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+    if let Some((prior,)) = existing {
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(SeedOutcome::AlreadySeeded {
+            kid: args.kid,
+            same_secret: prior == secret_bytes,
+        });
+    }
+
+    let active: Option<(String,)> = sqlx::query_as(
+        "SELECT kid FROM ff_waitpoint_hmac WHERE active = TRUE \
+         ORDER BY rotated_at_ms DESC LIMIT 1",
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    if let Some((active_kid,)) = active {
+        tx.rollback().await.ok();
+        return Err(EngineError::Validation {
+            kind: ff_core::engine_error::ValidationKind::InvalidInput,
+            detail: format!(
+                "seed_waitpoint_hmac_secret: a different kid {active_kid:?} is already active; \
+                 use rotate_waitpoint_hmac_secret_all to change kid"
+            ),
+        });
+    }
+
+    sqlx::query(
+        "INSERT INTO ff_waitpoint_hmac (kid, secret, rotated_at_ms, active) \
+         VALUES ($1, $2, $3, TRUE)",
+    )
+    .bind(&args.kid)
+    .bind(&secret_bytes)
+    .bind(now_ms)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(SeedOutcome::Seeded { kid: args.kid })
+}
+
 #[cfg(test)]
 mod hmac_tests {
     use super::*;

--- a/crates/ff-backend-postgres/tests/suspend_signal.rs
+++ b/crates/ff-backend-postgres/tests/suspend_signal.rs
@@ -24,14 +24,15 @@
 
 use ff_backend_postgres::signal::{
     current_active_kid, fetch_kid, hmac_sign, hmac_verify,
-    rotate_waitpoint_hmac_secret_all_impl, HmacVerifyError,
+    rotate_waitpoint_hmac_secret_all_impl, seed_waitpoint_hmac_secret_impl, HmacVerifyError,
 };
 use ff_backend_postgres::PostgresBackend;
 use ff_core::backend::{BackendTag, Handle, HandleKind};
 use ff_core::contracts::{
     ClaimResumedExecutionArgs, ClaimResumedExecutionResult, CompositeBody, CountKind,
     DeliverSignalArgs, DeliverSignalResult, IdempotencyKey, ResumeCondition, ResumePolicy,
-    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretOutcome, SignalMatcher,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretOutcome, SeedOutcome,
+    SeedWaitpointHmacSecretArgs, SignalMatcher,
     SuspendArgs, SuspendOutcome, SuspensionReasonCode, WaitpointBinding,
 };
 use ff_core::engine_backend::EngineBackend;
@@ -162,6 +163,123 @@ async fn rotate_all_kid_conflict_rejects() {
         err,
         EngineError::Conflict(ConflictKind::RotationConflict(_))
     ));
+}
+
+// ─── Issue #280: seed_waitpoint_hmac_secret ──────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn seed_happy_path_installs_new_kid() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+
+    let secret = "cc".repeat(32);
+    let out = seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-seed", secret.clone()),
+        1_000_000,
+    )
+    .await
+    .expect("seed ok");
+    assert!(matches!(out, SeedOutcome::Seeded { ref kid } if kid == "kid-seed"));
+
+    let (active_kid, _) = current_active_kid(&pool).await.unwrap().expect("active present");
+    assert_eq!(active_kid, "kid-seed");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn seed_replay_same_kid_and_secret_reports_already_seeded_matching() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let secret = "cc".repeat(32);
+    seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-seed", secret.clone()),
+        1_000_000,
+    )
+    .await
+    .unwrap();
+
+    // Replay: same kid + same secret ⇒ AlreadySeeded { same_secret: true }.
+    let out = seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-seed", secret),
+        2_000_000,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        out,
+        SeedOutcome::AlreadySeeded { ref kid, same_secret: true } if kid == "kid-seed"
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn seed_replay_same_kid_different_secret_reports_mismatch() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-seed", "aa".repeat(32)),
+        1_000_000,
+    )
+    .await
+    .unwrap();
+    let out = seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-seed", "bb".repeat(32)),
+        2_000_000,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        out,
+        SeedOutcome::AlreadySeeded { same_secret: false, .. }
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn seed_different_active_kid_is_validation_error() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-one", "aa".repeat(32)),
+        1_000_000,
+    )
+    .await
+    .unwrap();
+    let err = seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-two", "bb".repeat(32)),
+        2_000_000,
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, EngineError::Validation { .. }));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn seed_rejects_invalid_secret_hex_length() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let err = seed_waitpoint_hmac_secret_impl(
+        &pool,
+        SeedWaitpointHmacSecretArgs::new("kid-seed", "shortsecret"),
+        1_000_000,
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, EngineError::Validation { .. }));
 }
 
 #[tokio::test]

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -44,7 +44,8 @@ use ff_core::contracts::{
     ExecutionSnapshot, FlowSnapshot, FlowStatus, FlowSummary, ListExecutionsPage, ListFlowsPage,
     ListLanesPage, ListSuspendedPage, ReportUsageResult, ResumeCondition, ResumePolicy,
     ResumeTarget, RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllEntry,
-    RotateWaitpointHmacSecretAllResult, RotateWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs,
+    RotateWaitpointHmacSecretAllResult, RotateWaitpointHmacSecretArgs, SeedOutcome,
+    SeedWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs,
     SuspendOutcome, SuspendOutcomeDetails, SuspendedExecutionEntry, WaitpointBinding,
 };
 use ff_core::partition::{Partition, PartitionFamily};
@@ -4477,6 +4478,192 @@ impl EngineBackend for ValkeyBackend {
             entries.push(RotateWaitpointHmacSecretAllEntry::new(i as u16, res));
         }
         Ok(RotateWaitpointHmacSecretAllResult::new(entries))
+    }
+
+    /// Seed the initial waitpoint HMAC secret across every execution
+    /// partition (issue #280). Idempotent — intended to be called on
+    /// every boot by cairn-fabric + similar consumers, letting the
+    /// backend decide whether any partition needs an install.
+    ///
+    /// Semantics per partition, using the existing on-disk layout
+    /// (`waitpoint_hmac_secrets:{p:N}` hash with `current_kid` +
+    /// `secret:<kid>` fields):
+    ///
+    /// * `current_kid` absent → HSET both fields, partition reports
+    ///   "installed".
+    /// * `current_kid == args.kid` and stored secret matches →
+    ///   "already-seeded, same secret".
+    /// * `current_kid == args.kid` and stored secret differs →
+    ///   "already-seeded, different secret".
+    /// * `current_kid != args.kid` → `Validation(InvalidInput)`.
+    ///
+    /// The per-partition HSET is NOT atomic across partitions; a
+    /// crash mid-fanout leaves some partitions installed and others
+    /// empty. The next boot-time seed call repairs by installing the
+    /// still-empty partitions. This mirrors the pre-#280
+    /// `initialize_waitpoint_hmac_secret` boot behaviour which cairn
+    /// was calling via raw HSET.
+    ///
+    /// Return shape: `Seeded { kid }` when at least one partition
+    /// installed; otherwise `AlreadySeeded { kid, same_secret }`
+    /// where `same_secret` is true iff every partition had both the
+    /// supplied kid as `current_kid` AND matching secret bytes.
+    async fn seed_waitpoint_hmac_secret(
+        &self,
+        args: SeedWaitpointHmacSecretArgs,
+    ) -> Result<SeedOutcome, EngineError> {
+        use futures::stream::{FuturesUnordered, StreamExt};
+
+        if args.secret_hex.len() != 64 || !args.secret_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "secret_hex must be 64 hex characters (256-bit secret)".into(),
+            });
+        }
+        if args.kid.is_empty() {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "kid must be non-empty".into(),
+            });
+        }
+
+        enum PerPart {
+            Installed,
+            Match,
+            SameKidDifferentSecret,
+            DifferentKid(String),
+        }
+
+        let num = self.partition_config.num_flow_partitions;
+        let concurrency = self.admin_rotate_fanout_concurrency as usize;
+        let mut pending: FuturesUnordered<_> = FuturesUnordered::new();
+        let mut next_index: u16 = 0;
+        let mut by_index: Vec<Option<Result<PerPart, EngineError>>> =
+            (0..num).map(|_| None).collect();
+
+        loop {
+            while pending.len() < concurrency && next_index < num {
+                let partition = Partition {
+                    family: PartitionFamily::Execution,
+                    index: next_index,
+                };
+                let key = IndexKeys::new(&partition).waitpoint_hmac_secrets();
+                let client = self.client.clone();
+                let kid = args.kid.clone();
+                let secret_hex = args.secret_hex.clone();
+                let i = next_index;
+                pending.push(async move {
+                    let res: Result<PerPart, EngineError> = async {
+                        let stored_kid: Option<String> = client
+                            .cmd("HGET")
+                            .arg(&key)
+                            .arg("current_kid")
+                            .execute()
+                            .await
+                            .map_err(|e| {
+                                ff_core::engine_error::backend_context(
+                                    transport_fk(e),
+                                    format!("HGET {key} current_kid (seed probe)"),
+                                )
+                            })?;
+                        if let Some(stored_kid) = stored_kid {
+                            if stored_kid != kid {
+                                return Ok(PerPart::DifferentKid(stored_kid));
+                            }
+                            let field = format!("secret:{stored_kid}");
+                            let stored_secret: Option<String> = client
+                                .hget(&key, &field)
+                                .await
+                                .map_err(|e| {
+                                    ff_core::engine_error::backend_context(
+                                        transport_fk(e),
+                                        format!("HGET {key} secret:<kid> (seed probe)"),
+                                    )
+                                })?;
+                            match stored_secret.as_deref() {
+                                Some(s) if s == secret_hex => Ok(PerPart::Match),
+                                Some(_) => Ok(PerPart::SameKidDifferentSecret),
+                                None => {
+                                    client
+                                        .hset(&key, &field, &secret_hex)
+                                        .await
+                                        .map_err(|e| {
+                                            ff_core::engine_error::backend_context(
+                                                transport_fk(e),
+                                                format!(
+                                                    "HSET {key} secret:<kid> (seed repair torn write)"
+                                                ),
+                                            )
+                                        })?;
+                                    Ok(PerPart::Installed)
+                                }
+                            }
+                        } else {
+                            let secret_field = format!("secret:{kid}");
+                            let _: i64 = client
+                                .cmd("HSET")
+                                .arg(&key)
+                                .arg("current_kid")
+                                .arg(&kid)
+                                .arg(&secret_field)
+                                .arg(&secret_hex)
+                                .execute()
+                                .await
+                                .map_err(|e| {
+                                    ff_core::engine_error::backend_context(
+                                        transport_fk(e),
+                                        format!("HSET {key} (seed install)"),
+                                    )
+                                })?;
+                            Ok(PerPart::Installed)
+                        }
+                    }
+                    .await;
+                    (i, res)
+                });
+                next_index += 1;
+            }
+            match pending.next().await {
+                Some((i, res)) => by_index[i as usize] = Some(res),
+                None => break,
+            }
+        }
+
+        let mut installed = 0usize;
+        let mut matched = 0usize;
+        let mut different_secret = 0usize;
+        let mut different_kid: Option<String> = None;
+        for slot in by_index.into_iter() {
+            let res = slot.expect("every partition probed exactly once");
+            match res? {
+                PerPart::Installed => installed += 1,
+                PerPart::Match => matched += 1,
+                PerPart::SameKidDifferentSecret => different_secret += 1,
+                PerPart::DifferentKid(k) => {
+                    different_kid.get_or_insert(k);
+                }
+            }
+        }
+
+        if let Some(stored) = different_kid {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!(
+                    "seed_waitpoint_hmac_secret: stored current_kid {stored:?} differs \
+                     from supplied kid {:?}; use rotate_waitpoint_hmac_secret_all to change kid",
+                    args.kid
+                ),
+            });
+        }
+        if installed > 0 {
+            Ok(SeedOutcome::Seeded { kid: args.kid })
+        } else {
+            let same_secret = different_secret == 0 && matched > 0;
+            Ok(SeedOutcome::AlreadySeeded {
+                kid: args.kid,
+                same_secret,
+            })
+        }
     }
 
     #[cfg(feature = "streaming")]

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -3075,6 +3075,52 @@ impl RotateWaitpointHmacSecretAllResult {
     }
 }
 
+// ─── seed_waitpoint_hmac_secret (issue #280) ───
+
+/// Args for [`EngineBackend::seed_waitpoint_hmac_secret`].
+///
+/// Two required fields and no optional knobs, so there is no fluent
+/// builder — just `new(kid, secret_hex)`. `#[non_exhaustive]` is kept
+/// (with the paired constructor, per the project memory rule) so
+/// future additive knobs don't break callers.
+///
+/// Boot-time provisioning entry point for fresh deployments — see
+/// issue #280 for why cairn needed this in addition to
+/// [`RotateWaitpointHmacSecretAllArgs`]. Unlike rotate, seed is
+/// idempotent: callers invoke it on every boot and the backend
+/// decides whether to install.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct SeedWaitpointHmacSecretArgs {
+    pub kid: String,
+    pub secret_hex: String,
+}
+
+impl SeedWaitpointHmacSecretArgs {
+    pub fn new(kid: impl Into<String>, secret_hex: impl Into<String>) -> Self {
+        Self {
+            kid: kid.into(),
+            secret_hex: secret_hex.into(),
+        }
+    }
+}
+
+/// Result of [`EngineBackend::seed_waitpoint_hmac_secret`].
+///
+/// * `Seeded` — the backend had no `current_kid` (or no row in the
+///   global keystore) and installed `kid` as the active signing kid.
+/// * `AlreadySeeded` — a row for `kid` is already installed.
+///   `same_secret` reports whether the stored secret bytes match the
+///   caller-supplied hex; `false` means the caller should pick a fresh
+///   kid for rotation rather than silently re-installing under the
+///   existing kid.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SeedOutcome {
+    Seeded { kid: String },
+    AlreadySeeded { kid: String, same_secret: bool },
+}
+
 // ─── list_waitpoint_hmac_kids ───
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -54,8 +54,8 @@ use crate::backend::{
 };
 use crate::contracts::{
     CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
-    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SuspendArgs,
-    SuspendOutcome,
+    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SeedOutcome,
+    SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome,
 };
 #[cfg(feature = "core")]
 use crate::contracts::{
@@ -576,6 +576,35 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<RotateWaitpointHmacSecretAllResult, EngineError> {
         Err(EngineError::Unavailable {
             op: "rotate_waitpoint_hmac_secret_all",
+        })
+    }
+
+    /// Seed the initial waitpoint HMAC secret for a fresh deployment
+    /// (issue #280).
+    ///
+    /// **Idempotent.** If a `current_kid` (Valkey per-partition) or
+    /// an active kid row (Postgres) already exists with the given
+    /// `kid`, the method returns
+    /// [`SeedOutcome::AlreadySeeded`] without overwriting, reporting
+    /// whether the stored secret matches the caller-supplied one via
+    /// `same_secret`. Callers (cairn boot, operator tooling) invoke
+    /// this on every boot and let the backend decide whether to
+    /// install — removing the client-side "check then HSET" race that
+    /// cairn's raw-HSET boot path silently tolerated.
+    ///
+    /// For rotation of an already-seeded secret, use
+    /// [`Self::rotate_waitpoint_hmac_secret_all`] instead; seed is
+    /// install-only.
+    ///
+    /// The default impl returns [`EngineError::Unavailable`] with
+    /// `op = "seed_waitpoint_hmac_secret"` so backends that haven't
+    /// implemented the method surface the miss loudly.
+    async fn seed_waitpoint_hmac_secret(
+        &self,
+        _args: SeedWaitpointHmacSecretArgs,
+    ) -> Result<SeedOutcome, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "seed_waitpoint_hmac_secret",
         })
     }
 

--- a/crates/ff-server/tests/parity_stage_a_backfill.rs
+++ b/crates/ff-server/tests/parity_stage_a_backfill.rs
@@ -31,7 +31,7 @@ use ff_core::contracts::{
     EdgeDirection, EdgeSnapshot, ExecutionSnapshot, FlowSnapshot, ListExecutionsPage,
     ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs, ListSuspendedPage,
     ReplayExecutionArgs, ReportUsageAdminArgs, ReportUsageResult, ResetBudgetArgs, RevokeLeaseArgs,
-    
+    SeedWaitpointHmacSecretArgs,
     SetEdgeGroupPolicyResult, StageDependencyEdgeArgs, StreamCursor, StreamFrames, SuspendArgs,
     SuspendOutcome,
 };
@@ -540,6 +540,20 @@ async fn default_claim_for_worker_is_unavailable() {
     expect_unavailable(
         backend().claim_for_worker(args).await,
         "claim_for_worker",
+    );
+}
+
+// ─── Admin — seed_waitpoint_hmac_secret (issue #280) ────────────
+
+#[tokio::test]
+async fn default_seed_waitpoint_hmac_secret_is_unavailable() {
+    let args = SeedWaitpointHmacSecretArgs::new(
+        "kid-seed",
+        "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+    );
+    expect_unavailable(
+        backend().seed_waitpoint_hmac_secret(args).await,
+        "seed_waitpoint_hmac_secret",
     );
 }
 

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -265,6 +265,7 @@ but no longer trips on Postgres.
 | Scheduler (`claim_for_worker`) | `impl` | `impl` | Stage E3 `PostgresScheduler` + `claim_for_worker` trait impl + 6 reconcilers. |
 | Waitpoints (`list_pending_waitpoints`) | `impl` | `stub` | Wave 9. |
 | Admin rotation (`rotate_waitpoint_hmac_secret_all`) | `impl` | `stub` | Wave 9 (single-INSERT on the global HMAC table). |
+| Admin seed (`seed_waitpoint_hmac_secret`, issue #280) | `impl` | `impl` | Idempotent boot-time seed so cairn can drop its raw HSET boot path. Valkey fans out per-partition HSET against the `waitpoint_hmac_secrets:{p:N}` layout. Postgres INSERTs one row into `ff_waitpoint_hmac` when no kid is active. `AlreadySeeded { same_secret }` lets callers distinguish replay from real conflict. |
 | Cross-cutting (`backend_label`, `shutdown_prepare`, `ping`) | `impl` | `impl` | — |
 
 ### v0.8.0 shipped


### PR DESCRIPTION
## Summary

Adds `EngineBackend::seed_waitpoint_hmac_secret` (issue #280) so cairn-fabric can drop its raw-`HSET` boot path and unblock Postgres adoption.

- **Trait** (`ff-core`): `seed_waitpoint_hmac_secret(args) -> Result<SeedOutcome, _>` with default returning `EngineError::Unavailable { op: \"seed_waitpoint_hmac_secret\" }`. New contracts `SeedWaitpointHmacSecretArgs { kid, secret_hex }` and `SeedOutcome::{ Seeded { kid }, AlreadySeeded { kid, same_secret } }` — `#[non_exhaustive]` with paired `new()` per the project memory rule.
- **Valkey impl**: per-execution-partition HGET probe + HSET install against the existing `waitpoint_hmac_secrets:{p:N}` layout, reusing `admin_rotate_fanout_concurrency`. Idempotent: repairs torn `secret:<kid>` writes, returns `AlreadySeeded { same_secret: true }` on exact replay. A mismatched stored `current_kid` surfaces `Validation(InvalidInput)` — operators rotate, not re-seed.
- **Postgres impl**: single INSERT into `ff_waitpoint_hmac` when no kid is active. Replay against the same kid returns `AlreadySeeded` with `same_secret` comparing stored bytes. A different active kid surfaces `Validation(InvalidInput)`.
- **Validation**: `secret_hex` must be 64 ASCII-hex chars (256-bit secret); `kid` non-empty. Surfaced as `Validation(InvalidInput)`.

## Parity matrix

`docs/POSTGRES_PARITY_MATRIX.md`:

```
| Admin seed (seed_waitpoint_hmac_secret, issue #280) | impl | impl | ... |
```

## Tests

- `crates/ff-server/tests/parity_stage_a_backfill.rs::default_seed_waitpoint_hmac_secret_is_unavailable` — trait default falls through to `Unavailable { op }` with the correct label.
- `crates/ff-backend-postgres/tests/suspend_signal.rs` (gated on `FF_PG_TEST_URL`):
  - `seed_happy_path_installs_new_kid`
  - `seed_replay_same_kid_and_secret_reports_already_seeded_matching`
  - `seed_replay_same_kid_different_secret_reports_mismatch`
  - `seed_different_active_kid_is_validation_error`
  - `seed_rejects_invalid_secret_hex_length`
- Existing `waitpoint_hmac_rotation_fcall` integration tests still pass (no regression in the rotation FCALL path).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey -p ff-backend-postgres --features ff-sdk/direct-valkey-claim -- -D warnings`
- [x] `cargo test -p ff-backend-valkey -p ff-backend-postgres --lib`
- [x] `cargo test -p ff-server --test parity_stage_a_backfill default_seed_waitpoint_hmac_secret`
- [x] `cargo test -p ff-test --test waitpoint_hmac_rotation_fcall` (against live Valkey)
- [ ] PG integration tests run against `FF_PG_TEST_URL` in CI (gated `#[ignore]`)

## Out of scope (per issue #280)

- Deleting cairn's raw HSET code (peer-team change).
- Changing the internal boot-time `ValkeyBackend::boot::initialize_waitpoint_hmac_secret` path (stays backend-private).
- Any wire-format change.

Closes #280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new admin API that writes/validates the waitpoint HMAC signing secret (security-sensitive) across both backends, with new validation and error semantics that could affect boot-time provisioning and rotation workflows.
> 
> **Overview**
> Adds a new `EngineBackend::seed_waitpoint_hmac_secret` admin method plus contracts `SeedWaitpointHmacSecretArgs` and `SeedOutcome` to support **idempotent boot-time provisioning** of the waitpoint HMAC signing secret (issue #280).
> 
> Implements seeding in **Valkey** via per-execution-partition probe/install/repair against `waitpoint_hmac_secrets:{p:N}`, and in **Postgres** via transactional INSERT into `ff_waitpoint_hmac` when no active kid exists; both reject conflicting active kids and validate `kid`/`secret_hex`.
> 
> Extends tests to cover the new trait default `Unavailable` behavior and adds Postgres integration tests for seed success, replay, mismatch, and conflict cases; updates the Postgres parity matrix to include the new operation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761568f03d814e54f4d610ee53af463e7e1df206. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->