### PR TITLE
feat(RFC-018): Stage A — EngineBackend::capabilities_matrix + BackendIdentity + Capability enum (closes #277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`EngineBackend::capabilities_matrix()`** + `BackendIdentity` +
+  `Capability` enum + `CapabilityStatus` enum + `CapabilityMatrix`
+  type. Consumers can query a backend's supported operations at
+  runtime before dispatch; gated UI features + alternative code
+  paths no longer need to trap `EngineError::Unavailable` after
+  the fact. RFC-018 Stage A; Stage B (derived parity matrix) +
+  Stage C (HTTP `GET /v1/capabilities`) land in follow-ups.
+  Closes #277.
 - **`ValkeyBackend::with_embedded_scheduler`** public constructor —
   lets direct `Arc<dyn EngineBackend>` consumers (not going through
   `ff-server`) reach `EngineBackend::claim_for_worker`. Closes #293.

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -114,6 +114,133 @@ pub use ff_core::backend::PostgresConnection;
 /// and an optional `ff_observability::Metrics` handle mirroring
 /// [`ff_backend_valkey::ValkeyBackend`]. Future waves add the
 /// [`StreamNotifier`] handle once Wave 4 wires up LISTEN/NOTIFY.
+/// RFC-018 Stage A: static capability table for the Postgres
+/// backend at v0.8.1. Rows still `Unsupported` are Wave-9 follow-up
+/// scope — see `docs/POSTGRES_PARITY_MATRIX.md` for the authoritative
+/// per-row status. `Supported` rows correspond to trait methods
+/// `PostgresBackend` overrides with a real body (ingress,
+/// scheduler, seed, read, cross-cutting); `Unsupported` rows
+/// correspond to trait methods that return
+/// `EngineError::Unavailable` on Postgres today.
+///
+/// Streaming rows are marked `Unsupported` rather than omitted
+/// because the Postgres backend exposes the trait's streaming
+/// methods under the default `streaming` feature but returns
+/// `Unavailable` — that is an operationally distinct state from
+/// "compiled out," and consumers benefit from the typed signal.
+static POSTGRES_CAPS: &[(
+    ff_core::capability::Capability,
+    ff_core::capability::CapabilityStatus,
+)] = &[
+    (
+        ff_core::capability::Capability::ClaimForWorker,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ClaimFromReclaim,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::SuspendResumeByCount,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::CancelExecution,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::CancelFlow,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CancelFlowWaitTimeout,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CancelFlowWaitIndefinite,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::StreamRead,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::StreamBestEffortLive,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::StreamDurableSummary,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::DeliverSignal,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::ListPendingWaitpoints,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::RotateWaitpointHmac,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::SeedWaitpointHmac,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ReportUsage,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::ReportUsageAdminPath,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::ResetBudget,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::CreateFlow,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CreateExecution,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::StageDependencyEdge,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ApplyDependencyToChild,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::PreparableBoot,
+        // Postgres `prepare()` returns `NoOp` (schema migrations
+        // are applied out-of-band); reported as `Unsupported` so
+        // consumers don't waste a boot-time call expecting work.
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::SubscribeLeaseHistory,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::SubscribeCompletion,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::SubscribeSignalDelivery,
+        ff_core::capability::CapabilityStatus::Unsupported,
+    ),
+    (
+        ff_core::capability::Capability::Ping,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+];
+
 pub struct PostgresBackend {
     #[allow(dead_code)] // filled in across waves 2-7
     pool: PgPool,
@@ -618,6 +745,28 @@ impl EngineBackend for PostgresBackend {
 
     fn backend_label(&self) -> &'static str {
         "postgres"
+    }
+
+    /// RFC-018 Stage A: populate the capability matrix from the
+    /// static [`POSTGRES_CAPS`] table. The Postgres backend landed
+    /// through RFC-017 Stage E4 at v0.8.0; rows still marked
+    /// `Unsupported` here correspond to Wave-9 follow-up work
+    /// (`cancel_flow_header`, `ack_cancel_member`, read-model,
+    /// operator control, budget/quota, HMAC rotation,
+    /// `list_pending_waitpoints`). See
+    /// `docs/POSTGRES_PARITY_MATRIX.md` for the per-row breakdown.
+    fn capabilities_matrix(&self) -> ff_core::capability::CapabilityMatrix {
+        let mut matrix = ff_core::capability::CapabilityMatrix::new(
+            ff_core::capability::BackendIdentity::new(
+                "postgres",
+                ff_core::capability::Version::new(0, 8, 1),
+                "E-shipped",
+            ),
+        );
+        for (cap, status) in POSTGRES_CAPS.iter() {
+            matrix.set(*cap, status.clone());
+        }
+        matrix
     }
 
     /// Issue #281: no-op. Schema migrations are applied out-of-band

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -106,6 +106,121 @@ pub use ff_core::backend::BackendConfig;
 /// from the SDK's public API).
 ///
 /// [`ValkeyConnection::cluster`]: ff_core::backend::ValkeyConnection::cluster
+/// RFC-018 Stage A: static capability table for the Valkey backend.
+/// Reflects the current in-tree `impl EngineBackend for ValkeyBackend`
+/// coverage. `ClaimForWorker` is overridden at runtime in
+/// `capabilities_matrix()` based on scheduler presence — see the
+/// method body for the `Partial` / `Supported` selection.
+static VALKEY_CAPS: &[(
+    ff_core::capability::Capability,
+    ff_core::capability::CapabilityStatus,
+)] = &[
+    (
+        ff_core::capability::Capability::ClaimForWorker,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ClaimFromReclaim,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::SuspendResumeByCount,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CancelExecution,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CancelFlow,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CancelFlowWaitTimeout,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CancelFlowWaitIndefinite,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::StreamRead,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::StreamBestEffortLive,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::StreamDurableSummary,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::DeliverSignal,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ListPendingWaitpoints,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::RotateWaitpointHmac,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::SeedWaitpointHmac,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ReportUsage,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ReportUsageAdminPath,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ResetBudget,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CreateFlow,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::CreateExecution,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::StageDependencyEdge,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::ApplyDependencyToChild,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::PreparableBoot,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::SubscribeLeaseHistory,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::SubscribeCompletion,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::SubscribeSignalDelivery,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+    (
+        ff_core::capability::Capability::Ping,
+        ff_core::capability::CapabilityStatus::Supported,
+    ),
+];
+
 pub struct ValkeyBackend {
     client: ferriskey::Client,
     partition_config: PartitionConfig,
@@ -4755,6 +4870,45 @@ impl EngineBackend for ValkeyBackend {
 
     fn backend_label(&self) -> &'static str {
         "valkey"
+    }
+
+    /// RFC-018 Stage A: populate the capability matrix from the
+    /// static [`VALKEY_CAPS`] table, then adjust for runtime-gated
+    /// rows. Today the only runtime-gated capability is
+    /// `Capability::ClaimForWorker`, which requires the scheduler
+    /// to be wired via
+    /// [`ValkeyBackend::with_scheduler`] or
+    /// [`ValkeyBackend::with_embedded_scheduler`]; a plain
+    /// [`ValkeyBackend::connect`] reports `Partial` with a note
+    /// explaining the gating constraint.
+    fn capabilities_matrix(&self) -> ff_core::capability::CapabilityMatrix {
+        let mut matrix = ff_core::capability::CapabilityMatrix::new(
+            ff_core::capability::BackendIdentity::new(
+                "valkey",
+                ff_core::capability::Version::new(0, 8, 1),
+                "E-shipped",
+            ),
+        );
+        for (cap, status) in VALKEY_CAPS.iter() {
+            matrix.set(*cap, status.clone());
+        }
+        // Runtime gating — scheduler presence determines whether
+        // `claim_for_worker` can actually serve callers.
+        if self.scheduler.is_none() {
+            matrix.set(
+                ff_core::capability::Capability::ClaimForWorker,
+                ff_core::capability::CapabilityStatus::Partial {
+                    note: "requires with_embedded_scheduler or ff-server boot"
+                        .to_string(),
+                },
+            );
+        } else {
+            matrix.set(
+                ff_core::capability::Capability::ClaimForWorker,
+                ff_core::capability::CapabilityStatus::Supported,
+            );
+        }
+        matrix
     }
 
     /// RFC-017 Stage B: backend-scoped drain hook (§5.4). Closes

--- a/crates/ff-backend-valkey/tests/capabilities.rs
+++ b/crates/ff-backend-valkey/tests/capabilities.rs
@@ -1,0 +1,75 @@
+//! RFC-018 Stage A integration test: `ValkeyBackend::capabilities_matrix`.
+//!
+//! Asserts that a backend dialed via `ValkeyBackend::connect` reports
+//! `family = "valkey"` and gates `Capability::ClaimForWorker` as
+//! `Partial` (scheduler not wired), while a backend dialed via
+//! `ValkeyBackend::with_embedded_scheduler` promotes that row to
+//! `Supported`. Ignore-gated (live Valkey at 127.0.0.1:6379 required),
+//! matching the sibling live tests in
+//! `crates/ff-backend-valkey/src/lib.rs::tests`.
+
+use std::sync::Arc;
+
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::BackendConfig;
+use ff_core::capability::{Capability, CapabilityStatus};
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore]
+async fn capabilities_matrix_reports_valkey_family() {
+    let backend = ValkeyBackend::connect(BackendConfig::valkey("127.0.0.1", 6379))
+        .await
+        .expect("connect ValkeyBackend for capabilities smoke");
+    let m = backend.capabilities_matrix();
+    assert_eq!(m.identity.family, "valkey");
+    // Stage marker — v0.8.x post-RFC-017 Stage E ship.
+    assert_eq!(m.identity.rfc017_stage, "E-shipped");
+    // Always-supported rows that do not depend on scheduler wiring.
+    assert_eq!(m.get(Capability::Ping), CapabilityStatus::Supported);
+    assert_eq!(m.get(Capability::CreateFlow), CapabilityStatus::Supported);
+    assert_eq!(
+        m.get(Capability::CancelFlowWaitTimeout),
+        CapabilityStatus::Supported
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore]
+async fn claim_for_worker_is_partial_without_scheduler() {
+    let backend = ValkeyBackend::connect(BackendConfig::valkey("127.0.0.1", 6379))
+        .await
+        .expect("connect ValkeyBackend");
+    let m = backend.capabilities_matrix();
+    match m.get(Capability::ClaimForWorker) {
+        CapabilityStatus::Partial { note } => {
+            assert!(
+                note.contains("with_embedded_scheduler"),
+                "expected note to mention with_embedded_scheduler, got: {note}"
+            );
+        }
+        other => panic!(
+            "expected ClaimForWorker=Partial without scheduler, got {other:?}"
+        ),
+    }
+    // Partial still counts as "supported-ish" for the predicate.
+    assert!(m.supports(Capability::ClaimForWorker));
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore]
+async fn claim_for_worker_is_supported_with_embedded_scheduler() {
+    let metrics = Arc::new(ff_observability::Metrics::new());
+    let backend = ValkeyBackend::with_embedded_scheduler(
+        BackendConfig::valkey("127.0.0.1", 6379),
+        metrics,
+    )
+    .await
+    .expect("with_embedded_scheduler for capabilities smoke");
+    let m = backend.capabilities_matrix();
+    assert_eq!(m.identity.family, "valkey");
+    assert_eq!(
+        m.get(Capability::ClaimForWorker),
+        CapabilityStatus::Supported
+    );
+    assert!(m.supports(Capability::ClaimForWorker));
+}

--- a/crates/ff-core/src/capability.rs
+++ b/crates/ff-core/src/capability.rs
@@ -1,0 +1,357 @@
+//! RFC-018 Stage A — backend capability discovery surface.
+//!
+//! Consumers of `Arc<dyn EngineBackend>` (and HTTP clients hitting
+//! `ff-server`) historically had no typed way to ask "what can this
+//! backend actually do?" before dispatching — they discovered
+//! capability gaps empirically, by trying a trait method and catching
+//! [`crate::engine_error::EngineError::Unavailable`]. This module
+//! adds a first-class discovery primitive: a [`Capability`] enum,
+//! [`CapabilityStatus`] shape, [`BackendIdentity`] tuple, and a
+//! [`CapabilityMatrix`] container that [`crate::engine_backend::EngineBackend`]
+//! exposes via `capabilities_matrix()`.
+//!
+//! Stage A (this module) is additive: the trait method has a default
+//! impl that returns an empty matrix tagged `family = "unknown"`, so
+//! out-of-tree backends keep compiling. Concrete in-tree backends
+//! (`ValkeyBackend`, `PostgresBackend`) override to report real caps.
+//!
+//! Stages B + C (follow-up PRs) derive `docs/POSTGRES_PARITY_MATRIX.md`
+//! from the runtime matrix and expose `GET /v1/capabilities` on
+//! `ff-server`.
+//!
+//! See `rfcs/RFC-018-backend-capability-discovery.md` for the full
+//! design, the four owner-adjudicated open questions, and the
+//! Alternatives-considered record.
+
+use std::collections::BTreeMap;
+
+/// Coarse-grained unit of functionality a backend may or may not
+/// provide. Granularity is one entry per operator-UI grey-renderable
+/// feature — not per trait method. See RFC-018 §9 Q1 for the
+/// owner adjudication (`coarse`, recommended by the draft).
+///
+/// `#[non_exhaustive]`: adding variants in future RFC-018 stages is
+/// a minor bump, not a break. Consumers matching on `Capability`
+/// must carry a wildcard arm.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Capability {
+    // ── Claim + lifecycle ──
+    /// Scheduler-routed claim entrypoint
+    /// ([`EngineBackend::claim_for_worker`](crate::engine_backend::EngineBackend::claim_for_worker)).
+    ClaimForWorker,
+    /// Consume a reclaim grant to mint a resumed-kind handle.
+    ClaimFromReclaim,
+    /// Suspend + resume by buffered-signal count (RFC-013).
+    SuspendResumeByCount,
+
+    // ── Cancel ──
+    /// Operator-initiated single-execution cancel.
+    CancelExecution,
+    /// Operator-initiated flow cancel (no wait).
+    CancelFlow,
+    /// `cancel_flow` with `CancelFlowWait::WaitTimeout(Duration)`
+    /// (#298 driver).
+    CancelFlowWaitTimeout,
+    /// `cancel_flow` with `CancelFlowWait::WaitIndefinite`.
+    CancelFlowWaitIndefinite,
+
+    // ── Streams ──
+    /// `read_stream` (XRANGE-style bounded read).
+    StreamRead,
+    /// `tail_stream` (best-effort live tail).
+    StreamBestEffortLive,
+    /// Durable-summary frames + `read_summary`.
+    StreamDurableSummary,
+
+    // ── Signals + waitpoints ──
+    /// Deliver an external signal to a pending waitpoint.
+    DeliverSignal,
+    /// List pending-or-active waitpoints for an execution.
+    ListPendingWaitpoints,
+    /// Cluster-wide HMAC kid rotation.
+    RotateWaitpointHmac,
+    /// Idempotent initial HMAC-secret seed (#280).
+    SeedWaitpointHmac,
+
+    // ── Budget + quota ──
+    /// Worker-handle-path `report_usage`.
+    ReportUsage,
+    /// Admin-path `report_usage` (no worker handle; #297 driver).
+    ReportUsageAdminPath,
+    /// Reset a budget's usage counters.
+    ResetBudget,
+
+    // ── Ingress ──
+    /// Create a flow header.
+    CreateFlow,
+    /// Create an execution.
+    CreateExecution,
+    /// Stage a dependency edge.
+    StageDependencyEdge,
+    /// Apply a staged dependency edge to its downstream child.
+    ApplyDependencyToChild,
+
+    // ── Boot + subscriptions ──
+    /// Backend honours [`EngineBackend::prepare`](crate::engine_backend::EngineBackend::prepare)
+    /// with non-trivial work (e.g. Valkey `FUNCTION LOAD`).
+    PreparableBoot,
+    /// Subscribe to lease-epoch history for a handle.
+    SubscribeLeaseHistory,
+    /// Subscribe to completion notifications.
+    SubscribeCompletion,
+    /// Subscribe to signal-delivery notifications.
+    SubscribeSignalDelivery,
+
+    // ── Diagnostics ──
+    /// Backend-level reachability probe.
+    Ping,
+}
+
+/// Per-[`Capability`] support status reported by a concrete backend.
+///
+/// Consumers distinguish fully-supported from partially-gated
+/// ("works only with an extra setup step") and unsupported ("the
+/// trait method returns `EngineError::Unavailable` today") via
+/// these variants. `Unknown` is the safe default for pre-RFC-018
+/// backends that never populate a matrix row.
+///
+/// `#[non_exhaustive]`: future stages may add e.g. `SupportedSlow`
+/// or `Deprecated`; consumers must carry a wildcard arm.
+#[non_exhaustive]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CapabilityStatus {
+    /// Backend fully supports this capability on every call.
+    Supported,
+    /// Backend does not support this capability; calling the
+    /// corresponding trait method returns `EngineError::Unavailable`.
+    Unsupported,
+    /// Backend supports this capability only under specific
+    /// configuration. The `note` explains the gating constraint in
+    /// a human-readable form suitable for UI surfacing.
+    Partial {
+        /// Human-readable hint describing the gating constraint
+        /// (e.g. "requires with_embedded_scheduler").
+        note: String,
+    },
+    /// Backend has not reported a status for this capability.
+    /// Consumers should treat as "dispatch and catch" — equivalent
+    /// to pre-RFC-018 behaviour.
+    Unknown,
+}
+
+/// Backend crate version. Kept as a struct (not a semver string) per
+/// RFC-018 §9 Q2: consumers can write
+/// `if backend.capabilities_matrix().identity.version >= Version::new(0, 10, 0) { .. }`
+/// without pulling a semver-parsing dep.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Version {
+    /// Major version number.
+    pub major: u32,
+    /// Minor version number.
+    pub minor: u32,
+    /// Patch version number.
+    pub patch: u32,
+}
+
+impl Version {
+    /// Const constructor so concrete backends can declare a
+    /// `const` [`BackendIdentity`] without a function-call overhead
+    /// in `capabilities_matrix()`.
+    pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+/// Minimal-identity triple for a backend. Consumers that only need
+/// the family label + version (e.g. for metrics dimensioning) read
+/// this rather than the full [`CapabilityMatrix`].
+///
+/// `#[non_exhaustive]`: future stages may add fields (e.g. a
+/// backend-assigned `instance_id` or a `deployment_topology`
+/// hint); construct via the public constructor or struct literal on
+/// `Clone::clone` of an existing value.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct BackendIdentity {
+    /// Stable backend family name. `"valkey"`, `"postgres"`, or a
+    /// concrete string set by an out-of-tree backend. `"unknown"`
+    /// is the pre-RFC-018 default.
+    pub family: &'static str,
+    /// Backend crate version at build time.
+    pub version: Version,
+    /// RFC-017 migration stage this backend reports itself certified
+    /// at. One of `"A"`, `"B"`, `"C"`, `"D"`, `"E"`, `"E-shipped"`,
+    /// or `"unknown"` for backends that predate the RFC-017 staging.
+    pub rfc017_stage: &'static str,
+}
+
+impl BackendIdentity {
+    /// Direct-field constructor. Prefer this over struct-literal
+    /// syntax in consumer code: `#[non_exhaustive]` forbids literal
+    /// construction from outside the defining crate.
+    pub const fn new(
+        family: &'static str,
+        version: Version,
+        rfc017_stage: &'static str,
+    ) -> Self {
+        Self {
+            family,
+            version,
+            rfc017_stage,
+        }
+    }
+}
+
+/// Full capability snapshot for a backend: its [`BackendIdentity`]
+/// plus a stable-ordered map of [`Capability`] → [`CapabilityStatus`].
+///
+/// `BTreeMap` (not `HashMap`) so iteration order is deterministic —
+/// `ff-server`'s JSON response is byte-stable, cairn's operator UI
+/// can render rows in a fixed order, and tests comparing matrices
+/// across runs do not race on hash randomization.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct CapabilityMatrix {
+    /// Backend identity tuple this matrix was assembled for.
+    pub identity: BackendIdentity,
+    /// Per-capability status. Absent capabilities are treated as
+    /// [`CapabilityStatus::Unknown`] by [`Self::get`].
+    pub caps: BTreeMap<Capability, CapabilityStatus>,
+}
+
+impl CapabilityMatrix {
+    /// Build an empty matrix tagged with the given backend identity.
+    /// Backends populate rows via [`Self::set`] before returning the
+    /// matrix from `capabilities_matrix()`.
+    pub fn new(identity: BackendIdentity) -> Self {
+        Self {
+            identity,
+            caps: BTreeMap::new(),
+        }
+    }
+
+    /// Record the status for one capability. Returns `&mut self`
+    /// so backends can chain setup in a builder-style declaration.
+    pub fn set(&mut self, cap: Capability, status: CapabilityStatus) -> &mut Self {
+        self.caps.insert(cap, status);
+        self
+    }
+
+    /// Look up one capability's status. Absent rows return
+    /// [`CapabilityStatus::Unknown`] — callers that need to
+    /// distinguish "absent" from "explicitly marked unknown" must
+    /// consult `self.caps` directly.
+    pub fn get(&self, cap: Capability) -> CapabilityStatus {
+        self.caps
+            .get(&cap)
+            .cloned()
+            .unwrap_or(CapabilityStatus::Unknown)
+    }
+
+    /// Convenience predicate: the capability is
+    /// [`CapabilityStatus::Supported`] or [`CapabilityStatus::Partial`].
+    /// Both map to "you can call the trait method and it will work
+    /// (possibly with a caveat)"; `Unsupported` and `Unknown` both
+    /// map to "don't dispatch, or be ready to catch `Unavailable`."
+    pub fn supports(&self, cap: Capability) -> bool {
+        matches!(
+            self.get(cap),
+            CapabilityStatus::Supported | CapabilityStatus::Partial { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_new_is_const_and_ordered() {
+        const V: Version = Version::new(0, 9, 0);
+        assert_eq!(V.major, 0);
+        assert_eq!(V.minor, 9);
+        assert_eq!(V.patch, 0);
+        assert!(Version::new(0, 10, 0) > V);
+        assert!(Version::new(0, 9, 1) > V);
+        assert!(Version::new(1, 0, 0) > V);
+    }
+
+    #[test]
+    fn backend_identity_new_populates_fields() {
+        let id = BackendIdentity::new("valkey", Version::new(0, 9, 0), "E-shipped");
+        assert_eq!(id.family, "valkey");
+        assert_eq!(id.version, Version::new(0, 9, 0));
+        assert_eq!(id.rfc017_stage, "E-shipped");
+    }
+
+    #[test]
+    fn matrix_new_is_empty() {
+        let m = CapabilityMatrix::new(BackendIdentity::new(
+            "unknown",
+            Version::new(0, 0, 0),
+            "unknown",
+        ));
+        assert!(m.caps.is_empty());
+        // Unset capability resolves to Unknown.
+        assert_eq!(m.get(Capability::Ping), CapabilityStatus::Unknown);
+        assert!(!m.supports(Capability::Ping));
+    }
+
+    #[test]
+    fn matrix_set_get_supports() {
+        let mut m = CapabilityMatrix::new(BackendIdentity::new(
+            "valkey",
+            Version::new(0, 9, 0),
+            "E-shipped",
+        ));
+        m.set(Capability::Ping, CapabilityStatus::Supported)
+            .set(Capability::CancelExecution, CapabilityStatus::Unsupported)
+            .set(
+                Capability::ClaimForWorker,
+                CapabilityStatus::Partial {
+                    note: "requires with_embedded_scheduler".to_string(),
+                },
+            );
+
+        assert_eq!(m.get(Capability::Ping), CapabilityStatus::Supported);
+        assert!(m.supports(Capability::Ping));
+
+        assert_eq!(
+            m.get(Capability::CancelExecution),
+            CapabilityStatus::Unsupported
+        );
+        assert!(!m.supports(Capability::CancelExecution));
+
+        // Partial also reports as supported via the predicate.
+        assert!(m.supports(Capability::ClaimForWorker));
+        match m.get(Capability::ClaimForWorker) {
+            CapabilityStatus::Partial { note } => {
+                assert!(note.contains("with_embedded_scheduler"));
+            }
+            other => panic!("expected Partial, got {other:?}"),
+        }
+
+        // Chain returns &mut self so repeated .set() calls compose.
+        let rows = m.caps.len();
+        assert_eq!(rows, 3);
+    }
+
+    #[test]
+    fn matrix_set_overwrites_existing() {
+        let mut m = CapabilityMatrix::new(BackendIdentity::new(
+            "valkey",
+            Version::new(0, 9, 0),
+            "E-shipped",
+        ));
+        m.set(Capability::Ping, CapabilityStatus::Unsupported);
+        m.set(Capability::Ping, CapabilityStatus::Supported);
+        assert_eq!(m.get(Capability::Ping), CapabilityStatus::Supported);
+        assert_eq!(m.caps.len(), 1);
+    }
+}

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -932,6 +932,33 @@ pub trait EngineBackend: Send + Sync + 'static {
         "unknown"
     }
 
+    /// RFC-018 Stage A: snapshot of this backend's identity + the
+    /// capability matrix it can actually service. Consumers use this
+    /// at startup to gate UI features / choose between alternative
+    /// code paths before dispatching. See
+    /// `rfcs/RFC-018-backend-capability-discovery.md` for the full
+    /// discovery contract and the four owner-adjudicated open
+    /// questions (granularity: coarse; version: struct; sync; no
+    /// event stream).
+    ///
+    /// Default: returns an empty matrix tagged `family = "unknown"`
+    /// so pre-RFC-018 out-of-tree backends keep compiling and
+    /// consumers treat "no rows" as "dispatch and catch
+    /// [`EngineError::Unavailable`]" (pre-RFC-018 behaviour).
+    /// Concrete in-tree backends (`ValkeyBackend`, `PostgresBackend`)
+    /// override to populate the real matrix.
+    ///
+    /// Sync (no `.await`): backend-static info should not require a
+    /// probe on every query. Dynamic probes happen once at
+    /// `connect*` time and cache the result.
+    fn capabilities_matrix(&self) -> crate::capability::CapabilityMatrix {
+        crate::capability::CapabilityMatrix::new(crate::capability::BackendIdentity::new(
+            "unknown",
+            crate::capability::Version::new(0, 0, 0),
+            "unknown",
+        ))
+    }
+
     /// Issue #281: run one-time backend-specific boot preparation.
     ///
     /// Intended to run ONCE per deployment startup — NOT per request.
@@ -1151,5 +1178,263 @@ pub fn cancel_flow_wait_deadline(wait: CancelFlowWait) -> Option<Duration> {
         CancelFlowWait::NoWait => None,
         CancelFlowWait::WaitTimeout(d) => Some(d),
         CancelFlowWait::WaitIndefinite => Some(CANCEL_WAIT_INDEFINITE_CEILING),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::{Capability, CapabilityStatus};
+
+    /// A zero-state backend stub used to exercise the default
+    /// `capabilities_matrix()` impl without pulling in a real
+    /// transport. Only the default method is under test here; every
+    /// other method is unreachable on this type.
+    struct DefaultBackend;
+
+    #[async_trait]
+    impl EngineBackend for DefaultBackend {
+        async fn claim(
+            &self,
+            _lane: &LaneId,
+            _capabilities: &CapabilitySet,
+            _policy: ClaimPolicy,
+        ) -> Result<Option<Handle>, EngineError> {
+            unreachable!()
+        }
+        async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+            unreachable!()
+        }
+        async fn progress(
+            &self,
+            _handle: &Handle,
+            _percent: Option<u8>,
+            _message: Option<String>,
+        ) -> Result<(), EngineError> {
+            unreachable!()
+        }
+        async fn append_frame(
+            &self,
+            _handle: &Handle,
+            _frame: Frame,
+        ) -> Result<AppendFrameOutcome, EngineError> {
+            unreachable!()
+        }
+        async fn complete(
+            &self,
+            _handle: &Handle,
+            _payload: Option<Vec<u8>>,
+        ) -> Result<(), EngineError> {
+            unreachable!()
+        }
+        async fn fail(
+            &self,
+            _handle: &Handle,
+            _reason: FailureReason,
+            _classification: FailureClass,
+        ) -> Result<FailOutcome, EngineError> {
+            unreachable!()
+        }
+        async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {
+            unreachable!()
+        }
+        async fn suspend(
+            &self,
+            _handle: &Handle,
+            _args: SuspendArgs,
+        ) -> Result<SuspendOutcome, EngineError> {
+            unreachable!()
+        }
+        async fn create_waitpoint(
+            &self,
+            _handle: &Handle,
+            _waitpoint_key: &str,
+            _expires_in: Duration,
+        ) -> Result<PendingWaitpoint, EngineError> {
+            unreachable!()
+        }
+        async fn observe_signals(
+            &self,
+            _handle: &Handle,
+        ) -> Result<Vec<ResumeSignal>, EngineError> {
+            unreachable!()
+        }
+        async fn claim_from_reclaim(
+            &self,
+            _token: ReclaimToken,
+        ) -> Result<Option<Handle>, EngineError> {
+            unreachable!()
+        }
+        async fn delay(
+            &self,
+            _handle: &Handle,
+            _delay_until: TimestampMs,
+        ) -> Result<(), EngineError> {
+            unreachable!()
+        }
+        async fn wait_children(&self, _handle: &Handle) -> Result<(), EngineError> {
+            unreachable!()
+        }
+        async fn describe_execution(
+            &self,
+            _id: &ExecutionId,
+        ) -> Result<Option<ExecutionSnapshot>, EngineError> {
+            unreachable!()
+        }
+        async fn describe_flow(
+            &self,
+            _id: &FlowId,
+        ) -> Result<Option<FlowSnapshot>, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn list_edges(
+            &self,
+            _flow_id: &FlowId,
+            _direction: EdgeDirection,
+        ) -> Result<Vec<EdgeSnapshot>, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn describe_edge(
+            &self,
+            _flow_id: &FlowId,
+            _edge_id: &EdgeId,
+        ) -> Result<Option<EdgeSnapshot>, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn resolve_execution_flow_id(
+            &self,
+            _eid: &ExecutionId,
+        ) -> Result<Option<FlowId>, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn list_flows(
+            &self,
+            _partition: PartitionKey,
+            _cursor: Option<FlowId>,
+            _limit: usize,
+        ) -> Result<ListFlowsPage, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn list_lanes(
+            &self,
+            _cursor: Option<LaneId>,
+            _limit: usize,
+        ) -> Result<ListLanesPage, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn list_suspended(
+            &self,
+            _partition: PartitionKey,
+            _cursor: Option<ExecutionId>,
+            _limit: usize,
+        ) -> Result<ListSuspendedPage, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn list_executions(
+            &self,
+            _partition: PartitionKey,
+            _cursor: Option<ExecutionId>,
+            _limit: usize,
+        ) -> Result<ListExecutionsPage, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn deliver_signal(
+            &self,
+            _args: DeliverSignalArgs,
+        ) -> Result<DeliverSignalResult, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn claim_resumed_execution(
+            &self,
+            _args: ClaimResumedExecutionArgs,
+        ) -> Result<ClaimResumedExecutionResult, EngineError> {
+            unreachable!()
+        }
+        async fn cancel_flow(
+            &self,
+            _id: &FlowId,
+            _policy: CancelFlowPolicy,
+            _wait: CancelFlowWait,
+        ) -> Result<CancelFlowResult, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "core")]
+        async fn set_edge_group_policy(
+            &self,
+            _flow_id: &FlowId,
+            _downstream_execution_id: &ExecutionId,
+            _policy: crate::contracts::EdgeDependencyPolicy,
+        ) -> Result<crate::contracts::SetEdgeGroupPolicyResult, EngineError> {
+            unreachable!()
+        }
+        async fn report_usage(
+            &self,
+            _handle: &Handle,
+            _budget: &BudgetId,
+            _dimensions: crate::backend::UsageDimensions,
+        ) -> Result<ReportUsageResult, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "streaming")]
+        async fn read_stream(
+            &self,
+            _execution_id: &ExecutionId,
+            _attempt_index: AttemptIndex,
+            _from: StreamCursor,
+            _to: StreamCursor,
+            _count_limit: u64,
+        ) -> Result<StreamFrames, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "streaming")]
+        async fn tail_stream(
+            &self,
+            _execution_id: &ExecutionId,
+            _attempt_index: AttemptIndex,
+            _after: StreamCursor,
+            _block_ms: u64,
+            _count_limit: u64,
+            _visibility: TailVisibility,
+        ) -> Result<StreamFrames, EngineError> {
+            unreachable!()
+        }
+        #[cfg(feature = "streaming")]
+        async fn read_summary(
+            &self,
+            _execution_id: &ExecutionId,
+            _attempt_index: AttemptIndex,
+        ) -> Result<Option<SummaryDocument>, EngineError> {
+            unreachable!()
+        }
+    }
+
+    /// The default `capabilities_matrix()` impl returns an empty
+    /// matrix tagged `family = "unknown"` so pre-RFC-018 out-of-tree
+    /// backends keep compiling and consumers can distinguish
+    /// "backend predates RFC-018" from "backend reports concrete
+    /// rows." Every concrete in-tree backend overrides.
+    #[test]
+    fn default_capabilities_matrix_is_unknown_family() {
+        let b = DefaultBackend;
+        let m = b.capabilities_matrix();
+        assert_eq!(m.identity.family, "unknown");
+        assert_eq!(
+            m.identity.version,
+            crate::capability::Version::new(0, 0, 0)
+        );
+        assert_eq!(m.identity.rfc017_stage, "unknown");
+        assert!(m.caps.is_empty());
+        // Any capability resolves to Unknown on a default matrix.
+        assert_eq!(m.get(Capability::Ping), CapabilityStatus::Unknown);
+        assert!(!m.supports(Capability::Ping));
     }
 }

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Core types, state enums, partition math, key builders, and error codes for FlowFabric.
 
 pub mod backend;
