### PR TITLE
feat(EngineBackend): implement cancel_flow WaitTimeout + WaitIndefinite on both backends (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Consumers that talk to a running ff-server via HTTP continue to
   use `FlowFabricWorker::claim_via_server` and don't need the
   embedded scheduler.
+- `EngineBackend::cancel_flow` now supports `WaitTimeout(Duration)`
+  and `WaitIndefinite` on both Valkey and Postgres backends via a
+  shared `describe_flow` poll loop. Callers that previously needed
+  client-side `NoWait` + poll can now pass the wait mode through
+  the trait. Closes #298.
 - **`flowfabric` umbrella crate** — re-exports the ff-* family
   (`ff_core`, `ff_sdk`, and optionally `ff_backend_valkey`,
   `ff_backend_postgres`, `ff_engine`, `ff_scheduler`, `ff_script`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "uuid",
 ]
 

--- a/crates/ff-backend-postgres/src/flow.rs
+++ b/crates/ff-backend-postgres/src/flow.rs
@@ -27,7 +27,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use ff_core::backend::{CancelFlowPolicy, CancelFlowWait};
+use ff_core::backend::CancelFlowPolicy;
 use ff_core::contracts::{
     CancelFlowResult, EdgeDependencyPolicy, EdgeDirection, EdgeGroupSnapshot, EdgeGroupState,
     EdgeSnapshot, FlowSnapshot, FlowStatus, FlowSummary, ListFlowsPage, OnSatisfied,
@@ -557,7 +557,6 @@ pub async fn cancel_flow(
     partition_config: &ff_core::partition::PartitionConfig,
     id: &FlowId,
     policy: CancelFlowPolicy,
-    _wait: CancelFlowWait,
 ) -> Result<CancelFlowResult, EngineError> {
     let part = flow_partition_byte(id, partition_config);
     let flow_uuid: Uuid = id.0;

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -699,7 +699,11 @@ impl EngineBackend for PostgresBackend {
         policy: CancelFlowPolicy,
         wait: CancelFlowWait,
     ) -> Result<CancelFlowResult, EngineError> {
-        flow::cancel_flow(&self.pool, &self.partition_config, id, policy, wait).await
+        let result = flow::cancel_flow(&self.pool, &self.partition_config, id, policy).await?;
+        if let Some(deadline) = ff_core::engine_backend::cancel_flow_wait_deadline(wait) {
+            ff_core::engine_backend::wait_for_flow_cancellation(self, id, deadline).await?;
+        }
+        Ok(result)
     }
 
     #[cfg(feature = "core")]

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -653,15 +653,12 @@ fn cancel_policy_to_str(p: CancelFlowPolicy) -> &'static str {
     }
 }
 
-/// Stage 1a cancel-flow FCALL wrapper. Only
-/// [`CancelFlowWait::NoWait`] is supported at Stage 1a — the
-/// dispatch+wait loop that [`CancelFlowWait::WaitTimeout`] /
-/// [`CancelFlowWait::WaitIndefinite`] require lands in a
-/// follow-up stage (today's ff-sdk cancel_flow HTTP path does the
-/// wait client-side after the FCALL commits). Rejecting the
-/// wait modes explicitly with [`EngineError::Unavailable`] lets
-/// callers distinguish "backend won't do this yet" from a silent
-/// fallback. See RFC-012 §3.1.1 for the cancel_flow policy matrix.
+/// Cancel-flow FCALL wrapper. Runs the synchronous state-flip +
+/// member-cancel dispatch FCALL; the `wait` parameter is honoured by
+/// the trait-level `cancel_flow` via the shared
+/// [`wait_for_flow_cancellation`](ff_core::engine_backend::wait_for_flow_cancellation)
+/// helper which polls `describe_flow` once the FCALL commits. See
+/// RFC-012 §3.1.1 for the cancel_flow policy / wait matrix.
 #[tracing::instrument(
     name = "ff.cancel_flow",
     skip_all,
@@ -672,30 +669,7 @@ async fn cancel_flow_fcall(
     partition_config: &PartitionConfig,
     flow_id: &FlowId,
     policy: CancelFlowPolicy,
-    wait: CancelFlowWait,
 ) -> Result<CancelFlowResult, EngineError> {
-    match wait {
-        CancelFlowWait::NoWait => {}
-        CancelFlowWait::WaitTimeout(_) => {
-            return Err(EngineError::Unavailable {
-                op: "cancel_flow(wait=WaitTimeout)",
-            });
-        }
-        CancelFlowWait::WaitIndefinite => {
-            return Err(EngineError::Unavailable {
-                op: "cancel_flow(wait=WaitIndefinite)",
-            });
-        }
-        // `CancelFlowWait` is `#[non_exhaustive]`. Future wait
-        // variants must be reviewed here explicitly; fall closed
-        // with Unavailable so callers see a typed error instead of
-        // silent fallback to NoWait.
-        _ => {
-            return Err(EngineError::Unavailable {
-                op: "cancel_flow(wait=unknown)",
-            });
-        }
-    }
     let partition = flow_partition(flow_id, partition_config);
     let fctx = FlowKeyContext::new(&partition, flow_id);
     let fidx = FlowIndexKeys::new(&partition);
@@ -4385,11 +4359,15 @@ impl EngineBackend for ValkeyBackend {
         policy: CancelFlowPolicy,
         wait: CancelFlowWait,
     ) -> Result<CancelFlowResult, EngineError> {
-        cancel_flow_fcall(&self.client, &self.partition_config, id, policy, wait)
+        let result = cancel_flow_fcall(&self.client, &self.partition_config, id, policy)
             .await
             .map_err(|e| {
                 ff_core::engine_error::backend_context(e, "cancel_flow: FCALL ff_cancel_flow")
-            })
+            })?;
+        if let Some(deadline) = ff_core::engine_backend::cancel_flow_wait_deadline(wait) {
+            ff_core::engine_backend::wait_for_flow_cancellation(self, id, deadline).await?;
+        }
+        Ok(result)
     }
 
     async fn set_edge_group_policy(

--- a/crates/ff-core/Cargo.toml
+++ b/crates/ff-core/Cargo.toml
@@ -40,5 +40,6 @@ crc16 = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 futures-core = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -1084,3 +1084,72 @@ pub trait EngineBackend: Send + Sync + 'static {
 /// EngineBackend>` use.
 #[allow(dead_code)]
 fn _assert_dyn_compatible(_: &dyn EngineBackend) {}
+
+/// Polling interval for [`wait_for_flow_cancellation`]. Tight enough
+/// that a local single-node cancel cascade observes `cancelled` within
+/// one or two polls; slack enough that a `WaitIndefinite` caller does
+/// not hammer `describe_flow` on a live cluster.
+const CANCEL_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Defensive ceiling for [`CancelFlowWait::WaitIndefinite`] — if the
+/// reconciler cascade has not converged in five minutes, something is
+/// wedged and returning `Timeout` is strictly more useful than blocking
+/// forever. RFC-012 §3.1.1 expects real-world cascades to finish within
+/// `reconciler_interval + grace`, which is orders of magnitude below
+/// this.
+const CANCEL_WAIT_INDEFINITE_CEILING: Duration = Duration::from_secs(300);
+
+/// Poll `backend.describe_flow(flow_id)` until `public_flow_state` is
+/// `"cancelled"` or `deadline` elapses.
+///
+/// Shared by every backend's `cancel_flow` trait impl that honours
+/// [`CancelFlowWait::WaitTimeout`] / [`CancelFlowWait::WaitIndefinite`].
+/// The underlying `cancel_flow` FCALL / SQL transaction flips the
+/// flow-level state synchronously; member cancellations dispatch
+/// asynchronously via the reconciler, which also flips
+/// `public_flow_state` to `cancelled` once the cascade completes. This
+/// helper waits for that terminal flip.
+///
+/// Returns:
+/// * `Ok(())` once `public_flow_state = "cancelled"` is observed.
+/// * `Err(EngineError::Timeout { op: "cancel_flow", elapsed })` when
+///   `deadline` elapses first. `elapsed` is the wait budget (the
+///   requested timeout), not wall-clock precision.
+/// * `Err(e)` if `describe_flow` itself errors (propagated).
+pub async fn wait_for_flow_cancellation<B: EngineBackend + ?Sized>(
+    backend: &B,
+    flow_id: &crate::types::FlowId,
+    deadline: Duration,
+) -> Result<(), EngineError> {
+    let start = std::time::Instant::now();
+    loop {
+        match backend.describe_flow(flow_id).await? {
+            Some(snap) if snap.public_flow_state == "cancelled" => return Ok(()),
+            // `None` (flow removed) is also terminal from the caller's
+            // perspective — nothing left to wait on.
+            None => return Ok(()),
+            Some(_) => {}
+        }
+        if start.elapsed() >= deadline {
+            return Err(EngineError::Timeout {
+                op: "cancel_flow",
+                elapsed: deadline,
+            });
+        }
+        tokio::time::sleep(CANCEL_WAIT_POLL_INTERVAL).await;
+    }
+}
+
+/// Convert a [`CancelFlowWait`] into the deadline passed to
+/// [`wait_for_flow_cancellation`]. `NoWait` returns `None` — the caller
+/// must skip the wait entirely.
+pub fn cancel_flow_wait_deadline(wait: CancelFlowWait) -> Option<Duration> {
+    // `CancelFlowWait` is `#[non_exhaustive]`; this match lives in the
+    // defining crate so the exhaustiveness check keeps the compiler
+    // honest. Future variants must be wired here explicitly.
+    match wait {
+        CancelFlowWait::NoWait => None,
+        CancelFlowWait::WaitTimeout(d) => Some(d),
+        CancelFlowWait::WaitIndefinite => Some(CANCEL_WAIT_INDEFINITE_CEILING),
+    }
+}

--- a/crates/ff-test/tests/engine_backend_cancel_flow_wait.rs
+++ b/crates/ff-test/tests/engine_backend_cancel_flow_wait.rs
@@ -1,0 +1,147 @@
+//! Issue #298 regression: `EngineBackend::cancel_flow` must honour
+//! [`CancelFlowWait::WaitTimeout`] and [`CancelFlowWait::WaitIndefinite`]
+//! on the Valkey backend.
+//!
+//! Prior to #298 both wait modes returned
+//! [`EngineError::Unavailable`] at the trait boundary — Server had to
+//! work around it with a client-side poll over `NoWait`. This test
+//! covers the trait-level poll implementation:
+//!
+//! * `wait_timeout_returns_cancelled_when_cascade_completes_in_time` —
+//!   `cancel_flow` with `WaitTimeout(500ms)` on a memberless flow
+//!   returns `Ok(Cancelled)` and the flow's `public_flow_state` is
+//!   observably `cancelled`.
+//! * `wait_timeout_returns_timeout_when_deadline_exceeded` — the
+//!   shared `wait_for_flow_cancellation` helper returns
+//!   `EngineError::Timeout` when invoked with an impossibly tight
+//!   deadline against a still-open flow.
+//!
+//! Run with:
+//!   cargo test -p ff-test --test engine_backend_cancel_flow_wait -- \
+//!       --test-threads=1
+
+use ferriskey::Value;
+use ff_core::backend::{CancelFlowPolicy, CancelFlowWait};
+use ff_core::contracts::CancelFlowResult;
+use ff_core::engine_backend::wait_for_flow_cancellation;
+use ff_core::engine_error::EngineError;
+use ff_core::keys::{FlowIndexKeys, FlowKeyContext};
+use ff_core::partition::{flow_partition, PartitionConfig};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+fn test_config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+async fn seed_partition_config(tc: &TestCluster) {
+    let cfg = test_config();
+    let _: () = tc
+        .client()
+        .cmd("HSET")
+        .arg("ff:config:partitions")
+        .arg("num_flow_partitions")
+        .arg(cfg.num_flow_partitions.to_string().as_str())
+        .arg("num_budget_partitions")
+        .arg(cfg.num_budget_partitions.to_string().as_str())
+        .arg("num_quota_partitions")
+        .arg(cfg.num_quota_partitions.to_string().as_str())
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn create_flow_raw(tc: &TestCluster, fid: &FlowId) {
+    let cfg = test_config();
+    let partition = flow_partition(fid, &cfg);
+    let ctx = FlowKeyContext::new(&partition, fid);
+    let fidx = FlowIndexKeys::new(&partition);
+
+    let keys: Vec<String> = vec![ctx.core(), ctx.members(), fidx.flow_index()];
+    let now_ms = TimestampMs::now().0.to_string();
+    let args: Vec<String> = vec![
+        fid.to_string(),
+        "dag".to_owned(),
+        "cancel-wait-ns".to_owned(),
+        now_ms,
+    ];
+    let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_flow", &key_refs, &arg_refs)
+        .await
+        .expect("FCALL ff_create_flow failed");
+}
+
+#[tokio::test]
+async fn wait_timeout_returns_cancelled_when_cascade_completes_in_time() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+
+    let fid = FlowId::new();
+    create_flow_raw(&tc, &fid).await;
+
+    let backend = tc.backend();
+
+    // WaitTimeout(500ms) against a memberless flow: the FCALL flips
+    // `public_flow_state = "cancelled"` synchronously and the shared
+    // poll observes it on the first iteration, well inside the
+    // deadline.
+    let result = backend
+        .cancel_flow(
+            &fid,
+            CancelFlowPolicy::CancelAll,
+            CancelFlowWait::WaitTimeout(std::time::Duration::from_millis(500)),
+        )
+        .await
+        .expect("cancel_flow WaitTimeout ok");
+
+    assert!(
+        matches!(result, CancelFlowResult::Cancelled { .. }),
+        "expected Cancelled, got {result:?}",
+    );
+
+    // Sanity: describe_flow confirms the terminal state.
+    let snap = backend
+        .describe_flow(&fid)
+        .await
+        .expect("describe_flow ok")
+        .expect("flow must exist");
+    assert_eq!(snap.public_flow_state, "cancelled");
+}
+
+#[tokio::test]
+async fn wait_timeout_returns_timeout_when_deadline_exceeded() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+    seed_partition_config(&tc).await;
+
+    let fid = FlowId::new();
+    create_flow_raw(&tc, &fid).await;
+
+    let backend = tc.backend();
+
+    // Do NOT cancel the flow. Invoke the shared wait helper with an
+    // impossibly-tight deadline (1ms) against a still-`open` flow and
+    // assert the Timeout error shape. The poll runs one iteration,
+    // observes a non-cancelled state, then the deadline-check fires on
+    // the next loop entry because `start.elapsed() >= 1ms` after the
+    // first network round-trip.
+    let err = wait_for_flow_cancellation(
+        &*backend,
+        &fid,
+        std::time::Duration::from_millis(1),
+    )
+    .await
+    .expect_err("wait_for_flow_cancellation must time out on an open flow");
+
+    match err {
+        EngineError::Timeout { op, elapsed } => {
+            assert_eq!(op, "cancel_flow");
+            assert_eq!(elapsed, std::time::Duration::from_millis(1));
+        }
+        other => panic!("expected EngineError::Timeout, got {other:?}"),
+    }
+}

