### PR TITLE
rfcs: promote RFC-023 to accepted (post Round-3 narrow fix, unanimous approval across 3 reviewers)

### DIFF
--- a/rfcs/RFC-023-sqlite-dev-only-backend.md
+++ b/rfcs/RFC-023-sqlite-dev-only-backend.md
@@ -1,9 +1,10 @@
 # RFC-023: SQLite — dev-only backend (testing harness, Temporal-pattern)
 
-**Status:** DRAFT
+**Status:** ACCEPTED
 **Revision:** 3
 **Author:** FlowFabric Team (manager single-agent draft)
 **Proposed:** 2026-04-26
+**Accepted:** 2026-04-26
 **Target release:** v0.12.0 (next content delivery after v0.11.0 Postgres Wave 9)
 **Related RFCs:** RFC-012 (EngineBackend trait), RFC-017 (ff-server backend abstraction), RFC-018 (capability discovery), RFC-019 (stream-cursor subscriptions), RFC-020 (Postgres Wave 9 — shipped v0.11.0), RFC-022 (parked: full-parity SQLite — superseded in scope by this RFC)
 **Tracking issue:** #338


### PR DESCRIPTION
## Summary

- Move `rfcs/drafts/RFC-023-sqlite-dev-only-backend.md` → `rfcs/RFC-023-sqlite-dev-only-backend.md`
- Flip `Status: DRAFT` → `Status: ACCEPTED`, add `Accepted: 2026-04-26`
- Revision 3 preserved; no other content changes

Round-3 surgical fixes landed in #362 (f71c37a). Reviewers A+C ACCEPT in Round-2; B flipped to ACCEPT after the 3 narrow doc-alignment items in Round-3. Unanimous across 3 reviewers.

## Test plan

- [x] Pre-flight: at or past `f71c37a` (RFC-023 Round-3 merge)
- [x] File rename preserved history via `git mv`
- [x] Header reads `Status: ACCEPTED`, `Proposed: 2026-04-26`, `Accepted: 2026-04-26`, `Revision: 3`
- [x] No other changes in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that promotes RFC-023 from draft to accepted; no runtime code or behavior changes.
> 
> **Overview**
> Promotes `RFC-023-sqlite-dev-only-backend.md` to **ACCEPTED** status by updating the RFC header (adds `Accepted: 2026-04-26` and flips `Status: DRAFT` to `Status: ACCEPTED`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f95e7d30a2824e488f4ec7a81c1b3699fa0edd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->