### PR TITLE
chore(RFC-019): defer subscribe_instance_tags per audit — list_executions suffices (closes #311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to FlowFabric are documented here. Format loosely
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- `subscribe_instance_tags` deferred per audit (#311): `list_executions`
+  + `ScannerFilter` + pagination meets cairn's `instance_tag_backfill`
+  use case (one-shot backfill, not realtime tail). Trait method remains
+  (returns `Unavailable` on both backends); reserving the surface for
+  future concrete demand. RFC-019 §instance_tags amended.
+
 ## [0.9.0] - 2026-04-25
 
 v0.9 is **fully additive** on top of v0.8: no consumer source changes

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -302,7 +302,7 @@ but no longer trips on Postgres.
 | `subscribe_lease_history` | `impl` | `stub` | Valkey: `duplicate_connection()` + `XREAD BLOCK 5000 STREAMS ff:part:{fp:N}:lease_history <cursor>`; cursor is `0x01 ++ ms(BE8) ++ seq(BE8)`. Postgres stub until Stage B (LISTEN/NOTIFY on a `ff_lease_event` outbox) — follow-up issue filed. |
 | `subscribe_completion` | `stub` | `impl` | Postgres wraps `completion::subscribe` (`ff_completion_event` outbox + `LISTEN ff_completion`). Valkey stub until Stage B (fold RESP3 `subscribe_completions` into the trait) — follow-up issue filed. |
 | `subscribe_signal_delivery` | `stub` | `stub` | Stage B on both backends — follow-up issue filed. |
-| `subscribe_instance_tags` | `stub` | `stub` | Stage B on both backends — follow-up issue filed. |
+| `subscribe_instance_tags` | `n/a` | `n/a` | Audited #311 (2026-04-24) + deferred: cairn's one-shot `instance_tag_backfill` pattern is served by `list_executions` + `ScannerFilter::with_instance_tag(..)` pagination; a realtime tag-churn stream is speculative demand we do not have today. Trait method remains and returns `Unavailable` on both backends; reserving the surface for future concrete demand. RFC-019 §instance_tags amended. |
 
 ### Deferred to v0.9 / post-0.8
 

--- a/rfcs/RFC-019-stream-cursor-subscription.md
+++ b/rfcs/RFC-019-stream-cursor-subscription.md
@@ -248,11 +248,14 @@ permitted by at-least-once contract).
   `backend.subscribe_lease_history(cursor)` iteration. Direct
   `ferriskey` dep drops. Cursor persisted via cairn's existing
   checkpoint module.
-- **`instance_tag_backfill.rs`:** audited separately — it's one-shot
-  backfill, likely served by `list_executions` with the right filter;
-  may not need a subscription at all. Handled via
-  `subscribe_instance_tags` only if audit shows a subscription is
-  warranted.
+- **`instance_tag_backfill.rs`:** audited 2026-04-24 (#311) — one-shot
+  backfill served by `list_executions` + `ScannerFilter::with_instance_tag(..)`
+  pagination (client-side filter for v0.9; a future `list_executions`
+  filter parameter is the natural efficiency win, not a subscription).
+  `subscribe_instance_tags` deferred: trait method remains, both
+  backends return `Unavailable`, parity matrix row flipped to `n/a`.
+  Resume implementation only on concrete consumer demand for a
+  realtime tag-churn stream — not speculatively.
 - **LOC delta:** ~250 LOC deleted consumer-side; 2 of 5 direct
   `ferriskey` imports removed.
 
@@ -275,10 +278,10 @@ permitted by at-least-once contract).
 
 ### Stage B — Fill the matrix
 
-- Valkey: `subscribe_completion`, `subscribe_signal_delivery`,
-  `subscribe_instance_tags`.
-- Postgres: `subscribe_lease_history`, `subscribe_signal_delivery`,
-  `subscribe_instance_tags`.
+- Valkey: `subscribe_completion`, `subscribe_signal_delivery`.
+  (`subscribe_instance_tags` deferred — see §Cairn Migration Path.)
+- Postgres: `subscribe_lease_history`, `subscribe_signal_delivery`.
+  (`subscribe_instance_tags` deferred — see §Cairn Migration Path.)
 - ff-engine's internal `completion_listener.rs` DAG-promoter migrated
   to consume the trait method (deduplicating the pattern on the way in).
 


### PR DESCRIPTION
## Summary

Issue #311 asks for an **audit first**: is a realtime subscription actually needed for `subscribe_instance_tags`, or does `list_executions` + `ScannerFilter` serve cairn's `instance_tag_backfill` pattern?

**Audit outcome: (a) polling suffices — defer.**

- RFC-019 §Cairn Migration Path already flagged this family as the weakest of the four: "one-shot backfill, likely served by `list_executions` with the right filter; may not need a subscription at all."
- `ff_core::ScannerFilter::new().with_instance_tag(key, value)` is public and stable; `list_executions(partition, cursor, limit)` supports forward-only pagination on every backend.
- No `subscribe_instance_tags` call-sites exist in FlowFabric or cairn. The cairn pattern (per #282) is cursor-paginated backfill, not realtime tail.
- A realtime tag-churn stream is speculative demand we do not have today — and per owner standing guidance, speculative primitives are expensive.

Per RFC-019 §Implementation Plan §Stage B, the audit explicitly authorizes close-without-implement.

## Changes

Docs-only. No code paths touched.

- `CHANGELOG.md` — `[Unreleased] ### Changed` entry documenting the deferral.
- `docs/POSTGRES_PARITY_MATRIX.md` — `subscribe_instance_tags` row flipped `stub`/`stub` → `n/a`/`n/a` with audit pointer.
- `rfcs/RFC-019-stream-cursor-subscription.md` — §Cairn Migration Path updated with audit date + outcome; §Stage B checklist amended so `subscribe_instance_tags` is no longer a Stage B deliverable.

The trait method `EngineBackend::subscribe_instance_tags` stays in place (returns `EngineError::Unavailable` on both backends) — reserving the surface for future concrete demand. A future `list_executions` filter parameter is the natural efficiency growth path if/when a consumer needs it.

## Test plan

- [ ] CI green (docs-only change; clippy + tests unaffected).
- [ ] Parity matrix row correctly flipped to `n/a`/`n/a`.
- [ ] RFC §Cairn Migration Path + §Stage B both mention the audit + deferral consistently.
- [ ] Issue #311 closes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates that change RFC/parity-matrix guidance but do not affect runtime behavior; risk is limited to potential reviewer/user confusion if the guidance is misinterpreted.
> 
> **Overview**
> Defers implementing `EngineBackend::subscribe_instance_tags` after auditing cairn’s `instance_tag_backfill` use case, documenting that cursor-paginated `list_executions` plus `ScannerFilter::with_instance_tag(..)` is sufficient for one-shot backfills.
> 
> Updates the changelog, RFC-019 migration/stage plan, and the Postgres parity matrix to mark `subscribe_instance_tags` as **`n/a`** (while the trait method remains reserved and returns `Unavailable` on both backends).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52cf217fd5c40ec9bd05ff5dcf52134c97a1108. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->