### PR TITLE
ci(matrix): add ubuntu-latest × postgres 16 × standalone cell (Postgres backend parity gate)

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,15 +1,16 @@
 name: Matrix CI
 
-# Cross-host + cross-mode + cross-version verification.
+# Cross-host + cross-mode + cross-version + cross-backend verification.
 #
-# Matrix coverage (6 jobs):
+# Matrix coverage (7 jobs):
 #
-#   linux x86_64  × valkey 8   × standalone   -> ubuntu-latest
-#   linux x86_64  × valkey 8   × cluster      -> ubuntu-latest
-#   linux x86_64  × valkey 7.2 × standalone   -> ubuntu-latest    (floor guard)
-#   linux arm64   × valkey 8   × standalone   -> ubuntu-24.04-arm
-#   linux arm64   × valkey 8   × cluster      -> ubuntu-24.04-arm
-#   macos arm64   × valkey 8   × standalone   -> macos-latest
+#   linux x86_64  × valkey 8    × standalone  -> ubuntu-latest
+#   linux x86_64  × valkey 8    × cluster     -> ubuntu-latest
+#   linux x86_64  × valkey 7.2  × standalone  -> ubuntu-latest    (floor guard)
+#   linux arm64   × valkey 8    × standalone  -> ubuntu-24.04-arm
+#   linux arm64   × valkey 8    × cluster     -> ubuntu-24.04-arm
+#   macos arm64   × valkey 8    × standalone  -> macos-latest
+#   linux x86_64  × postgres 16 × standalone  -> ubuntu-latest    (backend parity)
 #
 # **Valkey versions:** RFC-011 §13 sets the floor at Valkey >= 7.2
 # (enforced at ff-server boot via `verify_valkey_version`). 7.2 is where
@@ -28,6 +29,22 @@ name: Matrix CI
 # and x86_64 Rust correctness is already validated through
 # ubuntu-latest. Linux covers the full Valkey version matrix where
 # we actually deploy.
+#
+# **Postgres 16 × standalone** (separate `matrix-postgres` job below):
+# backend-parity gate for the Postgres EngineBackend. Before this
+# cell existed, Postgres validation only ran during the tag-triggered
+# release smoke, so a PR could silently regress Postgres behavior and
+# surface the breakage only during a publish attempt (the partial-
+# publish risk CLAUDE.md §5 warns about). The cell runs the subset of
+# tests that currently passes against Postgres: `-p ff-backend-postgres`
+# (backend unit/integration, `-- --ignored` for live-Postgres tests)
+# and the `http_postgres_smoke` ingress test gated by the
+# `postgres-e2e` feature. The full `ff-test` suite is NOT run under
+# Postgres — docs/POSTGRES_PARITY_MATRIX.md tracks the trait methods
+# that still return `Unavailable` on the Postgres path. Cluster/ARM
+# Postgres variants are intentionally out of scope: Postgres cluster
+# semantics differ from Valkey Cluster, and one solid x86_64 cell
+# gives us the regression signal we need.
 
 on:
   # `paths-ignore` drops doc-only PRs from CI entirely (the matrix
@@ -249,6 +266,119 @@ jobs:
         run: |
           docker compose -f .github/cluster/docker-compose.cluster.yml logs --tail=80 2>&1 || true
 
