### PR TITLE
feat(pg-backend): Wave 9 Standalone-2 — list_pending_waitpoints + producer wiring for 0011 columns

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -35,8 +35,9 @@ use ff_core::contracts::{
     ApplyDependencyToChildResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
     CreateExecutionArgs, CreateExecutionResult, CreateFlowArgs, CreateFlowResult,
     DeliverSignalArgs, DeliverSignalResult, EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot,
-    ListExecutionsPage, ListFlowsPage, ListLanesPage, ListSuspendedPage,
-    SetEdgeGroupPolicyResult, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+    ListExecutionsPage, ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs,
+    ListPendingWaitpointsResult, ListSuspendedPage, SetEdgeGroupPolicyResult,
+    StageDependencyEdgeArgs, StageDependencyEdgeResult,
 };
 #[cfg(feature = "core")]
 use ff_core::state::PublicState;
@@ -630,6 +631,23 @@ impl EngineBackend for PostgresBackend {
         args: ClaimResumedExecutionArgs,
     ) -> Result<ClaimResumedExecutionResult, EngineError> {
         suspend_ops::claim_resumed_execution_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    // ── RFC-020 Wave 9 Standalone-2 — list_pending_waitpoints (§4.5) ─
+    //
+    // Read-only projection of `ff_waitpoint_pending` serving the 10-
+    // field `PendingWaitpointInfo` contract. Producer-side writes of
+    // the 3 new 0011 columns (`state`, `required_signal_names`,
+    // `activated_at_ms`) land alongside this method in the same PR —
+    // see `suspend_ops::suspend_core` INSERT site. Capability flip
+    // deferred to Wave 9 release PR per RFC §6.3.
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.list_pending_waitpoints", skip_all)]
+    async fn list_pending_waitpoints(
+        &self,
+        args: ListPendingWaitpointsArgs,
+    ) -> Result<ListPendingWaitpointsResult, EngineError> {
+        suspend_ops::list_pending_waitpoints_impl(&self.pool, args).await
     }
 
     // ── RFC-017 Stage A — ingress (promoted from inherent) ────

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -113,22 +113,29 @@ fn susp_uuid(s: &SuspensionId) -> Result<Uuid, EngineError> {
 /// the condition tree and collects every `SignalMatcher::ByName` that
 /// targets this specific waitpoint. `Wildcard` matchers contribute
 /// nothing (an empty result vec is the wire-level wildcard marker per
-/// `PendingWaitpointInfo::required_signal_names` docs). `OperatorOnly`
-/// / `TimeoutOnly` / `Count { matcher: None }` likewise return empty.
-/// Duplicates are de-duplicated preserving first-seen order.
+/// `PendingWaitpointInfo::required_signal_names` docs).
+///
+/// `OperatorOnly` / `TimeoutOnly` are rendered with the same sentinel
+/// names that the Valkey wire format emits (`__operator_only__` /
+/// `__timeout_only__`, see `ff-backend-valkey/src/lib.rs:3205-3222`)
+/// so an operator-only or timeout-only waitpoint is distinguishable
+/// from a true wildcard at the `PendingWaitpointInfo` surface. The
+/// `__`-prefix sentinel values are never real signal names.
+///
+/// `Count { matcher: None }` returns empty (any signal on the listed
+/// waitpoints counts). Duplicates are de-duplicated preserving
+/// first-seen order.
 fn derive_required_signal_names(cond: &ResumeCondition, wp_key: &str) -> Vec<String> {
+    const OPERATOR_ONLY_SENTINEL: &str = "__operator_only__";
+    const TIMEOUT_ONLY_SENTINEL: &str = "__timeout_only__";
+
     let mut out: Vec<String> = Vec::new();
     let mut push = |name: &str| {
         if !name.is_empty() && !out.iter().any(|e| e == name) {
             out.push(name.to_owned());
         }
     };
-    fn walk(
-        cond: &ResumeCondition,
-        target: &str,
-        inherited_matcher: Option<&SignalMatcher>,
-        push: &mut dyn FnMut(&str),
-    ) {
+    fn walk(cond: &ResumeCondition, target: &str, push: &mut dyn FnMut(&str)) {
         match cond {
             ResumeCondition::Single {
                 waitpoint_key,
@@ -139,8 +146,9 @@ fn derive_required_signal_names(cond: &ResumeCondition, wp_key: &str) -> Vec<Str
                 {
                     push(name.as_str());
                 }
-                let _ = inherited_matcher;
             }
+            ResumeCondition::OperatorOnly => push(OPERATOR_ONLY_SENTINEL),
+            ResumeCondition::TimeoutOnly => push(TIMEOUT_ONLY_SENTINEL),
             ResumeCondition::Composite(body) => walk_body(body, target, push),
             _ => {}
         }
@@ -149,7 +157,7 @@ fn derive_required_signal_names(cond: &ResumeCondition, wp_key: &str) -> Vec<Str
         match body {
             CompositeBody::AllOf { members } => {
                 for m in members {
-                    walk(m, target, None, push);
+                    walk(m, target, push);
                 }
             }
             CompositeBody::Count {
@@ -164,7 +172,7 @@ fn derive_required_signal_names(cond: &ResumeCondition, wp_key: &str) -> Vec<Str
             _ => {}
         }
     }
-    walk(cond, wp_key, None, &mut push);
+    walk(cond, wp_key, &mut push);
     out
 }
 
@@ -1125,10 +1133,7 @@ pub(crate) async fn list_pending_waitpoints_impl(
     for (wp_uid, wp_key, state, req_names, created_ms, activated_ms, expires_ms, _kid, token)
         in rows.into_iter().take(take_n)
     {
-        let wp_id = WaitpointId::parse(&wp_uid.to_string()).map_err(|e| EngineError::Validation {
-            kind: ValidationKind::Corruption,
-            detail: format!("stored waitpoint_id not parseable: {e}"),
-        })?;
+        let wp_id = WaitpointId::from_uuid(wp_uid);
         // Parse stored `<kid>:<hex>` into audit-safe pair. The `token_kid`
         // column is redundant with the parsed kid — we prefer the parsed
         // one so the surface stays byte-identical to Valkey's.

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -24,8 +24,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use ff_core::backend::{BackendTag, Handle, HandleKind, HandleOpaque, ResumeSignal, WaitpointHmac};
 use ff_core::contracts::{
     AdditionalWaitpointBinding, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
-    ClaimedResumedExecution, DeliverSignalArgs, DeliverSignalResult, ResumeCondition, SuspendArgs,
-    SuspendOutcome, SuspendOutcomeDetails, WaitpointBinding,
+    ClaimedResumedExecution, CompositeBody, DeliverSignalArgs, DeliverSignalResult,
+    ListPendingWaitpointsArgs, ListPendingWaitpointsResult, PendingWaitpointInfo, ResumeCondition,
+    SignalMatcher, SuspendArgs, SuspendOutcome, SuspendOutcomeDetails, WaitpointBinding,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
 use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
@@ -105,6 +106,82 @@ fn susp_uuid(s: &SuspensionId) -> Result<Uuid, EngineError> {
         kind: ValidationKind::InvalidInput,
         detail: format!("suspension_id not a UUID: {e}"),
     })
+}
+
+/// RFC-020 §3.1.1 — derive `required_signal_names` for a single
+/// `waitpoint_key` from the suspend call's `ResumeCondition`. Walks
+/// the condition tree and collects every `SignalMatcher::ByName` that
+/// targets this specific waitpoint. `Wildcard` matchers contribute
+/// nothing (an empty result vec is the wire-level wildcard marker per
+/// `PendingWaitpointInfo::required_signal_names` docs). `OperatorOnly`
+/// / `TimeoutOnly` / `Count { matcher: None }` likewise return empty.
+/// Duplicates are de-duplicated preserving first-seen order.
+fn derive_required_signal_names(cond: &ResumeCondition, wp_key: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push = |name: &str| {
+        if !name.is_empty() && !out.iter().any(|e| e == name) {
+            out.push(name.to_owned());
+        }
+    };
+    fn walk(
+        cond: &ResumeCondition,
+        target: &str,
+        inherited_matcher: Option<&SignalMatcher>,
+        push: &mut dyn FnMut(&str),
+    ) {
+        match cond {
+            ResumeCondition::Single {
+                waitpoint_key,
+                matcher,
+            } => {
+                if waitpoint_key == target
+                    && let SignalMatcher::ByName(name) = matcher
+                {
+                    push(name.as_str());
+                }
+                let _ = inherited_matcher;
+            }
+            ResumeCondition::Composite(body) => walk_body(body, target, push),
+            _ => {}
+        }
+    }
+    fn walk_body(body: &CompositeBody, target: &str, push: &mut dyn FnMut(&str)) {
+        match body {
+            CompositeBody::AllOf { members } => {
+                for m in members {
+                    walk(m, target, None, push);
+                }
+            }
+            CompositeBody::Count {
+                matcher, waitpoints, ..
+            } => {
+                if waitpoints.iter().any(|w| w == target)
+                    && let Some(SignalMatcher::ByName(name)) = matcher
+                {
+                    push(name.as_str());
+                }
+            }
+            _ => {}
+        }
+    }
+    walk(cond, wp_key, None, &mut push);
+    out
+}
+
+/// RFC-017 §8 / RFC-020 §4.5 — parse the stored `<kid>:<hex>` waitpoint
+/// token into a `(token_kid, token_fingerprint)` pair. `token_fingerprint`
+/// is the first 16 hex chars (8 bytes) of the HMAC digest — the §8 audit-
+/// friendly handle. Malformed input collapses to `("", "")` so callers
+/// can skip / log without surfacing a typed error. Mirrors
+/// `ff-backend-valkey::parse_waitpoint_token_kid_fp`.
+fn parse_waitpoint_token_kid_fp(raw: &str) -> (String, String) {
+    match raw.split_once(':') {
+        Some((kid, hex)) if !kid.is_empty() && !hex.is_empty() => {
+            let fp_len = hex.len().min(16);
+            (kid.to_owned(), hex[..fp_len].to_owned())
+        }
+        _ => (String::new(), String::new()),
+    }
 }
 
 // ─── SERIALIZABLE retry loop ─────────────────────────────────────────────
@@ -416,14 +493,31 @@ async fn suspend_core(
                 };
                 let msg = format!("{}:{}", payload.execution_id, wp_id);
                 let token = hmac_sign(&secret, &kid, msg.as_bytes());
+                // RFC-020 §3.1.1 — populate 0011 columns on insert.
+                // `suspend_core` atomically lands the suspension (exec_core
+                // flips to `suspended` in the same txn as this INSERT), so
+                // from any observer's perspective the waitpoint is already
+                // activated at the moment it becomes visible — there is no
+                // separate pending→active transition on Postgres. Write
+                // `state = 'active'` + `activated_at_ms = now` directly.
+                // `required_signal_names` is derived per-waitpoint from the
+                // resume condition; an empty vec denotes the wildcard case
+                // per the `PendingWaitpointInfo::required_signal_names`
+                // contract.
+                let required_names =
+                    derive_required_signal_names(&args.resume_condition, &wp_key);
                 sqlx::query(
                     "INSERT INTO ff_waitpoint_pending \
                        (partition_key, waitpoint_id, execution_id, token_kid, token, \
-                        created_at_ms, expires_at_ms, waitpoint_key) \
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
+                        created_at_ms, expires_at_ms, waitpoint_key, \
+                        state, required_signal_names, activated_at_ms) \
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $6) \
                      ON CONFLICT (partition_key, waitpoint_id) DO UPDATE SET \
                        token_kid = EXCLUDED.token_kid, token = EXCLUDED.token, \
-                       waitpoint_key = EXCLUDED.waitpoint_key",
+                       waitpoint_key = EXCLUDED.waitpoint_key, \
+                       state = EXCLUDED.state, \
+                       required_signal_names = EXCLUDED.required_signal_names, \
+                       activated_at_ms = EXCLUDED.activated_at_ms",
                 )
                 .bind(part)
                 .bind(wp_uuid(&wp_id)?)
@@ -433,6 +527,7 @@ async fn suspend_core(
                 .bind(now)
                 .bind(args.timeout_at.map(|t| t.0))
                 .bind(&wp_key)
+                .bind(&required_names)
                 .execute(&mut **tx)
                 .await
                 .map_err(map_sqlx_error)?;
@@ -939,4 +1034,134 @@ pub(crate) async fn observe_signals_impl(
         }
     }
     Ok(out)
+}
+
+// ─── list_pending_waitpoints ─────────────────────────────────────────────
+
+/// RFC-020 §4.5 — read-only projection of pending-or-active waitpoints
+/// for a given execution. SQL parity with Valkey's SSCAN + 2× HMGET
+/// shape: single-table scan of `ff_waitpoint_pending` with cursor
+/// `(waitpoint_id > $after ORDER BY waitpoint_id LIMIT $limit+1)`,
+/// surfaces the `PendingWaitpointInfo` 10-field contract.
+/// `token_fingerprint` is computed from the stored `<kid>:<hex>` token
+/// — the raw token never crosses the trait boundary per RFC-017 Stage
+/// D1 / §8.
+///
+/// Pre-read existence check on `ff_exec_core` mirrors Valkey's
+/// `EXISTS exec_core` so a non-existent execution surfaces `NotFound`
+/// rather than an empty page.
+///
+/// Rows with `state NOT IN ('pending', 'active')` (e.g. `'closed'`)
+/// are filtered server-side to match Valkey's client-side keep-filter.
+pub(crate) async fn list_pending_waitpoints_impl(
+    pool: &PgPool,
+    args: ListPendingWaitpointsArgs,
+) -> Result<ListPendingWaitpointsResult, EngineError> {
+    const DEFAULT_LIMIT: u32 = 100;
+    const MAX_LIMIT: u32 = 1000;
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as i64;
+    let after_uuid = match args.after.as_ref() {
+        Some(wp) => Some(wp_uuid(wp)?),
+        None => None,
+    };
+
+    // Existence probe — a non-existent execution is `NotFound`, not an
+    // empty page. Matches Valkey's `EXISTS exec_core` pre-check.
+    let exists: Option<(i16,)> = sqlx::query_as(
+        "SELECT 1::smallint FROM ff_exec_core \
+          WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    if exists.is_none() {
+        return Err(EngineError::NotFound { entity: "execution" });
+    }
+
+    // Page: request `limit + 1` so we can detect "more to come" without
+    // a second round-trip. Row tuple order matches the SELECT below:
+    // (waitpoint_id, waitpoint_key, state, required_signal_names,
+    //  created_at_ms, activated_at_ms, expires_at_ms, token_kid, token).
+    // Raw token is fingerprinted client-side — never returned across
+    // the trait boundary per RFC-017 Stage D1 / §8.
+    type Row = (
+        Uuid,
+        String,
+        String,
+        Vec<String>,
+        i64,
+        Option<i64>,
+        Option<i64>,
+        String,
+        String,
+    );
+    let rows: Vec<Row> = sqlx::query_as(
+        "SELECT waitpoint_id, waitpoint_key, state, required_signal_names, \
+                created_at_ms, activated_at_ms, expires_at_ms, token_kid, token \
+           FROM ff_waitpoint_pending \
+          WHERE partition_key = $1 \
+            AND execution_id = $2 \
+            AND state IN ('pending', 'active') \
+            AND ($3::uuid IS NULL OR waitpoint_id > $3) \
+          ORDER BY waitpoint_id \
+          LIMIT $4",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(after_uuid)
+    .bind(limit + 1)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let has_more = rows.len() as i64 > limit;
+    let take_n = if has_more { limit as usize } else { rows.len() };
+
+    let mut entries: Vec<PendingWaitpointInfo> = Vec::with_capacity(take_n);
+    for (wp_uid, wp_key, state, req_names, created_ms, activated_ms, expires_ms, _kid, token)
+        in rows.into_iter().take(take_n)
+    {
+        let wp_id = WaitpointId::parse(&wp_uid.to_string()).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("stored waitpoint_id not parseable: {e}"),
+        })?;
+        // Parse stored `<kid>:<hex>` into audit-safe pair. The `token_kid`
+        // column is redundant with the parsed kid — we prefer the parsed
+        // one so the surface stays byte-identical to Valkey's.
+        let (token_kid, token_fingerprint) = parse_waitpoint_token_kid_fp(&token);
+        let mut info = PendingWaitpointInfo::new(
+            wp_id,
+            wp_key,
+            state,
+            TimestampMs(created_ms),
+            args.execution_id.clone(),
+            token_kid,
+            token_fingerprint,
+        );
+        if !req_names.is_empty() {
+            info = info.with_required_signal_names(req_names);
+        }
+        if let Some(ms) = activated_ms {
+            info = info.with_activated_at(TimestampMs(ms));
+        }
+        if let Some(ms) = expires_ms {
+            info = info.with_expires_at(TimestampMs(ms));
+        }
+        entries.push(info);
+    }
+
+    let next_cursor = if has_more {
+        entries.last().map(|e| e.waitpoint_id.clone())
+    } else {
+        None
+    };
+    let mut result = ListPendingWaitpointsResult::new(entries);
+    if let Some(cursor) = next_cursor {
+        result = result.with_next_cursor(cursor);
+    }
+    Ok(result)
 }

--- a/crates/ff-backend-postgres/tests/list_pending_waitpoints.rs
+++ b/crates/ff-backend-postgres/tests/list_pending_waitpoints.rs
@@ -1,0 +1,496 @@
+//! RFC-020 Wave 9 Standalone-2 — integration tests for
+//! `list_pending_waitpoints` + producer-side writes of the 0011
+//! columns (`state`, `required_signal_names`, `activated_at_ms`).
+//!
+//! Follows the crate-local `FF_PG_TEST_URL` / `#[ignore]` convention
+//! used by `suspend_signal.rs` (per-test schema shadow of the global
+//! `ff_waitpoint_hmac` keystore — see issue #301).
+//!
+//! Covers:
+//!
+//! * [`producer_writes_active_state_and_activated_at`] — insert
+//!   populates `state = 'active'` + `activated_at_ms = now` (no
+//!   separate `pending→active` transition exists on Postgres; the
+//!   suspension lands atomically).
+//! * [`producer_writes_required_signal_names_byname`] — `Single`
+//!   with `SignalMatcher::ByName` produces a `[name]` vec.
+//! * [`producer_writes_required_signal_names_wildcard`] — `Single`
+//!   with `SignalMatcher::Wildcard` produces an empty vec (wildcard
+//!   wire marker).
+//! * [`producer_writes_required_signal_names_allof`] — `AllOf` tree
+//!   distributes per-waitpoint names correctly.
+//! * [`list_returns_not_found_for_missing_execution`] — matches
+//!   Valkey's `EXISTS exec_core` pre-check.
+//! * [`list_returns_single_waitpoint`] — happy-path end-to-end:
+//!   suspend, then list, verify all 10 contract fields.
+//! * [`list_paginates_with_cursor`] — multi-waitpoint AllOf, page
+//!   size 1, cursor threads correctly.
+
+use ff_backend_postgres::signal::rotate_waitpoint_hmac_secret_all_impl;
+use ff_backend_postgres::PostgresBackend;
+use ff_core::backend::{BackendTag, Handle, HandleKind};
+use ff_core::contracts::{
+    CompositeBody, ListPendingWaitpointsArgs, ResumeCondition, ResumePolicy,
+    RotateWaitpointHmacSecretAllArgs, SignalMatcher, SuspendArgs, SuspendOutcome,
+    SuspensionReasonCode, WaitpointBinding,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::EngineError;
+use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, SuspensionId, TimestampMs,
+    WaitpointId, WorkerInstanceId,
+};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ─── per-test pool + schema (shadow `ff_waitpoint_hmac`) ─────────────────
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+
+    let bootstrap = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&bootstrap)
+        .await
+        .expect("apply_migrations clean");
+
+    let schema = format!("ffpg_test_{}", Uuid::new_v4().simple());
+    sqlx::query(&format!("CREATE SCHEMA {schema}"))
+        .execute(&bootstrap)
+        .await
+        .expect("create per-test schema");
+    sqlx::query(&format!(
+        "CREATE TABLE {schema}.ff_waitpoint_hmac \
+         (LIKE public.ff_waitpoint_hmac INCLUDING ALL)"
+    ))
+    .execute(&bootstrap)
+    .await
+    .expect("create per-test ff_waitpoint_hmac");
+    bootstrap.close().await;
+
+    let schema_for_hook = schema.clone();
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .after_connect(move |conn, _meta| {
+            let schema = schema_for_hook.clone();
+            Box::pin(async move {
+                sqlx::query(&format!("SET search_path TO {schema}, public"))
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+
+    Some(pool)
+}
+
+struct ExecFixture {
+    backend: std::sync::Arc<dyn EngineBackend>,
+    pool: PgPool,
+    exec_id: ExecutionId,
+    part: i16,
+    exec_uuid: Uuid,
+    handle: Handle,
+}
+
+async fn setup_exec_or_skip() -> Option<ExecFixture> {
+    let pool = setup_or_skip().await?;
+
+    rotate_waitpoint_hmac_secret_all_impl(
+        &pool,
+        RotateWaitpointHmacSecretAllArgs::new("kid-lpw-1", "cd".repeat(32), 0),
+        1_000_000,
+    )
+    .await
+    .unwrap();
+
+    let lane = LaneId::new("default");
+    let exec_id = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let part = exec_id.partition() as i16;
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+
+    let now = TimestampMs::now().0;
+    sqlx::query(
+        "INSERT INTO ff_exec_core \
+           (partition_key, execution_id, lane_id, attempt_index, \
+            lifecycle_phase, ownership_state, eligibility_state, \
+            public_state, attempt_state, created_at_ms) \
+         VALUES ($1, $2, $3, 0, 'active', 'leased', 'not_applicable', \
+                 'running', 'running_attempt', $4)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lane.as_str())
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert exec_core");
+
+    let attempt_index = AttemptIndex::new(0);
+    let lease_epoch = LeaseEpoch(1);
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, worker_id, \
+            worker_instance_id, lease_epoch, lease_expires_at_ms, started_at_ms) \
+         VALUES ($1, $2, 0, 'w1', 'wi1', 1, $3, $4)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now + 30_000)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert attempt");
+
+    let payload = HandlePayload::new(
+        exec_id.clone(),
+        attempt_index,
+        AttemptId::new(),
+        LeaseId::new(),
+        lease_epoch,
+        30_000,
+        lane.clone(),
+        WorkerInstanceId::new("wi1"),
+    );
+    let opaque = encode_opaque(BackendTag::Postgres, &payload);
+    let handle = Handle::new(BackendTag::Postgres, HandleKind::Fresh, opaque);
+
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default())
+        as std::sync::Arc<dyn EngineBackend>;
+
+    Some(ExecFixture {
+        backend,
+        pool,
+        exec_id,
+        part,
+        exec_uuid,
+        handle,
+    })
+}
+
+// ─── producer-side column-write tests ────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn producer_writes_active_state_and_activated_at() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let wp_id = WaitpointId::new();
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        WaitpointBinding::Fresh {
+            waitpoint_id: wp_id.clone(),
+            waitpoint_key: "wpk:active-state".to_owned(),
+        },
+        ResumeCondition::Single {
+            waitpoint_key: "wpk:active-state".to_owned(),
+            matcher: SignalMatcher::ByName("ready".into()),
+        },
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::now(),
+    );
+    let before_ms = args.now.0;
+    fx.backend.suspend(&fx.handle, args).await.expect("suspend");
+
+    let row: (String, Option<i64>, Vec<String>) = sqlx::query_as(
+        "SELECT state, activated_at_ms, required_signal_names \
+           FROM ff_waitpoint_pending \
+          WHERE partition_key = $1 AND waitpoint_id = $2",
+    )
+    .bind(fx.part)
+    .bind(Uuid::parse_str(&wp_id.to_string()).unwrap())
+    .fetch_one(&fx.pool)
+    .await
+    .expect("fetch waitpoint row");
+
+    assert_eq!(row.0, "active", "Postgres suspend lands waitpoint active");
+    assert!(
+        row.1.is_some() && row.1.unwrap() >= before_ms,
+        "activated_at_ms populated on insert"
+    );
+    assert_eq!(row.2, vec!["ready".to_owned()]);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn producer_writes_required_signal_names_wildcard() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let wp_id = WaitpointId::new();
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        WaitpointBinding::Fresh {
+            waitpoint_id: wp_id.clone(),
+            waitpoint_key: "wpk:wild".to_owned(),
+        },
+        ResumeCondition::Single {
+            waitpoint_key: "wpk:wild".to_owned(),
+            matcher: SignalMatcher::Wildcard,
+        },
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::now(),
+    );
+    fx.backend.suspend(&fx.handle, args).await.expect("suspend");
+
+    let row: (Vec<String>,) = sqlx::query_as(
+        "SELECT required_signal_names FROM ff_waitpoint_pending \
+          WHERE partition_key = $1 AND waitpoint_id = $2",
+    )
+    .bind(fx.part)
+    .bind(Uuid::parse_str(&wp_id.to_string()).unwrap())
+    .fetch_one(&fx.pool)
+    .await
+    .unwrap();
+    assert!(
+        row.0.is_empty(),
+        "wildcard matcher → empty required_signal_names (wire marker)"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn producer_writes_required_signal_names_allof() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let wp_a_id = WaitpointId::new();
+    let wp_b_id = WaitpointId::new();
+    let cond = ResumeCondition::Composite(CompositeBody::AllOf {
+        members: vec![
+            ResumeCondition::Single {
+                waitpoint_key: "wpk:a".into(),
+                matcher: SignalMatcher::ByName("sig-a".into()),
+            },
+            ResumeCondition::Single {
+                waitpoint_key: "wpk:b".into(),
+                matcher: SignalMatcher::ByName("sig-b".into()),
+            },
+        ],
+    });
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        WaitpointBinding::Fresh {
+            waitpoint_id: wp_a_id.clone(),
+            waitpoint_key: "wpk:a".into(),
+        },
+        cond,
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::now(),
+    )
+    .with_waitpoint(WaitpointBinding::Fresh {
+        waitpoint_id: wp_b_id.clone(),
+        waitpoint_key: "wpk:b".into(),
+    });
+    fx.backend.suspend(&fx.handle, args).await.expect("suspend");
+
+    let a: (Vec<String>,) = sqlx::query_as(
+        "SELECT required_signal_names FROM ff_waitpoint_pending \
+          WHERE partition_key = $1 AND waitpoint_id = $2",
+    )
+    .bind(fx.part)
+    .bind(Uuid::parse_str(&wp_a_id.to_string()).unwrap())
+    .fetch_one(&fx.pool)
+    .await
+    .unwrap();
+    assert_eq!(a.0, vec!["sig-a".to_owned()]);
+
+    let b: (Vec<String>,) = sqlx::query_as(
+        "SELECT required_signal_names FROM ff_waitpoint_pending \
+          WHERE partition_key = $1 AND waitpoint_id = $2",
+    )
+    .bind(fx.part)
+    .bind(Uuid::parse_str(&wp_b_id.to_string()).unwrap())
+    .fetch_one(&fx.pool)
+    .await
+    .unwrap();
+    assert_eq!(b.0, vec!["sig-b".to_owned()]);
+}
+
+// ─── list_pending_waitpoints method tests ────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn list_returns_not_found_for_missing_execution() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+
+    let backend = PostgresBackend::from_pool(pool, PartitionConfig::default())
+        as std::sync::Arc<dyn EngineBackend>;
+
+    let missing = ExecutionId::solo(&LaneId::new("default"), &PartitionConfig::default());
+    let err = backend
+        .list_pending_waitpoints(ListPendingWaitpointsArgs::new(missing))
+        .await
+        .expect_err("missing exec → NotFound");
+    match err {
+        EngineError::NotFound { entity } => assert_eq!(entity, "execution"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn list_returns_single_waitpoint() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let wp_id = WaitpointId::new();
+    let now = TimestampMs::now();
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        WaitpointBinding::Fresh {
+            waitpoint_id: wp_id.clone(),
+            waitpoint_key: "wpk:lookup".into(),
+        },
+        ResumeCondition::Single {
+            waitpoint_key: "wpk:lookup".into(),
+            matcher: SignalMatcher::ByName("ready".into()),
+        },
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        now,
+    );
+    let outcome = fx.backend.suspend(&fx.handle, args).await.expect("suspend");
+    let SuspendOutcome::Suspended { .. } = outcome else {
+        panic!("expected Suspended");
+    };
+
+    let page = fx
+        .backend
+        .list_pending_waitpoints(ListPendingWaitpointsArgs::new(fx.exec_id.clone()))
+        .await
+        .expect("list ok");
+
+    assert_eq!(page.entries.len(), 1);
+    assert!(page.next_cursor.is_none(), "single entry → no next_cursor");
+    let entry = &page.entries[0];
+    assert_eq!(entry.waitpoint_id, wp_id);
+    assert_eq!(entry.waitpoint_key, "wpk:lookup");
+    assert_eq!(entry.state, "active");
+    assert_eq!(entry.required_signal_names, vec!["ready".to_owned()]);
+    assert_eq!(entry.created_at.0, now.0);
+    assert_eq!(
+        entry.activated_at.map(|t| t.0),
+        Some(now.0),
+        "activated_at populated"
+    );
+    assert!(entry.expires_at.is_none());
+    assert_eq!(entry.execution_id, fx.exec_id);
+    assert_eq!(entry.token_kid, "kid-lpw-1");
+    // Fingerprint is first-16-hex of the HMAC body; validate shape only.
+    assert_eq!(
+        entry.token_fingerprint.len(),
+        16,
+        "token_fingerprint is 16 hex chars"
+    );
+    assert!(
+        entry
+            .token_fingerprint
+            .chars()
+            .all(|c| c.is_ascii_hexdigit()),
+        "fingerprint is hex"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn list_paginates_with_cursor() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    // Suspend with 3 waitpoints via AllOf.
+    let wp1 = WaitpointId::new();
+    let wp2 = WaitpointId::new();
+    let wp3 = WaitpointId::new();
+    let cond = ResumeCondition::Composite(CompositeBody::AllOf {
+        members: vec![
+            ResumeCondition::Single {
+                waitpoint_key: "wpk:1".into(),
+                matcher: SignalMatcher::ByName("s1".into()),
+            },
+            ResumeCondition::Single {
+                waitpoint_key: "wpk:2".into(),
+                matcher: SignalMatcher::ByName("s2".into()),
+            },
+            ResumeCondition::Single {
+                waitpoint_key: "wpk:3".into(),
+                matcher: SignalMatcher::ByName("s3".into()),
+            },
+        ],
+    });
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        WaitpointBinding::Fresh {
+            waitpoint_id: wp1.clone(),
+            waitpoint_key: "wpk:1".into(),
+        },
+        cond,
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::now(),
+    )
+    .with_waitpoint(WaitpointBinding::Fresh {
+        waitpoint_id: wp2.clone(),
+        waitpoint_key: "wpk:2".into(),
+    })
+    .with_waitpoint(WaitpointBinding::Fresh {
+        waitpoint_id: wp3.clone(),
+        waitpoint_key: "wpk:3".into(),
+    });
+    fx.backend.suspend(&fx.handle, args).await.expect("suspend");
+
+    // Page 1: limit=2 → 2 entries + next_cursor.
+    let p1 = fx
+        .backend
+        .list_pending_waitpoints(
+            ListPendingWaitpointsArgs::new(fx.exec_id.clone()).with_limit(2),
+        )
+        .await
+        .expect("list p1");
+    assert_eq!(p1.entries.len(), 2);
+    let cursor = p1.next_cursor.clone().expect("next_cursor present");
+
+    // Page 2: resume from cursor → remaining entry, no further cursor.
+    let p2 = fx
+        .backend
+        .list_pending_waitpoints(
+            ListPendingWaitpointsArgs::new(fx.exec_id.clone())
+                .with_after(cursor)
+                .with_limit(2),
+        )
+        .await
+        .expect("list p2");
+    assert_eq!(p2.entries.len(), 1);
+    assert!(p2.next_cursor.is_none());
+
+    // Union of pages covers all 3 waitpoints (ordering is by
+    // waitpoint_id uuid, not insertion order).
+    let mut all: Vec<WaitpointId> =
+        p1.entries.iter().chain(p2.entries.iter()).map(|e| e.waitpoint_id.clone()).collect();
+    all.sort_by_key(|w| w.to_string());
+    let mut expected = vec![wp1, wp2, wp3];
+    expected.sort_by_key(|w| w.to_string());
+    assert_eq!(all, expected);
+
+    let _ = fx.exec_uuid; // suppress unused-field warning
+}

