### PR TITLE
fix(ferriskey): saturating_duration_since + narrow Instant doc (follow-up to #290/#302)

### DIFF
--- a/ferriskey/src/cluster/mod.rs
+++ b/ferriskey/src/cluster/mod.rs
@@ -2424,9 +2424,12 @@ where
             // Check if the current slot refresh is triggered before the wait duration has passed
             let last_run_rlock = last_run.read().await;
             if let Some(last_run_time) = *last_run_rlock {
-                // `Instant::duration_since` returns `Duration` directly; the
-                // monotonic clock cannot go backward, so no fallback needed.
-                let passed_time = Instant::now().duration_since(last_run_time);
+                // `saturating_duration_since` returns `Duration::ZERO` rather
+                // than panicking if the monotonic clock appears to go backward
+                // (platform-specific anomaly). A zero elapsed time forces a
+                // refresh, which matches the prior `SystemTime`-fallback
+                // behavior.
+                let passed_time = Instant::now().saturating_duration_since(last_run_time);
                 let wait_duration = rate_limiter.wait_duration();
                 if passed_time <= wait_duration {
                     debug!("Skipping slot refresh as the wait duration hasn't yet passed. Passed time = {:?},

--- a/ferriskey/src/cluster/topology.rs
+++ b/ferriskey/src/cluster/topology.rs
@@ -39,8 +39,10 @@ pub(crate) struct SlotRefreshState {
     ///
     /// Uses `Instant` (monotonic clock) rather than `SystemTime` because this
     /// value is only compared against itself to measure elapsed time for the
-    /// refresh throttle. `Instant` never jumps backward and is immune to NTP
-    /// steps, VM suspend/restore, and wall-clock drift.
+    /// refresh throttle. `Instant` is guaranteed non-decreasing and is
+    /// appropriate for elapsed-time measurement within this process: unaffected
+    /// by wall-clock / NTP adjustments that could otherwise fool the
+    /// rate-limiter.
     pub(crate) last_run: Arc<RwLock<Option<Instant>>>,
     pub(crate) rate_limiter: SlotsRefreshRateLimit,
 }


### PR DESCRIPTION
## Motivation

Follow-up to #302 addressing two bot-reviewer findings that landed after the PR had already been admin-merged:

1. **Panic-safety (gemini + copilot).** `Instant::duration_since` panics if `earlier > self`. While Rust guarantees `Instant` is monotonic (non-decreasing), some platform implementations have had regressions in practice (e.g. older macOS versions, certain ARM virtualized clocks). Switch to `saturating_duration_since`, which returns `Duration::ZERO` on anomaly instead of panicking. A zero elapsed time forces a refresh, which matches the prior `SystemTime`-fallback posture.

2. **Doc accuracy (copilot).** The doc comment added in #302 claimed `Instant` is "immune" to VM suspend/restore. Rust only guarantees `Instant` is non-decreasing; behavior across suspend is platform-dependent. Narrow the claim to what Rust actually guarantees: non-decreasing, unaffected by wall-clock / NTP adjustments.

No behavior change on the happy path (suspend/NTP unchanged). Eliminates a theoretical panic under exotic clock misbehavior.

## Diff summary

- `mod.rs`: `Instant::now().duration_since(last_run_time)` -> `Instant::now().saturating_duration_since(last_run_time)`. Updated comment.
- `topology.rs`: Tightened doc wording on `last_run` field.

## Verification

- `cargo build -p ferriskey` — clean.
- `cargo test -p ferriskey --lib` — 262 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the only behavior change is using `Instant::saturating_duration_since` to prevent a rare panic under clock anomalies; normal slot-refresh throttling behavior is unchanged.
> 
> **Overview**
> Prevents a potential panic in throttled slot refreshes by switching elapsed-time calculation from `Instant::duration_since` to `Instant::saturating_duration_since` in `cluster/mod.rs`, treating backward-clock anomalies as zero elapsed time (forcing a refresh).
> 
> Updates the `SlotRefreshState::last_run` documentation in `cluster/topology.rs` to narrow `Instant` guarantees to non-decreasing, wall-clock/NTP-independent elapsed-time measurement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90d5e95fe12ae4703c0829bbfcd388077124be3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->