### PR TITLE
feat(backend-sqlite): Phase 2a.2 — claim/complete/fail hot-path impls + attempt/exec_core queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 2a.2 hot-path trait impls (RFC-023).**
+  Replaces the `Unavailable` stubs for `claim`, `complete`, and `fail`
+  with real bodies paralleling `ff-backend-postgres::attempt`. Handle
+  minting + decode flows through the Phase 2a.1.5 `handle_codec`
+  (`BackendTag::Sqlite`, wire byte `0x03`); fence CAS is enforced under
+  `BEGIN IMMEDIATE` txns (§4.1 A3); capability subset-match reads the
+  `ff_execution_capabilities` junction (§4.1 A4) and compares in Rust
+  via `ff-core::caps`. Transient `SQLITE_BUSY` is wrapped by the
+  Phase-2a.1 `retry_serializable` helper (`MAX_ATTEMPTS = 3`,
+  5ms/10ms backoff). Phase 2a.3 (lease-lifecycle: renew, delay,
+  cancel, wait_children, append_frame) follows; no `Supports`-flag
+  flips land in this PR (§4.4 Rev-6 clarification: `claim` /
+  `complete` / `fail` are trait-mandatory hot-path ops without a
+  `Supports` bool).
+- `crates/ff-backend-sqlite/src/queries/attempt.rs` +
+  `.../queries/exec_core.rs` populated with hot-path SQL consts
+  (`SELECT_ELIGIBLE_EXEC_SQL`, `UPSERT_ATTEMPT_ON_CLAIM_SQL`,
+  `SELECT_ATTEMPT_EPOCH_SQL`, `UPDATE_ATTEMPT_COMPLETE_SQL`,
+  `UPDATE_ATTEMPT_FAIL_RETRY_SQL`, `UPDATE_ATTEMPT_FAIL_TERMINAL_SQL`,
+  `INSERT_COMPLETION_EVENT_SQL`, `UPDATE_EXEC_CORE_CLAIM_SQL`,
+  `UPDATE_EXEC_CORE_COMPLETE_SQL`, `UPDATE_EXEC_CORE_FAIL_RETRY_SQL`,
+  `UPDATE_EXEC_CORE_FAIL_TERMINAL_SQL`).
+- `ff-backend-sqlite::errors::map_sqlx_error` + `IsRetryableBusy for
+  EngineError` — lets `retry_serializable` classify translated
+  transport errors without a custom error type.
+- `crates/ff-backend-sqlite/tests/hot_path.rs` — 8 tests covering
+  claim happy path, claim no-work, capability-subset mismatch,
+  complete happy path, complete fence-mismatch →
+  `Contention(LeaseConflict)`, cross-backend (Valkey-tagged) handle
+  rejection via `ValidationKind::HandleFromOtherBackend`,
+  transient-fail retry scheduling, and permanent-fail terminal.
 - **`crates/ff-backend-sqlite` — SQLite dev-only backend (RFC-023 Phase 1a).**
   Activation requires `FF_DEV_MODE=1`. Construction is guarded at the
   `SqliteBackend::new` TYPE level (§4.5 / §3.3 A3) so every entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,27 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ff-backend-sqlite::errors::map_sqlx_error` + `IsRetryableBusy for
   EngineError` — lets `retry_serializable` classify translated
   transport errors without a custom error type.
-- `crates/ff-backend-sqlite/tests/hot_path.rs` — 8 tests covering
-  claim happy path, claim no-work, capability-subset mismatch,
-  complete happy path, complete fence-mismatch →
-  `Contention(LeaseConflict)`, cross-backend (Valkey-tagged) handle
-  rejection via `ValidationKind::HandleFromOtherBackend`,
-  transient-fail retry scheduling, and permanent-fail terminal.
+- `ff-backend-sqlite`: claim path now walks a bounded batch (16) of
+  eligible rows and matches capabilities in-Rust until it finds the
+  first serveable one — fixes a starvation window where a
+  high-priority row with unserveable caps would block the entire
+  lane for a given worker (PR-375 review).
+- `ff-backend-sqlite`: lease-lifecycle outbox parity with PG — claim
+  / complete / fail emit `ff_lease_event` rows (`acquired` /
+  `revoked`) under the same txn so a later
+  `subscribe_lease_history` reader sees the cascade (PR-375 review).
+- `ff-backend-sqlite`: `FailureClass` wildcard defaults to retry
+  (least-destructive) per the project's `#[non_exhaustive]` rule —
+  an unknown future variant MUST NOT silently burn the attempt on
+  backend upgrades.
+- `crates/ff-backend-sqlite/tests/hot_path.rs` — 10 tests covering
+  claim happy path, claim no-work, capability-subset mismatch
+  skip-return-None, capability-subset-walk-past-priority, claim +
+  complete lease-event emission, complete happy path, complete
+  fence-mismatch → `Contention(LeaseConflict)`, cross-backend
+  (Valkey-tagged) handle rejection via
+  `ValidationKind::HandleFromOtherBackend`, transient-fail retry
+  scheduling, and permanent-fail terminal.
 - **`crates/ff-backend-sqlite` — SQLite dev-only backend (RFC-023 Phase 1a).**
   Activation requires `FF_DEV_MODE=1`. Construction is guarded at the
   `SqliteBackend::new` TYPE level (§4.5 / §3.3 A3) so every entry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -41,7 +41,3 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"
 # environment, and `cargo test` runs per-binary tests in parallel by
 # default. `serial_test` enforces per-`#[serial]` ordering.
 serial_test = "3"
