### PR TITLE
feat(backend-sqlite): Phase 1b — 14 SQLite-dialect migrations + parity-drift lint

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -438,9 +438,22 @@ jobs:
             exit 1
           fi
 
+  # RFC-023 §4.1 + issue #365 — parity-drift lint for the PG ↔ SQLite
+  # migration pair. Blocks PRs that add a PG migration without a
+  # matching SQLite port (or an `.sqlite-skip` entry with an issue
+  # reference) and vice versa. Runs as a plain shell step — no cargo
+  # build needed.
+  migration-parity:
+    name: sqlite/postgres migration parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: scripts/lint-migrations.sh
+        run: bash scripts/lint-migrations.sh
+
   matrix-tests-complete:
     name: matrix-tests-complete
-    needs: [matrix, matrix-postgres, lua-drift]
+    needs: [matrix, matrix-postgres, lua-drift, migration-parity]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -449,6 +462,7 @@ jobs:
           MATRIX_RESULT: ${{ needs.matrix.result }}
           POSTGRES_RESULT: ${{ needs.matrix-postgres.result }}
           DRIFT_RESULT: ${{ needs.lua-drift.result }}
+          MIGRATION_PARITY_RESULT: ${{ needs.migration-parity.result }}
         run: |
           fail=0
           case "$MATRIX_RESULT" in
@@ -462,5 +476,9 @@ jobs:
           case "$DRIFT_RESULT" in
             success|skipped) echo "lua-drift: $DRIFT_RESULT — ok" ;;
             *) echo "lua-drift: $DRIFT_RESULT — blocking merge" >&2; fail=1 ;;
+          esac
+          case "$MIGRATION_PARITY_RESULT" in
+            success|skipped) echo "migration-parity: $MIGRATION_PARITY_RESULT — ok" ;;
+            *) echo "migration-parity: $MIGRATION_PARITY_RESULT — blocking merge" >&2; fail=1 ;;
           esac
           exit $fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,22 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - CI cell (`cargo check -p ff-sdk --no-default-features --features
   sqlite`) — mechanical regression guard for the RFC-023 Phase 1a
   worker.rs cfg-gate discipline.
+- **`ff-backend-sqlite` — Phase 1b: 14 hand-ported SQLite-dialect
+  migrations (0001-0014) covering exec / attempt / flow / budget /
+  quota / outbox schemas.** `SqliteBackend::new` now calls
+  `sqlx::migrate!` against the pool on construction. Flat tables (no
+  HASH-partitioning DDL), `jsonb → TEXT`, `bytea → BLOB`,
+  `uuid → BLOB`, `BIGSERIAL → INTEGER PRIMARY KEY AUTOINCREMENT`,
+  `pg_notify` triggers dropped (broadcast moves to Rust per RFC-023
+  §4.2), `CREATE INDEX CONCURRENTLY` / `USING GIN` / `INCLUDE(...)`
+  collapse to plain `CREATE INDEX`. Trait impls remain `Unavailable`
+  until Phase 2+.
+- `ff_execution_capabilities` junction table on SQLite (replaces the
+  PG `text[]` + GIN shape per RFC-023 §4.1 A4). `WITHOUT ROWID` +
+  reverse index for capability-first routing lookups.
+- `scripts/lint-migrations.sh` — parity-drift lint comparing the PG
+  and SQLite migration directories. Wired into `.github/workflows/
+  matrix.yml` as a quality-gate job (`migration-parity`).
 
 ### Changed
 

--- a/crates/ff-backend-sqlite/migrations/.sqlite-skip
+++ b/crates/ff-backend-sqlite/migrations/.sqlite-skip
@@ -1,9 +1,15 @@
-# RFC-023 §4.1 parity-drift lint sidecar. Phase 1a lands no migrations
-# (the first real entries arrive in Phase 1b, which ports the 14 PG
-# migrations). The `.sqlite-skip` format is documented in RFC-023
-# §4.1: one relative path per line pointing at the PG migration
-# intentionally skipped, `#` comments, inline `# issue:NNN` suffix for
-# tracking.
+# RFC-023 §4.1 parity-drift lint sidecar. Every PG migration under
+# `crates/ff-backend-postgres/migrations/` either has a SQLite sibling
+# in this directory with the same filename, or appears as an entry
+# below. Phase 1b ported all 14 genesis PG migrations; this file is
+# intentionally empty (no skipped migrations).
 #
-# Phase 1a intentionally has NO entries — the lint (also Phase 1b)
-# will first run against a populated migrations directory.
+# Format (§4.1 C-trivia-2):
+#   * One relative path per line (the PG migration intentionally
+#     skipped, e.g. `0012_pg_only_admin.sql`).
+#   * `#` starts a comment; inline `# issue:NNN` annotates the
+#     tracking issue.
+#   * Blank lines are ignored.
+#
+# The parity-drift lint (`scripts/lint-migrations.sh`) parses this
+# format directly.

--- a/crates/ff-backend-sqlite/migrations/0001_initial.sql
+++ b/crates/ff-backend-sqlite/migrations/0001_initial.sql
@@ -274,8 +274,9 @@ CREATE TABLE ff_stream_frame (
     PRIMARY KEY (partition_key, execution_id, attempt_index, ts_ms, seq)
 );
 
