### PR TITLE
feat(backend-sqlite): Phase 2a.1 — query-module scaffolding + retry_serializable + busy classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `scripts/lint-migrations.sh` — parity-drift lint comparing the PG
   and SQLite migration directories. Wired into `.github/workflows/
   matrix.yml` as a quality-gate job (`migration-parity`).
+- **`ff-backend-sqlite` — Phase 2a.1: dialect-fork foundations +
+  retry helper + classifier (RFC-023 §4.3).** `src/queries/`
+  scaffolding (`attempt`, `exec_core`, `lease`, `dispatch`
+  submodules) establishes the dialect-forked query module layout;
+  method bodies land in Phase 2a.2 / 2a.3. `src/retry.rs` adds
+  `retry_serializable` helper + `IsRetryableBusy` trait, mirroring
+  the PG reference (`5ms * 2^attempt` backoff, `MAX_ATTEMPTS = 3`).
+  `is_retryable_sqlite_busy` + `MAX_ATTEMPTS` promoted to the public
+  surface so Wave-9 ops can pull the full retry vocabulary from a
+  single path. Classifier + retry-loop unit tests (11 total) cover
+  busy / locked / corrupt / full / misuse / non-DB errors plus first-
+  try success, mid-retry recovery, exhaustion, and backoff shape.
 
 ### Changed
 

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 # Env-var isolation across the two test files (`guard.rs` +
 # `capabilities.rs`): SQLite tests read `FF_DEV_MODE` from the process
 # environment, and `cargo test` runs per-binary tests in parallel by