--- a/crates/ff-backend-postgres/tests/list_pending_waitpoints.rs
+++ b/crates/ff-backend-postgres/tests/list_pending_waitpoints.rs
@@ -11,14 +11,15 @@
 //! * [`producer_writes_active_state_and_activated_at`] — insert
 //!   populates `state = 'active'` + `activated_at_ms = now` (no
 //!   separate `pending→active` transition exists on Postgres; the
-//!   suspension lands atomically).
-//! * [`producer_writes_required_signal_names_byname`] — `Single`
-//!   with `SignalMatcher::ByName` produces a `[name]` vec.
+//!   suspension lands atomically). Also asserts `ByName` matcher →
+//!   `[name]` in `required_signal_names`.
 //! * [`producer_writes_required_signal_names_wildcard`] — `Single`
 //!   with `SignalMatcher::Wildcard` produces an empty vec (wildcard
 //!   wire marker).
 //! * [`producer_writes_required_signal_names_allof`] — `AllOf` tree
 //!   distributes per-waitpoint names correctly.
+//! * [`producer_writes_required_signal_names_operator_only`] —
+//!   `OperatorOnly` → `[__operator_only__]` sentinel (Valkey parity).
 //! * [`list_returns_not_found_for_missing_execution`] — matches
 //!   Valkey's `EXISTS exec_core` pre-check.
 //! * [`list_returns_single_waitpoint`] — happy-path end-to-end:
@@ -98,7 +99,6 @@ struct ExecFixture {
     pool: PgPool,
     exec_id: ExecutionId,
     part: i16,
-    exec_uuid: Uuid,
     handle: Handle,
 }
 
@@ -172,7 +172,6 @@ async fn setup_exec_or_skip() -> Option<ExecFixture> {
         pool,
         exec_id,
         part,
-        exec_uuid,
         handle,
     })
 }
@@ -321,6 +320,43 @@ async fn producer_writes_required_signal_names_allof() {
     .await
     .unwrap();
     assert_eq!(b.0, vec!["sig-b".to_owned()]);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn producer_writes_required_signal_names_operator_only() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let wp_id = WaitpointId::new();
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        WaitpointBinding::Fresh {
+            waitpoint_id: wp_id.clone(),
+            waitpoint_key: "wpk:op".into(),
+        },
+        ResumeCondition::OperatorOnly,
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::now(),
+    );
+    fx.backend.suspend(&fx.handle, args).await.expect("suspend");
+
+    let row: (Vec<String>,) = sqlx::query_as(
+        "SELECT required_signal_names FROM ff_waitpoint_pending \
+          WHERE partition_key = $1 AND waitpoint_id = $2",
+    )
+    .bind(fx.part)
+    .bind(Uuid::parse_str(&wp_id.to_string()).unwrap())
+    .fetch_one(&fx.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        row.0,
+        vec!["__operator_only__".to_owned()],
+        "OperatorOnly → sentinel name (Valkey parity)"
+    );
 }
 
 // ─── list_pending_waitpoints method tests ────────────────────────────────
