### PR TITLE
fix(ff-backend-postgres): UUID-scoped kids so suspend_signal tests parallelize (closes #301)

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -361,14 +361,18 @@ jobs:
         # FF_PG_TEST_URL is unset; with the service container in
         # place they execute for real.
         #
-        # `--test-threads=1`: the `suspend_signal` test file TRUNCATEs
-        # `ff_waitpoint_hmac` (a global, non-partitioned keystore
-        # table) in per-test setup. Under parallel test execution
-        # test A's TRUNCATE wipes test B's seeded kid, causing
-        # "kid X missing from keystore" failures. Same serial-
-        # isolation pattern as the Valkey `ff-test` integration run.
-        # Follow-up: isolate the keystore setup (UUID-scoped kids or
-        # per-test schema) so tests can parallelize again.
+        # `--test-threads=1`: the `ff_waitpoint_hmac` keystore race
+        # (issue #301) is fixed — `suspend_signal` tests now route
+        # the keystore through a per-test Postgres schema, so rotate
+        # / seed tests no longer race on a shared TRUNCATE. But the
+        # suspend / deliver_signal SERIALIZABLE retry budget (3
+        # attempts, Q11) is sized for the production claim rate, not
+        # for 16-way parallel integration tests hammering the same
+        # partitioned tables; under that load rw-conflicts
+        # occasionally exhaust the budget. Keystore-only tests
+        # parallelize cleanly; the suspend-family stays serial here
+        # to keep the cell deterministic. Same serial-isolation
+        # pattern as the Valkey `ff-test` integration run.
         run: cargo test -p ff-backend-postgres -- --ignored --test-threads=1
 
       - name: HTTP-over-Postgres smoke (ff-test::http_postgres_smoke)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`ff-backend-postgres` `suspend_signal` keystore race.** Tests
+  used to TRUNCATE the global `ff_waitpoint_hmac` table in per-test
+  setup; under parallel execution test A's TRUNCATE wiped the kids
+  test B had just seeded. Tests now route the keystore through a
+  per-test Postgres schema (`ffpg_test_<uuid>`) via pool
+  `search_path`, so rotate / seed tests don't race. Keystore-only
+  tests parallelize cleanly; matrix-CI Postgres cell keeps
+  `--test-threads=1` for suspend/deliver SERIALIZABLE budget
+  reasons unrelated to the keystore. Closes #301.
 - **ferriskey slot-refresh throttle** uses `Instant::now()` instead of
   `SystemTime::now()` for elapsed-time measurement. `Instant` is
   monotonic; immune to NTP steps, VM suspend/restore, and variable

--- a/crates/ff-backend-postgres/tests/suspend_signal.rs
+++ b/crates/ff-backend-postgres/tests/suspend_signal.rs
@@ -48,20 +48,26 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 /// Per-test isolation strategy (issue #301). The `ff_waitpoint_hmac`
-/// keystore is a single-row *global* table — rotate / seed semantics
-/// assert on "(prior_kid, active_kid) of the whole table". A shared
+/// keystore is a *global* table (one row per kid, with an `active`
+/// flag picking the current signing kid); rotate / seed semantics
+/// assert on the table-wide `(prior_kid, active_kid)` state. A shared
 /// `public` schema plus per-test `TRUNCATE` races under parallel test
 /// execution (test A's TRUNCATE wipes the kids test B just seeded).
 ///
-/// Fix: only the keystore is a shared singleton; the rest of the
+/// Fix: only the keystore has shared global state; the rest of the
 /// Wave-3 schema (partitioned tables) already isolates via unique
 /// execution UUIDs. So we give every test its own `ff_waitpoint_hmac`
 /// by:
 ///
-/// 1. Ensuring the workspace schema is applied once in `public`
-///    (idempotent `apply_migrations`).
+/// 1. Ensuring the workspace schema is applied to `public`. The call
+///    runs per test but is idempotent via sqlx's migration-tracking
+///    table — only the first invocation does work; subsequent calls
+///    are metadata-lookup no-ops under the advisory lock.
 /// 2. Creating a per-test Postgres schema (`ffpg_test_<uuid>`) holding
-///    only a fresh `ff_waitpoint_hmac` table.
+///    only a shadow `ff_waitpoint_hmac` table, built with
+///    `LIKE public.ff_waitpoint_hmac INCLUDING ALL` so it inherits
+///    future column / index / constraint changes to the canonical
+///    keystore without DDL drift here.
 /// 3. Setting `search_path = <test_schema>, public` on every pool
 ///    connection so the unqualified `ff_waitpoint_hmac` name in
 ///    `signal.rs` resolves to the test-local copy, while every other
@@ -70,15 +76,18 @@ use uuid::Uuid;
 ///
 /// Result: tests parallelize cleanly. No cross-schema FK touches the
 /// keystore (verified against migration DDL — the references are
-/// string kids, not SQL foreign keys). We don't `DROP SCHEMA CASCADE`
-/// on teardown: the test DB is throwaway and the per-test schema
-/// carries only a single 5-column table.
+/// string kids, not SQL foreign keys). Per-test schemas are NOT
+/// dropped on teardown (async Drop in tokio is messy); the test DB
+/// is throwaway and each schema carries only a single 4-column
+/// table. If `FF_PG_TEST_URL` ever points at a long-lived dev DB,
+/// periodic `DROP SCHEMA ffpg_test_* CASCADE` is the maintenance
+/// hook.
 async fn setup_or_skip() -> Option<PgPool> {
     let url = std::env::var("FF_PG_TEST_URL").ok()?;
 
-    // Apply the workspace schema to `public` once (idempotent via
-    // sqlx's migration-tracking table). First invocation seeds
-    // schema; subsequent calls no-op.
+    // Apply the workspace schema to `public`. Idempotent via sqlx's
+    // migration-tracking table; only the first test invocation does
+    // work, later calls are metadata lookups.
     let bootstrap = PgPoolOptions::new()
         .max_connections(1)
         .connect(&url)
@@ -95,14 +104,13 @@ async fn setup_or_skip() -> Option<PgPool> {
         .execute(&bootstrap)
         .await
         .expect("create per-test schema");
-    // Shadow copy of `ff_waitpoint_hmac` (matches 0001_initial.sql).
+    // Shadow copy of `ff_waitpoint_hmac` derived from the canonical
+    // migrated table definition via `LIKE ... INCLUDING ALL`. This
+    // picks up any future column / index / constraint changes to the
+    // keystore without a parallel DDL edit here.
     sqlx::query(&format!(
-        "CREATE TABLE {schema}.ff_waitpoint_hmac ( \
-            kid           text      NOT NULL PRIMARY KEY, \
-            secret        bytea     NOT NULL, \
-            rotated_at_ms bigint    NOT NULL, \
-            active        boolean   NOT NULL DEFAULT true \
-         )"
+        "CREATE TABLE {schema}.ff_waitpoint_hmac \
+         (LIKE public.ff_waitpoint_hmac INCLUDING ALL)"
     ))
     .execute(&bootstrap)
     .await

--- a/crates/ff-backend-postgres/tests/suspend_signal.rs
+++ b/crates/ff-backend-postgres/tests/suspend_signal.rs
@@ -47,23 +47,84 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+/// Per-test isolation strategy (issue #301). The `ff_waitpoint_hmac`
+/// keystore is a single-row *global* table — rotate / seed semantics
+/// assert on "(prior_kid, active_kid) of the whole table". A shared
+/// `public` schema plus per-test `TRUNCATE` races under parallel test
+/// execution (test A's TRUNCATE wipes the kids test B just seeded).
+///
+/// Fix: only the keystore is a shared singleton; the rest of the
+/// Wave-3 schema (partitioned tables) already isolates via unique
+/// execution UUIDs. So we give every test its own `ff_waitpoint_hmac`
+/// by:
+///
+/// 1. Ensuring the workspace schema is applied once in `public`
+///    (idempotent `apply_migrations`).
+/// 2. Creating a per-test Postgres schema (`ffpg_test_<uuid>`) holding
+///    only a fresh `ff_waitpoint_hmac` table.
+/// 3. Setting `search_path = <test_schema>, public` on every pool
+///    connection so the unqualified `ff_waitpoint_hmac` name in
+///    `signal.rs` resolves to the test-local copy, while every other
+///    table (partitioned exec/attempt/waitpoint rows) continues to
+///    resolve into `public`.
+///
+/// Result: tests parallelize cleanly. No cross-schema FK touches the
+/// keystore (verified against migration DDL — the references are
+/// string kids, not SQL foreign keys). We don't `DROP SCHEMA CASCADE`
+/// on teardown: the test DB is throwaway and the per-test schema
+/// carries only a single 5-column table.
 async fn setup_or_skip() -> Option<PgPool> {
     let url = std::env::var("FF_PG_TEST_URL").ok()?;
-    let pool = PgPoolOptions::new()
-        .max_connections(8)
+
+    // Apply the workspace schema to `public` once (idempotent via
+    // sqlx's migration-tracking table). First invocation seeds
+    // schema; subsequent calls no-op.
+    let bootstrap = PgPoolOptions::new()
+        .max_connections(1)
         .connect(&url)
         .await
         .expect("connect to FF_PG_TEST_URL");
-    ff_backend_postgres::apply_migrations(&pool)
+    ff_backend_postgres::apply_migrations(&bootstrap)
         .await
         .expect("apply_migrations clean");
-    // Reset the HMAC keystore between runs. Schema-0001 is shared
-    // across every suspend+signal test and these tests assert on
-    // (prior_kid, active_kid) shape.
-    sqlx::query("TRUNCATE TABLE ff_waitpoint_hmac")
-        .execute(&pool)
+
+    // Unique schema per test invocation. `simple()` avoids hyphens so
+    // the identifier stays unquoted-safe.
+    let schema = format!("ffpg_test_{}", Uuid::new_v4().simple());
+    sqlx::query(&format!("CREATE SCHEMA {schema}"))
+        .execute(&bootstrap)
         .await
-        .expect("truncate ff_waitpoint_hmac");
+        .expect("create per-test schema");
+    // Shadow copy of `ff_waitpoint_hmac` (matches 0001_initial.sql).
+    sqlx::query(&format!(
+        "CREATE TABLE {schema}.ff_waitpoint_hmac ( \
+            kid           text      NOT NULL PRIMARY KEY, \
+            secret        bytea     NOT NULL, \
+            rotated_at_ms bigint    NOT NULL, \
+            active        boolean   NOT NULL DEFAULT true \
+         )"
+    ))
+    .execute(&bootstrap)
+    .await
+    .expect("create per-test ff_waitpoint_hmac");
+    bootstrap.close().await;
+
+    let schema_for_hook = schema.clone();
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .after_connect(move |conn, _meta| {
+            let schema = schema_for_hook.clone();
+            Box::pin(async move {
+                sqlx::query(&format!("SET search_path TO {schema}, public"))
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+
     Some(pool)
 }
 
@@ -332,9 +393,10 @@ async fn hmac_sign_verify_round_trip_against_rotated_kid() {
 
 /// Minimal per-test fixture: fresh schema + a single pre-populated
 /// execution + attempt so the SERIALIZABLE `suspend` body has a row
-/// to mutate. Uniqueness across concurrent tests comes from the fresh
-/// UUID — we do NOT TRUNCATE partitioned tables here because doing so
-/// under `run_in_transaction` would collide with the trigger fanout.
+/// to mutate. Uniqueness across concurrent tests comes from the
+/// per-test schema set up in [`setup_or_skip`] (issue #301) plus the
+/// fresh execution UUID minted here — partitioned-table rows stay
+/// test-local without a per-test TRUNCATE.
 struct ExecFixture {
     backend: std::sync::Arc<dyn EngineBackend>,
     pool: PgPool,


### PR DESCRIPTION
## Summary

`crates/ff-backend-postgres/tests/suspend_signal.rs` TRUNCATEd the
global `ff_waitpoint_hmac` table in per-test setup. Under parallel
test execution test A's TRUNCATE wiped the kids test B had just
seeded, surfacing as "duplicate key" / "kid mismatch" failures.
`.github/workflows/matrix.yml` worked around it with
`cargo test ... -- --ignored --test-threads=1`.

## Root cause

Issue #301. The `ff_waitpoint_hmac` keystore is a global singleton
table — rotate / seed semantics assert on "(prior_kid, active_kid)
of the whole table". A shared `public` schema plus per-test
`TRUNCATE` is inherently racy across tests that each seed / rotate
a kid and expect their kid to persist until the test completes.

## Approach

Pure-UUID kid scoping can't work here: tests like
`rotate_all_happy_path` and `seed_happy_path_installs_new_kid`
assert on keystore *state* (`previous_kid == None`, "no active
kid exists"), not just their own kid's name. A different test's
active kid in the shared table would break those assertions.

Falling back to the per-test Postgres schema approach the issue
writeup listed as the fallback, **narrowed to just the keystore**:

1. `apply_migrations` runs once against `public` (idempotent via
   sqlx's migration-tracking table).
2. Each test invocation creates `ffpg_test_<uuid>` containing only
   a fresh `ff_waitpoint_hmac` table.
3. The pool's `after_connect` hook sets
   `search_path = <test_schema>, public` so the unqualified
   `ff_waitpoint_hmac` name in `signal.rs` resolves to the test's
   copy; every other (partitioned) table continues to resolve into
   `public` (exec/attempt/waitpoint rows already isolate via
   unique UUID keys). No cross-schema FK touches the keystore —
   references are string kids, not SQL foreign keys.

No production code changes.

## Verification

Against a live Postgres 16 (`ff_smoke_parallel` DB):

```
# Matches matrix.yml cell — 16/16 pass.
$ FF_PG_TEST_URL=... cargo test -p ff-backend-postgres \
    --test suspend_signal -- --ignored --test-threads=1
test result: ok. 16 passed; 0 failed; 0 ignored; ...

# Keystore-only tests parallelize cleanly — 9/9 x8 runs, no flake.
$ for i in {1..8}; do cargo test ... --test suspend_signal \
    -- --ignored rotate_ seed_ hmac_sign; done
(all 8: test result: ok. 9 passed; 0 failed; ...)

# Full backend suite still green serial.
$ cargo test -p ff-backend-postgres -- --ignored --test-threads=1
(24/24 pass)
```

## matrix.yml `--test-threads=1` retained

Issue #301 suggested dropping it. Keeping it. The keystore race is
structurally fixed (keystore-only tests reliably pass parallel),
but the suspend / deliver_signal SERIALIZABLE retry budget (3
attempts, Q11) is sized for production claim rates, not for 16-way
parallel integration tests hammering the same partitioned tables.
Under that load rw-conflicts occasionally exhaust the budget,
causing `Contention(RetryExhausted)` failures in
suspend-family tests. That's an orthogonal architectural concern —
scope-out per the issue's "Out of scope" bullet on schema
refactors. Comment updated to reflect the new rationale.

## Test plan

- [x] `cargo build -p ff-backend-postgres --tests` — clean.
- [x] `cargo test -p ff-backend-postgres --test suspend_signal -- --ignored --test-threads=1` — 16/16 PASS (matches matrix.yml).
- [x] Keystore-only parallel (rotate_ seed_ hmac_sign) x8 runs — 9/9 each, no flake.
- [x] Full `cargo test -p ff-backend-postgres -- --ignored --test-threads=1` — all PASS.
- [ ] matrix-postgres cell green in CI.

Closes #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that alter how live-Postgres integration tests set up schema/search_path; low production risk but could affect CI stability or local test DB behavior if assumptions about schema state differ.
> 
> **Overview**
> Fixes a flake in `ff-backend-postgres` live Postgres tests by removing the per-test `TRUNCATE ff_waitpoint_hmac` and instead creating a per-test schema containing only `ff_waitpoint_hmac`, with the pool configured via `after_connect` to set `search_path = <test_schema>, public`.
> 
> Updates the matrix-CI Postgres job commentary and the changelog to reflect that the keystore race is resolved, while keeping `--test-threads=1` due to unrelated SERIALIZABLE retry-budget contention in suspend/deliver tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61432cebb288f606a77a85a695d113a6c8ccead2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->