-CREATE INDEX ff_stream_frame_ts_seq_idx
-    ON ff_stream_frame (partition_key, execution_id, attempt_index, ts_ms, seq);
+-- No explicit ts/seq index: SQLite auto-indexes the PRIMARY KEY
+-- above, which already matches the (partition_key, execution_id,
+-- attempt_index, ts_ms, seq) scan shape used by stream catch-up.
 
 CREATE TABLE ff_stream_summary (
     partition_key       INTEGER NOT NULL,
@@ -324,8 +325,9 @@ CREATE TABLE ff_completion_event (
 CREATE UNIQUE INDEX ff_completion_event_partition_event_idx
     ON ff_completion_event (partition_key, event_id);
 
-CREATE INDEX ff_completion_event_event_id_idx
-    ON ff_completion_event (event_id);
+-- No explicit index on `event_id` alone: it is `INTEGER PRIMARY KEY
+-- AUTOINCREMENT`, i.e. an alias for SQLite's rowid, which is already
+-- the implicit primary index. A secondary index would be pure overhead.
 
 -- ============================================================
 -- Section 7 — Migration annotation + partition-config seed
@@ -339,6 +341,17 @@ VALUES (
     0
 );
 
+-- Seed the partition-config row.
+--
+-- NOTE: diverges from the PG seed (256/256/256). Per RFC-023 §4.1, the
+-- SQLite backend runs with scanner-supervisor fan-out N=1 — the notion
+-- of hashed partition routing does not apply to a single-writer
+-- embedded SQLite DB — so `num_*_partitions = 1` is the correct
+-- metadata-of-record here. Phase 2+ code must NOT read these values
+-- expecting PG parity; they describe the SQLite deployment shape.
+--
+-- `ff_version = '0.12.0'` matches the version in which this schema
+-- lands (RFC-023 Phase 1b).
 INSERT INTO ff_partition_config (
     singleton_lock,
     num_flow_partitions,

--- a/crates/ff-backend-sqlite/migrations/0001_initial.sql
+++ b/crates/ff-backend-sqlite/migrations/0001_initial.sql
@@ -1,0 +1,350 @@
+-- RFC-023 Phase 1b — SQLite-dialect port of
+-- `crates/ff-backend-postgres/migrations/0001_initial.sql`.
+--
+-- Port rules applied (per RFC-023 §4.1):
+--   * Flat tables — SQLite is single-writer, single-process; no
+--     HASH-partitioning (§4.1 A3). The `partition_key INTEGER NOT
+--     NULL` column stays on every table so downstream query shapes
+--     match the PG schema verbatim, but there is no partition DDL.
+--   * `uuid` → `BLOB` (16-byte binary form). Phase 2 query bodies
+--     serialize / deserialize at the SQL boundary.
+--   * `bytea` → `BLOB`. `jsonb` → `TEXT` (JSON1 `json_extract` etc.
+--     on read).
+--   * `text[]` for capability-routing (`required_capabilities`) is
+--     replaced with a normalized junction table
+--     `ff_execution_capabilities` per RFC-023 §4.1 A4. The column
+--     is dropped on this side.
+--   * Triggers with `pg_notify(...)` are dropped entirely —
+--     broadcast moves into the Rust post-commit path per
+--     RFC-023 §4.2.
+--   * `CREATE INDEX CONCURRENTLY` / `USING GIN` / `INCLUDE (...)`
+--     collapse to plain `CREATE INDEX` (see §4.1).
+--   * `BIGSERIAL` / `GENERATED ALWAYS AS IDENTITY` → `INTEGER
+--     PRIMARY KEY AUTOINCREMENT`.
+--   * `extract(epoch from clock_timestamp())*1000` →
+--     `CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)`.
+
+-- ============================================================
+-- Section 1 — Global tables
+-- ============================================================
+
+CREATE TABLE ff_waitpoint_hmac (
+    kid           TEXT    NOT NULL PRIMARY KEY,
+    secret        BLOB    NOT NULL,
+    rotated_at_ms INTEGER NOT NULL,
+    active        INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE ff_lane_registry (
+    lane_id          TEXT    NOT NULL PRIMARY KEY,
+    registered_at_ms INTEGER NOT NULL,
+    registered_by    TEXT    NOT NULL
+);
+
+CREATE TABLE ff_partition_config (
+    singleton_lock         INTEGER NOT NULL PRIMARY KEY DEFAULT 1
+                                    CHECK (singleton_lock = 1),
+    num_flow_partitions    INTEGER NOT NULL,
+    num_budget_partitions  INTEGER NOT NULL,
+    num_quota_partitions   INTEGER NOT NULL,
+    ff_version             TEXT    NOT NULL
+);
+
+CREATE TABLE ff_migration_annotation (
+    version              INTEGER NOT NULL PRIMARY KEY,
+    name                 TEXT    NOT NULL,
+    applied_at_ms        INTEGER NOT NULL,
+    backward_compatible  INTEGER NOT NULL
+);
+
+-- ============================================================
+-- Section 2 — Core execution + flow tables (flat, not partitioned)
+-- ============================================================
+
+-- `required_capabilities` lives on `ff_execution_capabilities`
+-- (junction, per RFC-023 §4.1 A4) rather than an inline array.
+CREATE TABLE ff_exec_core (
+    partition_key         INTEGER NOT NULL,
+    execution_id          BLOB    NOT NULL,
+    flow_id               BLOB,
+    lane_id               TEXT    NOT NULL,
+    attempt_index         INTEGER NOT NULL DEFAULT 0,
+    lifecycle_phase       TEXT    NOT NULL,
+    ownership_state       TEXT    NOT NULL,
+    eligibility_state     TEXT    NOT NULL,
+    public_state          TEXT    NOT NULL,
+    attempt_state         TEXT    NOT NULL,
+    blocking_reason       TEXT,
+    cancellation_reason   TEXT,
+    cancelled_by          TEXT,
+    priority              INTEGER NOT NULL DEFAULT 0,
+    created_at_ms         INTEGER NOT NULL,
+    terminal_at_ms        INTEGER,
+    deadline_at_ms        INTEGER,
+    payload               BLOB,
+    result                BLOB,
+    policy                TEXT,
+    raw_fields            TEXT    NOT NULL DEFAULT '{}',
+    PRIMARY KEY (partition_key, execution_id)
+);
+
+CREATE INDEX ff_exec_core_lane_phase_idx
+    ON ff_exec_core (partition_key, lane_id, lifecycle_phase);
+
+CREATE INDEX ff_exec_core_flow_idx
+    ON ff_exec_core (partition_key, flow_id)
+    WHERE flow_id IS NOT NULL;
+
+CREATE INDEX ff_exec_core_deadline_idx
+    ON ff_exec_core (partition_key, deadline_at_ms)
+    WHERE deadline_at_ms IS NOT NULL;
+
+-- Capability junction (RFC-023 §4.1 A4 — replaces PG text[] + GIN).
+-- `WITHOUT ROWID` matches RFC-023 §4.1 A4 spec.
+CREATE TABLE ff_execution_capabilities (
+    execution_id BLOB NOT NULL,
+    capability   TEXT NOT NULL,
+    PRIMARY KEY (execution_id, capability)
+) WITHOUT ROWID;
+
+-- Reverse index for capability-first routing lookups.
+CREATE INDEX ff_execution_capabilities_capability_idx
+    ON ff_execution_capabilities (capability, execution_id);
+
+CREATE TABLE ff_flow_core (
+    partition_key     INTEGER NOT NULL,
+    flow_id           BLOB    NOT NULL,
+    graph_revision    INTEGER NOT NULL DEFAULT 0,
+    public_flow_state TEXT    NOT NULL,
+    created_at_ms     INTEGER NOT NULL,
+    terminal_at_ms    INTEGER,
+    raw_fields        TEXT    NOT NULL DEFAULT '{}',
+    PRIMARY KEY (partition_key, flow_id)
+);
+
+CREATE TABLE ff_attempt (
+    partition_key        INTEGER NOT NULL,
+    execution_id         BLOB    NOT NULL,
+    attempt_index        INTEGER NOT NULL,
+    worker_id            TEXT,
+    worker_instance_id   TEXT,
+    lease_epoch          INTEGER NOT NULL DEFAULT 0,
+    lease_expires_at_ms  INTEGER,
+    started_at_ms        INTEGER,
+    terminal_at_ms       INTEGER,
+    outcome              TEXT,
+    usage                TEXT,
+    policy               TEXT,
+    raw_fields           TEXT    NOT NULL DEFAULT '{}',
+    PRIMARY KEY (partition_key, execution_id, attempt_index)
+);
+
+CREATE INDEX ff_attempt_lease_expiry_idx
+    ON ff_attempt (partition_key, lease_expires_at_ms)
+    WHERE lease_expires_at_ms IS NOT NULL;
+
+CREATE INDEX ff_attempt_worker_idx
+    ON ff_attempt (partition_key, worker_id)
+    WHERE worker_id IS NOT NULL;
+
+-- ============================================================
+-- Section 3 — Flow edges + sibling-cancel (RFC-016)
+-- ============================================================
+
+CREATE TABLE ff_edge (
+    partition_key  INTEGER NOT NULL,
+    flow_id        BLOB    NOT NULL,
+    edge_id        BLOB    NOT NULL,
+    upstream_eid   BLOB    NOT NULL,
+    downstream_eid BLOB    NOT NULL,
+    policy         TEXT    NOT NULL,
+    policy_version INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (partition_key, flow_id, edge_id)
+);
+
+-- PG uses INCLUDE(upstream_eid, policy_version). SQLite lacks
+-- covering indexes; plain key-only index is equivalent semantically,
+-- just forces a heap lookup for the extra cols.
+CREATE INDEX ff_edge_downstream_idx
+    ON ff_edge (partition_key, flow_id, downstream_eid);
+
+CREATE INDEX ff_edge_upstream_idx
+    ON ff_edge (partition_key, flow_id, upstream_eid);
+
+-- `cancel_siblings_pending_members` is `text[]` in PG. On SQLite it
+-- becomes a JSON array in a TEXT column; per-group mutations go
+-- through `json_insert` / `json_remove` (Phase 2). Not a junction —
+-- RFC-023 §4.1 A4 reserves the junction form for the capability
+-- routing path.
+CREATE TABLE ff_edge_group (
+    partition_key                    INTEGER NOT NULL,
+    flow_id                          BLOB    NOT NULL,
+    downstream_eid                   BLOB    NOT NULL,
+    policy                           TEXT    NOT NULL,
+    k_target                         INTEGER NOT NULL DEFAULT 0,
+    success_count                    INTEGER NOT NULL DEFAULT 0,
+    fail_count                       INTEGER NOT NULL DEFAULT 0,
+    skip_count                       INTEGER NOT NULL DEFAULT 0,
+    running_count                    INTEGER NOT NULL DEFAULT 0,
+    cancel_siblings_pending_flag     INTEGER NOT NULL DEFAULT 0,
+    cancel_siblings_pending_members  TEXT    NOT NULL DEFAULT '[]',
+    PRIMARY KEY (partition_key, flow_id, downstream_eid)
+);
+
+CREATE TABLE ff_pending_cancel_groups (
+    partition_key   INTEGER NOT NULL,
+    flow_id         BLOB    NOT NULL,
+    downstream_eid  BLOB    NOT NULL,
+    enqueued_at_ms  INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, flow_id, downstream_eid)
+);
+
+CREATE INDEX ff_pending_cancel_groups_enqueued_idx
+    ON ff_pending_cancel_groups (partition_key, enqueued_at_ms);
+
+CREATE TABLE ff_cancel_dispatch_outbox (
+    partition_key    INTEGER NOT NULL,
+    flow_id          BLOB    NOT NULL,
+    downstream_eid   BLOB    NOT NULL,
+    target_exec_id   BLOB    NOT NULL,
+    reason           TEXT    NOT NULL,
+    enqueued_at_ms   INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, flow_id, downstream_eid, target_exec_id)
+);
+
+CREATE INDEX ff_cancel_dispatch_outbox_enqueued_idx
+    ON ff_cancel_dispatch_outbox (partition_key, enqueued_at_ms);
+
+-- ============================================================
+-- Section 4 — Suspension + waitpoints (RFC-013/014)
+-- ============================================================
+
+CREATE TABLE ff_suspension_current (
+    partition_key   INTEGER NOT NULL,
+    execution_id    BLOB    NOT NULL,
+    suspension_id   BLOB    NOT NULL,
+    suspended_at_ms INTEGER NOT NULL,
+    timeout_at_ms   INTEGER,
+    reason_code     TEXT,
+    condition       TEXT    NOT NULL,
+    satisfied_set   TEXT    NOT NULL DEFAULT '[]',
+    member_map      TEXT    NOT NULL DEFAULT '{}',
+    PRIMARY KEY (partition_key, execution_id)
+);
+
+CREATE INDEX ff_suspension_current_suspended_at_idx
+    ON ff_suspension_current (partition_key, suspended_at_ms);
+
+CREATE INDEX ff_suspension_current_timeout_idx
+    ON ff_suspension_current (partition_key, timeout_at_ms)
+    WHERE timeout_at_ms IS NOT NULL;
+
+CREATE TABLE ff_waitpoint_pending (
+    partition_key  INTEGER NOT NULL,
+    waitpoint_id   BLOB    NOT NULL,
+    execution_id   BLOB    NOT NULL,
+    token_kid      TEXT    NOT NULL,
+    token          TEXT    NOT NULL,
+    created_at_ms  INTEGER NOT NULL,
+    expires_at_ms  INTEGER,
+    condition      TEXT,
+    PRIMARY KEY (partition_key, waitpoint_id)
+);
+
+CREATE INDEX ff_waitpoint_pending_expires_idx
+    ON ff_waitpoint_pending (partition_key, expires_at_ms)
+    WHERE expires_at_ms IS NOT NULL;
+
+CREATE INDEX ff_waitpoint_pending_exec_idx
+    ON ff_waitpoint_pending (partition_key, execution_id);
+
+-- ============================================================
+-- Section 5 — Stream tables (RFC-015)
+-- ============================================================
+
+CREATE TABLE ff_stream_frame (
+    partition_key   INTEGER NOT NULL,
+    execution_id    BLOB    NOT NULL,
+    attempt_index   INTEGER NOT NULL,
+    ts_ms           INTEGER NOT NULL,
+    seq             INTEGER NOT NULL,
+    fields          TEXT    NOT NULL,
+    mode            TEXT    NOT NULL,
+    created_at_ms   INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, execution_id, attempt_index, ts_ms, seq)
+);
+
+CREATE INDEX ff_stream_frame_ts_seq_idx
+    ON ff_stream_frame (partition_key, execution_id, attempt_index, ts_ms, seq);
+
+CREATE TABLE ff_stream_summary (
+    partition_key       INTEGER NOT NULL,
+    execution_id        BLOB    NOT NULL,
+    attempt_index       INTEGER NOT NULL,
+    document_json       TEXT    NOT NULL,
+    version             INTEGER NOT NULL DEFAULT 0,
+    patch_kind          TEXT,
+    last_updated_ms     INTEGER NOT NULL,
+    first_applied_ms    INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, execution_id, attempt_index)
+);
+
+CREATE TABLE ff_stream_meta (
+    partition_key        INTEGER NOT NULL,
+    execution_id         BLOB    NOT NULL,
+    attempt_index        INTEGER NOT NULL,
+    ema_rate_hz          REAL    NOT NULL DEFAULT 0,
+    last_append_ts_ms    INTEGER NOT NULL DEFAULT 0,
+    maxlen_applied_last  INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (partition_key, execution_id, attempt_index)
+);
+
+-- ============================================================
+-- Section 6 — Outbox (broadcast moves to Rust per RFC-023 §4.2)
+-- ============================================================
+-- The AFTER-INSERT pg_notify triggers from PG 0001 §Section 8 are
+-- intentionally omitted. Subscribers on SQLite wake via an in-Rust
+-- post-commit channel plumbed on the backend; durable replay still
+-- rides the `event_id > cursor` catch-up query against this table.
+CREATE TABLE ff_completion_event (
+    partition_key    INTEGER NOT NULL,
+    event_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id     BLOB    NOT NULL,
+    flow_id          BLOB,
+    outcome          TEXT    NOT NULL,
+    namespace        TEXT,
+    instance_tag     TEXT,
+    occurred_at_ms   INTEGER NOT NULL,
+    committed_at_ms  INTEGER NOT NULL DEFAULT (CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))
+);
+
+-- PG declares `(partition_key, event_id)` as the PK; SQLite requires
+-- AUTOINCREMENT columns to be the sole PRIMARY KEY. A UNIQUE index
+-- on the composite preserves the same lookup shape.
+CREATE UNIQUE INDEX ff_completion_event_partition_event_idx
+    ON ff_completion_event (partition_key, event_id);
+
+CREATE INDEX ff_completion_event_event_id_idx
+    ON ff_completion_event (event_id);
+
+-- ============================================================
+-- Section 7 — Migration annotation + partition-config seed
+-- ============================================================
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    1,
+    '0001_initial',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    0
+);
+
+INSERT INTO ff_partition_config (
+    singleton_lock,
+    num_flow_partitions,
+    num_budget_partitions,
+    num_quota_partitions,
+    ff_version
+) VALUES (
+    1, 1, 1, 1, '0.12.0'
+);