+pub mod capability;
 pub mod caps;
 pub mod completion_backend;
 pub mod contracts;

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -1,5 +1,16 @@
 # Postgres Parity Matrix — `EngineBackend` trait
 
+**RFC-018 Stage A note (2026-04-24):** this matrix is now callable at
+runtime via
+[`EngineBackend::capabilities_matrix()`](../crates/ff-core/src/engine_backend.rs)
+— concrete `ValkeyBackend` / `PostgresBackend` impls populate a
+`CapabilityMatrix` from their static tables, and consumers (cairn
+operator UI, operator tooling) can read the typed answer at startup
+instead of parsing this file. This document remains the
+human-readable reference during the RFC-017 migration; drift between
+the two is a bug. Stage B (this file generated from the runtime
+matrix + CI drift check) lands as a follow-up PR per RFC-018 §8.
+
 **Source of truth** for per-method status across Valkey and Postgres
 backends during the RFC-017 staged migration. Greppable by cairn-fabric
 runbooks + operator tooling. Updated at every stage merge.

--- a/rfcs/RFC-018-backend-capability-discovery.md
+++ b/rfcs/RFC-018-backend-capability-discovery.md
@@ -1,9 +1,18 @@
 # RFC-018: `EngineBackend` capability discovery surface
 
-**Status:** Draft
+**Status:** Accepted
 **Author:** FlowFabric Team (manager single-agent draft)
 **Created:** 2026-04-24
