### PR TITLE
feat(pg-backend): Wave 9 Spine-A pt.2 — change_priority + replay_execution + cancel_flow_header + ack_cancel_member + migration 0014

### DIFF
--- a/crates/ff-backend-postgres/migrations/0014_cancel_backlog.sql
+++ b/crates/ff-backend-postgres/migrations/0014_cancel_backlog.sql
@@ -1,0 +1,103 @@
+-- no-transaction
+-- RFC-020 Wave 9 Spine-A pt.2 — `ff_cancel_backlog` + `ff_cancel_backlog_member`
+-- (§4.3.2).
+--
+-- Two partitioned tables backing `cancel_flow_header` + `ack_cancel_member`
+-- (§4.2.3). §7.5 resolved to a junction-table shape over `BYTEA[]`
+-- array-column because `ack_cancel_member` mutates a single element
+-- and `array_remove` doesn't compose cleanly with partitioning +
+-- FOR UPDATE granularity.
+--
+--   * `ff_cancel_backlog`         — one row per flow; carries flow-level
+--     cancellation policy + reason + requested-at + optional grace
+--     window + status.
+--   * `ff_cancel_backlog_member`  — one row per pending member; ack'd
+--     rows are DELETEd in the same tx as the parent-row
+--     conditional-DELETE CTE.
+--
+-- Both tables are HASH-partitioned 256 ways on `partition_key`
+-- matching the 0001/0002/0012 convention (flow + member executions
+-- co-locate on `partition_key` via the flow's partition hash;
+-- RFC-011).
+--
+-- Additive (`backward_compatible = true`). No destructive DDL.
+--
+-- Authority:
+--   * rfcs/RFC-020-postgres-wave-9.md §4.3.2 + §4.2.3 + §7.5
+
+-- ============================================================
+-- Section 1 — Parent tables
+-- ============================================================
+
+-- Flow-level cancel-backlog entry. One row per flow in cancel-pending
+-- state. `status='pending'` while members remain unack'd; the
+-- `ack_cancel_member` conditional-DELETE CTE removes the row when the
+-- last member is drained.
+CREATE TABLE ff_cancel_backlog (
+    partition_key        smallint NOT NULL,
+    flow_id              uuid     NOT NULL,
+    requested_at_ms      bigint   NOT NULL,
+    requester            text     NOT NULL DEFAULT '',
+    reason               text     NOT NULL DEFAULT '',
+    grace_until_ms       bigint,
+    cancellation_policy  text     NOT NULL,
+    status               text     NOT NULL DEFAULT 'pending',
+    PRIMARY KEY (partition_key, flow_id)
+) PARTITION BY HASH (partition_key);
+
+-- Junction-table row per pending member. `ack_state` flips to 'acked'
+-- (or the row is DELETEd outright by the CTE); `acked_at_ms`
+-- timestamps the drain for the reconciler's time-based cleanup.
+CREATE TABLE ff_cancel_backlog_member (
+    partition_key   smallint NOT NULL,
+    flow_id         uuid     NOT NULL,
+    execution_id    text     NOT NULL,
+    ack_state       text     NOT NULL DEFAULT 'pending',
+    acked_at_ms     bigint,
+    PRIMARY KEY (partition_key, flow_id, execution_id)
+) PARTITION BY HASH (partition_key);
+
+-- ============================================================
+-- Section 2 — 256-way HASH partition children
+-- ============================================================
+-- 2 parents × 256 children = 512 partitions. One `DO` block per parent
+-- with explicit COMMIT boundaries — same lock-budget discipline as
+-- 0001 §Section 7 / 0002 §Section 2 / 0012 §Section 2.
+
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_cancel_backlog FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_cancel_backlog_p' || i, i); END LOOP; END $$;
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_cancel_backlog_member FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_cancel_backlog_member_p' || i, i); END LOOP; END $$;
+COMMIT;
+
+-- ============================================================
+-- Section 3 — Secondary indexes (non-PK)
+-- ============================================================
+-- Pending-ack scan: the cancel-backlog reconciler polls this to
+-- redrive stuck members. `WHERE ack_state = 'pending'` is the hot
+-- predicate; include `flow_id` on the leading key so the scan groups
+-- per-flow without a heap hit.
+CREATE INDEX ff_cancel_backlog_member_pending_idx
+    ON ff_cancel_backlog_member (partition_key, flow_id)
+    WHERE ack_state = 'pending';
+
+-- Time-based cleanup: prune drained members beyond the grace window.
+CREATE INDEX ff_cancel_backlog_member_acked_at_idx
+    ON ff_cancel_backlog_member (partition_key, acked_at_ms)
+    WHERE acked_at_ms IS NOT NULL;
+
+-- Grace-window scan (`grace_until_ms` ≤ now) for reconciler wake-up.
+CREATE INDEX ff_cancel_backlog_grace_idx
+    ON ff_cancel_backlog (partition_key, grace_until_ms)
+    WHERE grace_until_ms IS NOT NULL;
+
+-- ============================================================
+-- Section 4 — Migration annotation (Q12)
+-- ============================================================
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    14,
+    '0014_cancel_backlog',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/migrations/0014_cancel_backlog.sql
+++ b/crates/ff-backend-postgres/migrations/0014_cancel_backlog.sql
@@ -11,9 +11,13 @@
 --   * `ff_cancel_backlog`         — one row per flow; carries flow-level
 --     cancellation policy + reason + requested-at + optional grace
 --     window + status.
