### PR TITLE
feat(ff-backend-valkey): subscribe_completion (pubsub-backed; RFC-019 Stage B; closes #309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `ValkeyBackend::subscribe_completion` (RFC-019 Stage B; closes #309).
+  Pubsub-backed (at-most-once over live subscription window), cursor
+  always empty. Durable Postgres impl was Stage A; durable Valkey
+  impl is follow-up (not in Stage B scope).
+
 ### Changed
 
 - `subscribe_instance_tags` deferred per audit (#311): `list_executions`

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -6358,6 +6358,94 @@ impl EngineBackend for ValkeyBackend {
     ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
         subscribe_lease_history_impl(&self.client, cursor).await
     }
+
+    // ── RFC-019 Stage B — `subscribe_completion` (issue #309) ─────
+    //
+    // Pubsub-backed wrap over the existing
+    // `CompletionBackend::subscribe_completions` RESP3 subscriber
+    // (`ff:dag:completions` channel, see `completion.rs`). Valkey
+    // completions ride pubsub (at-most-once over the live subscription
+    // window) so the `StreamCursor` surface is a non-durable placeholder
+    // for Stage B: the incoming cursor is ignored and every emitted
+    // event carries `StreamCursor::empty()`. Consumers who need
+    // at-least-once replay with durable cursor resume use the Postgres
+    // backend (see `docs/POSTGRES_PARITY_MATRIX.md` row
+    // `subscribe_completion`). If someone later wants a durable Valkey
+    // completion subscription we move completions from pubsub to an
+    // XADD stream (separate issue — not Stage B scope per #309).
+    //
+    // Payload shape mirrors the Postgres adapter: outcome bytes go in
+    // `StreamEvent.payload`, `execution_id` is inlined, cursor is the
+    // family sentinel (empty for Valkey Stage B).
+    async fn subscribe_completion(
+        &self,
+        _cursor: ff_core::stream_subscribe::StreamCursor,
+    ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
+        use ff_core::stream_subscribe::{StreamCursor, StreamEvent, StreamFamily};
+        use futures_core::Stream;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        // Delegate to the RESP3 subscriber already exposed via the
+        // `CompletionBackend` trait. This shares the same
+        // reconnect/parse loop (`completion::subscriber_loop`) that
+        // ff-engine's `completion_listener` consumes — no duplicate
+        // pubsub machinery.
+        let inner =
+            ff_core::completion_backend::CompletionBackend::subscribe_completions(self).await?;
+
+        struct Adapter {
+            inner: ff_core::completion_backend::CompletionStream,
+            /// Set once the inner stream ends + we've emitted the
+            /// terminal `StreamDisconnected` error. Ensures we return
+            /// `Ready(None)` on subsequent polls instead of looping on
+            /// the error frame.
+            disconnected_emitted: bool,
+        }
+
+        impl Stream for Adapter {
+            type Item = Result<StreamEvent, EngineError>;
+            fn poll_next(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<Option<Self::Item>> {
+                if self.disconnected_emitted {
+                    return Poll::Ready(None);
+                }
+                match Pin::new(&mut self.inner).poll_next(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(None) => {
+                        // Underlying mpsc closed → subscriber loop
+                        // exited (consumer drop OR unrecoverable
+                        // backend drop). RFC-019 §disconnect contract:
+                        // surface a terminal `StreamDisconnected`
+                        // carrying the cursor to reconnect from. Valkey
+                        // Stage B has no durable cursor so yield the
+                        // empty sentinel and end.
+                        self.disconnected_emitted = true;
+                        Poll::Ready(Some(Err(EngineError::StreamDisconnected {
+                            cursor: StreamCursor::empty(),
+                        })))
+                    }
+                    Poll::Ready(Some(payload)) => {
+                        let event = StreamEvent::new(
+                            StreamFamily::Completion,
+                            StreamCursor::empty(),
+                            payload.produced_at_ms,
+                            bytes::Bytes::from(payload.outcome.into_bytes()),
+                        )
+                        .with_execution_id(payload.execution_id);
+                        Poll::Ready(Some(Ok(event)))
+                    }
+                }
+            }
+        }
+
+        Ok(Box::pin(Adapter {
+            inner,
+            disconnected_emitted: false,
+        }))
+    }
 }
 
 /// Aggregate partition-level lease-history stream key. RFC-019 Stage A

--- a/crates/ff-backend-valkey/tests/subscribe_completion.rs
+++ b/crates/ff-backend-valkey/tests/subscribe_completion.rs
@@ -1,0 +1,112 @@
+//! RFC-019 Stage B integration test — `subscribe_completion` on the
+//! Valkey backend (issue #309).
+//!
+//! Gated `#[ignore]` because it requires a live Valkey at
+//! `localhost:6379`. Run with:
+//!
+//! ```
+//! valkey-cli -h localhost -p 6379 ping
+//! cargo test -p ff-backend-valkey --test subscribe_completion -- --ignored
+//! ```
+//!
+//! The test:
+//! 1. Dials the backend + opens `subscribe_completion` with an empty
+//!    cursor (the only cursor Valkey Stage B accepts — pubsub-backed).
+//! 2. Publishes a synthetic completion payload on `ff:dag:completions`
+//!    (the channel the Lua emitters + `CompletionBackend` plumb
+//!    through). Matching the same surface via raw PUBLISH keeps the
+//!    test backend-surface-only + avoids dragging in `ff_script`.
+//! 3. Asserts the subscription yields the event inside a 5-second
+//!    window with `family = Completion`, empty cursor, and the
+//!    execution-id round-trips.
+
+use std::time::Duration;
+
+use ff_backend_valkey::{ValkeyBackend, COMPLETION_CHANNEL};
+use ff_core::backend::BackendConfig;
+use ff_core::stream_subscribe::{StreamCursor, StreamFamily};
+use futures_core::Stream;
+use tokio::time::timeout;
+
+/// Poll `.next()` on a pinned stream without dragging in `futures`.
+async fn next_item<S>(stream: &mut S) -> Option<S::Item>
+where
+    S: Stream + Unpin,
+{
+    std::future::poll_fn(|cx| std::pin::Pin::new(&mut *stream).poll_next(cx)).await
+}
+
+#[tokio::test]
+#[ignore = "requires live Valkey at localhost:6379"]
+async fn subscribe_completion_yields_publish_frame() {
+    let backend = ValkeyBackend::connect(BackendConfig::valkey("localhost", 6379))
+        .await
+        .expect("connect to localhost valkey");
+
+    let mut sub = backend
+        .subscribe_completion(StreamCursor::empty())
+        .await
+        .expect("subscribe_completion");
+
+    // Give the RESP3 SUBSCRIBE handshake a moment to land — without
+    // this the PUBLISH below can race ahead of the subscriber and the
+    // test strands on a no-event poll.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Dial a separate client just to PUBLISH. `ValkeyBackend::connect`
+    // returns a backend handle that does not expose the raw ferriskey
+    // client; opening our own client matches `subscribe_lease_history`
+    // test pattern.
+    let publisher = ferriskey::ClientBuilder::new()
+        .host("localhost", 6379)
+        .build()
+        .await
+        .expect("build raw publisher client");
+
+    // Wire shape matches `completion::WirePayload`: execution_id in
+    // `{fp:N}:<uuid>` form, bare flow_id uuid, outcome string.
+    // Use fixed uuids so the assertion is deterministic.
+    let exec_id = "{fp:0}:11111111-1111-4111-8111-111111111111";
+    let flow_id = "22222222-2222-4222-8222-222222222222";
+    let payload = format!(
+        r#"{{"execution_id":"{exec_id}","flow_id":"{flow_id}","outcome":"success"}}"#
+    );
+
+    let _: ferriskey::Value = publisher
+        .cmd("PUBLISH")
+        .arg(COMPLETION_CHANNEL)
+        .arg(payload.as_str())
+        .execute()
+        .await
+        .expect("PUBLISH synthetic completion");
+
+    let event = timeout(Duration::from_secs(5), next_item(&mut sub))
+        .await
+        .expect("subscription yielded within 5s")
+        .expect("stream ended unexpectedly")
+        .expect("backend surfaced error before event");
+
+    assert_eq!(
+        event.family,
+        StreamFamily::Completion,
+        "event family mismatch"
+    );
+    assert!(
+        event.cursor.as_bytes().is_empty(),
+        "Stage B cursor must be the empty sentinel (pubsub-backed, non-durable)"
+    );
+    assert_eq!(
+        event
+            .execution_id
+            .as_ref()
+            .map(std::string::ToString::to_string)
+            .as_deref(),
+        Some(exec_id),
+        "execution_id should round-trip"
+    );
+    assert_eq!(
+        event.payload.as_ref(),
+        b"success",
+        "payload should carry the outcome string"
+    );
+}

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -1137,8 +1137,15 @@ pub trait EngineBackend: Send + Sync + 'static {
     }
 
     /// Subscribe to completion events (terminal state transitions).
-    /// Postgres: wraps the existing `ff_completion_event` outbox +
-    /// LISTEN/NOTIFY machinery. Valkey: Stage B follow-up.
+    ///
+    /// - **Postgres** (RFC-019 Stage A): wraps the `ff_completion_event`
+    ///   outbox + LISTEN/NOTIFY machinery. Durable via event-id cursor.
+    /// - **Valkey** (RFC-019 Stage B, issue #309): wraps the RESP3
+    ///   `ff:dag:completions` pubsub subscriber. Pubsub is at-most-once
+    ///   over the live subscription window; the cursor is always the
+    ///   empty sentinel. If you need at-least-once replay with durable
+    ///   cursor resume, use the Postgres backend (see
+    ///   `docs/POSTGRES_PARITY_MATRIX.md` row `subscribe_completion`).
     async fn subscribe_completion(
         &self,
         _cursor: crate::stream_subscribe::StreamCursor,

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -300,7 +300,7 @@ but no longer trips on Postgres.
 | Method | Valkey | Postgres | Notes |
 |---|---|---|---|
 | `subscribe_lease_history` | `impl` | `stub` | Valkey: `duplicate_connection()` + `XREAD BLOCK 5000 STREAMS ff:part:{fp:N}:lease_history <cursor>`; cursor is `0x01 ++ ms(BE8) ++ seq(BE8)`. Postgres stub until Stage B (LISTEN/NOTIFY on a `ff_lease_event` outbox) — follow-up issue filed. |
-| `subscribe_completion` | `stub` | `impl` | Postgres wraps `completion::subscribe` (`ff_completion_event` outbox + `LISTEN ff_completion`). Valkey stub until Stage B (fold RESP3 `subscribe_completions` into the trait) — follow-up issue filed. |
+| `subscribe_completion` | `impl` | `impl` | Postgres wraps `completion::subscribe` (`ff_completion_event` outbox + `LISTEN ff_completion`), durable via event-id cursor. Valkey (Stage B, #309) wraps the RESP3 `ff:dag:completions` pubsub subscriber — **partial: non-durable cursor (pubsub-backed, at-most-once over the live subscription window). Postgres impl is durable via outbox + cursor.** Durable Valkey completion subscription is a separate follow-up if demanded. |
 | `subscribe_signal_delivery` | `stub` | `stub` | Stage B on both backends — follow-up issue filed. |
 | `subscribe_instance_tags` | `n/a` | `n/a` | Audited #311 (2026-04-24) + deferred: cairn's one-shot `instance_tag_backfill` pattern is served by `list_executions` + `ScannerFilter::with_instance_tag(..)` pagination; a realtime tag-churn stream is speculative demand we do not have today. Trait method remains and returns `Unavailable` on both backends; reserving the surface for future concrete demand. RFC-019 §instance_tags amended. |
 


### PR DESCRIPTION
## Summary

Implements `ValkeyBackend::subscribe_completion` by wrapping the existing RESP3 `CompletionBackend::subscribe_completions` subscriber on `ff:dag:completions` behind the RFC-019 trait surface. Postgres was Stage A (durable, event-id cursor); Valkey is Stage B (pubsub-backed, non-durable cursor).

## Design decision — non-durable cursor (per issue #309)

Valkey completions ride pubsub (at-most-once over the live subscription window). Per the issue's adjudication, Stage B ships the pubsub-wrap with an empty cursor rather than doing a pubsub→XADD refactor:

- Incoming `StreamCursor` is ignored (documented in both the trait doc-comment and the Valkey impl).
- Every emitted `StreamEvent` carries `StreamCursor::empty()`.
- On underlying subscriber drop, the stream yields a terminal `Err(EngineError::StreamDisconnected { cursor: empty })` then ends.
- Payload shape mirrors the Postgres adapter: outcome bytes in `StreamEvent.payload`, `execution_id` inlined.

Consumers who need at-least-once replay with durable cursor resume use the Postgres backend. A pubsub→XADD refactor for a durable Valkey cursor would be a separate issue; explicitly out-of-scope for Stage B.

`ff-engine`'s `completion_listener` is intentionally NOT refactored — per issue, that is a separate migration.

## Parity matrix diff

`docs/POSTGRES_PARITY_MATRIX.md` row `subscribe_completion`: Valkey `stub` → `impl` with note "Partial: non-durable cursor (pubsub-backed). Postgres impl is durable via outbox + cursor."

## Files changed

- `crates/ff-backend-valkey/src/lib.rs` — new `subscribe_completion` impl + adapter stream.
- `crates/ff-core/src/engine_backend.rs` — trait doc-comment expanded with Postgres vs Valkey semantics + parity-matrix pointer.
- `crates/ff-backend-valkey/tests/subscribe_completion.rs` — new `#[ignore]`-gated live-Valkey integration test.
- `docs/POSTGRES_PARITY_MATRIX.md` — row flip.
- `CHANGELOG.md` — new `[Unreleased] ### Added` entry.

## Test output

```
$ cargo clippy -p ff-backend-valkey --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ FF_WAITPOINT_HMAC_SECRET=... cargo test -p ff-backend-valkey --test subscribe_completion -- --ignored
running 1 test
test subscribe_completion_yields_publish_frame ... ok
test result: ok. 1 passed; 0 failed

$ FF_WAITPOINT_HMAC_SECRET=... cargo test -p ff-backend-valkey --lib
test result: ok. 26 passed; 0 failed; 7 ignored
```

## Test plan

- [x] `cargo build -p ff-backend-valkey` clean
- [x] `cargo clippy -p ff-backend-valkey --all-targets -- -D warnings` clean
- [x] Live-Valkey integration test passes (PUBLISH → subscription yields event, cursor empty, execution_id round-trips)
- [x] Lib tests 26/26 pass
- [ ] CI green on matrix (Valkey standalone + cluster + Postgres cells)

Closes #309.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Valkey streaming API that wraps pubsub completions with non-durable cursors; incorrect disconnect/cursor semantics could cause missed or duplicated terminal events for consumers relying on this subscription.
> 
> **Overview**
> Adds a Valkey implementation of `EngineBackend::subscribe_completion` by adapting the existing `CompletionBackend::subscribe_completions` pubsub stream into RFC-019 `StreamEvent`s (family `Completion`, payload=outcome bytes), and emitting a terminal `EngineError::StreamDisconnected` when the underlying stream ends.
> 
> Documents the **non-durable, at-most-once** semantics (ignored incoming cursor; emitted cursor always `StreamCursor::empty()`) in rustdocs, updates the Postgres parity matrix + CHANGELOG, and adds an ignored live-Valkey integration test that `PUBLISH`es to `ff:dag:completions` and asserts the subscription yields the expected event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90fc56adc9d2164d84a33778a200fce1d654a291. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->