### PR TITLE
feat(backend-sqlite): Phase 1a — non-SQL surface + worker.rs backend-agnostic refactor

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -200,11 +200,20 @@ jobs:
       - name: cargo check -p ff-core --no-default-features --features core
         run: cargo check -p ff-core --no-default-features --features core
 
+      # RFC-023 Phase 1a (§9 + §4.4 item 10): mechanical regression
+      # guard for the worker.rs ferriskey-cfg gate. Catches future PRs
+      # that add a ferriskey call outside the `valkey-default` cfg gate
+      # on `FlowFabricWorker` or a sibling module. Adds ~15s on
+      # cold-cache runners.
+      - name: cargo check -p ff-sdk --no-default-features --features sqlite
+        run: cargo check -p ff-sdk --no-default-features --features sqlite
+
       - name: cargo clippy
         run: |
           cargo clippy \
             -p ff-core -p ff-script -p ff-engine -p ff-scheduler \
             -p ff-sdk -p ff-server -p ff-test \
+            -p ff-backend-sqlite \
             --features ff-sdk/direct-valkey-claim \
             -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,6 +341,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
+            echo "::error::  cargo yank --version ${VER} ff-backend-sqlite"
             exit 1
           }
       - run: sleep 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,14 @@
 #     `publish-new` + `publish-update`.
 #   - GITHUB_TOKEN is auto-provided by GHA; `gh release create` uses it.
 #
-# Publish set (12 crates, topologically ordered):
+# Publish set (13 crates, topologically ordered):
 #   ferriskey -> ff-core -> ff-script -> ff-observability
 #     -> ff-observability-http
-#     -> ff-backend-valkey -> ff-backend-postgres
+#     -> ff-backend-valkey -> ff-backend-postgres -> ff-backend-sqlite
 #     -> ff-engine -> ff-scheduler
 #     -> ff-sdk -> ff-server -> flowfabric
+# ff-backend-sqlite added at v0.12.0 (RFC-023 Phase 1a). Dev-only —
+# construction guarded by FF_DEV_MODE=1.
 # flowfabric is the umbrella re-export crate (issue #279) and MUST
 # publish last — it depends on every other publishable crate.
 # ff-test is dev-only (publish = false) and not in the set.
@@ -324,6 +326,24 @@ jobs:
             exit 1
           }
       - run: sleep 30
+      - name: publish ff-backend-sqlite
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          VER="${TAG_VERSION#v}"
+          cargo publish -p ff-backend-sqlite --no-verify || {
+            echo "::error::cargo publish ff-backend-sqlite failed -- yank already-published crate(s) before re-tagging:"
+            echo "::error::  cargo yank --version ${VER} ferriskey"
+            echo "::error::  cargo yank --version ${VER} ff-core"
+            echo "::error::  cargo yank --version ${VER} ff-script"
+            echo "::error::  cargo yank --version ${VER} ff-observability"
+            echo "::error::  cargo yank --version ${VER} ff-observability-http"
+            echo "::error::  cargo yank --version ${VER} ff-scheduler"
+            echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
+            echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
+            exit 1
+          }
+      - run: sleep 30
       - name: publish ff-engine
         env:
           TAG_VERSION: ${{ github.ref_name }}
@@ -339,6 +359,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
+            echo "::error::  cargo yank --version ${VER} ff-backend-sqlite"
             exit 1
           }
       - run: sleep 30
@@ -357,6 +378,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
+            echo "::error::  cargo yank --version ${VER} ff-backend-sqlite"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             exit 1
           }
@@ -376,6 +398,7 @@ jobs:
             echo "::error::  cargo yank --version ${VER} ff-scheduler"
             echo "::error::  cargo yank --version ${VER} ff-backend-valkey"
             echo "::error::  cargo yank --version ${VER} ff-backend-postgres"
+            echo "::error::  cargo yank --version ${VER} ff-backend-sqlite"
             echo "::error::  cargo yank --version ${VER} ff-engine"
             echo "::error::  cargo yank --version ${VER} ff-sdk"
             exit 1
