### PR TITLE
docs(CLAUDE.md + README): release gate + v0.9 surface + multi-backend env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,31 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Release Gate (every version tag)
+
+**Never tag a release without running the full gate locally.** Crates.io + GitHub are public surfaces; a broken release harms every downstream consumer, and yanking is partial recovery at best.
+
+Mandatory gate before `git tag vX.Y.Z`:
+
+1. **Smoke** — `scripts/smoke-v0.7.sh` (or its successor) PASS on both Valkey + Postgres backends. No skipped scenarios. Capture output in the release PR body.
+2. **All examples build clean** — every subdir of `examples/` compiles at the new version. `cargo build --bins` in each.
+3. **At least one example live-runs** — whichever example needs no external credentials (today that's `retry-and-cancel` for Valkey-only scenarios, `umbrella-quickstart` for v0.9+ quickstart). Paste the full transcript in the PR body, showing every expected log line.
+4. **New example for release headlines** — if the release adds consumer-facing surface (new trait methods, new crates, new public fields), land a new example that exercises them in ~150-200 lines. This IS the consumer docs; if we can't cleanly demonstrate the feature, the feature isn't ready.
+5. **README validation** — sweep root `README.md` + each `examples/*/README.md` + `docs/CONSUMER_MIGRATION_*.md` for staleness against current main (stale version refs, removed flags, renamed methods, missing new features). One PR, one sweep, before tag.
+6. **CHANGELOG complete** — every `### Added` / `### Changed` / `### Fixed` entry since the prior tag is in the new version's section. No open `[Unreleased]` content at tag time.
+7. **POSTGRES_PARITY_MATRIX.md current** — every new trait method has a matrix row, every deferral has a pointer to the follow-up issue.
+8. **Pre-publish smoke job in release.yml** — must gate the tag workflow. Tag push triggers Verify → Smoke → Publish → GitHub Release; Smoke failure blocks Publish. Do not bypass with `--admin` on the release workflow.
+
+Skipping any of these has cost us a partial-publish recovery before (v0.3.0, v0.6.0, v0.8.0). The gate exists because shortcutting it causes measurable harm — real yanks, real consumer breakage, real trust cost.
+
+## 6. Autonomous-mode decision rule
+
+When operating without real-time owner feedback ("autonomous mode" / "finish what you can" directives):
+
+- **Decide** mechanical choices (wire compatibility, existing-pattern adherence, additive-only extensions, adjacency fixes).
+- **Defer with a note** genuine architectural forks that would change scope, consumer contract, or require real tradeoff adjudication. Leave them documented and move on.
+- **Never defer correctness-critical releases.** The release gate (§5 above) is not mechanical — it is the owner's insurance against shipping broken artifacts. Autonomous mode may cut a release; it must not cut one that fails any gate.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
                  │              │              │
           ┌──────┴──────┐ ┌────┴────┐ ┌───────┴───────┐
           │  ff-engine   │ │ ff-sdk  │ │ ff-scheduler  │
-          │  14 scanners │ │ worker  │ │ claim-grant   │
+          │  17 scanners │ │ worker  │ │ claim-grant   │
           └──────┬──────┘ │   API   │ │   cycle       │
                  │        └────┬────┘ └───────┬───────┘
                  │             │              │
@@ -136,10 +136,13 @@ For production deployments, use the Scheduler (`ff-scheduler`) which enforces ad
   | Variable | Default | Description |
   |----------|---------|-------------|
   | `FF_WAITPOINT_HMAC_SECRET` | *required* | Hex-encoded HMAC signing secret for waitpoint tokens (RFC-004 §Waitpoint Security). Even-length hex; 64 chars (32 bytes) recommended. |
-  | `FF_HOST` | `localhost` | Valkey host |
-  | `FF_PORT` | `6379` | Valkey port |
-  | `FF_TLS` | `false` | Enable TLS (`1` or `true`) |
-  | `FF_CLUSTER` | `false` | Enable cluster mode |
+  | `FF_BACKEND` | `valkey` | Backend family — `valkey` or `postgres`. Both first-class at v0.8.0 (RFC-017 Stage E4). |
+  | `FF_HOST` | `localhost` | Valkey host (ignored when `FF_BACKEND=postgres`) |
+  | `FF_PORT` | `6379` | Valkey port (ignored when `FF_BACKEND=postgres`) |
+  | `FF_TLS` | `false` | Enable Valkey TLS (`1` or `true`) |
+  | `FF_CLUSTER` | `false` | Enable Valkey cluster mode |
+  | `FF_POSTGRES_URL` | *(empty)* | Postgres connection URL (required when `FF_BACKEND=postgres`). Example: `postgres://user:pass@host:5432/db`. |
+  | `FF_POSTGRES_POOL_SIZE` | `10` | Postgres pool size (ignored on the Valkey path). |
   | `FF_LISTEN_ADDR` | `0.0.0.0:9090` | API listen address |
   | `FF_LANES` | `default` | Comma-separated lane names |
   | `FF_FLOW_PARTITIONS` | `256` | Flow partition count (exec keys co-locate under RFC-011) |


### PR DESCRIPTION
## Summary

Two concerns in one doc-only PR:

**1. CLAUDE.md gains a §5 Release Gate + §6 Autonomous-mode rule.** Encodes the 8-step pre-tag gate (smoke, examples build + one live-runs, new example for release headlines, README sweep, CHANGELOG + matrix current, release.yml smoke-before-publish). Future sessions follow it without being told; the lesson from v0.3.0/v0.6.0/v0.8.0 partial-publish recoveries is now durable.

**2. README.md sweep for current (pre-v0.9) main.** Updates stale refs:
- Valkey-only → Valkey+Postgres headline
- 14 → 17 scanners (counted in `crates/ff-engine/src/scanner/`)
- 22 → 27 REST endpoints (counted via `.route(` in `crates/ff-server/src/api.rs`)
- "Postgres in scope for later" → first-class at v0.8 (RFC-017 Stage E4)
- Quick-start step 2 adds the `FF_BACKEND=postgres` invocation
- Examples list: four → six (adds deploy-approval + v0.9 umbrella-quickstart, reorders by quickstart-first pedagogy — umbrella-quickstart lands in a parallel PR that this one references)
- Env-var table: adds `FF_BACKEND` / `FF_POSTGRES_URL` / `FF_POSTGRES_POOL_SIZE`, flags legacy Valkey vars as ignored on the Postgres path
- Latest-version callout linking each v0.9 issue + CHANGELOG + CONSUMER_MIGRATION

## Out of scope

- The v0.9 `umbrella-quickstart` example itself (parallel PR)
- Cutting v0.9.0 (release PR follows this)

## Verification

- README fixes verified against current `main` (`c.*route\(` count, `ls crates/ff-engine/src/scanner/`, `grep FF_BACKEND crates/ff-server/src/config.rs`).
- CLAUDE.md rendered locally; no broken links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; low risk beyond potential confusion if the new release checklist or env-var descriptions are inaccurate.
> 
> **Overview**
> Adds a new **release gating checklist** to `CLAUDE.md`, defining mandatory pre-tag steps (smoke tests on Valkey+Postgres, examples build/live-run, doc/changelog/matrix freshness, and CI publish gating).
> 
> Updates `README.md` to reflect current surface area by adjusting the scanner count in the architecture diagram and expanding the production env-var table with **multi-backend** knobs (`FF_BACKEND`, `FF_POSTGRES_URL`, `FF_POSTGRES_POOL_SIZE`) plus clarifying which Valkey settings are ignored on the Postgres path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2d8d2b939a5398335a379a1dbef42aa1bdde84. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->