--- a/crates/ff-backend-sqlite/migrations/0002_budget.sql
+++ b/crates/ff-backend-sqlite/migrations/0002_budget.sql
@@ -1,0 +1,44 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0002_budget.sql`.
+--
+-- Flat tables (no HASH partitioning, per RFC-023 §4.1). jsonb → TEXT;
+-- bigint → INTEGER; smallint → INTEGER.
+
+CREATE TABLE ff_budget_policy (
+    partition_key  INTEGER NOT NULL,
+    budget_id      TEXT    NOT NULL,
+    policy_json    TEXT    NOT NULL,
+    created_at_ms  INTEGER NOT NULL,
+    updated_at_ms  INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, budget_id)
+);
+
+CREATE TABLE ff_budget_usage (
+    partition_key     INTEGER NOT NULL,
+    budget_id         TEXT    NOT NULL,
+    dimensions_key    TEXT    NOT NULL,
+    current_value     INTEGER NOT NULL DEFAULT 0,
+    last_reset_at_ms  INTEGER,
+    updated_at_ms     INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, budget_id, dimensions_key)
+);
+
+CREATE TABLE ff_budget_usage_dedup (
+    partition_key  INTEGER NOT NULL,
+    dedup_key      TEXT    NOT NULL,
+    outcome_json   TEXT    NOT NULL,
+    applied_at_ms  INTEGER NOT NULL,
+    expires_at_ms  INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, dedup_key)
+);
+
+CREATE INDEX ff_budget_usage_dedup_expires_idx
+    ON ff_budget_usage_dedup (partition_key, expires_at_ms);
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    2,
+    '0002_budget',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0003_dispatch_outbox.sql
+++ b/crates/ff-backend-sqlite/migrations/0003_dispatch_outbox.sql
@@ -1,0 +1,19 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0003_dispatch_outbox.sql`.
+--
+-- Additive; same shape on SQLite.
+
+ALTER TABLE ff_completion_event
+    ADD COLUMN dispatched_at_ms INTEGER;
+
+CREATE INDEX ff_completion_event_pending_dispatch_idx
+    ON ff_completion_event (partition_key, committed_at_ms)
+    WHERE dispatched_at_ms IS NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    3,
+    '0003_dispatch_outbox',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0004_suspend_signal.sql
+++ b/crates/ff-backend-sqlite/migrations/0004_suspend_signal.sql
@@ -1,0 +1,23 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0004_suspend_signal.sql`.
+--
+-- Additive. Same shape; jsonb → TEXT.
+
+CREATE TABLE ff_suspend_dedup (
+    partition_key    INTEGER NOT NULL,
+    idempotency_key  TEXT    NOT NULL,
+    outcome_json     TEXT    NOT NULL,
+    created_at_ms    INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, idempotency_key)
+);
+
+ALTER TABLE ff_waitpoint_pending
+    ADD COLUMN waitpoint_key TEXT NOT NULL DEFAULT '';
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    4,
+    '0004_suspend_signal',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0005_timeout_scanners.sql
+++ b/crates/ff-backend-sqlite/migrations/0005_timeout_scanners.sql
@@ -1,0 +1,15 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0005_timeout_scanners.sql`.
+--
+-- Additive. Single ALTER.
+
+ALTER TABLE ff_suspension_current
+    ADD COLUMN timeout_behavior TEXT;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    5,
+    '0005_timeout_scanners',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0006_lease_event_outbox.sql
+++ b/crates/ff-backend-sqlite/migrations/0006_lease_event_outbox.sql
@@ -1,0 +1,26 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0006_lease_event_outbox.sql`.
+--
+-- Schema + index intact (subscribers still drain via
+-- `event_id > $cursor`). pg_notify trigger is dropped; broadcast
+-- moves to the in-Rust post-commit channel per RFC-023 §4.2.
+
+CREATE TABLE ff_lease_event (
+    event_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id    TEXT NOT NULL,
+    lease_id        TEXT,
+    event_type      TEXT NOT NULL,
+    occurred_at_ms  INTEGER NOT NULL,
+    partition_key   INTEGER NOT NULL
+);
+
+CREATE INDEX ff_lease_event_partition_key_idx
+    ON ff_lease_event (partition_key, event_id);
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    6,
+    '0006_lease_event_outbox',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0007_signal_event_outbox.sql
+++ b/crates/ff-backend-sqlite/migrations/0007_signal_event_outbox.sql
@@ -1,0 +1,26 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0007_signal_event_outbox.sql`.
+--
+-- Schema + index intact. pg_notify trigger dropped — Rust post-commit
+-- broadcast per RFC-023 §4.2.
+
+CREATE TABLE ff_signal_event (
+    event_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id    TEXT NOT NULL,
+    signal_id       TEXT NOT NULL,
+    waitpoint_id    TEXT,
+    source_identity TEXT,
+    delivered_at_ms INTEGER NOT NULL,
+    partition_key   INTEGER NOT NULL
+);
+
+CREATE INDEX ff_signal_event_partition_key_idx
+    ON ff_signal_event (partition_key, event_id);
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    7,
+    '0007_signal_event_outbox',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0008_lease_event_instance_tag.sql
+++ b/crates/ff-backend-sqlite/migrations/0008_lease_event_instance_tag.sql
@@ -1,0 +1,27 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0008_lease_event_instance_tag.sql`.
+--
+-- SQLite does not support multiple ADD COLUMNs in a single ALTER;
+-- split into two statements.
+
+ALTER TABLE ff_lease_event
+    ADD COLUMN namespace    TEXT;
+
+ALTER TABLE ff_lease_event
+    ADD COLUMN instance_tag TEXT;
+
+CREATE INDEX ff_lease_event_namespace_idx
+    ON ff_lease_event (partition_key, namespace)
+    WHERE namespace IS NOT NULL;
+
+CREATE INDEX ff_lease_event_instance_tag_idx
+    ON ff_lease_event (partition_key, instance_tag)
+    WHERE instance_tag IS NOT NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    8,
+    '0008_lease_event_instance_tag',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0009_signal_event_instance_tag.sql
+++ b/crates/ff-backend-sqlite/migrations/0009_signal_event_instance_tag.sql
@@ -1,0 +1,26 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0009_signal_event_instance_tag.sql`.
+--
+-- SQLite ALTER TABLE only supports one ADD COLUMN per statement.
+
+ALTER TABLE ff_signal_event
+    ADD COLUMN namespace    TEXT;
+
+ALTER TABLE ff_signal_event
+    ADD COLUMN instance_tag TEXT;
+
+CREATE INDEX ff_signal_event_namespace_idx
+    ON ff_signal_event (partition_key, namespace)
+    WHERE namespace IS NOT NULL;
+
+CREATE INDEX ff_signal_event_instance_tag_idx
+    ON ff_signal_event (partition_key, instance_tag)
+    WHERE instance_tag IS NOT NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    9,
+    '0009_signal_event_instance_tag',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0010_operator_event_outbox.sql
+++ b/crates/ff-backend-sqlite/migrations/0010_operator_event_outbox.sql
@@ -1,0 +1,37 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0010_operator_event_outbox.sql`.
+--
+-- Schema + indexes intact (including the event_type CHECK — SQLite
+-- supports CHECK). pg_notify trigger dropped; Rust post-commit
+-- broadcast per RFC-023 §4.2. jsonb → TEXT.
+
+CREATE TABLE ff_operator_event (
+    event_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id    TEXT NOT NULL,
+    event_type      TEXT NOT NULL
+        CHECK (event_type IN ('priority_changed', 'replayed', 'flow_cancel_requested')),
+    details         TEXT,
+    occurred_at_ms  INTEGER NOT NULL,
+    partition_key   INTEGER NOT NULL,
+    namespace       TEXT,
+    instance_tag    TEXT
+);
+
+CREATE INDEX ff_operator_event_partition_key_idx
+    ON ff_operator_event (partition_key, event_id);
+
+CREATE INDEX ff_operator_event_namespace_idx
+    ON ff_operator_event (partition_key, namespace)
+    WHERE namespace IS NOT NULL;
+
+CREATE INDEX ff_operator_event_instance_tag_idx
+    ON ff_operator_event (partition_key, instance_tag)
+    WHERE instance_tag IS NOT NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    10,
+    '0010_operator_event_outbox',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0011_waitpoint_pending_extensions.sql
+++ b/crates/ff-backend-sqlite/migrations/0011_waitpoint_pending_extensions.sql
@@ -1,0 +1,22 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0011_waitpoint_pending_extensions.sql`.
+--
+-- Additive. TEXT[] → TEXT holding a JSON array literal; SQLite's
+-- ALTER TABLE only supports one ADD COLUMN per statement.
+
+ALTER TABLE ff_waitpoint_pending
+    ADD COLUMN state TEXT NOT NULL DEFAULT 'pending';
+
+ALTER TABLE ff_waitpoint_pending
+    ADD COLUMN required_signal_names TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE ff_waitpoint_pending
+    ADD COLUMN activated_at_ms INTEGER;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    11,
+    '0011_waitpoint_pending_extensions',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0012_quota_policy.sql
+++ b/crates/ff-backend-sqlite/migrations/0012_quota_policy.sql
@@ -1,0 +1,45 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0012_quota_policy.sql`.
+--
+-- Flat tables; no HASH-partitioning DDL on SQLite (RFC-023 §4.1).
+
+CREATE TABLE ff_quota_policy (
+    partition_key                 INTEGER NOT NULL,
+    quota_policy_id               TEXT    NOT NULL,
+    requests_per_window_seconds   INTEGER NOT NULL,
+    max_requests_per_window       INTEGER NOT NULL,
+    active_concurrency_cap        INTEGER NOT NULL,
+    active_concurrency            INTEGER NOT NULL DEFAULT 0,
+    created_at_ms                 INTEGER NOT NULL,
+    updated_at_ms                 INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, quota_policy_id)
+);
+
+CREATE TABLE ff_quota_window (
+    partition_key     INTEGER NOT NULL,
+    quota_policy_id   TEXT    NOT NULL,
+    dimension         TEXT    NOT NULL DEFAULT '',
+    admitted_at_ms    INTEGER NOT NULL,
+    execution_id      TEXT    NOT NULL,
+    PRIMARY KEY (partition_key, quota_policy_id, dimension, admitted_at_ms, execution_id)
+);
+
+CREATE TABLE ff_quota_admitted (
+    partition_key     INTEGER NOT NULL,
+    quota_policy_id   TEXT    NOT NULL,
+    execution_id      TEXT    NOT NULL,
+    admitted_at_ms    INTEGER NOT NULL,
+    expires_at_ms     INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, quota_policy_id, execution_id)
+);
+
+CREATE INDEX ff_quota_admitted_expires_idx
+    ON ff_quota_admitted (partition_key, expires_at_ms);
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    12,
+    '0012_quota_policy',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0013_budget_policy_extensions.sql
+++ b/crates/ff-backend-sqlite/migrations/0013_budget_policy_extensions.sql
@@ -1,0 +1,34 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0013_budget_policy_extensions.sql`.
+--
+-- Additive. SQLite's ALTER TABLE only supports one ADD COLUMN per
+-- statement; the PG multi-ADD is split. Partial index shape unchanged.
+
+ALTER TABLE ff_budget_policy
+    ADD COLUMN scope_type          TEXT   NOT NULL DEFAULT '';
+ALTER TABLE ff_budget_policy
+    ADD COLUMN scope_id            TEXT   NOT NULL DEFAULT '';
+ALTER TABLE ff_budget_policy
+    ADD COLUMN enforcement_mode    TEXT   NOT NULL DEFAULT '';
+ALTER TABLE ff_budget_policy
+    ADD COLUMN breach_count        INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ff_budget_policy
+    ADD COLUMN soft_breach_count   INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ff_budget_policy
+    ADD COLUMN last_breach_at_ms   INTEGER;
+ALTER TABLE ff_budget_policy
+    ADD COLUMN last_breach_dim     TEXT;
+ALTER TABLE ff_budget_policy
+    ADD COLUMN next_reset_at_ms    INTEGER;
+
+CREATE INDEX ff_budget_policy_reset_due_idx
+    ON ff_budget_policy (partition_key, next_reset_at_ms)
+    WHERE next_reset_at_ms IS NOT NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    13,
+    '0013_budget_policy_extensions',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0014_cancel_backlog.sql
+++ b/crates/ff-backend-sqlite/migrations/0014_cancel_backlog.sql
@@ -1,0 +1,35 @@
+-- RFC-023 Phase 1b — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0014_cancel_backlog.sql`.
+--
+-- Flat tables; no partitioning. uuid → BLOB.
+
+CREATE TABLE ff_cancel_backlog (
+    partition_key        INTEGER NOT NULL,
+    flow_id              BLOB    NOT NULL,
+    requested_at_ms      INTEGER NOT NULL,
+    requester            TEXT    NOT NULL DEFAULT '',
+    reason               TEXT    NOT NULL DEFAULT '',
+    grace_until_ms       INTEGER,
+    cancellation_policy  TEXT    NOT NULL,
+    status               TEXT    NOT NULL DEFAULT 'pending',
+    PRIMARY KEY (partition_key, flow_id)
+);
+
+CREATE TABLE ff_cancel_backlog_member (
+    partition_key   INTEGER NOT NULL,
+    flow_id         BLOB    NOT NULL,
+    execution_id    TEXT    NOT NULL,
+    PRIMARY KEY (partition_key, flow_id, execution_id)
+);
+
+CREATE INDEX ff_cancel_backlog_grace_idx
+    ON ff_cancel_backlog (partition_key, grace_until_ms)
+    WHERE grace_until_ms IS NOT NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    14,
+    '0014_cancel_backlog',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -231,10 +231,17 @@ impl SqliteBackend {
              not supported in production. See RFC-023."
         );
 
-        // Phase 1a: no migrations to apply — the migrations directory
-        // is an empty placeholder with a `.sqlite-skip` tombstone.
-        // Phase 1b lands `sqlx::migrate!("./migrations").run(&pool)`
-        // alongside the first real migration file.
+        // RFC-023 Phase 1b: apply the 14 hand-ported SQLite-dialect
+        // migrations against the freshly-constructed pool. `sqlx::migrate!`
+        // embeds the files at compile time and records applied versions
+        // in `_sqlx_migrations` so reruns are idempotent.
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .map_err(|e| BackendError::Valkey {
+                kind: ff_core::engine_error::BackendErrorKind::Protocol,
+                message: format!("sqlite migrate for {path:?}: {e}"),
+            })?;
 
         let inner = Arc::new(SqliteBackendInner {
             pool,

--- a/crates/ff-backend-sqlite/tests/migrations.rs
+++ b/crates/ff-backend-sqlite/tests/migrations.rs
@@ -13,6 +13,11 @@ use serial_test::serial;
 /// DB under FF_DEV_MODE=1. The helper embeds a UUID in the URI so
 /// parallel tests never collide on the registry key.
 async fn fresh_backend() -> std::sync::Arc<SqliteBackend> {
+    // SAFETY: test-only env mutation; every caller is tagged
+    // `#[serial(ff_dev_mode)]` which serialises all FF_DEV_MODE
+    // readers + writers across this crate's test binaries, so no
+    // concurrent reader observes the write (the UB vector `set_var`
+    // is marked unsafe for in Rust 1.87+).
     unsafe {
         std::env::set_var("FF_DEV_MODE", "1");
     }