-**Target release:** v0.10.0
+**Acceptance:** 2026-04-24 — owner-adjudicated inline on §9 open
+questions (granularity: coarse; version: struct; sync; no event
+stream). Stage A implementation ships in the same PR as this
+promotion — `BackendIdentity` + `Capability` + `CapabilityStatus` +
+`CapabilityMatrix` + `Version` land in `ff-core`, trait default
+method added, `ValkeyBackend` + `PostgresBackend` populate real
+matrices. Stage B (derived parity matrix) and Stage C (HTTP
+`GET /v1/capabilities` + ff-sdk cache) remain follow-ups; closes
+issue #277 for v0.9.0.
+**Target release:** v0.9.0 (Stage A); Stage B/C land per §8.
 **Related RFCs:** RFC-012 (EngineBackend trait landing + Round-7 stabilisation), RFC-017 (ff-server backend abstraction + staged Postgres parity)
 **Related issues:** #277 (cairn PG-backend operator-UI blocker — driver for this RFC), #298 (`cancel_flow_wait` Unavailable shape on PG), #282 (backend-parity discovery tracking), #297 (token-budget example surfaced the "what does this backend support" gap)
 
@@ -341,15 +350,42 @@ Three stages, each CI-gated at the workspace boundary per `feedback_rfc_phases_v
 
 ---
 
-## 9. Open questions (owner-scoped)
+## 9. Open questions — owner adjudication (2026-04-24)
+
+All four open questions closed inline per the draft's own
+recommendations. Rejected options preserved verbatim in §3
+Alternatives (for posterity) and below (with the accepted choice
+marked) so future re-evaluation has the full record.
 
 1. **Capability granularity — ~20 coarse or 50+ fine?** This RFC proposes coarse (one per operator-UI-greyable feature, ~20 entries). Fine would be one per trait method (~50+, tracking RFC-017 §2.3's 51-method post-expansion count). **Recommend coarse** — cairn's UI grey-rendering is on operator-visible features (the "Cancel Flow" button), not per-method (the user does not see `cancel_flow_header` vs `cancel_flow_wait`). Coarse also keeps `Capability` enum growth slow; fine couples it to every trait-surface change. If owner picks fine, Stage A scope doubles.
 
+   **Accepted: coarse.** Stage A ships ~25 variants
+   (`crates/ff-core/src/capability.rs::Capability`). Driver (#277)
+   is UI grey-rendering, which is operator-visible-feature granular,
+   not trait-method granular. `#[non_exhaustive]` keeps the enum
+   growable in follow-up stages.
+
 2. **`Version` semantics — semver string, or `struct { major, minor, patch }`?** This RFC proposes `struct` for compile-time comparison (consumers can write `if backend.identity().version >= Version { major: 0, minor: 10, patch: 0 }` without parsing). Semver string is one-line simpler but forces consumers to pull a semver-parsing dep. **Recommend struct.**
