### PR TITLE
feat(pg-backend): Wave 9 migrations 0010 + 0011 — ff_operator_event outbox + ff_waitpoint_pending extensions (3 cols)

### DIFF
--- a/crates/ff-backend-postgres/migrations/0010_operator_event_outbox.sql
+++ b/crates/ff-backend-postgres/migrations/0010_operator_event_outbox.sql
@@ -1,0 +1,63 @@
+-- RFC-020 Wave 9 — `ff_operator_event` outbox + NOTIFY trigger.
+--
+-- New outbox channel for operator-control events emitted by Spine-A
+-- method impls (`cancel_execution` / `change_priority` /
+-- `replay_execution` / `cancel_flow_header`). Mirrors
+-- `ff_signal_event` (`0007_signal_event_outbox.sql`) +
+-- `ff_lease_event` (`0006_lease_event_outbox.sql`) shape: not
+-- partitioned, BIGSERIAL `event_id` PK, per-row `partition_key`,
+-- `pg_notify('ff_operator_event', event_id::text)` AFTER INSERT
+-- trigger.
+--
+-- `namespace` / `instance_tag` ship in the initial DDL (rather than
+-- bolted on in a later 0009-shaped migration) per RFC-020 §4.3.1 —
+-- Wave 9's consumer surface already expects RFC-019 subscriber
+-- filters to work.
+--
+-- Additive (`backward_compatible = true`).
+
+CREATE TABLE ff_operator_event (
+    event_id        BIGSERIAL PRIMARY KEY,
+    execution_id    TEXT NOT NULL,
+    event_type      TEXT NOT NULL
+        CHECK (event_type IN ('priority_changed', 'replayed', 'flow_cancel_requested')),
+    details         jsonb,
+    occurred_at_ms  BIGINT NOT NULL,
+    partition_key   INT NOT NULL,
+    namespace       TEXT,
+    instance_tag    TEXT
+);
+
+-- Subscriber catch-up: `WHERE partition_key = $1 AND event_id > $2`.
+CREATE INDEX ff_operator_event_partition_key_idx
+    ON ff_operator_event (partition_key, event_id);
+
+-- RFC-019 subscriber-filters (parity with `0009_signal_event_instance_tag.sql`).
+CREATE INDEX ff_operator_event_namespace_idx
+    ON ff_operator_event (partition_key, namespace)
+    WHERE namespace IS NOT NULL;
+
+CREATE INDEX ff_operator_event_instance_tag_idx
+    ON ff_operator_event (partition_key, instance_tag)
+    WHERE instance_tag IS NOT NULL;
+
+CREATE FUNCTION ff_notify_operator_event() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_notify('ff_operator_event', NEW.event_id::text);
+    RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER ff_operator_event_notify_trg
+    AFTER INSERT ON ff_operator_event
+    FOR EACH ROW
+    EXECUTE FUNCTION ff_notify_operator_event();
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    10,
+    '0010_operator_event_outbox',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/migrations/0011_waitpoint_pending_extensions.sql
+++ b/crates/ff-backend-postgres/migrations/0011_waitpoint_pending_extensions.sql
@@ -1,0 +1,37 @@
+-- RFC-020 Wave 9 — `ff_waitpoint_pending` additive columns for
+-- `list_pending_waitpoints` (Standalone-2).
+--
+-- The real `PendingWaitpointInfo` contract
+-- (`crates/ff-core/src/contracts/mod.rs:822-859`) has 10 fields; of
+-- those, three have no source column in the pre-Wave-9 schema:
+-- `state`, `required_signal_names`, `activated_at`. This migration
+-- adds them as additive, defaulted columns.
+--
+-- (`waitpoint_key` — a fourth contract field previously scoped into
+-- 0011 in RFC-020 Revision 3/4 — already exists on
+-- `ff_waitpoint_pending` as `TEXT NOT NULL DEFAULT ''` since
+-- migration 0004 (`0004_suspend_signal.sql:33-34`) and is populated
+-- by `suspend_ops.rs`. RFC-020 Revision 5 corrected the scope.)
+--
+-- Existing rows inserted pre-0011 get `state = 'pending'`, empty
+-- `required_signal_names`, NULL `activated_at_ms`. New inserts
+-- (post-0011) populate `required_signal_names` from the
+-- producer-side `suspend_*` path; activation transitions populate
+-- `state = 'active', activated_at_ms = now`. Producer + activation
+-- wiring changes land in the same PR as this migration (RFC-020
+-- §3.1.1, §6.1 step 4). This migration is schema-only.
+--
+-- Additive (`backward_compatible = true`).
+
+ALTER TABLE ff_waitpoint_pending
+    ADD COLUMN state                 TEXT NOT NULL DEFAULT 'pending',
+    ADD COLUMN required_signal_names TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN activated_at_ms       BIGINT;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    11,
+    '0011_waitpoint_pending_extensions',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/tests/schema_0010_0011.rs
+++ b/crates/ff-backend-postgres/tests/schema_0010_0011.rs
@@ -1,0 +1,290 @@
+//! RFC-020 Wave 9 schema smoke test — migrations 0010 + 0011.
+//!
+//! Applies every migration up through 0011 (sqlx is idempotent) and
+//! asserts:
+//!
+//!   0010 `ff_operator_event` —
+//!     * the outbox table exists and is not partitioned,
+//!     * `execution_id` is `TEXT`,
+//!     * CHECK constraint restricts `event_type` to the 3 operator-
+//!       control events,
+//!     * the three indexes defined in the migration exist,
+//!     * the `pg_notify` trigger is installed,
+//!     * `ff_migration_annotation` records `(10, _, _, true)`.
+//!
+//!   0011 `ff_waitpoint_pending` —
+//!     * the 3 new columns exist with the right types + defaults,
+//!     * `waitpoint_key` (from migration 0004) is still present as
+//!       `TEXT NOT NULL DEFAULT ''` (RFC-020 Revision 5 ground-truth
+//!       assertion),
+//!     * `ff_migration_annotation` records `(11, _, _, true)`.
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://user:pw@localhost/ff_wave9_test \
+//!   cargo test -p ff-backend-postgres --test schema_0010_0011 -- --ignored
+//! ```
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+// ---------- 0010 `ff_operator_event` ----------
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn operator_event_table_exists() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM pg_class c \
+         JOIN pg_namespace n ON c.relnamespace = n.oid \
+         WHERE n.nspname = 'public' AND c.relname = 'ff_operator_event'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let n: i64 = row.get("n");
+    assert_eq!(n, 1, "ff_operator_event table must exist");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn operator_event_is_not_partitioned() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    // Partitioned tables have a row in pg_partitioned_table.
+    let row = sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM pg_partitioned_table pt \
+         JOIN pg_class c ON c.oid = pt.partrelid \
+         WHERE c.relname = 'ff_operator_event'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let n: i64 = row.get("n");
+    assert_eq!(n, 0, "ff_operator_event must NOT be partitioned");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn operator_event_execution_id_is_text() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT data_type FROM information_schema.columns \
+         WHERE table_schema = 'public' AND table_name = 'ff_operator_event' \
+           AND column_name = 'execution_id'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let dt: String = row.get("data_type");
+    assert_eq!(dt, "text", "execution_id must be TEXT (not bytea)");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn operator_event_type_check_constraint() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    // Valid values should insert.
+    for et in &["priority_changed", "replayed", "flow_cancel_requested"] {
+        sqlx::query(
+            "INSERT INTO ff_operator_event \
+               (execution_id, event_type, occurred_at_ms, partition_key) \
+             VALUES ($1, $2, 0, 0)",
+        )
+        .bind("exec-test")
+        .bind(et)
+        .execute(&pool)
+        .await
+        .unwrap_or_else(|e| panic!("valid event_type {et} should insert: {e}"));
+    }
+    // Invalid value should fail the CHECK.
+    let res = sqlx::query(
+        "INSERT INTO ff_operator_event \
+           (execution_id, event_type, occurred_at_ms, partition_key) \
+         VALUES ('exec-bad', 'not_an_operator_event', 0, 0)",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+        res.is_err(),
+        "CHECK constraint must reject unknown event_type"
+    );
+    // Clean up.
+    sqlx::query("DELETE FROM ff_operator_event WHERE execution_id = 'exec-test'")
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn operator_event_indexes_exist() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    for idx in &[
+        "ff_operator_event_partition_key_idx",
+        "ff_operator_event_namespace_idx",
+        "ff_operator_event_instance_tag_idx",
+    ] {
+        let row = sqlx::query(
+            "SELECT COUNT(*)::bigint AS n FROM pg_indexes \
+             WHERE schemaname = 'public' AND indexname = $1",
+        )
+        .bind(idx)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let n: i64 = row.get("n");
+        assert_eq!(n, 1, "index {idx} must exist");
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn operator_event_notify_trigger_exists() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM pg_trigger t \
+         JOIN pg_class c ON c.oid = t.tgrelid \
+         WHERE c.relname = 'ff_operator_event' \
+           AND t.tgname = 'ff_operator_event_notify_trg'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let n: i64 = row.get("n");
+    assert_eq!(n, 1, "NOTIFY trigger must be installed");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn operator_event_migration_annotation_row() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT version, name, backward_compatible FROM ff_migration_annotation WHERE version = 10",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let v: i32 = row.get("version");
+    let n: String = row.get("name");
+    let bc: bool = row.get("backward_compatible");
+    assert_eq!(v, 10);
+    assert_eq!(n, "0010_operator_event_outbox");
+    assert!(bc, "0010 must be backward_compatible=true (additive)");
+}
+
+// ---------- 0011 `ff_waitpoint_pending` additive columns ----------
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn waitpoint_pending_new_columns_exist() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    // (column_name, data_type, is_nullable, column_default presence)
+    let expected: &[(&str, &str, &str, bool)] = &[
+        ("state", "text", "NO", true),
+        ("required_signal_names", "ARRAY", "NO", true),
+        ("activated_at_ms", "bigint", "YES", false),
+    ];
+    for (col, dt, nullable, has_default) in expected {
+        let row = sqlx::query(
+            "SELECT data_type, is_nullable, column_default \
+             FROM information_schema.columns \
+             WHERE table_schema = 'public' AND table_name = 'ff_waitpoint_pending' \
+               AND column_name = $1",
+        )
+        .bind(col)
+        .fetch_one(&pool)
+        .await
+        .unwrap_or_else(|e| panic!("column {col} must exist: {e}"));
+        let got_dt: String = row.get("data_type");
+        let got_null: String = row.get("is_nullable");
+        let got_default: Option<String> = row.get("column_default");
+        assert_eq!(&got_dt, dt, "column {col} data_type");
+        assert_eq!(&got_null, nullable, "column {col} nullability");
+        assert_eq!(
+            got_default.is_some(),
+            *has_default,
+            "column {col} default presence"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn waitpoint_key_from_0004_still_present() {
+    // RFC-020 Revision 5 ground-truth: `waitpoint_key` exists from
+    // migration 0004 as TEXT NOT NULL DEFAULT ''. 0011 does NOT add
+    // it. This test pins that invariant.
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT data_type, is_nullable, column_default \
+         FROM information_schema.columns \
+         WHERE table_schema = 'public' AND table_name = 'ff_waitpoint_pending' \
+           AND column_name = 'waitpoint_key'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let dt: String = row.get("data_type");
+    let nullable: String = row.get("is_nullable");
+    let default: Option<String> = row.get("column_default");
+    assert_eq!(dt, "text");
+    assert_eq!(nullable, "NO", "waitpoint_key is NOT NULL since 0004");
+    assert!(
+        default
+            .as_deref()
+            .map(|d| d.contains("''"))
+            .unwrap_or(false),
+        "waitpoint_key must default to empty string (from 0004), got: {default:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn waitpoint_pending_migration_annotation_row() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT version, name, backward_compatible FROM ff_migration_annotation WHERE version = 11",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let v: i32 = row.get("version");
+    let n: String = row.get("name");
+    let bc: bool = row.get("backward_compatible");
+    assert_eq!(v, 11);
+    assert_eq!(n, "0011_waitpoint_pending_extensions");
+    assert!(bc, "0011 must be backward_compatible=true (additive)");
+}


### PR DESCRIPTION
## Summary

Lands the two prerequisite migrations for RFC-020 Wave 9 method impls. Schema-only PR; method impls follow per RFC-020 §6.1.

- **Migration 0010** — `ff_operator_event` outbox + NOTIFY trigger (RFC-020 §4.3.1). New channel for operator-control events (`priority_changed` / `replayed` / `flow_cancel_requested`); mirrors `ff_signal_event`/`ff_lease_event` shape (not partitioned, `TEXT execution_id`, BIGSERIAL PK, AFTER-INSERT `pg_notify` trigger). CHECK constraint on `event_type`. RFC-019 subscriber-filter columns (`namespace` / `instance_tag`) + partial indexes ship in the initial DDL.
- **Migration 0011** — `ff_waitpoint_pending` additive columns (RFC-020 §4.5, Revision 5). 3 columns: `state TEXT NOT NULL DEFAULT 'pending'`, `required_signal_names TEXT[] NOT NULL DEFAULT '{}'`, `activated_at_ms BIGINT`. `waitpoint_key` already shipped via migration 0004 and is **not** added here (Revision 5 correction — see PR #348).

## RFC alignment

- §4.3.1 — 0010 DDL verbatim (table shape, trigger, CHECK-3, RFC-019 filter columns + indexes).
- §4.5 — 0011 DDL per Revision 5 (3 columns, no `waitpoint_key`).
- §3.1.1 — producer wiring **deferred** to the Standalone-2 impl PR (§6.1 step 4). Schema-only here.
- §6.1 — prerequisite for spine-A pt.1 (step 3) and standalone-2 (step 4).

## Tests

`tests/schema_0010_0011.rs` — 10 ignored tests under `FF_PG_TEST_URL`:

- Table existence + not-partitioned.
- `execution_id` is `TEXT`.
- CHECK constraint accepts the 3 valid values + rejects unknown.
- All 3 indexes (`partition_key_idx`, `namespace_idx`, `instance_tag_idx`) + NOTIFY trigger exist.
- `ff_migration_annotation` rows for versions 10 and 11 with `backward_compatible = true`.
- New 3 columns on `ff_waitpoint_pending` have the correct type / nullability / default.
- `waitpoint_key` pinning assertion — `TEXT NOT NULL DEFAULT ''` from migration 0004 (Revision 5 ground-truth).

Local verification on Postgres 14:

- `cargo build -p ff-backend-postgres` clean.
- `cargo clippy -p ff-backend-postgres --all-targets -- -D warnings` clean.
- All 10 new tests pass; all 41 pre-existing `ff-backend-postgres` ignored tests still pass against the same DB (migrations remain idempotent + additive).

## Non-goals

- No method-impl changes; no `Supports` flag flips; no capability-discovery touch.
- No `CHANGELOG` entry — internal migration, ships with Wave 9 release per RFC-020 §6.3.
- Producer-side write-path wiring for the new 0011 columns lands in the Standalone-2 impl PR.

## Test plan

- [ ] Matrix CI green.
- [ ] Postgres ignored-tests job green.
- [ ] Admin-merge after green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres DDL (table, indexes, and a NOTIFY trigger) and alters an existing table with new defaulted columns; while additive, schema changes and triggers can impact database performance/operational behavior if misconfigured.
> 
> **Overview**
> Adds migration `0010` introducing a new `ff_operator_event` outbox table for operator-control events, including an `event_type` CHECK constraint, partition/filter indexes, and an AFTER INSERT `pg_notify('ff_operator_event', ...)` trigger.
> 
> Adds migration `0011` extending `ff_waitpoint_pending` with three additive columns (`state`, `required_signal_names`, `activated_at_ms`) with defaults where applicable.
> 
> Adds ignored Postgres-backed smoke tests (`schema_0010_0011`) to assert both migrations apply correctly (table/columns, indexes, trigger, and `ff_migration_annotation` rows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 617180cac4801209e9223705295d751f16dcee3b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->