@@ -491,6 +527,4 @@ async fn list_paginates_with_cursor() {
     let mut expected = vec![wp1, wp2, wp3];
     expected.sort_by_key(|w| w.to_string());
     assert_eq!(all, expected);
-
-    let _ = fx.exec_uuid; // suppress unused-field warning
 }


### PR DESCRIPTION
## Summary

RFC-020 Wave 9 Standalone-2 — both halves per §6.1 step 4 in one PR:

1. **`list_pending_waitpoints` method impl** (§4.5) — reads the 3 new 0011 columns alongside the existing 7 `ff_waitpoint_pending` columns to serve the full 10-field `PendingWaitpointInfo` contract.
2. **Producer-side write-path** (§3.1.1) — `suspend_ops::suspend_core` INSERT now populates `state`, `required_signal_names`, `activated_at_ms`.

No capability flip (atomic at Wave 9 release per RFC §6.3). No outbox emits (read-only + producer writes, per §4.2.7 matrix).

## Details

**Producer (§3.1.1).** The Postgres `suspend_core` INSERT and the `exec_core → suspended` transition land in one SERIALIZABLE txn, so the waitpoint is observable only after activation — no separate `pending → active` transition site exists. Writes `state = 'active'` + `activated_at_ms = now` directly on insert. `required_signal_names` is derived per-waitpoint from `ResumeCondition`: `Single { ByName(s) }` → `[s]`, `Wildcard` → `[]` (wire-level wildcard marker), `Count { matcher: Some(ByName(s)), waitpoints }` scoped to a member → `[s]`. `AllOf` trees walk and attribute per-waitpoint.