+
+   **Accepted: struct.** Stage A ships
+   `ff_core::capability::Version { major, minor, patch }` with
+   `#[derive(Ord, PartialOrd)]` + const constructor. Consumers do
+   direct comparison without a semver-parsing dep. Pre-release /
+   build-metadata suffixes not in scope for Stage A.
 
 3. **Sync vs async `capabilities_matrix()`?** This RFC proposes sync. Rationale: backend-static info should not require a probe on every query; dynamic probes happen once at `connect_with_metrics` time and cache the result. Sync signature keeps the caller ergonomics clean (no `.await` on a diagnostic call). **Recommend sync.** Open because a hypothetical future backend might want to refresh on every call (e.g. a cluster where capabilities genuinely flip when membership changes); that backend would have to re-poll on connect and accept a possibly-stale answer until next reconnect — acceptable for our current needs.
 
+   **Accepted: sync.** Backends that need a runtime probe
+   (Postgres `LISTEN/NOTIFY` availability, Valkey module presence)
+   do it at `connect*` time and cache. The trait method returns
+   the cached matrix — consumers pay no `.await` on a diagnostic
+   call.
+
 4. **Event-stream of capability changes?** A consumer could subscribe to capability-flip events rather than polling. **Recommend no** — backend capabilities do not change across a deployment's lifecycle (a Postgres instance either has LISTEN/NOTIFY or does not, for its whole boot cycle). Cache at startup. Revisit only if a real consumer use case emerges post-Stage A.