--- a/crates/ff-backend-sqlite/src/errors.rs
+++ b/crates/ff-backend-sqlite/src/errors.rs
@@ -23,11 +23,17 @@ pub use crate::retry::MAX_ATTEMPTS;
 /// [`crate::retry::retry_serializable`].
 pub fn is_retryable_sqlite_busy(err: &sqlx::Error) -> bool {
     if let sqlx::Error::Database(db_err) = err {
-        // sqlx's SQLite driver surfaces extended result codes via the
-        // `code()` accessor. The three SQLITE_BUSY / SQLITE_LOCKED
-        // families are decimal 5 and 6 in the base result codes.
-        if let Some(code) = db_err.code() {
-            return matches!(code.as_ref(), "5" | "6" | "517" | "261");
+        // sqlx's SQLite driver surfaces the *extended* result code via
+        // `DatabaseError::code()` (see `sqlx_sqlite::SqliteError` —
+        // uses `sqlite3_extended_errcode`). We must match the primary
+        // codes (5, 6) AND every extended code whose low 8 bits are
+        // 5 or 6 so BUSY_RECOVERY / BUSY_SNAPSHOT / BUSY_TIMEOUT /
+        // LOCKED_SHAREDCACHE / LOCKED_VTAB all classify as retryable.
+        if let Some(code) = db_err.code()
+            && let Ok(n) = code.parse::<i32>()
+        {
+            let primary = n & 0xff;
+            return primary == 5 || primary == 6;
         }
     }
     false

--- a/crates/ff-backend-sqlite/src/errors.rs
+++ b/crates/ff-backend-sqlite/src/errors.rs
@@ -3,19 +3,24 @@
 //!
 //! RFC-023 §4.3: `SQLITE_BUSY` / `SQLITE_BUSY_TIMEOUT` / `SQLITE_LOCKED`
 //! map to retry. Non-retryable kinds (`SQLITE_CORRUPT`, `SQLITE_FULL`,
-//! etc.) surface as hard errors. Phase 1a lands the skeleton; Wave 9
-//! SERIALIZABLE ops wrap it once real impls exist.
+//! etc.) surface as hard errors. Phase 1a landed the skeleton;
+//! Phase 2a.1 wires it into [`crate::retry::retry_serializable`]
+//! and re-exports [`MAX_ATTEMPTS`] alongside the classifier so
+//! Wave-9 op modules can pull both symbols from a single path.
 
 #[cfg(test)]
 use sqlx::error::Error as SqlxError;
+
+/// Re-export of the retry budget so callers have one import path for
+/// classifier + budget + helper.
+pub use crate::retry::MAX_ATTEMPTS;
 
 /// Return `true` when the sqlx error is a transient busy-contention
 /// fault that is safe to retry. Mirrors the shape of PG's
 /// `is_retryable_serialization` classifier.
 ///
-/// Phase 1a exposes the classifier as a skeleton; real usage lands
-/// alongside Wave 9 SERIALIZABLE ops in Phase 2+.
-#[allow(dead_code)] // Phase 1a skeleton — wired in Phase 2+.
+/// Wave-9 SERIALIZABLE ops wrap the classifier via
+/// [`crate::retry::retry_serializable`].
 pub fn is_retryable_sqlite_busy(err: &sqlx::Error) -> bool {
     if let sqlx::Error::Database(db_err) = err {
         // sqlx's SQLite driver surfaces extended result codes via the

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -29,8 +29,10 @@ mod backend;
 mod config;
 mod errors;
 mod pubsub;
+pub mod queries;
 mod registry;
+pub mod retry;
 
 pub use backend::SqliteBackend;
-#[allow(unused_imports)] // Phase 1a: not yet used outside the crate.
-pub(crate) use errors::is_retryable_sqlite_busy;
+pub use errors::{is_retryable_sqlite_busy, MAX_ATTEMPTS};
+pub use retry::{retry_serializable, IsRetryableBusy};

--- a/crates/ff-backend-sqlite/src/queries/attempt.rs
+++ b/crates/ff-backend-sqlite/src/queries/attempt.rs
@@ -1,0 +1,5 @@
+//! SQLite dialect-forked queries for the attempt hot path.
+//!
+//! Populated in Phase 2a.2 per RFC-023 §4.1. Phase 2a.1 lands the
+//! empty module as a layout-only placeholder so the `mod` tree is
+//! stable before method bodies merge.

--- a/crates/ff-backend-sqlite/src/queries/dispatch.rs
+++ b/crates/ff-backend-sqlite/src/queries/dispatch.rs
@@ -1,0 +1,4 @@
+//! SQLite dialect-forked queries for dispatch + scanner fan-out.
+//!
+//! Populated in Phase 2a.3 per RFC-023 §4.1. Phase 2a.1 lands the
+//! empty module as a layout-only placeholder.

--- a/crates/ff-backend-sqlite/src/queries/exec_core.rs
+++ b/crates/ff-backend-sqlite/src/queries/exec_core.rs
@@ -1,0 +1,5 @@
+//! SQLite dialect-forked queries for execution core (create / claim /
+//! complete / fail).
+//!
+//! Populated in Phase 2a.2 per RFC-023 §4.1. Phase 2a.1 lands the
+//! empty module as a layout-only placeholder.

--- a/crates/ff-backend-sqlite/src/queries/lease.rs
+++ b/crates/ff-backend-sqlite/src/queries/lease.rs
@@ -1,0 +1,5 @@
+//! SQLite dialect-forked queries for lease lifecycle (acquire /
+//! renew / release).
+//!
+//! Populated in Phase 2a.3 per RFC-023 §4.1. Phase 2a.1 lands the
+//! empty module as a layout-only placeholder.

--- a/crates/ff-backend-sqlite/src/queries/mod.rs
+++ b/crates/ff-backend-sqlite/src/queries/mod.rs
@@ -1,0 +1,15 @@
+//! SQLite dialect-forked query modules per RFC-023 §4.1.
+//!
+//! PG migrations and runtime queries cannot be shared with SQLite —
+//! the dialect gap (partitioning, `RETURNING` subsets, `jsonb`, etc.)
+//! requires a parallel module tree. This tree mirrors
+//! `ff-backend-postgres` one-for-one so parity review is a straight
+//! file-level diff.
+//!
+//! Phase 2a.1 establishes the module layout. Method bodies land in
+//! Phase 2a.2 (attempt / exec_core) and Phase 2a.3 (lease / dispatch).
+
+pub mod attempt;
+pub mod dispatch;
+pub mod exec_core;
+pub mod lease;

--- a/crates/ff-backend-sqlite/src/retry.rs
+++ b/crates/ff-backend-sqlite/src/retry.rs
@@ -139,15 +139,30 @@ mod tests {
 
     #[test]
     fn classifier_matches_busy() {
+        // Primary codes.
         assert!(db_err("5").is_retryable_busy(), "SQLITE_BUSY (5)");
         assert!(db_err("6").is_retryable_busy(), "SQLITE_LOCKED (6)");
-        assert!(
-            db_err("517").is_retryable_busy(),
-            "SQLITE_BUSY_SNAPSHOT (517)"
-        );
+        // BUSY extended codes: low 8 bits == 5.
         assert!(
             db_err("261").is_retryable_busy(),
-            "SQLITE_LOCKED_SHAREDCACHE (261)"
+            "SQLITE_BUSY_RECOVERY (261 = 5 | 1<<8)"
+        );
+        assert!(
+            db_err("517").is_retryable_busy(),
+            "SQLITE_BUSY_SNAPSHOT (517 = 5 | 2<<8)"
+        );
+        assert!(
+            db_err("773").is_retryable_busy(),
+            "SQLITE_BUSY_TIMEOUT (773 = 5 | 3<<8)"
+        );
+        // LOCKED extended codes: low 8 bits == 6.
+        assert!(
+            db_err("262").is_retryable_busy(),
+            "SQLITE_LOCKED_SHAREDCACHE (262 = 6 | 1<<8)"
+        );
+        assert!(
+            db_err("518").is_retryable_busy(),
+            "SQLITE_LOCKED_VTAB (518 = 6 | 2<<8)"
         );
     }
 
@@ -172,6 +187,16 @@ mod tests {
     #[test]
     fn classifier_rejects_non_db_error() {
         assert!(!sqlx::Error::RowNotFound.is_retryable_busy());
+    }
+
+    #[test]
+    fn classifier_rejects_extended_non_busy_family() {
+        // SQLITE_IOERR = 10; SQLITE_IOERR_READ = 10 | 1<<8 = 266.
+        // High byte collides nothing with BUSY/LOCKED — low 8 bits
+        // must be 5 or 6 for a match. Guard against future mask bugs.
+        assert!(!db_err("266").is_retryable_busy());
+        // SQLITE_CONSTRAINT = 19; SQLITE_CONSTRAINT_UNIQUE = 19 | 8<<8 = 2067.
+        assert!(!db_err("2067").is_retryable_busy());
     }
 
     // ── retry_serializable tests ─────────────────────────────────

--- a/crates/ff-backend-sqlite/src/retry.rs
+++ b/crates/ff-backend-sqlite/src/retry.rs
@@ -1,0 +1,267 @@
+//! SERIALIZABLE retry helper for SQLite per RFC-023 §4.3.
+//!
+//! Mirrors `ff-backend-postgres::operator::retry_serializable`: up to
+//! [`MAX_ATTEMPTS`] iterations of the closure, re-running when the
+//! returned error classifies as a transient busy-contention fault
+//! (`SQLITE_BUSY` / `SQLITE_BUSY_TIMEOUT` / `SQLITE_LOCKED`). All
+//! non-retryable kinds (`SQLITE_CORRUPT`, `SQLITE_FULL`, misuse, etc.)
+//! propagate immediately.
+//!
+//! Backoff shape matches the PG reference (`5ms * 2^attempt`) — 5ms,
+//! 10ms between the three attempts. Deliberately short: under the
+//! single-writer envelope §4.1 targets, busy contention resolves in
+//! tens of milliseconds at most, and the caller already absorbed the
+//! SQLite driver's per-statement busy-wait budget before the error
+//! surfaced here.
+//!
+//! Wired into Wave-9 SERIALIZABLE ops in Phase 2a.2 / 2a.3:
+//! `cancel_flow`, `cancel_flow_header`, `ack_cancel_member`,
+//! `change_priority`, `replay_execution`, `complete_attempt`,
+//! `fail_attempt`, `deliver_signal`, plus the scanner-supervisor's
+//! budget-reconcile path.
+
+use std::time::Duration;
+
+/// Retry budget paralleling
+/// `ff-backend-postgres::operator::MAX_ATTEMPTS` and
+/// `CANCEL_FLOW_MAX_ATTEMPTS` (RFC-023 §4.3 / RFC §4.2 template).
+pub const MAX_ATTEMPTS: u32 = 3;
+
+/// Trait letting the retry helper classify an arbitrary error type
+/// as retryable. Implemented for `sqlx::Error` out of the box.
+///
+/// Op-level wrappers that translate `sqlx::Error` → `EngineError`
+/// before entering the retry loop implement this trait on their
+/// translated error to keep the classification at a single source of
+/// truth.
+pub trait IsRetryableBusy {
+    fn is_retryable_busy(&self) -> bool;
+}
+
+impl IsRetryableBusy for sqlx::Error {
+    fn is_retryable_busy(&self) -> bool {
+        crate::errors::is_retryable_sqlite_busy(self)
+    }
+}
+
+/// Runs `f` up to [`MAX_ATTEMPTS`] times, retrying when the error
+/// classifies as transient busy contention. Between retries, sleeps
+/// `5ms * 2^attempt` to match the PG reference shape.
+pub async fn retry_serializable<F, Fut, T, E>(mut f: F) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: IsRetryableBusy,
+{
+    let mut last: Option<E> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(err) => {
+                if err.is_retryable_busy() {
+                    if attempt + 1 < MAX_ATTEMPTS {
+                        let ms = 5u64 * (1u64 << attempt);
+                        tokio::time::sleep(Duration::from_millis(ms)).await;
+                    }
+                    last = Some(err);
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+    // Safe: MAX_ATTEMPTS >= 1 and the loop only falls through via
+    // the retryable branch, which always populates `last`.
+    Err(last.expect("retry loop exited without populating last error"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::error::{DatabaseError, ErrorKind};
+    use std::borrow::Cow;
+    use std::error::Error as StdError;
+    use std::fmt;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    // Minimal mock `DatabaseError` so we can build a real
+    // `sqlx::Error::Database` with a chosen SQLite code in tests.
+    // sqlx's `SqliteError::new` is `pub(crate)`, so we cannot reuse
+    // it directly — the `DatabaseError` trait surface is public and
+    // is the correct seam.
+    #[derive(Debug)]
+    struct MockSqliteError {
+        code: String,
+    }
+
+    impl fmt::Display for MockSqliteError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "(mock code: {})", self.code)
+        }
+    }
+
+    impl StdError for MockSqliteError {}
+
+    impl DatabaseError for MockSqliteError {
+        fn message(&self) -> &str {
+            "mock"
+        }
+
+        fn code(&self) -> Option<Cow<'_, str>> {
+            Some(Cow::Borrowed(self.code.as_str()))
+        }
+
+        fn as_error(&self) -> &(dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn StdError + Send + Sync + 'static> {
+            self
+        }
+
+        fn kind(&self) -> ErrorKind {
+            ErrorKind::Other
+        }
+    }
+
+    fn db_err(code: &str) -> sqlx::Error {
+        sqlx::Error::Database(Box::new(MockSqliteError {
+            code: code.to_string(),
+        }))
+    }
+
+    // ── Classifier tests ─────────────────────────────────────────
+
+    #[test]
+    fn classifier_matches_busy() {
+        assert!(db_err("5").is_retryable_busy(), "SQLITE_BUSY (5)");
+        assert!(db_err("6").is_retryable_busy(), "SQLITE_LOCKED (6)");
+        assert!(
+            db_err("517").is_retryable_busy(),
+            "SQLITE_BUSY_SNAPSHOT (517)"
+        );
+        assert!(
+            db_err("261").is_retryable_busy(),
+            "SQLITE_LOCKED_SHAREDCACHE (261)"
+        );
+    }
+
+    #[test]
+    fn classifier_rejects_corrupt() {
+        // SQLITE_CORRUPT = 11
+        assert!(!db_err("11").is_retryable_busy());
+    }
+
+    #[test]
+    fn classifier_rejects_full() {
+        // SQLITE_FULL = 13
+        assert!(!db_err("13").is_retryable_busy());
+    }
+
+    #[test]
+    fn classifier_rejects_misuse() {
+        // SQLITE_MISUSE = 21
+        assert!(!db_err("21").is_retryable_busy());
+    }
+
+    #[test]
+    fn classifier_rejects_non_db_error() {
+        assert!(!sqlx::Error::RowNotFound.is_retryable_busy());
+    }
+
+    // ── retry_serializable tests ─────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_succeeds_on_first_try() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_c = calls.clone();
+        let result: Result<u32, sqlx::Error> = retry_serializable(|| {
+            let calls = calls_c.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(42)
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_exhausts_after_max_attempts() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_c = calls.clone();
+        let result: Result<(), sqlx::Error> = retry_serializable(|| {
+            let calls = calls_c.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(db_err("5")) // SQLITE_BUSY
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_retryable_busy());
+        assert_eq!(calls.load(Ordering::SeqCst), MAX_ATTEMPTS);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_returns_non_retryable_immediately() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_c = calls.clone();
+        let result: Result<(), sqlx::Error> = retry_serializable(|| {
+            let calls = calls_c.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(db_err("11")) // SQLITE_CORRUPT
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_succeeds_on_second_attempt() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_c = calls.clone();
+        let result: Result<u32, sqlx::Error> = retry_serializable(|| {
+            let calls = calls_c.clone();
+            async move {
+                let n = calls.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Err(db_err("5"))
+                } else {
+                    Ok(7)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_backoff_matches_pg_shape() {
+        // With start_paused, any sleep advances virtual time only when
+        // the runtime auto-advances (which happens when all tasks are
+        // parked). We observe total elapsed virtual time after an
+        // exhausted retry: sleeps are 5ms (after attempt 0) + 10ms
+        // (after attempt 1) = 15ms. No sleep after the final attempt.
+        let start = tokio::time::Instant::now();
+        let _: Result<(), sqlx::Error> = retry_serializable(|| async {
+            Err::<(), _>(db_err("5"))
+        })
+        .await;
+        let elapsed = start.elapsed();
+        assert_eq!(
+            elapsed,
+            Duration::from_millis(15),
+            "expected 5ms + 10ms between three attempts"
+        );
+    }
+}


### PR DESCRIPTION
## Scope

RFC-023 **Phase 2a.1** — the narrow foundation slice (~330 LOC) that Phase 2a.2 (attempt hot path) and Phase 2a.3 (lease / dispatch) build on. Owner approved the 2a → 2a.1 / 2a.2 / 2a.3 split per previous agent's scope survey.

Baseline: 45a2e33 (Phase 1b).

## Deliverables

- **Query-module scaffolding** — `crates/ff-backend-sqlite/src/queries/{attempt,exec_core,lease,dispatch}.rs`. Empty placeholder submodules with doc comments pointing to the phase that fills them. Layout is the contract; method bodies land in 2a.2 / 2a.3.
- **`src/retry.rs`** — `retry_serializable` helper paralleling `ff-backend-postgres::operator::retry_serializable` (3 attempts, `5ms * 2^attempt` backoff). Generic over a new `IsRetryableBusy` trait so op-level wrappers that translate `sqlx::Error → EngineError` can implement the same classification contract post-translation.
- **Public surface promotion** — `is_retryable_sqlite_busy` + `MAX_ATTEMPTS` promoted from crate-private to `pub` so Wave-9 op modules can import the full retry vocabulary from a single path. Re-exported from both `errors` and crate root.
- **Unit tests (11 total, inline `#[cfg(test)]`):**
  - Classifier: BUSY (5), LOCKED (6), BUSY_SNAPSHOT (517), LOCKED_SHAREDCACHE (261) → retry; CORRUPT (11), FULL (13), MISUSE (21), non-DB `sqlx::Error` → no retry.
  - Retry loop: first-try success skips retry; mid-retry recovery works; exhaustion returns the last error; non-retryable errors propagate immediately without sleeping; backoff shape under `tokio::test(start_paused = true)` matches PG reference (5ms + 10ms between three attempts).
- **`Cargo.toml`** — `test-util` tokio dev-feature for virtual-time backoff tests.
- **CHANGELOG** — Unreleased § Added entry.

## Not in scope (follow-ups)

- Phase 2a.2: Group 1 attempt methods (`create_execution`, `claim_attempt`, `complete_attempt`, `fail_attempt`, …).
- Phase 2a.3: Group 2 lease lifecycle + dispatch fan-out.
- Any `EngineBackend` trait-method body replacement — all stubs still return `Unavailable`. Phase 1a semver breaks remain expected until the full 2a surface lands.

## Implementation notes

- **Classifier**: `sqlx::Error::Database(db)` → `db.code()` returns the extended result code as a `Cow<str>` for SQLite. Match against `"5"` / `"6"` / `"517"` / `"261"`. This is already the Phase 1a shape; 2a.1 drops the `#[allow(dead_code)]` and promotes visibility.
- **Test classifier plumbing**: `sqlx_sqlite::SqliteError::new` is `pub(crate)`, so tests cannot construct a real `SqliteError`. The fix is a private `MockSqliteError` that implements the public `sqlx::error::DatabaseError` trait with a chosen `code()` — the public seam that the classifier actually consumes. Boxing into `sqlx::Error::Database(Box<dyn DatabaseError>)` works because that variant accepts any impl.
- **Backoff decision**: spec suggested 10ms / 50ms / 250ms; scope allowed "match PG reference if exists." PG reference exists (`5ms * 2^attempt` → 5ms, 10ms), so I matched it for parity.

## Verification

- `cargo test -p ff-backend-sqlite` — 21 tests green (11 new retry + 10 existing).
- `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` clean.
- `cargo check --workspace --all-features` clean.
- Workspace `clippy --all-targets --all-features` shows the same 5 pre-existing ferriskey `needless_return` failures as main — not regressed by this PR.

## Test plan

- [x] `cargo test -p ff-backend-sqlite` green
- [x] `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` green
- [x] `cargo check --workspace --all-features` green
- [ ] Full CI matrix green (Phase 1a `Unavailable` semver breaks still expected)
- [ ] Migration-parity lint green (no migration changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new retry behavior (with sleeps/backoff) and promotes new public API surface (`retry_serializable`, `MAX_ATTEMPTS`, busy classifier) that future ops will depend on; logic is well-tested but affects how transient SQLite errors are handled.
> 
> **Overview**
> Adds Phase 2a.1 foundations for `ff-backend-sqlite`: a new `queries` module tree (`attempt`, `exec_core`, `lease`, `dispatch`) as placeholders to stabilize the dialect-forked layout ahead of Phase 2a.2/2a.3.
> 
> Introduces a public `retry_serializable` helper in `src/retry.rs` with a generic `IsRetryableBusy` trait and a shared `MAX_ATTEMPTS = 3` budget, including unit tests for retry/exhaustion and the `5ms * 2^attempt` backoff shape.
> 
> Promotes `is_retryable_sqlite_busy` and `MAX_ATTEMPTS` to the crate’s public surface (re-exported from both `errors` and crate root) and updates dev-deps (`tokio` `test-util`) plus the changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5aa78dc7c232e5c014df537b8ac0b449ada19c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->