@@ -394,7 +417,7 @@ jobs:
           VER="${TAG_VERSION#v}"
           cargo publish -p flowfabric --no-verify || {
             echo "::error::cargo publish flowfabric failed — yank every previously-published crate before re-tagging:"
-            echo "::error::  cargo yank --version ${VER} ferriskey ff-core ff-script ff-observability ff-observability-http ff-scheduler ff-backend-valkey ff-backend-postgres ff-engine ff-sdk ff-server"
+            echo "::error::  cargo yank --version ${VER} ferriskey ff-core ff-script ff-observability ff-observability-http ff-scheduler ff-backend-valkey ff-backend-postgres ff-backend-sqlite ff-engine ff-sdk ff-server"
             exit 1
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`crates/ff-backend-sqlite` — SQLite dev-only backend (RFC-023 Phase 1a).**
+  Activation requires `FF_DEV_MODE=1`. Construction is guarded at the
+  `SqliteBackend::new` TYPE level (§4.5 / §3.3 A3) so every entry
+  point — embedded, `ff_server::start_sqlite_branch`, and
+  `ff_sdk::FlowFabricWorker::connect_with` — pays the guard.
+  Phase 1a ships the scaffolding only: process-local per-path
+  registry (§4.2 B6), `sqlx::SqlitePool`, WARN banner on
+  construction, and an `EngineBackend` impl whose data-plane
+  methods return `EngineError::Unavailable`. Phase 1b lands the
+  hand-ported SQLite-dialect migrations; Phase 2+ replaces the stubs.
+- `BackendKind::Sqlite` variant on `ff_server::config::BackendKind`.
+- `SqliteServerConfig` (public, `#[non_exhaustive]`) with `new(path)`
+  + `with_pool_size(n)` + `with_wal(bool)` builders.
+- `ServerConfig::sqlite_dev()` — zero-config test/dev constructor
+  (in-memory SQLite, auth disabled, `127.0.0.1:0` bind).
+- `SqliteBackend::new(path)` embedded constructor returning
+  `Result<Arc<Self>, BackendError>`.
+- `BackendError::RequiresDevMode` variant (RFC-023 §4.5). Render
+  text matches the server-path §3.3 text (docs URL included).
+- `ServerError::SqliteRequiresDevMode(BackendError)` variant
+  wrapping the embedded-path refusal.
+- `FF_BACKEND=sqlite`, `FF_SQLITE_PATH`, `FF_SQLITE_POOL_SIZE`, and
+  `FF_DEV_MODE` env vars on `ServerConfig::from_env`. README +
+  rustdoc env tables updated.
+- CI cell (`cargo check -p ff-sdk --no-default-features --features
+  sqlite`) — mechanical regression guard for the RFC-023 Phase 1a
+  worker.rs cfg-gate discipline.
+
+### Changed
+
+- **`ServerError` is now `#[non_exhaustive]`** (RFC-023 §8 minor
+  break). Consumers with exhaustive matches must add a wildcard
+  arm.
+- **`ServerConfig` is now `#[non_exhaustive]`** (RFC-023 §8 minor
+  break) + gained a `sqlite: SqliteServerConfig` field. Struct-
+  literal consumers migrate to `ServerConfig::from_env()`,
+  `ServerConfig::sqlite_dev()`, or mutation from
+  `ServerConfig::default()`.
+- **`ff_sdk::FlowFabricWorker` surface under `--no-default-features,
+  features = ["sqlite"]`** (RFC-023 §4.4 item 10). The
+  `ff_sdk::worker` module is no longer gated on `valkey-default`;
+  `FlowFabricWorker::connect_with(config, backend, completion)` is
+  always reachable and no longer dials Valkey internally (no PING,
+  no alive-key SET-NX, no `ff:config:partitions` HGETALL).
+  Valkey-specific methods — `connect`, `claim_next`,
+  `claim_execution`, `claim_from_grant`, `claim_via_server`,
+  `claim_from_reclaim_grant`, `claim_resumed_execution`,
+  `read_execution_context`, `deliver_signal` — are now
+  `#[cfg(feature = "valkey-default")]` and ABSENT under
+  sqlite-only features. A backend-agnostic SDK claim/signal loop
+  is deferred to a future RFC. The embedded `ferriskey::Client`
+  field is `Option<Client>`; populated by `connect`, left `None`
+  by `connect_with`.
+
 ## [0.11.0] - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,11 +1015,9 @@ name = "ff-backend-sqlite"
 version = "0.11.0"
 dependencies = [
  "async-trait",
- "bytes",
  "ff-core",
  "serial_test",
  "sqlx",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff-backend-sqlite"
+version = "0.11.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "ff-core",
+ "serial_test",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ff-backend-valkey"
 version = "0.11.0"
 dependencies = [
@@ -1136,6 +1150,7 @@ version = "0.11.0"
 dependencies = [
  "async-trait",
  "ferriskey",
+ "ff-backend-sqlite",
  "ff-backend-valkey",
  "ff-core",
  "ff-script",
@@ -1156,6 +1171,7 @@ dependencies = [
  "axum",
  "ferriskey",
  "ff-backend-postgres",
+ "ff-backend-sqlite",
  "ff-backend-valkey",
  "ff-core",
  "ff-engine",
@@ -1999,6 +2015,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/ff-readiness-tests",
     "crates/ff-backend-valkey",
     "crates/ff-backend-postgres",
+    "crates/ff-backend-sqlite",
     "crates/ff-observability",
     "crates/ff-observability-http",
     "crates/flowfabric",
@@ -45,6 +46,7 @@ ff-server = { version = "0.11.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
 ff-backend-valkey = { version = "0.11.0", path = "crates/ff-backend-valkey" }
 ff-backend-postgres = { version = "0.11.0", path = "crates/ff-backend-postgres" }
+ff-backend-sqlite = { version = "0.11.0", path = "crates/ff-backend-sqlite" }
 ff-observability = { version = "0.11.0", path = "crates/ff-observability" }
 ff-observability-http = { version = "0.11.0", path = "crates/ff-observability-http" }
 ferriskey = { version = "0.11.0", path = "ferriskey" }

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -32,8 +32,6 @@ sqlx = { workspace = true, features = ["sqlite", "runtime-tokio", "macros", "mig
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
-thiserror = { workspace = true }
-bytes = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "ff-backend-sqlite"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "FlowFabric EngineBackend impl — SQLite dev-only backend (RFC-023, Phase 1a scaffold)"
+
+[features]
+# Mirror ff-core / ff-backend-postgres feature topology so method-gate
+# `#[cfg]`s line up with the trait surface.
+default = ["core", "streaming"]
+core = ["ff-core/core"]
+streaming = ["ff-core/streaming"]
+
+[dependencies]
+# Phase 1a: ff-core features match ff-backend-postgres so the SQLite
+# impl honours the same `EngineBackend` method surface. Trait impl
+# bodies arrive in Phase 2+; Phase 1a returns `EngineError::Unavailable`
+# from every method except `capabilities()` + `prepare()`.
+ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+
+# SQLite transport. Bundled SQLite is deliberately selected to decouple
+# the backend from the operating distro's libsqlite3 version — RFC-023
+# §7.1 owner recommendation. JSON1 + RETURNING (>= 3.35) rely on this.
+sqlx = { workspace = true, features = ["sqlite", "runtime-tokio", "macros", "migrate", "json", "chrono", "uuid"] }
+
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+# Env-var isolation across the two test files (`guard.rs` +
+# `capabilities.rs`): SQLite tests read `FF_DEV_MODE` from the process
+# environment, and `cargo test` runs per-binary tests in parallel by
+# default. `serial_test` enforces per-`#[serial]` ordering.
+serial_test = "3"

--- a/crates/ff-backend-sqlite/migrations/.sqlite-skip
+++ b/crates/ff-backend-sqlite/migrations/.sqlite-skip
@@ -1,0 +1,9 @@
+# RFC-023 §4.1 parity-drift lint sidecar. Phase 1a lands no migrations
+# (the first real entries arrive in Phase 1b, which ports the 14 PG
+# migrations). The `.sqlite-skip` format is documented in RFC-023
+# §4.1: one relative path per line pointing at the PG migration
+# intentionally skipped, `#` comments, inline `# issue:NNN` suffix for
+# tracking.
+#
+# Phase 1a intentionally has NO entries — the lint (also Phase 1b)
+# will first run against a populated migrations directory.

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -69,6 +69,21 @@ pub(crate) struct SqliteBackendInner {
     /// today the `Weak` entries decay naturally.
     #[allow(dead_code)]
     pub(crate) key: PathBuf,
+    /// Sentinel connection for shared-cache `:memory:` databases.
+    /// SQLite drops a shared-cache in-memory DB the moment the last
+    /// connection referencing it closes; the pool recycles idle
+    /// connections, so without a pinned sentinel the schema + data
+    /// would silently reset between pool checkouts. `None` for
+    /// filesystem-backed databases where the file itself is the
+    /// durable backing store.
+    ///
+    /// Held in a `Mutex` so `Drop` can take ownership — sqlx's
+    /// `SqliteConnection::close` is async + consumes `self`, but we
+    /// don't need graceful close here: process exit drops the
+    /// in-memory DB regardless. Presence alone is what keeps the
+    /// shared cache alive.
+    #[allow(dead_code)]
+    pub(crate) memory_sentinel: Option<std::sync::Mutex<Option<sqlx::SqliteConnection>>>,
 }
 
 /// RFC-023 SQLite dev-only backend.
@@ -94,6 +109,12 @@ impl SqliteBackend {
     /// path, `:memory:`, or a `file:...?mode=memory&cache=shared`
     /// URI.
     ///
+    /// Uses the [`SqliteServerConfig`] defaults (pool size 4, WAL on
+    /// for file paths). For operator-tuned pool/WAL settings, call
+    /// [`SqliteBackend::new_with_config`].
+    ///
+    /// [`SqliteServerConfig`]: ff_server::config::SqliteServerConfig
+    ///
     /// # Errors
     ///
     /// * [`BackendError::RequiresDevMode`] when `FF_DEV_MODE` is
@@ -102,17 +123,22 @@ impl SqliteBackend {
     ///   is backend-agnostic despite the variant name) when the
     ///   pool cannot be constructed.
     pub async fn new(path: &str) -> Result<Arc<Self>, BackendError> {
+        Self::new_with_tuning(path, 4, true).await
+    }
+
+    /// Operator-tuned entry point. `pool_size` sets the pool's max
+    /// connections; `wal_mode` enables `PRAGMA journal_mode=WAL` for
+    /// filesystem-backed databases (ignored for `:memory:` variants
+    /// per RFC-023 §4.6).
+    pub async fn new_with_tuning(
+        path: &str,
+        pool_size: u32,
+        wal_mode: bool,
+    ) -> Result<Arc<Self>, BackendError> {
         // §4.5 production guard — TYPE-level emission point (§3.3 A3).
         if std::env::var("FF_DEV_MODE").as_deref() != Ok("1") {
             return Err(BackendError::RequiresDevMode);
         }
-
-        // §3.3 WARN banner — emits on every successful construction.
-        tracing::warn!(
-            "FlowFabric SQLite backend active (FF_DEV_MODE=1). \
-             This backend is dev-only; single-writer, single-process, \
-             not supported in production. See RFC-023."
-        );
 
         // §4.2 B6: canonicalize the key. `:memory:` and
         // `file::memory:...` pass through verbatim (distinct per-URI
@@ -120,20 +146,37 @@ impl SqliteBackend {
         // `fs::canonicalize` when the file exists; absent files fall
         // back to the raw path so two concurrent constructions before
         // file creation still dedup.
-        let key = if path == ":memory:" || path.starts_with("file::memory:") {
-            PathBuf::from(path)
+        //
+        // F1: bare `:memory:` is rewritten to
+        // `file::memory:?cache=shared&uri=true` so a multi-connection
+        // pool shares ONE in-memory database. Without this rewrite,
+        // each pool connection opens its own private DB and tests see
+        // schema mismatches silently.
+        let is_memory =
+            path == ":memory:" || path.starts_with("file::memory:");
+        let effective_path: std::borrow::Cow<'_, str> = if path == ":memory:" {
+            std::borrow::Cow::Borrowed("file::memory:?cache=shared")
+        } else {
+            std::borrow::Cow::Borrowed(path)
+        };
+
+        let key = if is_memory {
+            PathBuf::from(effective_path.as_ref())
         } else {
             std::fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
         };
 
         if let Some(existing) = registry::lookup(&key) {
+            // F6: emit WARN only on first-time construction. Registry
+            // hits are dedup clones; operators already saw the banner
+            // when the original handle was built.
             return Ok(Arc::new(Self { inner: existing }));
         }
 
         // Build the pool. sqlx's SqliteConnectOptions parses the full
         // URI form as well as plain paths. `create_if_missing` is
         // what embedded-test consumers expect.
-        let opts: SqliteConnectOptions = path
+        let opts: SqliteConnectOptions = effective_path
             .parse::<SqliteConnectOptions>()
             .map_err(|e| BackendError::Valkey {
                 kind: ff_core::engine_error::BackendErrorKind::Protocol,
@@ -141,14 +184,52 @@ impl SqliteBackend {
             })?
             .create_if_missing(true);
 
+        // F2: apply WAL for filesystem-backed DBs only. SQLite's WAL
+        // is a no-op (and warns) for `:memory:` variants per RFC §4.6.
+        let opts = if wal_mode && !is_memory {
+            opts.journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+        } else {
+            opts
+        };
+
+        // F2: pool size from config, default 4. Minimum 1 — sqlx
+        // rejects 0 at pool-build time anyway.
+        let pool_max = pool_size.max(1);
         let pool = SqlitePoolOptions::new()
-            .max_connections(4)
-            .connect_with(opts)
+            .max_connections(pool_max)
+            .connect_with(opts.clone())
             .await
             .map_err(|e| BackendError::Valkey {
                 kind: ff_core::engine_error::BackendErrorKind::Transport,
                 message: format!("sqlite pool connect for {path:?}: {e}"),
             })?;
+
+        // F1: for shared-cache `:memory:` DBs, open a standalone
+        // sentinel connection and hold it for the `Arc`'s lifetime.
+        // The shared cache is torn down the moment the last connection
+        // closes; without the sentinel, a pool-idle cycle (all 4
+        // connections temporarily returned) would drop the DB between
+        // test assertions.
+        let memory_sentinel = if is_memory {
+            use sqlx::ConnectOptions;
+            let conn = opts.connect().await.map_err(|e| BackendError::Valkey {
+                kind: ff_core::engine_error::BackendErrorKind::Transport,
+                message: format!(
+                    "sqlite sentinel connect for {path:?}: {e}"
+                ),
+            })?;
+            Some(std::sync::Mutex::new(Some(conn)))
+        } else {
+            None
+        };
+
+        // F6: §3.3 WARN banner — now emitted AFTER registry-miss is
+        // confirmed so dedup clones don't spam the log.
+        tracing::warn!(
+            "FlowFabric SQLite backend active (FF_DEV_MODE=1). \
+             This backend is dev-only; single-writer, single-process, \
+             not supported in production. See RFC-023."
+        );
 
         // Phase 1a: no migrations to apply — the migrations directory
         // is an empty placeholder with a `.sqlite-skip` tombstone.
@@ -159,6 +240,7 @@ impl SqliteBackend {
             pool,
             pubsub: PubSub::new(),
             key: key.clone(),
+            memory_sentinel,
         });
         let inner = registry::insert(key, inner);
         Ok(Arc::new(Self { inner }))
@@ -168,6 +250,15 @@ impl SqliteBackend {
     /// without re-routing through the trait surface.
     #[allow(dead_code)]
     pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.inner.pool
+    }
+
+    /// Test-only pool accessor. Hidden from rustdoc; not a stable
+    /// API. Exists so the in-crate integration tests can verify
+    /// pool-level behaviour (F1 shared-cache sentinel) without
+    /// waiting for Phase 2 data-plane methods to land.
+    #[doc(hidden)]
+    pub fn pool_for_test(&self) -> &SqlitePool {
         &self.inner.pool
     }
 }

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -1,0 +1,461 @@
+//! `SqliteBackend` — RFC-023 dev-only SQLite [`EngineBackend`] impl.
+//!
+//! Phase 1a lands the scaffolding: construction guard, registry
+//! dedup, pool setup, WARN banner, and Unavailable stubs for every
+//! required trait method. Phase 2+ progressively replaces the stubs
+//! with real bodies paralleling `ff-backend-postgres`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::SqlitePool;
+
+use ff_core::backend::{
+    AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
+    FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
+    ReclaimToken, ResumeSignal, UsageDimensions,
+};
+use ff_core::capability::{BackendIdentity, Capabilities, Supports, Version};
+#[cfg(feature = "core")]
+use ff_core::contracts::{
+    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
+    DeliverSignalResult, EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot, ListExecutionsPage,
+    ListFlowsPage, ListLanesPage, ListSuspendedPage, SetEdgeGroupPolicyResult,
+};
+use ff_core::contracts::{
+    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult, SuspendArgs,
+    SuspendOutcome,
+};
+#[cfg(feature = "streaming")]
+use ff_core::contracts::{StreamCursor, StreamFrames};
+use ff_core::backend::PrepareOutcome;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{BackendError, EngineError};
+#[cfg(feature = "core")]
+use ff_core::partition::PartitionKey;
+#[cfg(feature = "streaming")]
+use ff_core::types::AttemptIndex;
+#[cfg(feature = "core")]
+use ff_core::types::EdgeId;
+use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
+
+use crate::pubsub::PubSub;
+use crate::registry;
+
+/// Phase-1a-wide `Unavailable` helper. Each stubbed method names
+/// itself here so call-site errors carry a stable identifier.
+#[inline]
+fn unavailable<T>(op: &'static str) -> Result<T, EngineError> {
+    Err(EngineError::Unavailable { op })
+}
+
+/// Internal shared state. `Arc<SqliteBackendInner>` is what the
+/// registry stores weak references to and what `SqliteBackend`
+/// wraps.
+pub(crate) struct SqliteBackendInner {
+    /// Connection pool. Held live even when the trait-object surface
+    /// isn't exercising it so Phase 2+ can migrate bodies without
+    /// re-plumbing construction.
+    #[allow(dead_code)]
+    pub(crate) pool: SqlitePool,
+    /// Per-backend wakeup channels (Phase 3 wiring).
+    #[allow(dead_code)]
+    pub(crate) pubsub: PubSub,
+    /// Registry key (canonical path or verbatim `:memory:` URI).
+    /// Held for Drop-time cleanup if we need it in a future phase;
+    /// today the `Weak` entries decay naturally.
+    #[allow(dead_code)]
+    pub(crate) key: PathBuf,
+}
+
+/// RFC-023 SQLite dev-only backend.
+///
+/// Construction demands `FF_DEV_MODE=1` (§4.5). Identical paths
+/// within a process return the same handle via the §4.2 B6
+/// registry.
+#[derive(Clone)]
+pub struct SqliteBackend {
+    inner: Arc<SqliteBackendInner>,
+}
+
+impl std::fmt::Debug for SqliteBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteBackend")
+            .field("key", &self.inner.key)
+            .finish()
+    }
+}
+
+impl SqliteBackend {
+    /// RFC-023 Phase 1a entry point. `path` accepts a filesystem
+    /// path, `:memory:`, or a `file:...?mode=memory&cache=shared`
+    /// URI.
+    ///
+    /// # Errors
+    ///
+    /// * [`BackendError::RequiresDevMode`] when `FF_DEV_MODE` is
+    ///   unset or not `"1"`.
+    /// * [`BackendError::Valkey`] (historical name — the classifier
+    ///   is backend-agnostic despite the variant name) when the
+    ///   pool cannot be constructed.
+    pub async fn new(path: &str) -> Result<Arc<Self>, BackendError> {
+        // §4.5 production guard — TYPE-level emission point (§3.3 A3).
+        if std::env::var("FF_DEV_MODE").as_deref() != Ok("1") {
+            return Err(BackendError::RequiresDevMode);
+        }
+
+        // §3.3 WARN banner — emits on every successful construction.
+        tracing::warn!(
+            "FlowFabric SQLite backend active (FF_DEV_MODE=1). \
+             This backend is dev-only; single-writer, single-process, \
+             not supported in production. See RFC-023."
+        );
+
+        // §4.2 B6: canonicalize the key. `:memory:` and
+        // `file::memory:...` pass through verbatim (distinct per-URI
+        // entries via embedded UUIDs). Filesystem paths resolve via
+        // `fs::canonicalize` when the file exists; absent files fall
+        // back to the raw path so two concurrent constructions before
+        // file creation still dedup.
+        let key = if path == ":memory:" || path.starts_with("file::memory:") {
+            PathBuf::from(path)
+        } else {
+            std::fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
+        };
+
+        if let Some(existing) = registry::lookup(&key) {
+            return Ok(Arc::new(Self { inner: existing }));
+        }
+
+        // Build the pool. sqlx's SqliteConnectOptions parses the full
+        // URI form as well as plain paths. `create_if_missing` is
+        // what embedded-test consumers expect.
+        let opts: SqliteConnectOptions = path
+            .parse::<SqliteConnectOptions>()
+            .map_err(|e| BackendError::Valkey {
+                kind: ff_core::engine_error::BackendErrorKind::Protocol,
+                message: format!("sqlite connect-opts parse for {path:?}: {e}"),
+            })?
+            .create_if_missing(true);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect_with(opts)
+            .await
+            .map_err(|e| BackendError::Valkey {
+                kind: ff_core::engine_error::BackendErrorKind::Transport,
+                message: format!("sqlite pool connect for {path:?}: {e}"),
+            })?;
+
+        // Phase 1a: no migrations to apply — the migrations directory
+        // is an empty placeholder with a `.sqlite-skip` tombstone.
+        // Phase 1b lands `sqlx::migrate!("./migrations").run(&pool)`
+        // alongside the first real migration file.
+
+        let inner = Arc::new(SqliteBackendInner {
+            pool,
+            pubsub: PubSub::new(),
+            key: key.clone(),
+        });
+        let inner = registry::insert(key, inner);
+        Ok(Arc::new(Self { inner }))
+    }
+
+    /// Accessor for Phase 2+ code that needs direct pool access
+    /// without re-routing through the trait surface.
+    #[allow(dead_code)]
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.inner.pool
+    }
+}
+
+#[async_trait]
+impl EngineBackend for SqliteBackend {
+    // ── Claim + lifecycle ──
+
+    async fn claim(
+        &self,
+        _lane: &LaneId,
+        _capabilities: &CapabilitySet,
+        _policy: ClaimPolicy,
+    ) -> Result<Option<Handle>, EngineError> {
+        unavailable("sqlite.claim")
+    }
+
+    async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+        unavailable("sqlite.renew")
+    }
+
+    async fn progress(
+        &self,
+        _handle: &Handle,
+        _percent: Option<u8>,
+        _message: Option<String>,
+    ) -> Result<(), EngineError> {
+        unavailable("sqlite.progress")
+    }
+
+    async fn append_frame(
+        &self,
+        _handle: &Handle,
+        _frame: Frame,
+    ) -> Result<AppendFrameOutcome, EngineError> {
+        unavailable("sqlite.append_frame")
+    }
+
+    async fn complete(
+        &self,
+        _handle: &Handle,
+        _payload: Option<Vec<u8>>,
+    ) -> Result<(), EngineError> {
+        unavailable("sqlite.complete")
+    }
+
+    async fn fail(
+        &self,
+        _handle: &Handle,
+        _reason: FailureReason,
+        _classification: FailureClass,
+    ) -> Result<FailOutcome, EngineError> {
+        unavailable("sqlite.fail")
+    }
+
+    async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {
+        unavailable("sqlite.cancel")
+    }
+
+    async fn suspend(
+        &self,
+        _handle: &Handle,
+        _args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        unavailable("sqlite.suspend")
+    }
+
+    async fn create_waitpoint(
+        &self,
+        _handle: &Handle,
+        _waitpoint_key: &str,
+        _expires_in: Duration,
+    ) -> Result<PendingWaitpoint, EngineError> {
+        unavailable("sqlite.create_waitpoint")
+    }
+
+    async fn observe_signals(&self, _handle: &Handle) -> Result<Vec<ResumeSignal>, EngineError> {
+        unavailable("sqlite.observe_signals")
+    }
+
+    async fn claim_from_reclaim(
+        &self,
+        _token: ReclaimToken,
+    ) -> Result<Option<Handle>, EngineError> {
+        unavailable("sqlite.claim_from_reclaim")
+    }
+
+    async fn delay(
+        &self,
+        _handle: &Handle,
+        _delay_until: TimestampMs,
+    ) -> Result<(), EngineError> {
+        unavailable("sqlite.delay")
+    }
+
+    async fn wait_children(&self, _handle: &Handle) -> Result<(), EngineError> {
+        unavailable("sqlite.wait_children")
+    }
+
+    // ── Read / admin ──
+
+    async fn describe_execution(
+        &self,
+        _id: &ExecutionId,
+    ) -> Result<Option<ExecutionSnapshot>, EngineError> {
+        unavailable("sqlite.describe_execution")
+    }
+
+    async fn describe_flow(
+        &self,
+        _id: &FlowId,
+    ) -> Result<Option<FlowSnapshot>, EngineError> {
+        unavailable("sqlite.describe_flow")
+    }
+
+    #[cfg(feature = "core")]
+    async fn list_edges(
+        &self,
+        _flow_id: &FlowId,
+        _direction: EdgeDirection,
+    ) -> Result<Vec<EdgeSnapshot>, EngineError> {
+        unavailable("sqlite.list_edges")
+    }
+
+    #[cfg(feature = "core")]
+    async fn describe_edge(
+        &self,
+        _flow_id: &FlowId,
+        _edge_id: &EdgeId,
+    ) -> Result<Option<EdgeSnapshot>, EngineError> {
+        unavailable("sqlite.describe_edge")
+    }
+
+    #[cfg(feature = "core")]
+    async fn resolve_execution_flow_id(
+        &self,
+        _eid: &ExecutionId,
+    ) -> Result<Option<FlowId>, EngineError> {
+        unavailable("sqlite.resolve_execution_flow_id")
+    }
+
+    #[cfg(feature = "core")]
+    async fn list_flows(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<FlowId>,
+        _limit: usize,
+    ) -> Result<ListFlowsPage, EngineError> {
+        unavailable("sqlite.list_flows")
+    }
+
+    #[cfg(feature = "core")]
+    async fn list_lanes(
+        &self,
+        _cursor: Option<LaneId>,
+        _limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        unavailable("sqlite.list_lanes")
+    }
+
+    #[cfg(feature = "core")]
+    async fn list_suspended(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError> {
+        unavailable("sqlite.list_suspended")
+    }
+
+    #[cfg(feature = "core")]
+    async fn list_executions(
+        &self,
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError> {
+        unavailable("sqlite.list_executions")
+    }
+
+    #[cfg(feature = "core")]
+    async fn deliver_signal(
+        &self,
+        _args: DeliverSignalArgs,
+    ) -> Result<DeliverSignalResult, EngineError> {
+        unavailable("sqlite.deliver_signal")
+    }
+
+    #[cfg(feature = "core")]
+    async fn claim_resumed_execution(
+        &self,
+        _args: ClaimResumedExecutionArgs,
+    ) -> Result<ClaimResumedExecutionResult, EngineError> {
+        unavailable("sqlite.claim_resumed_execution")
+    }
+
+    async fn cancel_flow(
+        &self,
+        _id: &FlowId,
+        _policy: CancelFlowPolicy,
+        _wait: CancelFlowWait,
+    ) -> Result<CancelFlowResult, EngineError> {
+        unavailable("sqlite.cancel_flow")
+    }
+
+    #[cfg(feature = "core")]
+    async fn set_edge_group_policy(
+        &self,
+        _flow_id: &FlowId,
+        _downstream_execution_id: &ExecutionId,
+        _policy: EdgeDependencyPolicy,
+    ) -> Result<SetEdgeGroupPolicyResult, EngineError> {
+        unavailable("sqlite.set_edge_group_policy")
+    }
+
+    async fn report_usage(
+        &self,
+        _handle: &Handle,
+        _budget: &BudgetId,
+        _dimensions: UsageDimensions,
+    ) -> Result<ReportUsageResult, EngineError> {
+        unavailable("sqlite.report_usage")
+    }
+
+    #[cfg(feature = "streaming")]
+    async fn read_stream(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _from: StreamCursor,
+        _to: StreamCursor,
+        _count_limit: u64,
+    ) -> Result<StreamFrames, EngineError> {
+        unavailable("sqlite.read_stream")
+    }
+
+    #[cfg(feature = "streaming")]
+    async fn tail_stream(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _after: StreamCursor,
+        _block_ms: u64,
+        _count_limit: u64,
+        _visibility: ff_core::backend::TailVisibility,
+    ) -> Result<StreamFrames, EngineError> {
+        unavailable("sqlite.tail_stream")
+    }
+
+    #[cfg(feature = "streaming")]
+    async fn read_summary(
+        &self,
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+    ) -> Result<Option<ff_core::backend::SummaryDocument>, EngineError> {
+        unavailable("sqlite.read_summary")
+    }
+
+    // ── RFC-018 capability discovery ──
+
+    fn backend_label(&self) -> &'static str {
+        "sqlite"
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        // RFC-023 §4.3: Phase 1a exposes only the identity tuple; real
+        // `Supports::*` flags flip at the Phase 4 release PR when trait
+        // bodies ship. Consumers seeing `supports.*` all-false under
+        // "sqlite" know to expect `Unavailable` on every data-plane
+        // call until Phase 2+ lands.
+        Capabilities::new(
+            BackendIdentity::new(
+                "sqlite",
+                Version::new(
+                    env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap_or(0),
+                    env!("CARGO_PKG_VERSION_MINOR").parse().unwrap_or(0),
+                    env!("CARGO_PKG_VERSION_PATCH").parse().unwrap_or(0),
+                ),
+                "Phase-1a",
+            ),
+            Supports::none(),
+        )
+    }
+
+    async fn prepare(&self) -> Result<PrepareOutcome, EngineError> {
+        // Phase 1a: no boot-time prep (no migrations yet). Phase 1b
+        // applies the migrations inside `SqliteBackend::new` itself
+        // rather than here, matching the PG posture.
+        Ok(PrepareOutcome::NoOp)
+    }
+}

--- a/crates/ff-backend-sqlite/src/config.rs
+++ b/crates/ff-backend-sqlite/src/config.rs
@@ -1,0 +1,5 @@
+//! Internal crate config — the public consumer-facing
+//! `ff_server::config::SqliteServerConfig` lives in `ff-server`.
+//! Phase 1a holds this module empty; Phase 2 introduces backend-
+//! internal pool tuning knobs here if needed (separate from the
+//! operator-facing `SqliteServerConfig`).

--- a/crates/ff-backend-sqlite/src/errors.rs
+++ b/crates/ff-backend-sqlite/src/errors.rs
@@ -1,0 +1,40 @@
+//! SQLite error classification — paralleling
+//! `ff-backend-postgres::is_retryable_serialization`.
+//!
+//! RFC-023 §4.3: `SQLITE_BUSY` / `SQLITE_BUSY_TIMEOUT` / `SQLITE_LOCKED`
+//! map to retry. Non-retryable kinds (`SQLITE_CORRUPT`, `SQLITE_FULL`,
+//! etc.) surface as hard errors. Phase 1a lands the skeleton; Wave 9
+//! SERIALIZABLE ops wrap it once real impls exist.
+
+#[cfg(test)]
+use sqlx::error::Error as SqlxError;
+
+/// Return `true` when the sqlx error is a transient busy-contention
+/// fault that is safe to retry. Mirrors the shape of PG's
+/// `is_retryable_serialization` classifier.
+///
+/// Phase 1a exposes the classifier as a skeleton; real usage lands
+/// alongside Wave 9 SERIALIZABLE ops in Phase 2+.
+#[allow(dead_code)] // Phase 1a skeleton — wired in Phase 2+.
+pub fn is_retryable_sqlite_busy(err: &sqlx::Error) -> bool {
+    if let sqlx::Error::Database(db_err) = err {
+        // sqlx's SQLite driver surfaces extended result codes via the
+        // `code()` accessor. The three SQLITE_BUSY / SQLITE_LOCKED
+        // families are decimal 5 and 6 in the base result codes.
+        if let Some(code) = db_err.code() {
+            return matches!(code.as_ref(), "5" | "6" | "517" | "261");
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_db_error_is_not_retryable() {
+        let err = SqlxError::RowNotFound;
+        assert!(!is_retryable_sqlite_busy(&err));
+    }
+}

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -1,0 +1,36 @@
+//! `EngineBackend` implementation backed by SQLite — **dev-only**
+//! per RFC-023.
+//!
+//! # Phase 1a scope
+//!
+//! This crate is the RFC-023 Phase 1a scaffold: construction
+//! semantics (`FF_DEV_MODE=1` guard, per-path registry, connection
+//! pool, WARN banner), the SQLite transient-busy error classifier
+//! skeleton, and an [`EngineBackend`](ff_core::engine_backend::EngineBackend)
+//! impl whose data-plane methods return
+//! [`EngineError::Unavailable`](ff_core::engine_error::EngineError::Unavailable).
+//! Phase 1b lands the hand-ported SQLite-dialect migrations;
+//! Phase 2+ replaces the Unavailable stubs with real bodies
+//! paralleling `ff-backend-postgres`.
+//!
+//! # Production guard
+//!
+//! [`SqliteBackend::new`] refuses to construct without
+//! `FF_DEV_MODE=1` in the process environment. The refusal is on
+//! the TYPE (RFC-023 §3.3 A3 / §4.5) so every path — embedded
+//! library consumers, `ff_server::start_sqlite_branch`, and
+//! `ff_sdk::FlowFabricWorker::connect_with` — pays the guard.
+//!
+//! No ferriskey dep — this crate's transport is `sqlx`.
+
+#![allow(clippy::result_large_err)]
+
+mod backend;
+mod config;
+mod errors;
+mod pubsub;
+mod registry;
+
+pub use backend::SqliteBackend;
+#[allow(unused_imports)] // Phase 1a: not yet used outside the crate.
+pub(crate) use errors::is_retryable_sqlite_busy;

--- a/crates/ff-backend-sqlite/src/pubsub.rs
+++ b/crates/ff-backend-sqlite/src/pubsub.rs
@@ -1,0 +1,42 @@
+//! In-process pub/sub scaffolding (RFC-023 §4.2).
+//!
+//! Phase 1a lands the empty broadcast-channel struct. Phase 3 wires
+//! up the outbox-inside-tx + broadcast-as-wakeup pattern per §4.2
+//! A2.
+
+use tokio::sync::broadcast;
+
+/// Placeholder capacity for the broadcast channels. Tuned in Phase 3
+/// when real producers + consumers arrive.
+const DEFAULT_CAPACITY: usize = 256;
+
+/// Per-backend in-process wakeup channels. One broadcast channel per
+/// RFC-019 subscription family; Phase 3 populates the `Sender` halves
+/// inside `SqliteBackendInner` and consumers on the subscribe side
+/// hold `Receiver` handles.
+#[allow(dead_code)] // Phase 1a scaffolding — handed to Phase 3.
+pub(crate) struct PubSub {
+    pub(crate) lease_history: broadcast::Sender<()>,
+    pub(crate) completion: broadcast::Sender<()>,
+    pub(crate) signal_delivery: broadcast::Sender<()>,
+}
+
+impl PubSub {
+    #[allow(dead_code)] // Phase 1a scaffolding — handed to Phase 3.
+    pub(crate) fn new() -> Self {
+        let (lease_history, _) = broadcast::channel(DEFAULT_CAPACITY);
+        let (completion, _) = broadcast::channel(DEFAULT_CAPACITY);
+        let (signal_delivery, _) = broadcast::channel(DEFAULT_CAPACITY);
+        Self {
+            lease_history,
+            completion,
+            signal_delivery,
+        }
+    }
+}
+
+impl Default for PubSub {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/ff-backend-sqlite/src/registry.rs
+++ b/crates/ff-backend-sqlite/src/registry.rs
@@ -1,0 +1,51 @@
+//! Process-local `SqliteBackend` registry (RFC-023 §4.2 B6).
+//!
+//! Enforces the "one `SqliteBackend` per file-path per process"
+//! invariant: multiple `SqliteBackend::new(path)` calls to the same
+//! canonicalized path return `Arc`-clones of the same underlying
+//! handle so broadcast channels + in-proc pub-sub stay consistent.
+//! Distinct `:memory:` URIs (which embed per-call UUIDs) get distinct
+//! entries by construction.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use crate::backend::SqliteBackendInner;
+
+/// Global registry of live SQLite backends keyed by canonical path
+/// (or the verbatim `:memory:` / `file::memory:...` URI when
+/// canonicalization is skipped).
+static REGISTRY: OnceLock<Mutex<HashMap<PathBuf, Weak<SqliteBackendInner>>>> =
+    OnceLock::new();
+
+fn registry() -> &'static Mutex<HashMap<PathBuf, Weak<SqliteBackendInner>>> {
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Look up an existing backend by key. Returns `Some(clone)` when a
+/// live entry exists; `None` when absent or the weak handle has
+/// decayed.
+pub(crate) fn lookup(key: &PathBuf) -> Option<Arc<SqliteBackendInner>> {
+    let guard = registry().lock().ok()?;
+    guard.get(key).and_then(Weak::upgrade)
+}
+
+/// Install a new backend in the registry. Idempotent under the
+/// key-present-live branch: if another thread installed between
+/// `lookup` and `insert`, returns the existing entry instead of
+/// overwriting.
+pub(crate) fn insert(
+    key: PathBuf,
+    inner: Arc<SqliteBackendInner>,
+) -> Arc<SqliteBackendInner> {
+    let mut guard = match registry().lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if let Some(existing) = guard.get(&key).and_then(Weak::upgrade) {
+        return existing;
+    }
+    guard.insert(key, Arc::downgrade(&inner));
+    inner
+}

--- a/crates/ff-backend-sqlite/src/registry.rs
+++ b/crates/ff-backend-sqlite/src/registry.rs
@@ -23,11 +23,24 @@ fn registry() -> &'static Mutex<HashMap<PathBuf, Weak<SqliteBackendInner>>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Poison policy: `lookup` and `insert` both recover from a
+/// poisoned lock rather than surfacing the poison. A panic in one
+/// dedup user should NOT silently disable dedup for the rest of
+/// the process — that would let a second backend spin up on the
+/// same path, defeating the §4.2 B6 invariant. Recovery is safe
+/// here because the map's own invariants (key→weak) don't depend
+/// on the panicked code path.
+fn lock_registry() -> std::sync::MutexGuard<'static, HashMap<PathBuf, Weak<SqliteBackendInner>>> {
+    registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Look up an existing backend by key. Returns `Some(clone)` when a
 /// live entry exists; `None` when absent or the weak handle has
 /// decayed.
 pub(crate) fn lookup(key: &PathBuf) -> Option<Arc<SqliteBackendInner>> {
-    let guard = registry().lock().ok()?;
+    let guard = lock_registry();
     guard.get(key).and_then(Weak::upgrade)
 }
 
@@ -39,10 +52,7 @@ pub(crate) fn insert(
     key: PathBuf,
     inner: Arc<SqliteBackendInner>,
 ) -> Arc<SqliteBackendInner> {
-    let mut guard = match registry().lock() {
-        Ok(g) => g,
-        Err(poisoned) => poisoned.into_inner(),
-    };
+    let mut guard = lock_registry();
     if let Some(existing) = guard.get(&key).and_then(Weak::upgrade) {
         return existing;
     }

--- a/crates/ff-backend-sqlite/tests/capabilities.rs
+++ b/crates/ff-backend-sqlite/tests/capabilities.rs
@@ -1,0 +1,34 @@
+//! RFC-023 §4.3 / §9 capability-matrix snapshot — Phase 1a subset.
+//!
+//! Phase 1a asserts that `capabilities()` reports
+//! `identity.family == "sqlite"` and every `Supports::*` flag is
+//! `false`. Phase 4 release PR flips the flags in lockstep with
+//! trait body landings.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::engine_backend::EngineBackend;
+use serial_test::serial;
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn capabilities_identity_and_supports() {
+    // SAFETY: test-only env mutation; `serial_test` serialises across
+    // the `ff_dev_mode` key so no other test races this.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let backend = SqliteBackend::new(":memory:")
+        .await
+        .expect("sqlite init under FF_DEV_MODE=1");
+
+    let caps = backend.capabilities();
+    assert_eq!(caps.identity.family, "sqlite");
+    // Phase 1a rfc017_stage label.
+    assert_eq!(caps.identity.rfc017_stage, "Phase-1a");
+
+    // Every support flag must be false at Phase 1a — Phase 4 flips
+    // them when trait bodies ship.
+    assert_eq!(caps.supports, ff_core::capability::Supports::none());
+
+    assert_eq!(backend.backend_label(), "sqlite");
+}

--- a/crates/ff-backend-sqlite/tests/guard.rs
+++ b/crates/ff-backend-sqlite/tests/guard.rs
@@ -65,6 +65,43 @@ async fn two_news_same_path_share_handle() {
     assert_eq!(b.backend_label(), "sqlite");
 }
 
+/// F1 regression: a bare `:memory:` path is rewritten to a shared-
+/// cache URI internally and a sentinel connection is held, so data
+/// written through one pool connection survives a pool idle cycle
+/// and is visible to subsequent checkouts.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn memory_shared_cache_survives_pool_cycle() {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let backend = SqliteBackend::new_with_tuning(":memory:", 4, true)
+        .await
+        .expect("construct");
+    let pool = backend.pool_for_test();
+
+    // Write on one connection, drop it, read on a fresh connection.
+    sqlx::query("CREATE TABLE f1 (v INTEGER)")
+        .execute(pool)
+        .await
+        .expect("create");
+    sqlx::query("INSERT INTO f1 VALUES (42)")
+        .execute(pool)
+        .await
+        .expect("insert");
+
+    // Force pool churn: acquire + drop several times.
+    for _ in 0..8 {
+        let _c = pool.acquire().await.expect("acquire");
+    }
+
+    let v: (i64,) = sqlx::query_as("SELECT v FROM f1")
+        .fetch_one(pool)
+        .await
+        .expect("select");
+    assert_eq!(v.0, 42);
+}
+
 #[tokio::test]
 #[serial(ff_dev_mode)]
 async fn distinct_memory_uris_are_distinct() {

--- a/crates/ff-backend-sqlite/tests/guard.rs
+++ b/crates/ff-backend-sqlite/tests/guard.rs
@@ -1,0 +1,86 @@
+//! RFC-023 §4.5 production-guard tests + §4.2 B6 registry-dedup test.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::engine_error::BackendError;
+use serial_test::serial;
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn refuses_without_ff_dev_mode() {
+    // SAFETY: test-only env mutation; `serial_test` key prevents
+    // races with sibling env-reading tests.
+    unsafe {
+        std::env::remove_var("FF_DEV_MODE");
+    }
+    let err = SqliteBackend::new(":memory:")
+        .await
+        .expect_err("must refuse without FF_DEV_MODE");
+
+    assert!(matches!(err, BackendError::RequiresDevMode));
+    // Exact message parity with RFC-023 §4.5 B2.
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("SqliteBackend requires FF_DEV_MODE=1"),
+        "unexpected render: {rendered}"
+    );
+    assert!(
+        rendered.contains("docs/dev-harness.md"),
+        "render missing docs URL: {rendered}"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn accepts_with_ff_dev_mode() {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let _backend = SqliteBackend::new(":memory:")
+        .await
+        .expect("must accept under FF_DEV_MODE=1");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn two_news_same_path_share_handle() {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    // Same URI → both calls must return the same underlying inner.
+    // We fingerprint via `Arc::strong_count` on a known-shared field.
+    let uri = "file:rfc-023-dedup?mode=memory&cache=shared";
+    let a = SqliteBackend::new(uri).await.expect("a");
+    let b = SqliteBackend::new(uri).await.expect("b");
+    // `SqliteBackend::clone` is `Arc`-cheap; two `new()` calls that
+    // share `inner` are not the same *outer* `Arc<SqliteBackend>`
+    // (each gets its own outer wrapper) but both wrappers must
+    // point at the same inner allocation. We verify by dropping one
+    // and confirming the other still works (i.e. registry keeps the
+    // inner alive only so long as at least one outer holds it).
+    drop(a);
+    // If `b` lost its inner, the drop above would have closed the
+    // pool. A trivial trait call that doesn't hit the data plane is
+    // enough to confirm the `Arc` is live.
+    use ff_core::engine_backend::EngineBackend;
+    assert_eq!(b.backend_label(), "sqlite");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn distinct_memory_uris_are_distinct() {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    // Fresh UUIDs per URI — registry must keep them distinct.
+    let a = SqliteBackend::new("file:rfc-023-dist-a?mode=memory&cache=shared")
+        .await
+        .expect("a");
+    let b = SqliteBackend::new("file:rfc-023-dist-b?mode=memory&cache=shared")
+        .await
+        .expect("b");
+    // Both must work independently. The registry entries are
+    // key-distinct, so dropping one must not affect the other.
+    drop(a);
+    use ff_core::engine_backend::EngineBackend;
+    assert_eq!(b.backend_label(), "sqlite");
+}

--- a/crates/ff-core/src/engine_error.rs
+++ b/crates/ff-core/src/engine_error.rs
@@ -508,11 +508,16 @@ pub enum BackendError {
 }
 
 impl BackendError {
-    /// Returns the classified backend kind if this error is a Valkey
-    /// transport fault. Forward-compatible with future backends:
-    /// non-Valkey variants return `None` on a call that names only the
-    /// Valkey kind; code that wants a backend-specific view should
-    /// match directly on [`BackendError`].
+    /// Returns the classified backend kind.
+    ///
+    /// Every variant maps to a [`BackendErrorKind`] — transport
+    /// variants return their carried `kind`, configuration/guard
+    /// variants return the closest-fitting classification (e.g.
+    /// [`BackendError::RequiresDevMode`] → [`BackendErrorKind::Protocol`]
+    /// because it is a configuration refusal, not a retryable
+    /// transport fault). Consumers needing to distinguish the
+    /// underlying variant should match directly on [`BackendError`];
+    /// `kind()` is the stable, classifier-only view.
     pub fn kind(&self) -> BackendErrorKind {
         match self {
             Self::Valkey { kind, .. } => *kind,

--- a/crates/ff-core/src/engine_error.rs
+++ b/crates/ff-core/src/engine_error.rs
@@ -494,6 +494,17 @@ pub enum BackendError {
         kind: BackendErrorKind,
         message: String,
     },
+
+    /// RFC-023 §4.5: the SQLite dev-only backend refused to construct
+    /// because `FF_DEV_MODE=1` was not set. Exact message text mirrors
+    /// §3.3 HTTP-path text so embedded and server paths give the same
+    /// actionable signal.
+    #[error(
+        "SqliteBackend requires FF_DEV_MODE=1 to activate. SQLite is \
+         dev-only; see https://github.com/avifenesh/FlowFabric/blob/main/docs/dev-harness.md \
+         for details."
+    )]
+    RequiresDevMode,
 }
 
 impl BackendError {
@@ -505,6 +516,9 @@ impl BackendError {
     pub fn kind(&self) -> BackendErrorKind {
         match self {
             Self::Valkey { kind, .. } => *kind,
+            // RFC-023: dev-mode guard refusal is a configuration/protocol
+            // fault, not a retryable transport condition.
+            Self::RequiresDevMode => BackendErrorKind::Protocol,
         }
     }
 
@@ -512,6 +526,11 @@ impl BackendError {
     pub fn message(&self) -> &str {
         match self {
             Self::Valkey { message, .. } => message.as_str(),
+            Self::RequiresDevMode => {
+                "SqliteBackend requires FF_DEV_MODE=1 to activate. SQLite is \
+                 dev-only; see https://github.com/avifenesh/FlowFabric/blob/main/docs/dev-harness.md \
+                 for details."
+            }
         }
     }
 }

--- a/crates/ff-readiness-tests/src/server.rs
+++ b/crates/ff-readiness-tests/src/server.rs
@@ -75,30 +75,33 @@ impl InProcessServer {
         let tls = crate::valkey::env_flag("FF_TLS");
         let cluster = crate::valkey::env_flag("FF_CLUSTER");
 
-        let config = ServerConfig {            valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: tls, cluster: cluster, skip_library_load: true },
-
-
-
-
-
+        // RFC-023 (v0.12.0): `ServerConfig` is now
+        // `#[non_exhaustive]`. Mutate in-place from `Default::default`
+        // rather than via struct literal (which is no longer permitted
+        // for non-exhaustive structs from outside the defining crate).
+        let mut config = ServerConfig::default();
+        config.valkey = ff_server::config::ValkeyServerConfig {
+            host,
+            port,
+            tls,
+            cluster,
+            skip_library_load: true,
+        };
+        config.partition_config = TEST_PARTITION_CONFIG;
+        config.lanes = vec![LaneId::new(lane)];
+        config.listen_addr = "127.0.0.1:0".into();
+        config.engine_config = ff_engine::EngineConfig {
             partition_config: TEST_PARTITION_CONFIG,
             lanes: vec![LaneId::new(lane)],
-            listen_addr: "127.0.0.1:0".into(),
-            engine_config: ff_engine::EngineConfig {
-                partition_config: TEST_PARTITION_CONFIG,
-                lanes: vec![LaneId::new(lane)],
-                ..Default::default()
-            },
-
-            cors_origins: vec!["*".to_owned()],
-            api_token: None,
-            waitpoint_hmac_secret: secret.to_owned(),
-            waitpoint_hmac_grace_ms: 86_400_000,
-            max_concurrent_stream_ops: 64,
-            backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-        
-};
+            ..Default::default()
+        };
+        config.cors_origins = vec!["*".to_owned()];
+        config.api_token = None;
+        config.waitpoint_hmac_secret = secret.to_owned();
+        config.waitpoint_hmac_grace_ms = 86_400_000;
+        config.max_concurrent_stream_ops = 64;
+        config.backend = ff_server::config::BackendKind::default();
+        config.postgres = Default::default();
 
         let server = Arc::new(Server::start(config).await.expect("Server::start"));
         let app = ff_server::api::router(server.clone(), &["*".to_owned()], None)

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -32,6 +32,15 @@ default = ["valkey-default"]
 
 direct-valkey-claim = ["valkey-default"]
 
+# RFC-023 Phase 1a (§9 CI cell): compile-only feature proving ff-sdk's
+# `FlowFabricWorker::connect_with` surface works under
+# `default-features = false, features = ["sqlite"]`. Pulls in the
+# SQLite backend crate so downstream consumers can hand its `Arc` to
+# `connect_with`. Does NOT activate the Valkey surface — the
+# `worker::connect` / claim / signal methods are `valkey-default`-gated
+# and remain absent under this feature.
+sqlite = ["dep:ff-backend-sqlite"]
+
 # Re-exports of ferriskey feature flags. Consumers opt in on ff-sdk and
 # the flag propagates to the underlying ferriskey crate. OFF by default
 # — the ~40-crate AWS dep graph does not land in builds that don't need
@@ -90,6 +99,10 @@ ff-script = { workspace = true }
 # build (`--no-default-features`) stays backend-free.
 ff-backend-valkey = { workspace = true, optional = true }
 ferriskey = { workspace = true, optional = true }
+# RFC-023 Phase 1a: optional SQLite backend edge, activated by the
+# `sqlite` feature above. Off by default so Valkey consumers pay no
+# sqlx compile cost.
+ff-backend-sqlite = { workspace = true, optional = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -103,6 +103,13 @@ pub use admin::{
     rotate_waitpoint_hmac_secret_all_partitions, FlowFabricAdminClient, PartitionRotationOutcome,
     RotateWaitpointSecretRequest, RotateWaitpointSecretResponse,
 };
+// RFC-023 Phase 1a: re-export `SqliteBackend` so consumers using
+// `ff-sdk = { default-features = false, features = ["sqlite"] }` can
+// name it as `ff_sdk::SqliteBackend` without pinning the
+// `ff-backend-sqlite` crate directly. Also keeps the dep graph
+// `ff-backend-sqlite` edge reachable from ff-sdk's public API.
+#[cfg(feature = "sqlite")]
+pub use ff_backend_sqlite::SqliteBackend;
 pub use config::WorkerConfig;
 pub use engine_error::{
     BugKind, ConflictKind, ContentionKind, EngineError, StateKind, ValidationKind,

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -90,7 +90,11 @@ pub mod layer;
 pub mod snapshot;
 #[cfg(feature = "valkey-default")]
 pub mod task;
-#[cfg(feature = "valkey-default")]
+// RFC-023 Phase 1a (§4.4 item 10): `worker` is always compiled.
+// The ferriskey-dependent methods inside it are `valkey-default`-
+// gated at the item level; the module itself no longer is, so
+// `FlowFabricWorker::connect_with` + the trait-forwarder accessors
+// are reachable under `default-features = false, features = ["sqlite"]`.
 pub mod worker;
 
 // Re-exports for convenience
@@ -145,7 +149,11 @@ pub use ff_core::contracts::{
 // scheduler is specialized and stays behind the `ff-scheduler` dep.
 pub use ff_core::backend::{ClaimPolicy, ReclaimToken};
 pub use ff_core::contracts::{ClaimGrant, ReclaimGrant};
-#[cfg(feature = "valkey-default")]
+// RFC-023 Phase 1a (§4.4 item 10): re-export always reachable. The
+// Valkey-specific methods (`connect`, `claim_*`, `deliver_signal`)
+// are item-level cfg-gated; under sqlite-only features the type
+// exposes `connect_with`, `backend`, `completion_backend`, `config`,
+// and `partition_config`.
 pub use worker::FlowFabricWorker;
 
 /// SDK error type.

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1,15 +1,23 @@
+#[cfg(feature = "valkey-default")]
 use std::collections::HashMap;
 #[cfg(feature = "direct-valkey-claim")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+// RFC-023 Phase 1a (§4.4 item 10b): ferriskey imports scoped behind
+// `valkey-default` so the module compiles under
+// `--no-default-features, features = ["sqlite"]`.
+#[cfg(feature = "valkey-default")]
 use ferriskey::{Client, Value};
+#[cfg(feature = "valkey-default")]
 use ff_core::keys::{ExecKeyContext, IndexKeys};
 use ff_core::partition::PartitionConfig;
+#[cfg(feature = "valkey-default")]
 use ff_core::types::*;
 use tokio::sync::Semaphore;
 
 use crate::config::WorkerConfig;
+#[cfg(feature = "valkey-default")]
 use crate::task::ClaimedTask;
 use crate::SdkError;
 
@@ -60,7 +68,20 @@ use crate::SdkError;
 /// }
 /// ```
 pub struct FlowFabricWorker {
-    client: Client,
+    /// RFC-023 Phase 1a (§4.4 item 10c): `ferriskey::Client` is
+    /// `valkey-default`-gated **and** `Option` wrapped. Under
+    /// sqlite-only features the field is absent. Under
+    /// `valkey-default` the field is `Some(client)` when the worker
+    /// was built via [`Self::connect`] (the Valkey-bundled entry
+    /// point that dials), and `None` when it was built via
+    /// [`Self::connect_with`] (the backend-agnostic entry point per
+    /// §4.4 item 10e — no ferriskey round-trip). Claim/signal hot
+    /// paths (all `valkey-default`-gated per §4.4 item 10f) expect
+    /// `Some`; a claim call against a `connect_with`-built worker
+    /// panics with a clear message until the backend-agnostic SDK
+    /// worker-loop RFC lands (tracked in §8).
+    #[cfg(feature = "valkey-default")]
+    client: Option<Client>,
     config: WorkerConfig,
     partition_config: PartitionConfig,
     /// Sorted, deduplicated, comma-separated capabilities — computed once
@@ -88,6 +109,7 @@ pub struct FlowFabricWorker {
     /// [`claim_next`]: FlowFabricWorker::claim_next
     /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
     /// [`claim_from_reclaim_grant`]: FlowFabricWorker::claim_from_reclaim_grant
+    #[cfg_attr(not(feature = "valkey-default"), allow(dead_code))]
     concurrency_semaphore: Arc<Semaphore>,
     /// Rolling offset for chunked partition scans. Each poll advances the
     /// cursor by `PARTITION_SCAN_CHUNK`, so over `ceil(num_partitions /
@@ -141,6 +163,29 @@ pub struct FlowFabricWorker {
 const PARTITION_SCAN_CHUNK: usize = 32;
 
 impl FlowFabricWorker {
+    /// RFC-023 Phase 1a helper: borrow the embedded `ferriskey::Client`,
+    /// panicking with a clear message if the worker was built via
+    /// [`Self::connect_with`] (which does not dial Valkey). Every
+    /// Valkey-specific claim/signal method funnels through this accessor
+    /// so the panic site is uniform and traceable.
+    ///
+    /// A backend-agnostic claim/signal API is deferred per §8 breaking-
+    /// change disclosure; until that lands, valkey-default consumers
+    /// must use [`Self::connect`] if they intend to drive the Valkey
+    /// claim/signal loop.
+    #[cfg(feature = "valkey-default")]
+    #[inline]
+    fn valkey_client(&self) -> &Client {
+        self.client.as_ref().expect(
+            "FlowFabricWorker was built via connect_with (no Valkey dial) \
+             but a Valkey-specific claim/signal method was invoked. \
+             Use FlowFabricWorker::connect to dial Valkey, or drive the \
+             backend directly through the trait surface via .backend().",
+        )
+    }
+}
+
+impl FlowFabricWorker {
     /// Connect to Valkey and prepare the worker.
     ///
     /// Establishes the ferriskey connection. Does NOT load the FlowFabric
@@ -160,6 +205,13 @@ impl FlowFabricWorker {
     /// or embed a UUID/timestamp) rather than hard-coding a stable
     /// value. Production workers that cleanly shut down release the
     /// key; only crashed / kill -9'd processes hit this trap.
+    ///
+    /// **RFC-023 Phase 1a (§4.4 item 10d, v0.12.0):** this Valkey-bundled
+    /// entry point is `#[cfg(feature = "valkey-default")]`-gated.
+    /// Consumers on the sqlite-only feature set must use
+    /// [`FlowFabricWorker::connect_with`] and drive the backend directly
+    /// through the trait surface.
+    #[cfg(feature = "valkey-default")]
     pub async fn connect(config: WorkerConfig) -> Result<Self, SdkError> {
         if config.lanes.is_empty() {
             return Err(SdkError::Config {
@@ -491,7 +543,7 @@ impl FlowFabricWorker {
         > = Some(valkey_backend);
 
         Ok(Self {
-            client,
+            client: Some(client),
             config,
             partition_config,
             #[cfg(feature = "direct-valkey-claim")]
@@ -589,10 +641,100 @@ impl FlowFabricWorker {
         backend: Arc<dyn ff_core::engine_backend::EngineBackend>,
         completion: Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>,
     ) -> Result<Self, SdkError> {
-        let mut worker = Self::connect(config).await?;
-        worker.backend = backend;
-        worker.completion_backend_handle = completion;
-        Ok(worker)
+        // RFC-023 Phase 1a (§4.4 item 10e, v0.12.0): direct
+        // backend-agnostic construction. No `Self::connect` preamble,
+        // no ferriskey round-trips (no PING, no alive-key SET-NX, no
+        // `ff:config:partitions` HGETALL). Callers needing a
+        // non-default `PartitionConfig` under non-Valkey backends use
+        // `connect` (Valkey) or override post-construction through a
+        // future `WorkerConfig` field (tracked as a v0.12.0 follow-up
+        // per §4.4 item 10e).
+        //
+        // Lane-empty validation (the one check `connect` did before
+        // any Valkey work) is hoisted here so every entry point
+        // refuses an empty lane list.
+        if config.lanes.is_empty() {
+            return Err(SdkError::Config {
+                context: "worker_config".into(),
+                field: None,
+                message: "at least one lane is required".into(),
+            });
+        }
+
+        let max_tasks = config.max_concurrent_tasks.max(1);
+        let concurrency_semaphore = Arc::new(Semaphore::new(max_tasks));
+        let partition_config = PartitionConfig::default();
+
+        #[cfg(feature = "direct-valkey-claim")]
+        let scan_cursor_init = scan_cursor_seed(
+            config.worker_instance_id.as_str(),
+            partition_config.num_flow_partitions.max(1) as usize,
+        );
+
+        // Build the capabilities CSV / hash inline for the
+        // direct-valkey-claim path. The validation mirrors `connect`'s
+        // ingress so the two entry points refuse the same malformed
+        // tokens.
+        #[cfg(feature = "direct-valkey-claim")]
+        for cap in &config.capabilities {
+            if cap.is_empty() {
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: "capability token must not be empty".into(),
+                });
+            }
+            if cap.contains(',') {
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: format!(
+                        "capability token may not contain ',' (CSV delimiter): {cap:?}"
+                    ),
+                });
+            }
+            if cap.chars().any(|c| c.is_control() || c.is_whitespace()) {
+                return Err(SdkError::Config {
+                    context: "worker_config".into(),
+                    field: Some("capabilities".into()),
+                    message: format!(
+                        "capability token must not contain whitespace or control \
+                         characters: {cap:?}"
+                    ),
+                });
+            }
+        }
+        #[cfg(feature = "direct-valkey-claim")]
+        let worker_capabilities_csv: String = {
+            let set: std::collections::BTreeSet<&str> = config
+                .capabilities
+                .iter()
+                .map(|s| s.as_str())
+                .filter(|s| !s.is_empty())
+                .collect();
+            set.into_iter().collect::<Vec<_>>().join(",")
+        };
+        #[cfg(feature = "direct-valkey-claim")]
+        let worker_capabilities_hash =
+            ff_core::hash::fnv1a_xor8hex(&worker_capabilities_csv);
+
+        Ok(Self {
+            #[cfg(feature = "valkey-default")]
+            client: None,
+            config,
+            partition_config,
+            #[cfg(feature = "direct-valkey-claim")]
+            worker_capabilities_csv,
+            #[cfg(feature = "direct-valkey-claim")]
+            worker_capabilities_hash,
+            #[cfg(feature = "direct-valkey-claim")]
+            lane_index: AtomicUsize::new(0),
+            concurrency_semaphore,
+            #[cfg(feature = "direct-valkey-claim")]
+            scan_cursor: AtomicUsize::new(scan_cursor_init),
+            backend,
+            completion_backend_handle: completion,
+        })
     }
 
     /// Borrow the `EngineBackend` this worker forwards Stage-1b trait
@@ -610,6 +752,7 @@ impl FlowFabricWorker {
     /// [`Self::backend`] still returns `Option` for API stability
     /// (Stage 1b holdover). Snapshot trait-forwarders in
     /// [`crate::snapshot`] need an un-wrapped reference.
+    #[cfg_attr(not(feature = "valkey-default"), allow(dead_code))]
     pub(crate) fn backend_ref(
         &self,
     ) -> &Arc<dyn ff_core::engine_backend::EngineBackend> {
@@ -729,8 +872,7 @@ impl FlowFabricWorker {
             // ZRANGEBYSCORE to get the highest-priority eligible execution.
             // Score format: -(priority * 1_000_000_000_000) + created_at_ms
             // ZRANGEBYSCORE with "-inf" "+inf" LIMIT 0 1 gives lowest score = highest priority.
-            let result: Value = self
-                .client
+            let result: Value = self.valkey_client()                
                 .cmd("ZRANGEBYSCORE")
                 .arg(&eligible_key)
                 .arg("-inf")
@@ -901,8 +1043,7 @@ impl FlowFabricWorker {
         let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-        let raw: Value = self
-            .client
+        let raw: Value = self.valkey_client()            
             .fcall("ff_issue_claim_grant", &key_refs, &arg_refs)
             .await
             .map_err(SdkError::from)?;
@@ -945,8 +1086,7 @@ impl FlowFabricWorker {
             &now_ms,
         ];
 
-        match self
-            .client
+        match self.valkey_client()            
             .fcall::<Value>("ff_block_execution_for_admission", &keys, &argv)
             .await
         {
@@ -983,6 +1123,7 @@ impl FlowFabricWorker {
     /// callers use `claim_from_grant`.
     ///
     /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
+    #[cfg(feature = "valkey-default")]
     async fn claim_execution(
         &self,
         execution_id: &ExecutionId,
@@ -997,7 +1138,7 @@ impl FlowFabricWorker {
         // The Lua uses total_attempt_count as the new index and dynamically builds
         // the attempt key from the hash tag, so KEYS[6-8] are placeholders, but
         // we pass the correct index for documentation/debugging.
-        let total_str: Option<String> = self.client
+        let total_str: Option<String> = self.valkey_client()
             .cmd("HGET")
             .arg(ctx.core())
             .arg("total_attempt_count")
@@ -1051,8 +1192,7 @@ impl FlowFabricWorker {
         let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-        let raw: Value = self
-            .client
+        let raw: Value = self.valkey_client()            
             .fcall("ff_claim_execution", &key_refs, &arg_refs)
             .await
             .map_err(SdkError::from)?;
@@ -1135,7 +1275,7 @@ impl FlowFabricWorker {
             .await?;
 
         Ok(ClaimedTask::new(
-            self.client.clone(),
+            self.valkey_client().clone(),
             self.backend.clone(),
             self.partition_config,
             execution_id.clone(),
@@ -1198,6 +1338,7 @@ impl FlowFabricWorker {
     ///
     /// [`ClaimGrant`]: ff_core::contracts::ClaimGrant
     /// [`ff_scheduler::Scheduler::claim_for_worker`]: https://docs.rs/ff-scheduler
+    #[cfg(feature = "valkey-default")]
     pub async fn claim_from_grant(
         &self,
         lane: LaneId,
@@ -1270,6 +1411,7 @@ impl FlowFabricWorker {
     /// (`FlowFabricAdminClient`) reused here so workers don't keep a
     /// second reqwest client around. Build once at worker boot and
     /// hand in by reference on every claim.
+    #[cfg(feature = "valkey-default")]
     pub async fn claim_via_server(
         &self,
         admin: &crate::FlowFabricAdminClient,
@@ -1334,6 +1476,7 @@ impl FlowFabricWorker {
     ///
     /// [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
     /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
+    #[cfg(feature = "valkey-default")]
     pub async fn claim_from_reclaim_grant(
         &self,
         grant: ff_core::contracts::ReclaimGrant,
@@ -1377,6 +1520,7 @@ impl FlowFabricWorker {
     /// [`claim_from_reclaim_grant`].
     ///
     /// [`claim_from_reclaim_grant`]: FlowFabricWorker::claim_from_reclaim_grant
+    #[cfg(feature = "valkey-default")]
     async fn claim_resumed_execution(
         &self,
         execution_id: &ExecutionId,
@@ -1389,7 +1533,7 @@ impl FlowFabricWorker {
         // This is load-bearing: the backend's KEYS[6] must point to the
         // real attempt hash, and the backend takes the index verbatim
         // from `ClaimResumedExecutionArgs::current_attempt_index`.
-        let att_idx_str: Option<String> = self.client
+        let att_idx_str: Option<String> = self.valkey_client()
             .cmd("HGET")
             .arg(ctx.core())
             .arg("current_attempt_index")
@@ -1420,7 +1564,7 @@ impl FlowFabricWorker {
             .await?;
 
         Ok(ClaimedTask::new(
-            self.client.clone(),
+            self.valkey_client().clone(),
             self.backend.clone(),
             self.partition_config,
             execution_id.clone(),
@@ -1441,6 +1585,7 @@ impl FlowFabricWorker {
     /// gated behind `direct-valkey-claim`; now shared by the
     /// feature-gated inline claim path and the public
     /// `claim_from_reclaim_grant` entry point.
+    #[cfg(feature = "valkey-default")]
     async fn read_execution_context(
         &self,
         execution_id: &ExecutionId,
@@ -1449,24 +1594,21 @@ impl FlowFabricWorker {
         let ctx = ExecKeyContext::new(partition, execution_id);
 
         // Read payload
-        let payload: Option<String> = self
-            .client
+        let payload: Option<String> = self.valkey_client()            
             .get(&ctx.payload())
             .await
             .map_err(|e| crate::backend_context(e, "GET payload failed"))?;
         let input_payload = payload.unwrap_or_default().into_bytes();
 
         // Read execution_kind from core
-        let kind: Option<String> = self
-            .client
+        let kind: Option<String> = self.valkey_client()            
             .hget(&ctx.core(), "execution_kind")
             .await
             .map_err(|e| crate::backend_context(e, "HGET execution_kind failed"))?;
         let execution_kind = kind.unwrap_or_default();
 
         // Read tags
-        let tags: HashMap<String, String> = self
-            .client
+        let tags: HashMap<String, String> = self.valkey_client()            
             .hgetall(&ctx.tags())
             .await
             .map_err(|e| crate::backend_context(e, "HGETALL tags"))?;
@@ -1484,6 +1626,7 @@ impl FlowFabricWorker {
     /// Forwards through
     /// [`EngineBackend::deliver_signal`](ff_core::engine_backend::EngineBackend::deliver_signal)
     /// — the trait-level trigger surface landed in issue #150.
+    #[cfg(feature = "valkey-default")]
     pub async fn deliver_signal(
         &self,
         execution_id: &ExecutionId,
@@ -1571,6 +1714,7 @@ fn extract_first_array_string(value: &Value) -> Option<String> {
 
 /// Read partition config from Valkey's `ff:config:partitions` hash.
 /// Returns Err if the key doesn't exist or can't be read.
+#[cfg(feature = "valkey-default")]
 async fn read_partition_config(client: &Client) -> Result<PartitionConfig, SdkError> {
     let key = ff_core::keys::global_config_partitions();
     let fields: HashMap<String, String> = client
@@ -1619,6 +1763,40 @@ mod completion_accessor_type_tests {
         // worker), so no I/O happens.
         let _f: fn(&FlowFabricWorker) -> Option<Arc<dyn CompletionBackend>> =
             FlowFabricWorker::completion_backend;
+    }
+}
+
+/// RFC-023 Phase 1a §4.4 item 10g compile-only anchor. Parallels
+/// `completion_accessor_type_tests` but fires under the sqlite-only
+/// feature set: proves `FlowFabricWorker::connect_with` is callable
+/// and returns the advertised type under `--no-default-features,
+/// features = ["sqlite"]`. The matching `§9` CI cell (`cargo check
+/// -p ff-sdk --no-default-features --features sqlite`) executes this
+/// compile check mechanically so future PRs that accidentally reach
+/// outside the `valkey-default` gate fail the build.
+#[cfg(all(test, not(feature = "valkey-default")))]
+mod sqlite_only_compile_surface_tests {
+    use super::FlowFabricWorker;
+    use ff_core::completion_backend::CompletionBackend;
+    use ff_core::engine_backend::EngineBackend;
+    use std::sync::Arc;
+
+    #[test]
+    fn addressable_surface_under_sqlite_only() {
+        // Type-level proof that the backend-agnostic accessors are
+        // reachable without the `valkey-default` feature. None of
+        // these are called; the assignment targets pin the signature.
+        let _a: fn(
+            &FlowFabricWorker,
+        ) -> Option<&Arc<dyn EngineBackend>> = FlowFabricWorker::backend;
+        let _b: fn(
+            &FlowFabricWorker,
+        ) -> Option<Arc<dyn CompletionBackend>> =
+            FlowFabricWorker::completion_backend;
+        let _c: fn(&FlowFabricWorker) -> &crate::config::WorkerConfig =
+            FlowFabricWorker::config;
+        let _d: fn(&FlowFabricWorker) -> &ff_core::partition::PartitionConfig =
+            FlowFabricWorker::partition_config;
     }
 }
 

--- a/crates/ff-server/Cargo.toml
+++ b/crates/ff-server/Cargo.toml
@@ -43,6 +43,11 @@ ff-backend-valkey = { workspace = true }
 # `Server::start_with_metrics`. Default features (`core` + `streaming`)
 # so the Postgres backend's full EngineBackend impl is reachable.
 ff-backend-postgres = { workspace = true }
+# RFC-023 (v0.12.0): SQLite dev-only backend branch on
+# `Server::start_with_metrics`. Construction is guarded by
+# `FF_DEV_MODE=1` at the type level; the dep is compile-time-present
+# but the backend refuses to run without the env var.
+ff-backend-sqlite = { workspace = true }
 ff-scheduler = { workspace = true }
 ff-observability = { workspace = true }
 ferriskey = { workspace = true }

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -157,9 +157,16 @@ impl Default for SqliteServerConfig {
 /// [`ValkeyServerConfig`] on the `valkey` field instead.
 ///
 /// **RFC-023 (v0.12.0):** gained `#[non_exhaustive]` + a `sqlite`
-/// field. Consumers constructing via struct literal must migrate to
-/// [`ServerConfig::from_env`], [`ServerConfig::sqlite_dev`], or the
-/// `..Default::default()` spread syntax.
+/// field. External consumers cannot use struct-literal construction
+/// (including `..Default::default()` spread syntax — Rust rejects
+/// the struct-update form on `#[non_exhaustive]` types from other
+/// crates). Build via one of:
+///
+/// * [`ServerConfig::from_env`] — production-ready, validates all
+///   env-driven axes.
+/// * [`ServerConfig::sqlite_dev`] — zero-config dev harness.
+/// * `ServerConfig::default()` followed by field-by-field mutation
+///   — for tests that need to override one or two axes.
 #[non_exhaustive]
 pub struct ServerConfig {
     /// Partition counts (execution/flow/budget/quota).

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -16,6 +16,11 @@ pub enum BackendKind {
     Valkey,
     /// Postgres backend. First-class since v0.8.0 (RFC-017 Stage E4).
     Postgres,
+    /// SQLite dev-only backend (RFC-023 v0.12.0). Activation requires
+    /// `FF_DEV_MODE=1`; the backend refuses to construct otherwise
+    /// regardless of entry point (embedded `SqliteBackend::new` or
+    /// HTTP `start_sqlite_branch`).
+    Sqlite,
 }
 
 impl BackendKind {
@@ -25,6 +30,7 @@ impl BackendKind {
         match self {
             Self::Valkey => "valkey",
             Self::Postgres => "postgres",
+            Self::Sqlite => "sqlite",
         }
     }
 }
@@ -95,11 +101,66 @@ impl Default for ValkeyServerConfig {
     }
 }
 
+/// RFC-023 (v0.12.0): SQLite dev-only connection parameters carried
+/// on [`ServerConfig`] when `backend == BackendKind::Sqlite`.
+///
+/// `#[non_exhaustive]` — consumers build via [`Self::new`] + the
+/// builder methods; adding future fields is additive.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SqliteServerConfig {
+    /// File path or in-memory URI — `:memory:`, `file::memory:...`,
+    /// or an ordinary filesystem path. Read from `FF_SQLITE_PATH`.
+    pub path: String,
+    /// Connection-pool size. Default `4` (1 writer + 3 readers under
+    /// WAL). Read from `FF_SQLITE_POOL_SIZE`.
+    pub pool_size: u32,
+    /// Enable WAL journaling. Default `true`. Ignored for
+    /// `:memory:` databases where WAL is a no-op.
+    pub wal_mode: bool,
+}
+
+impl SqliteServerConfig {
+    /// Construct a new config with the given path and defaults
+    /// (`pool_size = 4`, `wal_mode = true`).
+    pub fn new(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            pool_size: 4,
+            wal_mode: true,
+        }
+    }
+
+    /// Builder: override pool size (writer + readers combined).
+    pub fn with_pool_size(mut self, n: u32) -> Self {
+        self.pool_size = n;
+        self
+    }
+
+    /// Builder: toggle WAL journaling.
+    pub fn with_wal(mut self, on: bool) -> Self {
+        self.wal_mode = on;
+        self
+    }
+}
+
+impl Default for SqliteServerConfig {
+    fn default() -> Self {
+        Self::new(":memory:")
+    }
+}
+
 /// Server configuration, loaded from environment variables.
 ///
 /// **RFC-017 Stage E4 (v0.8.0):** the flat Valkey fields (`host`,
 /// `port`, `tls`, `cluster`, `skip_library_load`) were removed. Use
 /// [`ValkeyServerConfig`] on the `valkey` field instead.
+///
+/// **RFC-023 (v0.12.0):** gained `#[non_exhaustive]` + a `sqlite`
+/// field. Consumers constructing via struct literal must migrate to
+/// [`ServerConfig::from_env`], [`ServerConfig::sqlite_dev`], or the
+/// `..Default::default()` spread syntax.
+#[non_exhaustive]
 pub struct ServerConfig {
     /// Partition counts (execution/flow/budget/quota).
     pub partition_config: PartitionConfig,
@@ -151,6 +212,10 @@ pub struct ServerConfig {
     /// Meaningful only when `backend == BackendKind::Postgres`; the
     /// Valkey path ignores these fields.
     pub postgres: PostgresServerConfig,
+    /// RFC-023 (v0.12.0): SQLite dev-only connection parameters.
+    /// Meaningful only when `backend == BackendKind::Sqlite`; the
+    /// Valkey/Postgres paths ignore these fields.
+    pub sqlite: SqliteServerConfig,
 }
 
 impl ServerConfig {
@@ -215,9 +280,12 @@ impl ServerConfig {
     /// | `FF_FLOW_PROJECTOR_INTERVAL_S` | `15` | Flow projector scanner interval |
     /// | `FF_EXECUTION_DEADLINE_INTERVAL_S` | `5` | Execution-deadline scanner interval |
     /// | `FF_CANCEL_RECONCILER_INTERVAL_S` | `15` | Cancel reconciler scanner interval |
-    /// | `FF_BACKEND` | `valkey` | Backend family — `valkey` or `postgres`. Both are first-class at v0.8.0 (RFC-017 Stage E4 flipped `BACKEND_STAGE_READY` to `&["valkey", "postgres"]`). |
+    /// | `FF_BACKEND` | `valkey` | Backend family — `valkey`, `postgres`, or `sqlite` (RFC-023 dev-only). |
     /// | `FF_POSTGRES_URL` | *(empty)* | Postgres connection URL (libpq/sqlx shape, e.g. `postgres://user:pass@host:port/db`). Required when `FF_BACKEND=postgres`; ignored otherwise. |
     /// | `FF_POSTGRES_POOL_SIZE` | `10` | Max Postgres pool connections; ignored on the Valkey path. |
+    /// | `FF_SQLITE_PATH` | `:memory:` | SQLite database path or URI. Used when `FF_BACKEND=sqlite`. |
+    /// | `FF_SQLITE_POOL_SIZE` | `4` | Max SQLite pool connections (1 writer + (pool_size - 1) readers). |
+    /// | `FF_DEV_MODE` | *(unset)* | Must be `1` to activate `FF_BACKEND=sqlite`. Orthogonal to `FF_ENV=development` / `FF_BACKEND_ACCEPT_UNREADY=1`. |
     pub fn from_env() -> Result<Self, ConfigError> {
         let valkey = ValkeyServerConfig {
             host: env_or("FF_HOST", "localhost"),
@@ -390,15 +458,24 @@ impl ServerConfig {
             pool_size: env_u32_positive("FF_POSTGRES_POOL_SIZE", 10)?,
         };
 
+        // RFC-023 (v0.12.0): read SQLite fields unconditionally so
+        // operators can preset values; non-sqlite backends ignore.
+        let sqlite = SqliteServerConfig {
+            path: env_or("FF_SQLITE_PATH", ":memory:"),
+            pool_size: env_u32_positive("FF_SQLITE_POOL_SIZE", 4)?,
+            wal_mode: true,
+        };
+
         let backend = match std::env::var("FF_BACKEND") {
             Ok(v) => match v.to_ascii_lowercase().as_str() {
                 "" | "valkey" => BackendKind::Valkey,
                 "postgres" => BackendKind::Postgres,
+                "sqlite" => BackendKind::Sqlite,
                 other => {
                     return Err(ConfigError::InvalidValue {
                         var: "FF_BACKEND".to_owned(),
                         message: format!(
-                            "unknown backend '{other}': expected 'valkey' or 'postgres'"
+                            "unknown backend '{other}': expected 'valkey', 'postgres', or 'sqlite'"
                         ),
                     });
                 }
@@ -419,7 +496,29 @@ impl ServerConfig {
             backend,
             valkey,
             postgres,
+            sqlite,
         })
+    }
+
+    /// RFC-023 §4.4 item 4 (v0.12.0): zero-config SQLite dev harness
+    /// builder. Returns a `ServerConfig` pre-wired with
+    /// `backend = Sqlite`, `sqlite.path = ":memory:"`,
+    /// `listen_addr = "127.0.0.1:0"` (OS-picked port), and ALL auth
+    /// axes disabled: `api_token = None`, admin auth off,
+    /// `waitpoint_hmac_secret` set to a deterministic dev placeholder.
+    ///
+    /// **Dev/test only.** The returned config is unsafe for
+    /// production — every auth path is open and the SQLite backend
+    /// itself demands `FF_DEV_MODE=1` at construction time per
+    /// §4.5.
+    pub fn sqlite_dev() -> Self {
+        Self {
+            sqlite: SqliteServerConfig::new(":memory:"),
+            backend: BackendKind::Sqlite,
+            listen_addr: "127.0.0.1:0".into(),
+            api_token: None,
+            ..Default::default()
+        }
     }
 }
 
@@ -450,6 +549,7 @@ impl Default for ServerConfig {
             backend: BackendKind::default(),
             valkey: ValkeyServerConfig::default(),
             postgres: PostgresServerConfig::default(),
+            sqlite: SqliteServerConfig::default(),
         }
     }
 }

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -693,9 +693,14 @@ impl Server {
         tracing::info!(
             path = %config.sqlite.path,
             pool_size = config.sqlite.pool_size,
+            wal_mode = config.sqlite.wal_mode,
             "dialing SQLite backend (RFC-023 dev-only)"
         );
-        let sqlite_arc = ff_backend_sqlite::SqliteBackend::new(&config.sqlite.path)
+        let sqlite_arc = ff_backend_sqlite::SqliteBackend::new_with_tuning(
+            &config.sqlite.path,
+            config.sqlite.pool_size,
+            config.sqlite.wal_mode,
+        )
             .await
             .map_err(|e| match e {
                 ff_core::BackendError::RequiresDevMode => {

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -30,7 +30,7 @@ use crate::config::{BackendKind, ServerConfig};
 /// joins at Stage E (v0.8.0). Compiled into the binary by design —
 /// see RFC-017 §9.0 "Fleet-wide cutover requirement" for the
 /// rolling-upgrade implication.
-const BACKEND_STAGE_READY: &[&str] = &["valkey", "postgres"];
+const BACKEND_STAGE_READY: &[&str] = &["valkey", "postgres", "sqlite"];
 
 /// Upper bound on `member_execution_ids` returned in the
 /// [`CancelFlowResult::Cancelled`] response when the flow was already in a
@@ -86,7 +86,12 @@ pub struct Server {
 }
 
 /// Server error type.
+///
+/// **RFC-023 (v0.12.0):** `#[non_exhaustive]` was added; consumers
+/// writing exhaustive matches must include a wildcard arm. See
+/// `CHANGELOG.md` / `docs/CONSUMER_MIGRATION_0.12.md`.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ServerError {
     /// Backend transport error. Previously wrapped `ferriskey::Error`
     /// directly (#88); now carries a backend-agnostic
@@ -167,6 +172,15 @@ pub enum ServerError {
     /// `result_large_err` — `EngineError` is ~200 bytes).
     #[error("engine: {0}")]
     Engine(#[from] Box<ff_core::engine_error::EngineError>),
+
+    /// RFC-023 §4.5 (v0.12.0): the SQLite backend refused to construct
+    /// because `FF_DEV_MODE=1` was not set. Wraps the underlying
+    /// [`BackendError::RequiresDevMode`] so callers can recover the
+    /// full classification without a string match.
+    ///
+    /// [`BackendError::RequiresDevMode`]: ff_core::BackendError::RequiresDevMode
+    #[error("sqlite requires FF_DEV_MODE=1: {0}")]
+    SqliteRequiresDevMode(#[source] ff_core::BackendError),
 }
 
 /// Lift a native `ferriskey::Error` into [`ServerError::Backend`] via
@@ -254,6 +268,8 @@ impl ServerError {
             Self::ValkeyVersionTooLow { .. } => false,
             // Operator must change FF_BACKEND; not retryable.
             Self::BackendNotReady { .. } => false,
+            // RFC-023: operator must set FF_DEV_MODE=1; not retryable.
+            Self::SqliteRequiresDevMode(_) => false,
             // EngineError's classification helpers handle transport
             // retry semantics; mirror them so trait-dispatched handlers
             // keep the same retry policy as the Client path.
@@ -312,6 +328,7 @@ impl Server {
                 backend: match config.backend {
                     BackendKind::Postgres => "postgres",
                     BackendKind::Valkey => "valkey",
+                    BackendKind::Sqlite => "sqlite",
                 },
                 stage: "E4",
             });
@@ -324,6 +341,12 @@ impl Server {
         // construction entirely (E3 wires the scheduler twin).
         if matches!(config.backend, BackendKind::Postgres) {
             return Self::start_postgres_branch(config, metrics).await;
+        }
+        // RFC-023 §4.4 item 6 (v0.12.0): SQLite dev-only branch. The
+        // `FF_DEV_MODE=1` guard lives on `SqliteBackend::new`, not
+        // here — see §3.3 A3 single-emission contract.
+        if matches!(config.backend, BackendKind::Sqlite) {
+            return Self::start_sqlite_branch(config, metrics).await;
         }
         // Step 1: Connect to Valkey via ClientBuilder
         tracing::info!(
@@ -640,6 +663,53 @@ impl Server {
             "FlowFabric server started (Postgres backend, Stage E3). \
              6 Postgres reconcilers active; claim_for_worker routed to \
              PostgresScheduler. No ambient Valkey client."
+        );
+
+        Ok(Self {
+            admin_rotate_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+            engine: None,
+            config,
+            background_tasks: Arc::new(AsyncMutex::new(JoinSet::new())),
+            metrics,
+            backend,
+        })
+    }
+
+    /// RFC-023 §4.4 item 6 + §4.5 (v0.12.0): SQLite dev-only boot
+    /// branch. The `FF_DEV_MODE=1` guard + WARN banner live on the
+    /// `SqliteBackend::new` TYPE per the §3.3 A3 single-emission
+    /// contract; this branch constructs the backend, maps
+    /// [`BackendError::RequiresDevMode`] into
+    /// [`ServerError::SqliteRequiresDevMode`], and otherwise wires
+    /// the trait object into the `Server` exactly like the Postgres
+    /// branch. Engine + scanner + scheduler construction is skipped
+    /// (SQLite is Phase 1a stubs; trait impl lands in Phase 2+).
+    ///
+    /// [`BackendError::RequiresDevMode`]: ff_core::BackendError::RequiresDevMode
+    async fn start_sqlite_branch(
+        config: ServerConfig,
+        metrics: Arc<ff_observability::Metrics>,
+    ) -> Result<Self, ServerError> {
+        tracing::info!(
+            path = %config.sqlite.path,
+            pool_size = config.sqlite.pool_size,
+            "dialing SQLite backend (RFC-023 dev-only)"
+        );
+        let sqlite_arc = ff_backend_sqlite::SqliteBackend::new(&config.sqlite.path)
+            .await
+            .map_err(|e| match e {
+                ff_core::BackendError::RequiresDevMode => {
+                    ServerError::SqliteRequiresDevMode(e)
+                }
+                other => ServerError::Backend(other),
+            })?;
+        let backend: Arc<dyn EngineBackend> = sqlite_arc;
+
+        tracing::info!(
+            flow_partitions = config.partition_config.num_flow_partitions,
+            lanes = ?config.lanes.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
+            "FlowFabric server started (SQLite dev-only backend, RFC-023 Phase 1a). \
+             Trait impls beyond capabilities()/prepare() return Unavailable until Phase 2+."
         );
 
         Ok(Self {

--- a/crates/ff-test/tests/admin_rotate_api.rs
+++ b/crates/ff-test/tests/admin_rotate_api.rs
@@ -115,35 +115,31 @@ fn test_server_config(api_token: Option<String>) -> ff_server::config::ServerCon
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    ff_server::config::ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls: ff_test::fixtures::env_flag("FF_TLS"),
             cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
             skip_library_load: true,
-        },
-        partition_config: pc,
-        lanes: vec![ff_core::types::LaneId::new("admin-rotate-lane")],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![ff_core::types::LaneId::new("admin-rotate-lane")];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![ff_core::types::LaneId::new("admin-rotate-lane")],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token,
-        // Known-weak all-zeros secret — fine for tests, documented
-        // trivial-to-forge in RFC-004. Server bootstrap refuses to
-        // start without a secret, so we supply one. Every partition
-        // has this as its initial `current_kid = "default"` value.
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = api_token;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     }
 }
 

--- a/crates/ff-test/tests/e2e_api.rs
+++ b/crates/ff-test/tests/e2e_api.rs
@@ -98,31 +98,31 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    ff_server::config::ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls: ff_test::fixtures::env_flag("FF_TLS"),
             cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
             skip_library_load: true,
-        },
-        partition_config: config,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = config;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: config,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     }
 }
 

--- a/crates/ff-test/tests/e2e_flow_atomicity.rs
+++ b/crates/ff-test/tests/e2e_flow_atomicity.rs
@@ -32,31 +32,26 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: true },
-
-
-
-
-
-        partition_config: pc,
-        lanes: vec![LaneId::new("atomicity-lane")],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+    let config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: true };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new("atomicity-lane")];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new("atomicity-lane")],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-    
-};
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
+    };
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -6326,31 +6326,31 @@ async fn test_server() -> ff_server::server::Server {
     let cluster = std::env::var("FF_CLUSTER")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-    let server_config = ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    let server_config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls,
             cluster,
             skip_library_load: true, // TestCluster::connect() already loaded it
-        },
-
-        partition_config: config,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "0.0.0.0:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = config;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "0.0.0.0:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: config,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     };
     ff_server::server::Server::start(server_config)
         .await
@@ -7379,34 +7379,28 @@ async fn test_system_engine_with_concurrent_scanners() {
         let cluster = std::env::var("FF_CLUSTER")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        ServerConfig {            valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: tls, cluster: cluster, skip_library_load: true },
-
-
-
-
-
-            partition_config: config,
-            lanes: vec![LaneId::new(LANE)],
-            listen_addr: "0.0.0.0:0".into(),
-            engine_config: ff_engine::EngineConfig {
+        {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: host, port: port, tls: tls, cluster: cluster, skip_library_load: true };
+        __cfg.partition_config = config;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "0.0.0.0:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
                 partition_config: config,
                 lanes: vec![LaneId::new(LANE)],
-                // Short intervals for test responsiveness
                 delayed_promoter_interval: std::time::Duration::from_millis(100),
                 lease_expiry_interval: std::time::Duration::from_millis(500),
                 ..Default::default()
-            },
-
-            cors_origins: vec!["*".to_owned()],
-            api_token: None,
-            waitpoint_hmac_secret:
-                "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-            waitpoint_hmac_grace_ms: 86_400_000,
-            max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-        
-}
+            };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
+    }
     };
     let server = ff_server::server::Server::start(server_config)
         .await

--- a/crates/ff-test/tests/engine_backend_list_executions.rs
+++ b/crates/ff-test/tests/engine_backend_list_executions.rs
@@ -250,31 +250,31 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    ff_server::config::ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls: ff_test::fixtures::env_flag("FF_TLS"),
             cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
             skip_library_load: true,
-        },
-        partition_config: config,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = config;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: config,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     }
 }
 

--- a/crates/ff-test/tests/flow_edge_policies_stage_a.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_a.rs
@@ -50,31 +50,26 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
-
-
-
-
-
-        partition_config: pc,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+    let config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-    
-};
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
+    };
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_b.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_b.rs
@@ -49,31 +49,26 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
-
-
-
-
-
-        partition_config: pc,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+    let config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-    
-};
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
+    };
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_c.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_c.rs
@@ -53,32 +53,27 @@ async fn start_server(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
-
-
-
-
-
-        partition_config: pc,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+    let config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new(LANE)],
             edge_cancel_dispatcher_interval: Duration::from_millis(250),
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-    
-};
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
+    };
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_d.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_d.rs
@@ -65,33 +65,28 @@ async fn start_server(
     } else {
         Duration::from_secs(3600)
     };
-    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
-
-
-
-
-
-        partition_config: pc,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+    let config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new(LANE)],
             edge_cancel_dispatcher_interval: dispatcher_interval,
             edge_cancel_reconciler_interval: Duration::from_millis(500),
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-    
-};
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
+    };
     let server = ff_server::server::Server::start(config)
         .await
         .expect("Server::start");

--- a/crates/ff-test/tests/flow_edge_policies_stage_e.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_e.rs
@@ -89,34 +89,28 @@ async fn start_server_with_metrics(
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
     let pc = *tc.partition_config();
-    let config = ff_server::config::ServerConfig {        valkey: ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false },
-
-
-
-
-
-        partition_config: pc,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+    let config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: host, port: port, tls: ff_test::fixtures::env_flag("FF_TLS"), cluster: ff_test::fixtures::env_flag("FF_CLUSTER"), skip_library_load: false };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new(LANE)],
-            // Tight cadences so assertions fit in ASSERT_DEADLINE.
             edge_cancel_dispatcher_interval: Duration::from_millis(200),
             edge_cancel_reconciler_interval: Duration::from_millis(500),
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
-    
-};
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
+    };
     let server = ff_server::server::Server::start_with_metrics(config, metrics)
         .await
         .expect("Server::start_with_metrics");

--- a/crates/ff-test/tests/http_postgres_smoke.rs
+++ b/crates/ff-test/tests/http_postgres_smoke.rs
@@ -99,36 +99,31 @@ impl PgHttpSmoke {
         cleanup_postgres().await;
 
         let partition_config = PartitionConfig::default();
-        let config = ff_server::config::ServerConfig {            valkey: ff_server::config::ValkeyServerConfig { host: "localhost".into(), port: 6379, tls: false, cluster: false, skip_library_load: true },
-
-
-
-
-
-            partition_config,
-            lanes: vec![LaneId::new(LANE)],
-            listen_addr: "127.0.0.1:0".into(),
-            engine_config: ff_engine::EngineConfig {
+        let config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig { host: "localhost".into(), port: 6379, tls: false, cluster: false, skip_library_load: true };
+        __cfg.partition_config = partition_config;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
                 partition_config,
                 lanes: vec![LaneId::new(LANE)],
                 ..Default::default()
-            },
-
-            cors_origins: vec!["*".to_owned()],
-            api_token: None,
-            waitpoint_hmac_secret:
-                "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-            waitpoint_hmac_grace_ms: 86_400_000,
-            max_concurrent_stream_ops: 64,
-            backend: ff_server::config::BackendKind::Postgres,
-            postgres: {
+            };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::Postgres;
+        __cfg.postgres = {
                 let mut p = ff_server::config::PostgresServerConfig::default();
                 p.url = postgres_url();
                 p.pool_size = 10;
                 p
-            },
-        
-};
+            };
+        __cfg
+    };
 
         let server = ff_server::server::Server::start(config)
             .await

--- a/crates/ff-test/tests/list_lanes_population.rs
+++ b/crates/ff-test/tests/list_lanes_population.rs
@@ -51,35 +51,31 @@ fn server_config_with_lanes(lanes: Vec<LaneId>) -> ff_server::config::ServerConf
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    ff_server::config::ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls: ff_test::fixtures::env_flag("FF_TLS"),
             cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
             skip_library_load: true,
-        },
-        partition_config: config,
-        lanes: lanes.clone(),
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = config;
+        __cfg.lanes = lanes.clone();
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: config,
             lanes,
             ..Default::default()
-        },
-        // `skip_library_load=true` is honoured by other ff-test tests; the
-        // TestCluster fixture pre-loads the library. The lanes-index seed
-        // runs unconditionally regardless of this flag (it does not depend
-        // on the Lua library).
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     }
 }
 

--- a/crates/ff-test/tests/pending_waitpoints_api.rs
+++ b/crates/ff-test/tests/pending_waitpoints_api.rs
@@ -107,31 +107,31 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    ff_server::config::ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls: ff_test::fixtures::env_flag("FF_TLS"),
             cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
             skip_library_load: true,
-        },
-        partition_config: pc,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     }
 }
 

--- a/crates/ff-test/tests/pr_c1_cancel_flow_partial.rs
+++ b/crates/ff-test/tests/pr_c1_cancel_flow_partial.rs
@@ -59,30 +59,31 @@ async fn start_test_server() -> Server {
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 
-    let server_config = ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    let server_config = {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls,
             cluster,
             skip_library_load: true, // TestCluster::connect() already loaded
-        },
-        partition_config: config,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "0.0.0.0:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = config;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "0.0.0.0:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: config,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     };
     Server::start(server_config).await.expect("Server::start")
 }

--- a/crates/ff-test/tests/result_api.rs
+++ b/crates/ff-test/tests/result_api.rs
@@ -91,31 +91,31 @@ fn test_server_config() -> ff_server::config::ServerConfig {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(6379);
-    ff_server::config::ServerConfig {
-        valkey: ff_server::config::ValkeyServerConfig {
+    {
+        let mut __cfg = ff_server::config::ServerConfig::default();
+        __cfg.valkey = ff_server::config::ValkeyServerConfig {
             host,
             port,
             tls: ff_test::fixtures::env_flag("FF_TLS"),
             cluster: ff_test::fixtures::env_flag("FF_CLUSTER"),
             skip_library_load: true,
-        },
-        partition_config: pc,
-        lanes: vec![LaneId::new(LANE)],
-        listen_addr: "127.0.0.1:0".into(),
-        engine_config: ff_engine::EngineConfig {
+        };
+        __cfg.partition_config = pc;
+        __cfg.lanes = vec![LaneId::new(LANE)];
+        __cfg.listen_addr = "127.0.0.1:0".into();
+        __cfg.engine_config = ff_engine::EngineConfig {
             partition_config: pc,
             lanes: vec![LaneId::new(LANE)],
             ..Default::default()
-        },
-
-        cors_origins: vec!["*".to_owned()],
-        api_token: None,
-        waitpoint_hmac_secret:
-            "0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
-        waitpoint_hmac_grace_ms: 86_400_000,
-        max_concurrent_stream_ops: 64,
-        backend: ff_server::config::BackendKind::default(),
-        postgres: Default::default(),
+        };
+        __cfg.cors_origins = vec!["*".to_owned()];
+        __cfg.api_token = None;
+        __cfg.waitpoint_hmac_secret = "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        __cfg.waitpoint_hmac_grace_ms = 86_400_000;
+        __cfg.max_concurrent_stream_ops = 64;
+        __cfg.backend = ff_server::config::BackendKind::default();
+        __cfg.postgres = Default::default();
+        __cfg
     }
 }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,15 +39,21 @@ Twelve crates, all pinned to the same version, published in topological order:
    before Wave 1+ fills in method bodies. Published alongside the
    Valkey backend so dual-backend ff-server builds resolve against
    crates.io.
-9. `ff-engine`       — cross-partition dispatch + scanners
-   (includes the `completion_listener` module for push-based DAG
-   promotion; see [`rfc011-operator-runbook.md`](rfc011-operator-runbook.md)
-   §"DAG promotion: push listener + safety-net reconciler")
-10. `ff-sdk`         — worker SDK. `direct-valkey-claim` feature is
+9. `ff-backend-sqlite` — RFC-023 SQLite dev-only EngineBackend.
+   Phase 1a scaffold (v0.12.0) ships the crate as an
+   `Unavailable`-stub with the `FF_DEV_MODE=1` guard + registry dedup
+   in place; Phase 1b+ fills in the hand-ported SQLite migrations
+   and trait bodies. Published so consumers opting into the dev
+   harness can `cargo add ff-backend-sqlite` from crates.io.
+10. `ff-engine`       — cross-partition dispatch + scanners
+    (includes the `completion_listener` module for push-based DAG
+    promotion; see [`rfc011-operator-runbook.md`](rfc011-operator-runbook.md)
+    §"DAG promotion: push listener + safety-net reconciler")
+11. `ff-sdk`         — worker SDK. `direct-valkey-claim` feature is
     off by default; production deployments use the scheduler-routed
     HTTP path via `FlowFabricWorker::claim_via_server`
-11. `ff-server`      — HTTP server library + binary
-12. `flowfabric`     — umbrella re-export of the ff-* family
+12. `ff-server`      — HTTP server library + binary
+13. `flowfabric`     — umbrella re-export of the ff-* family
     (issue #279). Depends on every other publishable crate; MUST
     publish LAST. Lets consumers pin one crate + feature-flag the
     backend (`flowfabric = { version = "0.8", features = ["valkey"] }`

--- a/release.toml
+++ b/release.toml
@@ -4,7 +4,8 @@
 # workspace-wide version bump across the publishable crates:
 #   ferriskey, ff-core, ff-script, ff-observability,
 #   ff-observability-http, ff-scheduler, ff-backend-valkey,
-#   ff-backend-postgres, ff-engine, ff-sdk, ff-server, flowfabric
+#   ff-backend-postgres, ff-backend-sqlite, ff-engine, ff-sdk,
+#   ff-server, flowfabric
 # (flowfabric is the umbrella re-export crate added in v0.8.2 per
 # issue #279 — it depends on every other publishable crate and
 # publishes LAST in .github/workflows/release.yml.)

--- a/rfcs/RFC-023-sqlite-dev-only-backend.md
+++ b/rfcs/RFC-023-sqlite-dev-only-backend.md
@@ -1240,6 +1240,20 @@ consumers (B1).** Runtime behavior for `FF_BACKEND=valkey` and
 shape adjustments on two ff-server types that were not marked
 `#[non_exhaustive]`.
 
+> **V1 verification at Phase 1a base SHA (c035967, Revision 5
+> merge).** `BackendError` and `BackendKind` were already
+> `#[non_exhaustive]` pre-Phase-1a (see
+> `crates/ff-core/src/engine_error.rs:487-488` +
+> `crates/ff-server/src/config.rs:12-13`); Phase 1a only adds
+> variants to those enums, no attribute flip needed. `ServerError`
+> and `ServerConfig` were NOT `#[non_exhaustive]` pre-Phase-1a
+> (`crates/ff-server/src/server.rs:90` +
+> `crates/ff-server/src/config.rs:103`); Phase 1a adds the
+> attribute in the same PR that introduces
+> `ServerError::SqliteRequiresDevMode` + the `sqlite:
+> SqliteServerConfig` field, owning the minor break exactly as
+> §8 prescribes.
+
 **Unchanged:**
 
 - `FF_BACKEND=valkey` (default) and `FF_BACKEND=postgres` runtime


### PR DESCRIPTION
RFC-023 Phase 1a. Base SHA `c035967` (Revision 5 merge). All 14
deliverables landed whole.

## V1-V4 verification

V1 at base SHA `c035967`:
- `BackendError` at `crates/ff-core/src/engine_error.rs:487-488` — already `#[non_exhaustive]` ✓
- `BackendKind` at `crates/ff-server/src/config.rs:12-13` — already `#[non_exhaustive]` ✓
- `ServerError` at `crates/ff-server/src/server.rs:90` — NOT `#[non_exhaustive]`; this PR adds the attribute alongside `SqliteRequiresDevMode` ✓
- `ServerConfig` at `crates/ff-server/src/config.rs:103` — NOT `#[non_exhaustive]`; this PR adds the attribute alongside the `sqlite` field ✓

V2 (RFC §8 minor break ownership) — covered in CHANGELOG `### Changed`.
V3 (new public API surface) — `SqliteBackend::new`, `BackendKind::Sqlite`, `SqliteServerConfig`, `ServerConfig::sqlite_dev()`, `BackendError::RequiresDevMode`, `ServerError::SqliteRequiresDevMode`, `ff_sdk::FlowFabricWorker` addressable under sqlite-only features.
V4 — RFC §8 footnote added with line refs at Phase 1a base SHA.

## 14 deliverables

1. ✅ New crate `crates/ff-backend-sqlite/` with full layout (Cargo.toml, src/{backend, config, errors, pubsub, registry, lib}.rs, migrations/.gitkeep + .sqlite-skip placeholder, tests/{capabilities, guard}.rs)
2. ✅ `SqliteBackend::new` — guard (`FF_DEV_MODE=1`) + process-local registry (§4.2 B6) + sqlx pool + WARN banner (exact §3.3 text)
3. ✅ `BackendError::RequiresDevMode` additive variant with exact §4.5 B2 message text (docs URL included)
4. ✅ `SqliteServerConfig` (`#[non_exhaustive]`) with `new()`, `with_pool_size()`, `with_wal()` builders
5. ✅ `BackendKind::Sqlite` variant
6. ✅ `ServerConfig` — `#[non_exhaustive]` + `sqlite: SqliteServerConfig` field + `from_env` extended + `sqlite_dev()` constructor (ALL auth disabled, `127.0.0.1:0` bind, `:memory:`)
7. ✅ `ServerError::SqliteRequiresDevMode(BackendError)` + `#[non_exhaustive]` on enum
8. ✅ `start_sqlite_branch` — parallel to `start_postgres_branch`; wires `SqliteBackend::new`, maps `BackendError::RequiresDevMode → ServerError::SqliteRequiresDevMode`; does not re-emit banner (type owns emission); `BACKEND_STAGE_READY` extended
9. ✅ `EngineBackend` impl shell — all 30 required methods return `EngineError::Unavailable { op }`; `capabilities()` returns `family = "sqlite"` + `Supports::none()`; `prepare()` returns `Ok(NoOp)`; `backend_label()` returns `"sqlite"`
10. ✅ Worker.rs surgery (RFC §4.4 item 10, all 7 sub-steps a-g)
11. ✅ Workspace integration — `Cargo.toml` member + dep, `release.toml` header, `release.yml` publish step + full yank cascade, `docs/RELEASING.md` 12 → 13, `.github/workflows/matrix.yml` sqlite-only CI cell + clippy crate list
12. ✅ Tests — `capabilities.rs` (identity + Supports::none + backend_label), `guard.rs` (refuse w/o dev mode with exact message, accept w/ dev mode, registry dedup by URI, distinct URIs distinct). `serial_test` serialises `FF_DEV_MODE` env access. Sqlite-only ff-sdk compile test. All 7 new tests green.
13. ✅ CHANGELOG `[Unreleased]` `### Added` + `### Changed` entries
14. ✅ RFC §8 footnote with V1 line refs at base SHA

## Worker.rs surgery — line delta

Net: +165 / -15 lines on `crates/ff-sdk/src/worker.rs` (1650 → ~1800). Changes:
- Step a: lib.rs `pub mod worker` ungated (1 line removed)
- Step a: lib.rs re-export ungated (1 line removed)
- Step b: module-scope ferriskey imports cfg-gated (+2 cfg attrs)
- Step c: `client` field becomes `Option<Client>` + cfg-gated
- Step d: `connect` cfg-gated behind `valkey-default`
- Step e: `connect_with` rewritten (~100 lines body replacing the 5-line `Self::connect` preamble) — lane validation, capabilities CSV + hash validation, direct Self{} construction with `client: None`
- Step f: 7 methods + 1 free function + 1 helper (`valkey_client()` accessor) cfg-gated
- Step g: new `#[cfg(not(feature = "valkey-default"))]` compile-only test asserting `connect_with`, `backend`, `completion_backend`, `config`, `partition_config` signatures

RFC §4.4 item 10 estimated ~50-100 lines; actual ~165 (the extra
lines come from hoisting `connect`'s validation logic into
`connect_with` so both entry points refuse malformed lane/capability
inputs uniformly — the RFC framed `connect_with` as directly
constructing, which in ground-truth Rust required duplicating the
ingress validation).

## RFC-vs-reality gaps surfaced

One implementation discovery beyond Revisions 1-5:

**`FlowFabricWorker::client` shape under valkey-default.** RFC
§4.4 item 10e states `connect_with` should directly construct
with "no `client` field value at all (under `valkey-default` it is
populated only by the `connect` path, not by `connect_with`)" —
but the field exists in the struct under `valkey-default` and Rust
requires every field populated at construction. Resolved by making
the field `Option<Client>`: `connect` sets `Some(client)`,
`connect_with` sets `None`. A `valkey_client()` accessor panics
with a clear message if claim/signal methods are invoked against a
`connect_with`-built worker — matches RFC's §4.7.1 commentary
("cannot drive the claim/signal loop") and §8's
backend-agnostic-SDK-loop deferral.

Not a scope change; an implementation detail the RFC left implicit.
CHANGELOG + struct rustdoc document the shape.

## Consumer migration touched in this PR

`ServerError` + `ServerConfig` becoming `#[non_exhaustive]` broke
15 `ff-test` integration tests that constructed `ServerConfig`
via struct literal; all migrated to `ServerConfig::default()` +
mutation in a single commit. No external consumer of
`ServerConfig` struct-literal construction exists on crates.io as
of 2026-04-26.

## CI summary

- `cargo check --workspace` ✓
- `cargo check -p ff-sdk --no-default-features --features sqlite` ✓ (new CI cell)
- `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-sqlite --features ff-sdk/direct-valkey-claim -- -D warnings` ✓ (matches updated matrix.yml)
- `cargo test -p ff-backend-sqlite` ✓ (1 unit test + 5 integration tests)
- `cargo test -p ff-sdk --no-default-features --features sqlite --lib` ✓ (2 compile-surface tests)
- `cargo test -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server --features ff-sdk/direct-valkey-claim --lib` ✓

Postgres ignored tests + Valkey integration tests not run locally
(external services required); relying on CI. Matrix pre-existing
Valkey arm-cluster flake ignorable if sole failure per memory
guidance.

## Not in Phase 1a (per RFC-023 scope)

- 14 SQLite migrations (Phase 1b)
- `scripts/lint-migrations.sh` (Phase 1b)
- `.sqlite-skip` concrete entries (Phase 1b)
- Real trait impl bodies beyond Unavailable stubs (Phase 2+)
- `examples/ff-dev/` (Phase 4)
- `scripts/smoke-sqlite.sh` (Phase 4)
- Docs (`CONSUMER_MIGRATION_0.12.md`, `DEPLOYMENT.md`,
  `MIGRATIONS.md`, README env table, `docs/dev-harness.md`,
  parity matrix SQLite column) — Phase 4
- Capability matrix snapshot test (Phase 4)
- `Supports::*` flag flips (Phase 4 release PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new backend option and adjusts public API surfaces (`ServerConfig`/`ServerError` become `#[non_exhaustive]`, `ff-sdk` worker feature gating changes), which can cause downstream compile breaks and subtle behavior differences across feature sets.
> 
> **Overview**
> Introduces a new **dev-only SQLite backend** (`ff-backend-sqlite`) with a guarded constructor (`FF_DEV_MODE=1`), per-path in-process registry deduping, and an `EngineBackend` implementation that currently stubs all data-plane methods as `EngineError::Unavailable` while reporting `Capabilities` for `"sqlite"`.
> 
> Extends `ff-server` to support `FF_BACKEND=sqlite`: adds `BackendKind::Sqlite`, `SqliteServerConfig`, `ServerConfig::sqlite_dev()`, new env vars (`FF_SQLITE_PATH`, `FF_SQLITE_POOL_SIZE`, `FF_DEV_MODE`), and a `start_sqlite_branch` that maps `BackendError::RequiresDevMode` into `ServerError::SqliteRequiresDevMode`; **`ServerConfig` and `ServerError` are now `#[non_exhaustive]`**, forcing non-exhaustive matches/struct-literal callers to adjust.
> 
> Refactors `ff-sdk`’s `FlowFabricWorker` so `worker` is always compiled and `connect_with` is backend-agnostic (no implicit Valkey dial); Valkey-specific methods are item-level `valkey-default` gated and the embedded `ferriskey::Client` becomes optional. CI/release plumbing is updated to build/check the sqlite-only SDK surface and to publish `ff-backend-sqlite`, and tests that constructed `ServerConfig` via struct literals are migrated to `ServerConfig::default()` mutation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e771ed1704f8f51f1f9aec75ee231408066710. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->