### PR TITLE
fix(ferriskey): Instant::now() for slot-refresh throttle (monotonic clock; closes #290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **ferriskey slot-refresh throttle** uses `Instant::now()` instead of
+  `SystemTime::now()` for elapsed-time measurement. `Instant` is
+  monotonic; immune to NTP steps, VM suspend/restore, and variable
+  clock resolution. Closes #290.
 - **Cluster-topology bootstrap race (issue #275).** On a just-formed
   6-node Valkey cluster, `FUNCTION LOAD` could route to a node whose
   topology view still classified it as primary even though it had

--- a/ferriskey/src/cluster/mod.rs
+++ b/ferriskey/src/cluster/mod.rs
@@ -96,7 +96,7 @@ use std::{
         atomic::{self, AtomicUsize, Ordering},
     },
     task::{self, Poll},
-    time::{Duration, SystemTime},
+    time::{Duration, Instant},
 };
 use strum_macros::Display;
 use tokio::{
@@ -2424,16 +2424,9 @@ where
             // Check if the current slot refresh is triggered before the wait duration has passed
             let last_run_rlock = last_run.read().await;
             if let Some(last_run_time) = *last_run_rlock {
-                let passed_time = SystemTime::now()
-                    .duration_since(last_run_time)
-                    .unwrap_or_else(|err| {
-                        warn!(
-                            "Failed to get the duration since the last slot refresh, received error: {:?}",
-                            err
-                        );
-                        // Setting the passed time to 0 will force the current refresh to continue and reset the stored last_run timestamp with the current one
-                        Duration::from_secs(0)
-                    });
+                // `Instant::duration_since` returns `Duration` directly; the
+                // monotonic clock cannot go backward, so no fallback needed.
+                let passed_time = Instant::now().duration_since(last_run_time);
                 let wait_duration = rate_limiter.wait_duration();
                 if passed_time <= wait_duration {
                     debug!("Skipping slot refresh as the wait duration hasn't yet passed. Passed time = {:?},
@@ -2585,7 +2578,7 @@ where
         trigger: SlotRefreshTrigger,
     ) -> Result<()> {
         // Update the slot refresh last run timestamp
-        let now = SystemTime::now();
+        let now = Instant::now();
         let mut last_run_wlock = inner.slot_refresh_state.last_run.write().await;
         *last_run_wlock = Some(now);
         drop(last_run_wlock);

--- a/ferriskey/src/cluster/topology.rs
+++ b/ferriskey/src/cluster/topology.rs
@@ -11,7 +11,7 @@ use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tracing::info;
 
@@ -35,8 +35,13 @@ pub(crate) type TopologyHash = u64;
 pub(crate) struct SlotRefreshState {
     /// Indicates if a slot refresh is currently in progress
     pub(crate) in_progress: AtomicBool,
-    /// The last slot refresh run timestamp
-    pub(crate) last_run: Arc<RwLock<Option<SystemTime>>>,
+    /// The last slot refresh run timestamp.
+    ///
+    /// Uses `Instant` (monotonic clock) rather than `SystemTime` because this
+    /// value is only compared against itself to measure elapsed time for the
+    /// refresh throttle. `Instant` never jumps backward and is immune to NTP
+    /// steps, VM suspend/restore, and wall-clock drift.
+    pub(crate) last_run: Arc<RwLock<Option<Instant>>>,
     pub(crate) rate_limiter: SlotsRefreshRateLimit,
 }
 


### PR DESCRIPTION
## Motivation

Slot-refresh throttling in `ferriskey/src/cluster/mod.rs` reads and writes `SystemTime::now()` to compute elapsed time against `SlotRefreshState::last_run`. That's the wall clock, which can:

- Jump backward on NTP step corrections.
- Jump forward on VM suspend/restore, host clock drift, scheduler-frozen CPU.
- Have varying resolution across hardware (arm64 virtualized clocks 1-10us vs x86 nanosecond TSC).

Under any of those, `duration_since(last_run_time)` returns `Err(SystemTimeError)` (currently swallowed with a warn + force-refresh) or a bogus `Duration` that fools the rate-limiter into either refreshing too aggressively or not at all.

`Instant::now()` is monotonic by contract. Immune to NTP jumps, VM suspension, clock-drift correction. Purpose-built for elapsed-time measurement within a single process lifetime — exactly what the throttle gate is doing.

Surfaced during #275 investigation. Not the proximate cause (closed via #276 + #289) but real robustness debt. Closes #290.

## Diff summary

- `SlotRefreshState::last_run: RwLock<Option<SystemTime>>` -> `RwLock<Option<Instant>>`, with a doc comment explaining why.
- Both call sites (`mod.rs:2427` read, `mod.rs:2588` write) swap `SystemTime::now()` -> `Instant::now()`. `Instant::duration_since` returns `Duration` directly (not `Result`), so the `SystemTimeError` fallback + warn log drop out — simpler code.

Internal state only; nothing serialized crosses the wire. No API change. No behavior change on the happy path; edge-case correctness improves under clock-jump / VM-suspend.

## Verification

- `cargo build -p ferriskey` — clean.
- `cargo clippy -p ferriskey --all-targets -- -D warnings` — clean.
- `cargo test -p ferriskey --lib` — 262 passed.
- `cargo test -p ff-test --lib` — 9 passed (against running valkey `PONG`).

## Out of scope

- READONLY-aware slot invalidation on write-routed commands — separate, larger design.
- Any API change — `Instant` has a different wire shape than `SystemTime`, so any serialized clock field would break; this change is purely internal throttle state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal change: swaps the slot-refresh throttle timestamp from wall-clock `SystemTime` to monotonic `Instant`, reducing sensitivity to clock jumps without affecting external APIs or persisted data.
> 
> **Overview**
> Switches ferriskey’s slot-refresh throttling to use a monotonic clock by replacing `SystemTime` with `Instant` for `SlotRefreshState::last_run` and its read/write call sites, removing the prior error-handling fallback.
> 
> Updates the changelog to document the throttle robustness fix (closes #290).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5f083aa4c92a4c24c34f564d994dbd86b2fa1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->