### PR TITLE
feat(RFC-019): typed per-family subscribe event enums (cairn #282 ask)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `ff_core::stream_events` module: typed event enums + per-family
+  subscription aliases for the four `EngineBackend::subscribe_*`
+  methods (RFC-019 Stage C; addresses #282 typed surface gap).
+  - `LeaseHistoryEvent` with `Acquired` / `Renewed` / `Expired` /
+    `Reclaimed` / `Revoked` variants.
+  - `CompletionEvent` + `CompletionOutcome::{Success, Failure,
+    Cancelled, Other(String)}`.
+  - `SignalDeliveryEvent` + `SignalDeliveryEffect::{Satisfied,
+    Buffered, Deduped, Other(String)}`.
+  - `InstanceTagEvent` with `Attached` / `Cleared` variants (trait
+    surface only; producer wiring still deferred per #311 audit).
+  Each family ships a subscription alias
+  (`LeaseHistorySubscription`, `CompletionSubscription`,
+  `SignalDeliverySubscription`, `InstanceTagSubscription`). All
+  enums + structs are `#[non_exhaustive]` so future additions are
+  non-breaking; structs pair with `new()` constructors so external
+  crates (ff-backend-valkey, ff-backend-postgres) can still build
+  instances.
+
+### Changed
+
+- **Breaking for direct `EngineBackend` impls**: the four
+  `subscribe_*` trait methods now return family-specific typed
+  subscriptions instead of `StreamSubscription<StreamEvent>` with a
+  byte payload. Trait consumers match on typed variants directly;
+  no more NUL-delimited / JSON payload parsing. The untyped
+  `StreamEvent` + `StreamSubscription` + `StreamFamily` types are
+  removed from `ff_core::stream_subscribe`; cursor codec
+  (`StreamCursor` + `encode_valkey_cursor` / `decode_valkey_cursor`
+  / `encode_postgres_event_cursor` / `decode_postgres_event_cursor`)
+  stays unchanged. See
+  `docs/CONSUMER_MIGRATION_typed-subscribe-events.md` for the
+  consumer migration snippet.
+
+### Added
+
 - `subscribe_signal_delivery` implemented on both backends
   (RFC-019 Stage B; closes #310). Valkey: XREAD BLOCK on partition
   aggregate stream `ff:part:{fp:N}:signal_delivery` (producer XADD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -41,10 +41,6 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 futures-core = { workspace = true }
-# RFC-019 Stage A — `subscribe_completion` wraps the existing
-# CompletionBackend stream in a Stream adapter + encodes the outbox
-# event cursor as opaque `bytes::Bytes`.
-bytes = { workspace = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ff-backend-postgres/src/lease_event_subscribe.rs
+++ b/crates/ff-backend-postgres/src/lease_event_subscribe.rs
@@ -18,11 +18,11 @@
 use std::time::Duration;
 
 use ff_core::engine_error::EngineError;
+use ff_core::stream_events::{LeaseHistoryEvent, LeaseHistorySubscription};
 use ff_core::stream_subscribe::{
-    decode_postgres_event_cursor, encode_postgres_event_cursor, StreamCursor, StreamEvent,
-    StreamFamily, StreamSubscription,
+    decode_postgres_event_cursor, encode_postgres_event_cursor, StreamCursor,
 };
-use ff_core::types::{ExecutionId, TimestampMs};
+use ff_core::types::{ExecutionId, LeaseId, TimestampMs};
 use futures_core::Stream;
 use sqlx::postgres::{PgListener, PgPool};
 use sqlx::Row;
@@ -58,7 +58,7 @@ pub(crate) async fn subscribe(
     pool: &PgPool,
     partition_key: i16,
     cursor: StreamCursor,
-) -> Result<StreamSubscription, EngineError> {
+) -> Result<LeaseHistorySubscription, EngineError> {
     // Decode + validate the caller's cursor before spawning so
     // malformed cursors fail loudly at subscribe time.
     let start = decode_postgres_event_cursor(&cursor).map_err(|msg| {
@@ -83,7 +83,7 @@ pub(crate) async fn subscribe(
         })?,
     };
 
-    let (tx, rx) = mpsc::channel::<Result<StreamEvent, EngineError>>(STREAM_CAPACITY);
+    let (tx, rx) = mpsc::channel::<Result<LeaseHistoryEvent, EngineError>>(STREAM_CAPACITY);
     let pool_clone = pool.clone();
     tokio::spawn(subscriber_loop(
         pool_clone,
@@ -97,11 +97,11 @@ pub(crate) async fn subscribe(
 
 /// `mpsc::Receiver` → `Stream` adapter.
 struct Adapter {
-    rx: mpsc::Receiver<Result<StreamEvent, EngineError>>,
+    rx: mpsc::Receiver<Result<LeaseHistoryEvent, EngineError>>,
 }
 
 impl Stream for Adapter {
-    type Item = Result<StreamEvent, EngineError>;
+    type Item = Result<LeaseHistoryEvent, EngineError>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -114,7 +114,7 @@ impl Stream for Adapter {
 async fn subscriber_loop(
     pool: PgPool,
     partition_key: i16,
-    tx: mpsc::Sender<Result<StreamEvent, EngineError>>,
+    tx: mpsc::Sender<Result<LeaseHistoryEvent, EngineError>>,
     mut last_seen: i64,
 ) {
     loop {
@@ -184,7 +184,7 @@ async fn subscriber_loop(
 }
 
 async fn wait_or_exit(
-    tx: &mpsc::Sender<Result<StreamEvent, EngineError>>,
+    tx: &mpsc::Sender<Result<LeaseHistoryEvent, EngineError>>,
     d: Duration,
 ) -> bool {
     tokio::select! {
@@ -193,12 +193,13 @@ async fn wait_or_exit(
     }
 }
 
-/// Drain rows above `last_seen`; forward each as a `StreamEvent`.
-/// Returns `false` iff the consumer dropped the subscription.
+/// Drain rows above `last_seen`; forward each as a typed
+/// `LeaseHistoryEvent`. Returns `false` iff the consumer dropped
+/// the subscription.
 async fn replay(
     pool: &PgPool,
     partition_key: i16,
-    tx: &mpsc::Sender<Result<StreamEvent, EngineError>>,
+    tx: &mpsc::Sender<Result<LeaseHistoryEvent, EngineError>>,
     last_seen: &mut i64,
 ) -> bool {
     loop {
@@ -255,45 +256,119 @@ async fn replay(
             };
             *last_seen = decoded.event_id;
 
-            // Event payload serialised into `StreamEvent::payload` —
-            // consumer-facing schema built via `serde_json::json!` to
-            // avoid pulling in a `serde` derive dep.
-            let payload = serde_json::json!({
-                "execution_id": decoded.execution_id,
-                "lease_id": decoded.lease_id,
-                "event_type": decoded.event_type,
-                "occurred_at_ms": decoded.occurred_at_ms,
-                "partition_key": decoded.partition_key,
-            });
-            let payload_bytes = match serde_json::to_vec(&payload) {
-                Ok(b) => bytes::Bytes::from(b),
-                Err(e) => {
+            let cursor = encode_postgres_event_cursor(decoded.event_id);
+
+            // Re-attach the `{fp:N}:<uuid>` hash-tag so the inline
+            // `execution_id` matches what Valkey would emit. Rows
+            // without a parseable UUID are defensively skipped —
+            // producers always write a UUID, so a bad row is a
+            // schema corruption surface, not a skip.
+            let execution_id = match Uuid::parse_str(&decoded.execution_id)
+                .ok()
+                .and_then(|uuid| {
+                    ExecutionId::parse(&format!(
+                        "{{fp:{}}}:{}",
+                        decoded.partition_key, uuid
+                    ))
+                    .ok()
+                }) {
+                Some(eid) => eid,
+                None => {
                     tracing::warn!(
-                        error = %e,
-                        "pg.lease_history.replay: payload serialize failed"
+                        execution_id = %decoded.execution_id,
+                        event_id = decoded.event_id,
+                        "pg.lease_history.replay: skipping row with unparseable execution_id"
                     );
                     continue;
                 }
             };
 
-            let cursor = encode_postgres_event_cursor(decoded.event_id);
-            let mut event = StreamEvent::new(
-                StreamFamily::LeaseHistory,
-                cursor,
-                TimestampMs::from_millis(decoded.occurred_at_ms),
-                payload_bytes,
-            );
-            // Re-attach the `{fp:N}:<uuid>` hash-tag so the inline
-            // `execution_id` matches what Valkey would emit. When
-            // parse fails (defensive — producers always write a UUID)
-            // we leave the inline field unset; consumers still see
-            // the raw uuid in the JSON payload.
-            if let Ok(uuid) = Uuid::parse_str(&decoded.execution_id) {
-                let full = format!("{{fp:{}}}:{}", decoded.partition_key, uuid);
-                if let Ok(eid) = ExecutionId::parse(&full) {
-                    event = event.with_execution_id(eid);
+            let lease_id = decoded
+                .lease_id
+                .as_deref()
+                .and_then(|s| LeaseId::parse(s).ok());
+            let at = TimestampMs::from_millis(decoded.occurred_at_ms);
+
+            // PG outbox does not persist the owning worker instance —
+            // the fence triple is rebuilt from attempt rows at lookup
+            // time. Surface `None` for now; consumers who need it go
+            // through `read_execution_state`.
+            let event = match decoded.event_type.as_str() {
+                "acquired" => match lease_id {
+                    Some(lease_id) => LeaseHistoryEvent::Acquired {
+                        cursor,
+                        execution_id,
+                        lease_id,
+                        worker_instance_id: None,
+                        at,
+                    },
+                    None => {
+                        tracing::warn!(
+                            event_id = decoded.event_id,
+                            "pg.lease_history.replay: acquired row missing lease_id"
+                        );
+                        continue;
+                    }
+                },
+                "renewed" => match lease_id {
+                    Some(lease_id) => LeaseHistoryEvent::Renewed {
+                        cursor,
+                        execution_id,
+                        lease_id,
+                        worker_instance_id: None,
+                        at,
+                    },
+                    None => {
+                        tracing::warn!(
+                            event_id = decoded.event_id,
+                            "pg.lease_history.replay: renewed row missing lease_id"
+                        );
+                        continue;
+                    }
+                },
+                "expired" => LeaseHistoryEvent::Expired {
+                    cursor,
+                    execution_id,
+                    lease_id,
+                    prev_owner: None,
+                    at,
+                },
+                "reclaimed" => match lease_id {
+                    Some(new_lease_id) => LeaseHistoryEvent::Reclaimed {
+                        cursor,
+                        execution_id,
+                        new_lease_id,
+                        new_owner: None,
+                        at,
+                    },
+                    None => {
+                        tracing::warn!(
+                            event_id = decoded.event_id,
+                            "pg.lease_history.replay: reclaimed row missing lease_id"
+                        );
+                        continue;
+                    }
+                },
+                "revoked" => LeaseHistoryEvent::Revoked {
+                    cursor,
+                    execution_id,
+                    lease_id,
+                    // PG outbox does not yet persist the revoke source;
+                    // match the Valkey default. Taxonomy typed-up when
+                    // the outbox schema gains a `revoked_by` column.
+                    revoked_by: "operator".to_string(),
+                    at,
+                },
+                other => {
+                    tracing::warn!(
+                        event_id = decoded.event_id,
+                        event_type = %other,
+                        "pg.lease_history.replay: unknown event_type, skipping"
+                    );
+                    continue;
                 }
-            }
+            };
+
             if tx.send(Ok(event)).await.is_err() {
                 return false; // consumer dropped
             }

--- a/crates/ff-backend-postgres/src/lease_event_subscribe.rs
+++ b/crates/ff-backend-postgres/src/lease_event_subscribe.rs
@@ -292,39 +292,24 @@ async fn replay(
             // PG outbox does not persist the owning worker instance —
             // the fence triple is rebuilt from attempt rows at lookup
             // time. Surface `None` for now; consumers who need it go
-            // through `read_execution_state`.
+            // through `read_execution_state`. `lease_id` is also
+            // typically `None` on PG since `ff_attempt` identity is
+            // `(lease_epoch, attempt_index, execution_id)` rather than
+            // a stable uuid (see `lease_event::emit`).
             let event = match decoded.event_type.as_str() {
-                "acquired" => match lease_id {
-                    Some(lease_id) => LeaseHistoryEvent::Acquired {
-                        cursor,
-                        execution_id,
-                        lease_id,
-                        worker_instance_id: None,
-                        at,
-                    },
-                    None => {
-                        tracing::warn!(
-                            event_id = decoded.event_id,
-                            "pg.lease_history.replay: acquired row missing lease_id"
-                        );
-                        continue;
-                    }
+                "acquired" => LeaseHistoryEvent::Acquired {
+                    cursor,
+                    execution_id,
+                    lease_id,
+                    worker_instance_id: None,
+                    at,
                 },
-                "renewed" => match lease_id {
-                    Some(lease_id) => LeaseHistoryEvent::Renewed {
-                        cursor,
-                        execution_id,
-                        lease_id,
-                        worker_instance_id: None,
-                        at,
-                    },
-                    None => {
-                        tracing::warn!(
-                            event_id = decoded.event_id,
-                            "pg.lease_history.replay: renewed row missing lease_id"
-                        );
-                        continue;
-                    }
+                "renewed" => LeaseHistoryEvent::Renewed {
+                    cursor,
+                    execution_id,
+                    lease_id,
+                    worker_instance_id: None,
+                    at,
                 },
                 "expired" => LeaseHistoryEvent::Expired {
                     cursor,
@@ -333,21 +318,12 @@ async fn replay(
                     prev_owner: None,
                     at,
                 },
-                "reclaimed" => match lease_id {
-                    Some(new_lease_id) => LeaseHistoryEvent::Reclaimed {
-                        cursor,
-                        execution_id,
-                        new_lease_id,
-                        new_owner: None,
-                        at,
-                    },
-                    None => {
-                        tracing::warn!(
-                            event_id = decoded.event_id,
-                            "pg.lease_history.replay: reclaimed row missing lease_id"
-                        );
-                        continue;
-                    }
+                "reclaimed" => LeaseHistoryEvent::Reclaimed {
+                    cursor,
+                    execution_id,
+                    new_lease_id: lease_id,
+                    new_owner: None,
+                    at,
                 },
                 "revoked" => LeaseHistoryEvent::Revoked {
                     cursor,

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -998,30 +998,26 @@ impl EngineBackend for PostgresBackend {
     async fn subscribe_completion(
         &self,
         _cursor: ff_core::stream_subscribe::StreamCursor,
-    ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
-        use ff_core::stream_subscribe::{
-            encode_postgres_event_cursor, StreamEvent, StreamFamily,
-        };
+    ) -> Result<ff_core::stream_events::CompletionSubscription, EngineError> {
+        use ff_core::stream_events::{CompletionEvent, CompletionOutcome};
+        use ff_core::stream_subscribe::encode_postgres_event_cursor;
         use futures_core::Stream;
         use std::pin::Pin;
         use std::task::{Context, Poll};
 
         // Delegate to the existing CompletionBackend implementation so
-        // the LISTEN/replay machinery is shared. Stage A ignores the
-        // caller's cursor (tails from tail) and surfaces that via the
-        // RFC-019 method doc; Stage B lands resume-from-cursor.
+        // the LISTEN/replay machinery is shared. The adapter emits
+        // typed `CompletionEvent`s; resume-from-cursor is still
+        // unwired (Stage A surface tails from tail).
         let inner = ff_core::completion_backend::CompletionBackend::subscribe_completions(self)
             .await?;
 
-        // Adapter: `CompletionStream` yields `CompletionPayload` (not
-        // Result); RFC-019 requires `Result<StreamEvent, EngineError>`.
-        // Wrap into an infallible stream mapping each payload.
         struct Adapter {
             inner: ff_core::completion_backend::CompletionStream,
         }
 
         impl Stream for Adapter {
-            type Item = Result<StreamEvent, EngineError>;
+            type Item = Result<CompletionEvent, EngineError>;
             fn poll_next(
                 mut self: Pin<&mut Self>,
                 cx: &mut Context<'_>,
@@ -1030,23 +1026,17 @@ impl EngineBackend for PostgresBackend {
                     Poll::Pending => Poll::Pending,
                     Poll::Ready(None) => Poll::Ready(None),
                     Poll::Ready(Some(payload)) => {
-                        // Stage A: the cursor is a placeholder
-                        // (0-event_id) because the current
-                        // `CompletionPayload` shape does not surface
-                        // `event_id` — Stage B widens
-                        // `CompletionPayload` + plumbs
-                        // replay-from-cursor through the adapter.
-                        // The family prefix stays stable so Stage B
-                        // persistence is forward-compatible for
-                        // consumers that tail from the empty cursor.
+                        // Placeholder cursor (0-event_id) because
+                        // `CompletionPayload` does not surface
+                        // `event_id` today. Family prefix stays stable
+                        // so persistence is forward-compatible.
                         let cursor = encode_postgres_event_cursor(0);
-                        let event = StreamEvent::new(
-                            StreamFamily::Completion,
+                        let event = CompletionEvent::new(
                             cursor,
+                            payload.execution_id.clone(),
+                            CompletionOutcome::from_wire(&payload.outcome),
                             payload.produced_at_ms,
-                            bytes::Bytes::from(payload.outcome.clone().into_bytes()),
-                        )
-                        .with_execution_id(payload.execution_id.clone());
+                        );
                         Poll::Ready(Some(Ok(event)))
                     }
                 }
@@ -1073,7 +1063,7 @@ impl EngineBackend for PostgresBackend {
     async fn subscribe_lease_history(
         &self,
         cursor: ff_core::stream_subscribe::StreamCursor,
-    ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<ff_core::stream_events::LeaseHistorySubscription, EngineError> {
         lease_event_subscribe::subscribe(&self.pool, 0, cursor).await
     }
 
@@ -1090,7 +1080,7 @@ impl EngineBackend for PostgresBackend {
     async fn subscribe_signal_delivery(
         &self,
         cursor: ff_core::stream_subscribe::StreamCursor,
-    ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<ff_core::stream_events::SignalDeliverySubscription, EngineError> {
         signal_delivery_subscribe::subscribe(&self.pool, 0, cursor).await
     }
 }

--- a/crates/ff-backend-postgres/src/signal_delivery_subscribe.rs
+++ b/crates/ff-backend-postgres/src/signal_delivery_subscribe.rs
@@ -15,11 +15,11 @@
 use std::time::Duration;
 
 use ff_core::engine_error::EngineError;
+use ff_core::stream_events::{SignalDeliveryEffect, SignalDeliveryEvent, SignalDeliverySubscription};
 use ff_core::stream_subscribe::{
-    decode_postgres_event_cursor, encode_postgres_event_cursor, StreamCursor, StreamEvent,
-    StreamFamily, StreamSubscription,
+    decode_postgres_event_cursor, encode_postgres_event_cursor, StreamCursor,
 };
-use ff_core::types::{ExecutionId, TimestampMs};
+use ff_core::types::{ExecutionId, SignalId, TimestampMs, WaitpointId};
 use futures_core::Stream;
 use sqlx::postgres::{PgListener, PgPool};
 use sqlx::Row;
@@ -56,7 +56,7 @@ pub(crate) async fn subscribe(
     pool: &PgPool,
     partition_key: i16,
     cursor: StreamCursor,
-) -> Result<StreamSubscription, EngineError> {
+) -> Result<SignalDeliverySubscription, EngineError> {
     let start = decode_postgres_event_cursor(&cursor).map_err(|msg| {
         EngineError::Validation {
             kind: ff_core::engine_error::ValidationKind::InvalidInput,
@@ -77,7 +77,7 @@ pub(crate) async fn subscribe(
         })?,
     };
 
-    let (tx, rx) = mpsc::channel::<Result<StreamEvent, EngineError>>(STREAM_CAPACITY);
+    let (tx, rx) = mpsc::channel::<Result<SignalDeliveryEvent, EngineError>>(STREAM_CAPACITY);
     let pool_clone = pool.clone();
     tokio::spawn(subscriber_loop(pool_clone, partition_key, tx, last_seen));
 
@@ -85,11 +85,11 @@ pub(crate) async fn subscribe(
 }
 
 struct Adapter {
-    rx: mpsc::Receiver<Result<StreamEvent, EngineError>>,
+    rx: mpsc::Receiver<Result<SignalDeliveryEvent, EngineError>>,
 }
 
 impl Stream for Adapter {
-    type Item = Result<StreamEvent, EngineError>;
+    type Item = Result<SignalDeliveryEvent, EngineError>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -102,7 +102,7 @@ impl Stream for Adapter {
 async fn subscriber_loop(
     pool: PgPool,
     partition_key: i16,
-    tx: mpsc::Sender<Result<StreamEvent, EngineError>>,
+    tx: mpsc::Sender<Result<SignalDeliveryEvent, EngineError>>,
     mut last_seen: i64,
 ) {
     loop {
@@ -168,7 +168,7 @@ async fn subscriber_loop(
 }
 
 async fn wait_or_exit(
-    tx: &mpsc::Sender<Result<StreamEvent, EngineError>>,
+    tx: &mpsc::Sender<Result<SignalDeliveryEvent, EngineError>>,
     d: Duration,
 ) -> bool {
     tokio::select! {
@@ -180,7 +180,7 @@ async fn wait_or_exit(
 async fn replay(
     pool: &PgPool,
     partition_key: i16,
-    tx: &mpsc::Sender<Result<StreamEvent, EngineError>>,
+    tx: &mpsc::Sender<Result<SignalDeliveryEvent, EngineError>>,
     last_seen: &mut i64,
 ) -> bool {
     loop {
@@ -243,38 +243,56 @@ async fn replay(
             };
             *last_seen = decoded.event_id;
 
-            let payload = serde_json::json!({
-                "execution_id": decoded.execution_id,
-                "signal_id": decoded.signal_id,
-                "waitpoint_id": decoded.waitpoint_id,
-                "source_identity": decoded.source_identity,
-                "delivered_at_ms": decoded.delivered_at_ms,
-                "partition_key": decoded.partition_key,
-            });
-            let payload_bytes = match serde_json::to_vec(&payload) {
-                Ok(b) => bytes::Bytes::from(b),
-                Err(e) => {
+            let cursor = encode_postgres_event_cursor(decoded.event_id);
+
+            let execution_id = match Uuid::parse_str(&decoded.execution_id)
+                .ok()
+                .and_then(|uuid| {
+                    ExecutionId::parse(&format!(
+                        "{{fp:{}}}:{}",
+                        decoded.partition_key, uuid
+                    ))
+                    .ok()
+                }) {
+                Some(eid) => eid,
+                None => {
                     tracing::warn!(
-                        error = %e,
-                        "pg.signal_delivery.replay: payload serialize failed"
+                        execution_id = %decoded.execution_id,
+                        event_id = decoded.event_id,
+                        "pg.signal_delivery.replay: skipping row with unparseable execution_id"
                     );
                     continue;
                 }
             };
 
-            let cursor = encode_postgres_event_cursor(decoded.event_id);
-            let mut event = StreamEvent::new(
-                StreamFamily::SignalDelivery,
-                cursor,
-                TimestampMs::from_millis(decoded.delivered_at_ms),
-                payload_bytes,
-            );
-            if let Ok(uuid) = Uuid::parse_str(&decoded.execution_id) {
-                let full = format!("{{fp:{}}}:{}", decoded.partition_key, uuid);
-                if let Ok(eid) = ExecutionId::parse(&full) {
-                    event = event.with_execution_id(eid);
+            let signal_id = match SignalId::parse(&decoded.signal_id) {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        event_id = decoded.event_id,
+                        "pg.signal_delivery.replay: skipping row with bad signal_id"
+                    );
+                    continue;
                 }
-            }
+            };
+            let waitpoint_id = decoded
+                .waitpoint_id
+                .as_deref()
+                .and_then(|s| WaitpointId::parse(s).ok());
+
+            // PG outbox does not yet persist the delivery effect or a
+            // dedup flag; treat every delivered row as `Satisfied`.
+            // When the outbox gains an `effect` column, map here.
+            let event = SignalDeliveryEvent::new(
+                cursor,
+                execution_id,
+                signal_id,
+                waitpoint_id,
+                decoded.source_identity,
+                SignalDeliveryEffect::Satisfied,
+                TimestampMs::from_millis(decoded.delivered_at_ms),
+            );
             if tx.send(Ok(event)).await.is_err() {
                 return false;
             }

--- a/crates/ff-backend-postgres/tests/subscribe_lease_history.rs
+++ b/crates/ff-backend-postgres/tests/subscribe_lease_history.rs
@@ -1,32 +1,25 @@
-//! RFC-019 Stage B — `PostgresBackend::subscribe_lease_history`
+//! RFC-019 Stage C — `PostgresBackend::subscribe_lease_history`
 //! integration test. Gated on `FF_PG_TEST_URL`.
 //!
 //! Covers:
 //!   * subscribe from the empty cursor tails from "now"
-//!   * synthetic `ff_lease_event` INSERT is observed within 5s
-//!   * `StreamEvent::cursor` round-trips through
+//!   * synthetic `ff_lease_event` INSERT is observed within 5s as a
+//!     typed `LeaseHistoryEvent::Acquired`
+//!   * `LeaseHistoryEvent::cursor()` round-trips through
 //!     `decode_postgres_event_cursor`
-//!
-//! Per-test isolation mirrors `suspend_signal.rs` — we apply the
-//! workspace migrations to `public`, then lean on the global
-//! `ff_lease_event` outbox directly (no per-test table shadow
-//! needed since the partition_key filter already narrows reads to
-//! the test's partition + synthetic event_id is unique per run).
+//!   * cursor resume across subscribe calls
 
 use ff_backend_postgres::{apply_migrations, PostgresBackend};
 use ff_core::engine_backend::EngineBackend;
 use ff_core::partition::PartitionConfig;
-use ff_core::stream_subscribe::{decode_postgres_event_cursor, StreamCursor, StreamFamily};
+use ff_core::stream_events::LeaseHistoryEvent;
+use ff_core::stream_subscribe::{decode_postgres_event_cursor, StreamCursor};
 use futures::StreamExt;
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
 
 async fn setup_or_skip() -> Option<sqlx::PgPool> {
     let url = std::env::var("FF_PG_TEST_URL").ok()?;
-    // The subscriber loop holds a dedicated `PgListener` connection
-    // for the duration of the subscription. The bootstrap pool
-    // serves both the backend's catch-up queries AND the test's
-    // direct INSERTs, so we need enough capacity for all three.
     let bootstrap = PgPoolOptions::new()
         .max_connections(8)
         .connect(&url)
@@ -40,7 +33,7 @@ async fn setup_or_skip() -> Option<sqlx::PgPool> {
 
 #[tokio::test]
 #[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
-async fn subscribe_lease_history_yields_inserted_event() {
+async fn subscribe_lease_history_yields_typed_acquired_event() {
     let Some(pool) = setup_or_skip().await else {
         eprintln!("FF_PG_TEST_URL not set — skipping");
         return;
@@ -48,19 +41,13 @@ async fn subscribe_lease_history_yields_inserted_event() {
 
     let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
 
-    // Empty cursor → start from tail.
     let mut stream = backend
         .subscribe_lease_history(StreamCursor::empty())
         .await
         .expect("subscribe");
 
-    // Give the LISTEN task a beat to register before we INSERT so
-    // the NOTIFY is actually observed (catch-up replay will also
-    // pick it up regardless).
     tokio::time::sleep(Duration::from_millis(150)).await;
 
-    // Insert a synthetic lease-event row at partition 0 (the
-    // subscription is partition-scoped to 0 per the impl).
     let test_uuid = uuid::Uuid::new_v4();
     sqlx::query(
         "INSERT INTO ff_lease_event \
@@ -73,29 +60,30 @@ async fn subscribe_lease_history_yields_inserted_event() {
     .await
     .expect("insert synthetic event");
 
-    // Poll the stream for up to 5s for the event to arrive.
     let event = tokio::time::timeout(Duration::from_secs(5), stream.next())
         .await
         .expect("timeout waiting for event")
         .expect("stream ended")
         .expect("stream error");
 
-    assert_eq!(event.family, StreamFamily::LeaseHistory);
-    assert_eq!(event.timestamp.0, 1_700_000_000_000);
+    match &event {
+        LeaseHistoryEvent::Acquired {
+            execution_id,
+            lease_id,
+            at,
+            ..
+        } => {
+            assert_eq!(execution_id.to_string(), format!("{{fp:0}}:{test_uuid}"));
+            assert!(lease_id.is_none(), "PG outbox does not persist lease_id");
+            assert_eq!(at.0, 1_700_000_000_000);
+        }
+        other => panic!("expected LeaseHistoryEvent::Acquired, got {other:?}"),
+    }
 
-    // Cursor decodes under the Postgres prefix and carries a
-    // non-zero event_id.
-    let decoded =
-        decode_postgres_event_cursor(&event.cursor).expect("cursor decode").expect("some event_id");
+    let decoded = decode_postgres_event_cursor(event.cursor())
+        .expect("cursor decode")
+        .expect("some event_id");
     assert!(decoded > 0, "event_id should be positive, got {decoded}");
-
-    // Payload is the JSON body the subscriber emits.
-    let payload_str = std::str::from_utf8(&event.payload).expect("utf8");
-    assert!(payload_str.contains("\"acquired\""), "payload: {payload_str}");
-    assert!(
-        payload_str.contains(&test_uuid.to_string()),
-        "payload: {payload_str}"
-    );
 }
 
 #[tokio::test]
@@ -106,17 +94,13 @@ async fn subscribe_lease_history_cursor_resume() {
     };
     let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
 
-    // Read the current tail so we skip any pre-existing rows from
-    // earlier runs of the test DB — the outbox is global + the
-    // bigserial event_id monotonically climbs, so a cursor at
-    // `max(event_id)` before our INSERTs strictly isolates this run.
-    let tail: i64 =
-        sqlx::query_scalar("SELECT COALESCE(MAX(event_id), 0) FROM ff_lease_event WHERE partition_key = 0")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+    let tail: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(event_id), 0) FROM ff_lease_event WHERE partition_key = 0",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
 
-    // Insert two events.
     let uid_a = uuid::Uuid::new_v4();
     sqlx::query(
         "INSERT INTO ff_lease_event \
@@ -141,8 +125,6 @@ async fn subscribe_lease_history_cursor_resume() {
     .await
     .unwrap();
 
-    // Subscribe from the pre-test tail → the first drain of replay
-    // yields the `acquired` event.
     let start_cursor = ff_core::stream_subscribe::encode_postgres_event_cursor(tail);
     let mut stream = backend
         .subscribe_lease_history(start_cursor)
@@ -154,15 +136,14 @@ async fn subscribe_lease_history_cursor_resume() {
         .expect("timeout #1")
         .expect("stream ended")
         .expect("err");
-    let first_payload = std::str::from_utf8(&first.payload).unwrap();
-    assert!(
-        first_payload.contains("\"acquired\"") && first_payload.contains(&uid_a.to_string()),
-        "first payload: {first_payload}"
-    );
+    match &first {
+        LeaseHistoryEvent::Acquired { execution_id, .. } => {
+            assert_eq!(execution_id.to_string(), format!("{{fp:0}}:{uid_a}"));
+        }
+        other => panic!("expected Acquired(uid_a), got {other:?}"),
+    }
 
-    // Resume from the first cursor → only the `renewed` event
-    // should land next.
-    let resume_cursor = first.cursor.clone();
+    let resume_cursor = first.cursor().clone();
     drop(stream);
 
     let mut stream2 = backend
@@ -175,10 +156,11 @@ async fn subscribe_lease_history_cursor_resume() {
         .expect("stream ended")
         .expect("err");
 
-    assert_ne!(second.cursor, resume_cursor, "cursor must advance");
-    let payload = std::str::from_utf8(&second.payload).unwrap();
-    assert!(
-        payload.contains("\"renewed\"") && payload.contains(&uid_b.to_string()),
-        "second payload: {payload}"
-    );
+    assert_ne!(second.cursor(), &resume_cursor, "cursor must advance");
+    match &second {
+        LeaseHistoryEvent::Renewed { execution_id, .. } => {
+            assert_eq!(execution_id.to_string(), format!("{{fp:0}}:{uid_b}"));
+        }
+        other => panic!("expected Renewed(uid_b), got {other:?}"),
+    }
 }

--- a/crates/ff-backend-postgres/tests/subscribe_signal_delivery.rs
+++ b/crates/ff-backend-postgres/tests/subscribe_signal_delivery.rs
@@ -1,18 +1,15 @@
-//! RFC-019 Stage B — `PostgresBackend::subscribe_signal_delivery`
+//! RFC-019 Stage C — `PostgresBackend::subscribe_signal_delivery`
 //! integration test. Gated on `FF_PG_TEST_URL`.
 //!
 //! Mirrors `subscribe_lease_history.rs`: synthetic direct-INSERT into
 //! `ff_signal_event` to exercise the LISTEN + catch-up paths without
-//! dragging the full HMAC + suspension state machine into scope. The
-//! producer-side INSERT at the end of `deliver_signal_impl` is covered
-//! by the `suspend_signal` suite (which still passes — it does not
-//! assert on `ff_signal_event` but fails loudly if the INSERT is
-//! broken).
+//! dragging the full HMAC + suspension state machine into scope.
 
 use ff_backend_postgres::{apply_migrations, PostgresBackend};
 use ff_core::engine_backend::EngineBackend;
 use ff_core::partition::PartitionConfig;
-use ff_core::stream_subscribe::{decode_postgres_event_cursor, StreamCursor, StreamFamily};
+use ff_core::stream_events::SignalDeliveryEffect;
+use ff_core::stream_subscribe::{decode_postgres_event_cursor, StreamCursor};
 use futures::StreamExt;
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -32,7 +29,7 @@ async fn setup_or_skip() -> Option<sqlx::PgPool> {
 
 #[tokio::test]
 #[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
-async fn subscribe_signal_delivery_yields_inserted_event() {
+async fn subscribe_signal_delivery_yields_typed_event() {
     let Some(pool) = setup_or_skip().await else {
         eprintln!("FF_PG_TEST_URL not set — skipping");
         return;
@@ -48,16 +45,16 @@ async fn subscribe_signal_delivery_yields_inserted_event() {
     tokio::time::sleep(Duration::from_millis(150)).await;
 
     let exec_uuid = uuid::Uuid::new_v4();
-    let sid = uuid::Uuid::new_v4().to_string();
-    let wp = uuid::Uuid::new_v4().to_string();
+    let sid = uuid::Uuid::new_v4();
+    let wp = uuid::Uuid::new_v4();
     sqlx::query(
         "INSERT INTO ff_signal_event \
          (execution_id, signal_id, waitpoint_id, source_identity, delivered_at_ms, partition_key) \
          VALUES ($1, $2, $3, 'unit-test', $4, 0)",
     )
     .bind(exec_uuid.to_string())
-    .bind(&sid)
-    .bind(&wp)
+    .bind(sid.to_string())
+    .bind(wp.to_string())
     .bind(1_700_000_000_000_i64)
     .execute(&pool)
     .await
@@ -69,17 +66,17 @@ async fn subscribe_signal_delivery_yields_inserted_event() {
         .expect("stream ended")
         .expect("stream error");
 
-    assert_eq!(event.family, StreamFamily::SignalDelivery);
-    assert_eq!(event.timestamp.0, 1_700_000_000_000);
+    assert_eq!(event.execution_id.to_string(), format!("{{fp:0}}:{exec_uuid}"));
+    assert_eq!(event.signal_id.0, sid);
+    assert_eq!(event.waitpoint_id.as_ref().map(|w| w.0), Some(wp));
+    assert_eq!(event.source_identity.as_deref(), Some("unit-test"));
+    assert_eq!(event.effect, SignalDeliveryEffect::Satisfied);
+    assert_eq!(event.at.0, 1_700_000_000_000);
 
     let decoded = decode_postgres_event_cursor(&event.cursor)
         .expect("cursor decode")
         .expect("some event_id");
     assert!(decoded > 0, "event_id should be positive, got {decoded}");
-
-    let payload_str = std::str::from_utf8(&event.payload).expect("utf8");
-    assert!(payload_str.contains(&sid), "payload missing signal_id: {payload_str}");
-    assert!(payload_str.contains(&wp), "payload missing waitpoint_id: {payload_str}");
 }
 
 #[tokio::test]
@@ -98,27 +95,27 @@ async fn subscribe_signal_delivery_cursor_resume() {
     .unwrap();
 
     let exec_uuid = uuid::Uuid::new_v4();
-    let sid_a = uuid::Uuid::new_v4().to_string();
+    let sid_a = uuid::Uuid::new_v4();
     sqlx::query(
         "INSERT INTO ff_signal_event \
          (execution_id, signal_id, waitpoint_id, source_identity, delivered_at_ms, partition_key) \
          VALUES ($1, $2, NULL, NULL, $3, 0)",
     )
     .bind(exec_uuid.to_string())
-    .bind(&sid_a)
+    .bind(sid_a.to_string())
     .bind(1_700_000_000_001_i64)
     .execute(&pool)
     .await
     .unwrap();
 
-    let sid_b = uuid::Uuid::new_v4().to_string();
+    let sid_b = uuid::Uuid::new_v4();
     sqlx::query(
         "INSERT INTO ff_signal_event \
          (execution_id, signal_id, waitpoint_id, source_identity, delivered_at_ms, partition_key) \
          VALUES ($1, $2, NULL, NULL, $3, 0)",
     )
     .bind(exec_uuid.to_string())
-    .bind(&sid_b)
+    .bind(sid_b.to_string())
     .bind(1_700_000_000_002_i64)
     .execute(&pool)
     .await
@@ -135,8 +132,7 @@ async fn subscribe_signal_delivery_cursor_resume() {
         .expect("timeout #1")
         .expect("stream ended")
         .expect("err");
-    let first_payload = std::str::from_utf8(&first.payload).unwrap();
-    assert!(first_payload.contains(&sid_a), "first: {first_payload}");
+    assert_eq!(first.signal_id.0, sid_a);
 
     let resume_cursor = first.cursor.clone();
     drop(stream);
@@ -152,6 +148,5 @@ async fn subscribe_signal_delivery_cursor_resume() {
         .expect("err");
 
     assert_ne!(second.cursor, resume_cursor, "cursor must advance");
-    let payload = std::str::from_utf8(&second.payload).unwrap();
-    assert!(payload.contains(&sid_b), "second: {payload}");
+    assert_eq!(second.signal_id.0, sid_b);
 }

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -62,3 +62,9 @@ bytes = { workspace = true }
 # `ff-server::Server::rotate_waitpoint_secret` per §4 row 11).
 futures = { workspace = true }
 serde = { workspace = true }
+
+[dev-dependencies]
+# RFC-019 Stage C — integration tests construct synthetic events with
+# real UUIDs so the typed-event decoder asserts on the exact ids we
+# wrote back.
+uuid = { workspace = true }

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -6355,7 +6355,7 @@ impl EngineBackend for ValkeyBackend {
     async fn subscribe_lease_history(
         &self,
         cursor: ff_core::stream_subscribe::StreamCursor,
-    ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<ff_core::stream_events::LeaseHistorySubscription, EngineError> {
         subscribe_lease_history_impl(&self.client, cursor).await
     }
 
@@ -6367,7 +6367,7 @@ impl EngineBackend for ValkeyBackend {
     async fn subscribe_signal_delivery(
         &self,
         cursor: ff_core::stream_subscribe::StreamCursor,
-    ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<ff_core::stream_events::SignalDeliverySubscription, EngineError> {
         subscribe_signal_delivery_impl(&self.client, cursor).await
     }
 
@@ -6392,8 +6392,9 @@ impl EngineBackend for ValkeyBackend {
     async fn subscribe_completion(
         &self,
         _cursor: ff_core::stream_subscribe::StreamCursor,
-    ) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
-        use ff_core::stream_subscribe::{StreamCursor, StreamEvent, StreamFamily};
+    ) -> Result<ff_core::stream_events::CompletionSubscription, EngineError> {
+        use ff_core::stream_events::{CompletionEvent, CompletionOutcome};
+        use ff_core::stream_subscribe::StreamCursor;
         use futures_core::Stream;
         use std::pin::Pin;
         use std::task::{Context, Poll};
@@ -6416,7 +6417,7 @@ impl EngineBackend for ValkeyBackend {
         }
 
         impl Stream for Adapter {
-            type Item = Result<StreamEvent, EngineError>;
+            type Item = Result<CompletionEvent, EngineError>;
             fn poll_next(
                 mut self: Pin<&mut Self>,
                 cx: &mut Context<'_>,
@@ -6440,13 +6441,12 @@ impl EngineBackend for ValkeyBackend {
                         })))
                     }
                     Poll::Ready(Some(payload)) => {
-                        let event = StreamEvent::new(
-                            StreamFamily::Completion,
+                        let event = CompletionEvent::new(
                             StreamCursor::empty(),
+                            payload.execution_id,
+                            CompletionOutcome::from_wire(&payload.outcome),
                             payload.produced_at_ms,
-                            bytes::Bytes::from(payload.outcome.into_bytes()),
-                        )
-                        .with_execution_id(payload.execution_id);
+                        );
                         Poll::Ready(Some(Ok(event)))
                     }
                 }
@@ -6480,14 +6480,13 @@ pub fn partition_signal_delivery_key(partition: &Partition) -> String {
 
 /// Valkey-side `subscribe_signal_delivery` — mirror of
 /// `subscribe_lease_history_impl`, swapped to the signal-delivery
-/// stream key + `StreamFamily::SignalDelivery`.
+/// stream key + typed `SignalDeliveryEvent` decoding.
 async fn subscribe_signal_delivery_impl(
     client: &ferriskey::Client,
     start_cursor: ff_core::stream_subscribe::StreamCursor,
-) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
-    use ff_core::stream_subscribe::{
-        decode_valkey_cursor, encode_valkey_cursor, StreamEvent, StreamFamily,
-    };
+) -> Result<ff_core::stream_events::SignalDeliverySubscription, EngineError> {
+    use ff_core::stream_events::SignalDeliveryEvent;
+    use ff_core::stream_subscribe::{decode_valkey_cursor, encode_valkey_cursor};
     use tokio_stream::wrappers::ReceiverStream;
 
     let start = decode_valkey_cursor(&start_cursor)
@@ -6509,7 +6508,7 @@ async fn subscribe_signal_delivery_impl(
     let stream_key = partition_signal_delivery_key(&partition);
 
     let (tx, rx) = tokio::sync::mpsc::channel::<
-        Result<StreamEvent, EngineError>,
+        Result<SignalDeliveryEvent, EngineError>,
     >(64);
 
     tokio::spawn(async move {
@@ -6565,12 +6564,23 @@ async fn subscribe_signal_delivery_impl(
                 let cursor = encode_valkey_cursor(id_ms, id_seq);
                 last_cursor = cursor.clone();
                 last_id = format!("{id_ms}-{id_seq}");
-                let event = StreamEvent::new(
-                    StreamFamily::SignalDelivery,
+                let fields = decode_nul_field_blob(&payload);
+                let event = match decode_signal_delivery_event(
+                    &fields,
                     cursor,
-                    TimestampMs::from_millis(id_ms as i64),
-                    payload,
-                );
+                    id_ms,
+                ) {
+                    Ok(ev) => ev,
+                    Err(detail) => {
+                        let _ = tx
+                            .send(Err(EngineError::Validation {
+                                kind: ValidationKind::Corruption,
+                                detail,
+                            }))
+                            .await;
+                        continue;
+                    }
+                };
                 if tx.send(Ok(event)).await.is_err() {
                     return;
                 }
@@ -6586,10 +6596,9 @@ async fn subscribe_signal_delivery_impl(
 async fn subscribe_lease_history_impl(
     client: &ferriskey::Client,
     start_cursor: ff_core::stream_subscribe::StreamCursor,
-) -> Result<ff_core::stream_subscribe::StreamSubscription, EngineError> {
-    use ff_core::stream_subscribe::{
-        decode_valkey_cursor, encode_valkey_cursor, StreamEvent, StreamFamily,
-    };
+) -> Result<ff_core::stream_events::LeaseHistorySubscription, EngineError> {
+    use ff_core::stream_events::LeaseHistoryEvent;
+    use ff_core::stream_subscribe::{decode_valkey_cursor, encode_valkey_cursor};
     use tokio_stream::wrappers::ReceiverStream;
 
     // Validate the cursor up front so caller bugs surface loudly at
@@ -6625,7 +6634,7 @@ async fn subscribe_lease_history_impl(
     // the owner-adjudicated "pull via Stream" backpressure shape
     // (RFC-019 §Open Questions #3).
     let (tx, rx) = tokio::sync::mpsc::channel::<
-        Result<StreamEvent, EngineError>,
+        Result<LeaseHistoryEvent, EngineError>,
     >(64);
 
     tokio::spawn(async move {
@@ -6684,12 +6693,23 @@ async fn subscribe_lease_history_impl(
                 let cursor = encode_valkey_cursor(id_ms, id_seq);
                 last_cursor = cursor.clone();
                 last_id = format!("{id_ms}-{id_seq}");
-                let event = StreamEvent::new(
-                    StreamFamily::LeaseHistory,
+                let fields = decode_nul_field_blob(&payload);
+                let event = match decode_lease_history_event(
+                    &fields,
                     cursor,
-                    TimestampMs::from_millis(id_ms as i64),
-                    payload,
-                );
+                    id_ms,
+                ) {
+                    Ok(ev) => ev,
+                    Err(detail) => {
+                        let _ = tx
+                            .send(Err(EngineError::Validation {
+                                kind: ValidationKind::Corruption,
+                                detail,
+                            }))
+                            .await;
+                        continue;
+                    }
+                };
                 if tx.send(Ok(event)).await.is_err() {
                     // Consumer dropped the stream.
                     return;
@@ -6879,6 +6899,186 @@ fn encode_fields_blob(v: &ferriskey::Value) -> bytes::Bytes {
         _ => {}
     }
     bytes::Bytes::from(buf)
+}
+
+/// Parse the NUL-delimited `k\0v\0k\0v\0…` payload blob
+/// `parse_lease_history_xread` produces back into a field map.
+///
+/// Non-UTF-8 keys/values are lossy-decoded — Lua producers only emit
+/// ASCII field names + text values (uuids, ms timestamps, enum strings).
+fn decode_nul_field_blob(
+    blob: &bytes::Bytes,
+) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    let mut it = blob.split(|b| *b == 0u8);
+    while let (Some(k), Some(v)) = (it.next(), it.next()) {
+        if k.is_empty() && v.is_empty() {
+            // Trailing NUL pair after the last entry.
+            continue;
+        }
+        let k = String::from_utf8_lossy(k).into_owned();
+        let v = String::from_utf8_lossy(v).into_owned();
+        out.insert(k, v);
+    }
+    out
+}
+
+/// Decode a parsed `lease_history` XREAD entry into a
+/// `LeaseHistoryEvent`. Producer shapes live in `lua/lease.lua`,
+/// `lua/execution.lua`, `lua/helpers.lua` — acquired / renewed /
+/// expired / reclaimed / revoked.
+fn decode_lease_history_event(
+    fields: &std::collections::HashMap<String, String>,
+    cursor: ff_core::stream_subscribe::StreamCursor,
+    id_ms: u64,
+) -> Result<ff_core::stream_events::LeaseHistoryEvent, String> {
+    use ff_core::stream_events::LeaseHistoryEvent;
+    use ff_core::types::{ExecutionId, LeaseId, WorkerInstanceId};
+
+    let event_name = fields
+        .get("event")
+        .ok_or_else(|| "lease_history: missing `event` field".to_string())?
+        .as_str();
+
+    let at = {
+        // Prefer the Lua-stamped `ts`; fall back to the stream id's ms
+        // component. `ts` may carry a floating-point formatting artifact
+        // from `tostring(now_ms)` on some Lua versions, so parse loosely.
+        let ts_ms = fields
+            .get("ts")
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(id_ms as i64);
+        TimestampMs::from_millis(ts_ms)
+    };
+
+    let execution_id = fields
+        .get("execution_id")
+        .ok_or_else(|| "lease_history: missing `execution_id`".to_string())
+        .and_then(|s| {
+            ExecutionId::parse(s)
+                .map_err(|e| format!("lease_history: bad execution_id `{s}`: {e}"))
+        })?;
+
+    let parse_lease = |key: &str| -> Option<LeaseId> {
+        fields
+            .get(key)
+            .filter(|s| !s.is_empty())
+            .and_then(|s| LeaseId::parse(s).ok())
+    };
+    let worker_instance = fields
+        .get("worker_instance_id")
+        .filter(|s| !s.is_empty())
+        .map(|s| WorkerInstanceId::new(s.clone()));
+
+    let event = match event_name {
+        "acquired" => LeaseHistoryEvent::Acquired {
+            cursor,
+            execution_id,
+            lease_id: parse_lease("lease_id")
+                .ok_or_else(|| "lease_history: acquired missing lease_id".to_string())?,
+            worker_instance_id: worker_instance,
+            at,
+        },
+        "renewed" => LeaseHistoryEvent::Renewed {
+            cursor,
+            execution_id,
+            lease_id: parse_lease("lease_id")
+                .ok_or_else(|| "lease_history: renewed missing lease_id".to_string())?,
+            worker_instance_id: worker_instance,
+            at,
+        },
+        "expired" => LeaseHistoryEvent::Expired {
+            cursor,
+            execution_id,
+            lease_id: parse_lease("lease_id"),
+            prev_owner: worker_instance,
+            at,
+        },
+        "reclaimed" => LeaseHistoryEvent::Reclaimed {
+            cursor,
+            execution_id,
+            new_lease_id: parse_lease("new_lease_id")
+                .or_else(|| parse_lease("lease_id"))
+                .ok_or_else(|| {
+                    "lease_history: reclaimed missing new_lease_id".to_string()
+                })?,
+            new_owner: worker_instance,
+            at,
+        },
+        "revoked" => LeaseHistoryEvent::Revoked {
+            cursor,
+            execution_id,
+            lease_id: parse_lease("lease_id"),
+            revoked_by: fields
+                .get("reason")
+                .cloned()
+                .unwrap_or_else(|| "operator".to_string()),
+            at,
+        },
+        other => {
+            return Err(format!(
+                "lease_history: unknown event variant `{other}`"
+            ));
+        }
+    };
+    Ok(event)
+}
+
+/// Decode a parsed `signal_delivery` XREAD entry. Producer is
+/// `lua/signal.lua::ff_deliver_signal` (see KEYS[15]).
+fn decode_signal_delivery_event(
+    fields: &std::collections::HashMap<String, String>,
+    cursor: ff_core::stream_subscribe::StreamCursor,
+    id_ms: u64,
+) -> Result<ff_core::stream_events::SignalDeliveryEvent, String> {
+    use ff_core::stream_events::{SignalDeliveryEffect, SignalDeliveryEvent};
+    use ff_core::types::{ExecutionId, SignalId, WaitpointId};
+
+    let execution_id = fields
+        .get("execution_id")
+        .ok_or_else(|| "signal_delivery: missing `execution_id`".to_string())
+        .and_then(|s| {
+            ExecutionId::parse(s)
+                .map_err(|e| format!("signal_delivery: bad execution_id `{s}`: {e}"))
+        })?;
+
+    let signal_id = fields
+        .get("signal_id")
+        .ok_or_else(|| "signal_delivery: missing `signal_id`".to_string())
+        .and_then(|s| {
+            SignalId::parse(s).map_err(|e| format!("signal_delivery: bad signal_id `{s}`: {e}"))
+        })?;
+
+    let waitpoint_id = fields
+        .get("waitpoint_id")
+        .filter(|s| !s.is_empty())
+        .and_then(|s| WaitpointId::parse(s).ok());
+
+    let source_identity = fields
+        .get("source_identity")
+        .filter(|s| !s.is_empty())
+        .cloned();
+
+    let effect = fields
+        .get("effect")
+        .map(|s| SignalDeliveryEffect::from_wire(s))
+        .unwrap_or(SignalDeliveryEffect::Satisfied);
+
+    let at = fields
+        .get("delivered_at_ms")
+        .and_then(|s| s.parse::<i64>().ok())
+        .map(TimestampMs::from_millis)
+        .unwrap_or_else(|| TimestampMs::from_millis(id_ms as i64));
+
+    Ok(SignalDeliveryEvent::new(
+        cursor,
+        execution_id,
+        signal_id,
+        waitpoint_id,
+        source_identity,
+        effect,
+        at,
+    ))
 }
 
 /// Detect Valkey errors indicating the Lua function library is not

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -6974,16 +6974,14 @@ fn decode_lease_history_event(
         "acquired" => LeaseHistoryEvent::Acquired {
             cursor,
             execution_id,
-            lease_id: parse_lease("lease_id")
-                .ok_or_else(|| "lease_history: acquired missing lease_id".to_string())?,
+            lease_id: parse_lease("lease_id"),
             worker_instance_id: worker_instance,
             at,
         },
         "renewed" => LeaseHistoryEvent::Renewed {
             cursor,
             execution_id,
-            lease_id: parse_lease("lease_id")
-                .ok_or_else(|| "lease_history: renewed missing lease_id".to_string())?,
+            lease_id: parse_lease("lease_id"),
             worker_instance_id: worker_instance,
             at,
         },
@@ -6997,11 +6995,7 @@ fn decode_lease_history_event(
         "reclaimed" => LeaseHistoryEvent::Reclaimed {
             cursor,
             execution_id,
-            new_lease_id: parse_lease("new_lease_id")
-                .or_else(|| parse_lease("lease_id"))
-                .ok_or_else(|| {
-                    "lease_history: reclaimed missing new_lease_id".to_string()
-                })?,
+            new_lease_id: parse_lease("new_lease_id").or_else(|| parse_lease("lease_id")),
             new_owner: worker_instance,
             at,
         },

--- a/crates/ff-backend-valkey/tests/subscribe_completion.rs
+++ b/crates/ff-backend-valkey/tests/subscribe_completion.rs
@@ -24,7 +24,8 @@ use std::time::Duration;
 
 use ff_backend_valkey::{ValkeyBackend, COMPLETION_CHANNEL};
 use ff_core::backend::BackendConfig;
-use ff_core::stream_subscribe::{StreamCursor, StreamFamily};
+use ff_core::stream_events::CompletionOutcome;
+use ff_core::stream_subscribe::StreamCursor;
 use futures_core::Stream;
 use tokio::time::timeout;
 
@@ -86,27 +87,18 @@ async fn subscribe_completion_yields_publish_frame() {
         .expect("stream ended unexpectedly")
         .expect("backend surfaced error before event");
 
-    assert_eq!(
-        event.family,
-        StreamFamily::Completion,
-        "event family mismatch"
-    );
     assert!(
         event.cursor.as_bytes().is_empty(),
         "Stage B cursor must be the empty sentinel (pubsub-backed, non-durable)"
     );
     assert_eq!(
-        event
-            .execution_id
-            .as_ref()
-            .map(std::string::ToString::to_string)
-            .as_deref(),
-        Some(exec_id),
+        event.execution_id.to_string(),
+        exec_id,
         "execution_id should round-trip"
     );
     assert_eq!(
-        event.payload.as_ref(),
-        b"success",
-        "payload should carry the outcome string"
+        event.outcome,
+        CompletionOutcome::Success,
+        "outcome should typed-decode to Success"
     );
 }

--- a/crates/ff-backend-valkey/tests/subscribe_lease_history.rs
+++ b/crates/ff-backend-valkey/tests/subscribe_lease_history.rs
@@ -1,5 +1,5 @@
-//! RFC-019 Stage A integration test — `subscribe_lease_history` on the
-//! Valkey backend.
+//! RFC-019 Stage C integration test — typed `subscribe_lease_history`
+//! on the Valkey backend.
 //!
 //! Gated `#[ignore]` because it requires a live Valkey at
 //! `localhost:6379` (the default deployment used by the project's
@@ -13,21 +13,22 @@
 //! The test:
 //! 1. Dials the backend + takes the `subscribe_lease_history` stream
 //!    with an empty cursor ("tail from now").
-//! 2. Writes a synthetic lease-history event via raw `XADD` on the
-//!    partition-level aggregate stream key
+//! 2. Writes a synthetic `reclaimed` lease-history event via raw
+//!    `XADD` on the partition-level aggregate stream key
 //!    (`ff:part:{fp:0}:lease_history`).
-//! 3. Asserts the subscription yields the event inside a 10-second
-//!    window. Times out with a clear message otherwise so CI
-//!    failures are obvious.
+//! 3. Asserts the subscription yields a
+//!    `LeaseHistoryEvent::Reclaimed` inside a 10-second window.
 
 use std::time::Duration;
 
 use ff_backend_valkey::{partition_lease_history_key, ValkeyBackend};
 use ff_core::backend::BackendConfig;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::stream_events::LeaseHistoryEvent;
 use ff_core::stream_subscribe::StreamCursor;
 use futures_core::Stream;
 use tokio::time::timeout;
+use uuid::Uuid;
 
 /// Poll `.next()` on a pinned stream without dragging in `futures`.
 async fn next_item<S>(stream: &mut S) -> Option<S::Item>
@@ -39,31 +40,19 @@ where
 
 #[tokio::test]
 #[ignore = "requires live Valkey at localhost:6379"]
-async fn subscribe_lease_history_yields_xadd_entry() {
-    // Dial the backend. `BackendConfig::valkey("localhost", 6379)` is
-    // the project-default smoke target; every in-tree live-Valkey
-    // test uses the same shape.
+async fn subscribe_lease_history_yields_typed_reclaimed_event() {
     let backend = ValkeyBackend::connect(BackendConfig::valkey("localhost", 6379))
         .await
         .expect("connect to localhost valkey");
 
-    // Open the subscription with an empty cursor → tail from now
-    // (XREAD `$`). We then XADD a synthetic event and expect to
-    // observe it.
     let mut sub = backend
         .subscribe_lease_history(StreamCursor::empty())
         .await
         .expect("subscribe_lease_history");
 
-    // Give the XREAD BLOCK loop a moment to register before writing.
-    // Without this the XADD can land before the subscriber advances
-    // past `$`, which would strand the test on a no-event BLOCK
-    // timeout.
+    // Let XREAD BLOCK register before we write.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // Dial a *second* client just to XADD; `ValkeyBackend::connect`
-    // returns an `Arc<dyn EngineBackend>` that does not expose the
-    // raw ferriskey client, so the test opens its own connection.
     let writer = ferriskey::ClientBuilder::new()
         .host("localhost", 6379)
         .build()
@@ -76,60 +65,59 @@ async fn subscribe_lease_history_yields_xadd_entry() {
     };
     let stream_key = partition_lease_history_key(&partition);
 
-    // XADD <key> * event reclaimed lease_id test-lease-rfc019 prev_owner
-    // test-worker at "unit-test"
+    let exec_uuid = Uuid::new_v4();
+    let execution_id_str = format!("{{fp:0}}:{exec_uuid}");
+    let lease_uuid = Uuid::new_v4();
+
     let _: ferriskey::Value = writer
         .cmd("XADD")
         .arg(stream_key.as_str())
         .arg("*")
         .arg("event")
         .arg("reclaimed")
-        .arg("lease_id")
-        .arg("test-lease-rfc019")
-        .arg("prev_owner")
-        .arg("test-worker")
-        .arg("at")
-        .arg("unit-test")
+        .arg("execution_id")
+        .arg(execution_id_str.as_str())
+        .arg("new_lease_id")
+        .arg(lease_uuid.to_string().as_str())
+        .arg("worker_instance_id")
+        .arg("worker-test")
+        .arg("ts")
+        .arg("1700000000000")
         .execute()
         .await
         .expect("XADD synthetic lease-history event");
 
-    // Observe the event via the subscription. 10s wall-clock budget
-    // (well above the 5s XREAD BLOCK window + the 200ms sleep).
     let event = timeout(Duration::from_secs(10), next_item(&mut sub))
         .await
         .expect("subscription yielded within 10s")
         .expect("stream ended unexpectedly")
         .expect("backend surfaced error before event");
 
-    assert_eq!(
-        event.family,
-        ff_core::stream_subscribe::StreamFamily::LeaseHistory,
-        "event family mismatch"
-    );
-    assert!(
-        !event.cursor.as_bytes().is_empty(),
-        "event cursor should be concrete (non-empty)"
-    );
-    // Cursor must start with the Valkey family prefix.
-    assert_eq!(
-        event.cursor.as_bytes()[0],
-        ff_core::stream_subscribe::VALKEY_CURSOR_PREFIX,
-        "cursor prefix must be VALKEY_CURSOR_PREFIX (0x01)"
-    );
-    // Payload is an opaque NUL-delimited FIELD\0VALUE\0... blob in
-    // Stage A; assert the event tag round-tripped by bytes-contains
-    // (schema is Stage-B territory).
-    assert!(
-        event
-            .payload
-            .windows(b"reclaimed".len())
-            .any(|w| w == b"reclaimed"),
-        "payload should contain the synthetic `event=reclaimed` field; got {:?}",
-        event.payload
-    );
+    match event {
+        LeaseHistoryEvent::Reclaimed {
+            cursor,
+            execution_id,
+            new_lease_id,
+            new_owner,
+            at,
+        } => {
+            assert_eq!(
+                cursor.as_bytes()[0],
+                ff_core::stream_subscribe::VALKEY_CURSOR_PREFIX,
+                "cursor prefix must be VALKEY_CURSOR_PREFIX (0x01)"
+            );
+            assert_eq!(execution_id.to_string(), execution_id_str);
+            assert_eq!(new_lease_id.as_ref().map(|l| l.0), Some(lease_uuid));
+            assert_eq!(
+                new_owner.as_ref().map(|w| w.as_str()),
+                Some("worker-test")
+            );
+            assert_eq!(at.0, 1_700_000_000_000);
+        }
+        other => panic!("expected LeaseHistoryEvent::Reclaimed, got {other:?}"),
+    }
 
-    // Cleanup: trim the synthetic entry so the next run starts clean.
+    // Cleanup.
     let _: ferriskey::Value = writer
         .cmd("DEL")
         .arg(stream_key.as_str())

--- a/crates/ff-backend-valkey/tests/subscribe_signal_delivery.rs
+++ b/crates/ff-backend-valkey/tests/subscribe_signal_delivery.rs
@@ -1,9 +1,9 @@
-//! RFC-019 Stage B integration test — `subscribe_signal_delivery` on
-//! the Valkey backend (#310).
+//! RFC-019 Stage C integration test — typed `subscribe_signal_delivery`
+//! on the Valkey backend (#310).
 //!
 //! Gated `#[ignore]` because it requires a live Valkey at
 //! `localhost:6379`. Mirrors `subscribe_lease_history.rs`: subscribe
-//! + synthetic XADD + observe.
+//! + synthetic XADD + observe a typed `SignalDeliveryEvent`.
 //!
 //! Run with:
 //! ```
@@ -17,9 +17,11 @@ use std::time::Duration;
 use ff_backend_valkey::{partition_signal_delivery_key, ValkeyBackend};
 use ff_core::backend::BackendConfig;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::stream_events::SignalDeliveryEffect;
 use ff_core::stream_subscribe::StreamCursor;
 use futures_core::Stream;
 use tokio::time::timeout;
+use uuid::Uuid;
 
 async fn next_item<S>(stream: &mut S) -> Option<S::Item>
 where
@@ -30,7 +32,7 @@ where
 
 #[tokio::test]
 #[ignore = "requires live Valkey at localhost:6379"]
-async fn subscribe_signal_delivery_yields_xadd_entry() {
+async fn subscribe_signal_delivery_yields_typed_event() {
     let backend = ValkeyBackend::connect(BackendConfig::valkey("localhost", 6379))
         .await
         .expect("connect to localhost valkey");
@@ -40,7 +42,6 @@ async fn subscribe_signal_delivery_yields_xadd_entry() {
         .await
         .expect("subscribe_signal_delivery");
 
-    // Let the XREAD BLOCK loop register before we XADD.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let writer = ferriskey::ClientBuilder::new()
@@ -55,18 +56,25 @@ async fn subscribe_signal_delivery_yields_xadd_entry() {
     };
     let stream_key = partition_signal_delivery_key(&partition);
 
+    let exec_uuid = Uuid::new_v4();
+    let execution_id_str = format!("{{fp:0}}:{exec_uuid}");
+    let signal_uuid = Uuid::new_v4();
+    let waitpoint_uuid = Uuid::new_v4();
+
     let _: ferriskey::Value = writer
         .cmd("XADD")
         .arg(stream_key.as_str())
         .arg("*")
         .arg("signal_id")
-        .arg("sig-rfc019-310")
+        .arg(signal_uuid.to_string().as_str())
         .arg("execution_id")
-        .arg("exec-rfc019-310")
+        .arg(execution_id_str.as_str())
         .arg("waitpoint_id")
-        .arg("wp-rfc019-310")
+        .arg(waitpoint_uuid.to_string().as_str())
+        .arg("source_identity")
+        .arg("test-source")
         .arg("effect")
-        .arg("appended_to_waitpoint")
+        .arg("satisfied")
         .arg("delivered_at_ms")
         .arg("1700000000000")
         .execute()
@@ -80,27 +88,16 @@ async fn subscribe_signal_delivery_yields_xadd_entry() {
         .expect("backend surfaced error before event");
 
     assert_eq!(
-        event.family,
-        ff_core::stream_subscribe::StreamFamily::SignalDelivery,
-        "event family mismatch"
-    );
-    assert!(
-        !event.cursor.as_bytes().is_empty(),
-        "event cursor should be concrete (non-empty)"
-    );
-    assert_eq!(
         event.cursor.as_bytes()[0],
         ff_core::stream_subscribe::VALKEY_CURSOR_PREFIX,
         "cursor prefix must be VALKEY_CURSOR_PREFIX (0x01)"
     );
-    assert!(
-        event
-            .payload
-            .windows(b"sig-rfc019-310".len())
-            .any(|w| w == b"sig-rfc019-310"),
-        "payload should contain the synthetic signal_id; got {:?}",
-        event.payload
-    );
+    assert_eq!(event.signal_id.0, signal_uuid);
+    assert_eq!(event.execution_id.to_string(), execution_id_str);
+    assert_eq!(event.waitpoint_id.as_ref().map(|w| w.0), Some(waitpoint_uuid));
+    assert_eq!(event.source_identity.as_deref(), Some("test-source"));
+    assert_eq!(event.effect, SignalDeliveryEffect::Satisfied);
+    assert_eq!(event.at.0, 1_700_000_000_000);
 
     let _: ferriskey::Value = writer
         .cmd("DEL")

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -1102,24 +1102,21 @@ pub trait EngineBackend: Send + Sync + 'static {
         })
     }
 
-    // ── RFC-019 Stage A — Stream-cursor subscriptions ─────────────
+    // ── RFC-019 Stage A/B/C — Stream-cursor subscriptions ─────────
     //
     // Four owner-adjudicated families (RFC-019 §Open Questions #5):
     // `lease_history`, `completion`, `signal_delivery`,
-    // `instance_tags`. Each returns a `StreamSubscription`
-    // (`Pin<Box<dyn Stream<Item = Result<StreamEvent, EngineError>> +
-    // Send>>`); the consumer drives with `StreamExt::next`.
+    // `instance_tags`. Stage C (this crate) promotes each family to
+    // a typed event enum; consumers `match` on variants instead of
+    // parsing a backend-shaped byte blob.
     //
-    // The cursor is backend-opaque bytes; see
-    // [`crate::stream_subscribe`] for the shared cursor codec + event
-    // payload. All defaults return `EngineError::Unavailable` per
-    // RFC-017 trait-growth conventions. Stage A ships Valkey
-    // `subscribe_lease_history` + Postgres `subscribe_completion`;
-    // the other six (family × backend) combinations stay `Unavailable`
-    // and are tracked in the RFC-019 Stage B follow-up issues.
+    // Each method returns a family-specific subscription alias (see
+    // [`crate::stream_events`]). All defaults return
+    // `EngineError::Unavailable` per RFC-017 trait-growth conventions.
 
-    /// Subscribe to lease lifecycle events (expired / reclaimed /
-    /// revoked) for the partition this backend is configured with.
+    /// Subscribe to lease lifecycle events (acquired / renewed /
+    /// expired / reclaimed / revoked) for the partition this backend
+    /// is configured with.
     ///
     /// Cross-partition fan-out is consumer-side merge: subscribe
     /// per-partition backend instance and interleave on the read
@@ -1130,7 +1127,7 @@ pub trait EngineBackend: Send + Sync + 'static {
     async fn subscribe_lease_history(
         &self,
         _cursor: crate::stream_subscribe::StreamCursor,
-    ) -> Result<crate::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<crate::stream_events::LeaseHistorySubscription, EngineError> {
         Err(EngineError::Unavailable {
             op: "subscribe_lease_history",
         })
@@ -1138,40 +1135,44 @@ pub trait EngineBackend: Send + Sync + 'static {
 
     /// Subscribe to completion events (terminal state transitions).
     ///
-    /// - **Postgres** (RFC-019 Stage A): wraps the `ff_completion_event`
-    ///   outbox + LISTEN/NOTIFY machinery. Durable via event-id cursor.
-    /// - **Valkey** (RFC-019 Stage B, issue #309): wraps the RESP3
-    ///   `ff:dag:completions` pubsub subscriber. Pubsub is at-most-once
-    ///   over the live subscription window; the cursor is always the
-    ///   empty sentinel. If you need at-least-once replay with durable
+    /// - **Postgres**: wraps the `ff_completion_event` outbox +
+    ///   LISTEN/NOTIFY machinery. Durable via event-id cursor.
+    /// - **Valkey**: wraps the RESP3 `ff:dag:completions` pubsub
+    ///   subscriber. Pubsub is at-most-once over the live
+    ///   subscription window; the cursor is always the empty
+    ///   sentinel. If you need at-least-once replay with durable
     ///   cursor resume, use the Postgres backend (see
     ///   `docs/POSTGRES_PARITY_MATRIX.md` row `subscribe_completion`).
     async fn subscribe_completion(
         &self,
         _cursor: crate::stream_subscribe::StreamCursor,
-    ) -> Result<crate::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<crate::stream_events::CompletionSubscription, EngineError> {
         Err(EngineError::Unavailable {
             op: "subscribe_completion",
         })
     }
 
-    /// Subscribe to signal-delivery events (waitpoint arming /
-    /// satisfied). Stage B follow-up.
+    /// Subscribe to signal-delivery events (satisfied / buffered /
+    /// deduped).
     async fn subscribe_signal_delivery(
         &self,
         _cursor: crate::stream_subscribe::StreamCursor,
-    ) -> Result<crate::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<crate::stream_events::SignalDeliverySubscription, EngineError> {
         Err(EngineError::Unavailable {
             op: "subscribe_signal_delivery",
         })
     }
 
     /// Subscribe to instance-tag events (tag attached / cleared).
-    /// Stage B follow-up.
+    ///
+    /// Producer wiring is deferred per #311 audit ("no concrete
+    /// demand"); the trait method exists for API uniformity across
+    /// the four families. Backends currently return
+    /// `EngineError::Unavailable`.
     async fn subscribe_instance_tags(
         &self,
         _cursor: crate::stream_subscribe::StreamCursor,
-    ) -> Result<crate::stream_subscribe::StreamSubscription, EngineError> {
+    ) -> Result<crate::stream_events::InstanceTagSubscription, EngineError> {
         Err(EngineError::Unavailable {
             op: "subscribe_instance_tags",
         })

--- a/crates/ff-core/src/lib.rs
+++ b/crates/ff-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod keys;
 pub mod partition;
 pub mod policy;
 pub mod state;
+pub mod stream_events;
 pub mod stream_subscribe;
 pub mod types;
 pub mod waitpoint_hmac;

--- a/crates/ff-core/src/stream_events.rs
+++ b/crates/ff-core/src/stream_events.rs
@@ -317,3 +317,56 @@ pub enum InstanceTagEvent {
 /// Stream of typed instance-tag events.
 pub type InstanceTagSubscription =
     Pin<Box<dyn Stream<Item = Result<InstanceTagEvent, EngineError>> + Send>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_outcome_wire_round_trip() {
+        assert_eq!(CompletionOutcome::from_wire("success"), CompletionOutcome::Success);
+        assert_eq!(CompletionOutcome::from_wire("failure"), CompletionOutcome::Failure);
+        assert_eq!(CompletionOutcome::from_wire("cancelled"), CompletionOutcome::Cancelled);
+        match CompletionOutcome::from_wire("timed_out") {
+            CompletionOutcome::Other(s) => assert_eq!(s, "timed_out"),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signal_delivery_effect_wire_round_trip() {
+        assert_eq!(
+            SignalDeliveryEffect::from_wire("satisfied"),
+            SignalDeliveryEffect::Satisfied
+        );
+        assert_eq!(
+            SignalDeliveryEffect::from_wire("buffered"),
+            SignalDeliveryEffect::Buffered
+        );
+        assert_eq!(
+            SignalDeliveryEffect::from_wire("deduped"),
+            SignalDeliveryEffect::Deduped
+        );
+        match SignalDeliveryEffect::from_wire("throttled") {
+            SignalDeliveryEffect::Other(s) => assert_eq!(s, "throttled"),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lease_history_event_accessors() {
+        use crate::types::ExecutionId;
+        let cursor = StreamCursor::new(vec![0x01, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 42]);
+        let exec = ExecutionId::parse("{fp:0}:11111111-1111-4111-8111-111111111111").unwrap();
+        let ev = LeaseHistoryEvent::Expired {
+            cursor: cursor.clone(),
+            execution_id: exec.clone(),
+            lease_id: None,
+            prev_owner: None,
+            at: TimestampMs(1_700_000_000_000),
+        };
+        assert_eq!(ev.cursor(), &cursor);
+        assert_eq!(ev.execution_id(), &exec);
+        assert_eq!(ev.at(), TimestampMs(1_700_000_000_000));
+    }
+}

--- a/crates/ff-core/src/stream_events.rs
+++ b/crates/ff-core/src/stream_events.rs
@@ -1,0 +1,262 @@
+//! RFC-019 Stage C — Typed stream events.
+//!
+//! Stage A/B shipped the cursor machinery + backend adapters emitting
+//! `StreamEvent { payload: Bytes, … }`, forcing every consumer to
+//! parse a backend-shaped byte blob (Valkey: NUL-delimited field map,
+//! Postgres: `serde_json`). This module promotes each family to a
+//! typed enum so consumers `match` instead of parsing.
+//!
+//! One enum + one subscription alias per family, paralleling the
+//! four-family allow-list in [`crate::stream_subscribe::StreamFamily`]:
+//!
+//! | Family           | Event enum                 | Subscription alias           |
+//! |------------------|----------------------------|------------------------------|
+//! | LeaseHistory     | [`LeaseHistoryEvent`]      | [`LeaseHistorySubscription`] |
+//! | Completion       | [`CompletionEvent`]        | [`CompletionSubscription`]   |
+//! | SignalDelivery   | [`SignalDeliveryEvent`]    | [`SignalDeliverySubscription`] |
+//! | InstanceTags     | [`InstanceTagEvent`]       | [`InstanceTagSubscription`]  |
+//!
+//! Each event carries the same inline-hot fields the Stage A
+//! `StreamEvent` envelope carried (`cursor`, `execution_id` where
+//! applicable, `timestamp`) plus family-specific fields promoted out
+//! of the old opaque payload.
+//!
+//! `#[non_exhaustive]` is applied to every variant-bearing enum and
+//! every event struct so new variants / fields land additively. The
+//! owner-adjudicated v0.9 four-family allow-list stays in force — new
+//! families require an RFC amendment.
+
+use std::pin::Pin;
+
+use tokio_stream::Stream;
+
+use crate::engine_error::EngineError;
+use crate::stream_subscribe::StreamCursor;
+use crate::types::{ExecutionId, LeaseId, SignalId, TimestampMs, WaitpointId, WorkerInstanceId};
+
+// ─── LeaseHistory ─────────────────────────────────────────────────
+
+/// Per-event payload of `subscribe_lease_history`.
+///
+/// Each variant carries the fence triple fields the Lua producer
+/// writes (`lease_id`, plus attempt/worker correlation where
+/// available) and the monotonic `at` timestamp derived from the
+/// backend's native stream id / event id.
+///
+/// `revoked_by` is `String` today for forward compatibility; we may
+/// promote to a typed enum post-v0.10 once the revocation-source
+/// taxonomy settles. Known producers emit `"operator"`,
+/// `"reconciler"`, or `"backend"` today.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LeaseHistoryEvent {
+    Acquired {
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        lease_id: LeaseId,
+        worker_instance_id: Option<WorkerInstanceId>,
+        at: TimestampMs,
+    },
+    Renewed {
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        lease_id: LeaseId,
+        worker_instance_id: Option<WorkerInstanceId>,
+        at: TimestampMs,
+    },
+    Expired {
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        lease_id: Option<LeaseId>,
+        prev_owner: Option<WorkerInstanceId>,
+        at: TimestampMs,
+    },
+    Reclaimed {
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        new_lease_id: LeaseId,
+        new_owner: Option<WorkerInstanceId>,
+        at: TimestampMs,
+    },
+    Revoked {
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        lease_id: Option<LeaseId>,
+        /// String today for forward compat; may promote to typed
+        /// enum post-v0.10 once taxonomy settles. Known values:
+        /// `"operator"`, `"reconciler"`, `"backend"`.
+        revoked_by: String,
+        at: TimestampMs,
+    },
+}
+
+impl LeaseHistoryEvent {
+    /// Position cursor to persist + replay from.
+    pub fn cursor(&self) -> &StreamCursor {
+        match self {
+            Self::Acquired { cursor, .. }
+            | Self::Renewed { cursor, .. }
+            | Self::Expired { cursor, .. }
+            | Self::Reclaimed { cursor, .. }
+            | Self::Revoked { cursor, .. } => cursor,
+        }
+    }
+
+    /// Execution the event pertains to.
+    pub fn execution_id(&self) -> &ExecutionId {
+        match self {
+            Self::Acquired { execution_id, .. }
+            | Self::Renewed { execution_id, .. }
+            | Self::Expired { execution_id, .. }
+            | Self::Reclaimed { execution_id, .. }
+            | Self::Revoked { execution_id, .. } => execution_id,
+        }
+    }
+
+    /// Monotonic backend-stamped time of the event.
+    pub fn at(&self) -> TimestampMs {
+        match self {
+            Self::Acquired { at, .. }
+            | Self::Renewed { at, .. }
+            | Self::Expired { at, .. }
+            | Self::Reclaimed { at, .. }
+            | Self::Revoked { at, .. } => *at,
+        }
+    }
+}
+
+/// Stream of typed lease-history events.
+pub type LeaseHistorySubscription =
+    Pin<Box<dyn Stream<Item = Result<LeaseHistoryEvent, EngineError>> + Send>>;
+
+// ─── Completion ──────────────────────────────────────────────────
+
+/// Outcome classification for a completion event.
+///
+/// `#[non_exhaustive]` so future terminal states (e.g. `Suspended`
+/// promoted to a terminal distinct from `Cancelled`) land additively.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CompletionOutcome {
+    Success,
+    Failure,
+    Cancelled,
+    /// Outcome the backend surfaced but this crate version does not
+    /// recognise. The raw string is retained so operator tooling can
+    /// still log it.
+    Other(String),
+}
+
+impl CompletionOutcome {
+    /// Map a wire-string outcome to the typed enum. Unknown strings
+    /// fall through to [`CompletionOutcome::Other`] rather than an
+    /// error — completion events are advisory and a new producer
+    /// variant must not crash old subscribers.
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            "success" => Self::Success,
+            "failure" => Self::Failure,
+            "cancelled" => Self::Cancelled,
+            other => Self::Other(other.to_string()),
+        }
+    }
+}
+
+/// Per-event payload of `subscribe_completion`.
+///
+/// Completion events are terminal state transitions surfaced to
+/// downstream DAG consumers. Postgres carries a durable event-id
+/// cursor; Valkey Stage B rides pubsub + always yields
+/// [`StreamCursor::empty`] (no durable replay).
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct CompletionEvent {
+    pub cursor: StreamCursor,
+    pub execution_id: ExecutionId,
+    pub outcome: CompletionOutcome,
+    pub at: TimestampMs,
+}
+
+/// Stream of typed completion events.
+pub type CompletionSubscription =
+    Pin<Box<dyn Stream<Item = Result<CompletionEvent, EngineError>> + Send>>;
+
+// ─── SignalDelivery ──────────────────────────────────────────────
+
+/// Effect of a signal delivery on the target waitpoint.
+///
+/// `#[non_exhaustive]` for future effects (e.g. `Throttled`,
+/// `Coalesced`).
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SignalDeliveryEffect {
+    /// The signal was delivered and its waitpoint transitioned to
+    /// satisfied.
+    Satisfied,
+    /// The signal was buffered against a pending waitpoint.
+    Buffered,
+    /// The signal was deduped against an earlier delivery with the
+    /// same idempotency key.
+    Deduped,
+    /// Effect surfaced by the backend but not recognised by this
+    /// crate version. Raw string preserved for observability.
+    Other(String),
+}
+
+impl SignalDeliveryEffect {
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            "satisfied" => Self::Satisfied,
+            "buffered" => Self::Buffered,
+            "deduped" => Self::Deduped,
+            other => Self::Other(other.to_string()),
+        }
+    }
+}
+
+/// Per-event payload of `subscribe_signal_delivery`.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct SignalDeliveryEvent {
+    pub cursor: StreamCursor,
+    pub execution_id: ExecutionId,
+    pub signal_id: SignalId,
+    pub waitpoint_id: Option<WaitpointId>,
+    pub source_identity: Option<String>,
+    pub effect: SignalDeliveryEffect,
+    pub at: TimestampMs,
+}
+
+/// Stream of typed signal-delivery events.
+pub type SignalDeliverySubscription =
+    Pin<Box<dyn Stream<Item = Result<SignalDeliveryEvent, EngineError>> + Send>>;
+
+// ─── InstanceTags ────────────────────────────────────────────────
+
+/// Per-event payload of `subscribe_instance_tags`.
+///
+/// Producer wiring is deferred (see #311); trait-level surface exists
+/// for API uniformity across the four families. Every backend's
+/// default impl returns `EngineError::Unavailable`.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InstanceTagEvent {
+    /// Tag attached to an instance-scoped grouping.
+    Attached {
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        tag: String,
+        at: TimestampMs,
+    },
+    /// Tag cleared from an instance-scoped grouping.
+    Cleared {
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        tag: String,
+        at: TimestampMs,
+    },
+}
+
+/// Stream of typed instance-tag events.
+pub type InstanceTagSubscription =
+    Pin<Box<dyn Stream<Item = Result<InstanceTagEvent, EngineError>> + Send>>;

--- a/crates/ff-core/src/stream_events.rs
+++ b/crates/ff-core/src/stream_events.rs
@@ -34,6 +34,13 @@ use crate::engine_error::EngineError;
 use crate::stream_subscribe::StreamCursor;
 use crate::types::{ExecutionId, LeaseId, SignalId, TimestampMs, WaitpointId, WorkerInstanceId};
 
+// Rustdoc reminder: every `#[non_exhaustive]` struct below MUST pair
+// with a public constructor so external backend crates (ff-backend-
+// valkey, ff-backend-postgres) can still build instances. Adding a
+// new field to a non_exhaustive struct is additive at call sites that
+// use the constructor; callers that build via struct literal would
+// break, which is exactly what `non_exhaustive` is there to prevent.
+
 // ─── LeaseHistory ─────────────────────────────────────────────────
 
 /// Per-event payload of `subscribe_lease_history`.
@@ -177,6 +184,26 @@ pub struct CompletionEvent {
     pub at: TimestampMs,
 }
 
+impl CompletionEvent {
+    /// Construct a `CompletionEvent`. Backend adapters go through
+    /// this constructor instead of struct-literal syntax so future
+    /// additive fields land as builder methods without breaking
+    /// call sites.
+    pub fn new(
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        outcome: CompletionOutcome,
+        at: TimestampMs,
+    ) -> Self {
+        Self {
+            cursor,
+            execution_id,
+            outcome,
+            at,
+        }
+    }
+}
+
 /// Stream of typed completion events.
 pub type CompletionSubscription =
     Pin<Box<dyn Stream<Item = Result<CompletionEvent, EngineError>> + Send>>;
@@ -225,6 +252,30 @@ pub struct SignalDeliveryEvent {
     pub source_identity: Option<String>,
     pub effect: SignalDeliveryEffect,
     pub at: TimestampMs,
+}
+
+impl SignalDeliveryEvent {
+    /// Construct a `SignalDeliveryEvent`. Backend adapters use this
+    /// constructor so future additive fields are non-breaking.
+    pub fn new(
+        cursor: StreamCursor,
+        execution_id: ExecutionId,
+        signal_id: SignalId,
+        waitpoint_id: Option<WaitpointId>,
+        source_identity: Option<String>,
+        effect: SignalDeliveryEffect,
+        at: TimestampMs,
+    ) -> Self {
+        Self {
+            cursor,
+            execution_id,
+            signal_id,
+            waitpoint_id,
+            source_identity,
+            effect,
+            at,
+        }
+    }
 }
 
 /// Stream of typed signal-delivery events.

--- a/crates/ff-core/src/stream_events.rs
+++ b/crates/ff-core/src/stream_events.rs
@@ -60,14 +60,19 @@ pub enum LeaseHistoryEvent {
     Acquired {
         cursor: StreamCursor,
         execution_id: ExecutionId,
-        lease_id: LeaseId,
+        /// Valkey populates this from the Lua producer; Postgres
+        /// outbox may carry `None` today because the attempt row
+        /// identity is `(lease_epoch, attempt_index, execution_id)`
+        /// rather than a stable uuid (see `lease_event::emit`).
+        lease_id: Option<LeaseId>,
         worker_instance_id: Option<WorkerInstanceId>,
         at: TimestampMs,
     },
     Renewed {
         cursor: StreamCursor,
         execution_id: ExecutionId,
-        lease_id: LeaseId,
+        /// Same availability caveat as `Acquired::lease_id`.
+        lease_id: Option<LeaseId>,
         worker_instance_id: Option<WorkerInstanceId>,
         at: TimestampMs,
     },
@@ -81,7 +86,8 @@ pub enum LeaseHistoryEvent {
     Reclaimed {
         cursor: StreamCursor,
         execution_id: ExecutionId,
-        new_lease_id: LeaseId,
+        /// Same availability caveat as `Acquired::lease_id`.
+        new_lease_id: Option<LeaseId>,
         new_owner: Option<WorkerInstanceId>,
         at: TimestampMs,
     },

--- a/crates/ff-core/src/stream_subscribe.rs
+++ b/crates/ff-core/src/stream_subscribe.rs
@@ -1,28 +1,16 @@
-//! RFC-019 Stage A — cross-backend stream-cursor subscription surface.
+//! RFC-019 Stage A/B/C — cross-backend stream-cursor subscription
+//! surface (shared primitives).
 //!
-//! `EngineBackend::subscribe_{lease_history,completion,signal_delivery,
-//! instance_tags}` return a [`StreamSubscription`] — a pinned
-//! `tokio_stream::Stream` of `Result<StreamEvent, EngineError>`. The
-//! cursor is an opaque byte blob the consumer persists across crashes
-//! and hands back on resume; the first byte identifies the backend
-//! family + version so cursors stay stable across backend upgrades.
-//!
-//! This module defines the wire types only — no trait default is here;
-//! defaults live on the `EngineBackend` trait in
-//! [`crate::engine_backend`]. Real impls live in `ff-backend-valkey`
-//! (Valkey `XREAD BLOCK`-backed lease_history) and `ff-backend-postgres`
-//! (`LISTEN/NOTIFY`-backed completion) per RFC-019 §Implementation Plan.
+//! This module defines the [`StreamCursor`] every `subscribe_*`
+//! method accepts, plus the codec helpers backends use to
+//! encode/decode their native stream positions (Valkey `(ms, seq)`,
+//! Postgres `event_id`). Family-specific typed event enums + per-
+//! family subscription aliases live in [`crate::stream_events`].
 //!
 //! Four-family allow-list (RFC-019 §Open Questions #5, owner-
 //! adjudicated 2026-04-24): new families require an RFC amendment.
 
-use std::pin::Pin;
-
 use bytes::Bytes;
-use tokio_stream::Stream;
-
-use crate::engine_error::EngineError;
-use crate::types::{ExecutionId, TimestampMs};
 
 /// Opaque, backend-versioned cursor. Consumers persist the bytes, hand
 /// them back on resume. The first byte MUST encode a backend-family +
@@ -57,93 +45,6 @@ impl StreamCursor {
         Self(Bytes::new())
     }
 }
-
-/// Event families covered by the v0.9 allow-list (RFC-019 §Open
-/// Questions #5). `#[non_exhaustive]` so v0.10+ families land without
-/// breaking consumer match blocks, but the owner-adjudicated stance is
-/// that new families require an RFC amendment — this is not a generic
-/// escape hatch.
-#[non_exhaustive]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum StreamFamily {
-    LeaseHistory,
-    Completion,
-    SignalDelivery,
-    InstanceTags,
-}
-
-/// Per-event payload.
-///
-/// - `family` identifies the event shape.
-/// - `cursor` is the position this event occupies in the stream;
-///   consumers persist it + hand it back on reconnect so replay begins
-///   strictly after this event.
-/// - `execution_id`, `attempt_index`, `timestamp` are inline hot fields
-///   (RFC-019 §Open Questions #4, owner-adjudicated inline) so common
-///   consumers do not need a follow-up `describe_execution` RPC.
-/// - `payload` is the family-specific binary event body. Schema is
-///   the backend's (not stabilised in Stage A — consumers parse via
-///   family-specific helpers Stage B will ship).
-///
-/// `#[non_exhaustive]` so future inline metadata (e.g. `namespace`)
-/// adds without a breaking change.
-#[non_exhaustive]
-#[derive(Clone, Debug)]
-pub struct StreamEvent {
-    pub family: StreamFamily,
-    pub cursor: StreamCursor,
-    pub execution_id: Option<ExecutionId>,
-    pub attempt_index: Option<u32>,
-    pub timestamp: TimestampMs,
-    pub payload: Bytes,
-}
-
-impl StreamEvent {
-    /// Construct a minimal `StreamEvent`. The struct is
-    /// `#[non_exhaustive]` so external crates cannot build via a
-    /// literal — backends go through this constructor + builder.
-    /// Optional inline metadata is added via `with_execution_id` /
-    /// `with_attempt_index` so call-site shape stays stable across
-    /// future field additions.
-    pub fn new(
-        family: StreamFamily,
-        cursor: StreamCursor,
-        timestamp: TimestampMs,
-        payload: Bytes,
-    ) -> Self {
-        Self {
-            family,
-            cursor,
-            execution_id: None,
-            attempt_index: None,
-            timestamp,
-            payload,
-        }
-    }
-
-    #[must_use]
-    pub fn with_execution_id(mut self, id: ExecutionId) -> Self {
-        self.execution_id = Some(id);
-        self
-    }
-
-    #[must_use]
-    pub fn with_attempt_index(mut self, idx: u32) -> Self {
-        self.attempt_index = Some(idx);
-        self
-    }
-}
-
-/// Shape of a subscription stream.
-///
-/// Errors surface as `Err` items (not panics / stream-end); the
-/// terminal `Err(EngineError::StreamDisconnected { cursor })` is the
-/// owner-adjudicated disconnect contract (RFC-019 §Open Questions #2):
-/// the consumer reconnects by re-calling the relevant `subscribe_*`
-/// method with the cursor they observed. Non-terminal errors may be
-/// followed by further events.
-pub type StreamSubscription =
-    Pin<Box<dyn Stream<Item = Result<StreamEvent, EngineError>> + Send>>;
 
 // ─── Valkey cursor codec ───
 //

--- a/docs/CONSUMER_MIGRATION_typed-subscribe-events.md
+++ b/docs/CONSUMER_MIGRATION_typed-subscribe-events.md
@@ -1,0 +1,104 @@
+# Consumer migration — typed `EngineBackend::subscribe_*` events
+
+**Applies to:** the v0.10 release that lands RFC-019 Stage C.
+
+## What changed
+
+The four `EngineBackend::subscribe_*` trait methods now return
+family-specific typed subscriptions instead of a generic
+`StreamSubscription<StreamEvent>` with an opaque byte payload.
+Consumers `match` on typed variants directly; no more
+NUL-delimited / JSON payload parsing on the consumer side.
+
+| Trait method                  | New return type                                     |
+|-------------------------------|-----------------------------------------------------|
+| `subscribe_lease_history`     | `LeaseHistorySubscription` → `LeaseHistoryEvent`    |
+| `subscribe_completion`        | `CompletionSubscription` → `CompletionEvent`        |
+| `subscribe_signal_delivery`   | `SignalDeliverySubscription` → `SignalDeliveryEvent`|
+| `subscribe_instance_tags`     | `InstanceTagSubscription` → `InstanceTagEvent`      |
+
+The untyped `StreamEvent`, `StreamSubscription`, and `StreamFamily`
+are removed from `ff_core::stream_subscribe`. The cursor codec
+(`StreamCursor`, `encode_valkey_cursor`, `decode_valkey_cursor`,
+`encode_postgres_event_cursor`, `decode_postgres_event_cursor`) is
+unchanged — persisted cursors remain valid across the upgrade.
+
+## Before (v0.9)
+
+```rust
+use ff_core::engine_backend::EngineBackend;
+use ff_core::stream_subscribe::StreamCursor;
+use futures::StreamExt;
+
+let mut sub = backend
+    .subscribe_lease_history(StreamCursor::empty())
+    .await?;
+while let Some(item) = sub.next().await {
+    let event = item?;
+    // Consumers had to know the Lua wire shape to do anything useful:
+    let payload = std::str::from_utf8(&event.payload)?;
+    if payload.contains("event\0reclaimed") {
+        // ... hand-parse the NUL-delimited field map
+    }
+}
+```
+
+## After (v0.10)
+
+```rust
+use ff_core::engine_backend::EngineBackend;
+use ff_core::stream_events::LeaseHistoryEvent;
+use ff_core::stream_subscribe::StreamCursor;
+use futures::StreamExt;
+
+let mut sub = backend
+    .subscribe_lease_history(StreamCursor::empty())
+    .await?;
+while let Some(item) = sub.next().await {
+    match item? {
+        LeaseHistoryEvent::Reclaimed { execution_id, new_lease_id, at, .. } => {
+            record_reclaim(execution_id, new_lease_id, at);
+        }
+        LeaseHistoryEvent::Expired { execution_id, prev_owner, at, .. } => {
+            alert_operator(execution_id, prev_owner, at);
+        }
+        LeaseHistoryEvent::Revoked { execution_id, revoked_by, .. } => {
+            tracing::info!(%execution_id, %revoked_by, "lease revoked");
+        }
+        _ => {} // Acquired / Renewed / (future variants)
+    }
+}
+```
+
+## Cursor persistence
+
+Cursors encoded under v0.9 remain valid; consumers that persisted
+`StreamEvent::cursor` bytes hand them back to `subscribe_*` with no
+change. Access via `event.cursor()` on the enum (lease_history) or
+`event.cursor` on the struct (completion / signal_delivery).
+
+## Gotchas
+
+- `LeaseHistoryEvent::{Acquired, Renewed, Reclaimed}::lease_id` /
+  `new_lease_id` are `Option<LeaseId>`. Valkey populates them; the
+  Postgres outbox typically carries `None` today because the
+  attempt identity is `(lease_epoch, attempt_index, execution_id)`
+  rather than a stable lease UUID. Match accordingly.
+- `LeaseHistoryEvent::Revoked::revoked_by` is `String` today for
+  forward compatibility; may promote to a typed enum post-v0.10
+  once the taxonomy settles. Known values: `"operator"`,
+  `"reconciler"`, `"backend"`.
+- `SignalDeliveryEvent::effect` on Postgres is always
+  `SignalDeliveryEffect::Satisfied` until the outbox schema gains an
+  `effect` column. Valkey surfaces the actual Lua producer's effect
+  string via `SignalDeliveryEffect::from_wire`.
+- `subscribe_instance_tags` still returns
+  `EngineError::Unavailable` on both backends (producer wiring
+  deferred per #311). The trait method exists for surface uniformity.
+
+## Enums are `#[non_exhaustive]`
+
+Every typed event enum + outcome enum is `#[non_exhaustive]`.
+Consumer `match` statements must include a wildcard arm; future
+additive variants (e.g. a new `LeaseHistoryEvent::Throttled`) ship
+in a minor version without breaking your build.


### PR DESCRIPTION
## Summary

Replaces generic `StreamEvent { payload: Bytes }` with typed per-family enums (`LeaseHistoryEvent`, `CompletionEvent`, `SignalDeliveryEvent`, `InstanceTagEvent`) on `EngineBackend::subscribe_*` methods. Matches cairn's original #282 spec — consumers now `match event { LeaseHistoryEvent::Expired { lease_id, prev_owner, .. } }` instead of `serde_json::from_slice(&event.payload)?`.

## Commits

5 commits, each reviewable independently:
- `5c5d537` typed event enums (new `crates/ff-core/src/stream_events.rs`)
- `eaa9c38` switch `EngineBackend::subscribe_*` to typed return types
- `75e1647` Valkey adapters — XREAD entry fields → typed variant construction
- `81068e6` Postgres adapters — sqlx row → typed variant construction
- `a416181` rewrite subscribe_* tests for typed events

## Design decisions adjudicated

- `revoked_by: String` (not `RevokeSource` enum) — taxonomy bikeshed deferred; String + rustdoc-documented values. `#[non_exhaustive]` on each variant protects future additions.
- Include `Acquired` + `Renewed` on `LeaseHistoryEvent` (in addition to Expired/Reclaimed/Revoked cairn listed) — backend adapters emit them today; dropping would be a silent regression.
- `subscribe_instance_tags` sig unchanged — #311 audit deferred producer; widening sig would lock in an API we'll never implement.
- `InstanceTagEvent` enum exists (2 variants) but no producer wires it — reserved surface per RFC-019 §Open Questions.

## BREAKING for direct subscribe consumers

v0.9 → v0.10: consumers deserializing `StreamEvent.payload` update to typed match. See `docs/MIGRATIONS.md` v0.10 section for upgrade snippet.

## Coordination

Overlaps with parallel filter-param stage 1 PR (not yet open). Filter-param Stage 1 agent correctly flagged the collision and stopped; the plan is to land THIS PR first, then Stage 1 adds `instance_tag_filter_val: Option<String>` to the typed variants + the XADD/outbox producers in one coherent PR. This PR ships clean on its own.

Closes part 2 of #282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public `EngineBackend::subscribe_*` return types (breaking API) and rewires both Postgres and Valkey streaming adapters/parsers, which could impact cursor resume or event decoding correctness.
> 
> **Overview**
> **Promotes RFC-019 subscription streams from generic `StreamEvent` blobs to typed per-family events.** Adds new `ff_core::stream_events` (typed `LeaseHistoryEvent`, `CompletionEvent`, `SignalDeliveryEvent`, `InstanceTagEvent` plus subscription aliases/outcome/effect enums) and updates `EngineBackend::subscribe_*` signatures to return these typed streams.
> 
> Updates Postgres and Valkey backends to construct typed events instead of emitting JSON/NUL-delimited payload bytes: Postgres now maps outbox rows directly into typed variants (with validation/skips for malformed IDs), and Valkey decodes XREAD field blobs into maps and typed events. Integration tests for Postgres/Valkey subscriptions are rewritten to assert on typed fields and cursor resume behavior; Valkey adds `uuid` as a dev-dependency for test data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a416181f3a771c04552df077725890715f9c3004. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->