**Read path (§4.5).** Single-table scan `ff_waitpoint_pending WHERE partition_key = $1 AND execution_id = $2 AND state IN ('pending','active') AND ($3::uuid IS NULL OR waitpoint_id > $3) ORDER BY waitpoint_id LIMIT $4`. `EXISTS exec_core` pre-check mirrors Valkey's `NotFound` surface. Raw `token` is fingerprinted to `(token_kid, token_fingerprint)` client-side via `parse_waitpoint_token_kid_fp` (same helper shape as `ff-backend-valkey`). Default limit 100, cap 1000. `next_cursor` via `limit + 1` detection.

## RFC-vs-reality notes

- `ListPendingWaitpointsArgs` has no `ScannerFilter` field (per-execution query only), so no filter plumbing is wired despite the task brief mentioning it.
- RFC §3.1.1 pictured `state = 'pending'` at insert with a later activation transition; on Postgres both land atomically — impl writes `state = 'active'` on insert. Observable semantics unchanged.

## Test plan

- [x] `cargo clippy -p ff-backend-postgres --all-targets -- -D warnings` clean.
- [x] `cargo build -p ff-backend-postgres` clean.
- [x] `cargo test -p ff-backend-postgres -- --ignored --test-threads=1` with local Postgres (`FF_PG_TEST_URL`): 17 passed, 0 failed (6 new + 11 pre-existing suspend_signal tests).
- [x] New tests in `tests/list_pending_waitpoints.rs`:
  - `producer_writes_active_state_and_activated_at`
  - `producer_writes_required_signal_names_wildcard`
  - `producer_writes_required_signal_names_allof`
  - `list_returns_not_found_for_missing_execution`
  - `list_returns_single_waitpoint`
  - `list_paginates_with_cursor`
- [ ] Matrix-green on CI

---

References: RFC-020 §3.1.1, §4.5, §6.1 step 4. Migrations 0011 landed in #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Postgres backend read API and changes the suspend write path to populate new waitpoint columns, which affects core suspension/waitpoint persistence and paging queries.
> 
> **Overview**
> Implements RFC-020 Wave 9 Standalone-2 support in the Postgres backend by adding `EngineBackend::list_pending_waitpoints`, which pages `ff_waitpoint_pending` rows for an execution (with an `ff_exec_core` existence check, `state` filtering, and cursor-based pagination) and returns the full 10-field `PendingWaitpointInfo` contract while exposing only a token fingerprint.
> 
> Updates the suspend producer path to write the new 0011 waitpoint columns on insert (`state='active'`, derived `required_signal_names`, and `activated_at_ms`), including helper logic to extract required signal names from `ResumeCondition` and to parse token kid/fingerprint.
> 
> Adds ignored Postgres integration tests covering both the new column write behavior and the `list_pending_waitpoints` API semantics (NotFound, field mapping, and pagination).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48dec9322282c5e3e6d4b30a2de1206d9fc02781. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->