--- a/crates/ff-test/tests/pg_engine_backend_flow.rs
+++ b/crates/ff-test/tests/pg_engine_backend_flow.rs
@@ -490,3 +490,68 @@ async fn set_edge_group_policy_fresh_write_then_idempotent() {
         .expect("re-set ok");
     assert_eq!(second, SetEdgeGroupPolicyResult::AlreadySet);
 }
+
+/// Issue #298: `cancel_flow(WaitTimeout)` polls `describe_flow` until
+/// `public_flow_state = "cancelled"`. On Postgres the cancel
+/// transaction flips the state row synchronously, so a memberless flow
+/// observes the terminal state on the first poll — well inside the
+/// 500ms deadline.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_flow_wait_timeout_returns_cancelled_when_cascade_completes_in_time() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let flow_id = FlowId::new();
+    seed_flow(&pool, &flow_id, "open").await;
+
+    let backend = backend(pool);
+    let res = backend
+        .cancel_flow(
+            &flow_id,
+            CancelFlowPolicy::CancelAll,
+            CancelFlowWait::WaitTimeout(std::time::Duration::from_millis(500)),
+        )
+        .await
+        .expect("cancel_flow WaitTimeout ok");
+    assert!(
+        matches!(res, CancelFlowResult::Cancelled { .. }),
+        "expected Cancelled, got {res:?}",
+    );
+
+    let snap = backend
+        .describe_flow(&flow_id)
+        .await
+        .expect("describe_flow ok")
+        .expect("flow must exist");
+    assert_eq!(snap.public_flow_state, "cancelled");
+}
+
+/// Issue #298: the shared `wait_for_flow_cancellation` helper must
+/// surface `EngineError::Timeout` when invoked with a deadline that
+/// cannot be met against a still-open flow.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_flow_wait_timeout_returns_timeout_when_deadline_exceeded() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let flow_id = FlowId::new();
+    seed_flow(&pool, &flow_id, "open").await;
+
+    let backend = backend(pool);
+    let err = ff_core::engine_backend::wait_for_flow_cancellation(
+        &*backend,
+        &flow_id,
+        std::time::Duration::from_millis(1),
+    )
+    .await
+    .expect_err("must time out on an open flow");
+    match err {
+        EngineError::Timeout { op, elapsed } => {
+            assert_eq!(op, "cancel_flow");
+            assert_eq!(elapsed, std::time::Duration::from_millis(1));
+        }
+        other => panic!("expected EngineError::Timeout, got {other:?}"),
+    }
+}

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -258,7 +258,7 @@ but no longer trips on Postgres.
 | Family | Valkey | Postgres | Notes |
 |---|---|---|---|
 | Ingress (create_flow, create_execution, add_execution_to_flow, stage_dependency_edge, apply_dependency_to_child) | `impl` | `impl` | Full HTTP parity. `http_postgres_smoke` exercises all 5 end-to-end. |
