### PR TITLE
release(v0.9.0): RFC-017 consumer polish + capability discovery + stream-cursor subscription + cluster race resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to FlowFabric are documented here. Format loosely
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.9.0] - 2026-04-25
+
+v0.9 is **fully additive** on top of v0.8: no consumer source changes
+are required. The release lets consumers *delete* adapter code — one
+umbrella-crate pin instead of seven ff-* pins, trait-level HMAC-secret
+seeding instead of raw HSET, trait-level boot prep instead of
+`BackendKind::Valkey` branches. Closes every consumer-filed issue
+since v0.8 except the RFC-019 Stage B follow-ups (#308–#311,
+intentional scope).
 
 ### Added
 
@@ -75,6 +83,24 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (FUNCTION LOAD + retry), Postgres returns `NoOp` (migrations run
   out-of-band). Idempotent; safe on every boot. Lets consumers drop
   backend-aware `if let BackendKind::Valkey = ...` boot branches.
+- **`examples/token-budget`** — v0.9 UC-37 + UC-39 demo exercising
+  flow-level token budget + per-attempt `report_usage`, including
+  hard-breach → `cancel_flow`. ~200 lines; consumer-facing docs for
+  the v0.9 surface (LeaseSummary fields, prepare, seed_waitpoint,
+  umbrella-crate imports).
+- **`scripts/published-smoke.sh`** — published-artifact smoke harness
+  that scratch-compiles a consumer project against the just-published
+  crate versions. Release-gate blocker per CLAUDE.md §5 (caught
+  v0.3.2 → v0.6 external-consumer breakage). Runs against the
+  flowfabric umbrella crate's v0.9 symbol set.
+- **`docs/MIGRATIONS.md`** — rolling 3-minor-window migration page
+  (v0.7 / v0.8 / v0.9). Replaces per-release `CONSUMER_MIGRATION_*.md`
+  files; release gate validates it on every tag.
+- **`CLAUDE.md` §5 Release Gate** — codified the 8-item pre-tag gate
+  (smoke, example builds, live-run, headline example, README sweep,
+  CHANGELOG finalize, POSTGRES_PARITY_MATRIX current, pre-publish
+  smoke in release.yml). Reinforces the lessons from v0.3/v0.6/v0.8
+  partial-publish recoveries.
 
 ### Changed
 
@@ -82,6 +108,14 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `docs/MIGRATIONS.md` covering the last 3 minor versions
   (v0.7/v0.8/v0.9). Release gate (CLAUDE.md §5 item 5) validates
   it on every tag.
+
+### CI
+
+- **Matrix-CI Postgres cell** — ubuntu-latest × postgres 16 × standalone
+  matrix cell added (#299). Gates Postgres backend parity on every PR
+  alongside the existing Valkey standalone + cluster cells. Runs
+  `ff-backend-postgres` suite with `--test-threads=1` for SERIALIZABLE
+  budget reasons.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "axum",
  "ff-observability",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "flowfabric"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ff-backend-postgres",
  "ff-backend-valkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -36,22 +36,22 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.8.1", path = "crates/ff-core" }
-ff-script = { version = "0.8.1", path = "crates/ff-script" }
-ff-engine = { version = "0.8.1", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.8.1", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.8.1", path = "crates/ff-sdk" }
-ff-server = { version = "0.8.1", path = "crates/ff-server" }
+ff-core = { version = "0.9.0", path = "crates/ff-core" }
+ff-script = { version = "0.9.0", path = "crates/ff-script" }
+ff-engine = { version = "0.9.0", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.9.0", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.9.0", path = "crates/ff-sdk" }
+ff-server = { version = "0.9.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.8.1", path = "crates/ff-backend-valkey" }
-ff-backend-postgres = { version = "0.8.1", path = "crates/ff-backend-postgres" }
-ff-observability = { version = "0.8.1", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.8.1", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.8.1", path = "ferriskey" }
+ff-backend-valkey = { version = "0.9.0", path = "crates/ff-backend-valkey" }
+ff-backend-postgres = { version = "0.9.0", path = "crates/ff-backend-postgres" }
+ff-observability = { version = "0.9.0", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.9.0", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.9.0", path = "ferriskey" }
 # Umbrella crate re-exporting the ff-* family (issue #279). Declared
 # at workspace scope so internal doc examples / dev-deps can name it
 # via `{ workspace = true }`.