@@ -45,8 +50,8 @@ async fn migrations_apply_and_schema_is_present() {
 
     // Spot-check a handful of table names drawn from every
     // contributing migration. `sqlite_master` is the canonical SQLite
-    // catalog; `type='table'` filters out indexes + the sqlx metadata
-    // table.
+    // catalog; `type='table'` filters out indexes and views.
+    // `_sqlx_migrations` IS a table and is expected — asserted below.
     let mut rows =
         sqlx::query_as::<_, (String,)>("SELECT name FROM sqlite_master WHERE type='table'")
             .fetch_all(pool)

--- a/crates/ff-backend-sqlite/tests/migrations.rs
+++ b/crates/ff-backend-sqlite/tests/migrations.rs
@@ -1,0 +1,178 @@
+//! RFC-023 Phase 1b — migration applier regression tests.
+//!
+//! Phase 1a shipped an empty migrations dir; Phase 1b lands 14
+//! hand-ported SQLite-dialect migrations and wires `sqlx::migrate!`
+//! into `SqliteBackend::new`. These tests assert the constructor
+//! applies every migration against a fresh in-memory DB and that
+//! the schema-of-record matches the ports.
+
+use ff_backend_sqlite::SqliteBackend;
+use serial_test::serial;
+
+/// Construct a `SqliteBackend` against a fresh shared-cache `:memory:`
+/// DB under FF_DEV_MODE=1. The helper embeds a UUID in the URI so
+/// parallel tests never collide on the registry key.
+async fn fresh_backend() -> std::sync::Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:rfc-023-migrations-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri)
+        .await
+        .expect("construct with migrations")
+}
+
+/// Cheap unique-id helper; avoids pulling a new `uuid` dev-dep.
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    // Thread-id disambiguates parallel `#[tokio::test]` runners.
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn migrations_apply_and_schema_is_present() {
+    let backend = fresh_backend().await;
+    let pool = backend.pool_for_test();
+
+    // Spot-check a handful of table names drawn from every
+    // contributing migration. `sqlite_master` is the canonical SQLite
+    // catalog; `type='table'` filters out indexes + the sqlx metadata
+    // table.
+    let mut rows =
+        sqlx::query_as::<_, (String,)>("SELECT name FROM sqlite_master WHERE type='table'")
+            .fetch_all(pool)
+            .await
+            .expect("query sqlite_master");
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    let names: Vec<String> = rows.into_iter().map(|(n,)| n).collect();
+
+    for expected in [
+        // 0001 — genesis schema
+        "ff_waitpoint_hmac",
+        "ff_lane_registry",
+        "ff_partition_config",
+        "ff_migration_annotation",
+        "ff_exec_core",
+        "ff_execution_capabilities",
+        "ff_flow_core",
+        "ff_attempt",
+        "ff_edge",
+        "ff_edge_group",
+        "ff_suspension_current",
+        "ff_waitpoint_pending",
+        "ff_stream_frame",
+        "ff_completion_event",
+        // 0002 — budget
+        "ff_budget_policy",
+        "ff_budget_usage",
+        "ff_budget_usage_dedup",
+        // 0004 — suspend-signal
+        "ff_suspend_dedup",
+        // 0006 / 0007 — lease + signal event outbox
+        "ff_lease_event",
+        "ff_signal_event",
+        // 0010 — operator event outbox
+        "ff_operator_event",
+        // 0012 — quota policy
+        "ff_quota_policy",
+        "ff_quota_window",
+        "ff_quota_admitted",
+        // 0014 — cancel backlog
+        "ff_cancel_backlog",
+        "ff_cancel_backlog_member",
+    ] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "expected table `{expected}` not present; got {names:?}"
+        );
+    }
+
+    // sqlx migration metadata table must exist post-apply.
+    assert!(
+        names.iter().any(|n| n == "_sqlx_migrations"),
+        "sqlx migration metadata table missing; got {names:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn sqlx_migration_ledger_records_all_14() {
+    let backend = fresh_backend().await;
+    let pool = backend.pool_for_test();
+
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM _sqlx_migrations WHERE success = 1")
+            .fetch_one(pool)
+            .await
+            .expect("query _sqlx_migrations");
+    assert_eq!(count, 14, "expected 14 successful migrations, got {count}");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn ff_execution_capabilities_junction_schema() {
+    // RFC-023 §4.1 A4: normalized junction replaces the PG `text[] +
+    // GIN` shape. Verify the junction table + reverse index.
+    let backend = fresh_backend().await;
+    let pool = backend.pool_for_test();
+
+    // `pragma_table_info` is a table-valued function exposed by
+    // SQLite >= 3.16; projects to (cid, name, type, notnull, dflt_value, pk).
+    let cols: Vec<(i64, String, String, i64, Option<String>, i64)> =
+        sqlx::query_as("SELECT cid, name, type, \"notnull\", dflt_value, pk FROM pragma_table_info('ff_execution_capabilities')")
+            .fetch_all(pool)
+            .await
+            .expect("pragma_table_info");
+    let by_name: std::collections::HashMap<_, _> =
+        cols.iter().map(|c| (c.1.as_str(), c)).collect();
+
+    let exec = by_name
+        .get("execution_id")
+        .expect("execution_id column present");
+    assert_eq!(exec.2, "BLOB");
+    assert_eq!(exec.3, 1, "execution_id NOT NULL");
+    assert_eq!(exec.5, 1, "execution_id part of PK");
+
+    let cap = by_name
+        .get("capability")
+        .expect("capability column present");
+    assert_eq!(cap.2, "TEXT");
+    assert_eq!(cap.3, 1, "capability NOT NULL");
+    assert_eq!(cap.5, 2, "capability second PK column");
+
+    // Reverse index for capability-first routing must exist.
+    let (idx_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM sqlite_master \
+         WHERE type='index' AND name='ff_execution_capabilities_capability_idx'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("query reverse index");
+    assert_eq!(idx_count, 1, "capability reverse index missing");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn migration_annotation_ledger_populated() {
+    // Every migration INSERTs a row into `ff_migration_annotation`;
+    // verify all 14 versions landed.
+    let backend = fresh_backend().await;
+    let pool = backend.pool_for_test();
+
+    let rows: Vec<(i64,)> =
+        sqlx::query_as("SELECT version FROM ff_migration_annotation ORDER BY version")
+            .fetch_all(pool)
+            .await
+            .expect("query annotations");
+    let versions: Vec<i64> = rows.into_iter().map(|(v,)| v).collect();
+    assert_eq!(versions, (1..=14).collect::<Vec<i64>>());
+}

--- a/scripts/lint-migrations.sh
+++ b/scripts/lint-migrations.sh
@@ -66,4 +66,20 @@ if [ ${#orphan_sqlite[@]} -gt 0 ]; then
   exit 1
 fi
 
+# Third pass: every .sqlite-skip entry must name a real PG migration,
+# otherwise stale/typo'd entries silently hide intended parity work.
+stale_skips=()
+for skip in $SKIP_SET; do
+  if ! printf '%s\n' $pg_files | grep -qx "$skip"; then
+    stale_skips+=("$skip")
+  fi
+done
+
+if [ ${#stale_skips[@]} -gt 0 ]; then
+  echo "ERROR: .sqlite-skip entries do not match any PG migration filename:" >&2
+  printf '  %s\n' "${stale_skips[@]}" >&2
+  echo "  (remove stale entries or fix the filename to match $PG_DIR)" >&2
+  exit 1
+fi
+
 echo "OK: migration parity verified ($(echo "$pg_files" | wc -w | tr -d ' ') pairs)"

--- a/scripts/lint-migrations.sh
+++ b/scripts/lint-migrations.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# RFC-023 §4.1 + C-trivia-2 + issue #365 — parity-drift lint.
+#
+# Compares PG vs SQLite migration files. Every PG migration must
+# have a SQLite sibling with the same filename OR be listed in
+# `crates/ff-backend-sqlite/migrations/.sqlite-skip`. Every SQLite
+# migration must have a PG sibling — no PG-less additions.
+#
+# Skip-list format (per RFC-023 §4.1 C-trivia-2):
+#   * one relative path per line
+#   * `#`-prefixed lines are comments
+#   * inline `# issue:NNN` suffix on a path line cites a tracking issue
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PG_DIR="$ROOT/crates/ff-backend-postgres/migrations"
+SQLITE_DIR="$ROOT/crates/ff-backend-sqlite/migrations"
+SKIP_FILE="$SQLITE_DIR/.sqlite-skip"
+
+if [ ! -d "$PG_DIR" ]; then
+  echo "ERROR: PG migrations dir missing: $PG_DIR" >&2
+  exit 2
+fi
+if [ ! -d "$SQLITE_DIR" ]; then
+  echo "ERROR: SQLite migrations dir missing: $SQLITE_DIR" >&2
+  exit 2
+fi
+
+# Build skip-set (strip comments + blank lines, take first whitespace field).
+SKIP_SET=""
+if [ -f "$SKIP_FILE" ]; then
+  SKIP_SET=$(grep -vE '^\s*(#|$)' "$SKIP_FILE" | awk '{print $1}' | sort -u || true)
+fi
+
+pg_files=$(cd "$PG_DIR" && ls | grep -E '^[0-9]+_.*\.sql$' | sort || true)
+sqlite_files=$(cd "$SQLITE_DIR" && ls | grep -E '^[0-9]+_.*\.sql$' | sort || true)
+
+missing_siblings=()
+for pg in $pg_files; do
+  if printf '%s\n' $sqlite_files | grep -qx "$pg"; then
+    continue
+  fi
+  if printf '%s\n' $SKIP_SET | grep -qx "$pg"; then
+    continue
+  fi
+  missing_siblings+=("$pg")
+done
+
+if [ ${#missing_siblings[@]} -gt 0 ]; then
+  echo "ERROR: PG migrations without SQLite sibling or .sqlite-skip entry:" >&2
+  printf '  %s\n' "${missing_siblings[@]}" >&2
+  exit 1
+fi
+
+orphan_sqlite=()
+for sq in $sqlite_files; do
+  if ! printf '%s\n' $pg_files | grep -qx "$sq"; then
+    orphan_sqlite+=("$sq")
+  fi
+done
+
+if [ ${#orphan_sqlite[@]} -gt 0 ]; then
+  echo "ERROR: SQLite migrations without PG sibling:" >&2
+  printf '  %s\n' "${orphan_sqlite[@]}" >&2
+  exit 1
+fi
+
+echo "OK: migration parity verified ($(echo "$pg_files" | wc -w | tr -d ' ') pairs)"


### PR DESCRIPTION
## Summary

RFC-023 Phase 1b. Hand-ports the 14 genesis PG migrations (0001-0014) to SQLite-dialect SQL, wires `sqlx::migrate!("./migrations").run(&pool)` into `SqliteBackend::new`, and lands `scripts/lint-migrations.sh` as a CI quality gate (`migration-parity` job).

After this merges, Phase 2 can begin flipping `Unavailable` trait stubs into real impls against this schema.

## Migrations (all 14 ported)

| File | Shape | Notes |
|---|---|---|
| 0001_initial.sql | CREATE TABLE × many | Flat tables; `text[] required_capabilities` → `ff_execution_capabilities` junction (WITHOUT ROWID + reverse index) per §4.1 A4 |
| 0002_budget.sql | CREATE TABLE × 3 | Flat; `jsonb → TEXT`, `bigint → INTEGER` |
| 0003_dispatch_outbox.sql | ALTER + partial index | Additive |
| 0004_suspend_signal.sql | CREATE TABLE + ALTER | Additive |
| 0005_timeout_scanners.sql | ALTER | Additive |
| 0006_lease_event_outbox.sql | CREATE TABLE + index | `pg_notify` trigger dropped — Rust post-commit broadcast per §4.2 |
| 0007_signal_event_outbox.sql | CREATE TABLE + index | `pg_notify` trigger dropped |
| 0008_lease_event_instance_tag.sql | ALTERs + partial indexes | Split multi-ADD into one-per-statement (SQLite dialect) |
| 0009_signal_event_instance_tag.sql | ALTERs + partial indexes | Split multi-ADD |
| 0010_operator_event_outbox.sql | CREATE TABLE + indexes + CHECK | `pg_notify` trigger dropped |
| 0011_waitpoint_pending_extensions.sql | ALTERs | `TEXT[]` → `TEXT` JSON array default `'[]'` |
| 0012_quota_policy.sql | CREATE TABLE × 3 | Flat |
| 0013_budget_policy_extensions.sql | ALTERs + partial index | Split multi-ADD |
| 0014_cancel_backlog.sql | CREATE TABLE × 2 + partial index | Flat; uuid → BLOB |

## Port rules applied (RFC-023 §4.1)

- Flat tables — no HASH-partitioning; `partition_key INTEGER NOT NULL` column preserved on every table so downstream query shapes match PG.
- `jsonb` → `TEXT`, `bytea` → `BLOB`, `uuid` → `BLOB`, `BIGSERIAL` / `GENERATED ALWAYS AS IDENTITY` → `INTEGER PRIMARY KEY AUTOINCREMENT`, `double precision` → `REAL`, `boolean` → `INTEGER`.
- `required_capabilities text[] + GIN` → normalized `ff_execution_capabilities` junction per §4.1 A4.
- `pg_notify(...)` triggers + `CREATE FUNCTION` dropped — broadcast moves to Rust (§4.2).
- `CREATE INDEX CONCURRENTLY` / `USING GIN` / `INCLUDE(...)` collapse to plain `CREATE INDEX`.
- SQLite-specific: `(partition_key, event_id)` PK on `ff_completion_event` becomes `event_id INTEGER PRIMARY KEY AUTOINCREMENT` + composite UNIQUE index (SQLite requires AUTOINCREMENT to be the sole PK).
- `extract(epoch from clock_timestamp())*1000` → `CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)`.

## RFC-vs-reality gaps

None that block Phase 1b. Notes:

- `ff_edge_group.cancel_siblings_pending_members` (`text[]` in PG) ports to `TEXT` holding a JSON array, not a junction. RFC-023 §4.1 A4 scopes the junction form specifically to the capability-routing GIN path; other `text[]` uses fall back to JSON1 manipulation (`json_insert`/`json_remove`) in Phase 2+ query bodies.
- `ff_waitpoint_pending.required_signal_names` ports to `TEXT` default `'[]'` for the same reason.
- `INCLUDE (upstream_eid, policy_version)` on `ff_edge_downstream_idx` drops to a plain key-only index — SQLite has no covering-index syntax. Semantically equivalent; a row lookup replaces the covering read.
- `ff_completion_event` PK reshape (see above) is a SQLite dialect constraint, not a semantic drift: `(partition_key, event_id)` lookups still O(log n) via the composite UNIQUE index.

## `.sqlite-skip`

Intentionally empty (header comment only). All 14 PG migrations have SQLite siblings.

## Tests

- `crates/ff-backend-sqlite/tests/migrations.rs` (new):
  - Applies migrations against a fresh `:memory:` DB under `FF_DEV_MODE=1`.
  - Spot-checks ~25 tables from every contributing migration via `sqlite_master`.
  - Asserts `_sqlx_migrations` ledger records 14 successful applications.
  - Verifies `ff_execution_capabilities` junction schema + reverse index.
  - Confirms `ff_migration_annotation` rows cover versions 1..=14.
- Existing `capabilities.rs` + `guard.rs` stay green.

## CI

- New `migration-parity` job runs `scripts/lint-migrations.sh`; wired through the `matrix-tests-complete` sentinel so branch protection blocks drift (both PG-without-SQLite and SQLite-without-PG cases).
- Verified locally: lint returns exit 0 on the clean tree, exit 1 on both negative tests (remove a SQLite sibling / add a PG-less orphan).

## Test plan

- [x] `cargo build -p ff-backend-sqlite` clean
- [x] `cargo test -p ff-backend-sqlite` — 11 tests pass (1 unit, 1 capabilities, 5 guard, 4 migrations)
- [x] `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` clean
- [x] `cargo check --workspace --all-features` clean
- [x] `scripts/lint-migrations.sh` passes locally (14 pairs)
- [x] Lint negative cases: removing a sibling exits 1; adding an orphan exits 1
- [ ] Full matrix CI green
- [ ] Admin-merge after matrix-green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new SQLite schema via 14 migrations that now run automatically on backend construction, so any dialect/compat mismatch will fail startup or tests. Adds a CI gate that can block merges if migration directories drift between Postgres and SQLite.
> 
> **Overview**
> Adds RFC-023 Phase 1b SQLite database schema by **porting Postgres migrations `0001`–`0014` to SQLite** (including a normalized `ff_execution_capabilities` junction table) and updates `SqliteBackend::new` to **run `sqlx::migrate!` on startup**.
> 
> Introduces regression tests that assert all 14 migrations apply cleanly on a fresh in-memory DB and that key tables/indexes/ledgers exist.
> 
> Adds `scripts/lint-migrations.sh` and wires it into CI as a new `migration-parity` job, blocking merges when Postgres/SQLite migration directories diverge unless explicitly listed in `.sqlite-skip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5a701e8dd7afe47bf144e7017e184fb6919484. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->