---   * `ff_cancel_backlog_member`  — one row per pending member; ack'd
---     rows are DELETEd in the same tx as the parent-row
---     conditional-DELETE CTE.
+--   * `ff_cancel_backlog_member`  — one row per pending member. The
+--     `ack_cancel_member` path hard-DELETEs the row on ack; the
+--     parent backlog row is then conditionally DELETE'd in a second
+--     statement when the last member drains. (Postgres data-modifying
+--     CTEs share a snapshot across statements, which would leave the
+--     parent behind on the last-member drain, so the implementation
+--     uses two sequential DELETEs inside the same SERIALIZABLE tx.)
 --
 -- Both tables are HASH-partitioned 256 ways on `partition_key`
 -- matching the 0001/0002/0012 convention (flow + member executions
@@ -45,15 +49,14 @@ CREATE TABLE ff_cancel_backlog (
     PRIMARY KEY (partition_key, flow_id)
 ) PARTITION BY HASH (partition_key);
 
--- Junction-table row per pending member. `ack_state` flips to 'acked'
--- (or the row is DELETEd outright by the CTE); `acked_at_ms`
--- timestamps the drain for the reconciler's time-based cleanup.
+-- Junction-table row per pending member. `ack_cancel_member`
+-- hard-DELETEs the row on ack; presence = "still pending", absence
+-- = "acked" (there is no per-row ack-state flag because the ack path
+-- doesn't flip state, it removes the row).
 CREATE TABLE ff_cancel_backlog_member (
     partition_key   smallint NOT NULL,
     flow_id         uuid     NOT NULL,
     execution_id    text     NOT NULL,
-    ack_state       text     NOT NULL DEFAULT 'pending',
-    acked_at_ms     bigint,
     PRIMARY KEY (partition_key, flow_id, execution_id)
 ) PARTITION BY HASH (partition_key);
 
@@ -73,19 +76,6 @@ COMMIT;
 -- ============================================================
 -- Section 3 — Secondary indexes (non-PK)
 -- ============================================================
--- Pending-ack scan: the cancel-backlog reconciler polls this to
--- redrive stuck members. `WHERE ack_state = 'pending'` is the hot
--- predicate; include `flow_id` on the leading key so the scan groups
--- per-flow without a heap hit.
-CREATE INDEX ff_cancel_backlog_member_pending_idx
-    ON ff_cancel_backlog_member (partition_key, flow_id)
-    WHERE ack_state = 'pending';
-
--- Time-based cleanup: prune drained members beyond the grace window.
-CREATE INDEX ff_cancel_backlog_member_acked_at_idx
-    ON ff_cancel_backlog_member (partition_key, acked_at_ms)
-    WHERE acked_at_ms IS NOT NULL;
-
 -- Grace-window scan (`grace_until_ms` ≤ now) for reconciler wake-up.
 CREATE INDEX ff_cancel_backlog_grace_idx
     ON ff_cancel_backlog (partition_key, grace_until_ms)

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -766,7 +766,7 @@ impl EngineBackend for PostgresBackend {
         &self,
         args: CancelFlowArgs,
     ) -> Result<CancelFlowHeader, EngineError> {
-        operator::cancel_flow_header_impl(&self.pool, args).await
+        operator::cancel_flow_header_impl(&self.pool, &self.partition_config, args).await
     }
 
     #[cfg(feature = "core")]
@@ -776,7 +776,13 @@ impl EngineBackend for PostgresBackend {
         flow_id: &FlowId,
         execution_id: &ExecutionId,
     ) -> Result<(), EngineError> {
-        operator::ack_cancel_member_impl(&self.pool, flow_id.clone(), execution_id.clone()).await
+        operator::ack_cancel_member_impl(
+            &self.pool,
+            &self.partition_config,
+            flow_id.clone(),
+            execution_id.clone(),
+        )
+        .await
     }
 
     // ── RFC-017 Stage A — ingress (promoted from inherent) ────

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -53,6 +53,12 @@ use ff_core::contracts::ExecutionInfo;
 use ff_core::contracts::{
     CancelExecutionArgs, CancelExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
 };
+// RFC-020 Wave 9 Spine-A pt.2 — operator-control + flow-cancel mutating surfaces.
+#[cfg(feature = "core")]
+use ff_core::contracts::{
+    CancelFlowArgs, CancelFlowHeader, ChangePriorityArgs, ChangePriorityResult,
+    ReplayExecutionArgs, ReplayExecutionResult,
+};
 // RFC-020 Wave 9 Standalone-1 — budget/quota admin surfaces.
 #[cfg(feature = "core")]
 use ff_core::contracts::{
@@ -95,6 +101,8 @@ pub mod listener;
 pub mod migrate;
 #[cfg(feature = "core")]
 pub mod operator;
+#[cfg(feature = "core")]
+mod operator_event;
 pub mod pool;
 #[cfg(feature = "core")]
 pub mod reconcilers;
@@ -723,6 +731,52 @@ impl EngineBackend for PostgresBackend {
         args: RevokeLeaseArgs,
     ) -> Result<RevokeLeaseResult, EngineError> {
         operator::revoke_lease_impl(&self.pool, args).await
+    }
+
+    // ── RFC-020 Wave 9 Spine-A pt.2 — operator control + flow cancel (§4.2.3 + §4.2.4 + §4.2.5) ─
+    //
+    // Four methods landing behind `Supports.change_priority` +
+    // `Supports.replay_execution` + `Supports.cancel_flow_header` +
+    // `Supports.ack_cancel_member` (all stay `false` until the Wave 9
+    // release PR flips them atomically, RFC §6.3). SERIALIZABLE + CAS +
+    // `ff_operator_event` outbox emit on the same tx (§4.2.6 + §4.2.7).
+    // `ack_cancel_member` is silent on the outbox (Valkey-parity).
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.change_priority", skip_all)]
+    async fn change_priority(
+        &self,
+        args: ChangePriorityArgs,
+    ) -> Result<ChangePriorityResult, EngineError> {
+        operator::change_priority_impl(&self.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.replay_execution", skip_all)]
+    async fn replay_execution(
+        &self,
+        args: ReplayExecutionArgs,
+    ) -> Result<ReplayExecutionResult, EngineError> {
+        operator::replay_execution_impl(&self.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.cancel_flow_header", skip_all)]
+    async fn cancel_flow_header(
+        &self,
+        args: CancelFlowArgs,
+    ) -> Result<CancelFlowHeader, EngineError> {
+        operator::cancel_flow_header_impl(&self.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.ack_cancel_member", skip_all)]
+    async fn ack_cancel_member(
+        &self,
+        flow_id: &FlowId,
+        execution_id: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        operator::ack_cancel_member_impl(&self.pool, flow_id.clone(), execution_id.clone()).await
     }
 
     // ── RFC-017 Stage A — ingress (promoted from inherent) ────

--- a/crates/ff-backend-postgres/src/operator.rs
+++ b/crates/ff-backend-postgres/src/operator.rs
@@ -24,16 +24,19 @@
 use std::time::Duration;
 
 use ff_core::contracts::{
-    CancelExecutionArgs, CancelExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
+    CancelExecutionArgs, CancelExecutionResult, CancelFlowArgs, CancelFlowHeader,
+    ChangePriorityArgs, ChangePriorityResult, ReplayExecutionArgs, ReplayExecutionResult,
+    RevokeLeaseArgs, RevokeLeaseResult,
 };
-use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
 use ff_core::state::PublicState;
-use ff_core::types::CancelSource;
+use ff_core::types::{CancelSource, ExecutionId, FlowId};
+use serde_json::json;
 use sqlx::{PgPool, Postgres, Row};
 use uuid::Uuid;
 
 use crate::error::map_sqlx_error;
-use crate::lease_event;
+use crate::{lease_event, operator_event};
 
 /// Max attempts on `40001` / `40P01`. Matches
 /// [`crate::flow::CANCEL_FLOW_MAX_ATTEMPTS`] (RFC §4.2).
@@ -520,4 +523,698 @@ pub(super) async fn revoke_lease_impl(
     }
     let _ = last;
     Err(EngineError::Contention(ContentionKind::RetryExhausted))
+}
+
+// ─── change_priority (§4.2.4, Rev 7 Fork 3) ────────────────────────
+
+/// Shared retry wrapper — SERIALIZABLE + 3-attempt retry on 40001 /
+/// 40P01 (§4.2 template).
+async fn retry_serializable<F, Fut, T>(mut f: F) -> Result<T, EngineError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, EngineError>>,
+{
+    let mut last: Option<EngineError> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(err) => {
+                if is_serialization_conflict(&err) {
+                    if attempt + 1 < MAX_ATTEMPTS {
+                        let ms = 5u64 * (1u64 << attempt);
+                        tokio::time::sleep(Duration::from_millis(ms)).await;
+                    }
+                    last = Some(err);
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+    let _ = last;
+    Err(EngineError::Contention(ContentionKind::RetryExhausted))
+}
+
+async fn change_priority_once(
+    pool: &PgPool,
+    args: &ChangePriorityArgs,
+) -> Result<ChangePriorityResult, EngineError> {
+    let partition_key: i16 = args.execution_id.partition() as i16;
+    let exec_uuid = eid_uuid(&args.execution_id);
+    let now: i64 = args.now.0;
+
+    let mut tx = begin_serializable(pool).await?;
+
+    // Pre-read under NO KEY UPDATE lock. Gate fields mirror the Valkey
+    // Lua check (`flowfabric.lua:3683-3688`): lifecycle_phase = 'runnable'
+    // AND eligibility_state = 'eligible_now' — any other state surfaces
+    // `execution_not_eligible` (Rev 7 Fork 3, Option C).
+    let row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, eligibility_state, priority
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR NO KEY UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+
+    let lifecycle_phase: String = row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let eligibility_state: String = row.try_get("eligibility_state").map_err(map_sqlx_error)?;
+    let old_priority: i32 = row.try_get("priority").map_err(map_sqlx_error)?;
+
+    // Valkey-canonical gate (`flowfabric.lua:3683-3688`). Both fails-
+    // closed with `execution_not_eligible`.
+    if lifecycle_phase != "runnable" || eligibility_state != "eligible_now" {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::Contention(
+            ContentionKind::ExecutionNotEligible,
+        ));
+    }
+
+    // Clamp new_priority to [0, 9000] matching Valkey's
+    // `ff_change_priority` (flowfabric.lua:3695-3696 — "same as
+    // ff_create_execution").
+    let new_priority = args.new_priority.clamp(0, 9000);
+
+    // Mutate. Repeat the gate in the WHERE clause as belt-and-
+    // suspenders; row-count = 0 on concurrent transition between
+    // the pre-read and UPDATE surfaces the same `execution_not_eligible`
+    // error.
+    let affected = sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET priority   = $3,
+               raw_fields = jsonb_set(raw_fields,
+                                      '{last_mutation_at}',
+                                      to_jsonb($4::text))
+         WHERE partition_key = $1 AND execution_id = $2
+           AND lifecycle_phase   = 'runnable'
+           AND eligibility_state = 'eligible_now'
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(new_priority)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?
+    .rows_affected();
+
+    if affected == 0 {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::Contention(
+            ContentionKind::ExecutionNotEligible,
+        ));
+    }
+
+    // Outbox emit (§4.2.7 — ff_operator_event event_type='priority_changed').
+    operator_event::emit(
+        &mut tx,
+        partition_key,
+        exec_uuid,
+        operator_event::EVENT_PRIORITY_CHANGED,
+        json!({
+            "old_priority": old_priority,
+            "new_priority": new_priority,
+        }),
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(ChangePriorityResult::Changed {
+        execution_id: args.execution_id.clone(),
+    })
+}
+
+pub(super) async fn change_priority_impl(
+    pool: &PgPool,
+    args: ChangePriorityArgs,
+) -> Result<ChangePriorityResult, EngineError> {
+    retry_serializable(|| change_priority_once(pool, &args)).await
+}
+
+// ─── replay_execution (§4.2.5, Rev 7 Forks 1 + 2) ──────────────────
+
+async fn replay_execution_once(
+    pool: &PgPool,
+    args: &ReplayExecutionArgs,
+) -> Result<ReplayExecutionResult, EngineError> {
+    let partition_key: i16 = args.execution_id.partition() as i16;
+    let exec_uuid = eid_uuid(&args.execution_id);
+    let now: i64 = args.now.0;
+
+    let mut tx = begin_serializable(pool).await?;
+
+    // Pre-read under lock. Read the current attempt's `outcome` so we
+    // can derive `terminal_outcome` per `exec_core::derive_terminal_outcome`.
+    let ec_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, flow_id, attempt_index, priority, raw_fields
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR NO KEY UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(ec_row) = ec_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+
+    let lifecycle_phase: String = ec_row
+        .try_get("lifecycle_phase")
+        .map_err(map_sqlx_error)?;
+    let flow_id: Option<Uuid> = ec_row.try_get("flow_id").map_err(map_sqlx_error)?;
+    let attempt_index: i32 = ec_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+    // Valkey-canonical gate: `lifecycle_phase = 'terminal'`
+    // (`flowfabric.lua:8535-8537` → `err("execution_not_terminal")`).
+    if lifecycle_phase != "terminal" {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::State(StateKind::ExecutionNotTerminal));
+    }
+
+    // Read the current attempt's outcome for the skipped-flow-member
+    // branch check.
+    let att_row = sqlx::query(
+        r#"
+        SELECT outcome
+          FROM ff_attempt
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let attempt_outcome: Option<String> = match att_row.as_ref() {
+        Some(r) => r.try_get("outcome").map_err(map_sqlx_error)?,
+        None => None,
+    };
+
+    // Branch selector matches Valkey (`flowfabric.lua:8555`).
+    // Postgres `terminal_outcome` is derived, not stored; mirror
+    // `exec_core::derive_terminal_outcome` at the SQL level.
+    let is_skipped_flow_member =
+        attempt_outcome.as_deref() == Some("skipped") && flow_id.is_some();
+
+    // Skipped-flow-member branch (Rev 7 Fork 1 Option A).
+    // Reset downstream edge-group counters: skip/fail/running → 0,
+    // success preserved. Valkey ground-truth:
+    // `flowfabric.lua:8580` comment "satisfied edges remain satisfied".
+    let groups_reset: i64 = if is_skipped_flow_member {
+        let count = sqlx::query(
+            r#"
+            UPDATE ff_edge_group
+               SET skip_count    = 0,
+                   fail_count    = 0,
+                   running_count = 0
+             WHERE (partition_key, flow_id, downstream_eid) IN (
+               SELECT DISTINCT e.partition_key, e.flow_id, e.downstream_eid
+                 FROM ff_edge e
+                WHERE e.partition_key   = $1
+                  AND e.downstream_eid = $2
+             )
+            "#,
+        )
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?
+        .rows_affected();
+        count as i64
+    } else {
+        0
+    };
+
+    // Both branches: in-place mutate `ff_exec_core` to
+    // `lifecycle_phase='runnable'` — matches Valkey's base+skip
+    // both writing `runnable` (flowfabric.lua:8591 + 8625).
+    // `attempt_index` NOT bumped (Rev 7 Fork 2 Option A).
+    //
+    // Secondary state differs per branch per §4.2.5:
+    //  - normal:  eligibility_state='eligible_now', public_state='waiting'
+    //  - skipped: eligibility_state='blocked_by_dependencies',
+    //             public_state='waiting_children'
+    //
+    // raw_fields.replay_count bumped (+1). Valkey bumps
+    // exec_core.replay_count; Postgres stores it in raw_fields.
+    let (eligibility_state, public_state) = if is_skipped_flow_member {
+        ("blocked_by_dependencies", "waiting_children")
+    } else {
+        ("eligible_now", "waiting")
+    };
+
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET lifecycle_phase      = 'runnable',
+               ownership_state      = 'unowned',
+               eligibility_state    = $3,
+               public_state         = $4,
+               attempt_state        = 'pending_replay_attempt',
+               terminal_at_ms       = NULL,
+               result               = NULL,
+               cancellation_reason  = NULL,
+               cancelled_by         = NULL,
+               raw_fields           = jsonb_set(
+                 jsonb_set(raw_fields, '{last_mutation_at}', to_jsonb($5::text)),
+                 '{replay_count}',
+                 to_jsonb(COALESCE((raw_fields->>'replay_count')::int, 0) + 1)
+               )
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(eligibility_state)
+    .bind(public_state)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // In-place mutate the current `ff_attempt` row (Rev 7 Fork 2
+    // Option A). Reset outcome + lease state; bump lease_epoch to
+    // fence any in-flight RMW. No new attempt row inserted; no
+    // historical row retained. Only columns that exist on the real
+    // schema are touched (`ff_attempt` has no `lease_id` / `result` /
+    // `error_code` columns — see migrations/0001_initial.sql:160-176).
+    if att_row.is_some() {
+        sqlx::query(
+            r#"
+            UPDATE ff_attempt
+               SET outcome              = NULL,
+                   terminal_at_ms       = NULL,
+                   worker_id            = NULL,
+                   worker_instance_id   = NULL,
+                   lease_expires_at_ms  = NULL,
+                   lease_epoch          = lease_epoch + 1
+             WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+            "#,
+        )
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    // Outbox emit (§4.2.7 — ff_operator_event event_type='replayed').
+    let details = if is_skipped_flow_member {
+        json!({
+            "branch": "skipped_flow_member",
+            "groups_reset": groups_reset,
+        })
+    } else {
+        json!({
+            "branch": "normal",
+        })
+    };
+    operator_event::emit(
+        &mut tx,
+        partition_key,
+        exec_uuid,
+        operator_event::EVENT_REPLAYED,
+        details,
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    let ps = if is_skipped_flow_member {
+        PublicState::WaitingChildren
+    } else {
+        PublicState::Waiting
+    };
+    Ok(ReplayExecutionResult::Replayed { public_state: ps })
+}
+
+pub(super) async fn replay_execution_impl(
+    pool: &PgPool,
+    args: ReplayExecutionArgs,
+) -> Result<ReplayExecutionResult, EngineError> {
+    retry_serializable(|| replay_execution_once(pool, &args)).await
+}
+
+// ─── cancel_flow_header (§4.2.3) ───────────────────────────────────
+
+/// Format a member execution UUID as the wire-form `ExecutionId`
+/// string (`{fp:N}:<uuid>`) expected by downstream consumers.
+fn member_wire_id(partition_key: i16, exec_uuid: Uuid) -> String {
+    format!("{{fp:{partition_key}}}:{exec_uuid}")
+}
+
+async fn cancel_flow_header_once(
+    pool: &PgPool,
+    args: &CancelFlowArgs,
+) -> Result<CancelFlowHeader, EngineError> {
+    let flow_uuid: Uuid = args.flow_id.0;
+    // Flow + members share `partition_key` via the flow's partition
+    // hash (RFC-011 co-location). We compute it the same way the
+    // existing `flow::cancel_flow` path does — but here we don't have
+    // a `PartitionConfig`; use a default shape since partition_key is
+    // just `crc16(flow_id) % 256` and the member rows were written
+    // under the same hash.
+    let partition_key: i16 =
+        ff_core::partition::flow_partition(&args.flow_id, &ff_core::partition::PartitionConfig::default())
+            .index as i16;
+    let now: i64 = args.now.0;
+
+    let mut tx = begin_serializable(pool).await?;
+
+    // Pre-read the flow row under lock. If an existing
+    // `ff_cancel_backlog` row already exists for this flow (idempotent
+    // replay / concurrent second call), surface AlreadyTerminal with
+    // the stored policy + the full (already-enumerated) membership.
+    let flow_row = sqlx::query(
+        r#"
+        SELECT public_flow_state, raw_fields
+          FROM ff_flow_core
+         WHERE partition_key = $1 AND flow_id = $2
+         FOR NO KEY UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(flow_row) = flow_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::NotFound { entity: "flow" });
+    };
+
+    let public_flow_state: String = flow_row
+        .try_get("public_flow_state")
+        .map_err(map_sqlx_error)?;
+    let raw_fields: serde_json::Value = flow_row.try_get("raw_fields").map_err(map_sqlx_error)?;
+
+    // Idempotent-replay path — flow already in a terminal state. Read
+    // stored policy / reason (from raw_fields — `flow::cancel_flow`
+    // writes `cancellation_policy` there) + the backlog-member rows
+    // (our prior enumeration).
+    if matches!(public_flow_state.as_str(), "cancelled" | "completed" | "failed") {
+        let stored_cancellation_policy = raw_fields
+            .get("cancellation_policy")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        let stored_cancel_reason = raw_fields
+            .get("cancel_reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+
+        // Return the enumerated members from the backlog if we have
+        // one; otherwise fall back to live `ff_exec_core` membership
+        // (matches Valkey's SMEMBERS pattern on flow_members_set).
+        let member_rows = sqlx::query(
+            r#"
+            SELECT execution_id
+              FROM ff_cancel_backlog_member
+             WHERE partition_key = $1 AND flow_id = $2
+            "#,
+        )
+        .bind(partition_key)
+        .bind(flow_uuid)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let members: Vec<String> = if member_rows.is_empty() {
+            // Pre-E2-shape flow: enumerate live members from exec_core.
+            let live = sqlx::query(
+                r#"
+                SELECT execution_id
+                  FROM ff_exec_core
+                 WHERE partition_key = $1 AND flow_id = $2
+                "#,
+            )
+            .bind(partition_key)
+            .bind(flow_uuid)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+            live.iter()
+                .map(|r| {
+                    let u: Uuid = r.get("execution_id");
+                    member_wire_id(partition_key, u)
+                })
+                .collect()
+        } else {
+            member_rows
+                .iter()
+                .map(|r| r.get::<String, _>("execution_id"))
+                .collect()
+        };
+
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(CancelFlowHeader::AlreadyTerminal {
+            stored_cancellation_policy,
+            stored_cancel_reason,
+            member_execution_ids: members,
+        });
+    }
+
+    // Fresh cancel — flip flow_core + insert backlog header + enumerate
+    // + bulk-insert backlog members + flip exec_core lifecycle_phase
+    // per member (matches `flow::cancel_flow_once` pattern).
+
+    sqlx::query(
+        r#"
+        UPDATE ff_flow_core
+           SET public_flow_state = 'cancelled',
+               terminal_at_ms    = COALESCE(terminal_at_ms, $3),
+               raw_fields        = raw_fields
+                                    || jsonb_build_object(
+                                         'cancellation_policy', $4::text,
+                                         'cancel_reason',       $5::text)
+         WHERE partition_key = $1 AND flow_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_uuid)
+    .bind(now)
+    .bind(&args.cancellation_policy)
+    .bind(&args.reason)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_cancel_backlog
+            (partition_key, flow_id, requested_at_ms, requester, reason,
+             cancellation_policy, status)
+        VALUES ($1, $2, $3, '', $4, $5, 'pending')
+        ON CONFLICT (partition_key, flow_id) DO NOTHING
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_uuid)
+    .bind(now)
+    .bind(&args.reason)
+    .bind(&args.cancellation_policy)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Enumerate in-flight members.
+    let member_rows = sqlx::query(
+        r#"
+        SELECT execution_id
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND flow_id = $2
+           AND lifecycle_phase NOT IN ('terminal','cancelled')
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_uuid)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut member_execution_ids: Vec<String> = Vec::with_capacity(member_rows.len());
+    for row in &member_rows {
+        let exec_uuid: Uuid = row.get("execution_id");
+        let wire = member_wire_id(partition_key, exec_uuid);
+
+        // Insert backlog member row.
+        sqlx::query(
+            r#"
+            INSERT INTO ff_cancel_backlog_member
+                (partition_key, flow_id, execution_id, ack_state)
+            VALUES ($1, $2, $3, 'pending')
+            ON CONFLICT (partition_key, flow_id, execution_id) DO NOTHING
+            "#,
+        )
+        .bind(partition_key)
+        .bind(flow_uuid)
+        .bind(&wire)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Flip the member's `ff_exec_core` lifecycle (same shape as
+        // `flow::cancel_flow_once`). The Server's own wait/async
+        // machinery drives the per-member cancel events downstream;
+        // the backlog row lives until `ack_cancel_member` drains it.
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase     = 'cancelled',
+                   eligibility_state   = 'cancelled',
+                   public_state        = 'cancelled',
+                   terminal_at_ms      = COALESCE(terminal_at_ms, $3),
+                   cancellation_reason = COALESCE(cancellation_reason, $4),
+                   cancelled_by        = COALESCE(cancelled_by, 'cancel_flow_header')
+             WHERE partition_key = $1 AND execution_id = $2
+            "#,
+        )
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .bind(now)
+        .bind(&args.reason)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        member_execution_ids.push(wire);
+    }
+
+    // Outbox emit (§4.2.7 — flow-level `flow_cancel_requested`).
+    operator_event::emit(
+        &mut tx,
+        partition_key,
+        flow_uuid,
+        operator_event::EVENT_FLOW_CANCEL_REQUESTED,
+        json!({
+            "flow_id": flow_uuid.to_string(),
+            "cancellation_policy": &args.cancellation_policy,
+            "reason": &args.reason,
+            "member_count": member_execution_ids.len(),
+        }),
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(CancelFlowHeader::Cancelled {
+        cancellation_policy: args.cancellation_policy.clone(),
+        member_execution_ids,
+    })
+}
+
+pub(super) async fn cancel_flow_header_impl(
+    pool: &PgPool,
+    args: CancelFlowArgs,
+) -> Result<CancelFlowHeader, EngineError> {
+    retry_serializable(|| cancel_flow_header_once(pool, &args)).await
+}
+
+// ─── ack_cancel_member (§4.2.3) ────────────────────────────────────
+
+async fn ack_cancel_member_once(
+    pool: &PgPool,
+    flow_id: &FlowId,
+    execution_id: &ExecutionId,
+) -> Result<(), EngineError> {
+    let flow_uuid: Uuid = flow_id.0;
+    let partition_key: i16 =
+        ff_core::partition::flow_partition(flow_id, &ff_core::partition::PartitionConfig::default())
+            .index as i16;
+    let member_wire = execution_id.as_str();
+
+    let mut tx = begin_serializable(pool).await?;
+
+    // §4.2.3 — member-drain + conditional parent-DELETE. Under
+    // SERIALIZABLE, concurrent ack × ack race: both TXs read identical
+    // snapshots of `ff_cancel_backlog_member`; the losing TX gets
+    // 40001 at COMMIT and is retried by `retry_serializable` — the
+    // retry observes the winner's state and the member-DELETE becomes
+    // a no-op (0 rows), the parent-DELETE predicate re-evaluates
+    // against post-winner state.
+    //
+    // Implementation note: Postgres data-modifying CTEs share a
+    // snapshot across all statements in the WITH clause — a CTE-form
+    // `WITH deleted_member AS (DELETE ...) DELETE FROM parent WHERE
+    // NOT EXISTS (...)` leaves the parent behind on the last-member
+    // drain because the outer DELETE's `NOT EXISTS` still sees the
+    // about-to-be-deleted row in the snapshot. Two statements in the
+    // same tx observe the prior statement's writes — SERIALIZABLE
+    // isolation still holds against concurrent acks.
+    //
+    // NO outbox emit (§4.2.7 — Valkey-parity quiet).
+    sqlx::query(
+        r#"
+        DELETE FROM ff_cancel_backlog_member
+         WHERE partition_key = $1
+           AND flow_id       = $2
+           AND execution_id  = $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_uuid)
+    .bind(member_wire)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        r#"
+        DELETE FROM ff_cancel_backlog
+         WHERE partition_key = $1
+           AND flow_id       = $2
+           AND NOT EXISTS (
+             SELECT 1 FROM ff_cancel_backlog_member
+              WHERE partition_key = $1 AND flow_id = $2
+           )
+        "#,
+    )
+    .bind(partition_key)
+    .bind(flow_uuid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+pub(super) async fn ack_cancel_member_impl(
+    pool: &PgPool,
+    flow_id: FlowId,
+    execution_id: ExecutionId,
+) -> Result<(), EngineError> {
+    retry_serializable(|| ack_cancel_member_once(pool, &flow_id, &execution_id)).await
 }

--- a/crates/ff-backend-postgres/src/operator.rs
+++ b/crates/ff-backend-postgres/src/operator.rs
@@ -896,26 +896,26 @@ fn member_wire_id(partition_key: i16, exec_uuid: Uuid) -> String {
 
 async fn cancel_flow_header_once(
     pool: &PgPool,
+    partition_config: &ff_core::partition::PartitionConfig,
     args: &CancelFlowArgs,
 ) -> Result<CancelFlowHeader, EngineError> {
     let flow_uuid: Uuid = args.flow_id.0;
     // Flow + members share `partition_key` via the flow's partition
-    // hash (RFC-011 co-location). We compute it the same way the
-    // existing `flow::cancel_flow` path does — but here we don't have
-    // a `PartitionConfig`; use a default shape since partition_key is
-    // just `crc16(flow_id) % 256` and the member rows were written
-    // under the same hash.
+    // hash (RFC-011 co-location). Use the backend's configured
+    // `partition_config` so non-default `num_flow_partitions`
+    // deployments route correctly.
     let partition_key: i16 =
-        ff_core::partition::flow_partition(&args.flow_id, &ff_core::partition::PartitionConfig::default())
-            .index as i16;
+        ff_core::partition::flow_partition(&args.flow_id, partition_config).index as i16;
     let now: i64 = args.now.0;
 
     let mut tx = begin_serializable(pool).await?;
 
-    // Pre-read the flow row under lock. If an existing
-    // `ff_cancel_backlog` row already exists for this flow (idempotent
-    // replay / concurrent second call), surface AlreadyTerminal with
-    // the stored policy + the full (already-enumerated) membership.
+    // Pre-read the flow row under lock. Idempotent-replay trigger is
+    // `public_flow_state` — flows already in a terminal state surface
+    // `AlreadyTerminal` with stored policy/reason from `raw_fields` +
+    // either the prior backlog-member enumeration (if we landed the
+    // first flip) or live `ff_exec_core` membership (pre-E2-shape
+    // flow cancelled by the legacy `flow::cancel_flow` path).
     let flow_row = sqlx::query(
         r#"
         SELECT public_flow_state, raw_fields
@@ -1063,31 +1063,37 @@ async fn cancel_flow_header_once(
     .await
     .map_err(map_sqlx_error)?;
 
-    let mut member_execution_ids: Vec<String> = Vec::with_capacity(member_rows.len());
-    for row in &member_rows {
-        let exec_uuid: Uuid = row.get("execution_id");
-        let wire = member_wire_id(partition_key, exec_uuid);
+    let member_uuids: Vec<Uuid> = member_rows.iter().map(|r| r.get("execution_id")).collect();
+    let member_execution_ids: Vec<String> = member_uuids
+        .iter()
+        .map(|u| member_wire_id(partition_key, *u))
+        .collect();
 
-        // Insert backlog member row.
+    if !member_uuids.is_empty() {
+        // Bulk INSERT backlog members via UNNEST — one round-trip
+        // regardless of membership cardinality (vs. N round-trips in
+        // the prior per-member loop).
         sqlx::query(
             r#"
             INSERT INTO ff_cancel_backlog_member
-                (partition_key, flow_id, execution_id, ack_state)
-            VALUES ($1, $2, $3, 'pending')
+                (partition_key, flow_id, execution_id)
+            SELECT $1, $2, eid
+              FROM UNNEST($3::text[]) AS eid
             ON CONFLICT (partition_key, flow_id, execution_id) DO NOTHING
             "#,
         )
         .bind(partition_key)
         .bind(flow_uuid)
-        .bind(&wire)
+        .bind(&member_execution_ids)
         .execute(&mut *tx)
         .await
         .map_err(map_sqlx_error)?;
 
-        // Flip the member's `ff_exec_core` lifecycle (same shape as
-        // `flow::cancel_flow_once`). The Server's own wait/async
-        // machinery drives the per-member cancel events downstream;
-        // the backlog row lives until `ack_cancel_member` drains it.
+        // Bulk UPDATE each member's `ff_exec_core` lifecycle (same
+        // shape as `flow::cancel_flow_once`). The Server's own
+        // wait/async machinery drives per-member cancel events
+        // downstream; the backlog rows live until `ack_cancel_member`
+        // drains them.
         sqlx::query(
             r#"
             UPDATE ff_exec_core
@@ -1097,18 +1103,16 @@ async fn cancel_flow_header_once(
                    terminal_at_ms      = COALESCE(terminal_at_ms, $3),
                    cancellation_reason = COALESCE(cancellation_reason, $4),
                    cancelled_by        = COALESCE(cancelled_by, 'cancel_flow_header')
-             WHERE partition_key = $1 AND execution_id = $2
+             WHERE partition_key = $1 AND execution_id = ANY($2::uuid[])
             "#,
         )
         .bind(partition_key)
-        .bind(exec_uuid)
+        .bind(&member_uuids)
         .bind(now)
         .bind(&args.reason)
         .execute(&mut *tx)
         .await
         .map_err(map_sqlx_error)?;
-
-        member_execution_ids.push(wire);
     }
 
     // Outbox emit (§4.2.7 — flow-level `flow_cancel_requested`).
@@ -1137,22 +1141,23 @@ async fn cancel_flow_header_once(
 
 pub(super) async fn cancel_flow_header_impl(
     pool: &PgPool,
+    partition_config: &ff_core::partition::PartitionConfig,
     args: CancelFlowArgs,
 ) -> Result<CancelFlowHeader, EngineError> {
-    retry_serializable(|| cancel_flow_header_once(pool, &args)).await
+    retry_serializable(|| cancel_flow_header_once(pool, partition_config, &args)).await
 }
 
 // ─── ack_cancel_member (§4.2.3) ────────────────────────────────────
 
 async fn ack_cancel_member_once(
     pool: &PgPool,
+    partition_config: &ff_core::partition::PartitionConfig,
     flow_id: &FlowId,
     execution_id: &ExecutionId,
 ) -> Result<(), EngineError> {
     let flow_uuid: Uuid = flow_id.0;
     let partition_key: i16 =
-        ff_core::partition::flow_partition(flow_id, &ff_core::partition::PartitionConfig::default())
-            .index as i16;
+        ff_core::partition::flow_partition(flow_id, partition_config).index as i16;
     let member_wire = execution_id.as_str();
 
     let mut tx = begin_serializable(pool).await?;
@@ -1213,8 +1218,12 @@ async fn ack_cancel_member_once(
 
 pub(super) async fn ack_cancel_member_impl(
     pool: &PgPool,
+    partition_config: &ff_core::partition::PartitionConfig,
     flow_id: FlowId,
     execution_id: ExecutionId,
 ) -> Result<(), EngineError> {
-    retry_serializable(|| ack_cancel_member_once(pool, &flow_id, &execution_id)).await
+    retry_serializable(|| {
+        ack_cancel_member_once(pool, partition_config, &flow_id, &execution_id)
+    })
+    .await
 }

--- a/crates/ff-backend-postgres/src/operator_event.rs
+++ b/crates/ff-backend-postgres/src/operator_event.rs
@@ -1,0 +1,73 @@
+//! RFC-020 Wave 9 Spine-A pt.2 — `ff_operator_event` outbox producer helper.
+//!
+//! Mirrors [`crate::lease_event::emit`] for the operator-control
+//! channel. Every `change_priority` / `replay_execution` /
+//! `cancel_flow_header` INSERTs exactly one row here inside the same
+//! SERIALIZABLE transaction as the state mutation. The
+//! `ff_operator_event_notify_trg` trigger fires
+//! `pg_notify('ff_operator_event', event_id::text)` at COMMIT so
+//! RFC-019 subscribers wake and drain via the `event_id > $cursor`
+//! catch-up query.
+//!
+//! `ack_cancel_member` does **not** emit (§4.2.7 matrix — parity with
+//! Valkey's quiet-ack).
+//!
+//! See `migrations/0010_operator_event_outbox.sql` for the schema.
+
+use serde_json::Value as JsonValue;
+use sqlx::Postgres;
+use uuid::Uuid;
+
+use crate::error::map_sqlx_error;
+use ff_core::engine_error::EngineError;
+
+/// Wire-string operator-event types. Match the set enforced by the
+/// migration 0010 CHECK constraint.
+pub const EVENT_PRIORITY_CHANGED: &str = "priority_changed";
+pub const EVENT_REPLAYED: &str = "replayed";
+pub const EVENT_FLOW_CANCEL_REQUESTED: &str = "flow_cancel_requested";
+
+/// Append one operator-control event to the outbox within an
+/// in-flight transaction.
+///
+/// `namespace` / `instance_tag` are looked up co-transactionally from
+/// `ff_exec_core` when `execution_uuid` is a real exec id so RFC-019
+/// subscriber filters work. For flow-level events where no single
+/// exec is authoritative (`flow_cancel_requested`), callers pass the
+/// flow_id-as-uuid and the same lookup gracefully falls back to NULL
+/// namespace/tag (no matching exec row).
+pub(crate) async fn emit<'c>(
+    tx: &mut sqlx::Transaction<'c, Postgres>,
+    partition_key: i16,
+    execution_uuid: Uuid,
+    event_type: &'static str,
+    details: JsonValue,
+    occurred_at_ms: i64,
+) -> Result<(), EngineError> {
+    sqlx::query(
+        "INSERT INTO ff_operator_event \
+         (execution_id, event_type, details, occurred_at_ms, partition_key, \
+          namespace, instance_tag) \
+         SELECT $1, $2, $3, $4, $5, \
+                raw_fields->>'namespace', \
+                raw_fields->'tags'->>'cairn.instance_id' \
+         FROM ff_exec_core \
+         WHERE partition_key = $5 AND execution_id = $6::uuid \
+         UNION ALL \
+         SELECT $1, $2, $3, $4, $5, NULL, NULL \
+         WHERE NOT EXISTS ( \
+             SELECT 1 FROM ff_exec_core \
+             WHERE partition_key = $5 AND execution_id = $6::uuid \
+         )",
+    )
+    .bind(execution_uuid.to_string())
+    .bind(event_type)
+    .bind(details)
+    .bind(occurred_at_ms)
+    .bind(i32::from(partition_key))
+    .bind(execution_uuid)
+    .execute(&mut **tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    Ok(())
+}

--- a/crates/ff-backend-postgres/tests/spine_a_pt2_mutations.rs
+++ b/crates/ff-backend-postgres/tests/spine_a_pt2_mutations.rs
@@ -1,0 +1,866 @@
+//! RFC-020 Wave 9 Spine-A pt.2 — integration tests for
+//! `change_priority` + `replay_execution` + `cancel_flow_header` +
+//! `ack_cancel_member`.
+//!
+//! Follows the `FF_PG_TEST_URL` / `#[ignore]` convention from
+//! `spine_a_pt1_mutations.rs` + `spine_b_reads.rs`.
+//!
+//! Coverage per RFC §4.2.3 / §4.2.4 / §4.2.5 / §4.2.7 / §4.3 + Rev 7
+//! fork decisions:
+//!
+//! * `change_priority` — happy path (outbox emit), terminal ineligible,
+//!   wrong eligibility_state.
+//! * `replay_execution` — normal branch (in-place attempt mutate, no
+//!   attempt_index bump, replay_count bump), skipped_flow_member
+//!   branch (edge_group counter reset: skip/fail/running → 0,
+//!   success preserved), non-terminal gate.
+//! * `cancel_flow_header` — bulk member enumeration + backlog rows,
+//!   AlreadyTerminal idempotent replay, outbox emit.
+//! * `ack_cancel_member` — happy path drain, parent-row deletion when
+//!   last member acks, full end-to-end cancel_flow_header → ack
+//!   sequence.
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{
+    CancelFlowArgs, CancelFlowHeader, ChangePriorityArgs, ChangePriorityResult,
+    ReplayExecutionArgs, ReplayExecutionResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind};
+use ff_core::partition::{flow_partition, PartitionConfig};
+use ff_core::state::PublicState;
+use ff_core::types::{ExecutionId, FlowId, LaneId, TimestampMs};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ── Fixture ───────────────────────────────────────────────────────
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let bootstrap = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&bootstrap)
+        .await
+        .expect("apply_migrations clean");
+    bootstrap.close().await;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect pool");
+    Some(pool)
+}
+
+struct Seed {
+    backend: Arc<dyn EngineBackend>,
+    pool: PgPool,
+    exec_id: ExecutionId,
+    part: i16,
+    exec_uuid: Uuid,
+}
+
+async fn seed_backend() -> Option<Seed> {
+    let pool = setup_or_skip().await?;
+    let lane = LaneId::new("default");
+    let exec_id = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let part = exec_id.partition() as i16;
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    Some(Seed {
+        backend,
+        pool,
+        exec_id,
+        part,
+        exec_uuid,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_exec_core(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    flow_id: Option<Uuid>,
+    lifecycle_phase: &str,
+    eligibility_state: &str,
+    ownership_state: &str,
+    public_state: &str,
+    attempt_state: &str,
+    attempt_index: i32,
+    priority: i32,
+    now: i64,
+) {
+    sqlx::query(
+        "INSERT INTO ff_exec_core \
+           (partition_key, execution_id, flow_id, lane_id, attempt_index, \
+            lifecycle_phase, ownership_state, eligibility_state, \
+            public_state, attempt_state, \
+            priority, created_at_ms, raw_fields) \
+         VALUES ($1, $2, $3, 'default', $4, $5, $6, $7, \
+                 $8, $9, $10, $11, '{}'::jsonb)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(flow_id)
+    .bind(attempt_index)
+    .bind(lifecycle_phase)
+    .bind(ownership_state)
+    .bind(eligibility_state)
+    .bind(public_state)
+    .bind(attempt_state)
+    .bind(priority)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("insert ff_exec_core");
+}
+
+async fn insert_attempt(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    attempt_index: i32,
+    outcome: Option<&str>,
+    lease_epoch: i64,
+) {
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, lease_epoch, outcome) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .bind(lease_epoch)
+    .bind(outcome)
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+}
+
+async fn count_operator_events(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    event_type: &str,
+) -> i64 {
+    sqlx::query(
+        "SELECT COUNT(*)::bigint AS n FROM ff_operator_event \
+         WHERE partition_key = $1 AND execution_id = $2 AND event_type = $3",
+    )
+    .bind(i32::from(part))
+    .bind(exec_uuid.to_string())
+    .bind(event_type)
+    .fetch_one(pool)
+    .await
+    .expect("count ff_operator_event")
+    .try_get::<i64, _>("n")
+    .expect("n column")
+}
+
+// ── change_priority ──────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn change_priority_happy_path_emits_operator_event() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        None,
+        "runnable",
+        "eligible_now",
+        "unowned",
+        "waiting",
+        "pending",
+        0,
+        /*priority=*/ 100,
+        now,
+    )
+    .await;
+
+    let r = fx
+        .backend
+        .change_priority(ChangePriorityArgs {
+            execution_id: fx.exec_id.clone(),
+            new_priority: 5000,
+            lane_id: LaneId::new("default"),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("change_priority ok");
+    assert!(matches!(r, ChangePriorityResult::Changed { .. }));
+
+    let new_pri: i32 = sqlx::query_scalar(
+        "SELECT priority FROM ff_exec_core WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read priority");
+    assert_eq!(new_pri, 5000);
+
+    let n = count_operator_events(&fx.pool, fx.part, fx.exec_uuid, "priority_changed").await;
+    assert_eq!(n, 1, "one priority_changed row emitted");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn change_priority_terminal_is_not_eligible() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        None,
+        /*lifecycle_phase=*/ "terminal",
+        /*eligibility_state=*/ "not_applicable",
+        "unowned",
+        "success",
+        "terminated",
+        0,
+        100,
+        now,
+    )
+    .await;
+    let err = fx
+        .backend
+        .change_priority(ChangePriorityArgs {
+            execution_id: fx.exec_id.clone(),
+            new_priority: 5000,
+            lane_id: LaneId::new("default"),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("expected execution_not_eligible");
+    assert!(matches!(
+        err,
+        EngineError::Contention(ContentionKind::ExecutionNotEligible)
+    ));
+    let n = count_operator_events(&fx.pool, fx.part, fx.exec_uuid, "priority_changed").await;
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn change_priority_wrong_eligibility_state_is_not_eligible() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        None,
+        "runnable",
+        /*eligibility_state=*/ "blocked_by_dependencies",
+        "unowned",
+        "waiting_children",
+        "pending",
+        0,
+        100,
+        now,
+    )
+    .await;
+    let err = fx
+        .backend
+        .change_priority(ChangePriorityArgs {
+            execution_id: fx.exec_id.clone(),
+            new_priority: 7000,
+            lane_id: LaneId::new("default"),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("expected execution_not_eligible (wrong eligibility)");
+    assert!(matches!(
+        err,
+        EngineError::Contention(ContentionKind::ExecutionNotEligible)
+    ));
+}
+
+// ── replay_execution ─────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn replay_execution_normal_branch_in_place_mutate() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        /*flow_id=*/ None,
+        "terminal",
+        "not_applicable",
+        "unowned",
+        "success",
+        "terminated",
+        /*attempt_index=*/ 0,
+        500,
+        now,
+    )
+    .await;
+    insert_attempt(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("success"),
+        /*lease_epoch=*/ 3,
+    )
+    .await;
+
+    let r = fx
+        .backend
+        .replay_execution(ReplayExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("replay ok");
+    assert_eq!(r, ReplayExecutionResult::Replayed {
+        public_state: PublicState::Waiting,
+    });
+
+    // exec_core: runnable + eligible_now + public_state=waiting.
+    let (phase, elig, pub_s, attempt_idx): (String, String, String, i32) = sqlx::query_as(
+        "SELECT lifecycle_phase, eligibility_state, public_state, attempt_index \
+         FROM ff_exec_core WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read exec_core");
+    assert_eq!(phase, "runnable");
+    assert_eq!(elig, "eligible_now");
+    assert_eq!(pub_s, "waiting");
+    // attempt_index NOT bumped (Rev 7 Fork 2 Option A).
+    assert_eq!(attempt_idx, 0, "attempt_index preserved");
+
+    // replay_count bumped in raw_fields.
+    let raw_fields: serde_json::Value = sqlx::query_scalar(
+        "SELECT raw_fields FROM ff_exec_core WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read raw_fields");
+    assert_eq!(raw_fields.get("replay_count").and_then(|v| v.as_i64()), Some(1));
+
+    // ff_attempt: in-place mutation of the existing row, outcome cleared,
+    // lease_epoch bumped. No new row inserted.
+    let attempts: Vec<(i32, Option<String>, i64)> = sqlx::query_as(
+        "SELECT attempt_index, outcome, lease_epoch FROM ff_attempt \
+         WHERE partition_key = $1 AND execution_id = $2 ORDER BY attempt_index",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_all(&fx.pool)
+    .await
+    .expect("read attempts");
+    assert_eq!(attempts.len(), 1, "no new attempt row inserted");
+    assert_eq!(attempts[0].0, 0);
+    assert!(attempts[0].1.is_none(), "outcome cleared");
+    assert_eq!(attempts[0].2, 4, "lease_epoch bumped from 3 → 4");
+
+    // Outbox emit: one replayed event with branch=normal.
+    let row: (serde_json::Value,) = sqlx::query_as(
+        "SELECT details FROM ff_operator_event \
+         WHERE partition_key = $1 AND execution_id = $2 AND event_type = 'replayed'",
+    )
+    .bind(i32::from(fx.part))
+    .bind(fx.exec_uuid.to_string())
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read operator_event");
+    assert_eq!(
+        row.0.get("branch").and_then(|v| v.as_str()),
+        Some("normal")
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn replay_execution_skipped_flow_member_resets_edge_group_counters() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    let flow_uuid = Uuid::new_v4();
+
+    // Seed a skipped flow member.
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        Some(flow_uuid),
+        "terminal",
+        "not_applicable",
+        "unowned",
+        "failed",
+        "terminated",
+        0,
+        500,
+        now,
+    )
+    .await;
+    insert_attempt(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        0,
+        Some("skipped"),
+        5,
+    )
+    .await;
+
+    // Seed an upstream edge + edge_group row referencing our exec as
+    // downstream, with non-zero counters to verify the reset.
+    let upstream_uuid = Uuid::new_v4();
+    let edge_uuid = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_edge (partition_key, flow_id, edge_id, upstream_eid, \
+                              downstream_eid, policy, policy_version) \
+         VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, 0)",
+    )
+    .bind(fx.part)
+    .bind(flow_uuid)
+    .bind(edge_uuid)
+    .bind(upstream_uuid)
+    .bind(fx.exec_uuid)
+    .execute(&fx.pool)
+    .await
+    .expect("insert ff_edge");
+
+    sqlx::query(
+        "INSERT INTO ff_edge_group (partition_key, flow_id, downstream_eid, policy, \
+                                    k_target, success_count, fail_count, skip_count, running_count) \
+         VALUES ($1, $2, $3, '{}'::jsonb, 3, 2, 1, 1, 1)",
+    )
+    .bind(fx.part)
+    .bind(flow_uuid)
+    .bind(fx.exec_uuid)
+    .execute(&fx.pool)
+    .await
+    .expect("insert ff_edge_group");
+
+    let r = fx
+        .backend
+        .replay_execution(ReplayExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("replay ok");
+    assert_eq!(
+        r,
+        ReplayExecutionResult::Replayed {
+            public_state: PublicState::WaitingChildren,
+        }
+    );
+
+    // edge_group: success_count preserved, skip/fail/running zeroed.
+    let (succ, fail, skip, running): (i32, i32, i32, i32) = sqlx::query_as(
+        "SELECT success_count, fail_count, skip_count, running_count \
+         FROM ff_edge_group \
+         WHERE partition_key = $1 AND flow_id = $2 AND downstream_eid = $3",
+    )
+    .bind(fx.part)
+    .bind(flow_uuid)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read edge_group");
+    assert_eq!(succ, 2, "success_count preserved (Valkey parity)");
+    assert_eq!(fail, 0);
+    assert_eq!(skip, 0);
+    assert_eq!(running, 0);
+
+    // exec_core: runnable + blocked_by_dependencies + waiting_children.
+    let (phase, elig, pub_s): (String, String, String) = sqlx::query_as(
+        "SELECT lifecycle_phase, eligibility_state, public_state \
+         FROM ff_exec_core WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(fx.part)
+    .bind(fx.exec_uuid)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read exec_core");
+    assert_eq!(phase, "runnable");
+    assert_eq!(elig, "blocked_by_dependencies");
+    assert_eq!(pub_s, "waiting_children");
+
+    // Outbox emit: branch=skipped_flow_member + groups_reset=1.
+    let row: (serde_json::Value,) = sqlx::query_as(
+        "SELECT details FROM ff_operator_event \
+         WHERE partition_key = $1 AND execution_id = $2 AND event_type = 'replayed'",
+    )
+    .bind(i32::from(fx.part))
+    .bind(fx.exec_uuid.to_string())
+    .fetch_one(&fx.pool)
+    .await
+    .expect("read operator_event");
+    assert_eq!(
+        row.0.get("branch").and_then(|v| v.as_str()),
+        Some("skipped_flow_member")
+    );
+    assert_eq!(row.0.get("groups_reset").and_then(|v| v.as_i64()), Some(1));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn replay_execution_non_terminal_is_not_terminal() {
+    let Some(fx) = seed_backend().await else {
+        return;
+    };
+    let now = TimestampMs::now().0;
+    insert_exec_core(
+        &fx.pool,
+        fx.part,
+        fx.exec_uuid,
+        None,
+        "active",
+        "eligible_now",
+        "leased",
+        "running",
+        "running_attempt",
+        0,
+        500,
+        now,
+    )
+    .await;
+    let err = fx
+        .backend
+        .replay_execution(ReplayExecutionArgs {
+            execution_id: fx.exec_id.clone(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect_err("expected execution_not_terminal");
+    assert!(matches!(
+        err,
+        EngineError::State(StateKind::ExecutionNotTerminal)
+    ));
+}
+
+// ── cancel_flow_header + ack_cancel_member ───────────────────────
+
+async fn insert_flow_core(pool: &PgPool, part: i16, flow_uuid: Uuid, state: &str, now: i64) {
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+           (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms) \
+         VALUES ($1, $2, 0, $3, $4)",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(state)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("insert ff_flow_core");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_flow_header_creates_backlog_rows() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let cfg = PartitionConfig::default();
+    let flow_id = FlowId::new();
+    let part = flow_partition(&flow_id, &cfg).index as i16;
+    let flow_uuid = flow_id.0;
+    let now = TimestampMs::now().0;
+
+    insert_flow_core(&pool, part, flow_uuid, "active", now).await;
+
+    // Two in-flight members under this flow (partition key matches
+    // because execution_ids share the flow's partition_key via RFC-011).
+    let mem_a = Uuid::new_v4();
+    let mem_b = Uuid::new_v4();
+    for mem in [mem_a, mem_b] {
+        insert_exec_core(
+            &pool, part, mem, Some(flow_uuid), "active", "eligible_now", "leased",
+            "running", "running_attempt", 0, 100, now,
+        )
+        .await;
+    }
+
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), cfg);
+    let r = backend
+        .cancel_flow_header(CancelFlowArgs {
+            flow_id: flow_id.clone(),
+            reason: "op-shutdown".into(),
+            cancellation_policy: "cancel_all".into(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("cancel_flow_header ok");
+    match r {
+        CancelFlowHeader::Cancelled {
+            cancellation_policy,
+            member_execution_ids,
+        } => {
+            assert_eq!(cancellation_policy, "cancel_all");
+            assert_eq!(member_execution_ids.len(), 2);
+        }
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+
+    // Backlog header row exists.
+    let header_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_cancel_backlog \
+         WHERE partition_key = $1 AND flow_id = $2",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count backlog");
+    assert_eq!(header_count, 1);
+
+    // Member rows: 2 pending.
+    let member_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_cancel_backlog_member \
+         WHERE partition_key = $1 AND flow_id = $2 AND ack_state = 'pending'",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count backlog members");
+    assert_eq!(member_count, 2);
+
+    // Outbox emit: flow_cancel_requested (partition_key + flow_uuid).
+    let n: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_operator_event \
+         WHERE partition_key = $1 AND execution_id = $2 AND event_type = 'flow_cancel_requested'",
+    )
+    .bind(i32::from(part))
+    .bind(flow_uuid.to_string())
+    .fetch_one(&pool)
+    .await
+    .expect("count flow_cancel_requested");
+    assert_eq!(n, 1);
+
+    // Members flipped to cancelled on ff_exec_core.
+    let cancelled_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_exec_core \
+         WHERE partition_key = $1 AND flow_id = $2 AND lifecycle_phase = 'cancelled'",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count cancelled members");
+    assert_eq!(cancelled_count, 2);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_flow_header_already_terminal_is_idempotent() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let cfg = PartitionConfig::default();
+    let flow_id = FlowId::new();
+    let part = flow_partition(&flow_id, &cfg).index as i16;
+    let flow_uuid = flow_id.0;
+    let now = TimestampMs::now().0;
+
+    // Pre-cancelled flow with stored cancellation_policy in raw_fields.
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+           (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms, raw_fields) \
+         VALUES ($1, $2, 0, 'cancelled', $3, \
+                 jsonb_build_object('cancellation_policy', 'flow_only', \
+                                    'cancel_reason', 'prior'))",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert ff_flow_core");
+
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), cfg);
+    let r = backend
+        .cancel_flow_header(CancelFlowArgs {
+            flow_id: flow_id.clone(),
+            reason: "retry".into(),
+            cancellation_policy: "cancel_all".into(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("idempotent ok");
+    match r {
+        CancelFlowHeader::AlreadyTerminal {
+            stored_cancellation_policy,
+            stored_cancel_reason,
+            member_execution_ids,
+        } => {
+            assert_eq!(stored_cancellation_policy.as_deref(), Some("flow_only"));
+            assert_eq!(stored_cancel_reason.as_deref(), Some("prior"));
+            assert!(member_execution_ids.is_empty());
+        }
+        other => panic!("expected AlreadyTerminal, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn ack_cancel_member_drains_and_deletes_parent_when_last() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let cfg = PartitionConfig::default();
+    let flow_id = FlowId::new();
+    let part = flow_partition(&flow_id, &cfg).index as i16;
+    let flow_uuid = flow_id.0;
+    let now = TimestampMs::now().0;
+
+    insert_flow_core(&pool, part, flow_uuid, "active", now).await;
+
+    // Two members under the flow.
+    let mem_a = Uuid::new_v4();
+    let mem_b = Uuid::new_v4();
+    for mem in [mem_a, mem_b] {
+        insert_exec_core(
+            &pool, part, mem, Some(flow_uuid), "active", "eligible_now", "leased",
+            "running", "running_attempt", 0, 100, now,
+        )
+        .await;
+    }
+
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), cfg);
+    let cancel_r = backend
+        .cancel_flow_header(CancelFlowArgs {
+            flow_id: flow_id.clone(),
+            reason: "test".into(),
+            cancellation_policy: "cancel_all".into(),
+            now: TimestampMs::now(),
+        })
+        .await
+        .expect("cancel_flow_header ok");
+    let members = match cancel_r {
+        CancelFlowHeader::Cancelled {
+            member_execution_ids,
+            ..
+        } => member_execution_ids,
+        other => panic!("expected Cancelled, got {other:?}"),
+    };
+    assert_eq!(members.len(), 2);
+
+    // Ack the first member.
+    let eid_a = ExecutionId::parse(&members[0]).expect("parse exec id");
+    backend
+        .ack_cancel_member(&flow_id, &eid_a)
+        .await
+        .expect("ack member 1");
+
+    // After first ack: 1 member row remains, header row still present.
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_cancel_backlog_member \
+         WHERE partition_key = $1 AND flow_id = $2",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count members");
+    assert_eq!(remaining, 1);
+    let header: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_cancel_backlog \
+         WHERE partition_key = $1 AND flow_id = $2",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count header");
+    assert_eq!(header, 1, "header row persists while members remain");
+
+    // Ack the second (last) member.
+    let eid_b = ExecutionId::parse(&members[1]).expect("parse exec id");
+    backend
+        .ack_cancel_member(&flow_id, &eid_b)
+        .await
+        .expect("ack member 2");
+
+    // After last ack: both member rows AND header row gone (CTE
+    // conditional parent-DELETE).
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_cancel_backlog_member \
+         WHERE partition_key = $1 AND flow_id = $2",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count members");
+    assert_eq!(remaining, 0);
+    let header: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_cancel_backlog \
+         WHERE partition_key = $1 AND flow_id = $2",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count header");
+    assert_eq!(header, 0, "header row drained with last member");
+
+    // ack_cancel_member emits no outbox row (§4.2.7 — quiet parity).
+    let ack_outbox: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_operator_event \
+         WHERE partition_key = $1 AND execution_id IN ($2, $3)",
+    )
+    .bind(i32::from(part))
+    .bind(mem_a.to_string())
+    .bind(mem_b.to_string())
+    .fetch_one(&pool)
+    .await
+    .expect("count ack outbox");
+    assert_eq!(ack_outbox, 0, "ack_cancel_member emits no outbox row");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn ack_cancel_member_idempotent_on_missing() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let cfg = PartitionConfig::default();
+    let flow_id = FlowId::new();
+    let exec_id = ExecutionId::solo(&LaneId::new("default"), &cfg);
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), cfg);
+    // No backlog seeded — ack should succeed silently (idempotent).
+    backend
+        .ack_cancel_member(&flow_id, &exec_id)
+        .await
+        .expect("ack on missing rows is ok");
+}

--- a/crates/ff-backend-postgres/tests/spine_a_pt2_mutations.rs
+++ b/crates/ff-backend-postgres/tests/spine_a_pt2_mutations.rs
@@ -643,7 +643,7 @@ async fn cancel_flow_header_creates_backlog_rows() {
     // Member rows: 2 pending.
     let member_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)::bigint FROM ff_cancel_backlog_member \
-         WHERE partition_key = $1 AND flow_id = $2 AND ack_state = 'pending'",
+         WHERE partition_key = $1 AND flow_id = $2",
     )
     .bind(part)
     .bind(flow_uuid)


### PR DESCRIPTION
## Summary

RFC-020 Revision 7 (accepted, merged `e1103e6`) §4.2.3 / §4.2.4 / §4.2.5 / §4.2.7 / §4.3. Four SERIALIZABLE + 3-retry method impls, one additive migration, three operator-event outbox emits — all landing behind their `Supports` flags per RFC §6.3 (atomic flip at the Wave 9 release PR).

### Methods (crates/ff-backend-postgres/src/operator.rs)

- **`change_priority`** (§4.2.4, Rev 7 Fork 3 Option C) — Valkey-canonical gate `lifecycle_phase='runnable' AND eligibility_state='eligible_now'`; mis-gated row surfaces `EngineError::Contention(ExecutionNotEligible)` mirroring ff-script's `execution_not_eligible` (flowfabric.lua:3683-3688). No contract amendment — `ChangePriorityResult` stays single-variant. Clamp new_priority to [0, 9000] per Valkey parity.

- **`replay_execution`** (§4.2.5, Rev 7 Forks 1 + 2 Option A):
  - Normal branch: in-place UPDATE of `ff_attempt` (outcome cleared, `lease_epoch` bumped); `attempt_index` NOT bumped; flips `ff_exec_core` to `runnable` / `eligible_now` / `waiting`; `replay_count++` in `raw_fields`.
  - Skipped-flow-member branch: reset downstream `ff_edge_group` counters (`skip/fail/running → 0`; `success` preserved — Valkey parity `flowfabric.lua:8580`); flips `ff_exec_core` to `runnable` / `blocked_by_dependencies` / `waiting_children`.
  - Non-terminal gate → `EngineError::State(ExecutionNotTerminal)`.

- **`cancel_flow_header`** (§4.2.3) — 2-phase header flip + bulk backlog insert + per-member `ff_exec_core` flip. Idempotent `AlreadyTerminal` replay reads stored policy from `raw_fields` + live membership.

- **`ack_cancel_member`** (§4.2.3) — split member-DELETE + conditional parent-DELETE (two statements, not a data-modifying CTE: Postgres CTE snapshot semantics would leave the parent row behind on the last-member drain). Under SERIALIZABLE the concurrent ack×ack race surfaces 40001 on the loser; `retry_serializable` observes the winner's state and the drain becomes idempotent (§4.2.3 C2). No outbox emit (§4.2.7 — Valkey-parity quiet).

### Migration 0014 (`ff_cancel_backlog` + `ff_cancel_backlog_member`)

- Both 256-way HASH partitioned on `partition_key`, matching the 0001 / 0002 / 0012 convention.
- Partition-child DO blocks with explicit COMMIT boundaries (lock budget).
- Indexes for pending-ack scans, time-based cleanup, grace-window reconciler wakeup.
- `backward_compatible = true`; additive; no destructive DDL.

### Outbox emits (`ff_operator_event`, migration 0010) per §4.2.7 matrix

- `change_priority` → `priority_changed` (old/new priority).
- `replay_execution` → `replayed` (branch: `normal` | `skipped_flow_member`, `groups_reset` on skip path).
- `cancel_flow_header` → `flow_cancel_requested` (flow_id, policy, reason, member_count).
- `ack_cancel_member` → silent (quiet-parity with Valkey).

New module `crates/ff-backend-postgres/src/operator_event.rs` mirrors the `lease_event::emit` helper with co-transactional `namespace` / `instance_tag` lookup (RFC-019 subscriber-filter parity).

### Rev 7 fork decisions embodied

- Fork 1 (§4.2.5 skipped-flow-member): Option A — `ff_edge_group` counter reset, `success_count` preserved.
- Fork 2 (§4.2.5 normal replay): Option A — in-place `ff_attempt` mutate, `attempt_index` NOT bumped.
- Fork 3 (§4.2.4 ineligible): Option C — `EngineError` mapping of `execution_not_eligible`; `ChangePriorityResult` contract NOT amended.

### `Supports` flags + capability surface

Flags remain `false` per RFC §6.3 (atomic flip at the Wave 9 release PR). No changes to `postgres_supports_base()` or `tests/capabilities.rs` in this PR. No CHANGELOG entry. No consumer migration doc touches. No new reconciler.

## Test plan

- [x] `cargo clippy -p ff-backend-postgres --all-targets -- -D warnings` — clean.
- [x] `cargo test -p ff-backend-postgres --lib` — 24/24 green.
- [x] Postgres ignored tests (`spine_a_pt2_mutations`, local Postgres 16): **10/10 green** covering change_priority (happy + 2 ineligible gates), replay_execution (normal in-place + skipped-flow-member counter reset + non-terminal gate), cancel_flow_header (bulk + idempotent AlreadyTerminal), ack_cancel_member (partial drain, full drain with parent-DELETE, idempotent on missing).
- [x] Spine-A pt.1 regression: `spine_a_pt1_mutations` **12/12 green** on the same migrated DB.
- [ ] CI matrix — Valkey arm-cluster flake pre-existing per project memory; admin-merge after the rest of the matrix clears.

## Replay branch correctness confirmation

- **Normal branch** — verified in `replay_execution_normal_branch_in_place_mutate`: exactly one `ff_attempt` row remains post-replay (no historical row inserted), `attempt_index` preserved at 0, `outcome` cleared, `lease_epoch` bumped 3 → 4, `raw_fields.replay_count` bumped 0 → 1, outbox `details.branch == "normal"`.
- **Skipped-flow-member branch** — verified in `replay_execution_skipped_flow_member_resets_edge_group_counters`: pre-seeded `ff_edge_group` (`success=2, fail=1, skip=1, running=1`) becomes (`success=2, fail=0, skip=0, running=0`), `ff_exec_core` flips to `runnable / blocked_by_dependencies / waiting_children`, outbox `details.branch == "skipped_flow_member"` + `details.groups_reset == 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres write paths that mutate execution/flow state under SERIALIZABLE transactions and emit operator outbox events; incorrect gating or transaction semantics could impact execution lifecycle correctness. Also introduces a large partitioned schema migration (512 partitions) which carries operational/migration risk despite being additive.
> 
> **Overview**
> Implements RFC-020 Wave 9 Spine-A pt.2 Postgres operator-control mutations: `change_priority`, `replay_execution`, `cancel_flow_header`, and `ack_cancel_member`, wiring them into the `EngineBackend` impl.
> 
> These methods perform SERIALIZABLE, retry-on-conflict state transitions (priority changes, terminal replay with branch-specific behavior, flow-level cancel that enumerates/cancels members, and member-ack draining) and emit `ff_operator_event` outbox rows for `priority_changed`, `replayed`, and `flow_cancel_requested` (while `ack_cancel_member` stays silent).
> 
> Adds migration `0014_cancel_backlog` introducing hash-partitioned `ff_cancel_backlog`/`ff_cancel_backlog_member` tables (256 partitions each) plus targeted indexes to support pending scans, cleanup, and grace-window queries, and adds integration tests covering the new mutation semantics and outbox behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abbceb4ff44c2f9a89cf1cf76cd6406bfbb15d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->