### PR TITLE
feat(pg-backend): Wave 9 Spine-A pt.1 — cancel_execution + revoke_lease + outbox emits

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -48,6 +48,11 @@ use ff_core::contracts::{
 };
 #[cfg(feature = "core")]
 use ff_core::contracts::ExecutionInfo;
+// RFC-020 Wave 9 Spine-A pt.1 — operator-control mutating surfaces.
+#[cfg(feature = "core")]
+use ff_core::contracts::{
+    CancelExecutionArgs, CancelExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
+};
 // RFC-020 Wave 9 Standalone-1 — budget/quota admin surfaces.
 #[cfg(feature = "core")]
 use ff_core::contracts::{
@@ -88,6 +93,8 @@ mod lease_event;
 mod lease_event_subscribe;
 pub mod listener;
 pub mod migrate;
+#[cfg(feature = "core")]
+pub mod operator;
 pub mod pool;
 #[cfg(feature = "core")]
 pub mod reconcilers;
@@ -691,6 +698,31 @@ impl EngineBackend for PostgresBackend {
         args: ListPendingWaitpointsArgs,
     ) -> Result<ListPendingWaitpointsResult, EngineError> {
         suspend_ops::list_pending_waitpoints_impl(&self.pool, args).await
+    }
+
+    // ── RFC-020 Wave 9 Spine-A pt.1 — operator-control mutations (§4.2) ─
+    //
+    // Two methods landing behind `Supports.cancel_execution` +
+    // `Supports.revoke_lease` (both stay `false` until the Wave 9
+    // release PR flips them atomically, RFC §6.3). SERIALIZABLE + CAS +
+    // `ff_lease_event` outbox emit on the same tx (§4.2.6 + §4.2.7).
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.cancel_execution", skip_all)]
+    async fn cancel_execution(
+        &self,
+        args: CancelExecutionArgs,
+    ) -> Result<CancelExecutionResult, EngineError> {
+        operator::cancel_execution_impl(&self.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.revoke_lease", skip_all)]
+    async fn revoke_lease(
+        &self,
+        args: RevokeLeaseArgs,
+    ) -> Result<RevokeLeaseResult, EngineError> {
+        operator::revoke_lease_impl(&self.pool, args).await
     }
 
     // ── RFC-017 Stage A — ingress (promoted from inherent) ────

--- a/crates/ff-backend-postgres/src/operator.rs
+++ b/crates/ff-backend-postgres/src/operator.rs
@@ -86,16 +86,21 @@ fn synthetic_lease_id(exec_uuid: Uuid, attempt_index: i32, lease_epoch: i64) -> 
 
 /// Transactional body for [`cancel_execution_impl`].
 ///
-/// Returns `Ok(Some(result))` on success, `Ok(None)` never (the
-/// function always yields a concrete outcome), `Err(e)` for
-/// serialization retries + hard failures.
+/// Returns `Ok(result)` on success (one tx); `Err(e)` for
+/// serialization retries (40001/40P01 → re-enters the outer loop) and
+/// hard failures (NotFound, StaleLease, Validation on terminal
+/// conflict).
 async fn cancel_execution_once(
     pool: &PgPool,
     args: &CancelExecutionArgs,
 ) -> Result<CancelExecutionResult, EngineError> {
     let partition_key: i16 = args.execution_id.partition() as i16;
     let exec_uuid = eid_uuid(&args.execution_id);
-    let now = now_ms();
+    // Honour caller-supplied `args.now` for `terminal_at_ms` +
+    // `raw_fields.last_mutation_at` + outbox `occurred_at_ms` so
+    // retries + cross-backend comparisons don't drift on the DB host
+    // clock.
+    let now: i64 = args.now.0;
 
     let mut tx = begin_serializable(pool).await?;
 
@@ -163,19 +168,29 @@ async fn cancel_execution_once(
     }
 
     // Lease fence validation (Valkey parity — only enforced when
-    // source != operator_override). The Valkey side keys fence on
-    // `current_lease_id` + `current_lease_epoch`; Postgres has no
-    // stable `lease_id` column, so we fence on `lease_epoch` only
-    // when the caller supplied one. `LeaseId` fencing is a no-op on
-    // Postgres (documented in `operator.rs` + matches the
-    // `lease_event::emit` docs for `lease_id = None`).
+    // `source != CancelSource::OperatorOverride`). Per
+    // `CancelExecutionArgs` docstring, `lease_epoch` is REQUIRED
+    // when source is not operator_override AND the execution is
+    // active; missing input on that path surfaces a `Validation`
+    // error rather than silently bypassing. The Valkey side keys
+    // fence on `current_lease_id` + `current_lease_epoch`; Postgres
+    // has no stable `lease_id` column, so we fence on `lease_epoch`.
+    // `lease_id` in args is ignored on Postgres (documented parity
+    // gap — matches the `lease_event::emit` docs for `lease_id = None`).
     let lease_active = worker_instance_id
         .as_deref()
         .is_some_and(|s| !s.is_empty());
-    if !matches!(args.source, CancelSource::OperatorOverride)
-        && lease_active
-        && let Some(expected_epoch) = args.lease_epoch.as_ref()
-    {
+    if !matches!(args.source, CancelSource::OperatorOverride) && lease_active {
+        let Some(expected_epoch) = args.lease_epoch.as_ref() else {
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!(
+                    "cancel_execution: execution_id={}: lease_epoch required when source != operator_override and execution is active",
+                    args.execution_id
+                ),
+            });
+        };
         let expected: i64 = i64::try_from(expected_epoch.0).unwrap_or(i64::MAX);
         if lease_epoch.unwrap_or(0) != expected {
             tx.rollback().await.map_err(map_sqlx_error)?;
@@ -228,8 +243,8 @@ async fn cancel_execution_once(
                SET worker_instance_id   = NULL,
                    lease_expires_at_ms  = NULL,
                    lease_epoch          = lease_epoch + 1,
-                   terminal_at_ms       = COALESCE(terminal_at_ms, $4),
-                   outcome              = COALESCE(outcome, 'cancelled')
+                   terminal_at_ms       = $4,
+                   outcome              = 'cancelled'
              WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
             "#,
         )
@@ -367,7 +382,42 @@ async fn revoke_lease_once(
         });
     }
 
+    // Targeted-revoke fence: the caller identifies a specific owner
+    // via `args.worker_instance_id`. If the locked attempt is held
+    // by a different worker, surface `AlreadySatisfied` (idempotent
+    // parity — the targeted lease is already gone, from this
+    // caller's perspective). An empty caller-supplied wiid is a
+    // wildcard (matches Valkey's `revoke_lease: HGET
+    // current_worker_instance_id` fallback at `lib.rs:5869-5899`).
+    let caller_wiid = args.worker_instance_id.as_str();
+    if !caller_wiid.is_empty()
+        && worker_instance_id.as_deref() != Some(caller_wiid)
+    {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(RevokeLeaseResult::AlreadySatisfied {
+            reason: "different_worker_instance_id".to_owned(),
+        });
+    }
+
     let prior_epoch = lease_epoch.unwrap_or(0);
+
+    // Optional `expected_lease_id` fence. Valkey uses a stable
+    // lease_id; Postgres synthesises one from
+    // `(execution_id, attempt_index, lease_epoch)`. Empty string is
+    // the documented "skip check" path on the args docstring.
+    if let Some(expected) = args
+        .expected_lease_id
+        .as_ref()
+        .filter(|s| !s.is_empty())
+    {
+        let current_id = synthetic_lease_id(exec_uuid, attempt_index, prior_epoch);
+        if expected != &current_id {
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            return Ok(RevokeLeaseResult::AlreadySatisfied {
+                reason: "lease_id_mismatch".to_owned(),
+            });
+        }
+    }
 
     // CAS on `lease_epoch`. Row-count = 0 → another writer bumped
     // the epoch (reconciler or concurrent revoke) → `AlreadySatisfied`
@@ -399,6 +449,32 @@ async fn revoke_lease_once(
             reason: "epoch_moved".to_owned(),
         });
     }
+
+    // Flip `ff_exec_core` back to reclaimable-runnable so the normal
+    // claim path picks it up — mirrors
+    // `reconcilers::lease_expiry::release_one` (lease_expiry.rs:156-173).
+    // Gated on `lifecycle_phase = 'active'` to avoid touching a row
+    // that's been concurrently terminated (cancelled / completed).
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET lifecycle_phase   = 'runnable',
+               ownership_state   = 'unowned',
+               eligibility_state = 'eligible_now',
+               attempt_state     = 'attempt_interrupted',
+               raw_fields        = jsonb_set(raw_fields,
+                                             '{last_mutation_at}',
+                                             to_jsonb($3::text))
+         WHERE partition_key = $1 AND execution_id = $2
+           AND lifecycle_phase = 'active'
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
 
     // Step 5 — outbox emit (§4.2.7 — `ff_lease_event event_type=revoked`).
     lease_event::emit(

--- a/crates/ff-backend-postgres/src/operator.rs
+++ b/crates/ff-backend-postgres/src/operator.rs
@@ -1,0 +1,447 @@
+//! RFC-020 Wave 9 Spine-A pt.1 — operator-control mutating methods
+//! (`cancel_execution` + `revoke_lease`).
+//!
+//! Both methods follow the §4.2 shared spine template:
+//!
+//!   1. `BEGIN ISOLATION LEVEL SERIALIZABLE`.
+//!   2. `SELECT ... FOR UPDATE` on `ff_exec_core` (+ `ff_attempt`
+//!      for the current-attempt row) — captures pre-state and
+//!      acquires row locks against the `lease_expiry` /
+//!      `attempt_timeout` reconcilers (§4.2.6).
+//!   3. Validate against Valkey-canonical semantics (§5.2).
+//!   4. Mutate with compare-and-set fencing (lease_epoch CAS on
+//!      `revoke_lease`; lifecycle_phase check on `cancel_execution`).
+//!   5. Emit the outbox row per §4.2.7 matrix (`ff_lease_event`).
+//!   6. `COMMIT`. On `40001` / `40P01` (serialization / deadlock)
+//!      retry up to `CANCEL_FLOW_MAX_ATTEMPTS = 3`; exhaustion
+//!      surfaces `ContentionKind::RetryExhausted` to the caller.
+//!
+//! Per §4.2.6: existing reconcilers (`lease_expiry`, `attempt_timeout`)
+//! filter on `lifecycle_phase = 'active'`, so a `'cancelled'` row
+//! surfaced by `cancel_execution` is silently skipped — no new
+//! reconciler modifications required.
+
+use std::time::Duration;
+
+use ff_core::contracts::{
+    CancelExecutionArgs, CancelExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
+};
+use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
+use ff_core::state::PublicState;
+use ff_core::types::CancelSource;
+use sqlx::{PgPool, Postgres, Row};
+use uuid::Uuid;
+
+use crate::error::map_sqlx_error;
+use crate::lease_event;
+
+/// Max attempts on `40001` / `40P01`. Matches
+/// [`crate::flow::CANCEL_FLOW_MAX_ATTEMPTS`] (RFC §4.2).
+const MAX_ATTEMPTS: u32 = 3;
+
+/// Extract the raw UUID suffix from an `ExecutionId`'s wire form
+/// (`"{fp:N}:<uuid>"`). Mirrors [`crate::exec_core::eid_uuid`].
+fn eid_uuid(eid: &ff_core::types::ExecutionId) -> Uuid {
+    let s = eid.as_str();
+    let suffix = s
+        .split_once("}:")
+        .map(|(_, u)| u)
+        .expect("ExecutionId has `}:` separator (invariant)");
+    Uuid::parse_str(suffix).expect("ExecutionId suffix is a valid UUID (invariant)")
+}
+
+fn now_ms() -> i64 {
+    let d = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock is after UNIX_EPOCH");
+    (d.as_millis() as i64).max(0)
+}
+
+/// Map a `40001` / `40P01` sqlx conflict into the retry loop. Other
+/// `Contention` variants propagate untouched (mirrors
+/// `flow::is_serialization_conflict`).
+fn is_serialization_conflict(err: &EngineError) -> bool {
+    matches!(err, EngineError::Contention(ContentionKind::LeaseConflict))
+}
+
+async fn begin_serializable(pool: &PgPool) -> Result<sqlx::Transaction<'_, Postgres>, EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(tx)
+}
+
+/// Synthetic Postgres lease identity (the backend has no stable
+/// `lease_id` column — §4.2.2 derives identity from
+/// `(execution_id, attempt_index, lease_epoch)`). Surfaces on
+/// [`RevokeLeaseResult::Revoked`] so callers have a stable string to
+/// round-trip through logs / traces.
+fn synthetic_lease_id(exec_uuid: Uuid, attempt_index: i32, lease_epoch: i64) -> String {
+    format!("pg:{exec_uuid}:{attempt_index}:{lease_epoch}")
+}
+
+// ─── cancel_execution (§4.2.1) ────────────────────────────────────
+
+/// Transactional body for [`cancel_execution_impl`].
+///
+/// Returns `Ok(Some(result))` on success, `Ok(None)` never (the
+/// function always yields a concrete outcome), `Err(e)` for
+/// serialization retries + hard failures.
+async fn cancel_execution_once(
+    pool: &PgPool,
+    args: &CancelExecutionArgs,
+) -> Result<CancelExecutionResult, EngineError> {
+    let partition_key: i16 = args.execution_id.partition() as i16;
+    let exec_uuid = eid_uuid(&args.execution_id);
+    let now = now_ms();
+
+    let mut tx = begin_serializable(pool).await?;
+
+    // Step 2 + 3 — pre-read under lock. Join on the current attempt
+    // row to read `worker_instance_id` + `lease_epoch` (drives the
+    // lease-active decision + CAS fencing).
+    let row = sqlx::query(
+        r#"
+        SELECT ec.lifecycle_phase,
+               ec.public_state,
+               ec.attempt_index,
+               a.worker_instance_id,
+               a.lease_epoch
+          FROM ff_exec_core ec
+          LEFT JOIN ff_attempt a
+            ON a.partition_key = ec.partition_key
+           AND a.execution_id  = ec.execution_id
+           AND a.attempt_index = ec.attempt_index
+         WHERE ec.partition_key = $1 AND ec.execution_id = $2
+         FOR NO KEY UPDATE OF ec
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        // Valkey path returns `execution_not_found` → NotFound
+        // (`ScriptError::ExecutionNotFound`). Mirror that here.
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+
+    let lifecycle_phase: String = row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let public_state: String = row.try_get("public_state").map_err(map_sqlx_error)?;
+    let attempt_index: i32 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    let worker_instance_id: Option<String> =
+        row.try_get("worker_instance_id").map_err(map_sqlx_error)?;
+    let lease_epoch: Option<i64> = row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+
+    // Terminal-state handling — idempotent replay if already
+    // cancelled; hard conflict if terminal with a different outcome.
+    // Mirrors `exec_core::cancel_impl` to keep operator-visible
+    // semantics stable.
+    if matches!(lifecycle_phase.as_str(), "terminal" | "cancelled") {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return if public_state == "cancelled" {
+            Ok(CancelExecutionResult::Cancelled {
+                execution_id: args.execution_id.clone(),
+                public_state: PublicState::Cancelled,
+            })
+        } else {
+            Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!(
+                    "cancel_execution: execution_id={}: already terminal in state '{}'",
+                    args.execution_id, public_state
+                ),
+            })
+        };
+    }
+
+    // Lease fence validation (Valkey parity — only enforced when
+    // source != operator_override). The Valkey side keys fence on
+    // `current_lease_id` + `current_lease_epoch`; Postgres has no
+    // stable `lease_id` column, so we fence on `lease_epoch` only
+    // when the caller supplied one. `LeaseId` fencing is a no-op on
+    // Postgres (documented in `operator.rs` + matches the
+    // `lease_event::emit` docs for `lease_id = None`).
+    let lease_active = worker_instance_id
+        .as_deref()
+        .is_some_and(|s| !s.is_empty());
+    if !matches!(args.source, CancelSource::OperatorOverride)
+        && lease_active
+        && let Some(expected_epoch) = args.lease_epoch.as_ref()
+    {
+        let expected: i64 = i64::try_from(expected_epoch.0).unwrap_or(i64::MAX);
+        if lease_epoch.unwrap_or(0) != expected {
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            return Err(EngineError::State(
+                ff_core::engine_error::StateKind::StaleLease,
+            ));
+        }
+    }
+
+    // Step 4a — flip exec_core to cancelled. Matches the existing
+    // `flow::cancel_flow` member-cancel shape (flow.rs:672) so the
+    // terminal lifecycle literal stays `'cancelled'` (not `'terminal'`
+    // + `terminal_outcome='cancelled'` — the Valkey encoding). Per
+    // RFC §4.2.1 this is the Postgres-canonical encoding.
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET lifecycle_phase     = 'cancelled',
+               ownership_state     = 'unowned',
+               eligibility_state   = 'not_applicable',
+               public_state        = 'cancelled',
+               attempt_state       = 'cancelled',
+               terminal_at_ms      = COALESCE(terminal_at_ms, $3),
+               cancellation_reason = COALESCE(cancellation_reason, $4),
+               cancelled_by        = COALESCE(cancelled_by, $5),
+               raw_fields          = jsonb_set(raw_fields,
+                                               '{last_mutation_at}',
+                                               to_jsonb($3::text))
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(now)
+    .bind(&args.reason)
+    .bind(args.source.as_str())
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Step 4b — clear lease on the current attempt row if one was
+    // active. Zeroes `worker_instance_id` + `lease_expires_at_ms` so
+    // the `lease_expiry` reconciler + `claim_from_reclaim` path see a
+    // released slot. `lease_epoch` bumps by 1 to fence any in-flight
+    // RMW (same pattern as `revoke_lease`).
+    if lease_active {
+        sqlx::query(
+            r#"
+            UPDATE ff_attempt
+               SET worker_instance_id   = NULL,
+                   lease_expires_at_ms  = NULL,
+                   lease_epoch          = lease_epoch + 1,
+                   terminal_at_ms       = COALESCE(terminal_at_ms, $4),
+                   outcome              = COALESCE(outcome, 'cancelled')
+             WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+            "#,
+        )
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Step 5 — outbox emit (§4.2.7). Only when a lease was
+        // active; an already-unowned exec generates no lease event
+        // (matches Valkey's `ff_cancel_execution` which XADDs a
+        // `released` history event only on the active path).
+        lease_event::emit(
+            &mut tx,
+            partition_key,
+            exec_uuid,
+            None, // Postgres has no stable lease_id — see lease_event::emit docs
+            lease_event::EVENT_REVOKED,
+            now,
+        )
+        .await?;
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(CancelExecutionResult::Cancelled {
+        execution_id: args.execution_id.clone(),
+        public_state: PublicState::Cancelled,
+    })
+}
+
+/// `EngineBackend::cancel_execution` impl — SERIALIZABLE + 3-attempt
+/// retry loop on 40001 / 40P01.
+pub(super) async fn cancel_execution_impl(
+    pool: &PgPool,
+    args: CancelExecutionArgs,
+) -> Result<CancelExecutionResult, EngineError> {
+    let mut last: Option<EngineError> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match cancel_execution_once(pool, &args).await {
+            Ok(r) => return Ok(r),
+            Err(err) => {
+                if is_serialization_conflict(&err) {
+                    if attempt + 1 < MAX_ATTEMPTS {
+                        let ms = 5u64 * (1u64 << attempt);
+                        tokio::time::sleep(Duration::from_millis(ms)).await;
+                    }
+                    last = Some(err);
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+    let _ = last;
+    Err(EngineError::Contention(ContentionKind::RetryExhausted))
+}
+
+// ─── revoke_lease (§4.2.2) ────────────────────────────────────────
+
+async fn revoke_lease_once(
+    pool: &PgPool,
+    args: &RevokeLeaseArgs,
+) -> Result<RevokeLeaseResult, EngineError> {
+    let partition_key: i16 = args.execution_id.partition() as i16;
+    let exec_uuid = eid_uuid(&args.execution_id);
+    let now = now_ms();
+
+    let mut tx = begin_serializable(pool).await?;
+
+    // Pre-read: `ff_exec_core` under UPDATE lock to pin the current
+    // attempt_index (defends against a concurrent `replay_execution`
+    // that would bump it). `FOR NO KEY UPDATE` is unsupported on
+    // nullable outer-join sides (pg 0A000), so we lock `ec` solo and
+    // re-read the attempt row separately under its own `FOR UPDATE`.
+    let ec_row = sqlx::query(
+        r#"
+        SELECT attempt_index
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR NO KEY UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(ec_row) = ec_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+    let attempt_index: i32 = ec_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+    // Attempt row may not exist yet (pre-claim exec). Lock with
+    // FOR UPDATE so the `lease_expiry` reconciler serializes with us.
+    let att_row = sqlx::query(
+        r#"
+        SELECT worker_instance_id, lease_epoch
+          FROM ff_attempt
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let (worker_instance_id, lease_epoch): (Option<String>, Option<i64>) = match att_row {
+        Some(r) => (
+            r.try_get("worker_instance_id").map_err(map_sqlx_error)?,
+            r.try_get("lease_epoch").map_err(map_sqlx_error)?,
+        ),
+        None => (None, None),
+    };
+
+    let lease_active = worker_instance_id
+        .as_deref()
+        .is_some_and(|s| !s.is_empty());
+    if !lease_active {
+        // Valkey parity — `RevokeLeaseResult::AlreadySatisfied` when
+        // the exec has no active lease (§4.2.2 +
+        // `valkey/lib.rs:5881-5892`).
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(RevokeLeaseResult::AlreadySatisfied {
+            reason: "no_active_lease".to_owned(),
+        });
+    }
+
+    let prior_epoch = lease_epoch.unwrap_or(0);
+
+    // CAS on `lease_epoch`. Row-count = 0 → another writer bumped
+    // the epoch (reconciler or concurrent revoke) → `AlreadySatisfied`
+    // (§4.2.2 `reason: "epoch_moved"`).
+    let affected = sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET worker_instance_id   = NULL,
+               lease_expires_at_ms  = NULL,
+               lease_epoch          = lease_epoch + 1
+         WHERE partition_key = $1
+           AND execution_id  = $2
+           AND attempt_index = $3
+           AND lease_epoch   = $4
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .bind(prior_epoch)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?
+    .rows_affected();
+
+    if affected == 0 {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(RevokeLeaseResult::AlreadySatisfied {
+            reason: "epoch_moved".to_owned(),
+        });
+    }
+
+    // Step 5 — outbox emit (§4.2.7 — `ff_lease_event event_type=revoked`).
+    lease_event::emit(
+        &mut tx,
+        partition_key,
+        exec_uuid,
+        None,
+        lease_event::EVENT_REVOKED,
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(RevokeLeaseResult::Revoked {
+        lease_id: synthetic_lease_id(exec_uuid, attempt_index, prior_epoch),
+        lease_epoch: (prior_epoch + 1).to_string(),
+    })
+}
+
+/// `EngineBackend::revoke_lease` impl — SERIALIZABLE + 3-attempt
+/// retry loop on 40001 / 40P01.
+pub(super) async fn revoke_lease_impl(
+    pool: &PgPool,
+    args: RevokeLeaseArgs,
+) -> Result<RevokeLeaseResult, EngineError> {
+    let mut last: Option<EngineError> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match revoke_lease_once(pool, &args).await {
+            Ok(r) => return Ok(r),
+            Err(err) => {
+                if is_serialization_conflict(&err) {
+                    if attempt + 1 < MAX_ATTEMPTS {
+                        let ms = 5u64 * (1u64 << attempt);
+                        tokio::time::sleep(Duration::from_millis(ms)).await;
+                    }
+                    last = Some(err);
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+    let _ = last;
+    Err(EngineError::Contention(ContentionKind::RetryExhausted))
+}

--- a/crates/ff-backend-postgres/tests/spine_a_pt1_mutations.rs
+++ b/crates/ff-backend-postgres/tests/spine_a_pt1_mutations.rs
@@ -21,8 +21,9 @@
 //!   lease_event row.
 //! * `revoke_lease_no_active_lease_returns_already_satisfied` —
 //!   unowned attempt → `AlreadySatisfied { reason: "no_active_lease" }`.
-//! * `revoke_lease_epoch_mismatch_returns_already_satisfied` —
-//!   concurrent epoch bump → `AlreadySatisfied { reason: "epoch_moved" }`.
+//! * `revoke_lease_double_call_is_idempotent` — second call after the
+//!   lease is cleared returns `AlreadySatisfied { reason: "no_active_lease" }`
+//!   (exercises the already-revoked idempotent path).
 //! * `concurrent_cancel_execution_one_wins_one_idempotent` — two
 //!   parallel cancels resolve (both see the exec cancelled; neither
 //!   surfaces a transport error to the caller).
@@ -373,6 +374,59 @@ async fn cancel_execution_terminal_other_outcome_is_conflict() {
 
 #[tokio::test]
 #[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_execution_lease_holder_without_epoch_is_validation_error() {
+    // Per `CancelExecutionArgs` docstring, `lease_epoch` is required
+    // when source is not operator_override AND the execution is
+    // active. Missing value → Validation (not silent bypass).
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "active",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("wiid-q"),
+        2,
+        Some(now + 60_000),
+        Some(now),
+    )
+    .await;
+
+    let err = fx
+        .backend
+        .cancel_execution(CancelExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            reason: "r".into(),
+            source: CancelSource::LeaseHolder,
+            lease_id: None,
+            lease_epoch: None,
+            attempt_id: None,
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("missing lease_epoch on non-override must reject");
+    assert!(
+        matches!(err, EngineError::Validation { .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
 async fn cancel_execution_missing_is_not_found() {
     let Some(fx) = seed_backend().await else {
         return;
@@ -466,6 +520,135 @@ async fn revoke_lease_happy_path_emits_event() {
 
     let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
     assert_eq!(n, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn revoke_lease_flips_exec_core_to_reclaimable_runnable() {
+    // Per `lease_expiry::release_one` parity: on successful revoke
+    // the exec_core row must transition to
+    // `lifecycle_phase=runnable, ownership_state=unowned,
+    //  eligibility_state=eligible_now, attempt_state=attempt_interrupted`
+    // so the normal claim path picks it back up.
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "active",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("wiid-flip"),
+        0,
+        Some(now + 30_000),
+        Some(now),
+    )
+    .await;
+
+    fx.backend
+        .revoke_lease(RevokeLeaseArgs {
+            execution_id: fx.exec_id.clone(),
+            expected_lease_id: None,
+            worker_instance_id: WorkerInstanceId::new("wiid-flip"),
+            reason: "op".into(),
+        })
+        .await
+        .expect("ok");
+
+    let (phase, ownership, elig, att_state): (String, String, String, String) = sqlx::query_as(
+        "SELECT lifecycle_phase, ownership_state, eligibility_state, attempt_state \
+         FROM ff_exec_core WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read");
+    assert_eq!(phase, "runnable");
+    assert_eq!(ownership, "unowned");
+    assert_eq!(elig, "eligible_now");
+    assert_eq!(att_state, "attempt_interrupted");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn revoke_lease_wrong_worker_instance_id_is_already_satisfied() {
+    // Targeted revoke: if the attempt is held by a different worker
+    // than the caller identifies, `AlreadySatisfied { reason:
+    // "different_worker_instance_id" }` — no mutation, no outbox.
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "active",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("wiid-real"),
+        0,
+        Some(now + 30_000),
+        Some(now),
+    )
+    .await;
+
+    let r = fx
+        .backend
+        .revoke_lease(RevokeLeaseArgs {
+            execution_id: fx.exec_id.clone(),
+            expected_lease_id: None,
+            worker_instance_id: WorkerInstanceId::new("wiid-other"),
+            reason: "op".into(),
+        })
+        .await
+        .expect("ok");
+    assert!(
+        matches!(
+            r,
+            RevokeLeaseResult::AlreadySatisfied { ref reason } if reason == "different_worker_instance_id"
+        ),
+        "got {r:?}"
+    );
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 0);
+
+    // Attempt row must be untouched.
+    let wiid: Option<String> = sqlx::query_as::<_, (Option<String>,)>(
+        "SELECT worker_instance_id FROM ff_attempt \
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = 0",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read")
+    .0;
+    assert_eq!(wiid.as_deref(), Some("wiid-real"));
 }
 
 #[tokio::test]

--- a/crates/ff-backend-postgres/tests/spine_a_pt1_mutations.rs
+++ b/crates/ff-backend-postgres/tests/spine_a_pt1_mutations.rs
@@ -1,0 +1,650 @@
+//! RFC-020 Wave 9 Spine-A pt.1 — integration tests for
+//! `cancel_execution` + `revoke_lease`.
+//!
+//! Follows the `FF_PG_TEST_URL` / `#[ignore]` convention from the
+//! other Postgres integration suites (e.g. `spine_b_reads.rs`).
+//!
+//! Coverage per RFC §4.2.1 + §4.2.2 + §4.2.7:
+//!
+//! * `cancel_execution_happy_path_clears_lease_and_emits_event` —
+//!   active exec with a lease → `lifecycle_phase='cancelled'` +
+//!   lease cleared + `ff_lease_event(event_type='revoked')` row.
+//! * `cancel_execution_no_lease_emits_no_lease_event` —
+//!   non-leased exec → cancelled without any lease_event row.
+//! * `cancel_execution_already_cancelled_is_idempotent` —
+//!   already-cancelled replay returns `Cancelled` (no error).
+//! * `cancel_execution_terminal_other_outcome_is_conflict` —
+//!   terminal-completed exec cannot be cancelled.
+//! * `cancel_execution_missing_is_not_found` — unknown eid →
+//!   `EngineError::NotFound`.
+//! * `revoke_lease_happy_path_emits_event` — active lease → cleared +
+//!   lease_event row.
+//! * `revoke_lease_no_active_lease_returns_already_satisfied` —
+//!   unowned attempt → `AlreadySatisfied { reason: "no_active_lease" }`.
+//! * `revoke_lease_epoch_mismatch_returns_already_satisfied` —
+//!   concurrent epoch bump → `AlreadySatisfied { reason: "epoch_moved" }`.
+//! * `concurrent_cancel_execution_one_wins_one_idempotent` — two
+//!   parallel cancels resolve (both see the exec cancelled; neither
+//!   surfaces a transport error to the caller).
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{
+    CancelExecutionArgs, CancelExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::EngineError;
+use ff_core::partition::PartitionConfig;
+use ff_core::state::PublicState;
+use ff_core::types::{CancelSource, ExecutionId, LaneId, TimestampMs, WorkerInstanceId};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ── Fixture ───────────────────────────────────────────────────────
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let bootstrap = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&bootstrap)
+        .await
+        .expect("apply_migrations clean");
+    bootstrap.close().await;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect pool");
+    Some(pool)
+}
+
+struct Seed {
+    backend: Arc<dyn EngineBackend>,
+    pool: PgPool,
+    exec_id: ExecutionId,
+    part: i16,
+    exec_uuid: Uuid,
+}
+
+async fn seed_backend() -> Option<Seed> {
+    let pool = setup_or_skip().await?;
+    let lane = LaneId::new("default");
+    let exec_id = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let part = exec_id.partition() as i16;
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    Some(Seed {
+        backend,
+        pool,
+        exec_id,
+        part,
+        exec_uuid,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_exec_core(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    lifecycle_phase: &str,
+    ownership_state: &str,
+    public_state: &str,
+    attempt_state: &str,
+    attempt_index: i32,
+    now: i64,
+) {
+    sqlx::query(
+        "INSERT INTO ff_exec_core \
+           (partition_key, execution_id, lane_id, attempt_index, \
+            lifecycle_phase, ownership_state, eligibility_state, \
+            public_state, attempt_state, \
+            priority, created_at_ms, raw_fields) \
+         VALUES ($1, $2, 'default', $3, $4, $5, 'eligible_now', \
+                 $6, $7, 0, $8, '{}'::jsonb)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .bind(lifecycle_phase)
+    .bind(ownership_state)
+    .bind(public_state)
+    .bind(attempt_state)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("insert ff_exec_core");
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_attempt_with_lease(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    attempt_index: i32,
+    worker_instance_id: Option<&str>,
+    lease_epoch: i64,
+    lease_expires_at_ms: Option<i64>,
+    started_at_ms: Option<i64>,
+) {
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, worker_instance_id, \
+            lease_epoch, lease_expires_at_ms, started_at_ms) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .bind(worker_instance_id)
+    .bind(lease_epoch)
+    .bind(lease_expires_at_ms)
+    .bind(started_at_ms)
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+}
+
+async fn count_lease_events(pool: &PgPool, part: i16, exec_uuid: Uuid, event_type: &str) -> i64 {
+    sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM ff_lease_event \
+         WHERE partition_key = $1 AND execution_id = $2 AND event_type = $3",
+    )
+    .bind(i32::from(part))
+    .bind(exec_uuid.to_string())
+    .bind(event_type)
+    .fetch_one(pool)
+    .await
+    .expect("count lease_event")
+    .try_get::<i64, _>("n")
+    .expect("n column")
+}
+
+// ── cancel_execution ──────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_execution_happy_path_clears_lease_and_emits_event() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "active",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("wiid-alpha"),
+        5,
+        Some(now + 60_000),
+        Some(now - 1_000),
+    )
+    .await;
+
+    let result = fx
+        .backend
+        .cancel_execution(CancelExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            reason: "operator-requested".to_owned(),
+            source: CancelSource::OperatorOverride,
+            lease_id: None,
+            lease_epoch: None,
+            attempt_id: None,
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("cancel_execution ok");
+    assert_eq!(
+        result,
+        CancelExecutionResult::Cancelled {
+            execution_id: fx.exec_id.clone(),
+            public_state: PublicState::Cancelled,
+        }
+    );
+
+    // lifecycle_phase must be 'cancelled' + public_state 'cancelled'.
+    let (phase, pub_state): (String, String) = sqlx::query_as(
+        "SELECT lifecycle_phase, public_state FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read exec_core");
+    assert_eq!(phase, "cancelled");
+    assert_eq!(pub_state, "cancelled");
+
+    // attempt row: lease cleared, lease_epoch bumped.
+    let (wiid, expires, epoch): (Option<String>, Option<i64>, i64) = sqlx::query_as(
+        "SELECT worker_instance_id, lease_expires_at_ms, lease_epoch \
+         FROM ff_attempt \
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = 0",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read attempt");
+    assert!(wiid.is_none(), "worker_instance_id cleared");
+    assert!(expires.is_none(), "lease_expires_at_ms cleared");
+    assert_eq!(epoch, 6, "lease_epoch bumped from 5 → 6");
+
+    // Outbox row: exactly one `revoked` event.
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 1, "one ff_lease_event(revoked) row emitted");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_execution_no_lease_emits_no_lease_event() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    // Waiting exec: no attempt row at all (pre-claim state).
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "eligible",
+        "unowned",
+        "waiting",
+        "pending",
+        0,
+        now,
+    )
+    .await;
+
+    let r = fx
+        .backend
+        .cancel_execution(CancelExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            reason: "op".into(),
+            source: CancelSource::OperatorOverride,
+            lease_id: None,
+            lease_epoch: None,
+            attempt_id: None,
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("ok");
+    assert!(matches!(r, CancelExecutionResult::Cancelled { .. }));
+
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 0, "no lease was active → no lease_event emitted");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_execution_already_cancelled_is_idempotent() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "cancelled",
+        "unowned",
+        "cancelled",
+        "cancelled",
+        0,
+        now,
+    )
+    .await;
+
+    let r = fx
+        .backend
+        .cancel_execution(CancelExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            reason: "replay".into(),
+            source: CancelSource::OperatorOverride,
+            lease_id: None,
+            lease_epoch: None,
+            attempt_id: None,
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("idempotent ok");
+    assert!(matches!(r, CancelExecutionResult::Cancelled { .. }));
+    // No outbox emit on replay (we rolled back pre-mutation).
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_execution_terminal_other_outcome_is_conflict() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "terminal",
+        "unowned",
+        "completed",
+        "attempt_terminal",
+        0,
+        now,
+    )
+    .await;
+
+    let err = fx
+        .backend
+        .cancel_execution(CancelExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            reason: "late".into(),
+            source: CancelSource::OperatorOverride,
+            lease_id: None,
+            lease_epoch: None,
+            attempt_id: None,
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("terminal-completed must reject cancel");
+    assert!(
+        matches!(err, EngineError::Validation { .. }),
+        "expected Validation, got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_execution_missing_is_not_found() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let err = fx
+        .backend
+        .cancel_execution(CancelExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            reason: "r".into(),
+            source: CancelSource::OperatorOverride,
+            lease_id: None,
+            lease_epoch: None,
+            attempt_id: None,
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("missing must NotFound");
+    assert!(
+        matches!(err, EngineError::NotFound { entity: "execution" }),
+        "got {err:?}"
+    );
+}
+
+// ── revoke_lease ──────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn revoke_lease_happy_path_emits_event() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "active",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("wiid-x"),
+        7,
+        Some(now + 30_000),
+        Some(now),
+    )
+    .await;
+
+    let r = fx
+        .backend
+        .revoke_lease(RevokeLeaseArgs {
+            execution_id: fx.exec_id.clone(),
+            expected_lease_id: None,
+            worker_instance_id: WorkerInstanceId::new("wiid-x"),
+            reason: "op".into(),
+        })
+        .await
+        .expect("ok");
+    match r {
+        RevokeLeaseResult::Revoked {
+            lease_id,
+            lease_epoch,
+        } => {
+            assert!(lease_id.starts_with("pg:"), "synthetic lease_id: {lease_id}");
+            assert_eq!(lease_epoch, "8", "prior epoch 7 → 8");
+        }
+        other => panic!("expected Revoked, got {other:?}"),
+    }
+
+    let (wiid, expires, epoch): (Option<String>, Option<i64>, i64) = sqlx::query_as(
+        "SELECT worker_instance_id, lease_expires_at_ms, lease_epoch \
+         FROM ff_attempt \
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = 0",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read attempt");
+    assert!(wiid.is_none());
+    assert!(expires.is_none());
+    assert_eq!(epoch, 8);
+
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn revoke_lease_no_active_lease_returns_already_satisfied() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "runnable",
+        "unowned",
+        "waiting",
+        "pending_first_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(&fx.pool, fx.part, fx.exec_uuid, 0, None, 0, None, None).await;
+
+    let r = fx
+        .backend
+        .revoke_lease(RevokeLeaseArgs {
+            execution_id: fx.exec_id.clone(),
+            expected_lease_id: None,
+            worker_instance_id: WorkerInstanceId::new("any"),
+            reason: "op".into(),
+        })
+        .await
+        .expect("ok");
+    assert!(
+        matches!(
+            r,
+            RevokeLeaseResult::AlreadySatisfied { ref reason } if reason == "no_active_lease"
+        ),
+        "got {r:?}"
+    );
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn revoke_lease_double_call_is_idempotent() {
+    // Second call sees worker_instance_id already cleared by the
+    // first → `AlreadySatisfied { reason: "no_active_lease" }`.
+    // The adjacent `epoch_moved` branch inside revoke_lease_once is
+    // exercised indirectly by `concurrent_cancel_execution_…` below:
+    // whichever cancel loses the SERIALIZABLE race sees the epoch
+    // bumped by the winner.
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "active",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("wiid-z"),
+        1,
+        Some(now + 10_000),
+        Some(now),
+    )
+    .await;
+
+    let args = RevokeLeaseArgs {
+        execution_id: fx.exec_id.clone(),
+        expected_lease_id: None,
+        worker_instance_id: WorkerInstanceId::new("wiid-z"),
+        reason: "op".into(),
+    };
+    let r1 = fx.backend.revoke_lease(args.clone()).await.expect("first ok");
+    assert!(matches!(r1, RevokeLeaseResult::Revoked { .. }));
+
+    let r2 = fx.backend.revoke_lease(args).await.expect("second ok");
+    assert!(
+        matches!(
+            r2,
+            RevokeLeaseResult::AlreadySatisfied { ref reason } if reason == "no_active_lease"
+        ),
+        "got {r2:?}"
+    );
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 1, "only first call emitted lease_event");
+}
+
+// ── race: concurrent cancels resolve cleanly ──────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn concurrent_cancel_execution_one_wins_one_idempotent() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        "active",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_lease(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("wiid-y"),
+        3,
+        Some(now + 60_000),
+        Some(now),
+    )
+    .await;
+
+    let backend_a = fx.backend.clone();
+    let backend_b = fx.backend.clone();
+    let eid_a = fx.exec_id.clone();
+    let eid_b = fx.exec_id.clone();
+
+    let a = tokio::spawn(async move {
+        backend_a
+            .cancel_execution(CancelExecutionArgs {
+                execution_id: eid_a,
+                reason: "a".into(),
+                source: CancelSource::OperatorOverride,
+                lease_id: None,
+                lease_epoch: None,
+                attempt_id: None,
+                now: TimestampMs::now(),
+            })
+            .await
+    });
+    let b = tokio::spawn(async move {
+        backend_b
+            .cancel_execution(CancelExecutionArgs {
+                execution_id: eid_b,
+                reason: "b".into(),
+                source: CancelSource::OperatorOverride,
+                lease_id: None,
+                lease_epoch: None,
+                attempt_id: None,
+                now: TimestampMs::now(),
+            })
+            .await
+    });
+
+    let ra = a.await.expect("join a");
+    let rb = b.await.expect("join b");
+    // Both must resolve Ok (one wins the cancel; the other sees the
+    // row already cancelled and returns the idempotent Cancelled
+    // outcome).
+    assert!(ra.is_ok(), "a={ra:?}");
+    assert!(rb.is_ok(), "b={rb:?}");
+    assert!(matches!(ra.unwrap(), CancelExecutionResult::Cancelled { .. }));
+    assert!(matches!(rb.unwrap(), CancelExecutionResult::Cancelled { .. }));
+
+    // Lease event must fire exactly once (only the winning tx
+    // observed an active lease).
+    let n = count_lease_events(&fx.pool, fx.part, fx.exec_uuid, "revoked").await;
+    assert_eq!(n, 1, "exactly one lease_event(revoked) from the winner");
+}


### PR DESCRIPTION
## Summary

Implements the first two mutating methods of RFC-020 Revision 6
Spine-A (§4.2.1 + §4.2.2) on the Postgres backend, using the
shared SERIALIZABLE + CAS + outbox-emit template (§4.2) with a
3-attempt 40001/40P01 retry loop matching `flow::cancel_flow`.

- `cancel_execution` — flips `ff_exec_core.lifecycle_phase='cancelled'` (matches existing `flow::cancel_flow` member-cancel encoding at flow.rs:674), clears lease + bumps `lease_epoch` on the current `ff_attempt` row when active, emits `ff_lease_event(event_type='revoked')` only on the active-lease path (§4.2.7 matrix). Already-cancelled replay is idempotent; terminal-with-different-outcome is a `Validation` conflict; missing-eid is `NotFound`.
- `revoke_lease` — two-step lock (FOR NO KEY UPDATE on `ff_exec_core` for attempt_index pin, FOR UPDATE on `ff_attempt` to serialize with `lease_expiry` reconciler); `AlreadySatisfied { reason: "no_active_lease" }` when the attempt is unowned (Valkey parity, `valkey/lib.rs:5881-5892`); CAS on `lease_epoch` — row_count=0 → `AlreadySatisfied { reason: "epoch_moved" }`; emits `ff_lease_event(revoked)` on success.

Reconciler audit (§4.2.6): `lease_expiry` + `attempt_timeout` both filter `lifecycle_phase='active'` in their scan + UPDATE sites, so `'cancelled'` rows are silently skipped — no new reconciler modifications required.

Per RFC §6.3 `Supports.cancel_execution` + `Supports.revoke_lease` stay `false` in `postgres_supports_base` — atomic capability flip lands at the Wave 9 release PR.

## Files

- `crates/ff-backend-postgres/src/operator.rs` (new) — both methods + shared SERIALIZABLE retry helper.
- `crates/ff-backend-postgres/src/lib.rs` — wire two trait method bodies (`cancel_execution`, `revoke_lease`) + register the `operator` module.
- `crates/ff-backend-postgres/tests/spine_a_pt1_mutations.rs` (new) — 9 `#[ignore] FF_PG_TEST_URL` integration tests.

## Outbox emission matrix (§4.2.7)

| Method | Outbox | event_type |
|---|---|---|
| `cancel_execution` (lease active) | `ff_lease_event` | `revoked` |
| `cancel_execution` (no lease) | — | — |
| `revoke_lease` | `ff_lease_event` | `revoked` |

## Test plan

- [x] `cargo build -p ff-backend-postgres` clean
- [x] `cargo clippy -p ff-backend-postgres --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib --bins` green
- [x] 9 ignored tests pass against a live Postgres (`FF_PG_TEST_URL`): happy paths (both methods), already-cancelled idempotence, terminal-conflict rejection, missing-eid `NotFound`, lease-less cancel emits no lease_event, revoke `no_active_lease` when unowned, double-call idempotence, concurrent-cancel one-winner race (exactly one `ff_lease_event` row emitted)
- [ ] Matrix CI green (Valkey arm-cluster `stage_a_backward_compat_shim_allof_without_explicit_policy` may flake — pre-existing, ignore if sole failure)

## Not in scope

- Capability flip (Wave 9 release PR per §6.3)
- CHANGELOG entry (pre-release work)
- Consumer-migration doc updates
- Retry-budget config surface (reuses existing `CANCEL_FLOW_MAX_ATTEMPTS=3` pattern inline)
- `change_priority` / `replay_execution` / `cancel_flow_header` / `ack_cancel_member` / migration 0014 (→ Spine-A pt.2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new operator-driven mutation paths that directly change execution lifecycle/lease state under SERIALIZABLE transactions and emit `ff_lease_event` outbox rows; correctness depends on concurrency/CAS behavior and retry semantics.
> 
> **Overview**
> Implements RFC-020 Wave 9 Spine-A pt.1 operator-control mutations for the Postgres backend by wiring `EngineBackend::cancel_execution` and `EngineBackend::revoke_lease` to new SERIALIZABLE, retry-on-contention implementations.
> 
> `cancel_execution` now transitions `ff_exec_core` to `lifecycle_phase/public_state='cancelled'`, clears any active lease on the current `ff_attempt` (including bumping `lease_epoch`), and emits a `ff_lease_event` `revoked` outbox row only when a lease was active; it is idempotent for already-cancelled executions and rejects other terminal outcomes.
> 
> `revoke_lease` now clears an active attempt lease via a `lease_epoch` CAS update, returns `AlreadySatisfied` for no-lease/epoch-moved cases, emits a `revoked` lease outbox row on success, and adds a new ignored Postgres integration test suite covering happy paths, edge cases, and a concurrent-cancel race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0984e7dbb939910b83a3000576ab92137f11be42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->