### PR TITLE
feat(pg-backend): Wave 9 Standalone-1 — budget/quota admin + migrations 0012/0013 + budget_reset reconciler

### DIFF
--- a/crates/ff-backend-postgres/migrations/0012_quota_policy.sql
+++ b/crates/ff-backend-postgres/migrations/0012_quota_policy.sql
@@ -1,0 +1,113 @@
+-- no-transaction
+-- RFC-020 Wave 9 Standalone-1 — quota-policy schema (Revision 6 §4.4.1).
+--
+-- Creates the three quota tables the Standalone-1 admin methods + a
+-- future admission impl need:
+--
+--   * `ff_quota_policy`  — definitional row per policy (+
+--     `active_concurrency` counter column folding what Valkey holds
+--     in a dedicated :concurrency key).
+--   * `ff_quota_window`  — sliding-window admission records (one row
+--     per (policy, dim, admitted_at_ms, execution_id)).
+--   * `ff_quota_admitted` — admitted-set tracking for idempotent
+--     admission guards (mirrors Valkey's admitted_set SADD).
+--
+-- All three tables are HASH-partitioned 256 ways on `partition_key`
+-- matching the 0001/0002 hot-table convention. Partition-child
+-- creation uses one `DO` block per parent with explicit COMMIT
+-- boundaries between blocks to stay under
+-- `max_locks_per_transaction` — identical pattern to 0002 §Section 2.
+--
+-- Reviewer finding (gemini-code-assist, PR #350 Round 6 #2):
+-- `ff_quota_window_sweep_idx` is redundant — the PK
+-- `(partition_key, quota_policy_id, dimension, admitted_at_ms,
+-- execution_id)` already supports sweep scans as a B-tree prefix
+-- match. No separate sweep index.
+--
+-- Authority:
+--   * rfcs/RFC-020-postgres-wave-9.md §4.4.1 + §7.12
+--   * crates/ff-script/src/flowfabric.lua:6839-6878 (ff_create_quota_policy)
+
+-- ============================================================
+-- Section 1 — Parent tables
+-- ============================================================
+
+-- Policy definition (one row per policy). `active_concurrency` folds
+-- Valkey's dedicated concurrency counter key onto a column on the
+-- policy row; admission-rate contention is analysed in RFC §4.4.4 +
+-- §7.12 (splitting to a separate sharded-counter table is the
+-- follow-up migration if it surfaces).
+CREATE TABLE ff_quota_policy (
+    partition_key                 smallint NOT NULL,
+    quota_policy_id               text     NOT NULL,
+    requests_per_window_seconds   bigint   NOT NULL,
+    max_requests_per_window       bigint   NOT NULL,
+    active_concurrency_cap        bigint   NOT NULL,
+    active_concurrency            bigint   NOT NULL DEFAULT 0,
+    created_at_ms                 bigint   NOT NULL,
+    updated_at_ms                 bigint   NOT NULL,
+    PRIMARY KEY (partition_key, quota_policy_id)
+) PARTITION BY HASH (partition_key);
+
+-- Sliding-window admission record. One row per admitted request per
+-- (policy, dimension). ZREMRANGEBYSCORE maps to DELETE WHERE
+-- admitted_at_ms < now - window_ms — sweep scans use the PK as a
+-- B-tree prefix match; no dedicated sweep index (review #2).
+CREATE TABLE ff_quota_window (
+    partition_key     smallint NOT NULL,
+    quota_policy_id   text     NOT NULL,
+    dimension         text     NOT NULL DEFAULT '',
+    admitted_at_ms    bigint   NOT NULL,
+    execution_id      text     NOT NULL,
+    PRIMARY KEY (partition_key, quota_policy_id, dimension, admitted_at_ms, execution_id)
+) PARTITION BY HASH (partition_key);
+
+-- Idempotent admitted-set: presence = admitted-within-current-window.
+-- Mirrors Valkey's SADD admitted_set. `expires_at_ms` bounds the row
+-- for the admitted-guard TTL semantic (Valkey's `admitted_guard_key`
+-- SET NX PX window_ms) — a sweeper trims expired rows.
+CREATE TABLE ff_quota_admitted (
+    partition_key     smallint NOT NULL,
+    quota_policy_id   text     NOT NULL,
+    execution_id      text     NOT NULL,
+    admitted_at_ms    bigint   NOT NULL,
+    expires_at_ms     bigint   NOT NULL,
+    PRIMARY KEY (partition_key, quota_policy_id, execution_id)
+) PARTITION BY HASH (partition_key);
+
+-- ============================================================
+-- Section 2 — 256-way HASH partition children
+-- ============================================================
+-- 3 parents × 256 children = 768 partitions. One `DO` block per parent
+-- with explicit COMMIT boundaries — same lock-budget discipline as
+-- 0001 §Section 7 + 0002 §Section 2.
+
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_quota_policy FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_quota_policy_p' || i, i); END LOOP; END $$;
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_quota_window FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_quota_window_p' || i, i); END LOOP; END $$;
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_quota_admitted FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_quota_admitted_p' || i, i); END LOOP; END $$;
+COMMIT;
+
+-- ============================================================
+-- Section 3 — Secondary indexes (non-PK)
+-- ============================================================
+-- Sweep index on `ff_quota_admitted(expires_at_ms)` for the TTL
+-- sweeper (future reconciler; not wired in Wave 9).
+-- Plain `CREATE INDEX` is safe here because these partition children
+-- are zero-row post-create; `CONCURRENTLY` on partitioned parents is
+-- not supported on Postgres 16 and unnecessary on empty tables.
+CREATE INDEX ff_quota_admitted_expires_idx
+    ON ff_quota_admitted (partition_key, expires_at_ms);
+
+-- ============================================================
+-- Section 4 — Migration annotation (Q12)
+-- ============================================================
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    12,
+    '0012_quota_policy',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/migrations/0013_budget_policy_extensions.sql
+++ b/crates/ff-backend-postgres/migrations/0013_budget_policy_extensions.sql
@@ -1,0 +1,82 @@
+-- no-transaction
+-- RFC-020 Wave 9 Standalone-1 — `ff_budget_policy` additive columns
+-- for breach-counter + scope + reset-scheduling surfaces (Revision 6
+-- §4.4.1 + §4.4.5).
+--
+-- The real `BudgetStatus` contract
+-- (`crates/ff-core/src/contracts/mod.rs:1413-1430`) has 9 fields not
+-- present on the pre-Wave-9 `ff_budget_policy` schema shipped by
+-- `0002_budget.sql`. This migration adds:
+--
+--   * `scope_type`         — e.g. "flow", "namespace" (from CreateBudgetArgs).
+--   * `scope_id`           — matching scope reference.
+--   * `enforcement_mode`   — "strict" | "warn".
+--   * `breach_count`       — hard-breach counter (HINCRBY twin).
+--   * `soft_breach_count`  — soft-breach counter (HINCRBY twin).
+--   * `last_breach_at_ms`  — last HardBreach wall time.
+--   * `last_breach_dim`    — dimension name of last HardBreach.
+--   * `next_reset_at_ms`   — scheduler pointer for the `budget_reset`
+--                            reconciler (NULL = no auto-reset).
+--
+-- `created_at_ms` is NOT added — it already exists on
+-- `ff_budget_policy` from migration 0002. The `BudgetStatus.created_at`
+-- field reads that pre-existing column.
+--
+-- Plus: a partial index `ff_budget_policy_reset_due_idx` that backs
+-- the `budget_reset` reconciler scan (RFC §4.4.3). Partial because
+-- most budgets have `next_reset_at_ms = NULL` (no scheduled reset);
+-- non-scheduled rows must not bloat the index.
+--
+-- Existing rows (pre-0013) get `scope_type=''`, `breach_count=0`,
+-- `next_reset_at_ms=NULL`. Wave 9's Standalone-1 impl populates the
+-- columns on `create_budget` writes post-0013; pre-0013-inserted
+-- rows return `scope_type=''` etc. in `get_budget_status` — degraded
+-- but non-breaking.
+--
+-- Postgres 16 floor (`.github/workflows/matrix.yml` pins
+-- `postgres:16-alpine`): `ALTER TABLE … ADD COLUMN` with a defaulted
+-- NOT NULL stores the default in catalog metadata and runs
+-- O(1)-metadata-only (no table rewrite). Partition-child rewrite is
+-- not needed.
+--
+-- `backward_compatible = true` — all adds are nullable-or-defaulted;
+-- pre-0013 binaries ignore the columns and stay correct.
+
+ALTER TABLE ff_budget_policy
+    ADD COLUMN scope_type          text   NOT NULL DEFAULT '',
+    ADD COLUMN scope_id            text   NOT NULL DEFAULT '',
+    ADD COLUMN enforcement_mode    text   NOT NULL DEFAULT '',
+    ADD COLUMN breach_count        bigint NOT NULL DEFAULT 0,
+    ADD COLUMN soft_breach_count   bigint NOT NULL DEFAULT 0,
+    ADD COLUMN last_breach_at_ms   bigint,
+    ADD COLUMN last_breach_dim     text,
+    ADD COLUMN next_reset_at_ms    bigint;
+
+-- Partial index backing the `budget_reset` reconciler scan. Partial
+-- on `next_reset_at_ms IS NOT NULL` so the index size scales with
+-- the scheduled-reset subset, not the full policy set.
+--
+-- **RFC-vs-reality note.** RFC-020 Revision 6 §4.4.5 specifies
+-- `CREATE INDEX CONCURRENTLY` for this index. Postgres 16 does NOT
+-- support `CONCURRENTLY` on partitioned parents (`ff_budget_policy`
+-- is HASH-partitioned since 0002) — the statement errors with
+-- `cannot create index on partitioned table "ff_budget_policy"
+-- concurrently`. Matching the 0001/0002 convention for partitioned
+-- hot tables we use plain `CREATE INDEX`. The 0013 migration only
+-- adds the `next_reset_at_ms` column in the SAME statement block; at
+-- this point every existing row has `next_reset_at_ms = NULL` (the
+-- default), so the partial-index build touches zero rows and the
+-- AccessExclusiveLock on the parent is brief (metadata-only).
+-- Post-0013 writes from Standalone-1 `create_budget` populate the
+-- column on new rows only.
+CREATE INDEX ff_budget_policy_reset_due_idx
+    ON ff_budget_policy (partition_key, next_reset_at_ms)
+    WHERE next_reset_at_ms IS NOT NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    13,
+    '0013_budget_policy_extensions',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/src/budget.rs
+++ b/crates/ff-backend-postgres/src/budget.rs
@@ -191,7 +191,7 @@ pub(crate) async fn report_usage_admin_impl(
         });
     }
     let mut custom: BTreeMap<String, u64> = BTreeMap::new();
-    for (d, v) in args.dimensions.into_iter().zip(args.deltas.into_iter()) {
+    for (d, v) in args.dimensions.into_iter().zip(args.deltas) {
         custom.insert(d, v);
     }
     // `UsageDimensions` is `#[non_exhaustive]`; build via `new()` +

--- a/crates/ff-backend-postgres/src/budget.rs
+++ b/crates/ff-backend-postgres/src/budget.rs
@@ -1,32 +1,41 @@
 //! Budget family — Postgres impl.
 //!
-//! **RFC-v0.7 Wave 4f.** Implements `EngineBackend::report_usage`
-//! against the Wave 3b schema (`0002_budget.sql`): `ff_budget_policy`,
+//! **RFC-v0.7 Wave 4f.** Ships `EngineBackend::report_usage` against
+//! the Wave 3b schema (`0002_budget.sql`): `ff_budget_policy`,
 //! `ff_budget_usage`, `ff_budget_usage_dedup`.
 //!
-//! Isolation per v0.7 migration-master §Q11: READ COMMITTED + row-level
-//! `FOR UPDATE` on `ff_budget_usage` and `FOR SHARE` on
-//! `ff_budget_policy` — NOT SERIALIZABLE. Worker-A Tier A: trivial
-//! single-key atomic increment per dimension.
+//! **RFC-020 Wave 9 Standalone-1 (Revision 6).** Extends this module
+//! with the 5 budget/quota admin methods — `create_budget`,
+//! `reset_budget`, `create_quota_policy`, `get_budget_status`,
+//! `report_usage_admin` — writing against 0012 (`ff_quota_policy` +
+//! window + admitted set) and 0013 (additive breach / scope / reset
+//! columns on `ff_budget_policy`). `report_usage_impl` is narrowly
+//! extended to maintain the new breach counters per §4.4.6 and to
+//! hold the policy row under `FOR NO KEY UPDATE` (replacing the
+//! previous `FOR SHARE` — reviewer-finding deadlock fix on the
+//! breach-UPDATE path).
 //!
-//! Idempotency per RFC-012 §R7.2.3: the caller-supplied
-//! `UsageDimensions::dedup_key` is used as the key for an
-//! `INSERT … ON CONFLICT DO NOTHING`; on conflict the cached
+//! Isolation per v0.7 migration-master §Q11: READ COMMITTED + row-
+//! level locking on `report_usage_impl` (hot path). `reset_budget`
+//! runs SERIALIZABLE to match Valkey's Lua atomicity — the zero-all
+//! pattern must not interleave with a concurrent `report_usage`
+//! mid-flight.
+//!
+//! Idempotency per RFC-012 §R7.2.3: the caller-supplied `dedup_key`
+//! keys an `INSERT ... ON CONFLICT DO NOTHING`; on conflict the cached
 //! `outcome_json` row is returned verbatim (replay).
-//!
-//! `update_budget_policy` is NOT on the `EngineBackend` trait today
-//! (only `report_usage` is). Wave 4f therefore ships only
-//! `report_usage_impl`; definitional writes land via a test-only
-//! helper (`upsert_policy_for_test`) that the integration suite
-//! seeds through directly.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use ff_core::backend::UsageDimensions;
-use ff_core::contracts::ReportUsageResult;
-use ff_core::engine_error::{EngineError, ValidationKind};
-use ff_core::partition::{budget_partition, PartitionConfig};
-use ff_core::types::BudgetId;
+use ff_core::contracts::{
+    BudgetStatus, CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs,
+    CreateQuotaPolicyResult, ReportUsageAdminArgs, ReportUsageResult, ResetBudgetArgs,
+    ResetBudgetResult,
+};
+use ff_core::engine_error::{backend_context, EngineError, ValidationKind};
+use ff_core::partition::{budget_partition, quota_partition, PartitionConfig};
+use ff_core::types::{BudgetId, TimestampMs};
 use serde_json::{json, Value as JsonValue};
 use sqlx::{PgPool, Row};
 
@@ -150,8 +159,59 @@ fn limits_from_policy(policy: &JsonValue, key: &str) -> BTreeMap<String, u64> {
 /// idempotency key" retention: 24h by default.
 const DEDUP_TTL_MS: i64 = 24 * 60 * 60 * 1_000;
 
-/// `EngineBackend::report_usage` — Postgres impl.
+// ───────────────────────────────────────────────────────────────────
+// §4.4.6 — `report_usage_impl` / `report_usage_admin` shared core
+// ───────────────────────────────────────────────────────────────────
+
+/// `EngineBackend::report_usage` — Postgres impl (worker-path). Thin
+/// wrapper around [`report_usage_and_check_core`].
 pub(crate) async fn report_usage_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    budget: &BudgetId,
+    dimensions: UsageDimensions,
+) -> Result<ReportUsageResult, EngineError> {
+    report_usage_and_check_core(pool, partition_config, budget, dimensions).await
+}
+
+/// Admin-path `report_usage_admin`. Translates the admin-shape
+/// `ReportUsageAdminArgs` (parallel `dimensions` / `deltas` vectors)
+/// to `UsageDimensions` and delegates to the shared core. See RFC-020
+/// §4.4.6 "report_usage_admin entry point".
+pub(crate) async fn report_usage_admin_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    budget: &BudgetId,
+    args: ReportUsageAdminArgs,
+) -> Result<ReportUsageResult, EngineError> {
+    if args.dimensions.len() != args.deltas.len() {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "report_usage_admin: dimensions and deltas length mismatch".into(),
+        });
+    }
+    let mut custom: BTreeMap<String, u64> = BTreeMap::new();
+    for (d, v) in args.dimensions.into_iter().zip(args.deltas.into_iter()) {
+        custom.insert(d, v);
+    }
+    // `UsageDimensions` is `#[non_exhaustive]`; build via `new()` +
+    // mutate the fields we have direct access to (`custom`,
+    // `dedup_key`). `input_tokens` / `output_tokens` / `wall_ms` stay
+    // at their `Default` values — the shared core only inspects
+    // `custom` + `dedup_key`.
+    let mut ud = UsageDimensions::new();
+    ud.custom = custom;
+    ud.dedup_key = args.dedup_key;
+    report_usage_and_check_core(pool, partition_config, budget, ud).await
+}
+
+/// Shared body of `report_usage` + `report_usage_admin`. §4.4.6 lifts
+/// the Revision 5 §7.2 pin narrowly: this function now (1) loads the
+/// policy row with `FOR NO KEY UPDATE` rather than `FOR SHARE`
+/// (deadlock fix for the breach-UPDATE path) and (2) maintains the
+/// `breach_count` / `soft_breach_count` columns + `last_breach_*`
+/// metadata on the 0013 columns.
+async fn report_usage_and_check_core(
     pool: &PgPool,
     partition_config: &PartitionConfig,
     budget: &BudgetId,
@@ -220,12 +280,16 @@ pub(crate) async fn report_usage_impl(
         None => None,
     };
 
-    // ── Load policy (FOR SHARE so concurrent report_usage can proceed
-    //    but an in-flight policy update blocks on the FOR UPDATE it
-    //    would hold — when that admin surface lands). ──
+    // ── Load policy row ──
+    //
+    // §4.4.6 lock-mode correction: `FOR NO KEY UPDATE` serialises the
+    // breach path deterministically (two concurrent callers both
+    // hitting hard-breach now serialise on this SELECT, not deadlock
+    // on the breach UPDATE that would otherwise need NO-KEY-UPDATE
+    // while each tx holds SHARE).
     let policy_row = sqlx::query(
         "SELECT policy_json FROM ff_budget_policy \
-         WHERE partition_key = $1 AND budget_id = $2 FOR SHARE",
+         WHERE partition_key = $1 AND budget_id = $2 FOR NO KEY UPDATE",
     )
     .bind(partition_key)
     .bind(&budget_id_str)
@@ -236,8 +300,7 @@ pub(crate) async fn report_usage_impl(
     let policy: JsonValue = match policy_row {
         Some(r) => r.get("policy_json"),
         // No policy row ⇒ no limits defined. Treat all reports as Ok
-        // and still apply increments (the Valkey impl behaves the
-        // same when the definition Hash is absent).
+        // and still apply increments (Valkey parity).
         None => JsonValue::Object(Default::default()),
     };
     let hard_limits = limits_from_policy(&policy, "hard_limits");
@@ -245,14 +308,8 @@ pub(crate) async fn report_usage_impl(
 
     // ── Compute admission per dimension. Hard breach on ANY dim
     //    rejects the whole report (no increments applied); soft breach
-    //    is advisory (increments applied). Iterate in sorted-key order
-    //    so the reported dimension is deterministic on multi-dim
-    //    reports. ──
-    //
-    // Per-dim: SELECT current_value FOR UPDATE (locks the row for the
-    // remainder of the txn). Row may not exist yet (first report for
-    // that dim) — INSERT … ON CONFLICT DO NOTHING first, then re-SELECT
-    // so the lock is held deterministically.
+    //    is advisory (increments applied). Sorted-key iteration keeps
+    //    the reported dimension deterministic on multi-dim reports. ──
     let mut per_dim_current: BTreeMap<String, u64> = BTreeMap::new();
     for (dim, delta) in dimensions.custom.iter() {
         let dim_key = dim_row_key(dim);
@@ -288,7 +345,27 @@ pub(crate) async fn report_usage_impl(
             && *hard > 0
             && new_val > *hard
         {
-            // Hard breach: no increments applied, commit dedup outcome.
+            // §4.4.6 — Hard breach: no increments applied, maintain
+            // `breach_count` + `last_breach_*` on the policy row
+            // (mirrors Valkey `HINCRBY breach_count 1` + `HSET
+            // last_breach_at/last_breach_dim` at
+            // flowfabric.lua:6576-6580), commit dedup outcome.
+            sqlx::query(
+                "UPDATE ff_budget_policy \
+                 SET breach_count      = breach_count + 1, \
+                     last_breach_at_ms = $3, \
+                     last_breach_dim   = $4, \
+                     updated_at_ms     = $3 \
+                 WHERE partition_key = $1 AND budget_id = $2",
+            )
+            .bind(partition_key)
+            .bind(&budget_id_str)
+            .bind(now)
+            .bind(dim)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+
             let outcome = ReportUsageResult::HardBreach {
                 dimension: dim.clone(),
                 current_usage: cur as u64,
@@ -336,6 +413,24 @@ pub(crate) async fn report_usage_impl(
         }
     }
 
+    // §4.4.6 — on soft breach, HINCRBY soft_breach_count (Valkey
+    // parity at flowfabric.lua:6614). Hard-breach path returned early
+    // above; this block only fires on the non-hard-breach outcome.
+    if soft_breach.is_some() {
+        sqlx::query(
+            "UPDATE ff_budget_policy \
+             SET soft_breach_count = soft_breach_count + 1, \
+                 updated_at_ms     = $3 \
+             WHERE partition_key = $1 AND budget_id = $2",
+        )
+        .bind(partition_key)
+        .bind(&budget_id_str)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
     let outcome = soft_breach.unwrap_or(ReportUsageResult::Ok);
     if let Some(dk) = dedup_owned.as_deref() {
         finalize_dedup(&mut tx, partition_key, dk, &outcome).await?;
@@ -345,7 +440,7 @@ pub(crate) async fn report_usage_impl(
 }
 
 /// Write the final `outcome_json` onto the dedup row we inserted at
-/// the top of [`report_usage_impl`].
+/// the top of [`report_usage_and_check_core`].
 async fn finalize_dedup(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     partition_key: i16,
@@ -366,11 +461,10 @@ async fn finalize_dedup(
     Ok(())
 }
 
-/// Test-only helper: upsert a `ff_budget_policy` row directly. The
-/// trait has no `update_budget_policy` method in v0.7 (Wave 4f
-/// verification), so the Postgres backend exposes this as a public
-/// helper so the integration suite can seed policies without going
-/// through an op we haven't yet added to the trait surface.
+/// Test-only helper: upsert a `ff_budget_policy` row directly. Pre-
+/// dates the trait-lifted `create_budget` (RFC-020 §4.4.2); retained
+/// for tests that still seed a raw `policy_json` blob + exercise the
+/// policy-row-missing branch of `report_usage_impl`.
 #[doc(hidden)]
 pub async fn upsert_policy_for_test(
     pool: &PgPool,
@@ -396,5 +490,421 @@ pub async fn upsert_policy_for_test(
     .execute(pool)
     .await
     .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.2 — `create_budget`
+// ───────────────────────────────────────────────────────────────────
+
+/// Pack a [`CreateBudgetArgs`] into the `policy_json` blob shape
+/// `report_usage_and_check_core` + `get_budget_status` consume. Writes
+/// parallel `dimensions` / `hard_limits` / `soft_limits` vectors into
+/// `{hard_limits: {dim: u64, ...}, soft_limits: {dim: u64, ...},
+/// reset_interval_ms, on_hard_limit, on_soft_limit}` — the shape
+/// already used by `upsert_policy_for_test` + `limits_from_policy`.
+fn build_policy_json(args: &CreateBudgetArgs) -> JsonValue {
+    let mut hard = serde_json::Map::new();
+    let mut soft = serde_json::Map::new();
+    for (i, dim) in args.dimensions.iter().enumerate() {
+        if let Some(h) = args.hard_limits.get(i).copied() {
+            hard.insert(dim.clone(), json!(h));
+        }
+        if let Some(s) = args.soft_limits.get(i).copied() {
+            soft.insert(dim.clone(), json!(s));
+        }
+    }
+    json!({
+        "hard_limits": hard,
+        "soft_limits": soft,
+        "reset_interval_ms": args.reset_interval_ms,
+        "on_hard_limit": args.on_hard_limit,
+        "on_soft_limit": args.on_soft_limit,
+    })
+}
+
+pub(crate) async fn create_budget_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    args: CreateBudgetArgs,
+) -> Result<CreateBudgetResult, EngineError> {
+    if args.dimensions.len() != args.hard_limits.len()
+        || args.dimensions.len() != args.soft_limits.len()
+    {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "create_budget: dimensions / hard_limits / soft_limits length mismatch"
+                .into(),
+        });
+    }
+
+    let partition = budget_partition(&args.budget_id, partition_config);
+    let partition_key: i16 = partition.index as i16;
+    let budget_id = args.budget_id.clone();
+    let now: i64 = args.now.0;
+    let policy_json = build_policy_json(&args);
+    let reset_interval_ms = args.reset_interval_ms as i64;
+
+    // `next_reset_at_ms` seeded to `now + interval` when interval > 0
+    // so the `budget_reset` reconciler picks it up (RFC §4.4.3).
+    // Matches Valkey's `ff_create_budget` `ZADD resets_zset` scheduling
+    // at flowfabric.lua:6522-6526.
+    let row = sqlx::query(
+        "INSERT INTO ff_budget_policy \
+             (partition_key, budget_id, policy_json, scope_type, scope_id, \
+              enforcement_mode, breach_count, soft_breach_count, \
+              last_breach_at_ms, last_breach_dim, next_reset_at_ms, \
+              created_at_ms, updated_at_ms) \
+         VALUES ($1, $2, $3, $4, $5, $6, 0, 0, NULL, NULL, \
+                 CASE WHEN $7::bigint > 0 THEN $8::bigint + $7::bigint ELSE NULL END, \
+                 $8, $8) \
+         ON CONFLICT (partition_key, budget_id) DO NOTHING \
+         RETURNING created_at_ms",
+    )
+    .bind(partition_key)
+    .bind(budget_id.to_string())
+    .bind(policy_json)
+    .bind(&args.scope_type)
+    .bind(&args.scope_id)
+    .bind(&args.enforcement_mode)
+    .bind(reset_interval_ms)
+    .bind(now)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    match row {
+        Some(_) => Ok(CreateBudgetResult::Created { budget_id }),
+        None => Ok(CreateBudgetResult::AlreadySatisfied { budget_id }),
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.3 — `reset_budget`
+// ───────────────────────────────────────────────────────────────────
+
+pub(crate) async fn reset_budget_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    args: ResetBudgetArgs,
+) -> Result<ResetBudgetResult, EngineError> {
+    let partition = budget_partition(&args.budget_id, partition_config);
+    let partition_key: i16 = partition.index as i16;
+    let budget_id_str = args.budget_id.to_string();
+    let now: i64 = args.now.0;
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    // SERIALIZABLE matches Valkey's Lua atomicity — the zero-all
+    // pattern must not see mid-flight increments from concurrent
+    // `report_usage` / `report_usage_admin`.
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // Lock the policy row with `FOR NO KEY UPDATE` before zeroing —
+    // serialises against a concurrent breach-UPDATE on the same row
+    // (§4.4.6 lock-mode discipline).
+    let policy_row = sqlx::query(
+        "SELECT policy_json FROM ff_budget_policy \
+         WHERE partition_key = $1 AND budget_id = $2 FOR NO KEY UPDATE",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(policy_row) = policy_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(backend_context(
+            EngineError::NotFound { entity: "budget" },
+            format!("reset_budget: {}", args.budget_id),
+        ));
+    };
+    let policy_json: JsonValue = policy_row.get("policy_json");
+    let reset_interval_ms: i64 = policy_json
+        .get("reset_interval_ms")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    // Zero all usage rows for this budget.
+    sqlx::query(
+        "UPDATE ff_budget_usage \
+         SET current_value = 0, last_reset_at_ms = $3, updated_at_ms = $3 \
+         WHERE partition_key = $1 AND budget_id = $2",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Reset policy metadata + reschedule.
+    let row = sqlx::query(
+        "UPDATE ff_budget_policy \
+         SET last_breach_at_ms = NULL, \
+             last_breach_dim   = NULL, \
+             updated_at_ms     = $3, \
+             next_reset_at_ms  = CASE \
+                 WHEN $4::bigint > 0 THEN $3 + $4::bigint \
+                 ELSE NULL \
+             END \
+         WHERE partition_key = $1 AND budget_id = $2 \
+         RETURNING next_reset_at_ms",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .bind(now)
+    .bind(reset_interval_ms)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let next_reset: Option<i64> = row
+        .try_get::<Option<i64>, _>("next_reset_at_ms")
+        .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(ResetBudgetResult::Reset {
+        // `ResetBudgetResult::Reset` carries a non-optional
+        // `TimestampMs`; when no interval is configured the budget
+        // has no scheduled-reset, so report `0` (matches Valkey's
+        // zero-score-when-unset behaviour for ZADD resets_zset).
+        next_reset_at: TimestampMs(next_reset.unwrap_or(0)),
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.1 — `create_quota_policy`
+// ───────────────────────────────────────────────────────────────────
+
+pub(crate) async fn create_quota_policy_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    args: CreateQuotaPolicyArgs,
+) -> Result<CreateQuotaPolicyResult, EngineError> {
+    let partition = quota_partition(&args.quota_policy_id, partition_config);
+    let partition_key: i16 = partition.index as i16;
+    let qid = args.quota_policy_id.clone();
+    let now: i64 = args.now.0;
+
+    let row = sqlx::query(
+        "INSERT INTO ff_quota_policy \
+             (partition_key, quota_policy_id, requests_per_window_seconds, \
+              max_requests_per_window, active_concurrency_cap, \
+              active_concurrency, created_at_ms, updated_at_ms) \
+         VALUES ($1, $2, $3, $4, $5, 0, $6, $6) \
+         ON CONFLICT (partition_key, quota_policy_id) DO NOTHING \
+         RETURNING created_at_ms",
+    )
+    .bind(partition_key)
+    .bind(qid.to_string())
+    .bind(args.window_seconds as i64)
+    .bind(args.max_requests_per_window as i64)
+    .bind(args.max_concurrent as i64)
+    .bind(now)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    match row {
+        Some(_) => Ok(CreateQuotaPolicyResult::Created {
+            quota_policy_id: qid,
+        }),
+        None => Ok(CreateQuotaPolicyResult::AlreadySatisfied {
+            quota_policy_id: qid,
+        }),
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.7 — `get_budget_status`
+// ───────────────────────────────────────────────────────────────────
+
+pub(crate) async fn get_budget_status_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    budget: &BudgetId,
+) -> Result<BudgetStatus, EngineError> {
+    let partition = budget_partition(budget, partition_config);
+    let partition_key: i16 = partition.index as i16;
+    let budget_id_str = budget.to_string();
+
+    // SELECT 1: policy row (definitional + counters + scheduler).
+    let policy_row = sqlx::query(
+        "SELECT scope_type, scope_id, enforcement_mode, \
+                breach_count, soft_breach_count, \
+                last_breach_at_ms, last_breach_dim, \
+                next_reset_at_ms, created_at_ms, \
+                policy_json \
+         FROM ff_budget_policy \
+         WHERE partition_key = $1 AND budget_id = $2",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(policy_row) = policy_row else {
+        return Err(backend_context(
+            EngineError::NotFound { entity: "budget" },
+            format!("get_budget_status: {budget}"),
+        ));
+    };
+
+    let scope_type: String = policy_row.get("scope_type");
+    let scope_id: String = policy_row.get("scope_id");
+    let enforcement_mode: String = policy_row.get("enforcement_mode");
+    let breach_count: i64 = policy_row.get("breach_count");
+    let soft_breach_count: i64 = policy_row.get("soft_breach_count");
+    let last_breach_at_ms: Option<i64> = policy_row
+        .try_get::<Option<i64>, _>("last_breach_at_ms")
+        .map_err(map_sqlx_error)?;
+    let last_breach_dim: Option<String> = policy_row
+        .try_get::<Option<String>, _>("last_breach_dim")
+        .map_err(map_sqlx_error)?;
+    let next_reset_at_ms: Option<i64> = policy_row
+        .try_get::<Option<i64>, _>("next_reset_at_ms")
+        .map_err(map_sqlx_error)?;
+    let created_at_ms: i64 = policy_row.get("created_at_ms");
+    let policy_json: JsonValue = policy_row.get("policy_json");
+
+    // SELECT 2: usage rows (one per dimension).
+    let usage_rows = sqlx::query(
+        "SELECT dimensions_key, current_value \
+         FROM ff_budget_usage \
+         WHERE partition_key = $1 AND budget_id = $2",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut usage: HashMap<String, u64> = HashMap::new();
+    for r in &usage_rows {
+        let key: String = r.get("dimensions_key");
+        let val: i64 = r.get("current_value");
+        if key == "_init" {
+            continue;
+        }
+        usage.insert(key, val.max(0) as u64);
+    }
+
+    // Limits parse from policy_json (shape documented on
+    // `build_policy_json` above; matches Valkey's 3× HGETALL shape
+    // byte-for-byte post-stringification).
+    let hard_limits: HashMap<String, u64> =
+        limits_from_policy(&policy_json, "hard_limits").into_iter().collect();
+    let soft_limits: HashMap<String, u64> =
+        limits_from_policy(&policy_json, "soft_limits").into_iter().collect();
+
+    // Valkey stringifies i64 timestamps; mirror byte-for-byte so the
+    // contract shape is identical across backends.
+    let fmt_opt = |v: Option<i64>| -> Option<String> { v.map(|n| n.to_string()) };
+
+    Ok(BudgetStatus {
+        budget_id: budget.to_string(),
+        scope_type,
+        scope_id,
+        enforcement_mode,
+        usage,
+        hard_limits,
+        soft_limits,
+        breach_count: breach_count.max(0) as u64,
+        soft_breach_count: soft_breach_count.max(0) as u64,
+        last_breach_at: fmt_opt(last_breach_at_ms),
+        last_breach_dim,
+        next_reset_at: fmt_opt(next_reset_at_ms),
+        created_at: Some(created_at_ms.to_string()),
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.3 — `budget_reset` reconciler entry point
+// ───────────────────────────────────────────────────────────────────
+
+/// Called per row returned by the `budget_reset` reconciler scan.
+/// Looks up the policy's `reset_interval_ms` from `policy_json`,
+/// zeroes usage rows + resets breach metadata + reschedules
+/// `next_reset_at_ms` under SERIALIZABLE. Same tx shape as
+/// `reset_budget_impl` but keyed off the scanner-supplied
+/// `(partition_key, budget_id)` pair rather than a caller-supplied
+/// `BudgetId`.
+pub(crate) async fn budget_reset_reconciler_apply(
+    pool: &PgPool,
+    partition_key: i16,
+    budget_id: &str,
+    now: i64,
+) -> Result<(), EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let policy_row = sqlx::query(
+        "SELECT policy_json, next_reset_at_ms FROM ff_budget_policy \
+         WHERE partition_key = $1 AND budget_id = $2 FOR NO KEY UPDATE",
+    )
+    .bind(partition_key)
+    .bind(budget_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(policy_row) = policy_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    // Defensive re-check: a concurrent `reset_budget` may have already
+    // advanced `next_reset_at_ms` past `now`. If so this scanner tick
+    // is a no-op.
+    let next_reset: Option<i64> = policy_row
+        .try_get::<Option<i64>, _>("next_reset_at_ms")
+        .map_err(map_sqlx_error)?;
+    if !matches!(next_reset, Some(n) if n <= now) {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+    let policy_json: JsonValue = policy_row.get("policy_json");
+    let reset_interval_ms: i64 = policy_json
+        .get("reset_interval_ms")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    sqlx::query(
+        "UPDATE ff_budget_usage \
+         SET current_value = 0, last_reset_at_ms = $3, updated_at_ms = $3 \
+         WHERE partition_key = $1 AND budget_id = $2",
+    )
+    .bind(partition_key)
+    .bind(budget_id)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        "UPDATE ff_budget_policy \
+         SET last_breach_at_ms = NULL, \
+             last_breach_dim   = NULL, \
+             updated_at_ms     = $3, \
+             next_reset_at_ms  = CASE \
+                 WHEN $4::bigint > 0 THEN $3 + $4::bigint \
+                 ELSE NULL \
+             END \
+         WHERE partition_key = $1 AND budget_id = $2",
+    )
+    .bind(partition_key)
+    .bind(budget_id)
+    .bind(now)
+    .bind(reset_interval_ms)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
     Ok(())
 }

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -46,6 +46,12 @@ use ff_core::contracts::{
     RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SeedOutcome,
     SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome,
 };
+// RFC-020 Wave 9 Standalone-1 — budget/quota admin surfaces.
+#[cfg(feature = "core")]
+use ff_core::contracts::{
+    BudgetStatus, CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs,
+    CreateQuotaPolicyResult, ReportUsageAdminArgs, ResetBudgetArgs, ResetBudgetResult,
+};
 #[cfg(feature = "streaming")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
 use ff_core::engine_backend::EngineBackend;
@@ -846,6 +852,59 @@ impl EngineBackend for PostgresBackend {
         dimensions: UsageDimensions,
     ) -> Result<ReportUsageResult, EngineError> {
         budget::report_usage_impl(&self.pool, &self.partition_config, budget, dimensions).await
+    }
+
+    // ── RFC-020 Wave 9 Standalone-1 — budget/quota admin (§4.4) ─────
+    //
+    // Five methods landing behind capability flags that stay `false`
+    // until the Wave 9 release PR flips them atomically (RFC §6.3).
+    // Schema + trait impls land now; capability-surface flip is one
+    // PR later.
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.create_budget", skip_all)]
+    async fn create_budget(
+        &self,
+        args: CreateBudgetArgs,
+    ) -> Result<CreateBudgetResult, EngineError> {
+        budget::create_budget_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.reset_budget", skip_all)]
+    async fn reset_budget(
+        &self,
+        args: ResetBudgetArgs,
+    ) -> Result<ResetBudgetResult, EngineError> {
+        budget::reset_budget_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.create_quota_policy", skip_all)]
+    async fn create_quota_policy(
+        &self,
+        args: CreateQuotaPolicyArgs,
+    ) -> Result<CreateQuotaPolicyResult, EngineError> {
+        budget::create_quota_policy_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.get_budget_status", skip_all)]
+    async fn get_budget_status(
+        &self,
+        id: &BudgetId,
+    ) -> Result<BudgetStatus, EngineError> {
+        budget::get_budget_status_impl(&self.pool, &self.partition_config, id).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.report_usage_admin", skip_all)]
+    async fn report_usage_admin(
+        &self,
+        budget_id: &BudgetId,
+        args: ReportUsageAdminArgs,
+    ) -> Result<ReportUsageResult, EngineError> {
+        budget::report_usage_admin_impl(&self.pool, &self.partition_config, budget_id, args).await
     }
 
     // ── HMAC secret rotation (v0.7 migration-master Q4) ──

--- a/crates/ff-backend-postgres/src/reconcilers/budget_reset.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/budget_reset.rs
@@ -1,0 +1,82 @@
+//! Postgres `budget_reset` reconciler (RFC-020 Wave 9 Standalone-1,
+//! §4.4.3 Gap 2 Option B).
+//!
+//! Mirrors [`ff_engine::scanner::budget_reset`] — scans per-partition
+//! for `ff_budget_policy` rows whose `next_reset_at_ms` has lapsed and
+//! invokes the shared [`crate::budget::budget_reset_reconciler_apply`]
+//! codepath (same body as the admin `reset_budget` FCALL). Named
+//! `budget_reset` to match the Valkey scanner name so observability
+//! metrics align across backends.
+//!
+//! Scan shape backed by the partial index
+//! `ff_budget_policy_reset_due_idx (partition_key, next_reset_at_ms)
+//! WHERE next_reset_at_ms IS NOT NULL` from migration 0013 — scan
+//! cost scales with the scheduled-reset subset, not the full policy
+//! set.
+//!
+//! Race discipline: a manual `reset_budget` + the reconciler's reset
+//! resolve identically. Both observe `next_reset_at_ms` under `FOR
+//! NO KEY UPDATE`; the second commit re-zeros (no-op) + overwrites
+//! `next_reset_at_ms` with the later `now + interval`, picked up on
+//! the next tick.
+
+use sqlx::{PgPool, Row};
+
+use ff_core::engine_error::EngineError;
+
+use crate::budget;
+use crate::error::map_sqlx_error;
+use crate::reconcilers::ScanReport;
+
+const BATCH_SIZE: i64 = 20;
+
+/// Scan one partition for budgets with a lapsed `next_reset_at_ms`
+/// and apply the reset transaction per hit.
+pub async fn scan_tick(pool: &PgPool, partition_key: i16) -> Result<ScanReport, EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    // Bounded batch scan. Backed by `ff_budget_policy_reset_due_idx`
+    // (partial). `ORDER BY next_reset_at_ms` keeps the earliest-due
+    // budgets first — same prioritisation as Valkey's ZRANGEBYSCORE.
+    let rows = sqlx::query(
+        r#"
+        SELECT budget_id
+          FROM ff_budget_policy
+         WHERE partition_key = $1
+           AND next_reset_at_ms IS NOT NULL
+           AND next_reset_at_ms <= $2
+         ORDER BY next_reset_at_ms ASC
+         LIMIT $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(now_ms)
+    .bind(BATCH_SIZE)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = ScanReport::default();
+    for row in rows {
+        let budget_id: String = row.try_get("budget_id").map_err(map_sqlx_error)?;
+        match budget::budget_reset_reconciler_apply(pool, partition_key, &budget_id, now_ms).await {
+            Ok(()) => report.processed += 1,
+            Err(e) => {
+                tracing::warn!(
+                    partition = partition_key,
+                    budget_id = %budget_id,
+                    error = %e,
+                    "budget_reset reconciler: reset failed",
+                );
+                report.errors += 1;
+            }
+        }
+    }
+    Ok(report)
+}

--- a/crates/ff-backend-postgres/src/reconcilers/mod.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/mod.rs
@@ -9,6 +9,7 @@
 //! per-hop-tx dispatch cascade from Wave 5a.
 
 pub mod attempt_timeout;
+pub mod budget_reset;
 pub mod dependency;
 pub mod edge_cancel_dispatcher;
 pub mod edge_cancel_reconciler;

--- a/crates/ff-backend-postgres/src/scanner_supervisor.rs
+++ b/crates/ff-backend-postgres/src/scanner_supervisor.rs
@@ -39,6 +39,11 @@ pub struct PostgresScannerConfig {
     pub dependency_reconciler_interval: Duration,
     pub edge_cancel_dispatcher_interval: Duration,
     pub edge_cancel_reconciler_interval: Duration,
+    /// RFC-020 Wave 9 Standalone-1: cadence for the `budget_reset`
+    /// reconciler. Matches the Valkey side's
+    /// `ff-server::config::budget_reset_interval` knob so the same
+    /// env value drives both backends.
+    pub budget_reset_interval: Duration,
     /// Stale-threshold for the dependency reconciler (ms). Matches
     /// the Valkey scanner's `stale_threshold_ms` knob.
     pub dependency_stale_threshold_ms: i64,
@@ -105,9 +110,13 @@ pub fn spawn_scanners(pool: PgPool, cfg: PostgresScannerConfig) -> PostgresScann
     let (tx, rx) = watch::channel(false);
     let js = Arc::new(Mutex::new(JoinSet::new()));
 
-    // Capture partition count up-front so each task doesn't need the
-    // full PartitionConfig reference.
+    // Capture partition counts up-front so each task doesn't need the
+    // full PartitionConfig reference. `budget_reset` iterates over the
+    // budget partition space (`num_budget_partitions`), distinct from
+    // the execution/flow partition space the other partition-scoped
+    // reconcilers walk.
     let num_partitions: i16 = cfg.partition_config.num_flow_partitions as i16;
+    let num_budget_partitions: i16 = cfg.partition_config.num_budget_partitions as i16;
     let filter = cfg.scanner_filter.clone();
 
     // ── Partition-scoped reconcilers ──
@@ -155,6 +164,31 @@ pub fn spawn_scanners(pool: PgPool, cfg: PostgresScannerConfig) -> PostgresScann
                 .await
                 .map(|_| ())
         }),
+    );
+
+    // ── `budget_reset` (RFC-020 Wave 9 Standalone-1) ──
+    //
+    // Walks the budget partition space, not the flow/exec space, so
+    // it uses `num_budget_partitions`. Filter is ignored — budget IDs
+    // are not namespace/instance-tagged (mirrors the Valkey
+    // `BudgetResetScanner` which accepts the filter "for uniform API"
+    // and does not apply it, issue #122).
+    spawn_partition_scan(
+        &js,
+        &tx,
+        rx.clone(),
+        pool.clone(),
+        cfg.budget_reset_interval,
+        num_budget_partitions,
+        filter.clone(),
+        "pg.budget_reset",
+        |pool, part, _filter| {
+            Box::pin(async move {
+                reconcilers::budget_reset::scan_tick(&pool, part)
+                    .await
+                    .map(|_| ())
+            })
+        },
     );
 
     // ── Global (non-partition-scoped) reconcilers ──
@@ -209,9 +243,10 @@ pub fn spawn_scanners(pool: PgPool, cfg: PostgresScannerConfig) -> PostgresScann
     );
 
     tracing::info!(
-        scanners = 6,
+        scanners = 7,
         num_partitions,
-        "postgres scanner supervisor spawned (RFC-017 Stage E3)"
+        num_budget_partitions,
+        "postgres scanner supervisor spawned (RFC-017 Stage E3 + RFC-020 Wave 9 budget_reset)"
     );
 
     PostgresScannerHandle {

--- a/crates/ff-backend-postgres/tests/pg_budget_admin.rs
+++ b/crates/ff-backend-postgres/tests/pg_budget_admin.rs
@@ -1,0 +1,400 @@
+//! RFC-020 Wave 9 Standalone-1 integration tests.
+//!
+//! Exercises `create_budget`, `reset_budget`, `create_quota_policy`,
+//! `get_budget_status`, `report_usage_admin` trait methods + the
+//! `budget_reset` reconciler against a live Postgres with migrations
+//! 0012 + 0013 applied.
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://... cargo test -p ff-backend-postgres \
+//!     --test pg_budget_admin -- --ignored
+//! ```
+
+use std::sync::Arc;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{
+    CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
+    ReportUsageAdminArgs, ReportUsageResult, ResetBudgetArgs, ResetBudgetResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::EngineError;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{BudgetId, QuotaPolicyId, TimestampMs};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+fn backend(pool: PgPool) -> Arc<PostgresBackend> {
+    PostgresBackend::from_pool(pool, PartitionConfig::default())
+}
+
+fn budget_args(
+    id: &BudgetId,
+    reset_interval_ms: u64,
+    hard_tokens: u64,
+    soft_tokens: u64,
+) -> CreateBudgetArgs {
+    CreateBudgetArgs {
+        budget_id: id.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-1".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms,
+        dimensions: vec!["tokens".into()],
+        hard_limits: vec![hard_tokens],
+        soft_limits: vec![soft_tokens],
+        now: TimestampMs(now_ms()),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn create_budget_created_then_already_satisfied() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool);
+    let bid = BudgetId::new();
+
+    let r1 = backend
+        .create_budget(budget_args(&bid, 0, 100, 80))
+        .await
+        .expect("create_budget first call");
+    assert!(matches!(r1, CreateBudgetResult::Created { .. }));
+
+    let r2 = backend
+        .create_budget(budget_args(&bid, 0, 100, 80))
+        .await
+        .expect("create_budget second call");
+    assert!(matches!(r2, CreateBudgetResult::AlreadySatisfied { .. }));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn create_quota_policy_created_then_already_satisfied() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool);
+    let qid = QuotaPolicyId::new();
+    let args = CreateQuotaPolicyArgs {
+        quota_policy_id: qid.clone(),
+        window_seconds: 60,
+        max_requests_per_window: 100,
+        max_concurrent: 10,
+        now: TimestampMs(now_ms()),
+    };
+
+    let r1 = backend
+        .create_quota_policy(args.clone())
+        .await
+        .expect("create_quota_policy first");
+    assert!(matches!(r1, CreateQuotaPolicyResult::Created { .. }));
+
+    let r2 = backend
+        .create_quota_policy(args)
+        .await
+        .expect("create_quota_policy idempotent");
+    assert!(matches!(r2, CreateQuotaPolicyResult::AlreadySatisfied { .. }));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn get_budget_status_happy_and_not_found() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool);
+    let bid = BudgetId::new();
+
+    // Not-found → NotFound { entity: "budget" }.
+    let missing = backend.get_budget_status(&bid).await.unwrap_err();
+    match missing {
+        EngineError::NotFound { entity } => assert_eq!(entity, "budget"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+
+    // Happy path after create_budget + report_usage_admin.
+    backend
+        .create_budget(budget_args(&bid, 0, 100, 80))
+        .await
+        .expect("create_budget");
+
+    let status = backend.get_budget_status(&bid).await.expect("status");
+    assert_eq!(status.scope_type, "flow");
+    assert_eq!(status.scope_id, "flow-1");
+    assert_eq!(status.enforcement_mode, "strict");
+    assert_eq!(status.hard_limits.get("tokens").copied(), Some(100));
+    assert_eq!(status.soft_limits.get("tokens").copied(), Some(80));
+    assert_eq!(status.breach_count, 0);
+    assert_eq!(status.soft_breach_count, 0);
+    assert!(status.created_at.is_some());
+    assert!(status.next_reset_at.is_none(), "no reset scheduled");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn report_usage_admin_soft_then_hard_breach_updates_counters() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool);
+    let bid = BudgetId::new();
+
+    backend
+        .create_budget(budget_args(&bid, 0, /*hard*/ 100, /*soft*/ 50))
+        .await
+        .unwrap();
+
+    // 60 tokens → soft breach (> 50, <= 100). Increment applied.
+    let r1 = backend
+        .report_usage_admin(
+            &bid,
+            ReportUsageAdminArgs::new(
+                vec!["tokens".into()],
+                vec![60],
+                TimestampMs(now_ms()),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(r1, ReportUsageResult::SoftBreach { .. }),
+        "expected SoftBreach, got {r1:?}"
+    );
+    let status = backend.get_budget_status(&bid).await.unwrap();
+    assert_eq!(status.soft_breach_count, 1);
+    assert_eq!(status.breach_count, 0);
+    assert_eq!(status.usage.get("tokens").copied(), Some(60));
+
+    // Another 60 → would push to 120 > 100 hard limit. Hard breach,
+    // no increment. `breach_count` increments; `last_breach_dim` set.
+    let r2 = backend
+        .report_usage_admin(
+            &bid,
+            ReportUsageAdminArgs::new(
+                vec!["tokens".into()],
+                vec![60],
+                TimestampMs(now_ms()),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(r2, ReportUsageResult::HardBreach { .. }),
+        "expected HardBreach, got {r2:?}"
+    );
+    let status2 = backend.get_budget_status(&bid).await.unwrap();
+    assert_eq!(status2.breach_count, 1);
+    assert_eq!(status2.soft_breach_count, 1);
+    assert_eq!(status2.last_breach_dim.as_deref(), Some("tokens"));
+    assert_eq!(
+        status2.usage.get("tokens").copied(),
+        Some(60),
+        "hard-breach must NOT apply the increment"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn reset_budget_zeroes_usage_and_advances_next_reset() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool);
+    let bid = BudgetId::new();
+
+    // reset_interval_ms = 3600s worth; create_budget seeds
+    // next_reset_at_ms = now + interval.
+    let interval_ms: u64 = 3_600_000;
+    backend
+        .create_budget(budget_args(&bid, interval_ms, 100, 80))
+        .await
+        .unwrap();
+    backend
+        .report_usage_admin(
+            &bid,
+            ReportUsageAdminArgs::new(
+                vec!["tokens".into()],
+                vec![40],
+                TimestampMs(now_ms()),
+            ),
+        )
+        .await
+        .unwrap();
+
+    let pre = backend.get_budget_status(&bid).await.unwrap();
+    assert_eq!(pre.usage.get("tokens").copied(), Some(40));
+    assert!(pre.next_reset_at.is_some());
+
+    let now_before_reset = now_ms();
+    let r = backend
+        .reset_budget(ResetBudgetArgs {
+            budget_id: bid.clone(),
+            now: TimestampMs(now_before_reset),
+        })
+        .await
+        .unwrap();
+    let next = match r {
+        ResetBudgetResult::Reset { next_reset_at } => next_reset_at.0,
+        #[allow(unreachable_patterns)]
+        _ => panic!("unexpected ResetBudgetResult shape"),
+    };
+    assert!(
+        next >= now_before_reset + interval_ms as i64,
+        "next_reset_at must advance: got {next}, expected >= {}",
+        now_before_reset + interval_ms as i64,
+    );
+
+    let post = backend.get_budget_status(&bid).await.unwrap();
+    assert_eq!(post.usage.get("tokens").copied(), Some(0));
+    assert!(post.last_breach_at.is_none());
+    assert!(post.last_breach_dim.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn reset_budget_not_found_returns_notfound() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool);
+    let bid = BudgetId::new();
+    let err = backend
+        .reset_budget(ResetBudgetArgs {
+            budget_id: bid,
+            now: TimestampMs(now_ms()),
+        })
+        .await
+        .unwrap_err();
+    match err {
+        EngineError::NotFound { entity } => assert_eq!(entity, "budget"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_reset_reconciler_zeroes_counters_and_advances() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool.clone());
+    let partition_config = PartitionConfig::default();
+    let bid = BudgetId::new();
+    let interval_ms: u64 = 60_000; // 1 minute
+
+    // Create with past `next_reset_at_ms` so the reconciler picks it up:
+    // we bypass the now-plus-interval path on create_budget by directly
+    // backdating the column to (now - 1).
+    backend
+        .create_budget(budget_args(&bid, interval_ms, 100, 80))
+        .await
+        .unwrap();
+    backend
+        .report_usage_admin(
+            &bid,
+            ReportUsageAdminArgs::new(
+                vec!["tokens".into()],
+                vec![25],
+                TimestampMs(now_ms()),
+            ),
+        )
+        .await
+        .unwrap();
+
+    // Backdate next_reset_at_ms so the reconciler sees it as due.
+    let partition = ff_core::partition::budget_partition(&bid, &partition_config);
+    let pk: i16 = partition.index as i16;
+    let past = now_ms() - 1;
+    sqlx::query(
+        "UPDATE ff_budget_policy SET next_reset_at_ms = $3 \
+         WHERE partition_key = $1 AND budget_id = $2",
+    )
+    .bind(pk)
+    .bind(bid.to_string())
+    .bind(past)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Run one reconciler tick on the budget partition.
+    let report =
+        ff_backend_postgres::reconcilers::budget_reset::scan_tick(&pool, pk)
+            .await
+            .expect("scan_tick");
+    assert!(report.processed >= 1, "reconciler must process >= 1 row");
+
+    let post = backend.get_budget_status(&bid).await.unwrap();
+    assert_eq!(post.usage.get("tokens").copied(), Some(0));
+    // Scheduler must advance `next_reset_at_ms` to `now + interval`.
+    let next_str = post.next_reset_at.expect("next_reset_at must be set");
+    let next: i64 = next_str.parse().expect("parse next_reset_at as i64");
+    assert!(next > past, "next_reset_at must advance past the backdated ts");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn report_usage_admin_dedup_key_is_idempotent() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend = backend(pool);
+    let bid = BudgetId::new();
+    backend
+        .create_budget(budget_args(&bid, 0, 100, 80))
+        .await
+        .unwrap();
+
+    let dkey = format!("dedup-{}", uuid::Uuid::new_v4());
+    let make = || {
+        let mut a = ReportUsageAdminArgs::new(
+            vec!["tokens".into()],
+            vec![10],
+            TimestampMs(now_ms()),
+        );
+        a.dedup_key = Some(dkey.clone());
+        a
+    };
+
+    let r1 = backend.report_usage_admin(&bid, make()).await.unwrap();
+    assert!(matches!(r1, ReportUsageResult::Ok));
+    let r2 = backend.report_usage_admin(&bid, make()).await.unwrap();
+    // Replay returns the cached outcome (Ok), not a double-counted
+    // increment.
+    assert!(
+        matches!(r2, ReportUsageResult::Ok | ReportUsageResult::AlreadyApplied),
+        "replay should be Ok or AlreadyApplied, got {r2:?}",
+    );
+    let status = backend.get_budget_status(&bid).await.unwrap();
+    assert_eq!(
+        status.usage.get("tokens").copied(),
+        Some(10),
+        "dedup'd replay must not double-count",
+    );
+}

--- a/crates/ff-backend-postgres/tests/schema_0012_0013.rs
+++ b/crates/ff-backend-postgres/tests/schema_0012_0013.rs
@@ -1,0 +1,226 @@
+//! RFC-020 Wave 9 Standalone-1 schema smoke test — migrations
+//! 0012 (`ff_quota_policy` + window + admitted) + 0013 (budget
+//! policy extensions).
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://user:pw@localhost/ff_wave9_s1_test \
+//!   cargo test -p ff-backend-postgres --test schema_0012_0013 -- --ignored
+//! ```
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+// ---------- 0012 `ff_quota_policy` + `ff_quota_window` + `ff_quota_admitted` ----------
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn quota_tables_exist_and_are_hash_partitioned() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    for tbl in &["ff_quota_policy", "ff_quota_window", "ff_quota_admitted"] {
+        let row = sqlx::query(
+            "SELECT COUNT(*)::bigint AS n FROM pg_partitioned_table pt \
+             JOIN pg_class c ON c.oid = pt.partrelid \
+             WHERE c.relname = $1 AND pt.partstrat = 'h'",
+        )
+        .bind(tbl)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let n: i64 = row.get("n");
+        assert_eq!(n, 1, "{tbl} must be HASH-partitioned");
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn quota_tables_have_256_partition_children() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    for tbl in &["ff_quota_policy", "ff_quota_window", "ff_quota_admitted"] {
+        let row = sqlx::query(
+            "SELECT COUNT(*)::bigint AS n \
+             FROM pg_inherits i \
+             JOIN pg_class p ON p.oid = i.inhparent \
+             WHERE p.relname = $1",
+        )
+        .bind(tbl)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let n: i64 = row.get("n");
+        assert_eq!(n, 256, "{tbl} must have 256 partition children");
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn quota_policy_has_active_concurrency_column() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT data_type, column_default FROM information_schema.columns \
+         WHERE table_schema = 'public' AND table_name = 'ff_quota_policy' \
+           AND column_name = 'active_concurrency'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let dt: String = row.get("data_type");
+    assert_eq!(dt, "bigint");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn quota_admitted_expires_index_exists() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM pg_indexes \
+         WHERE schemaname = 'public' AND indexname = 'ff_quota_admitted_expires_idx'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let n: i64 = row.get("n");
+    assert_eq!(n, 1, "ff_quota_admitted_expires_idx must exist");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn quota_window_has_no_redundant_sweep_index() {
+    // Round-6 reviewer finding: the PK covers sweep scans as a B-tree
+    // prefix match; no separate `ff_quota_window_sweep_idx`.
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM pg_indexes \
+         WHERE schemaname = 'public' AND indexname = 'ff_quota_window_sweep_idx'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let n: i64 = row.get("n");
+    assert_eq!(n, 0, "redundant sweep index must not be created");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn migration_0012_annotation_row() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT version, name, backward_compatible FROM ff_migration_annotation WHERE version = 12",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let v: i32 = row.get("version");
+    let n: String = row.get("name");
+    let bc: bool = row.get("backward_compatible");
+    assert_eq!(v, 12);
+    assert_eq!(n, "0012_quota_policy");
+    assert!(bc, "0012 must be backward_compatible=true (additive)");
+}
+
+// ---------- 0013 `ff_budget_policy` extensions ----------
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_policy_new_columns_exist() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    // (column_name, data_type, is_nullable, has_default)
+    let expected: &[(&str, &str, &str, bool)] = &[
+        ("scope_type", "text", "NO", true),
+        ("scope_id", "text", "NO", true),
+        ("enforcement_mode", "text", "NO", true),
+        ("breach_count", "bigint", "NO", true),
+        ("soft_breach_count", "bigint", "NO", true),
+        ("last_breach_at_ms", "bigint", "YES", false),
+        ("last_breach_dim", "text", "YES", false),
+        ("next_reset_at_ms", "bigint", "YES", false),
+    ];
+    for (col, dt, nullable, has_default) in expected {
+        let row = sqlx::query(
+            "SELECT data_type, is_nullable, column_default \
+             FROM information_schema.columns \
+             WHERE table_schema = 'public' AND table_name = 'ff_budget_policy' \
+               AND column_name = $1",
+        )
+        .bind(col)
+        .fetch_one(&pool)
+        .await
+        .unwrap_or_else(|e| panic!("column {col} must exist: {e}"));
+        let got_dt: String = row.get("data_type");
+        let got_null: String = row.get("is_nullable");
+        let got_default: Option<String> = row.get("column_default");
+        assert_eq!(&got_dt, dt, "column {col} data_type");
+        assert_eq!(&got_null, nullable, "column {col} nullability");
+        assert_eq!(
+            got_default.is_some(),
+            *has_default,
+            "column {col} default presence"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn budget_policy_reset_due_partial_index_exists() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT indexdef FROM pg_indexes \
+         WHERE schemaname = 'public' AND indexname = 'ff_budget_policy_reset_due_idx'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("ff_budget_policy_reset_due_idx must exist");
+    let def: String = row.get("indexdef");
+    assert!(
+        def.contains("next_reset_at_ms IS NOT NULL"),
+        "partial index predicate must gate on NULL: {def}",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn migration_0013_annotation_row() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let row = sqlx::query(
+        "SELECT version, name, backward_compatible FROM ff_migration_annotation WHERE version = 13",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let v: i32 = row.get("version");
+    let n: String = row.get("name");
+    let bc: bool = row.get("backward_compatible");
+    assert_eq!(v, 13);
+    assert_eq!(n, "0013_budget_policy_extensions");
+    assert!(bc, "0013 must be backward_compatible=true (additive)");
+}

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -620,6 +620,7 @@ impl Server {
             dependency_reconciler_interval: config.engine_config.dependency_reconciler_interval,
             edge_cancel_dispatcher_interval: config.engine_config.edge_cancel_dispatcher_interval,
             edge_cancel_reconciler_interval: config.engine_config.edge_cancel_reconciler_interval,
+            budget_reset_interval: config.engine_config.budget_reset_interval,
             dependency_stale_threshold_ms:
                 ff_backend_postgres::PostgresScannerConfig::DEFAULT_DEP_STALE_MS,
             scanner_filter: config.engine_config.scanner_filter.clone(),


### PR DESCRIPTION
## Summary

RFC-020 Wave 9 Standalone-1 (Revision 6, §4.4) — Postgres implementations
for the 5 budget/quota admin methods plus two additive migrations and a
new `budget_reset` reconciler. Whole-or-nothing ship per §3 / §6.1.

## What lands

**Five trait method impls** (in `crates/ff-backend-postgres/src/budget.rs`,
wired as `impl EngineBackend for PostgresBackend` in `lib.rs`):

- `create_budget` — INSERT against `ff_budget_policy` populating the 8
  new 0013 columns + `next_reset_at_ms` seeding when `reset_interval_ms > 0`.
- `reset_budget` — SERIALIZABLE tx; zeroes all usage rows + clears
  breach metadata + advances `next_reset_at_ms`.
- `create_quota_policy` — INSERT into `ff_quota_policy`.
- `get_budget_status` — 2-SELECT shape (policy row + usage rows);
  limits parsed from `policy_json` per §4.4.7.
- `report_usage_admin` — shared `report_usage_and_check_core` helper
  per §4.4.6 "report_usage_admin entry point"; narrowly extends
  `report_usage_impl` to maintain the new `breach_count` /
  `soft_breach_count` / `last_breach_*` columns and switches the
  policy-row lock from `FOR SHARE` to `FOR NO KEY UPDATE` (reviewer-
  finding deadlock fix on the breach-UPDATE path).

**Two additive migrations** (`backward_compatible = true`):

- `0012_quota_policy.sql` — `ff_quota_policy` + `ff_quota_window` +
  `ff_quota_admitted` (3 parents × 256 HASH children = 768 partitions).
  `active_concurrency` folded onto the policy row per §4.4.4. No
  redundant `ff_quota_window_sweep_idx` (round-6 review #2).
- `0013_budget_policy_extensions.sql` — 8 additive columns on
  `ff_budget_policy` (scope_type, scope_id, enforcement_mode,
  breach_count, soft_breach_count, last_breach_at_ms, last_breach_dim,
  next_reset_at_ms) + partial index
  `ff_budget_policy_reset_due_idx WHERE next_reset_at_ms IS NOT NULL`.

**One reconciler** — `crates/ff-backend-postgres/src/reconcilers/budget_reset.rs`,
named `budget_reset` matching the Valkey scanner name for observability
alignment. Iterates `num_budget_partitions` (distinct from the
execution/flow partition space); backed by the partial index;
per-row apply via shared `budget::budget_reset_reconciler_apply` under
SERIALIZABLE. Wired into `PostgresScannerConfig::budget_reset_interval`
driven by `ff-server::config::budget_reset_interval`.

## Not in scope (per RFC §6.3)

- `Supports.budget_admin` / `Supports.quota_admin` — stay `false`.
  Atomic flip reserved for the Wave 9 release PR.
- No CHANGELOG entry (release PR batches).
- No consumer migration doc (release artifact).
- No outbox events (§4.2.7 — budget/quota has no outbox).

## RFC-vs-reality gap surfaced

Revision 6 §4.4.5 specifies `CREATE INDEX CONCURRENTLY` for the
partial index on `ff_budget_policy_reset_due_idx`. **Postgres 16 does
not support `CONCURRENTLY` on partitioned parents** (`ff_budget_policy`
has been HASH-partitioned since 0002). Matching the existing
0001/0002 convention, 0013 uses plain `CREATE INDEX`. The column is
added in the same migration so the partial-index build touches zero
rows — the `AccessExclusiveLock` on the parent is metadata-only.
Documented inline in 0013.

## Tests

- `crates/ff-backend-postgres/tests/schema_0012_0013.rs` — 9 schema
  smoke assertions (HASH partitioning, 256-child count, columns +
  nullability, partial-index predicate, migration annotations,
  absence of the redundant sweep index).
- `crates/ff-backend-postgres/tests/pg_budget_admin.rs` — 8 integration
  tests: create_budget idempotency, create_quota_policy idempotency,
  get_budget_status happy + NotFound, report_usage_admin soft-then-
  hard-breach counter maintenance, reset_budget zero + advance,
  reset_budget NotFound, budget_reset reconciler round-trip
  (backdate → scan → verify zeroed + advanced), dedup-key replay.

All tests are `#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]`
per the existing pattern.

## Verification

Local Postgres 16 smoke run against a fresh database:

```
$ export FF_PG_TEST_URL="postgres://ff_test:ff_test@localhost/ff_wave9_s1_test"
$ cargo test -p ff-backend-postgres --test pg_budget_admin --test schema_0012_0013 -- --ignored --test-threads=1
...
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Full ignored PG suite (75 tests) passes end-to-end; no regressions in
`schema_0002.rs` (budget tables) or `pg_engine_backend_attempt.rs`.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --lib` green (no regressions)
- [x] `cargo clippy -p ff-backend-postgres -- -D warnings` clean
- [x] Postgres integration tests (FF_PG_TEST_URL) — 17 new + 58 existing pass
- [x] Migrations 0012 + 0013 apply cleanly on a fresh DB
- [x] `examples/token-budget` builds against the updated workspace
- [ ] **Manual pre-merge:** `examples/token-budget` live-run on
      `FF_BACKEND=postgres` end-to-end per RFC §6.3 release gate.
      Deferred to the merger because it requires an ff-server instance
      in PG-backend mode + a populated Valkey companion for the
      worker-loop bits the example also touches; the 8 integration
      tests exercise the exact same 5 trait methods on the same schema
      as the example, so trait-level parity is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres schema (including 768 new partitions) and new write-path/admin operations with updated locking/isolation, plus a new background reconciler; issues would primarily surface as migration/lock contention or incorrect budget counter/reset behavior.
> 
> **Overview**
> Implements the Wave 9 Standalone-1 Postgres backend surfaces for budget/quota admin: `create_budget`, `reset_budget`, `create_quota_policy`, `get_budget_status`, and `report_usage_admin`, and wires them into the `EngineBackend` impl.
> 
> Adds two **backward-compatible** migrations: `0012` introduces hash-partitioned quota tables (`ff_quota_policy`, `ff_quota_window`, `ff_quota_admitted`) with an expires sweep index, and `0013` extends `ff_budget_policy` with scope/enforcement fields, breach counters/metadata, reset scheduling (`next_reset_at_ms`), plus a partial index to scan reset-due budgets.
> 
> Updates the budget hot path to lock policy rows with `FOR NO KEY UPDATE` and to maintain the new breach counters/metadata, and adds a new Postgres `budget_reset` reconciler (plus scanner supervisor/server wiring) that periodically resets due budgets and reschedules the next reset. Integration and schema smoke tests are added (ignored by default) to exercise the new APIs, migrations, and reconciler behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36561b5c8be89cf6fdadb338d7f7e2818490b5cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->