-| Flow family (`describe_flow`, `list_flows`, `list_edges`, `describe_edge`, `cancel_flow`, `set_edge_group_policy`) | `impl` | `impl` | RFC-v0.7 Wave 4c. |
+| Flow family (`describe_flow`, `list_flows`, `list_edges`, `describe_edge`, `cancel_flow`, `set_edge_group_policy`) | `impl` | `impl` | RFC-v0.7 Wave 4c. `cancel_flow` accepts all three `CancelFlowWait` modes (`NoWait`, `WaitTimeout(Duration)`, `WaitIndefinite`) on both backends via shared `wait_for_flow_cancellation` poll (#298). |
 | Flow cancel (`cancel_flow_header`, `ack_cancel_member`) | `impl` | `stub` | Wave 9 follow-up; Postgres `cancel_flow` covers the bulk path, the header/ack split lands with cancel-backlog machinery. |
 | Read model (`read_execution_info`, `read_execution_state`, `get_execution_result`) | `impl` | `stub` | Wave 9 PG read-model migration. |
 | Operator control (`cancel_execution`, `change_priority`, `replay_execution`, `revoke_lease`) | `impl` | `stub` | Wave 9. |


### PR DESCRIPTION
## Motivation

Closes #298. Pays down the RFC-012 Stage 1a deferral on
`EngineBackend::cancel_flow` wait modes:

- `ValkeyBackend::cancel_flow` rejected `WaitTimeout` / `WaitIndefinite`
  with `EngineError::Unavailable`.
- `PostgresBackend::cancel_flow` silently ignored `_wait`.
- PR #297 (token-budget example) landed with a `NoWait` + client-side
  poll workaround, exposing the gap in the trait contract.

Owner adjudication on #298 was "implement, don't remove" — this PR does
that.

## Approach

* New shared helper in `ff-core`:
  `engine_backend::wait_for_flow_cancellation(backend, flow_id, deadline)`
  polls `describe_flow` at 100ms until `public_flow_state = "cancelled"`
  (or the flow vanishes), returning `EngineError::Timeout` on deadline.
* `engine_backend::cancel_flow_wait_deadline(wait)` maps `CancelFlowWait`
  → `Option<Duration>` (`NoWait` ⇒ skip; `WaitIndefinite` ⇒ 5min
  defensive ceiling per RFC-012 §3.1.1).
* Valkey trait impl: runs the existing FCALL, then calls the poll when
  `wait` asks for it. `cancel_flow_fcall`'s Unavailable branches are
  removed.
* Postgres trait impl: runs the existing SERIALIZABLE transaction, then
  calls the poll. `flow::cancel_flow` drops the unused `_wait`
  parameter.

`ff-core` gains a `tokio = { features = ["time"] }` dep for the poll's
`sleep`; every trait consumer already runs on tokio, so this is
additive-only.

## Matrix diff

`docs/POSTGRES_PARITY_MATRIX.md` §v0.8.0 Flow-family row now reads:

> `cancel_flow` accepts all three `CancelFlowWait` modes (`NoWait`,
> `WaitTimeout(Duration)`, `WaitIndefinite`) on both backends via
> shared `wait_for_flow_cancellation` poll (#298).

## CHANGELOG entry

`[Unreleased] ### Added`:

> `EngineBackend::cancel_flow` now supports `WaitTimeout(Duration)` and
> `WaitIndefinite` on both Valkey and Postgres backends via a shared
> `describe_flow` poll loop. Callers that previously needed client-side
> `NoWait` + poll can now pass the wait mode through the trait.
> Closes #298.

## Test evidence

New tests in `ff-test`:

* `engine_backend_cancel_flow_wait.rs` (Valkey, runs vs local Valkey)
  * `wait_timeout_returns_cancelled_when_cascade_completes_in_time`
  * `wait_timeout_returns_timeout_when_deadline_exceeded`
  ```
  running 2 tests
  test wait_timeout_returns_cancelled_when_cascade_completes_in_time ... ok
  test wait_timeout_returns_timeout_when_deadline_exceeded ... ok
  test result: ok. 2 passed; 0 failed; 0 ignored
  ```
* `pg_engine_backend_flow.rs` gains the same two scenarios under the
  existing `#[ignore]` live-Postgres gate (matches the file's existing
  test style).

Regression gates:

* `cargo build --workspace` — clean.
* `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-valkey -p ff-backend-postgres -p flowfabric --features ff-sdk/direct-valkey-claim -- -D warnings` — clean.
* `http_postgres_smoke --features postgres-e2e` — pass.

## Server-facade follow-up

`Server::cancel_flow_inner` still runs its own poll over `NoWait` via the
HTTP `?wait=true` query param. Migrating it to the trait's new wait
modes is out of scope here — Server behavior stays byte-identical. Will
land as a separate PR so this change is purely a trait-level behavior
completion.

## Out of scope

* Migrating `Server::cancel_flow_inner` to use the trait wait modes.
* Changing HTTP `?wait=true` semantics.
* New trait methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `cancel_flow` semantics across both backends to potentially block and adds new timeout behavior driven by polling `describe_flow`; could impact latency and load if misused or if `describe_flow` is flaky.
> 
> **Overview**
> Implements trait-level support for `EngineBackend::cancel_flow` wait modes by adding a shared `describe_flow` polling helper (`wait_for_flow_cancellation`) and mapping `CancelFlowWait` to an internal deadline (including a 5-minute ceiling for `WaitIndefinite`).
> 
> Updates both Valkey and Postgres backends to always perform the underlying cancel operation, then optionally block until the flow reaches `public_flow_state = "cancelled"` (or disappears), removing Valkey’s prior `Unavailable` errors for wait modes and dropping Postgres’s previously-ignored wait parameter.
> 
> Adds regression tests for both backends (Valkey live; Postgres ignored-by-default) covering successful wait-with-timeout and timeout error paths, and updates docs/changelog/parity matrix; `ff-core` gains a `tokio` time dependency to support the poll sleep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2c36a7dbc23bed3dac01c6f6a09d2ac3b19c16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->