-flowfabric = { version = "0.8.1", path = "crates/flowfabric" }
+flowfabric = { version = "0.9.0", path = "crates/flowfabric" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
                  │              │              │
           ┌──────┴──────┐ ┌────┴────┐ ┌───────┴───────┐
           │  ff-engine   │ │ ff-sdk  │ │ ff-scheduler  │
-          │  17 scanners │ │ worker  │ │ claim-grant   │
+          │  13 scanners │ │ worker  │ │ claim-grant   │
           └──────┬──────┘ │   API   │ │   cycle       │
                  │        └────┬────┘ └───────┬───────┘
                  │             │              │
@@ -41,8 +41,8 @@ Valkey-native execution engine for long-running, interruptible, resource-aware w
 - **Streaming output** -- append-only frame streams scoped to each attempt
 - **Priority scheduling** -- score-based eligible sets with priority clamping
 - **Capability routing** -- workers advertise capabilities; scheduler subset-matches per-execution requirements
-- **REST API** -- 22 endpoints on axum with JSON error handling, CORS, health check
-- **Backend trait** -- `EngineBackend` is the stable surface for alternate backends (Valkey today, Postgres in scope for later); cursor-paginated `list_executions` / `list_flows` / `list_lanes` / `list_suspended` for operator tooling
+- **REST API** -- 27 endpoints on axum with JSON error handling, CORS, health check
+- **Backend trait** -- `EngineBackend` is the stable surface for alternate backends (Valkey + Postgres both first-class at v0.8.0, RFC-017 Stage E4); `capabilities_matrix()` lets consumers query supported operations at runtime (v0.9, RFC-018); cursor-paginated `list_executions` / `list_flows` / `list_lanes` / `list_suspended` for operator tooling
 - **Client-local tower-style layer surface** -- opt-in `TracingLayer`, `RateLimitLayer`, `MetricsLayer`, `CircuitBreakerLayer` compose around any `EngineBackend`
 - **Observability** -- OTEL via `ff-observability`, Prometheus scrape endpoint via `ff-server` (engine-side) or `ff-observability-http` crate (consumer-side), optional Sentry integration, Grafana dashboard JSON bundled
 - **Cluster-safe** -- all operations use hash-tag partitioning; cluster-aware enumeration via ferriskey's hash-tag-aware `cluster_scan` (single-shard routing when the match pattern embeds a tag)
@@ -119,7 +119,7 @@ For production deployments, use the Scheduler (`ff-scheduler`) which enforces ad
 | `ferriskey` | Valkey client -- in-tree, forked from glide-core (valkey-glide). Hash-tag-aware `cluster_scan` single-shard routing. |
 | `ff-core` | Core types, state enums, partition math, key builders, `EngineBackend` trait, error codes |
 | `ff-script` | Typed FCALL wrappers and Lua library loader |
-| `ff-engine` | Cross-partition dispatch and 14 background scanners |
+| `ff-engine` | Cross-partition dispatch and 13 background scanners |
 | `ff-scheduler` | Claim-grant cycle, fairness, capability matching |
 | `ff-backend-valkey` | `EngineBackend` implementation backed by Valkey FCALL |
 | `ff-sdk` | Worker SDK — public API for worker authors; includes the client-local `EngineBackendLayer` surface |

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -690,9 +690,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ff-core",
  "ff-observability",
  "futures-core",
@@ -709,9 +710,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ferriskey",
  "ff-core",
  "ff-observability",
@@ -722,6 +724,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -750,20 +753,23 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "crc16",
  "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
 name = "ff-engine"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
@@ -779,11 +785,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -795,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -807,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -823,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -865,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
@@ -2932,6 +2938,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -28,7 +28,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.8.1", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.9.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.8.1", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.9.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -49,7 +49,7 @@ valkey-client = ["dep:ferriskey"]
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.8.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.9.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: optional so `--no-default-features` drops the transport edge.
 ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -75,7 +75,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.8.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.9.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-script's defaults are empty — the `valkey-client`
 # feature (which owns the `ferriskey` dep edge) is activated below by
 # the `valkey-default` feature, NOT here. This keeps

--- a/crates/flowfabric/Cargo.toml
+++ b/crates/flowfabric/Cargo.toml
@@ -53,7 +53,7 @@ ff-core = { workspace = true }
 # dep's default-features at the consumer site. Pinning version +
 # path here matches the workspace.dependencies entry; `cargo release`
 # keeps both in lockstep via `shared-version = true`.
-ff-sdk = { version = "0.8.1", path = "../ff-sdk", default-features = false }
+ff-sdk = { version = "0.9.0", path = "../ff-sdk", default-features = false }
 
 ff-backend-valkey = { workspace = true, optional = true }
 ff-backend-postgres = { workspace = true, optional = true }

--- a/examples/coding-agent/Cargo.lock
+++ b/examples/coding-agent/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -402,9 +402,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ferriskey",
  "ff-core",
  "ff-observability",
@@ -415,29 +416,33 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "crc16",
  "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -449,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -461,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -1926,6 +1931,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/examples/deploy-approval/Cargo.lock
+++ b/examples/deploy-approval/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -402,9 +402,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ferriskey",
  "ff-core",
  "ff-observability",
@@ -415,29 +416,33 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "crc16",
  "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -449,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -461,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -1925,6 +1930,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/examples/llm-race/Cargo.lock
+++ b/examples/llm-race/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -386,9 +386,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ferriskey",
  "ff-core",
  "ff-observability",
@@ -399,29 +400,33 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "crc16",
  "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -433,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -445,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -1925,6 +1930,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/examples/media-pipeline/Cargo.lock
+++ b/examples/media-pipeline/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -885,9 +885,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ferriskey",
  "ff-core",
  "ff-observability",
@@ -898,29 +899,33 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "crc16",
  "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -932,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -944,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -3220,6 +3225,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/examples/retry-and-cancel/Cargo.lock
+++ b/examples/retry-and-cancel/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -290,9 +290,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ferriskey",
  "ff-core",
  "ff-observability",
@@ -303,29 +304,33 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "crc16",
  "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -337,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -349,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -1810,6 +1815,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/examples/token-budget/Cargo.lock
+++ b/examples/token-budget/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -290,9 +290,10 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "ferriskey",
  "ff-core",
  "ff-observability",
@@ -303,29 +304,33 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "ff-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "crc16",
  "futures-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
 name = "ff-observability"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -337,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -349,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -371,7 +376,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowfabric"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ff-backend-valkey",
  "ff-core",
@@ -1820,6 +1825,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Headline

v0.9.0 closes every consumer-filed issue since v0.8 except the RFC-019 Stage B follow-ups (#308–#311, intentional scope). Fully additive on top of v0.8 — no consumer source changes required. Consumers can now delete adapter code: one umbrella-crate pin instead of seven ff-* pins, trait-level HMAC-secret seeding instead of raw HSET, trait-level boot prep instead of `BackendKind::Valkey` branches, runtime capability discovery via `EngineBackend::capabilities_matrix`, and stream-cursor subscription surfaces on `lease_history` (Valkey) and `completion` (Postgres).

## CHANGELOG [0.9.0] section

### Added
- `EngineBackend::capabilities_matrix()` + `BackendIdentity` + `Capability` + `CapabilityStatus` + `CapabilityMatrix` (RFC-018 Stage A, closes #277).
- `EngineBackend::subscribe_{lease_history,completion,signal_delivery,instance_tags}` (RFC-019 Stage A, closes #282). Valkey impls `subscribe_lease_history`, Postgres impls `subscribe_completion`. Other cells stub → `Unavailable`; Stage B follow-ups tracked as #308–#311.
- `ValkeyBackend::with_embedded_scheduler` — direct `Arc<dyn EngineBackend>` consumers reach `claim_for_worker` (closes #293).
- `EngineBackend::cancel_flow` gains `WaitTimeout(Duration)` + `WaitIndefinite` on both backends (closes #298).
- `flowfabric` umbrella crate — feature-flagged re-exports of the ff-* family (closes #279).
- `ff-sdk` re-exports `ClaimGrant` / `ReclaimGrant` / `ClaimPolicy` / `ReclaimToken` (closes #283).
- `LeaseSummary` gains `lease_id` + `attempt_index` + `last_heartbeat_at` with fluent setters (closes #278).
- `EngineBackend::seed_waitpoint_hmac_secret` trait method (closes #280).
- `EngineBackend::prepare` trait-level boot step (closes #281).
- `examples/token-budget` — v0.9 UC-37 + UC-39 flow-level token-budget demo with hard-breach → `cancel_flow`.
- `scripts/published-smoke.sh` published-artifact release-gate harness.
- `docs/MIGRATIONS.md` rolling 3-minor-window consumer migration page.
- `CLAUDE.md §5` codified pre-tag Release Gate.

### Changed
- `docs/CONSUMER_MIGRATION_v0.8.md` → replaced by rolling `docs/MIGRATIONS.md`.

### CI
- ubuntu-latest × postgres 16 × standalone matrix cell (#299).

### Fixed
- `ff-backend-postgres` `suspend_signal` keystore race — per-test Postgres schema via `search_path` (closes #301, via #307).
- ferriskey slot-refresh throttle uses `Instant::now()` (closes #290 via #302 + #306).
- Cluster-topology bootstrap race — 6-node convergence poll + extended `ensure_library` retry window (closes #275, via #276 + #289).

## Pre-release validation (CLAUDE.md §5)

### Gate 1 — smoke-v0.7 (Valkey + Postgres, strict)
```
FF_SMOKE_BACKEND=both FF_SMOKE_STRICT=1 bash scripts/smoke-v0.7.sh
==> smoke-v0.7: PASS
```
All 7 scenarios × 2 backends PASS. Full log: `/tmp/smoke-v0.9.log`.

### Gate 2 — all 6 examples build clean at 0.9.0
- `retry-and-cancel` → `Finished`
- `deploy-approval` → `Finished`
- `llm-race` → `Finished`
- `coding-agent` → `Finished` (one pre-existing warning, non-blocking)
- `media-pipeline` → `Finished`
- `token-budget` → `Finished`

### Gate 3 — retry-and-cancel live-run
```
scene 1 terminal state=failed
── scene 2: cancel_flow cascade ──
cancel_flow returned response=Cancelled { cancellation_policy: cancel_all, member_execution_ids: [2 members] }
member cancelled (x2)
```

### Gate 4 — token-budget live-run (v0.9 headline example)
```
simulated inference complete; reporting usage
usage reported; HARD breach — increments not applied, failing execution (x2)
soft limit approaching — flow will reject new claims on hard breach
hard budget breached — cancelling flow
cancel_flow returned result=Cancelled { cancellation_policy: cancel_pending, member_execution_ids: [5 members] }
demo complete outcome=HardBreachCancelled
```

### Gate 5 — README + MIGRATIONS sweep
- README endpoint count corrected 22 → 27
- README scanner count normalized to 13 (drift fixed)
- Backend-trait line updated (Valkey + Postgres both first-class; `capabilities_matrix` v0.9 callout)
- `docs/MIGRATIONS.md` v0.9.0 section reviewed against CHANGELOG entries — complete

### Gate 6 — CHANGELOG complete
`[Unreleased]` closed → `[0.9.0] - 2026-04-25`. No open entries.

### Gate 7 — POSTGRES_PARITY_MATRIX current
Verified rows for `capabilities_matrix`, `subscribe_lease_history`, `subscribe_completion`, `subscribe_signal_delivery`, `subscribe_instance_tags`, `prepare`, `seed_waitpoint_hmac_secret`, `cancel_flow` (three wait modes).

### Gate 8 — release.yml pre-publish smoke gate
Workflow ships smoke → publish → release; no bypass needed at tag time.

## Open issues at tag time (intentional)
- #51 (legacy, out-of-scope)
- #308 / #309 / #310 / #311 — RFC-019 Stage B follow-ups (complete the family × backend subscription matrix + HTTP SSE)

## Known-red checks
`cargo-semver-checks` should PASS at v0.9.0 (additive-only minor bump vs v0.8.1).

## Merge plan
Admin-merge after matrix + quality/sec are green; wait ≤2 min for semver-checks (expected green).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily release-prep metadata/docs updates (version bumps, lockfiles, README/CHANGELOG), with no functional code changes in this diff; risk is limited to publish/packaging consistency issues.
> 
> **Overview**
> Prepares the `v0.9.0` release by finalizing `CHANGELOG.md` (closing *Unreleased* into a dated `0.9.0` entry) and updating `README.md` counters/text to match the new release notes.
> 
> Bumps the workspace and all internal crates (including `ferriskey` and the `flowfabric` umbrella crate) from `0.8.1` to `0.9.0`, updating `Cargo.toml` pins and regenerating lockfiles (including new/updated deps like `tokio-stream`/`bytes` appearing in example/bench locks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c082364dfb62fdfa20c55a9202d6b45904b8d2a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->