### PR TITLE
feat(pg-backend): Wave 9 Spine-B — read_execution_info/state + get_execution_result

### DIFF
--- a/crates/ff-backend-postgres/src/exec_core.rs
+++ b/crates/ff-backend-postgres/src/exec_core.rs
@@ -36,9 +36,13 @@ use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use ff_core::contracts::decode::build_execution_snapshot;
-use ff_core::contracts::{CreateExecutionArgs, ExecutionSnapshot, ListExecutionsPage};
+use ff_core::contracts::{CreateExecutionArgs, ExecutionInfo, ExecutionSnapshot, ListExecutionsPage};
 use ff_core::engine_error::{EngineError, ValidationKind};
 use ff_core::partition::{PartitionConfig, PartitionKey};
+use ff_core::state::{
+    AttemptState, BlockingReason, EligibilityState, LifecyclePhase, OwnershipState, PublicState,
+    StateVector, TerminalOutcome,
+};
 use ff_core::types::{ExecutionId, FlowId};
 use serde_json::Value as JsonValue;
 use sqlx::{PgPool, Row};
@@ -480,5 +484,313 @@ pub(super) async fn resolve_execution_flow_id_impl(
                 "resolve_execution_flow_id: exec_core.flow_id='{s}' is not a valid FlowId: {e}"
             ),
         })