+
+   **Accepted: no.** Cache at startup. Revisit only if a real
+   consumer use case emerges post-Stage A — no stub hook added in
+   this PR so the trait surface stays lean.
 
 ---
 


### PR DESCRIPTION
## Summary

Promote RFC-018 from draft (PR #303) to accepted and land Stage A in the same PR. Closes #277 for v0.9.0.

### Part 1: RFC promotion

- `rfcs/drafts/RFC-018-backend-capability-discovery.md` → `rfcs/RFC-018-backend-capability-discovery.md`
- Status flipped `Draft` → `Accepted`; acceptance line dated 2026-04-24.
- §9 open questions adjudicated inline (draft's own recommendations accepted, rejected options preserved verbatim in §3 Alternatives):
  1. Granularity: **coarse** (~25 variants)
  2. Version shape: **`struct { major, minor, patch }`** with `Ord` + const ctor
  3. `capabilities_matrix()`: **sync**
  4. Capability-change event stream: **no** (cache at startup)

### Part 2: Stage A implementation

- **`crates/ff-core/src/capability.rs`** — new module with `Capability` enum (26 variants, `#[non_exhaustive]`), `CapabilityStatus` (`Supported`/`Unsupported`/`Partial { note }`/`Unknown`), `Version`, `BackendIdentity`, `CapabilityMatrix` (BTreeMap-backed for deterministic iteration) + `new`/`set`/`get`/`supports`.
- **`EngineBackend::capabilities_matrix()`** default trait method — returns empty matrix tagged `family = "unknown"`; additive, out-of-tree backends keep compiling.
- **`ValkeyBackend`** override: `VALKEY_CAPS` static table + runtime scheduler-gated `Partial` for `ClaimForWorker` (promoted to `Supported` when scheduler is wired via `with_embedded_scheduler` / `with_scheduler`).
- **`PostgresBackend`** override: `POSTGRES_CAPS` static table reflecting v0.8.0 Stage-E4 parity. Wave-9 follow-up rows (read-model, operator control, budget/quota, HMAC rotation, `list_pending_waitpoints`, streams, subscriptions, `ClaimFromReclaim`, `SuspendResumeByCount`) are `Unsupported`; ingress + scheduler + seed + ping + cancel_flow are `Supported`.
- Consumers reach the types via `flowfabric::core::capability::{..}` through the existing `pub use ff_core as core` re-export.
- **`docs/POSTGRES_PARITY_MATRIX.md`** header note about runtime-callable matrix (Stage B derivation lands as follow-up per RFC-018 §8).
- **CHANGELOG** `[Unreleased] ### Added` entry.
- **Tests**: unit tests in `capability::tests` (Version, BackendIdentity, CapabilityMatrix), unit test in `engine_backend::tests` for the default `unknown`-family matrix, and integration tests `crates/ff-backend-valkey/tests/capabilities.rs` (`#[ignore]`-gated, matching sibling live-test pattern) asserting family + Partial/Supported selection for `ClaimForWorker`.

### Out of scope (follow-ups)

- **Stage B** — generate `POSTGRES_PARITY_MATRIX.md` from the runtime matrix + CI drift check.
- **Stage C** — `GET /v1/capabilities` HTTP handler on `ff-server` + `ff-sdk` startup-cache helper.
- Consumer-side caching infra in ff-sdk.

### Verification

\`\`\`
cargo build --workspace                                                                    # clean
cargo clippy -p ff-core … -p flowfabric --features ff-sdk/direct-valkey-claim -D warnings  # clean
cargo test -p ff-core --lib                                                                # 206/206 pass
cargo test -p ff-backend-valkey --test capabilities -- --ignored                           # 3/3 pass (live Valkey)
cargo test -p ff-test -- --test-threads=1                                                  # all pass
\`\`\`

The default-parallel `ff-test` invocation trips a pre-existing partition-routing race in `completion_backend::subscribe_yields_published_completion` / `two_streams_both_receive`; reproduces on unmodified `main`, passes under `--test-threads=1`. Not caused by RFC-018.

### PR hygiene

- Closes #277 — cairn PG-backend operator-UI greying blocker.
- Closes #303 — supersedes the RFC-018 draft PR.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test -p ff-core --lib`
- [x] Live-Valkey integration test: `cargo test -p ff-backend-valkey --test capabilities -- --ignored`
- [x] Full `ff-test` suite (single-threaded on shared Valkey)

Closes #277
Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `EngineBackend` trait method and new public `ff_core::capability` API, plus backend-specific capability tables; while additive, it touches core trait surfaces and could affect downstream implementations/feature gating if assumptions change.
> 
> **Overview**
> Adds RFC-018 Stage A capability discovery: new `ff_core::capability` module (`Capability`, `CapabilityStatus`, `BackendIdentity`, `CapabilityMatrix`, `Version`) and a default `EngineBackend::capabilities_matrix()` returning an empty `unknown` matrix for backwards compatibility.
> 
> Updates `ValkeyBackend` and `PostgresBackend` to return concrete matrices from static tables (with Valkey dynamically marking `ClaimForWorker` as `Partial` unless a scheduler is wired), and adds tests (unit coverage in `ff-core` plus ignored live Valkey integration tests) along with doc/changelog updates noting the runtime-callable parity signal and RFC-018 acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceab69fa9a2ce740f58b85ce7fb1f1344b6bd25d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->