### PR TITLE
fix(script): extend FUNCTION LOAD retry window for cluster-topology race (#275)

### DIFF
--- a/crates/ff-script/src/loader.rs
+++ b/crates/ff-script/src/loader.rs
@@ -51,8 +51,19 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
         }
     }
 
-    // Load the library with retry for transient errors
-    const MAX_ATTEMPTS: u32 = 3;
+    // Load the library with retry for transient errors.
+    //
+    // Cluster-topology race (issue #275): on a just-formed cluster,
+    // `FUNCTION LOAD` can route to a node that's a replica at dispatch
+    // time (gossip hasn't fully converged). Valkey rejects with
+    // `READONLY: You can't write against a read only replica.`
+    //
+    // Treat READONLY as transient: back off with exponential delay so
+    // slot-map refresh catches the settled topology. 6 attempts with
+    // 1s/2s/4s/4s/4s inter-attempt waits gives ~15s total window,
+    // bounded well under typical `cluster-node-timeout` (5s default).
+    const MAX_ATTEMPTS: u32 = 6;
+    let backoff_ms: [u64; 5] = [1_000, 2_000, 4_000, 4_000, 4_000];
     let mut last_err = None;
     for attempt in 1..=MAX_ATTEMPTS {
         match client.function_load_replace(LIBRARY_SOURCE).await {
@@ -65,15 +76,17 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
                     tracing::error!(attempt, error = %e, "FUNCTION LOAD failed with permanent error");
                     return Err(LoadError::Valkey(e));
                 }
+                let backoff = backoff_ms.get((attempt as usize).saturating_sub(1)).copied().unwrap_or(4_000);
                 tracing::warn!(
                     attempt,
                     max_attempts = MAX_ATTEMPTS,
+                    backoff_ms = backoff,
                     error = %e,
-                    "FUNCTION LOAD failed (transient), retrying in 1s"
+                    "FUNCTION LOAD failed (transient), retrying"
                 );
                 last_err = Some(e);
                 if attempt < MAX_ATTEMPTS {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to #276 bootstrap-convergence fix. Matrix-CI cluster legs continued to fail intermittently with \`READONLY: You can't write against a read only replica.\` after #276 merged — meaning the bootstrap-quorum poll + CLUSTER NODES verification isn't enough. The race survives past bootstrap and into the first \`FUNCTION LOAD\` dispatch during \`Server::start_with_metrics\`.

## Fix

Widen the \`ensure_library\` retry envelope from 3×1s = 4s to 6 attempts with 1s/2s/4s/4s/4s backoff = 15s total. READONLY is already treated as transient (\`is_permanent_load_error\` only flags syntax errors); this PR just gives ferriskey's slot-map refresh enough time to catch the settled topology.

## Bounds

15s < typical \`cluster-node-timeout\` ceiling (5s in our CI, 15s in production defaults). Boot time increase is bounded; if cluster truly isn't forming, the error surfaces within the same bounded window (just louder logging).

## Alternatives considered

- **Fix in ferriskey**: add READONLY-aware slot-refresh in the cluster client. Real fix but architectural; defer to a ferriskey PR (#275 comment-2 suggests \`SystemTime::now\` → \`Instant::now\` while we're there).
- **Defer load until first FCALL**: skip \`FUNCTION LOAD\` at boot; let the "function not found" auto-reload kick in during first user command. Wider blast radius — boot becomes silently broken until a user triggers it.

Retry-extension is the minimal, surgical fix for the boot-time manifestation. Ferriskey-level hardening stays open as #275 follow-up.

## Verification

Local build clean. Matrix-CI cluster legs will get ~10 runs of soak time as cairn PRs (#284 #286 #288 and the remaining 2) merge through main.

Issue: https://github.com/avifenesh/FlowFabric/issues/275

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup-time Valkey function library loading behavior by extending retries and introducing exponential backoff; low complexity but can delay boot by up to ~15s and may mask persistent cluster issues until the window expires.
> 
> **Overview**
> Improves resilience of `ensure_library` when loading the Lua function library into a newly formed Valkey cluster by **expanding the retry window** and adding **exponential backoff** for transient `FUNCTION LOAD` failures (notably `READONLY` during topology convergence).
> 
> Increases attempts from `3` to `6`, varies sleep between retries (`1s/2s/4s/4s/4s`), and logs the per-attempt backoff to make these transient load failures easier to diagnose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec5c65a9623f19b206ea9e6c1c754503a9e2941. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->