### PR TITLE
feat(engine-backend): suspend_by_triple — service-layer entry point (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `EngineBackend::suspend_by_triple(exec_id, LeaseFence, SuspendArgs)`
+  — service-layer entry point for suspending an execution when the
+  caller holds a lease fence triple but no worker `Handle` (cairn #322;
+  unblocks cairn's pause-by-operator, enter-waiting-approval, and
+  cancel-with-timeout-record call sites that today fall back to raw
+  FCALL glue). Additive with a default impl returning
+  `EngineError::Unavailable { op: "suspend_by_triple" }`; Valkey and
+  Postgres backends override. Semantics mirror `suspend` (same
+  `SuspendArgs` validation, same `SuspendOutcome` lifecycle, same
+  RFC-013 §3 replay / dedup contract) — the only difference is the
+  fencing source. On Valkey the triple's `(lease_id, lease_epoch,
+  attempt_id)` drives the Lua fence against `lease_current`;
+  `attempt_index` + `lane_id` + `worker_instance_id` are recovered
+  from `exec_core`. On Postgres the fence is `lease_epoch` against
+  `ff_attempt`; `attempt_index` is read from `ff_exec_core` (Postgres
+  attempts are keyed by `(execution_id, attempt_index)` — the triple's
+  `attempt_id` is advisory on this backend).
 - `ff_core::handle_codec::v1_handle_for_tests` — test-only fixture
   that synthesises a pre-Wave-1c (v1) handle byte buffer for the
   given `HandlePayload`. Gated behind the new `test-fixtures` feature
@@ -16,7 +33,6 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Motivated by downstream cross-version compat testing (cairn #323)
   where event logs persisted under FF 0.3 must still decode under
   FF 0.9+.
-
 - `ff_core::stream_events` module: typed event enums + per-family
   subscription aliases for the four `EngineBackend::subscribe_*`
   methods (RFC-019 Stage C; addresses #282 typed surface gap).

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -56,7 +56,7 @@ use ff_core::partition::PartitionConfig;
 use ff_core::types::AttemptIndex;
 #[cfg(feature = "core")]
 use ff_core::types::EdgeId;
-use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
+use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, LeaseFence, TimestampMs};
 // Wave 5a — re-export `PgPool` so crates that depend on
 // `ff-backend-postgres` (and not `sqlx` directly) can name the pool
 // type in their own APIs (e.g. `ff-engine::dispatch_via_postgres`).
@@ -456,6 +456,23 @@ impl EngineBackend for PostgresBackend {
         args: SuspendArgs,
     ) -> Result<SuspendOutcome, EngineError> {
         suspend_ops::suspend_impl(&self.pool, &self.partition_config, handle, args).await
+    }
+
+    #[tracing::instrument(name = "pg.suspend_by_triple", skip_all)]
+    async fn suspend_by_triple(
+        &self,
+        exec_id: ExecutionId,
+        triple: LeaseFence,
+        args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        suspend_ops::suspend_by_triple_impl(
+            &self.pool,
+            &self.partition_config,
+            exec_id,
+            triple,
+            args,
+        )
+        .await
     }
 
     #[tracing::instrument(name = "pg.create_waitpoint", skip_all)]

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -31,8 +31,8 @@ use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
 use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
 use ff_core::partition::PartitionConfig;
 use ff_core::types::{
-    AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, SignalId, SuspensionId, TimestampMs,
-    WaitpointId,
+    AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseFence, SignalId, SuspensionId,
+    TimestampMs, WaitpointId,
 };
 use serde_json::{json, Value as JsonValue};
 use sqlx::{PgPool, Postgres, Transaction};
@@ -265,6 +265,66 @@ pub(crate) async fn suspend_impl(
     args: SuspendArgs,
 ) -> Result<SuspendOutcome, EngineError> {
     let payload = decode_handle(handle)?;
+    suspend_core(pool, payload, args).await
+}
+
+/// Cairn #322 — service-layer entry point: suspend when the caller
+/// holds a lease fence triple but no `Handle`. Resolves `attempt_index`
+/// from `ff_attempt` by `(exec_id, attempt_id)` then delegates to the
+/// same transactional body used by [`suspend_impl`].
+pub(crate) async fn suspend_by_triple_impl(
+    pool: &PgPool,
+    _partition_config: &PartitionConfig,
+    exec_id: ExecutionId,
+    triple: LeaseFence,
+    args: SuspendArgs,
+) -> Result<SuspendOutcome, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&exec_id)?;
+    // Postgres-side attempts are keyed by `(execution_id, attempt_index)`;
+    // there is no `attempt_id` column on `ff_attempt`. The triple's
+    // `attempt_id` is therefore advisory on this backend — the
+    // authoritative "which attempt" pointer lives on `ff_exec_core`.
+    // Read it outside the serializable body; `suspend_core` re-fences
+    // against `lease_epoch` (`FOR UPDATE`) inside the txn so a racing
+    // attempt-bump or lease-bump surfaces as `Contention(LeaseConflict)`.
+    let row: Option<(i32,)> = sqlx::query_as(
+        "SELECT attempt_index FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    let attempt_index_i = match row {
+        Some((i,)) => i,
+        None => return Err(EngineError::NotFound { entity: "execution" }),
+    };
+    let attempt_index =
+        AttemptIndex::new(u32::try_from(attempt_index_i.max(0)).unwrap_or(0));
+
+    // Synthesize a HandlePayload — `suspend_core` only reads
+    // `execution_id`, `attempt_index`, and `lease_epoch`; the rest of
+    // the payload fields are carried through to the replayed-outcome
+    // handle encoding (kind = Suspended).
+    let payload = HandlePayload::new(
+        exec_id,
+        attempt_index,
+        triple.attempt_id,
+        triple.lease_id,
+        triple.lease_epoch,
+        0,
+        ff_core::types::LaneId::new(""),
+        ff_core::types::WorkerInstanceId::new(""),
+    );
+    suspend_core(pool, payload, args).await
+}
+
+async fn suspend_core(
+    pool: &PgPool,
+    payload: HandlePayload,
+    args: SuspendArgs,
+) -> Result<SuspendOutcome, EngineError> {
     let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
     let attempt_index_i = i32::try_from(payload.attempt_index.0).unwrap_or(0);
     let expected_epoch = payload.lease_epoch.0;

--- a/crates/ff-backend-postgres/tests/suspend_signal.rs
+++ b/crates/ff-backend-postgres/tests/suspend_signal.rs
@@ -40,8 +40,8 @@ use ff_core::engine_error::{ConflictKind, ContentionKind, EngineError};
 use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
 use ff_core::partition::PartitionConfig;
 use ff_core::types::{
-    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, SignalId, SuspensionId,
-    TimestampMs, WaitpointId, WaitpointToken, WorkerId, WorkerInstanceId,
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseFence, LeaseId, SignalId,
+    SuspensionId, TimestampMs, WaitpointId, WaitpointToken, WorkerId, WorkerInstanceId,
 };
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
@@ -1010,4 +1010,64 @@ async fn deliver_signal_retry_exhaustion_returns_retry_exhausted() {
     // Q11 contract regardless of scheduling.
     assert_eq!(ff_backend_postgres::signal::SERIALIZABLE_RETRY_BUDGET, 3);
     let _ = wp_uuid; // silence dead-binding lint
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Cairn #322 — suspend_by_triple service-layer entry point.
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn suspend_by_triple_fresh_returns_suspended() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let triple = LeaseFence {
+        lease_id: LeaseId::new(),
+        lease_epoch: fx.lease_epoch,
+        attempt_id: AttemptId::new(),
+    };
+
+    let (args, _wp_id) = make_suspend_args("wpk:triple");
+    let suspension_id = args.suspension_id.clone();
+    let outcome = fx
+        .backend
+        .suspend_by_triple(fx.exec_id.clone(), triple, args)
+        .await
+        .expect("suspend_by_triple ok");
+
+    match outcome {
+        SuspendOutcome::Suspended { details, handle } => {
+            assert_eq!(details.suspension_id, suspension_id);
+            assert_eq!(details.waitpoint_key, "wpk:triple");
+            assert_eq!(handle.kind, HandleKind::Suspended);
+            assert_eq!(handle.backend, BackendTag::Postgres);
+        }
+        other => panic!("expected Suspended, got {other:?}"),
+    }
+
+    // Lease epoch bumped on suspend — a replay with the stale triple
+    // surfaces as LeaseConflict.
+    let stale = LeaseFence {
+        lease_id: LeaseId::new(),
+        lease_epoch: fx.lease_epoch,
+        attempt_id: AttemptId::new(),
+    };
+    let (args2, _) = make_suspend_args("wpk:triple-replay");
+    let err = fx
+        .backend
+        .suspend_by_triple(fx.exec_id.clone(), stale, args2)
+        .await
+        .expect_err("stale epoch must reject");
+    assert!(
+        matches!(err, EngineError::Contention(ContentionKind::LeaseConflict))
+            || matches!(err, EngineError::Contention(ContentionKind::RetryExhausted)),
+        "expected LeaseConflict or RetryExhausted, got {err:?}"
+    );
+    let _ = fx.exec_uuid; // silence dead-binding lint
+    let _ = fx.part;
+    let _ = fx.attempt_index;
+    let _ = fx.lane;
+    let _ = fx.pool;
 }

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -56,8 +56,8 @@ use ff_core::engine_error::EngineError;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
 use ff_core::partition::{PartitionConfig, execution_partition, flow_partition};
 use ff_core::types::{
-    AttemptId, AttemptIndex, BudgetId, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch, LeaseId,
-    SignalId, TimestampMs, WaitpointId, WorkerInstanceId,
+    AttemptId, AttemptIndex, BudgetId, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch, LeaseFence,
+    LeaseId, SignalId, TimestampMs, WaitpointId, WorkerInstanceId,
 };
 use ff_script::engine_error_ext::transport_script;
 use ff_script::error::ScriptError;
@@ -4202,6 +4202,83 @@ impl EngineBackend for ValkeyBackend {
             .await
             .map_err(|e| {
                 ff_core::engine_error::backend_context(e, "suspend: FCALL ff_suspend_execution")
+            })
+    }
+
+    async fn suspend_by_triple(
+        &self,
+        exec_id: ExecutionId,
+        triple: LeaseFence,
+        args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        // RFC-013 §4 — validate args before any pre-read so malformed
+        // SuspendArgs surface as `Validation(InvalidInput)` regardless
+        // of execution state. Mirrors `suspend`.
+        validate_suspend_args(&args)?;
+
+        // Pre-read the exec_core fields that `suspend_impl` would
+        // otherwise pull from the Handle payload: lane_id, current
+        // attempt_index, current worker_instance_id. Lease fence fields
+        // (lease_id, lease_epoch, attempt_id) come from `triple`
+        // directly — the Lua side fences against these on `lease_current`.
+        let partition = execution_partition(&exec_id, &self.partition_config);
+        let ctx = ExecKeyContext::new(&partition, &exec_id);
+        let core_key = ctx.core();
+        let core: HashMap<String, String> = self
+            .client
+            .cmd("HGETALL")
+            .arg(&core_key)
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        if core.is_empty() {
+            return Err(EngineError::NotFound { entity: "execution" });
+        }
+        let lane_str = core.get("lane_id").cloned().unwrap_or_default();
+        if lane_str.is_empty() {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::Corruption,
+                detail: "suspend_by_triple: exec_core missing lane_id".into(),
+            });
+        }
+        let att_idx_str = core
+            .get("current_attempt_index")
+            .cloned()
+            .unwrap_or_default();
+        let att_idx: u32 = att_idx_str.parse().map_err(|_| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!(
+                "suspend_by_triple: exec_core.current_attempt_index not a u32: {att_idx_str:?}"
+            ),
+        })?;
+        let wiid_str = core
+            .get("current_worker_instance_id")
+            .cloned()
+            .unwrap_or_default();
+        // An empty `current_worker_instance_id` means the lease was
+        // already released — the fence check on `lease_current` will
+        // fail with `stale_lease`; pass a placeholder so we still reach
+        // the FCALL and surface the canonical error.
+        let worker_instance_id = WorkerInstanceId::new(wiid_str);
+
+        let fields = handle_codec::HandleFields::new(
+            exec_id,
+            AttemptIndex::new(att_idx),
+            triple.attempt_id,
+            triple.lease_id,
+            triple.lease_epoch,
+            // lease_ttl_ms is unused on the suspend FCALL path; pass 0.
+            0,
+            LaneId::new(lane_str),
+            worker_instance_id,
+        );
+        suspend_impl(&self.client, &self.partition_config, &fields, args)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "suspend_by_triple: FCALL ff_suspend_execution",
+                )
             })
     }
 

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -82,7 +82,7 @@ use crate::engine_error::EngineError;
 use crate::types::AttemptIndex;
 #[cfg(feature = "core")]
 use crate::types::EdgeId;
-use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
+use crate::types::{BudgetId, ExecutionId, FlowId, LaneId, LeaseFence, TimestampMs};
 
 /// The engine write surface — a single trait a backend implementation
 /// honours to serve a `FlowFabricWorker`.
@@ -188,6 +188,36 @@ pub trait EngineBackend: Send + Sync + 'static {
         handle: &Handle,
         args: SuspendArgs,
     ) -> Result<SuspendOutcome, EngineError>;
+
+    /// Suspend by execution id + lease fence triple, for service-layer
+    /// callers that hold a run record / lease-claim descriptor but no
+    /// worker [`Handle`] (cairn issue #322).
+    ///
+    /// Semantics mirror [`Self::suspend`] exactly — the same
+    /// [`SuspendArgs`] validation, the same [`SuspendOutcome`]
+    /// lifecycle, the same RFC-013 §3 dedup / replay contract. The
+    /// only difference is the fencing source: instead of the
+    /// `(lease_id, lease_epoch, attempt_id)` fields embedded in a
+    /// `Handle`, the backend fences against the triple passed directly.
+    /// Attempt-index, lane, and worker-instance metadata that
+    /// [`Self::suspend`] reads from the handle payload are recovered
+    /// from the backend's authoritative execution record (Valkey:
+    /// `exec_core` HGETs; Postgres: `ff_attempt` row lookup).
+    ///
+    /// The default impl returns [`EngineError::Unavailable`] so
+    /// existing backend impls remain non-breaking. Production backends
+    /// (Valkey, Postgres) override.
+    async fn suspend_by_triple(
+        &self,
+        exec_id: ExecutionId,
+        triple: LeaseFence,
+        args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        let _ = (exec_id, triple, args);
+        Err(EngineError::Unavailable {
+            op: "suspend_by_triple",
+        })
+    }
 
     /// Issue a pending waitpoint for future signal delivery.
     ///

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -35,7 +35,7 @@ use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::EngineError;
 #[cfg(feature = "valkey-default")]
 use ff_core::types::AttemptIndex;
-use ff_core::types::{BudgetId, EdgeId, ExecutionId, FlowId, LaneId, TimestampMs};
+use ff_core::types::{BudgetId, EdgeId, ExecutionId, FlowId, LaneId, LeaseFence, TimestampMs};
 
 /// Outcome of a delegated call, as a borrowed view for hook
 /// consumption. Kept allocation-free: error category is a
@@ -192,6 +192,19 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
         args: SuspendArgs,
     ) -> Result<SuspendOutcome, EngineError> {
         with_hooks!(self, "suspend", self.inner.suspend(handle, args).await)
+    }
+
+    async fn suspend_by_triple(
+        &self,
+        exec_id: ExecutionId,
+        triple: LeaseFence,
+        args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        with_hooks!(
+            self,
+            "suspend_by_triple",
+            self.inner.suspend_by_triple(exec_id, triple, args).await
+        )
     }
 
     async fn create_waitpoint(

--- a/crates/ff-test/tests/engine_backend_suspend_by_triple.rs
+++ b/crates/ff-test/tests/engine_backend_suspend_by_triple.rs
@@ -1,0 +1,246 @@
+//! Integration coverage for cairn #322 —
+//! [`ff_core::engine_backend::EngineBackend::suspend_by_triple`] on the
+//! Valkey-backed impl.
+//!
+//! Mirrors the happy-path flow of `engine_backend_suspend.rs` but
+//! drives suspend via the service-layer entry point (exec_id + lease
+//! fence triple) instead of a Handle. Asserts the returned outcome is
+//! equivalent to `suspend(&Handle, ..)` and that the suspended handle
+//! on success is tagged `HandleKind::Suspended`.
+
+use std::sync::Arc;
+
+use ferriskey::Value;
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::{BackendTag, HandleKind};
+use ff_core::contracts::{
+    ResumeCondition, ResumePolicy, SignalMatcher, SuspendArgs, SuspendOutcome,
+    SuspensionReasonCode, WaitpointBinding,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, PartitionConfig};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+const LANE: &str = "sbt-lane";
+const NS: &str = "sbt-ns";
+const WORKER: &str = "sbt-worker";
+const WORKER_INST: &str = "sbt-worker-1";
+
+fn config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+async fn build_backend(tc: &TestCluster) -> Arc<dyn EngineBackend> {
+    ValkeyBackend::from_client_and_partitions(tc.client().clone(), config())
+}
+
+/// Seed a live execution + claim and return the fence triple the
+/// caller would have captured from the claim record.
+async fn create_and_claim_triple(tc: &TestCluster, eid: &ExecutionId) -> LeaseFence {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+    let wid = WorkerInstanceId::new(WORKER_INST);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "sbt".to_owned(),
+        "0".to_owned(),
+        "sbt-runner".to_owned(),
+        "{}".to_owned(),
+        r#"{"test":true}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("ff_create_execution");
+
+    let grant_keys: Vec<String> = vec![ctx.core(), ctx.claim_grant(), idx.lane_eligible(&lane_id)];
+    let grant_args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        WORKER_INST.to_owned(),
+        LANE.to_owned(),
+        String::new(),
+        "5000".to_owned(),
+        String::new(),
+        String::new(),
+        String::new(),
+    ];
+    let kr: Vec<&str> = grant_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = grant_args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_issue_claim_grant", &kr, &ar)
+        .await
+        .expect("ff_issue_claim_grant");
+
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+    let att_idx = AttemptIndex::new(0);
+    let lease_ttl_ms: u64 = 30_000;
+    let renew_before = lease_ttl_ms * 2 / 3;
+    let claim_keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.claim_grant(),
+        idx.lane_eligible(&lane_id),
+        idx.lease_expiry(),
+        idx.worker_leases(&wid),
+        ctx.attempt_hash(att_idx),
+        ctx.attempt_usage(att_idx),
+        ctx.attempt_policy(att_idx),
+        ctx.attempts(),
+        ctx.lease_current(),
+        ctx.lease_history(),
+        idx.lane_active(&lane_id),
+        idx.attempt_timeout(),
+        idx.execution_deadline(),
+    ];
+    let claim_args: Vec<String> = vec![
+        eid.to_string(),
+        WORKER.to_owned(),
+        WORKER_INST.to_owned(),
+        LANE.to_owned(),
+        String::new(),
+        lease_id.to_string(),
+        lease_ttl_ms.to_string(),
+        renew_before.to_string(),
+        attempt_id.to_string(),
+        "{}".to_owned(),
+        String::new(),
+        String::new(),
+    ];
+    let kr: Vec<&str> = claim_keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = claim_args.iter().map(String::as_str).collect();
+    let raw: Value = tc
+        .client()
+        .fcall("ff_claim_execution", &kr, &ar)
+        .await
+        .expect("ff_claim_execution");
+    let arr = match &raw {
+        Value::Array(a) => a,
+        _ => panic!("claim: expected Array"),
+    };
+    let epoch_str = match arr.get(3) {
+        Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
+        Some(Ok(Value::Int(n))) => n.to_string(),
+        _ => panic!("claim: no epoch"),
+    };
+    let lease_epoch = LeaseEpoch(epoch_str.parse::<u64>().unwrap_or(0));
+
+    LeaseFence {
+        lease_id,
+        lease_epoch,
+        attempt_id,
+    }
+}
+
+fn make_single_args(wp_key: &str, matcher: &str) -> SuspendArgs {
+    SuspendArgs::new(
+        SuspensionId::new(),
+        WaitpointBinding::Fresh {
+            waitpoint_id: WaitpointId::new(),
+            waitpoint_key: wp_key.to_owned(),
+        },
+        ResumeCondition::Single {
+            waitpoint_key: wp_key.to_owned(),
+            matcher: SignalMatcher::ByName(matcher.to_owned()),
+        },
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::now(),
+    )
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn suspend_by_triple_fresh_returns_suspended_handle() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    let triple = create_and_claim_triple(&tc, &eid).await;
+    let backend = build_backend(&tc).await;
+
+    let wp_key = format!("wpk:{}", WaitpointId::new());
+    let args = make_single_args(&wp_key, "approve");
+    let suspension_id = args.suspension_id.clone();
+
+    let outcome = backend
+        .suspend_by_triple(eid.clone(), triple, args)
+        .await
+        .expect("suspend_by_triple: fresh → Suspended");
+
+    match outcome {
+        SuspendOutcome::Suspended { details, handle: h } => {
+            assert_eq!(details.suspension_id, suspension_id);
+            assert_eq!(details.waitpoint_key, wp_key);
+            assert_eq!(h.kind, HandleKind::Suspended);
+            assert_eq!(h.backend, BackendTag::Valkey);
+            assert!(!details.waitpoint_token.as_str().is_empty());
+        }
+        other => panic!("expected Suspended, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn suspend_by_triple_stale_fence_surfaces_contention() {
+    // Triple with a bumped lease_epoch must fail the Lua fence check
+    // and surface as a typed error — same contract as `suspend`.
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    let mut triple = create_and_claim_triple(&tc, &eid).await;
+    triple.lease_epoch = LeaseEpoch(triple.lease_epoch.0 + 999);
+    let backend = build_backend(&tc).await;
+
+    let wp_key = format!("wpk:{}", WaitpointId::new());
+    let args = make_single_args(&wp_key, "approve");
+
+    let err = backend
+        .suspend_by_triple(eid, triple, args)
+        .await
+        .expect_err("stale lease_epoch must reject");
+    // The Lua fence path surfaces as a typed State / Contention /
+    // Validation error; the exact discriminant is decided by ff-script.
+    // We just assert the call did not silently succeed and that the
+    // underlying reason is stale-lease or fence-related.
+    let s = err.to_string();
+    assert!(
+        s.to_lowercase().contains("stale")
+            || s.to_lowercase().contains("lease")
+            || s.to_lowercase().contains("fence")
+            || matches!(
+                err,
+                ff_core::engine_error::EngineError::State(_)
+                    | ff_core::engine_error::EngineError::Contention(_)
+                    | ff_core::engine_error::EngineError::Validation { .. }
+            ),
+        "unexpected error shape: {s}"
+    );
+}

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -308,6 +308,12 @@ but no longer trips on Postgres.
 | `subscribe_signal_delivery` | `impl` | `impl` | Valkey: `duplicate_connection()` + `XREAD BLOCK 5000 STREAMS ff:part:{fp:N}:signal_delivery <cursor>`; cursor is `0x01 ++ ms(BE8) ++ seq(BE8)`. Producer XADD lives in `ff_deliver_signal` at KEYS[15]. Postgres: `ff_signal_event` outbox + `LISTEN ff_signal_event`; cursor is `0x02 ++ event_id(BE8)`. Producer INSERT lives in `suspend_ops::deliver_signal_impl`'s SERIALIZABLE tx. **#282 ScannerFilter surface**: trait method takes `filter: &ScannerFilter`; Valkey gates via the shared #122 `FilterGate`; Postgres filters in-memory against denormalised `namespace`/`instance_tag` columns on `ff_signal_event` (migration 0009). (Stage B, #310 / #282) |
 | `subscribe_instance_tags` | `n/a` | `n/a` | Audited #311 (2026-04-24) + deferred: cairn's one-shot `instance_tag_backfill` pattern is served by `list_executions` + `ScannerFilter::with_instance_tag(..)` pagination; a realtime tag-churn stream is speculative demand we do not have today. Trait method remains and returns `Unavailable` on both backends; reserving the surface for future concrete demand. RFC-019 §instance_tags amended. |
 
+### Post-v0.9 additive methods
+
+| Method | Valkey | Postgres | Notes |
+|---|---|---|---|
+| `suspend_by_triple` | `impl` | `impl` | Cairn #322 service-layer entry point for suspend-by-triple (pause-by-operator, enter-waiting-approval, cancel-with-timeout-record). Valkey: HGETALL `exec_core` pre-read for `lane_id` / `current_attempt_index` / `current_worker_instance_id`, then the existing `ff_suspend_execution` FCALL with fence fields sourced from the triple — identical Lua dedup / §3 replay contract as `suspend`. Postgres: single `SELECT attempt_index FROM ff_exec_core` pre-read (Postgres attempts are keyed by `attempt_index`, not the triple's `attempt_id` — the `attempt_id` field is advisory on this backend), then the shared `suspend_core` SERIALIZABLE body. Default trait impl returns `EngineError::Unavailable { op: "suspend_by_triple" }` so downstream impls remain non-breaking. |
+
 ### Deferred to v0.9 / post-0.8
 
 Every Postgres column row still marked `stub` in the Stage A table


### PR DESCRIPTION
## Summary

Closes #322. Additive `EngineBackend::suspend_by_triple(exec_id, LeaseFence, SuspendArgs)` — non-breaking service-layer entry point for consumers that hold a lease fence triple but no worker `Handle`. Unblocks cairn's pause-by-operator, enter-waiting-approval, and cancel-with-timeout-record call sites.

- Default trait impl returns `EngineError::Unavailable { op: "suspend_by_triple" }`; Valkey + Postgres override. `HookedBackend` forwards.
- Valkey override: HGETALL `exec_core` pre-read for `lane_id` / `current_attempt_index` / `current_worker_instance_id`, then the existing `ff_suspend_execution` FCALL with fence fields from the triple. Identical Lua dedup / RFC-013 §3 replay contract as `suspend`.
- Postgres override: shared `suspend_core` SERIALIZABLE body factored out of `suspend_impl`. `suspend_by_triple_impl` resolves `attempt_index` from `ff_exec_core` (Postgres attempts are keyed by `attempt_index`, not the triple's `attempt_id` — advisory on this backend; fencing remains `lease_epoch` via `ff_attempt FOR UPDATE`).
- CHANGELOG `[Unreleased] ### Added` entry + POSTGRES_PARITY_MATRIX.md row under a new "Post-v0.9 additive methods" section.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-core -p ff-backend-valkey -p ff-backend-postgres -p ff-sdk --all-features -- -D warnings` clean (pre-existing `result_large_err` / `needless_range_loop` findings in `ff-sdk`/`ff-test` tests unrelated to this PR and reproducible on `main`)
- [x] `cargo test --workspace --all-features --exclude ferriskey` green except for the pre-existing `completion_backend::two_streams_both_receive` flake reproducible on `main`
- [x] New Valkey test `engine_backend_suspend_by_triple`: both cases pass against a live Valkey
- [x] New Postgres test `suspend_by_triple_fresh_returns_suspended` + all 16 pre-existing `suspend_signal` tests pass against a live Postgres (sequential; parallel runs hit pre-existing pool-contention flakes unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new suspension entry point that changes how fencing/attempt metadata is derived for suspend operations, touching lease/epoch contention paths in both Valkey and Postgres backends. While largely reusing existing suspend logic, mistakes could surface as incorrect lease-conflict handling or unexpected NotFound/validation errors under races.
> 
> **Overview**
> Adds a new `EngineBackend::suspend_by_triple(exec_id, LeaseFence, SuspendArgs)` method (defaulting to `EngineError::Unavailable`) so service-layer callers can suspend an execution without a worker `Handle`, while keeping the same validation, idempotency/replay, and `SuspendOutcome` semantics as `suspend`.
> 
> Implements the method in **Valkey** by pre-reading required metadata from `exec_core` and then calling the existing `ff_suspend_execution` FCALL with fence fields sourced from the provided triple, and in **Postgres** by factoring shared suspend logic into `suspend_core` and adding a `suspend_by_triple_impl` path that reads the current `attempt_index` from `ff_exec_core` before running the same SERIALIZABLE fenced suspend transaction.
> 
> Adds integration coverage for both backends (including stale-fence contention behavior), and updates `CHANGELOG.md` plus `docs/POSTGRES_PARITY_MATRIX.md` to document the new additive method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f006bef1954f66c71aca18a4bb34e5221a2866. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->