### PR TITLE
rfcs: promote RFC-020 to accepted (post Round-4 unanimous)

### DIFF
--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -327,3 +327,11 @@ rows. The consumer migration guide
 ([`docs/MIGRATIONS.md`](MIGRATIONS.md) § v0.8 → `FF_BACKEND=postgres`)
 lists the current Postgres `Unavailable` surface so consumers know
 what to expect.
+
+### Wave 9 planned
+
+Design for the Wave 9 Postgres deferrals is committed in
+[`rfcs/RFC-020-postgres-wave-9.md`](../rfcs/RFC-020-postgres-wave-9.md)
+(ACCEPTED 2026-04-26, Revision 4, target v0.11). Parity rows above
+will flip as the RFC lands in implementation PRs — no rows are
+pre-flipped here.

--- a/rfcs/RFC-020-postgres-wave-9.md
+++ b/rfcs/RFC-020-postgres-wave-9.md
@@ -1,8 +1,9 @@
 # RFC-020: Postgres Wave 9 — deferred backend impls
 
-**Status:** DRAFT — Revision 4
+**Status:** ACCEPTED — Revision 4
 **Author:** FlowFabric Team (manager single-agent draft)
 **Proposed:** 2026-04-26
+**Accepted:** 2026-04-26
 **Revision 2:** 2026-04-26 — Round-1 reviewer findings addressed (schema-ground-truth, design-spine reframe, drop G6, full-parity + coherent-wave directive)
 **Revision 3:** 2026-04-26 — Round-2 reviewer findings addressed: (A1/A2) new `ff_operator_event` channel (migration 0010) instead of repurposing `ff_signal_event`; (A3) `PendingWaitpointInfo` contract aligned, additive migration 0011 adds `waitpoint_key`/`state`/`required_signal_names`/`activated_at_ms`; (A4) reconciler per-attempt scoping audited; (A5) `outcome`/`lifecycle_phase` column-binding clarified; (B1–B4) release-PR line items tightened; (C1) per-release-risk engagement in §8.7; (C2) intra-ack race traced to SERIALIZABLE retry; (C3a–d) resolved in §4.2.4/§4.2.7/§4.1/§6.3. Scope grows by two additive migrations (0010 + 0011); method count unchanged at 13.
 **Revision 4:** 2026-04-26 — Round-3 reviewer-A findings addressed: (NEW-1) `lifecycle_phase` enum literals corrected to lowercase real-enum values (`cancelled` / `runnable` / `NOT IN ('terminal','cancelled')`) across §4.2.1, §4.2.4, §4.2.5, §4.2.6; (NEW-4) stray `FOR UPDATE` removed from UPDATE in §4.2.4; (NEW-5) `waitpoint_key` pre-0011 projection behavior pinned in §4.5 (COALESCE to `''` + degraded-row counter); (NEW-2) SERIALIZABLE retry budget pinned to 3 (matches `CANCEL_FLOW_MAX_ATTEMPTS` in `flow.rs:52`) in §4.2.3; (B-1) scope note for the producer-side `suspend_*` write-path change added to §3; (B-2) rollback-forward-only caveat added to §6.2; (C-polish) §8 adds a one-liner pointing at §4.2.4 for the repurpose-`ff_signal_event` rejection. No scope, alternatives, or new forks re-opened.


### PR DESCRIPTION
## Summary

Promotes RFC-020 (Postgres Wave 9) from draft to accepted after 4 review rounds reached unanimous ACCEPT.

- Moves `rfcs/drafts/RFC-020-postgres-wave-9.md` -> `rfcs/RFC-020-postgres-wave-9.md`
- Header: `Status: DRAFT` -> `ACCEPTED`, adds `Accepted: 2026-04-26`, preserves `Proposed: 2026-04-26` + `Revision: 4`
- Adds a short "Wave 9 planned" pointer at the bottom of `docs/POSTGRES_PARITY_MATRIX.md` linking to the committed design. No parity rows flipped — implementation has not started.

No code changes. No CHANGELOG (draft -> accepted is process, not consumer-visible).

## Test plan

- [x] CI green (doc-only diff: file rename + pointer addition)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that promotes an RFC to accepted status and adds a cross-reference; no runtime behavior or schema changes.
> 
> **Overview**
> Promotes `RFC-020-postgres-wave-9.md` from *DRAFT* to **ACCEPTED** (adds an `Accepted` date) to lock in the Wave 9 Postgres parity plan.
> 
> Updates `docs/POSTGRES_PARITY_MATRIX.md` with a new **“Wave 9 planned”** section linking to the accepted RFC, without flipping any parity rows or implying implementation has started.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b8a386c90033f4406ebc624ec7c4feab673cd6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->