+  # ── Postgres backend parity cell ─────────────────────────────────
+  #
+  # Separate job (not a row of the Valkey matrix) because the matrix
+  # axes above are Valkey-shaped (host × valkey-version × cluster-mode)
+  # and a Postgres row would leave most of those axes inapplicable.
+  # Running a distinct job keeps the YAML + the failure signal clean.
+  #
+  # Test subset rationale: per docs/POSTGRES_PARITY_MATRIX.md the
+  # Postgres EngineBackend still returns `Unavailable` for a number of
+  # trait methods that the full `ff-test` suite exercises on Valkey.
+  # Running the full suite here would flag known deferrals as failures.
+  # Instead we run:
+  #   * `cargo test -p ff-backend-postgres -- --ignored` — the
+  #     backend's own schema + attempt-family + suspend-signal tests
+  #     (#[ignore]'d by default because they need a live DB; we have
+  #     one in the service container).
+  #   * `cargo test -p ff-test --test http_postgres_smoke
+  #        --features postgres-e2e` — the HTTP-over-Postgres ingress
+  #     smoke (RFC-017 Wave 8 Stage E1).
+  #   * `cargo test -p ff-server --lib` — backend-agnostic ff-server
+  #     unit tests (no live backend needed; picks up skew between the
+  #     Postgres feature-flag assembly and ff-server's internal API).
+  matrix-postgres:
+    name: ubuntu-latest · postgres 16 · standalone
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        # Mirrors release.yml:154-164 verbatim. `postgres:16-alpine`
+        # is the reference image; `pg_isready` healthcheck gates job
+        # startup so tests don't race the DB boot.
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ff_smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      FF_BACKEND: postgres
+      FF_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/ff_smoke
+      # `ff-backend-postgres` crate tests look for `FF_PG_TEST_URL`
+      # (the older env-var name used in the schema_* / suspend_signal
+      # / pg_engine_backend_attempt test files). Set both so either
+      # naming works without editing the test harness.
+      FF_PG_TEST_URL: postgres://postgres:postgres@localhost:5432/ff_smoke
+      FF_WAITPOINT_HMAC_SECRET: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+        with:
+          key: ubuntu-latest-postgres-16-standalone
+
+      - name: Install sqlx-cli + postgres client
+        # Mirrors release.yml:185-190. postgresql-client gives us
+        # `pg_isready` + `psql` for diagnostics; sqlx-cli applies the
+        # migrations in the step below (even though the backend
+        # itself calls `apply_migrations` idempotently on boot, running
+        # migrations up-front keeps the "what schema is this test
+        # running against" question answerable from the job log).
+        run: |
+          cargo install sqlx-cli --no-default-features --features postgres
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends postgresql-client
+
+      - name: Apply Postgres migrations
+        working-directory: crates/ff-backend-postgres
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/ff_smoke
+        run: sqlx migrate run
+
+      - name: cargo build (workspace)
+        run: cargo build --workspace
+
+      - name: ff-backend-postgres tests
+        # `-- --ignored` runs the `#[ignore]`'d live-Postgres tests
+        # (schema_0001, schema_0002, pg_engine_backend_attempt,
+        # suspend_signal). Those tests skip gracefully when
+        # FF_PG_TEST_URL is unset; with the service container in
+        # place they execute for real.
+        run: cargo test -p ff-backend-postgres -- --ignored
+
+      - name: HTTP-over-Postgres smoke (ff-test::http_postgres_smoke)
+        # RFC-017 Wave 8 Stage E1. Feature-gated because the test
+        # requires `ff-test/postgres-e2e` to pull in the Postgres
+        # dial branch deps and the test module is `#[cfg]`'d on the
+        # feature.
+        run: cargo test -p ff-test --test http_postgres_smoke --features postgres-e2e
+
+      - name: ff-server unit tests
+        # Backend-agnostic unit tests for ff-server. Runs under the
+        # Postgres job so a feature-flag-propagation bug that only
+        # surfaces in Postgres-configured builds (cf.
+        # feedback_feature_flag_propagation.md) fails CI here rather
+        # than silently in release.
+        run: cargo test -p ff-server --lib
+
+      - name: Dump Postgres logs (diagnostics)
+        if: failure()
+        run: |
+          docker ps -a
+          # The service container name is auto-generated; list and dump.
+          for c in $(docker ps -a --filter "ancestor=postgres:16-alpine" --format '{{.ID}}'); do
+            echo "=== docker logs $c ==="
+            docker logs "$c" 2>&1 | tail -200 || true
+          done
+
   # Always-runs sentinel. Branch protection should list
   # `matrix-tests-complete` as the required status check — NOT the
   # per-matrix-job name — so a doc-only PR (which skips the matrix via
@@ -280,19 +410,24 @@ jobs:
 
   matrix-tests-complete:
     name: matrix-tests-complete
-    needs: [matrix, lua-drift]
+    needs: [matrix, matrix-postgres, lua-drift]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate matrix result
         env:
           MATRIX_RESULT: ${{ needs.matrix.result }}
+          POSTGRES_RESULT: ${{ needs.matrix-postgres.result }}
           DRIFT_RESULT: ${{ needs.lua-drift.result }}
         run: |
           fail=0
           case "$MATRIX_RESULT" in
             success|skipped) echo "matrix: $MATRIX_RESULT — ok" ;;
             *) echo "matrix: $MATRIX_RESULT — blocking merge" >&2; fail=1 ;;
+          esac
+          case "$POSTGRES_RESULT" in
+            success|skipped) echo "matrix-postgres: $POSTGRES_RESULT — ok" ;;
+            *) echo "matrix-postgres: $POSTGRES_RESULT — blocking merge" >&2; fail=1 ;;
           esac
           case "$DRIFT_RESULT" in
             success|skipped) echo "lua-drift: $DRIFT_RESULT — ok" ;;

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -317,13 +317,21 @@ jobs:
       # / pg_engine_backend_attempt test files). Set both so either
       # naming works without editing the test harness.
       FF_PG_TEST_URL: postgres://postgres:postgres@localhost:5432/ff_smoke
-      FF_WAITPOINT_HMAC_SECRET: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
         with:
           key: ubuntu-latest-postgres-16-standalone
+
+      # Generate a fresh HMAC secret per-run rather than hard-coding a
+      # test literal. Release.yml does the same; keeps GitGuardian's
+      # secret-pattern scanner from false-positiving on long hex
+      # literals in workflow YAML. Export via GITHUB_ENV so later
+      # steps inherit it.
+      - name: Generate FF_WAITPOINT_HMAC_SECRET
+        run: |
+          echo "FF_WAITPOINT_HMAC_SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
 
       - name: Install sqlx-cli + postgres client
         # Mirrors release.yml:185-190. postgresql-client gives us

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -352,7 +352,16 @@ jobs:
         # suspend_signal). Those tests skip gracefully when
         # FF_PG_TEST_URL is unset; with the service container in
         # place they execute for real.