+}
+
+// ─── RFC-020 Wave 9 Spine-B — read model (3 methods) ─────────────
+//
+// All three reads project from the `ff_exec_core` row for the target
+// `(partition_key, execution_id)`; `read_execution_info` additionally
+// LATERAL-joins `ff_attempt` for the current-attempt row (outcome +
+// started_at). READ COMMITTED is sufficient — all three are
+// single-query, read-only, no CAS. Per RFC §4.1 + §7.8,
+// `get_execution_result` is current-attempt semantics (matches Valkey's
+// `GET ctx.result()` primitive; `result` column on `ff_exec_core`).
+//
+// Postgres storage strings for the 6 state-vector dimensions are a
+// superset of the in-core enum literals (`cancelled`, `blocked`,
+// `eligible`, `pending`, `released`, `running`, `pending_claim`, …).
+// These Postgres-specific literals are collapsed to the closest
+// user-facing enum variant by the normalisation helpers below before
+// JSON-deserialising; unknown tokens surface as `Corruption` errors
+// rather than silently defaulting.
+
+fn normalise_lifecycle_phase(raw: &str) -> &str {
+    match raw {
+        "cancelled" | "terminal" => "terminal",
+        "pending" | "runnable" | "eligible" | "blocked" | "leased" => "runnable",
+        "active" => "active",
+        "suspended" => "suspended",
+        "submitted" => "submitted",
+        other => other,
+    }
+}
+
+fn normalise_ownership_state(raw: &str) -> &str {
+    match raw {
+        "released" | "unowned" => "unowned",
+        "leased" => "leased",
+        "lease_expired_reclaimable" => "lease_expired_reclaimable",
+        "lease_revoked" => "lease_revoked",
+        other => other,
+    }
+}
+
+fn normalise_eligibility_state(raw: &str) -> &str {
+    match raw {
+        "cancelled" => "not_applicable",
+        other => other,
+    }
+}
+
+fn normalise_attempt_state(raw: &str) -> &str {
+    match raw {
+        "pending_claim" => "pending_first_attempt",
+        "running" => "running_attempt",
+        other => other,
+    }
+}
+
+macro_rules! json_enum {
+    ($ty:ty, $field:expr, $raw:expr) => {{
+        let quoted = format!("\"{}\"", $raw);
+        serde_json::from_str::<$ty>(&quoted).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!(
+                "exec_core: {}: '{}' is not a known value: {}",
+                $field, $raw, e
+            ),
+        })
+    }};
+}
+
+/// Map an `ff_attempt.outcome` string to a [`TerminalOutcome`]. Only
+/// meaningful when `lifecycle_phase` is terminal/cancelled; otherwise
+/// returns `TerminalOutcome::None`.
+fn derive_terminal_outcome(
+    phase_norm: &str,
+    phase_raw: &str,
+    attempt_outcome: Option<&str>,
+) -> TerminalOutcome {
+    if phase_norm != "terminal" {
+        return TerminalOutcome::None;
+    }
+    if phase_raw == "cancelled" {
+        return TerminalOutcome::Cancelled;
+    }
+    match attempt_outcome {
+        Some("success") => TerminalOutcome::Success,
+        Some("failed") => TerminalOutcome::Failed,
+        Some("cancelled") => TerminalOutcome::Cancelled,
+        Some("expired") => TerminalOutcome::Expired,
+        Some("skipped") => TerminalOutcome::Skipped,
+        _ => TerminalOutcome::None,
+    }
+}
+
+/// RFC-020 §4.1 — `read_execution_state`: single-column point read of
+/// `public_state`. `Ok(None)` when the execution is missing.
+pub(super) async fn read_execution_state_impl(
+    pool: &PgPool,
+    _partition_config: &PartitionConfig,
+    id: &ExecutionId,
+) -> Result<Option<PublicState>, EngineError> {
+    let partition_key: i16 = id.partition() as i16;
+    let execution_id = eid_uuid(id);
+
+    let row: Option<(String,)> = sqlx::query_as(
+        r#"
+        SELECT public_state
+        FROM ff_exec_core
+        WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(execution_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some((raw,)) = row else {
+        return Ok(None);
+    };
+    let parsed: PublicState = json_enum!(PublicState, "public_state", &raw)?;
+    Ok(Some(parsed))
+}
+
+/// RFC-020 §4.1 — `read_execution_info`: multi-column projection of
+/// `ff_exec_core` + `LEFT JOIN LATERAL` on `ff_attempt` (current attempt
+/// row) to build [`ExecutionInfo`]. `Ok(None)` when the execution is
+/// missing. Partition-local (both tables co-located on `partition_key`,
+/// RFC-011).
+pub(super) async fn read_execution_info_impl(
+    pool: &PgPool,
+    _partition_config: &PartitionConfig,
+    id: &ExecutionId,
+) -> Result<Option<ExecutionInfo>, EngineError> {
+    let partition_key: i16 = id.partition() as i16;
+    let execution_id = eid_uuid(id);
+
+    let row = sqlx::query(
+        r#"
+        SELECT ec.flow_id,
+               ec.lane_id,
+               ec.priority,
+               ec.lifecycle_phase,
+               ec.ownership_state,
+               ec.eligibility_state,
+               ec.public_state,
+               ec.attempt_state,
+               ec.blocking_reason,
+               ec.attempt_index,
+               ec.created_at_ms,
+               ec.terminal_at_ms,
+               ec.raw_fields,
+               a.outcome    AS attempt_outcome,
+               a.started_at_ms AS attempt_started_at_ms
+        FROM ff_exec_core ec
+        LEFT JOIN LATERAL (
+            SELECT outcome, started_at_ms
+            FROM ff_attempt
+            WHERE partition_key = ec.partition_key
+              AND execution_id  = ec.execution_id
+              AND attempt_index = ec.attempt_index
+        ) a ON TRUE
+        WHERE ec.partition_key = $1 AND ec.execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(execution_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let flow_id_uuid: Option<Uuid> = row.try_get("flow_id").map_err(map_sqlx_error)?;
+    let lane_id: String = row.try_get("lane_id").map_err(map_sqlx_error)?;
+    let priority: i32 = row.try_get("priority").map_err(map_sqlx_error)?;
+    let lifecycle_phase_raw: String =
+        row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let ownership_state_raw: String =
+        row.try_get("ownership_state").map_err(map_sqlx_error)?;
+    let eligibility_state_raw: String =
+        row.try_get("eligibility_state").map_err(map_sqlx_error)?;
+    let public_state_raw: String = row.try_get("public_state").map_err(map_sqlx_error)?;
+    let attempt_state_raw: String = row.try_get("attempt_state").map_err(map_sqlx_error)?;
+    let blocking_reason_opt: Option<String> =
+        row.try_get("blocking_reason").map_err(map_sqlx_error)?;
+    let attempt_index: i32 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    let created_at_ms: i64 = row.try_get("created_at_ms").map_err(map_sqlx_error)?;
+    let terminal_at_ms_opt: Option<i64> =
+        row.try_get("terminal_at_ms").map_err(map_sqlx_error)?;
+    let raw_fields: JsonValue = row.try_get("raw_fields").map_err(map_sqlx_error)?;
+    let attempt_outcome_opt: Option<String> =
+        row.try_get("attempt_outcome").map_err(map_sqlx_error)?;
+    let attempt_started_at_ms_opt: Option<i64> =
+        row.try_get("attempt_started_at_ms").map_err(map_sqlx_error)?;
+
+    let lifecycle_phase: LifecyclePhase = json_enum!(
+        LifecyclePhase,
+        "lifecycle_phase",
+        normalise_lifecycle_phase(&lifecycle_phase_raw)
+    )?;
+    let ownership_state: OwnershipState = json_enum!(
+        OwnershipState,
+        "ownership_state",
+        normalise_ownership_state(&ownership_state_raw)
+    )?;
+    let eligibility_state: EligibilityState = json_enum!(
+        EligibilityState,
+        "eligibility_state",
+        normalise_eligibility_state(&eligibility_state_raw)
+    )?;
+    let public_state: PublicState = json_enum!(PublicState, "public_state", &public_state_raw)?;
+    let attempt_state: AttemptState = json_enum!(
+        AttemptState,
+        "attempt_state",
+        normalise_attempt_state(&attempt_state_raw)
+    )?;
+    let blocking_reason: BlockingReason = match blocking_reason_opt
+        .as_deref()
+        .filter(|s| !s.is_empty())
+    {
+        None => BlockingReason::None,
+        Some(raw) => json_enum!(BlockingReason, "blocking_reason", raw)?,
+    };
+    let terminal_outcome = derive_terminal_outcome(
+        normalise_lifecycle_phase(&lifecycle_phase_raw),
+        &lifecycle_phase_raw,
+        attempt_outcome_opt.as_deref(),
+    );
+
+    let state_vector = StateVector {
+        lifecycle_phase,
+        ownership_state,
+        eligibility_state,
+        blocking_reason,
+        terminal_outcome,
+        attempt_state,
+        public_state,
+    };
+
+    // Scalar fields from raw_fields JSON (namespace, execution_kind,
+    // blocking_detail). Same shape as `describe_execution_impl` reads.
+    let mut namespace = String::new();
+    let mut execution_kind = String::new();
+    let mut blocking_detail = String::new();
+    if let JsonValue::Object(map) = &raw_fields {
+        if let Some(JsonValue::String(s)) = map.get("namespace") {
+            namespace = s.clone();
+        }
+        if let Some(JsonValue::String(s)) = map.get("execution_kind") {
+            execution_kind = s.clone();
+        }
+        if let Some(JsonValue::String(s)) = map.get("blocking_detail") {
+            blocking_detail = s.clone();
+        }
+    }
+
+    let flow_id = flow_id_uuid
+        .map(|fid| format!("{{fp:{part}}}:{fid}", part = id.partition()));
+
+    Ok(Some(ExecutionInfo {
+        execution_id: id.clone(),
+        namespace,
+        lane_id,
+        priority,
+        execution_kind,
+        state_vector,
+        public_state,
+        created_at: created_at_ms.to_string(),
+        started_at: attempt_started_at_ms_opt.map(|v| v.to_string()),
+        completed_at: terminal_at_ms_opt.map(|v| v.to_string()),
+        current_attempt_index: attempt_index.max(0) as u32,
+        flow_id,
+        blocking_detail,
+    }))
+}
+
+/// RFC-020 §4.1 + §7.8 — `get_execution_result`: current-attempt
+/// semantics (matches Valkey's `GET ctx.result()`). Reads the `result`
+/// column from `ff_exec_core`; `Ok(None)` when the execution is missing
+/// or the result is `NULL` (not yet terminal, or cancelled without a
+/// payload).
+pub(super) async fn get_execution_result_impl(
+    pool: &PgPool,
+    _partition_config: &PartitionConfig,
+    id: &ExecutionId,
+) -> Result<Option<Vec<u8>>, EngineError> {
+    let partition_key: i16 = id.partition() as i16;
+    let execution_id = eid_uuid(id);
+
+    let row: Option<(Option<Vec<u8>>,)> = sqlx::query_as(
+        r#"
+        SELECT result
+        FROM ff_exec_core
+        WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(execution_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    match row {
+        None => Ok(None),
+        Some((payload,)) => Ok(payload),
+    }
 }
 

--- a/crates/ff-backend-postgres/src/exec_core.rs
+++ b/crates/ff-backend-postgres/src/exec_core.rs
@@ -504,10 +504,21 @@ pub(super) async fn resolve_execution_flow_id_impl(
 // JSON-deserialising; unknown tokens surface as `Corruption` errors
 // rather than silently defaulting.
 
+// Normalisation maps: `ff_exec_core` literal → closest
+// serde-snake_case enum variant. Each arm is grounded in an actual
+// write site in this crate; unknown tokens fall through so
+// `json_enum!` surfaces `Corruption` loudly.
+
 fn normalise_lifecycle_phase(raw: &str) -> &str {
     match raw {
+        // Terminal family — `cancelled` is Postgres-specific
+        // (flow.rs:674 writes it directly), `terminal` is canonical.
         "cancelled" | "terminal" => "terminal",
-        "pending" | "runnable" | "eligible" | "blocked" | "leased" => "runnable",
+        // Pre-runnable + runnable variants collapse to `Runnable`
+        // (the user-facing enum only distinguishes 5 phases). `blocked`
+        // is a legacy literal still referenced in dispatch.rs:352's
+        // CASE clause but no longer written by current paths.
+        "pending" | "runnable" | "eligible" | "blocked" => "runnable",
         "active" => "active",
         "suspended" => "suspended",
         "submitted" => "submitted",
@@ -517,6 +528,8 @@ fn normalise_lifecycle_phase(raw: &str) -> &str {
 
 fn normalise_ownership_state(raw: &str) -> &str {
     match raw {
+        // `released` is a Postgres-specific post-suspension marker
+        // (suspend_ops.rs:585); nearest enum variant is `Unowned`.
         "released" | "unowned" => "unowned",
         "leased" => "leased",
         "lease_expired_reclaimable" => "lease_expired_reclaimable",
@@ -527,15 +540,41 @@ fn normalise_ownership_state(raw: &str) -> &str {
 
 fn normalise_eligibility_state(raw: &str) -> &str {
     match raw {
+        // Terminal-cancelled rows → `NotApplicable` (Valkey parity).
         "cancelled" => "not_applicable",
+        // Scheduler ClaimGrant transitional state; nearest user-facing
+        // variant is still `EligibleNow` (the exec is about to be
+        // claimed — scheduler has picked it but the worker hasn't
+        // acknowledged yet).
+        "pending_claim" => "eligible_now",
         other => other,
     }
 }
 
 fn normalise_attempt_state(raw: &str) -> &str {
     match raw {
-        "pending_claim" => "pending_first_attempt",
+        // `pending` is the Postgres initial-insert literal
+        // (exec_core.rs:166); `pending_claim` is the scheduler transitional
+        // write. Both collapse to `PendingFirstAttempt`.
+        "pending" | "pending_claim" => "pending_first_attempt",
+        // Bare `running` from the suspension-resume claim path
+        // (suspend_ops.rs:958); canonical form is `running_attempt`.
         "running" => "running_attempt",
+        // `cancelled` attempt_state (flow.rs cancel path) has no direct
+        // enum variant; nearest is `AttemptTerminal`.
+        "cancelled" => "attempt_terminal",
+        other => other,
+    }
+}
+
+/// Collapse Postgres `public_state` literals to the
+/// `PublicState` snake_case serde form.
+fn normalise_public_state(raw: &str) -> &str {
+    match raw {
+        // Postgres writes the bare `running` literal on the
+        // resume-claim path (suspend_ops.rs:958). Valkey / the
+        // `PublicState` enum spell it `active`.
+        "running" => "active",
         other => other,
     }
 }
@@ -603,7 +642,8 @@ pub(super) async fn read_execution_state_impl(
     let Some((raw,)) = row else {
         return Ok(None);
     };
-    let parsed: PublicState = json_enum!(PublicState, "public_state", &raw)?;
+    let parsed: PublicState =
+        json_enum!(PublicState, "public_state", normalise_public_state(&raw))?;
     Ok(Some(parsed))
 }
 
@@ -696,7 +736,11 @@ pub(super) async fn read_execution_info_impl(
         "eligibility_state",
         normalise_eligibility_state(&eligibility_state_raw)
     )?;
-    let public_state: PublicState = json_enum!(PublicState, "public_state", &public_state_raw)?;
+    let public_state: PublicState = json_enum!(
+        PublicState,
+        "public_state",
+        normalise_public_state(&public_state_raw)
+    )?;
     let attempt_state: AttemptState = json_enum!(
         AttemptState,
         "attempt_state",

--- a/crates/ff-backend-postgres/src/exec_core.rs
+++ b/crates/ff-backend-postgres/src/exec_core.rs
@@ -660,6 +660,11 @@ pub(super) async fn read_execution_info_impl(
     let partition_key: i16 = id.partition() as i16;
     let execution_id = eid_uuid(id);
 
+    // LATERAL joins: `cur` pins to the current attempt (for
+    // `outcome` — drives `TerminalOutcome`); `first` pins to the
+    // earliest attempt row on the execution (attempt_index ASC — drives
+    // `started_at`, which per `ExecutionInfo` contract is the
+    // first-claim timestamp preserved across retries — Valkey parity).
     let row = sqlx::query(
         r#"
         SELECT ec.flow_id,
@@ -675,16 +680,25 @@ pub(super) async fn read_execution_info_impl(
                ec.created_at_ms,
                ec.terminal_at_ms,
                ec.raw_fields,
-               a.outcome    AS attempt_outcome,
-               a.started_at_ms AS attempt_started_at_ms
+               cur.outcome       AS attempt_outcome,
+               first_att.started_at_ms AS first_started_at_ms
         FROM ff_exec_core ec
         LEFT JOIN LATERAL (
-            SELECT outcome, started_at_ms
+            SELECT outcome
             FROM ff_attempt
             WHERE partition_key = ec.partition_key
               AND execution_id  = ec.execution_id
               AND attempt_index = ec.attempt_index
-        ) a ON TRUE
+        ) cur ON TRUE
+        LEFT JOIN LATERAL (
+            SELECT started_at_ms
+            FROM ff_attempt
+            WHERE partition_key = ec.partition_key
+              AND execution_id  = ec.execution_id
+              AND started_at_ms IS NOT NULL
+            ORDER BY attempt_index ASC
+            LIMIT 1
+        ) first_att ON TRUE
         WHERE ec.partition_key = $1 AND ec.execution_id = $2
         "#,
     )
@@ -718,8 +732,8 @@ pub(super) async fn read_execution_info_impl(
     let raw_fields: JsonValue = row.try_get("raw_fields").map_err(map_sqlx_error)?;
     let attempt_outcome_opt: Option<String> =
         row.try_get("attempt_outcome").map_err(map_sqlx_error)?;
-    let attempt_started_at_ms_opt: Option<i64> =
-        row.try_get("attempt_started_at_ms").map_err(map_sqlx_error)?;
+    let first_started_at_ms_opt: Option<i64> =
+        row.try_get("first_started_at_ms").map_err(map_sqlx_error)?;
 
     let lifecycle_phase: LifecyclePhase = json_enum!(
         LifecyclePhase,
@@ -786,8 +800,10 @@ pub(super) async fn read_execution_info_impl(
         }
     }
 
-    let flow_id = flow_id_uuid
-        .map(|fid| format!("{{fp:{part}}}:{fid}", part = id.partition()));
+    // `ExecutionInfo.flow_id` is the bare UUID wire form of `FlowId`
+    // (per `uuid_id!` macro — no hash-tag prefix). Valkey stores the
+    // bare UUID in `exec_core["flow_id"]` too (Valkey parity).
+    let flow_id = flow_id_uuid.map(|fid| fid.to_string());
 
     Ok(Some(ExecutionInfo {
         execution_id: id.clone(),
@@ -798,7 +814,7 @@ pub(super) async fn read_execution_info_impl(
         state_vector,
         public_state,
         created_at: created_at_ms.to_string(),
-        started_at: attempt_started_at_ms_opt.map(|v| v.to_string()),
+        started_at: first_started_at_ms_opt.map(|v| v.to_string()),
         completed_at: terminal_at_ms_opt.map(|v| v.to_string()),
         current_attempt_index: attempt_index.max(0) as u32,
         flow_id,

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -46,6 +46,8 @@ use ff_core::contracts::{
     RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SeedOutcome,
     SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome,
 };
+#[cfg(feature = "core")]
+use ff_core::contracts::ExecutionInfo;
 #[cfg(feature = "streaming")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
 use ff_core::engine_backend::EngineBackend;
@@ -631,6 +633,41 @@ impl EngineBackend for PostgresBackend {
         args: ClaimResumedExecutionArgs,
     ) -> Result<ClaimResumedExecutionResult, EngineError> {
         suspend_ops::claim_resumed_execution_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    // ── RFC-020 Wave 9 Spine-B — read model (3 methods, §4.1) ────────
+    //
+    // Partition-local single-row reads against `ff_exec_core` (+ LATERAL
+    // join on `ff_attempt` for `read_execution_info`). READ COMMITTED
+    // (no CAS; all three are read-only). `get_execution_result` returns
+    // current-attempt semantics per §7.8 (matches Valkey's
+    // `GET ctx.result()` primitive). Capability flips land at the Wave 9
+    // release PR per RFC §6.3.
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.read_execution_state", skip_all)]
+    async fn read_execution_state(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<PublicState>, EngineError> {
+        exec_core::read_execution_state_impl(&self.pool, &self.partition_config, id).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.read_execution_info", skip_all)]
+    async fn read_execution_info(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<ExecutionInfo>, EngineError> {
+        exec_core::read_execution_info_impl(&self.pool, &self.partition_config, id).await
+    }
+
+    #[tracing::instrument(name = "pg.get_execution_result", skip_all)]
+    async fn get_execution_result(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<Vec<u8>>, EngineError> {
+        exec_core::get_execution_result_impl(&self.pool, &self.partition_config, id).await
     }
 
     // ── RFC-020 Wave 9 Standalone-2 — list_pending_waitpoints (§4.5) ─

--- a/crates/ff-backend-postgres/tests/spine_b_reads.rs
+++ b/crates/ff-backend-postgres/tests/spine_b_reads.rs
@@ -1,0 +1,396 @@
+//! RFC-020 Wave 9 Spine-B — integration tests for the 3 read methods
+//! (`read_execution_state`, `read_execution_info`, `get_execution_result`).
+//!
+//! Follows the `FF_PG_TEST_URL` / `#[ignore]` convention used by the
+//! other Postgres integration suites.
+//!
+//! Coverage:
+//!
+//! * `read_execution_state_missing_returns_none` — `Ok(None)` when the
+//!   execution id is unknown.
+//! * `read_execution_state_returns_public_state` — point read against a
+//!   seeded `ff_exec_core` row returns the parsed [`PublicState`].
+//! * `read_execution_info_missing_returns_none` — `Ok(None)` when the
+//!   execution id is unknown.
+//! * `read_execution_info_lateral_joins_current_attempt` — seeds two
+//!   attempt rows (index 0 + 1) + bumps `ff_exec_core.attempt_index = 1`;
+//!   asserts the LATERAL join pins to attempt_index=1 and its
+//!   `started_at_ms` flows into `ExecutionInfo::started_at`.
+//! * `read_execution_info_terminal_derives_outcome` — terminal exec
+//!   with attempt outcome=`success` surfaces `TerminalOutcome::Success`.
+//! * `get_execution_result_missing_returns_none` — `Ok(None)` when the
+//!   execution id is unknown.
+//! * `get_execution_result_active_returns_none` — `Ok(None)` when the
+//!   execution is seeded non-terminal with NULL `result`.
+//! * `get_execution_result_terminal_returns_payload` — seeds a terminal
+//!   execution with non-empty `result`; returns the bytes.
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::state::{LifecyclePhase, PublicState, TerminalOutcome};
+use ff_core::types::{ExecutionId, LaneId, TimestampMs};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ── Fixture: pool + `PostgresBackend` ────────────────────────────
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+
+    let bootstrap = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&bootstrap)
+        .await
+        .expect("apply_migrations clean");
+    bootstrap.close().await;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect pool");
+    Some(pool)
+}
+
+struct Seed {
+    backend: std::sync::Arc<dyn EngineBackend>,
+    pool: PgPool,
+    exec_id: ExecutionId,
+    part: i16,
+    exec_uuid: Uuid,
+}
+
+async fn seed_backend() -> Option<Seed> {
+    let pool = setup_or_skip().await?;
+    let lane = LaneId::new("default");
+    let exec_id = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let part = exec_id.partition() as i16;
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default())
+        as std::sync::Arc<dyn EngineBackend>;
+    Some(Seed {
+        backend,
+        pool,
+        exec_id,
+        part,
+        exec_uuid,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_exec_core(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    lane_id: &str,
+    lifecycle_phase: &str,
+    ownership_state: &str,
+    eligibility_state: &str,
+    public_state: &str,
+    attempt_state: &str,
+    attempt_index: i32,
+    now_ms: i64,
+    terminal_at_ms: Option<i64>,
+    result_payload: Option<Vec<u8>>,
+    raw_fields: serde_json::Value,
+) {
+    sqlx::query(
+        "INSERT INTO ff_exec_core \
+           (partition_key, execution_id, lane_id, attempt_index, \
+            lifecycle_phase, ownership_state, eligibility_state, \
+            public_state, attempt_state, \
+            priority, created_at_ms, terminal_at_ms, result, raw_fields) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, $10, $11, $12, $13)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lane_id)
+    .bind(attempt_index)
+    .bind(lifecycle_phase)
+    .bind(ownership_state)
+    .bind(eligibility_state)
+    .bind(public_state)
+    .bind(attempt_state)
+    .bind(now_ms)
+    .bind(terminal_at_ms)
+    .bind(result_payload)
+    .bind(raw_fields)
+    .execute(pool)
+    .await
+    .expect("insert ff_exec_core");
+}
+
+async fn insert_attempt(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    attempt_index: i32,
+    outcome: Option<&str>,
+    started_at_ms: Option<i64>,
+) {
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, lease_epoch, outcome, started_at_ms) \
+         VALUES ($1, $2, $3, 0, $4, $5)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .bind(outcome)
+    .bind(started_at_ms)
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+}
+
+// ── read_execution_state ──────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_state_missing_returns_none() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let missing = ExecutionId::solo(&LaneId::new("default"), &PartitionConfig::default());
+    let got = fx.backend.read_execution_state(&missing).await.expect("call ok");
+    assert!(got.is_none(), "missing exec → Ok(None)");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_state_returns_public_state() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "active",
+        "leased",
+        "not_applicable",
+        "active",
+        "running_attempt",
+        0,
+        now,
+        None,
+        None,
+        serde_json::json!({}),
+    )
+    .await;
+
+    let got = fx
+        .backend
+        .read_execution_state(&fx.exec_id)
+        .await
+        .expect("call ok");
+    assert_eq!(got, Some(PublicState::Active));
+}
+
+// ── read_execution_info ───────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_info_missing_returns_none() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let missing = ExecutionId::solo(&LaneId::new("default"), &PartitionConfig::default());
+    let got = fx.backend.read_execution_info(&missing).await.expect("call ok");
+    assert!(got.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_info_lateral_joins_current_attempt() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    // Bump attempt_index to 1 — the LATERAL join must pin to this row,
+    // NOT the attempt_index=0 row (which represents a prior attempt).
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "workers",
+        "active",
+        "leased",
+        "not_applicable",
+        "active",
+        "running_attempt",
+        1,
+        now,
+        None,
+        None,
+        serde_json::json!({
+            "namespace": "ns-a",
+            "execution_kind": "task",
+            "blocking_detail": "",
+        }),
+    )
+    .await;
+    // Attempt 0: prior attempt; should be IGNORED by the LATERAL join.
+    insert_attempt(&fx.pool, fx.part, fx.exec_uuid, 0, Some("failed"), Some(1_000)).await;
+    // Attempt 1: current attempt; started_at should surface.
+    insert_attempt(&fx.pool, fx.part, fx.exec_uuid, 1, None, Some(now + 500)).await;
+
+    let info = fx
+        .backend
+        .read_execution_info(&fx.exec_id)
+        .await
+        .expect("call ok")
+        .expect("exec present");
+
+    assert_eq!(info.execution_id, fx.exec_id);
+    assert_eq!(info.namespace, "ns-a");
+    assert_eq!(info.lane_id, "workers");
+    assert_eq!(info.execution_kind, "task");
+    assert_eq!(info.public_state, PublicState::Active);
+    assert_eq!(info.state_vector.lifecycle_phase, LifecyclePhase::Active);
+    assert_eq!(info.state_vector.terminal_outcome, TerminalOutcome::None);
+    assert_eq!(info.current_attempt_index, 1);
+    assert_eq!(info.started_at.as_deref(), Some((now + 500).to_string().as_str()));
+    assert!(info.completed_at.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_info_terminal_derives_outcome() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "terminal",
+        "unowned",
+        "not_applicable",
+        "completed",
+        "attempt_terminal",
+        0,
+        now,
+        Some(now + 1_000),
+        None,
+        serde_json::json!({}),
+    )
+    .await;
+    insert_attempt(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("success"),
+        Some(now - 500),
+    )
+    .await;
+
+    let info = fx
+        .backend
+        .read_execution_info(&fx.exec_id)
+        .await
+        .expect("call ok")
+        .expect("exec present");
+
+    assert_eq!(info.public_state, PublicState::Completed);
+    assert_eq!(info.state_vector.lifecycle_phase, LifecyclePhase::Terminal);
+    assert_eq!(info.state_vector.terminal_outcome, TerminalOutcome::Success);
+    assert_eq!(
+        info.completed_at.as_deref(),
+        Some((now + 1_000).to_string().as_str())
+    );
+}
+
+// ── get_execution_result ──────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn get_execution_result_missing_returns_none() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let missing = ExecutionId::solo(&LaneId::new("default"), &PartitionConfig::default());
+    let got = fx
+        .backend
+        .get_execution_result(&missing)
+        .await
+        .expect("call ok");
+    assert!(got.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn get_execution_result_active_returns_none() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "active",
+        "leased",
+        "not_applicable",
+        "active",
+        "running_attempt",
+        0,
+        now,
+        None,
+        None,
+        serde_json::json!({}),
+    )
+    .await;
+
+    let got = fx
+        .backend
+        .get_execution_result(&fx.exec_id)
+        .await
+        .expect("call ok");
+    assert!(got.is_none(), "active exec with NULL result → Ok(None)");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn get_execution_result_terminal_returns_payload() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    let payload = b"hello-world-result".to_vec();
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "terminal",
+        "unowned",
+        "not_applicable",
+        "completed",
+        "attempt_terminal",
+        0,
+        now,
+        Some(now + 1),
+        Some(payload.clone()),
+        serde_json::json!({}),
+    )
+    .await;
+
+    let got = fx
+        .backend
+        .get_execution_result(&fx.exec_id)
+        .await
+        .expect("call ok");
+    assert_eq!(got.as_deref(), Some(payload.as_slice()));
+}

--- a/crates/ff-backend-postgres/tests/spine_b_reads.rs
+++ b/crates/ff-backend-postgres/tests/spine_b_reads.rs
@@ -176,7 +176,7 @@ async fn read_execution_state_returns_public_state() {
         "active",
         "leased",
         "not_applicable",
-        "active",
+        "running", // Postgres writes `running`; read layer normalises → Active
         "running_attempt",
         0,
         now,
@@ -224,7 +224,7 @@ async fn read_execution_info_lateral_joins_current_attempt() {
         "active",
         "leased",
         "not_applicable",
-        "active",
+        "running", // Postgres writes `running`; read layer normalises → Active
         "running_attempt",
         1,
         now,
@@ -343,7 +343,7 @@ async fn get_execution_result_active_returns_none() {
         "active",
         "leased",
         "not_applicable",
-        "active",
+        "running",
         "running_attempt",
         0,
         now,
@@ -393,4 +393,126 @@ async fn get_execution_result_terminal_returns_payload() {
         .await
         .expect("call ok");
     assert_eq!(got.as_deref(), Some(payload.as_slice()));
+}
+
+// ── Normalization coverage for write-site literals ───────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_info_fresh_create_literals() {
+    // Mirrors exactly the literals `create_execution_impl` writes on
+    // INSERT: submitted/unowned/eligible_now/waiting/pending. Exercises
+    // `attempt_state = 'pending'` → `PendingFirstAttempt` normalisation.
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "submitted",
+        "unowned",
+        "eligible_now",
+        "waiting",
+        "pending", // Postgres create-time literal
+        0,
+        now,
+        None,
+        None,
+        serde_json::json!({}),
+    )
+    .await;
+
+    let info = fx
+        .backend
+        .read_execution_info(&fx.exec_id)
+        .await
+        .expect("call ok")
+        .expect("exec present");
+    assert_eq!(info.public_state, PublicState::Waiting);
+    // `pending` normalises to `PendingFirstAttempt`.
+    assert_eq!(
+        info.state_vector.attempt_state,
+        ff_core::state::AttemptState::PendingFirstAttempt
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_info_cancelled_row() {
+    // Postgres cancel path writes lifecycle_phase='cancelled',
+    // eligibility_state='cancelled', public_state='cancelled',
+    // attempt_state='cancelled' (flow.rs:674 + attempt.rs cancel).
+    // Exercises every normalisation branch on the terminal-cancel row.
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "cancelled",
+        "unowned",
+        "cancelled",
+        "cancelled",
+        "cancelled",
+        0,
+        now,
+        Some(now + 1),
+        None,
+        serde_json::json!({}),
+    )
+    .await;
+
+    let info = fx
+        .backend
+        .read_execution_info(&fx.exec_id)
+        .await
+        .expect("call ok")
+        .expect("exec present");
+    assert_eq!(info.public_state, PublicState::Cancelled);
+    assert_eq!(info.state_vector.lifecycle_phase, LifecyclePhase::Terminal);
+    assert_eq!(info.state_vector.terminal_outcome, TerminalOutcome::Cancelled);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_info_pending_claim_eligibility() {
+    // Scheduler ClaimGrant transitional literal `pending_claim` on
+    // `eligibility_state`; must normalise to `EligibleNow`.
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "runnable",
+        "unowned",
+        "pending_claim",
+        "waiting",
+        "pending_claim",
+        0,
+        now,
+        None,
+        None,
+        serde_json::json!({}),
+    )
+    .await;
+    let info = fx
+        .backend
+        .read_execution_info(&fx.exec_id)
+        .await
+        .expect("call ok")
+        .expect("exec present");
+    assert_eq!(
+        info.state_vector.eligibility_state,
+        ff_core::state::EligibilityState::EligibleNow
+    );
 }

--- a/crates/ff-backend-postgres/tests/spine_b_reads.rs
+++ b/crates/ff-backend-postgres/tests/spine_b_reads.rs
@@ -209,13 +209,27 @@ async fn read_execution_info_missing_returns_none() {
 
 #[tokio::test]
 #[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
-async fn read_execution_info_lateral_joins_current_attempt() {
+async fn read_execution_info_lateral_joins_both_attempts() {
+    // Two LATERAL joins in `read_execution_info`:
+    //   * current-attempt (attempt_index = ec.attempt_index) drives
+    //     `outcome` → `TerminalOutcome`;
+    //   * first-attempt (earliest started_at_ms) drives
+    //     `ExecutionInfo.started_at` (first-claim timestamp, preserved
+    //     across retries — Valkey-parity contract).
+    //
+    // Seed two attempts:
+    //   * attempt 0 started at `first_start` (old first-claim);
+    //   * attempt 1 started at `later_start` (current attempt);
+    // then bump `ec.attempt_index = 1`.
+    // The read must surface
+    //   * `started_at = first_start` (NOT later_start)
+    //   * `outcome`-derived state from attempt_index=1 (NULL → None)
     let Some(fx) = seed_backend().await else {
         return;
     };
     let now = TimestampMs::now().0;
-    // Bump attempt_index to 1 — the LATERAL join must pin to this row,
-    // NOT the attempt_index=0 row (which represents a prior attempt).
+    let first_start = now - 10_000;
+    let later_start = now - 100;
     insert_exec_core(
         &fx.pool,
         fx.part,
@@ -237,10 +251,11 @@ async fn read_execution_info_lateral_joins_current_attempt() {
         }),
     )
     .await;
-    // Attempt 0: prior attempt; should be IGNORED by the LATERAL join.
-    insert_attempt(&fx.pool, fx.part, fx.exec_uuid, 0, Some("failed"), Some(1_000)).await;
-    // Attempt 1: current attempt; started_at should surface.
-    insert_attempt(&fx.pool, fx.part, fx.exec_uuid, 1, None, Some(now + 500)).await;
+    // Attempt 0: first-claim row; drives `started_at`.
+    insert_attempt(&fx.pool, fx.part, fx.exec_uuid, 0, Some("failed"), Some(first_start))
+        .await;
+    // Attempt 1: current attempt; drives `outcome` (no terminal outcome yet).
+    insert_attempt(&fx.pool, fx.part, fx.exec_uuid, 1, None, Some(later_start)).await;
 
     let info = fx
         .backend
@@ -255,9 +270,18 @@ async fn read_execution_info_lateral_joins_current_attempt() {
     assert_eq!(info.execution_kind, "task");
     assert_eq!(info.public_state, PublicState::Active);
     assert_eq!(info.state_vector.lifecycle_phase, LifecyclePhase::Active);
+    // Current-attempt (index=1) has no outcome → None (not the
+    // attempt-0 `failed` outcome, which would be a LATERAL mispin).
     assert_eq!(info.state_vector.terminal_outcome, TerminalOutcome::None);
     assert_eq!(info.current_attempt_index, 1);
-    assert_eq!(info.started_at.as_deref(), Some((now + 500).to_string().as_str()));
+    // First-claim `started_at` (attempt_index=0 row); NOT the current
+    // attempt's `later_start`.
+    assert_eq!(
+        info.started_at.as_deref(),
+        Some(first_start.to_string().as_str()),
+        "started_at must be first-claim timestamp (attempt 0), \
+         not current-attempt (attempt 1)"
+    );
     assert!(info.completed_at.is_none());
 }
 
@@ -497,7 +521,10 @@ async fn read_execution_info_pending_claim_eligibility() {
         "unowned",
         "pending_claim",
         "waiting",
-        "pending_claim",
+        // Attempt_state must be a persisted literal; `pending_claim` is
+        // only written on `eligibility_state`. Use the create-time
+        // `pending` (covers the initial-INSERT path).
+        "pending",
         0,
         now,
         None,
@@ -514,5 +541,56 @@ async fn read_execution_info_pending_claim_eligibility() {
     assert_eq!(
         info.state_vector.eligibility_state,
         ff_core::state::EligibilityState::EligibleNow
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_execution_info_flow_id_returns_bare_uuid() {
+    // `ExecutionInfo.flow_id` is the bare UUID wire form of `FlowId`
+    // (per `uuid_id!` macro, no hash-tag prefix).
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    // Seed a row and then UPDATE flow_id to a known uuid (the helper
+    // doesn't take flow_id; a direct update keeps the fixture surface
+    // small).
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "default",
+        "submitted",
+        "unowned",
+        "eligible_now",
+        "waiting",
+        "pending",
+        0,
+        now,
+        None,
+        None,
+        serde_json::json!({}),
+    )
+    .await;
+    let flow_uuid = Uuid::new_v4();
+    sqlx::query("UPDATE ff_exec_core SET flow_id = $1 WHERE partition_key = $2 AND execution_id = $3")
+        .bind(flow_uuid)
+        .bind(fx.part)
+        .bind(fx.exec_uuid)
+        .execute(&fx.pool)
+        .await
+        .expect("update flow_id");
+
+    let info = fx
+        .backend
+        .read_execution_info(&fx.exec_id)
+        .await
+        .expect("call ok")
+        .expect("exec present");
+    assert_eq!(
+        info.flow_id.as_deref(),
+        Some(flow_uuid.to_string().as_str()),
+        "flow_id is bare UUID, not hash-tagged"
     );
 }


### PR DESCRIPTION
## Summary

Implements the Spine-B read-model trio on the Postgres backend per
RFC-020 Revision 6 §4.1. All three methods currently return
`EngineError::Unavailable`; this PR replaces those stubs with real
partition-local reads against `ff_exec_core` + a LATERAL join on
`ff_attempt` for the composite case.

* **`read_execution_state`** — `SELECT public_state FROM ff_exec_core`,
  parses the snake_case literal into `PublicState`. `Ok(None)` when the
  execution id is unknown.
* **`read_execution_info`** — multi-column projection of `ff_exec_core`
  + `LEFT JOIN LATERAL` on `ff_attempt` pinned to
  `attempt_index = ec.attempt_index` (the current attempt). Builds a
  full `ExecutionInfo` with 6-dim `StateVector`, deriving
  `TerminalOutcome` from `ff_attempt.outcome` when terminal.
* **`get_execution_result`** — single-column `SELECT result` (bytea).
  Per RFC §4.1 + §7.8, current-attempt semantics (matches Valkey's
  `GET ctx.result()` primitive). `Ok(None)` when the execution is
  missing or the result column is `NULL`.

All three reads use READ COMMITTED (no CAS; read-only, single-query).
Empty rows surface as `Ok(None)` — trait-contract parity with the
Valkey backend.

Postgres storage literals for the 6 state-vector dimensions are a
superset of the in-core enum forms (`cancelled`, `blocked`, `eligible`,
`released`, `pending_claim`, `running`, …). A small normalisation layer
collapses them to the closest enum variant before JSON-deserialising;
unknown tokens surface as `EngineError::Validation { Corruption }`
rather than silently defaulting.

Per RFC §6.3, the `Supports.read_execution_info/state/get_execution_result`
capability flags stay `false` in this PR — atomic flip at the Wave 9
release PR. No CHANGELOG entry, no consumer-migration doc edits, no
outbox emission (reads don't emit per §4.2.7).

## Test plan

- [x] `cargo build -p ff-backend-postgres` (default features) — clean
- [x] `cargo clippy -p ff-backend-postgres --all-targets -- -D warnings` — clean
- [x] `cargo test -p ff-backend-postgres --lib` — 24 passed
- [x] `FF_PG_TEST_URL=… cargo test -p ff-backend-postgres --test spine_b_reads -- --ignored` — **8 passed** (local Postgres)
  - `read_execution_state_missing_returns_none` + `read_execution_state_returns_public_state`
  - `read_execution_info_missing_returns_none` + `read_execution_info_lateral_joins_current_attempt` (two-attempt fixture verifies LATERAL pin to current attempt) + `read_execution_info_terminal_derives_outcome` (TerminalOutcome::Success from attempt.outcome=success)
  - `get_execution_result_missing_returns_none` + `get_execution_result_active_returns_none` + `get_execution_result_terminal_returns_payload`
- [ ] Workspace matrix-CI green (runs on push)

## References

- RFC-020 §4.1 (Spine-B read-model — join-on-read decision)
- RFC-020 §7.1 (read-model shape — resolved)
- RFC-020 §7.8 (`get_execution_result` current-attempt — resolved)
- Valkey reference impls: `crates/ff-backend-valkey/src/lib.rs:5254` (`get_execution_result`), `:6235` (`read_execution_info`), `:6308` (`read_execution_state`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres implementations for execution read-model methods, including state-string normalization and a LATERAL join to current attempt; incorrect mappings or join assumptions could surface as corruption errors or wrong read results, though changes are read-only.
> 
> **Overview**
> Implements RFC-020 Wave 9 Spine-B read-model support in the Postgres backend by replacing the previously-unavailable stubs with real partition-local reads for `read_execution_state`, `read_execution_info`, and `get_execution_result`.
> 
> `read_execution_info` now projects from `ff_exec_core` and LATERAL-joins `ff_attempt` for the current attempt to populate `ExecutionInfo` (including derived `TerminalOutcome`), with explicit normalization/parsing of Postgres state literals into core enums and corruption errors on unknown tokens.
> 
> Adds an ignored Postgres integration test suite (`spine_b_reads.rs`) that seeds `ff_exec_core`/`ff_attempt` rows to validate missing-row behavior, current-attempt pinning, terminal outcome derivation, and result payload reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04c943bc47709e27ed0df11cbcf043dcbf86cc25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->