-# Phase 2a.2 hot-path tests seed `ff_exec_core` / `ff_attempt` rows via
-# raw SQL (the `create_execution` trait surface lands in Phase 2b) and
-# need direct `uuid` to bind 16-byte BLOBs.
-uuid = { workspace = true }

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -32,6 +32,7 @@ sqlx = { workspace = true, features = ["sqlite", "runtime-tokio", "macros", "mig
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
@@ -40,3 +41,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"
 # environment, and `cargo test` runs per-binary tests in parallel by
 # default. `serial_test` enforces per-`#[serial]` ordering.
 serial_test = "3"
+# Phase 2a.2 hot-path tests seed `ff_exec_core` / `ff_attempt` rows via
+# raw SQL (the `create_execution` trait surface lands in Phase 2b) and
+# need direct `uuid` to bind 16-byte BLOBs.
+uuid = { workspace = true }

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -104,13 +104,18 @@ fn split_exec_id(
 
 /// Acquire a pooled connection and issue `BEGIN IMMEDIATE`, escalating
 /// the txn to RESERVED so §4.1 A3's single-writer invariant holds for
-/// the full read-modify-write window. Returns the live connection for
-/// subsequent statements; the caller commits or rolls back explicitly.
+/// the full read-modify-write window.
 ///
-/// SQLite's `BEGIN IMMEDIATE` is the single-writer equivalent of PG's
-/// `FOR UPDATE SKIP LOCKED`: contending writers block (or return
-/// `SQLITE_BUSY`, which the retry helper catches) rather than
-/// silently reading stale snapshots.
+/// The caller MUST arrange an explicit `commit()` on success and a
+/// `rollback_quiet()` on every error path. Use
+/// [`commit_or_rollback`] as the single tail-call so a `COMMIT`
+/// failure deterministically rolls back — otherwise a half-open txn
+/// could return to the pool and poison a later borrower.
+///
+/// sqlx's `Transaction` abstraction opens a plain `BEGIN` on SQLite
+/// (no `IMMEDIATE` escalation on the public API today); we manage
+/// the lock here manually and the per-op helpers in this file close
+/// the rollback loop.
 async fn begin_immediate(
     pool: &SqlitePool,
 ) -> Result<sqlx::pool::PoolConnection<sqlx::Sqlite>, EngineError> {
@@ -122,21 +127,29 @@ async fn begin_immediate(
     Ok(conn)
 }
 
-async fn commit(
+/// Commit the pending txn; on `COMMIT` failure issue a best-effort
+/// `ROLLBACK` so the connection is returned to the pool in a clean
+/// state (otherwise a pool-reuse borrower observes a half-open txn).
+/// A secondary rollback error is swallowed — SQLite auto-rolls-back
+/// on connection close, which happens when the pool drops an
+/// unhealthy connection, so correctness is preserved.
+async fn commit_or_rollback(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
 ) -> Result<(), EngineError> {
-    sqlx::query("COMMIT")
+    if let Err(e) = sqlx::query("COMMIT")
         .execute(&mut **conn)
         .await
-        .map_err(map_sqlx_error)?;
+        .map_err(map_sqlx_error)
+    {
+        let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
+        return Err(e);
+    }
     Ok(())
 }
 
-async fn rollback(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
-    // Best-effort: a failed rollback means the txn is already gone
-    // (e.g. the caller raised a typed error mid-op) and the
-    // connection is about to be dropped anyway. Swallow to keep the
-    // original error shape intact.
+/// Best-effort rollback on an error path. A failed rollback is
+/// swallowed so the original error surfaces unchanged.
+async fn rollback_quiet(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
     let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
 }
 
@@ -183,49 +196,93 @@ async fn claim_impl(
     let part: i64 = 0;
 
     let mut conn = begin_immediate(pool).await?;
+    let result = claim_inner(&mut conn, part, lane, capabilities, policy).await;
+    match result {
+        Ok(Some(handle)) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(Some(handle))
+        }
+        Ok(None) => {
+            rollback_quiet(&mut conn).await;
+            Ok(None)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
 
-    let row = sqlx::query(q_attempt::SELECT_ELIGIBLE_EXEC_SQL)
+/// Inside-txn body of [`claim_impl`] — any `?` short-circuit surfaces
+/// to the caller which guarantees `rollback_quiet` via
+/// [`claim_impl`]'s match arms.
+async fn claim_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    lane: &ff_core::types::LaneId,
+    capabilities: &CapabilitySet,
+    policy: &ClaimPolicy,
+) -> Result<Option<Handle>, EngineError> {
+    // Scan up to CAP_SCAN_BATCH eligible rows in priority order and
+    // walk until we find the first capability-satisfying one. Under
+    // §4.1 A3 SQLite runs on a single partition, so a high-priority
+    // row whose required caps the worker lacks would starve
+    // downstream-priority matches if we only inspected the top
+    // candidate (caught in PR-375 review). Bounded scan budget keeps
+    // the lock window predictable.
+    const CAP_SCAN_BATCH: i64 = 16;
+
+    let candidate_rows = sqlx::query(q_attempt::SELECT_ELIGIBLE_EXEC_SQL)
         .bind(part)
         .bind(lane.as_str())
-        .fetch_optional(&mut *conn)
+        .bind(CAP_SCAN_BATCH)
+        .fetch_all(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
 
-    let Some(row) = row else {
-        rollback(&mut conn).await;
-        return Ok(None);
-    };
-
-    let exec_uuid: Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
-    let attempt_index_i: i64 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
-
-    // Capability subset check (§4.1 A4): read tokens from the junction
-    // table, match in Rust via `caps::matches` — same shape as PG's
-    // Rust-side match, different read source.
-    let cap_rows = sqlx::query(q_attempt::SELECT_EXEC_CAPABILITIES_SQL)
-        .bind(exec_uuid)
-        .fetch_all(&mut *conn)
-        .await
-        .map_err(map_sqlx_error)?;
-    let tokens: Vec<String> = cap_rows
-        .iter()
-        .map(|r| r.try_get::<String, _>("capability"))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(map_sqlx_error)?;
-    let req = CapabilityRequirement::new(tokens);
-    if !caps_matches(&req, capabilities) {
-        // Release the lock; caller's retry cadence picks up a matching
-        // worker later (documented at PG reference §isolation note).
-        rollback(&mut conn).await;
+    if candidate_rows.is_empty() {
         return Ok(None);
     }
+
+    let mut claimable: Option<(Uuid, i64)> = None;
+    for row in &candidate_rows {
+        let exec_uuid: Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
+        let attempt_index_i: i64 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+        // Capability subset check (§4.1 A4): junction table read +
+        // Rust-side `caps::matches`. Same post-lock Rust match as the
+        // PG path at `ff-backend-postgres/src/attempt.rs:170-182`.
+        let cap_rows = sqlx::query(q_attempt::SELECT_EXEC_CAPABILITIES_SQL)
+            .bind(exec_uuid)
+            .fetch_all(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let tokens: Vec<String> = cap_rows
+            .iter()
+            .map(|r| r.try_get::<String, _>("capability"))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sqlx_error)?;
+        let req = CapabilityRequirement::new(tokens);
+        if caps_matches(&req, capabilities) {
+            claimable = Some((exec_uuid, attempt_index_i));
+            break;
+        }
+    }
+
+    let Some((exec_uuid, attempt_index_i)) = claimable else {
+        // Every candidate in the batch required a capability the
+        // worker lacks; surface `None` so the caller's retry cadence
+        // re-enters later. A different-caps worker takes the batch
+        // when it claims.
+        return Ok(None);
+    };
 
     let now = now_ms();
     let lease_ttl_ms = i64::from(policy.lease_ttl_ms);
     let expires = now.saturating_add(lease_ttl_ms);
 
-    // UPSERT the attempt row. `RETURNING lease_epoch` gives us the
-    // post-UPSERT epoch in one round-trip (SQLite >= 3.35).
+    // UPSERT the attempt row. `RETURNING lease_epoch` round-trips
+    // the post-UPSERT epoch in one statement (SQLite >= 3.35).
     let epoch_row = sqlx::query(q_attempt::UPSERT_ATTEMPT_ON_CLAIM_SQL)
         .bind(part)
         .bind(exec_uuid)
@@ -234,7 +291,7 @@ async fn claim_impl(
         .bind(policy.worker_instance_id.as_str())
         .bind(expires)
         .bind(now)
-        .fetch_one(&mut *conn)
+        .fetch_one(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
     let epoch_i: i64 = epoch_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
@@ -242,11 +299,16 @@ async fn claim_impl(
     sqlx::query(q_exec::UPDATE_EXEC_CORE_CLAIM_SQL)
         .bind(part)
         .bind(exec_uuid)
-        .execute(&mut *conn)
+        .execute(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
 
-    commit(&mut conn).await?;
+    // RFC-019 Stage B outbox parity (PG reference at
+    // `ff-backend-postgres/src/lease_event.rs`): record a lease
+    // lifecycle event so a later `subscribe_lease_history` reader
+    // observes the acquisition. The PG `pg_notify` trigger is dropped
+    // per §4.2; in-Rust broadcast wiring lands in a later phase.
+    insert_lease_event(conn, part, exec_uuid, "acquired", now).await?;
 
     let attempt_index = AttemptIndex::new(u32::try_from(attempt_index_i.max(0)).unwrap_or(0));
     let exec_id = ff_core::types::ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}"))
@@ -275,53 +337,89 @@ async fn complete_impl(
     let payload = decode_handle(handle)?;
     let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
     let attempt_index = i64::from(payload.attempt_index.0);
-    let now = now_ms();
+    let expected_epoch = payload.lease_epoch.0;
 
     let mut conn = begin_immediate(pool).await?;
+    let result = complete_inner(
+        &mut conn,
+        part,
+        exec_uuid,
+        attempt_index,
+        expected_epoch,
+        payload_bytes,
+    )
+    .await;
+    match result {
+        Ok(()) => commit_or_rollback(&mut conn).await,
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
 
-    if let Err(e) = fence_check(&mut conn, part, exec_uuid, attempt_index, payload.lease_epoch.0)
+async fn complete_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+    expected_epoch: u64,
+    payload_bytes: Option<Vec<u8>>,
+) -> Result<(), EngineError> {
+    fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
+    let now = now_ms();
+
+    sqlx::query(q_attempt::UPDATE_ATTEMPT_COMPLETE_SQL)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .execute(&mut **conn)
         .await
-    {
-        rollback(&mut conn).await;
-        return Err(e);
+        .map_err(map_sqlx_error)?;
+
+    sqlx::query(q_exec::UPDATE_EXEC_CORE_COMPLETE_SQL)
+        .bind(now)
+        .bind(payload_bytes.as_deref())
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
+        .bind("success")
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
+    Ok(())
+}
+
+/// Classify whether a `fail()` call reschedules a retry or transitions
+/// to terminal. Mirrors the PG reference behaviour
+/// (`ff-backend-postgres/src/attempt.rs:622-626` — Transient /
+/// InfraCrash → retry; Permanent / Timeout / Cancelled → terminal),
+/// and handles the `#[non_exhaustive]` catch-all by defaulting future
+/// variants to the **least-destructive** retry path per the project's
+/// non-exhaustive-enum rule: terminal-failed is irreversible, so an
+/// unknown classification MUST NOT silently burn the attempt.
+fn classify_retryable(classification: FailureClass) -> bool {
+    match classification {
+        FailureClass::Transient | FailureClass::InfraCrash => true,
+        FailureClass::Permanent | FailureClass::Timeout | FailureClass::Cancelled => false,
+        // #[non_exhaustive]: unknown future variant → retry (least
+        // destructive). A deliberate terminal variant is fine to add
+        // here alongside Permanent in a follow-up PR; defaulting
+        // unknowns to terminal would regress outcomes on backend
+        // upgrades where a new variant lands before this classifier
+        // is taught about it.
+        _ => true,
     }
-
-    let do_writes = async {
-        sqlx::query(q_attempt::UPDATE_ATTEMPT_COMPLETE_SQL)
-            .bind(now)
-            .bind(part)
-            .bind(exec_uuid)
-            .bind(attempt_index)
-            .execute(&mut *conn)
-            .await
-            .map_err(map_sqlx_error)?;
-
-        sqlx::query(q_exec::UPDATE_EXEC_CORE_COMPLETE_SQL)
-            .bind(now)
-            .bind(payload_bytes.as_deref())
-            .bind(part)
-            .bind(exec_uuid)
-            .execute(&mut *conn)
-            .await
-            .map_err(map_sqlx_error)?;
-
-        sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
-            .bind("success")
-            .bind(now)
-            .bind(part)
-            .bind(exec_uuid)
-            .execute(&mut *conn)
-            .await
-            .map_err(map_sqlx_error)?;
-
-        Ok::<(), EngineError>(())
-    };
-
-    if let Err(e) = do_writes.await {
-        rollback(&mut conn).await;
-        return Err(e);
-    }
-    commit(&mut conn).await
 }
 
 async fn fail_impl(
@@ -333,90 +431,140 @@ async fn fail_impl(
     let payload = decode_handle(handle)?;
     let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
     let attempt_index = i64::from(payload.attempt_index.0);
-    let now = now_ms();
-    let retryable = matches!(
-        classification,
-        FailureClass::Transient | FailureClass::InfraCrash
-    );
+    let expected_epoch = payload.lease_epoch.0;
+    let retryable = classify_retryable(classification);
 
     let mut conn = begin_immediate(pool).await?;
-
-    if let Err(e) = fence_check(&mut conn, part, exec_uuid, attempt_index, payload.lease_epoch.0)
-        .await
-    {
-        rollback(&mut conn).await;
-        return Err(e);
+    let result = fail_inner(
+        &mut conn,
+        part,
+        exec_uuid,
+        attempt_index,
+        expected_epoch,
+        retryable,
+        &reason,
+        classification,
+    )
+    .await;
+    match result {
+        Ok(outcome) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(outcome)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
     }
+}
+
+#[allow(clippy::too_many_arguments)] // every arg is load-bearing attempt state
+async fn fail_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+    expected_epoch: u64,
+    retryable: bool,
+    reason: &FailureReason,
+    classification: FailureClass,
+) -> Result<FailOutcome, EngineError> {
+    fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
+    let now = now_ms();
 
     if retryable {
-        let do_writes = async {
-            sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_RETRY_SQL)
-                .bind(now)
-                .bind(part)
-                .bind(exec_uuid)
-                .bind(attempt_index)
-                .execute(&mut *conn)
-                .await
-                .map_err(map_sqlx_error)?;
+        sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_RETRY_SQL)
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
 
-            sqlx::query(q_exec::UPDATE_EXEC_CORE_FAIL_RETRY_SQL)
-                .bind(&reason.message)
-                .bind(part)
-                .bind(exec_uuid)
-                .execute(&mut *conn)
-                .await
-                .map_err(map_sqlx_error)?;
+        sqlx::query(q_exec::UPDATE_EXEC_CORE_FAIL_RETRY_SQL)
+            .bind(&reason.message)
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
 
-            Ok::<(), EngineError>(())
-        };
-
-        if let Err(e) = do_writes.await {
-            rollback(&mut conn).await;
-            return Err(e);
-        }
-        commit(&mut conn).await?;
+        insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
+        // Log the transient failure so operators tracing a retry loop
+        // can correlate cause without re-reading the attempt row
+        // themselves (Gemini review #1).
+        tracing::warn!(
+            error.message = %reason.message,
+            classification = ?classification,
+            execution_id = %exec_uuid,
+            attempt_index = attempt_index,
+            "sqlite.fail: scheduling retry"
+        );
         Ok(FailOutcome::RetryScheduled {
             delay_until: ff_core::types::TimestampMs::from_millis(now),
         })
     } else {
-        let do_writes = async {
-            sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_TERMINAL_SQL)
-                .bind(now)
-                .bind(part)
-                .bind(exec_uuid)
-                .bind(attempt_index)
-                .execute(&mut *conn)
-                .await
-                .map_err(map_sqlx_error)?;
+        sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_TERMINAL_SQL)
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
 
-            sqlx::query(q_exec::UPDATE_EXEC_CORE_FAIL_TERMINAL_SQL)
-                .bind(now)
-                .bind(&reason.message)
-                .bind(part)
-                .bind(exec_uuid)
-                .execute(&mut *conn)
-                .await
-                .map_err(map_sqlx_error)?;
+        sqlx::query(q_exec::UPDATE_EXEC_CORE_FAIL_TERMINAL_SQL)
+            .bind(now)
+            .bind(&reason.message)
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
 
-            sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
-                .bind("failed")
-                .bind(now)
-                .bind(part)
-                .bind(exec_uuid)
-                .execute(&mut *conn)
-                .await
-                .map_err(map_sqlx_error)?;
+        sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
+            .bind("failed")
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
 
-            Ok::<(), EngineError>(())
-        };
-
-        if let Err(e) = do_writes.await {
-            rollback(&mut conn).await;
-            return Err(e);
-        }
-        commit(&mut conn).await?;
+        insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
         Ok(FailOutcome::TerminalFailed)
     }
+}
+
+/// Emit one RFC-019 Stage B lease-lifecycle outbox row.
+///
+/// Mirrors `ff-backend-postgres/src/lease_event.rs`. The PG
+/// `pg_notify` trigger is dropped per RFC-023 §4.2 (broadcast moves
+/// into a Rust post-commit channel in a later phase); durable replay
+/// via `event_id > cursor` continues to ride against this table.
+async fn insert_lease_event(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    event_type: &str,
+    now: i64,
+) -> Result<(), EngineError> {
+    sqlx::query(
+        r#"
+        INSERT INTO ff_lease_event (
+            execution_id, lease_id, event_type, occurred_at_ms, partition_key
+        ) VALUES (?1, NULL, ?2, ?3, ?4)
+        "#,
+    )
+    .bind(exec_uuid.to_string())
+    .bind(event_type)
+    .bind(now)
+    .bind(part)
+    .execute(&mut **conn)
+    .await
+    .map_err(map_sqlx_error)?;
+    Ok(())
 }
 
 

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -7,17 +7,21 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sqlx::SqlitePool;
+use sqlx::{Row, SqlitePool};
+use uuid::Uuid;
 
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
-    FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
-    ReclaimToken, ResumeSignal, UsageDimensions,
+    FailOutcome, FailureClass, FailureReason, Frame, Handle, HandleKind, LeaseRenewal,
+    PendingWaitpoint, ReclaimToken, ResumeSignal, UsageDimensions,
 };
+use ff_core::caps::{matches as caps_matches, CapabilityRequirement};
+use ff_core::handle_codec::HandlePayload;
+use ff_core::types::{AttemptId, AttemptIndex, LeaseEpoch, LeaseId};
 use ff_core::capability::{BackendIdentity, Capabilities, Supports, Version};
 #[cfg(feature = "core")]
 use ff_core::contracts::{
@@ -33,11 +37,14 @@ use ff_core::contracts::{
 use ff_core::contracts::{StreamCursor, StreamFrames};
 use ff_core::backend::PrepareOutcome;
 use ff_core::engine_backend::EngineBackend;
-use ff_core::engine_error::{BackendError, EngineError};
+use ff_core::engine_error::{BackendError, ContentionKind, EngineError, ValidationKind};
+
+use crate::errors::map_sqlx_error;
+use crate::handle_codec::{decode_handle, encode_handle};
+use crate::queries::{attempt as q_attempt, exec_core as q_exec};
+use crate::retry::retry_serializable;
 #[cfg(feature = "core")]
 use ff_core::partition::PartitionKey;
-#[cfg(feature = "streaming")]
-use ff_core::types::AttemptIndex;
 #[cfg(feature = "core")]
 use ff_core::types::EdgeId;
 use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
@@ -51,6 +58,367 @@ use crate::registry;
 fn unavailable<T>(op: &'static str) -> Result<T, EngineError> {
     Err(EngineError::Unavailable { op })
 }
+
+// ── Phase 2a.2 helpers: hot-path shared logic ──────────────────────────
+
+/// Unix-millis wall clock. Matches the PG reference shape
+/// (`ff-backend-postgres/src/attempt.rs:55-63`); SQLite stores the
+/// same `*_ms` fields so the value is directly comparable.
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX)
+}
+
+/// Decompose an [`ff_core::types::ExecutionId`] formatted `{fp:N}:<uuid>`
+/// into `(partition_index, uuid_bytes)` — SQLite stores the UUID as a
+/// 16-byte `BLOB` (§4.1) so we bind via `uuid::Uuid`.
+fn split_exec_id(
+    eid: &ff_core::types::ExecutionId,
+) -> Result<(i64, Uuid), EngineError> {
+    let s = eid.as_str();
+    let rest = s.strip_prefix("{fp:").ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id missing `{{fp:` prefix: {s}"),
+    })?;
+    let close = rest.find("}:").ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id missing `}}:`: {s}"),
+    })?;
+    let part: i64 = rest[..close]
+        .parse()
+        .map_err(|_| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("execution_id partition index not u16: {s}"),
+        })?;
+    let uuid = Uuid::parse_str(&rest[close + 2..]).map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id UUID invalid: {s}"),
+    })?;
+    Ok((part, uuid))
+}
+
+/// Acquire a pooled connection and issue `BEGIN IMMEDIATE`, escalating
+/// the txn to RESERVED so §4.1 A3's single-writer invariant holds for
+/// the full read-modify-write window. Returns the live connection for
+/// subsequent statements; the caller commits or rolls back explicitly.
+///
+/// SQLite's `BEGIN IMMEDIATE` is the single-writer equivalent of PG's
+/// `FOR UPDATE SKIP LOCKED`: contending writers block (or return
+/// `SQLITE_BUSY`, which the retry helper catches) rather than
+/// silently reading stale snapshots.
+async fn begin_immediate(
+    pool: &SqlitePool,
+) -> Result<sqlx::pool::PoolConnection<sqlx::Sqlite>, EngineError> {
+    let mut conn = pool.acquire().await.map_err(map_sqlx_error)?;
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(conn)
+}
+
+async fn commit(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+) -> Result<(), EngineError> {
+    sqlx::query("COMMIT")
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+async fn rollback(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
+    // Best-effort: a failed rollback means the txn is already gone
+    // (e.g. the caller raised a typed error mid-op) and the
+    // connection is about to be dropped anyway. Swallow to keep the
+    // original error shape intact.
+    let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
+}
+
+/// Fence check: under the `BEGIN IMMEDIATE` lock, read the attempt
+/// row's `lease_epoch` and compare against the handle-embedded epoch.
+/// Mismatch ⇒ [`ContentionKind::LeaseConflict`] (terminal for this
+/// call; caller does not retry a fence mismatch).
+async fn fence_check(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+    expected_epoch: u64,
+) -> Result<(), EngineError> {
+    let row = sqlx::query(q_attempt::SELECT_ATTEMPT_EPOCH_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .fetch_optional(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let Some(row) = row else {
+        return Err(EngineError::NotFound { entity: "attempt" });
+    };
+    let epoch_i: i64 = row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+    let observed = u64::try_from(epoch_i).unwrap_or(0);
+    if observed != expected_epoch {
+        return Err(EngineError::Contention(ContentionKind::LeaseConflict));
+    }
+    Ok(())
+}
+
+// ── Phase 2a.2 hot-path bodies ─────────────────────────────────────────
+
+async fn claim_impl(
+    pool: &SqlitePool,
+    lane: &ff_core::types::LaneId,
+    capabilities: &CapabilitySet,
+    policy: &ClaimPolicy,
+) -> Result<Option<Handle>, EngineError> {
+    // RFC-023 §4.1 A3: SQLite is single-writer with
+    // `num_flow_partitions = 1`, so we scan only partition 0 rather
+    // than iterating 0..256 as the PG path does.
+    let part: i64 = 0;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let row = sqlx::query(q_attempt::SELECT_ELIGIBLE_EXEC_SQL)
+        .bind(part)
+        .bind(lane.as_str())
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        rollback(&mut conn).await;
+        return Ok(None);
+    };
+
+    let exec_uuid: Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
+    let attempt_index_i: i64 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+    // Capability subset check (§4.1 A4): read tokens from the junction
+    // table, match in Rust via `caps::matches` — same shape as PG's
+    // Rust-side match, different read source.
+    let cap_rows = sqlx::query(q_attempt::SELECT_EXEC_CAPABILITIES_SQL)
+        .bind(exec_uuid)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let tokens: Vec<String> = cap_rows
+        .iter()
+        .map(|r| r.try_get::<String, _>("capability"))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_sqlx_error)?;
+    let req = CapabilityRequirement::new(tokens);
+    if !caps_matches(&req, capabilities) {
+        // Release the lock; caller's retry cadence picks up a matching
+        // worker later (documented at PG reference §isolation note).
+        rollback(&mut conn).await;
+        return Ok(None);
+    }
+
+    let now = now_ms();
+    let lease_ttl_ms = i64::from(policy.lease_ttl_ms);
+    let expires = now.saturating_add(lease_ttl_ms);
+
+    // UPSERT the attempt row. `RETURNING lease_epoch` gives us the
+    // post-UPSERT epoch in one round-trip (SQLite >= 3.35).
+    let epoch_row = sqlx::query(q_attempt::UPSERT_ATTEMPT_ON_CLAIM_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index_i)
+        .bind(policy.worker_id.as_str())
+        .bind(policy.worker_instance_id.as_str())
+        .bind(expires)
+        .bind(now)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let epoch_i: i64 = epoch_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+
+    sqlx::query(q_exec::UPDATE_EXEC_CORE_CLAIM_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    commit(&mut conn).await?;
+
+    let attempt_index = AttemptIndex::new(u32::try_from(attempt_index_i.max(0)).unwrap_or(0));
+    let exec_id = ff_core::types::ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}"))
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("reassembling exec id: {e}"),
+        })?;
+    let payload = HandlePayload::new(
+        exec_id,
+        attempt_index,
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(u64::try_from(epoch_i).unwrap_or(1)),
+        u64::from(policy.lease_ttl_ms),
+        lane.clone(),
+        policy.worker_instance_id.clone(),
+    );
+    Ok(Some(encode_handle(&payload, HandleKind::Fresh)))
+}
+
+async fn complete_impl(
+    pool: &SqlitePool,
+    handle: &Handle,
+    payload_bytes: Option<Vec<u8>>,
+) -> Result<(), EngineError> {
+    let payload = decode_handle(handle)?;
+    let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
+    let attempt_index = i64::from(payload.attempt_index.0);
+    let now = now_ms();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    if let Err(e) = fence_check(&mut conn, part, exec_uuid, attempt_index, payload.lease_epoch.0)
+        .await
+    {
+        rollback(&mut conn).await;
+        return Err(e);
+    }
+
+    let do_writes = async {
+        sqlx::query(q_attempt::UPDATE_ATTEMPT_COMPLETE_SQL)
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        sqlx::query(q_exec::UPDATE_EXEC_CORE_COMPLETE_SQL)
+            .bind(now)
+            .bind(payload_bytes.as_deref())
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
+            .bind("success")
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        Ok::<(), EngineError>(())
+    };
+
+    if let Err(e) = do_writes.await {
+        rollback(&mut conn).await;
+        return Err(e);
+    }
+    commit(&mut conn).await
+}
+
+async fn fail_impl(
+    pool: &SqlitePool,
+    handle: &Handle,
+    reason: FailureReason,
+    classification: FailureClass,
+) -> Result<FailOutcome, EngineError> {
+    let payload = decode_handle(handle)?;
+    let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
+    let attempt_index = i64::from(payload.attempt_index.0);
+    let now = now_ms();
+    let retryable = matches!(
+        classification,
+        FailureClass::Transient | FailureClass::InfraCrash
+    );
+
+    let mut conn = begin_immediate(pool).await?;
+
+    if let Err(e) = fence_check(&mut conn, part, exec_uuid, attempt_index, payload.lease_epoch.0)
+        .await
+    {
+        rollback(&mut conn).await;
+        return Err(e);
+    }
+
+    if retryable {
+        let do_writes = async {
+            sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_RETRY_SQL)
+                .bind(now)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(attempt_index)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            sqlx::query(q_exec::UPDATE_EXEC_CORE_FAIL_RETRY_SQL)
+                .bind(&reason.message)
+                .bind(part)
+                .bind(exec_uuid)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            Ok::<(), EngineError>(())
+        };
+
+        if let Err(e) = do_writes.await {
+            rollback(&mut conn).await;
+            return Err(e);
+        }
+        commit(&mut conn).await?;
+        Ok(FailOutcome::RetryScheduled {
+            delay_until: ff_core::types::TimestampMs::from_millis(now),
+        })
+    } else {
+        let do_writes = async {
+            sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_TERMINAL_SQL)
+                .bind(now)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(attempt_index)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            sqlx::query(q_exec::UPDATE_EXEC_CORE_FAIL_TERMINAL_SQL)
+                .bind(now)
+                .bind(&reason.message)
+                .bind(part)
+                .bind(exec_uuid)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
+                .bind("failed")
+                .bind(now)
+                .bind(part)
+                .bind(exec_uuid)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            Ok::<(), EngineError>(())
+        };
+
+        if let Err(e) = do_writes.await {
+            rollback(&mut conn).await;
+            return Err(e);
+        }
+        commit(&mut conn).await?;
+        Ok(FailOutcome::TerminalFailed)
+    }
+}
+
 
 /// Internal shared state. `Arc<SqliteBackendInner>` is what the
 /// registry stores weak references to and what `SqliteBackend`
@@ -276,11 +644,12 @@ impl EngineBackend for SqliteBackend {
 
     async fn claim(
         &self,
-        _lane: &LaneId,
-        _capabilities: &CapabilitySet,
-        _policy: ClaimPolicy,
+        lane: &LaneId,
+        capabilities: &CapabilitySet,
+        policy: ClaimPolicy,
     ) -> Result<Option<Handle>, EngineError> {
-        unavailable("sqlite.claim")
+        let pool = &self.inner.pool;
+        retry_serializable(|| claim_impl(pool, lane, capabilities, &policy)).await
     }
 
     async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
@@ -306,19 +675,21 @@ impl EngineBackend for SqliteBackend {
 
     async fn complete(
         &self,
-        _handle: &Handle,
-        _payload: Option<Vec<u8>>,
+        handle: &Handle,
+        payload: Option<Vec<u8>>,
     ) -> Result<(), EngineError> {
-        unavailable("sqlite.complete")
+        let pool = &self.inner.pool;
+        retry_serializable(|| complete_impl(pool, handle, payload.clone())).await
     }
 
     async fn fail(
         &self,
-        _handle: &Handle,
-        _reason: FailureReason,
-        _classification: FailureClass,
+        handle: &Handle,
+        reason: FailureReason,
+        classification: FailureClass,
     ) -> Result<FailOutcome, EngineError> {
-        unavailable("sqlite.fail")
+        let pool = &self.inner.pool;
+        retry_serializable(|| fail_impl(pool, handle, reason.clone(), classification)).await
     }
 
     async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {

--- a/crates/ff-backend-sqlite/src/errors.rs
+++ b/crates/ff-backend-sqlite/src/errors.rs
@@ -11,9 +11,40 @@
 #[cfg(test)]
 use sqlx::error::Error as SqlxError;
 
+use ff_core::engine_error::EngineError;
+
 /// Re-export of the retry budget so callers have one import path for
 /// classifier + budget + helper.
 pub use crate::retry::MAX_ATTEMPTS;
+
+/// Translate a `sqlx::Error` surfaced during a SQLite op into the
+/// canonical [`EngineError`] shape. Mirrors
+/// `ff-backend-postgres::error::map_sqlx_error`: transient transport
+/// faults box through [`EngineError::Transport`] with
+/// `backend = "sqlite"`; retry-classification happens at the retry
+/// helper layer via [`IsRetryableBusy`] on the translated error.
+pub(crate) fn map_sqlx_error(err: sqlx::Error) -> EngineError {
+    EngineError::Transport {
+        backend: "sqlite",
+        source: Box::new(err),
+    }
+}
+
+/// Let the Wave-9 retry helper classify [`EngineError`] values without
+/// unwrapping — the closure passed to
+/// [`crate::retry::retry_serializable`] returns `Result<_, EngineError>`
+/// and we inspect the boxed transport source to decide whether to loop.
+impl crate::retry::IsRetryableBusy for EngineError {
+    fn is_retryable_busy(&self) -> bool {
+        if let EngineError::Transport { backend, source } = self
+            && *backend == "sqlite"
+            && let Some(sqlx_err) = source.downcast_ref::<sqlx::Error>()
+        {
+            return is_retryable_sqlite_busy(sqlx_err);
+        }
+        false
+    }
+}
 
 /// Return `true` when the sqlx error is a transient busy-contention
 /// fault that is safe to retry. Mirrors the shape of PG's

--- a/crates/ff-backend-sqlite/src/handle_codec.rs
+++ b/crates/ff-backend-sqlite/src/handle_codec.rs
@@ -18,17 +18,16 @@
 //! the embedded tag means something upstream is lying; we treat that
 //! as `HandleFromOtherBackend` too.
 //!
-//! At Phase 2a.1.5 the SQLite backend still returns `Unavailable` for
-//! every trait method that touches a [`Handle`], so the bodies here
-//! are unused by the live hot path today — they exist to lock in the
-//! backend-tag invariant and to give Phase 2a.2 a ready-to-use API.
+//! Phase 2a.2 wires these helpers into the live hot path — `claim`
+//! mints handles via [`encode_handle`]; `complete` / `fail` decode +
+//! validate the caller's handle via [`decode_handle`] before any
+//! write.
 
 use ff_core::backend::{BackendTag, Handle, HandleKind, HandleOpaque};
 use ff_core::engine_error::{EngineError, ValidationKind};
 use ff_core::handle_codec::{decode as core_decode, encode as core_encode, HandlePayload};
 
 /// Encode a [`HandlePayload`] into a SQLite-tagged [`Handle`].
-#[allow(dead_code)] // Wired up in Phase 2a.2+ when Handle-bearing ops land.
 pub(crate) fn encode_handle(payload: &HandlePayload, kind: HandleKind) -> Handle {
     let opaque: HandleOpaque = core_encode(BackendTag::Sqlite, payload);
     Handle::new(BackendTag::Sqlite, kind, opaque)
@@ -38,7 +37,6 @@ pub(crate) fn encode_handle(payload: &HandlePayload, kind: HandleKind) -> Handle
 /// Valkey/Postgres-tagged handle decodes successfully at the core
 /// codec layer but is rejected here with
 /// `ValidationKind::HandleFromOtherBackend`.
-#[allow(dead_code)] // Wired up in Phase 2a.2+.
 pub(crate) fn decode_handle(handle: &Handle) -> Result<HandlePayload, EngineError> {
     if handle.backend != BackendTag::Sqlite {
         return Err(EngineError::Validation {

--- a/crates/ff-backend-sqlite/src/queries/attempt.rs
+++ b/crates/ff-backend-sqlite/src/queries/attempt.rs
@@ -26,11 +26,16 @@
 //! [`ff_core::engine_error::ContentionKind::LeaseConflict`] without
 //! retrying (it is a semantic conflict, not transient busy).
 
-/// Scan one eligible row in the partition/lane. Caller iterates the
-/// `(partition_key, priority, created_at_ms)` order; `LIMIT 1`
-/// yields the highest-priority-oldest runnable row. No `FOR UPDATE
-/// SKIP LOCKED` — the enclosing `BEGIN IMMEDIATE` already serializes
-/// writers per §4.1 A3.
+/// Scan up to `?3` eligible rows in the partition/lane ordered by
+/// `(priority DESC, created_at_ms ASC)`. No `FOR UPDATE SKIP LOCKED`
+/// — the enclosing `BEGIN IMMEDIATE` already serializes writers per
+/// §4.1 A3.
+///
+/// The batch shape (vs. `LIMIT 1`) lets `claim_impl` walk past rows
+/// whose required capabilities the current worker lacks without
+/// starving lower-priority-but-eligible members of the same lane —
+/// caught in PR-375 review. Bounded budget keeps the lock window
+/// predictable even when the top-priority row has an exotic cap set.
 pub(crate) const SELECT_ELIGIBLE_EXEC_SQL: &str = r#"
     SELECT execution_id, attempt_index
       FROM ff_exec_core
@@ -39,7 +44,7 @@ pub(crate) const SELECT_ELIGIBLE_EXEC_SQL: &str = r#"
        AND lifecycle_phase = 'runnable'
        AND eligibility_state = 'eligible_now'
      ORDER BY priority DESC, created_at_ms ASC
-     LIMIT 1
+     LIMIT ?3
 "#;
 
 /// Fetch the capability tokens bound to an execution via the junction

--- a/crates/ff-backend-sqlite/src/queries/attempt.rs
+++ b/crates/ff-backend-sqlite/src/queries/attempt.rs
@@ -1,5 +1,142 @@
 //! SQLite dialect-forked queries for the attempt hot path.
 //!
-//! Populated in Phase 2a.2 per RFC-023 §4.1. Phase 2a.1 lands the
-//! empty module as a layout-only placeholder so the `mod` tree is
-//! stable before method bodies merge.
+//! Populated in Phase 2a.2 per RFC-023 §4.1. The SQL strings are
+//! module-level `const`s so `backend.rs` call sites reference them
+//! by name and cross-dialect review lines them up against the PG
+//! reference at `ff-backend-postgres/src/attempt.rs` statement-by-
+//! statement.
+//!
+//! # Dialect translation summary
+//!
+//! | PG pattern                      | SQLite fork                                     |
+//! | ------------------------------- | ----------------------------------------------- |
+//! | `FOR UPDATE SKIP LOCKED`        | `BEGIN IMMEDIATE` txn + plain SELECT (§4.1 A3)  |
+//! | `text[] @> ARRAY[...]`          | junction-table SELECT + Rust subset match (A4)  |
+//! | `jsonb_build_object(...)`       | `json_set(raw_fields, '$.field', ?)`            |
+//! | `BIGSERIAL RETURNING`           | `INTEGER PRIMARY KEY AUTOINCREMENT` + RETURNING |
+//! | `BYTEA` binds                   | `BLOB` binds (sqlx auto-encodes `&[u8]`)        |
+//!
+//! # Fence-triple contract
+//!
+//! `BEGIN IMMEDIATE` on SQLite escalates the txn to RESERVED, so the
+//! single-writer invariant (§3.2) holds for the full read-modify-write
+//! window. Fence CAS is expressed as a plain SELECT of the attempt
+//! row's `lease_epoch` under the txn lock; a mismatch against the
+//! caller's handle surfaces as
+//! [`ff_core::engine_error::ContentionKind::LeaseConflict`] without
+//! retrying (it is a semantic conflict, not transient busy).
+
+/// Scan one eligible row in the partition/lane. Caller iterates the
+/// `(partition_key, priority, created_at_ms)` order; `LIMIT 1`
+/// yields the highest-priority-oldest runnable row. No `FOR UPDATE
+/// SKIP LOCKED` — the enclosing `BEGIN IMMEDIATE` already serializes
+/// writers per §4.1 A3.
+pub(crate) const SELECT_ELIGIBLE_EXEC_SQL: &str = r#"
+    SELECT execution_id, attempt_index
+      FROM ff_exec_core
+     WHERE partition_key = ?1
+       AND lane_id = ?2
+       AND lifecycle_phase = 'runnable'
+       AND eligibility_state = 'eligible_now'
+     ORDER BY priority DESC, created_at_ms ASC
+     LIMIT 1
+"#;
+
+/// Fetch the capability tokens bound to an execution via the junction
+/// table (RFC-023 §4.1 A4). Caller collects the returned rows into a
+/// [`ff_core::caps::CapabilityRequirement`] and runs
+/// `caps::matches(&req, worker)` in Rust — same shape as the PG path
+/// (see `ff-backend-postgres/src/attempt.rs:170-182`), just reading
+/// from the junction instead of a PG `text[]` column.
+pub(crate) const SELECT_EXEC_CAPABILITIES_SQL: &str = r#"
+    SELECT capability
+      FROM ff_execution_capabilities
+     WHERE execution_id = ?1
+"#;
+
+/// UPSERT the attempt row on claim. On first claim the row is fresh
+/// (`lease_epoch = 1`); on a retry-attempt re-claim the PK matches
+/// the prior (attempt_index, execution_id) and we bump
+/// `lease_epoch = prior + 1`, rotate worker identity, clear the
+/// outcome. Mirror of the PG ON CONFLICT DO UPDATE at
+/// `ff-backend-postgres/src/attempt.rs:192-218`.
+pub(crate) const UPSERT_ATTEMPT_ON_CLAIM_SQL: &str = r#"
+    INSERT INTO ff_attempt (
+        partition_key, execution_id, attempt_index,
+        worker_id, worker_instance_id,
+        lease_epoch, lease_expires_at_ms, started_at_ms
+    ) VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?7)
+    ON CONFLICT (partition_key, execution_id, attempt_index)
+    DO UPDATE SET
+        worker_id = excluded.worker_id,
+        worker_instance_id = excluded.worker_instance_id,
+        lease_epoch = ff_attempt.lease_epoch + 1,
+        lease_expires_at_ms = excluded.lease_expires_at_ms,
+        started_at_ms = excluded.started_at_ms,
+        outcome = NULL
+    RETURNING lease_epoch
+"#;
+
+/// Fence check: read the attempt row's current `lease_epoch` so the
+/// caller can compare it against the handle-embedded epoch before any
+/// terminal write. Cheaper shape than PG's `SELECT ... FOR UPDATE` —
+/// SQLite's `BEGIN IMMEDIATE` already holds the RESERVED lock for the
+/// full txn, so a plain SELECT is sufficient.
+pub(crate) const SELECT_ATTEMPT_EPOCH_SQL: &str = r#"
+    SELECT lease_epoch
+      FROM ff_attempt
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+/// Mark the attempt row as terminal-success. Drops the lease by
+/// nulling `lease_expires_at_ms` so the scanner does not re-issue
+/// reclaim grants. Mirror of PG at
+/// `ff-backend-postgres/src/attempt.rs:538-552`.
+pub(crate) const UPDATE_ATTEMPT_COMPLETE_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET terminal_at_ms = ?1,
+           outcome = 'success',
+           lease_expires_at_ms = NULL
+     WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4
+"#;
+
+/// Mark the attempt row as retry-scheduled. `outcome = 'retry'` is the
+/// PG/Valkey-parity token; the `exec_core` flip to runnable +
+/// attempt_index bump lives in `exec_core::UPDATE_EXEC_CORE_FAIL_RETRY_SQL`.
+/// Mirror of PG at `ff-backend-postgres/src/attempt.rs:630-645`.
+pub(crate) const UPDATE_ATTEMPT_FAIL_RETRY_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET terminal_at_ms = ?1,
+           outcome = 'retry',
+           lease_expires_at_ms = NULL
+     WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4
+"#;
+
+/// Mark the attempt row as terminal-failed (retry budget exhausted or
+/// classification was permanent). Mirror of PG at
+/// `ff-backend-postgres/src/attempt.rs:684-698`.
+pub(crate) const UPDATE_ATTEMPT_FAIL_TERMINAL_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET terminal_at_ms = ?1,
+           outcome = 'failed',
+           lease_expires_at_ms = NULL
+     WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4
+"#;
+
+/// Outbox write for the completion event. The AFTER-INSERT `pg_notify`
+/// trigger from the PG schema is intentionally dropped (RFC-023 §4.2 —
+/// broadcast moves into a Rust post-commit path); durable replay still
+/// rides `event_id > cursor` catch-up against this table, so the
+/// insert shape is identical to the PG statement at
+/// `ff-backend-postgres/src/attempt.rs:575-592` (and `:720-737` for
+/// the `failed` variant).
+pub(crate) const INSERT_COMPLETION_EVENT_SQL: &str = r#"
+    INSERT INTO ff_completion_event (
+        partition_key, execution_id, flow_id, outcome,
+        namespace, instance_tag, occurred_at_ms
+    )
+    SELECT partition_key, execution_id, flow_id, ?1,
+           NULL, NULL, ?2
+      FROM ff_exec_core
+     WHERE partition_key = ?3 AND execution_id = ?4
+"#;

--- a/crates/ff-backend-sqlite/src/queries/exec_core.rs
+++ b/crates/ff-backend-sqlite/src/queries/exec_core.rs
@@ -1,5 +1,62 @@
 //! SQLite dialect-forked queries for execution core (create / claim /
 //! complete / fail).
 //!
-//! Populated in Phase 2a.2 per RFC-023 §4.1. Phase 2a.1 lands the
-//! empty module as a layout-only placeholder.
+//! Populated in Phase 2a.2 per RFC-023 §4.1. The SQL strings are kept
+//! as module-level `const`s so `backend.rs` call sites reference them
+//! by name and migration-parity review can line them up against the
+//! PG reference statement-by-statement.
+
+/// Flip exec_core to `active/leased/running` on a successful claim
+/// (mirror of PG's claim-path UPDATE at
+/// `ff-backend-postgres/src/attempt.rs:236-250`).
+pub(crate) const UPDATE_EXEC_CORE_CLAIM_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'active',
+           ownership_state = 'leased',
+           eligibility_state = 'not_applicable',
+           attempt_state = 'running_attempt'
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Flip exec_core to terminal success, recording the result payload
+/// (mirror of `ff-backend-postgres/src/attempt.rs:554-572`).
+pub(crate) const UPDATE_EXEC_CORE_COMPLETE_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'terminal',
+           ownership_state = 'unowned',
+           eligibility_state = 'not_applicable',
+           attempt_state = 'attempt_terminal',
+           terminal_at_ms = ?1,
+           result = ?2
+     WHERE partition_key = ?3 AND execution_id = ?4
+"#;
+
+/// Re-enqueue the execution for a retry attempt: flip lifecycle back to
+/// runnable, bump attempt_index, stash the last failure message in the
+/// TEXT-encoded `raw_fields` JSON document via SQLite's `json_set` (JSON1).
+/// Mirrors PG's `jsonb_build_object(...)` concat at
+/// `ff-backend-postgres/src/attempt.rs:647-664`.
+pub(crate) const UPDATE_EXEC_CORE_FAIL_RETRY_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'runnable',
+           ownership_state = 'unowned',
+           eligibility_state = 'eligible_now',
+           attempt_state = 'pending_retry_attempt',
+           attempt_index = attempt_index + 1,
+           raw_fields = json_set(raw_fields, '$.last_failure_message', ?1)
+     WHERE partition_key = ?2 AND execution_id = ?3
+"#;
+
+/// Flip exec_core to terminal failed — retry budget exhausted or
+/// classification was permanent. Mirror of PG at
+/// `ff-backend-postgres/src/attempt.rs:700-718`.
+pub(crate) const UPDATE_EXEC_CORE_FAIL_TERMINAL_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'terminal',
+           ownership_state = 'unowned',
+           eligibility_state = 'not_applicable',
+           attempt_state = 'attempt_terminal',
+           terminal_at_ms = ?1,
+           raw_fields = json_set(raw_fields, '$.last_failure_message', ?2)
+     WHERE partition_key = ?3 AND execution_id = ?4
+"#;

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -1,0 +1,394 @@
+//! RFC-023 Phase 2a.2 — claim / complete / fail hot-path tests.
+//!
+//! The tests drive the [`SqliteBackend`] through the `EngineBackend`
+//! trait surface: they seed `ff_exec_core` + `ff_execution_capabilities`
+//! rows via raw SQL (the `create_execution` trait method lands in Phase
+//! 2b), call `claim` to mint a real handle, then exercise
+//! `complete`/`fail` against the handle and assert the post-state via
+//! follow-up SELECTs.
+//!
+//! # Test-environment invariant
+//!
+//! Every test is `#[serial(ff_dev_mode)]` — `SqliteBackend::new` refuses
+//! construction without `FF_DEV_MODE=1`, and the shared environment
+//! variable must not race across test binaries.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{
+    BackendTag, CapabilitySet, ClaimPolicy, FailureClass, FailureReason, Handle, HandleKind,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
+use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, WorkerId,
+    WorkerInstanceId,
+};
+use serial_test::serial;
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ── Setup helpers ──────────────────────────────────────────────────────
+
+/// Spin up an isolated SQLite backend against a shared-cache `:memory:`
+/// URI whose name embeds nanotime + thread-id so parallel tests never
+/// collide on the registry key.
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    // SAFETY: test-only env mutation; every caller is tagged
+    // `#[serial(ff_dev_mode)]` which serializes all env readers +
+    // writers across test binaries.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:rfc-023-hot-path-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("construct backend")
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+/// Seed one runnable, eligible execution on partition 0 / `lane_id`
+/// with the given capability tokens. Returns `(execution_id, exec_uuid)`.
+async fn seed_runnable_execution(
+    backend: &SqliteBackend,
+    lane_id: &str,
+    capabilities: &[&str],
+) -> (ExecutionId, Uuid) {
+    let pool = backend.pool_for_test();
+    let exec_uuid = Uuid::new_v4();
+    // Partition 0 per RFC-023 §4.1 A3 — num_flow_partitions = 1.
+    let exec_id = ExecutionId::parse(&format!("{{fp:0}}:{exec_uuid}"))
+        .expect("construct exec_id");
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, lane_id, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state, priority, created_at_ms
+        ) VALUES (0, ?1, ?2, 0,
+                  'runnable', 'unowned', 'eligible_now',
+                  'pending', 'initial', 0, 1)
+        "#,
+    )
+    .bind(exec_uuid)
+    .bind(lane_id)
+    .execute(pool)
+    .await
+    .expect("seed ff_exec_core");
+
+    for cap in capabilities {
+        sqlx::query(
+            r#"
+            INSERT INTO ff_execution_capabilities (execution_id, capability)
+            VALUES (?1, ?2)
+            "#,
+        )
+        .bind(exec_uuid)
+        .bind(*cap)
+        .execute(pool)
+        .await
+        .expect("seed ff_execution_capabilities");
+    }
+
+    (exec_id, exec_uuid)
+}
+
+/// Build a non-blocking `ClaimPolicy` with a deterministic worker
+/// identity + a 30s lease TTL.
+fn claim_policy() -> ClaimPolicy {
+    ClaimPolicy::new(
+        WorkerId::new("test-worker"),
+        WorkerInstanceId::new("test-worker-instance"),
+        30_000,
+        None,
+    )
+}
+
+/// Read one attempt row's terminal state for post-condition assertions.
+async fn read_attempt_outcome(
+    backend: &SqliteBackend,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+) -> Option<String> {
+    let pool = backend.pool_for_test();
+    sqlx::query_scalar::<_, Option<String>>(
+        "SELECT outcome FROM ff_attempt \
+          WHERE partition_key = 0 AND execution_id = ?1 AND attempt_index = ?2",
+    )
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_one(pool)
+    .await
+    .expect("read attempt outcome")
+}
+
+/// Read one exec_core row's `lifecycle_phase`.
+async fn read_exec_phase(backend: &SqliteBackend, exec_uuid: Uuid) -> String {
+    let pool = backend.pool_for_test();
+    sqlx::query_scalar::<_, String>(
+        "SELECT lifecycle_phase FROM ff_exec_core \
+          WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read lifecycle_phase")
+}
+
+// ── claim ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_happy_path_mints_handle_and_transitions_state() {
+    let backend = fresh_backend().await;
+    let (_exec_id, exec_uuid) =
+        seed_runnable_execution(&backend, "default", &["capA"]).await;
+
+    let caps = CapabilitySet::new(["capA"]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("Some(handle)");
+
+    // Handle must be SQLite-tagged and Fresh.
+    assert_eq!(h.backend, BackendTag::Sqlite);
+    assert_eq!(h.kind, HandleKind::Fresh);
+
+    // exec_core flipped to active.
+    assert_eq!(read_exec_phase(&backend, exec_uuid).await, "active");
+
+    // Attempt row created with no terminal outcome yet.
+    assert_eq!(read_attempt_outcome(&backend, exec_uuid, 0).await, None);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_returns_none_when_no_eligible_rows() {
+    let backend = fresh_backend().await;
+    // No seed.
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let r = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim");
+    assert!(r.is_none());
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_capability_mismatch_skips_and_returns_none() {
+    let backend = fresh_backend().await;
+    let (_exec_id, exec_uuid) =
+        seed_runnable_execution(&backend, "default", &["capA", "capB"]).await;
+
+    // Worker does not carry capB — expect Ok(None), exec_core unchanged.
+    let caps = CapabilitySet::new(["capA"]);
+    let r = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim");
+    assert!(r.is_none());
+    // exec_core still runnable — no attempt row written.
+    assert_eq!(read_exec_phase(&backend, exec_uuid).await, "runnable");
+}
+
+// ── complete ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_writes_terminal_and_clears_lease() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    backend
+        .complete(&h, Some(b"result".to_vec()))
+        .await
+        .expect("complete");
+
+    // exec_core is terminal now.
+    assert_eq!(read_exec_phase(&backend, exec_uuid).await, "terminal");
+    // Attempt outcome is success.
+    assert_eq!(
+        read_attempt_outcome(&backend, exec_uuid, 0).await,
+        Some("success".into())
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_fence_mismatch_returns_contention() {
+    let backend = fresh_backend().await;
+    let (eid, _exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    // Mint a second handle with a wrong epoch pointing at the same
+    // attempt — decoder must accept the shape but fence_check must reject.
+    let bad_payload = HandlePayload::new(
+        eid.clone(),
+        AttemptIndex::new(0),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(999), // deliberately wrong
+        30_000,
+        LaneId::new("default"),
+        WorkerInstanceId::new("test-worker-instance"),
+    );
+    let bad_opaque = encode_opaque(BackendTag::Sqlite, &bad_payload);
+    let bad_handle = Handle::new(BackendTag::Sqlite, HandleKind::Fresh, bad_opaque);
+
+    let err = backend
+        .complete(&bad_handle, None)
+        .await
+        .expect_err("fence mismatch must surface as Contention");
+    assert!(
+        matches!(err, EngineError::Contention(ContentionKind::LeaseConflict)),
+        "expected LeaseConflict, got {err:?}"
+    );
+
+    // Good handle still works — the txn rolled back cleanly.
+    backend.complete(&h, None).await.expect("complete");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn handle_from_valkey_rejected_on_complete() {
+    let backend = fresh_backend().await;
+    // Forge a Valkey-tagged handle — SqliteBackend must reject with
+    // `HandleFromOtherBackend`.
+    let payload = HandlePayload::new(
+        ExecutionId::solo(&LaneId::new("default"), &PartitionConfig::default()),
+        AttemptIndex::new(0),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(1),
+        30_000,
+        LaneId::new("default"),
+        WorkerInstanceId::new("test-worker-instance"),
+    );
+    let valkey_opaque = encode_opaque(BackendTag::Valkey, &payload);
+    let valkey_handle = Handle::new(BackendTag::Valkey, HandleKind::Fresh, valkey_opaque);
+
+    let err = backend
+        .complete(&valkey_handle, None)
+        .await
+        .expect_err("valkey-tagged handle must be rejected");
+    match err {
+        EngineError::Validation { kind, detail } => {
+            assert_eq!(kind, ValidationKind::HandleFromOtherBackend);
+            assert!(
+                detail.contains("Valkey"),
+                "detail should name the foreign backend: {detail:?}"
+            );
+        }
+        other => panic!("expected Validation, got {other:?}"),
+    }
+}
+
+// ── fail ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn fail_transient_schedules_retry_and_reruns_runnable() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    let out = backend
+        .fail(
+            &h,
+            FailureReason::new("transient boom"),
+            FailureClass::Transient,
+        )
+        .await
+        .expect("fail");
+    use ff_core::backend::FailOutcome;
+    assert!(
+        matches!(out, FailOutcome::RetryScheduled { .. }),
+        "expected RetryScheduled, got {out:?}"
+    );
+
+    // Execution is back to runnable with attempt_index bumped.
+    assert_eq!(read_exec_phase(&backend, exec_uuid).await, "runnable");
+    let pool = backend.pool_for_test();
+    let ai: i64 = sqlx::query_scalar(
+        "SELECT attempt_index FROM ff_exec_core \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read attempt_index");
+    assert_eq!(ai, 1);
+
+    // The original attempt (attempt_index=0) is marked 'retry'.
+    assert_eq!(
+        read_attempt_outcome(&backend, exec_uuid, 0).await,
+        Some("retry".into())
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn fail_permanent_writes_terminal_failed() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    let out = backend
+        .fail(
+            &h,
+            FailureReason::new("permanent boom"),
+            FailureClass::Permanent,
+        )
+        .await
+        .expect("fail");
+    use ff_core::backend::FailOutcome;
+    assert!(
+        matches!(out, FailOutcome::TerminalFailed),
+        "expected TerminalFailed, got {out:?}"
+    );
+
+    assert_eq!(read_exec_phase(&backend, exec_uuid).await, "terminal");
+    assert_eq!(
+        read_attempt_outcome(&backend, exec_uuid, 0).await,
+        Some("failed".into())
+    );
+}

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -359,6 +359,91 @@ async fn fail_transient_schedules_retry_and_reruns_runnable() {
     );
 }
 
+/// Capability subset check walks past higher-priority rows that the
+/// worker cannot serve rather than returning `None` immediately. This
+/// is the fix for PR-375 review finding on single-partition starvation.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_walks_past_capability_mismatch_to_match_lower_priority() {
+    let backend = fresh_backend().await;
+    let pool = backend.pool_for_test();
+
+    // Seed two rows on the same lane:
+    // * high-priority requires capB (worker lacks it)
+    // * low-priority requires capA (worker has it)
+    let hi = Uuid::new_v4();
+    let lo = Uuid::new_v4();
+    for (uuid, priority, cap) in [(hi, 10, "capB"), (lo, 0, "capA")] {
+        sqlx::query(
+            r#"
+            INSERT INTO ff_exec_core (
+                partition_key, execution_id, lane_id, attempt_index,
+                lifecycle_phase, ownership_state, eligibility_state,
+                public_state, attempt_state, priority, created_at_ms
+            ) VALUES (0, ?1, 'default', 0,
+                      'runnable', 'unowned', 'eligible_now',
+                      'pending', 'initial', ?2, 1)
+            "#,
+        )
+        .bind(uuid)
+        .bind(priority)
+        .execute(pool)
+        .await
+        .expect("seed exec_core");
+        sqlx::query(
+            "INSERT INTO ff_execution_capabilities (execution_id, capability) VALUES (?1, ?2)",
+        )
+        .bind(uuid)
+        .bind(cap)
+        .execute(pool)
+        .await
+        .expect("seed caps");
+    }
+
+    let caps = CapabilitySet::new(["capA"]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("claims the matching lower-priority row");
+
+    // The low-priority row got claimed; the high-priority row is still
+    // runnable.
+    assert_eq!(h.backend, BackendTag::Sqlite);
+    assert_eq!(read_exec_phase(&backend, lo).await, "active");
+    assert_eq!(read_exec_phase(&backend, hi).await, "runnable");
+}
+
+/// claim + complete each emit a row into `ff_lease_event` (acquired /
+/// revoked) so `subscribe_lease_history` readers observe a coherent
+/// lifecycle. Mirrors the PG path via `lease_event::emit`.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_and_complete_emit_lease_events() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+    backend.complete(&h, None).await.expect("complete");
+
+    let pool = backend.pool_for_test();
+    let events: Vec<(String, String)> = sqlx::query_as(
+        "SELECT event_type, execution_id FROM ff_lease_event \
+          WHERE execution_id = ?1 ORDER BY event_id ASC",
+    )
+    .bind(exec_uuid.to_string())
+    .fetch_all(pool)
+    .await
+    .expect("read lease events");
+    let types: Vec<&str> = events.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(types, vec!["acquired", "revoked"]);
+}
+
 #[tokio::test]
 #[serial(ff_dev_mode)]
 async fn fail_permanent_writes_terminal_failed() {


### PR DESCRIPTION
## Summary

RFC-023 Phase 2a.2. Replaces the `Unavailable` stubs for `claim`, `complete`, and `fail` on `SqliteBackend` with real bodies paralleling `ff-backend-postgres::attempt`. Handle minting + decode flows through the Phase 2a.1.5 `handle_codec` (PR #374). Retry proceeds against the unblocked base — the prior 2a.2 agent correctly stopped at the BackendTag gap.

## Methods replaced (Group 1 minimal coherent slice)

- `claim` — scans partition 0 (§4.1 A3 — SQLite is single-writer with `num_flow_partitions = 1`), UPSERTs the attempt row with `RETURNING lease_epoch`, flips `exec_core` to `active`, mints a SQLite-tagged handle.
- `complete` — decodes handle, fences on `lease_epoch` CAS, writes terminal + completion-event outbox row.
- `fail` — decodes handle, fences, branches on `FailureClass` to either retry-schedule (`runnable` + `attempt_index + 1` + `json_set('$.last_failure_message')`) or terminal-fail (+ completion-event).

Per §4.4 Rev-6 clarification, none of these methods have a `Supports` bool — they are trait-mandatory hot-path ops. No Supports-flag flips land here; only `claim_for_worker` is Supports-gated (deferred to scheduler-routing phase).

Deferred to Phase 2a.3: `renew`, `delay`, `cancel`, `wait_children`, `progress`, `append_frame` — lease-lifecycle surface not required for end-to-end claim→complete/fail.

## Capability subset-match approach

Junction-table read (§4.1 A4) via `SELECT capability FROM ff_execution_capabilities WHERE execution_id = ?`, collect into `CapabilityRequirement`, Rust-side `caps::matches(&req, worker)`. Same post-lock shape as the PG path — sourced from a junction instead of a `text[]` column. Chose this over inline `HAVING COUNT(*)` because the worker's token set is not directly bindable as SQL params in a clean subset-match shape; app-side match mirrors PG and keeps the SQL flat.

## Fence CAS approach

Under `BEGIN IMMEDIATE` (which escalates to RESERVED, single-writer serialization per §4.1 A3), read `ff_attempt.lease_epoch` for the handle-addressed row and compare against the embedded epoch. Mismatch → `EngineError::Contention(ContentionKind::LeaseConflict)` — returned without retry (a fence conflict is semantic, not transient busy). Matches the PG reference (`fence_check` at `ff-backend-postgres/src/attempt.rs:404-433`), minus the `FOR UPDATE` clause since SQLite's RESERVED lock already covers the read-modify-write window.

## Handle-codec wiring

- `claim` success → `handle_codec::encode_handle(&payload, HandleKind::Fresh)` — Phase 2a.1.5 §4.5 SQLite-tagged v2 buffer (wire byte `0x03`).
- `complete` / `fail` → `handle_codec::decode_handle(&handle)` — rejects `BackendTag::Valkey` / `BackendTag::Postgres` with `ValidationKind::HandleFromOtherBackend` before any txn is opened.
- `#[allow(dead_code)]` removed from both codec fns; one hot_path test exercises the cross-backend rejection path end-to-end.

## SQL translation summary

| PG pattern | SQLite fork |
| --- | --- |
| `FOR UPDATE SKIP LOCKED` | `BEGIN IMMEDIATE` + plain SELECT (§4.1 A3) |
| `text[] @> ARRAY[...]` | junction SELECT + Rust `caps::matches` (A4) |
| `jsonb_build_object(...)` | `json_set(raw_fields, '$.field', ?)` |
| `BIGSERIAL RETURNING` | `INTEGER PRIMARY KEY AUTOINCREMENT` + `RETURNING` (SQLite 3.35+) |
| `BYTEA` binds | `BLOB` (sqlx auto-encodes `&[u8]`) |
| `40001/40P01 serialization` retry | `SQLITE_BUSY` family retry via Phase-2a.1 `retry_serializable` + `IsRetryableBusy` |

## Progression

- Phase 2a.1.5 (PR #374, `1f0ed64`) — BackendTag::Sqlite + wire byte 0x03 + codec ✅
- **Phase 2a.2 (this PR)** — claim/complete/fail hot path
- Phase 2a.3 — lease lifecycle (renew, delay, cancel, wait_children, progress, append_frame)
- Phase 2b — producer paths (create_execution, create_flow, add_execution_to_flow, …)

## RFC-vs-reality notes

- §4.1 SQL fork: the single-writer `BEGIN IMMEDIATE` strategy translates cleanly; `RETURNING lease_epoch` avoids the per-upsert `SELECT lease_epoch` round-trip that the PG reference does.
- §4.3 retry: the Phase-2a.1 `retry_serializable` works as-is on an `EngineError` closure once we impl `IsRetryableBusy for EngineError` that peeks into the `Transport { backend: "sqlite", source }` variant for a `sqlx::Error` downcast.
- §4.5 handle decode: the reject-on-foreign-tag is the `handle_codec::decode_handle` wrapper, not a new codec — exactly the Rev-6 documented posture.
- Outbox broadcast (§4.2): `ff_completion_event` insert writes durable rows; the PG `pg_notify` AFTER-INSERT trigger is intentionally absent (Rust post-commit channel slated for Phase 2a.3+).

## Test plan

- [x] `cargo test -p ff-backend-sqlite --all-features` — 18 tests green (8 new in `hot_path.rs`, 10 pre-existing).
- [x] `cargo clippy -p ff-backend-sqlite --all-targets --all-features -- -D warnings` clean.
- [x] `cargo check --workspace --all-features` clean.
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` clean (Phase 1a CI gate preserved).
- [ ] CI matrix green (verified on PR).
- [ ] Migration-parity lint green (verified on PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces real state-transition and leasing logic (including fencing and retries) in the backend hot path, where subtle SQL/txn bugs can cause incorrect claiming or terminal writes. Scope is contained to the dev-only SQLite backend and is covered by new integration tests.
> 
> **Overview**
> **SQLite backend now supports the core claim→complete/fail lifecycle** by replacing `EngineBackend` stubs with real implementations that run under `BEGIN IMMEDIATE` transactions, mint/validate SQLite-tagged handles, enforce lease-epoch fencing, and do capability subset checks via the `ff_execution_capabilities` junction.
> 
> Adds SQLite-dialect hot-path SQL constants for `ff_exec_core`/`ff_attempt` updates (including completion outbox inserts), wires SQLx errors into `EngineError` with busy-retry classification for `retry_serializable`, and introduces a new `tests/hot_path.rs` suite covering claim/complete/fail success and key error cases (no work, capability mismatch, fence conflict, foreign-backend handle rejection, retry vs terminal failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57090b40dae9199330dc663219b29e38e8fcabf6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->