-        run: cargo test -p ff-backend-postgres -- --ignored
+        #
+        # `--test-threads=1`: the `suspend_signal` test file TRUNCATEs
+        # `ff_waitpoint_hmac` (a global, non-partitioned keystore
+        # table) in per-test setup. Under parallel test execution
+        # test A's TRUNCATE wipes test B's seeded kid, causing
+        # "kid X missing from keystore" failures. Same serial-
+        # isolation pattern as the Valkey `ff-test` integration run.
+        # Follow-up: isolate the keystore setup (UUID-scoped kids or
+        # per-test schema) so tests can parallelize again.
+        run: cargo test -p ff-backend-postgres -- --ignored --test-threads=1
 
       - name: HTTP-over-Postgres smoke (ff-test::http_postgres_smoke)
         # RFC-017 Wave 8 Stage E1. Feature-gated because the test


### PR DESCRIPTION
## Motivation

Close the PR-side regression gap for the Postgres backend. Before this PR, Matrix CI had 6 cells — **all Valkey-only**. Postgres validation happened only in the tag-triggered Release workflow's pre-publish smoke (`release.yml`), so a PR could silently regress Postgres behavior and the breakage would surface only when someone tried to cut a release — exactly the partial-publish risk CLAUDE.md §5 warns about.

## Cell config

New 7th Matrix cell: **`ubuntu-latest · postgres 16 · standalone`**.

Implemented as a separate `matrix-postgres` job (not a row of the Valkey `matrix` job) because the existing matrix axes are Valkey-shaped (host × valkey-version × cluster-mode) and most of those axes don't apply to Postgres. A distinct job keeps the YAML + failure signal clean.

Service container mirrors `release.yml:154-164` verbatim:

```yaml
services:
  postgres:
    image: postgres:16-alpine
    env:
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: postgres
      POSTGRES_DB: ff_smoke
    ports: [5432:5432]
    options: >-
      --health-cmd "pg_isready -U postgres" ...
env:
  FF_BACKEND: postgres
  FF_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/ff_smoke
  FF_PG_TEST_URL: postgres://postgres:postgres@localhost:5432/ff_smoke
  FF_WAITPOINT_HMAC_SECRET: 0123...cdef
```

Note: `FF_PG_TEST_URL` is the older env-var name used by the `ff-backend-postgres` in-crate tests (`schema_0001.rs`, `suspend_signal.rs`, `pg_engine_backend_attempt.rs`). Setting both keeps either naming working without editing those tests.

## Tests the cell runs + why

1. `cargo test -p ff-backend-postgres -- --ignored` — backend unit/integration (schema_0001/0002, pg_engine_backend_attempt, suspend_signal). The `-- --ignored` flag is required because those tests are `#[ignore]`'d by default (need a live DB).
2. `cargo test -p ff-test --test http_postgres_smoke --features postgres-e2e` — RFC-017 Wave 8 Stage E1 HTTP-over-Postgres ingress smoke. Feature-gated because the test module is `#[cfg(feature = "postgres-e2e")]`.
3. `cargo test -p ff-server --lib` — backend-agnostic ff-server unit tests. Catches feature-flag-propagation bugs that only surface in Postgres-configured builds (cf. `feedback_feature_flag_propagation.md`).

**NOT run:** the full `ff-test` integration suite. Per `docs/POSTGRES_PARITY_MATRIX.md` the Postgres `EngineBackend` still returns `Unavailable` for a number of trait methods; running the full suite would flag known deferrals as failures. This is documented in the job comment in the YAML.

## Out of scope

- ARM Postgres cell — start small
- Postgres cluster/Patroni cell — Postgres cluster semantics differ from Valkey Cluster
- Extending `smoke-v0.7.sh` beyond what release.yml already does
- Fixing any Postgres parity-matrix gaps surfaced by the new cell (those become follow-up issues)

## Sentinel

`matrix-tests-complete` now `needs: [matrix, matrix-postgres, lua-drift]` and aggregates the new cell's result alongside the others. Branch protection (which lists the sentinel as the required check) will block PRs when the Postgres cell fails.

## Test plan

- [ ] Matrix CI `matrix-postgres` cell runs green on this PR
- [ ] `matrix-tests-complete` aggregates the new result correctly
- [ ] Existing Valkey cells remain unaffected (no shared matrix changes)
- [ ] If the cell exposes a real Postgres regression, file a follow-up issue per the task spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low product risk since this only changes GitHub Actions, but it can increase CI time and start blocking merges if Postgres-specific tests/migrations are flaky.
> 
> **Overview**
> Adds a new **Postgres backend parity** job to Matrix CI (`ubuntu-latest · postgres 16 · standalone`) using a `postgres:16-alpine` service container, running migrations and a targeted Postgres test subset (ignored `ff-backend-postgres` live-DB tests, `ff-test`’s `http_postgres_smoke` under `postgres-e2e`, plus `ff-server --lib`).
> 
> Updates the `matrix-tests-complete` sentinel to also depend on and aggregate the new `matrix-postgres` result, making Postgres regressions detectable on PRs instead of only in the release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f914a9e3db15a399e4a013b4c83531b269123c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->