### PR TITLE
feat(backend-sqlite): Phase 2a.3 — lease lifecycle + progress + append_frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 2a.3 lease-lifecycle + progress +
+  append_frame (RFC-023).** Replaces the `Unavailable` stubs for `renew`,
+  `progress`, `append_frame`, and `claim_from_reclaim` with real bodies
+  paralleling `ff-backend-postgres::attempt` + `ff-backend-postgres::stream`.
+  Fence CAS via `SELECT_ATTEMPT_EPOCH_SQL` under `BEGIN IMMEDIATE`
+  (§4.1 A3) gates every write; `LeaseConflict` on mismatch, no retry.
+  Lease-event outbox emits `renewed` / `reclaimed` rows to
+  `ff_lease_event` for RFC-019 subscribe parity. `append_frame` covers
+  the full RFC-015 write surface — `Durable`, `DurableSummary` with
+  in-Rust JSON Merge Patch (RFC 7396 incl. `__ff_null__` sentinel), and
+  `BestEffortLive` with EMA-driven MAXLEN trim. Read surface
+  (`read_stream` / `tail_stream` / `read_summary`) remains deferred
+  (Phase 2b). `progress` merges `progress_pct` + `progress_message`
+  into `ff_exec_core.raw_fields` via `json_set(coalesce(...))` so
+  partial updates preserve prior values.
+- `crates/ff-backend-sqlite/src/queries/lease.rs` populated with
+  `UPDATE_ATTEMPT_RENEW_SQL`, `SELECT_LATEST_ATTEMPT_FOR_RECLAIM_SQL`,
+  `UPDATE_ATTEMPT_RECLAIM_SQL`, `UPDATE_EXEC_CORE_RECLAIM_SQL`.
+- `crates/ff-backend-sqlite/src/queries/stream.rs` (new) populated with
+  the RFC-015 write-path SQL: `SELECT_MAX_SEQ_SQL`,
+  `INSERT_STREAM_FRAME_SQL`, `SELECT_STREAM_SUMMARY_SQL`,
+  `INSERT_STREAM_SUMMARY_SQL`, `UPDATE_STREAM_SUMMARY_SQL`,
+  `SELECT_STREAM_META_SQL`, `UPSERT_STREAM_META_SQL`,
+  `TRIM_STREAM_FRAMES_SQL`, `COUNT_STREAM_FRAMES_SQL`.
+- `crates/ff-backend-sqlite/src/queries/exec_core.rs`:
+  `UPDATE_EXEC_CORE_PROGRESS_SQL` added for the `progress` path.
+- `crates/ff-backend-sqlite/Cargo.toml`: direct `serde_json` dep added
+  (summary DurableSummary path merges in Rust before write-back).
 - **`crates/ff-backend-sqlite` — Phase 2a.2 hot-path trait impls (RFC-023).**
   Replaces the `Unavailable` stubs for `claim`, `complete`, and `fail`
   with real bodies paralleling `ff-backend-postgres::attempt`. Handle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ version = "0.11.0"
 dependencies = [
  "async-trait",
  "ff-core",
+ "serde_json",
  "serial_test",
  "sqlx",
  "tokio",

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -33,6 +33,10 @@ async-trait = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
+# Phase 2a.3: `append_frame` DurableSummary path reads + merges the
+# stored `document_json` in Rust (RFC 7396) before writing it back, so
+# the crate needs direct serde_json access.
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -14,34 +14,37 @@ use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Row, SqlitePool};
 use uuid::Uuid;
 
+use ff_core::backend::PrepareOutcome;
 use ff_core::backend::{
-    AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
-    FailOutcome, FailureClass, FailureReason, Frame, Handle, HandleKind, LeaseRenewal,
-    PendingWaitpoint, ReclaimToken, ResumeSignal, UsageDimensions,
+    AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy, FailOutcome,
+    FailureClass, FailureReason, Frame, FrameKind, Handle, HandleKind, LeaseRenewal, PatchKind,
+    PendingWaitpoint, ReclaimToken, ResumeSignal, SUMMARY_NULL_SENTINEL, StreamMode,
+    UsageDimensions,
 };
-use ff_core::caps::{matches as caps_matches, CapabilityRequirement};
-use ff_core::handle_codec::HandlePayload;
-use ff_core::types::{AttemptId, AttemptIndex, LeaseEpoch, LeaseId};
 use ff_core::capability::{BackendIdentity, Capabilities, Supports, Version};
-#[cfg(feature = "core")]
-use ff_core::contracts::{
-    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
-    DeliverSignalResult, EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot, ListExecutionsPage,
-    ListFlowsPage, ListLanesPage, ListSuspendedPage, SetEdgeGroupPolicyResult,
-};
+use ff_core::caps::{CapabilityRequirement, matches as caps_matches};
 use ff_core::contracts::{
     CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult, SuspendArgs,
     SuspendOutcome,
 };
+#[cfg(feature = "core")]
+use ff_core::contracts::{
+    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs, DeliverSignalResult,
+    EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot, ListExecutionsPage, ListFlowsPage,
+    ListLanesPage, ListSuspendedPage, SetEdgeGroupPolicyResult,
+};
 #[cfg(feature = "streaming")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
-use ff_core::backend::PrepareOutcome;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::{BackendError, ContentionKind, EngineError, ValidationKind};
+use ff_core::handle_codec::HandlePayload;
+use ff_core::types::{AttemptId, AttemptIndex, LeaseEpoch, LeaseId};
 
 use crate::errors::map_sqlx_error;
 use crate::handle_codec::{decode_handle, encode_handle};
-use crate::queries::{attempt as q_attempt, exec_core as q_exec};
+use crate::queries::{
+    attempt as q_attempt, exec_core as q_exec, lease as q_lease, stream as q_stream,
+};
 use crate::retry::retry_serializable;
 #[cfg(feature = "core")]
 use ff_core::partition::PartitionKey;
@@ -77,24 +80,22 @@ fn now_ms() -> i64 {
 /// Decompose an [`ff_core::types::ExecutionId`] formatted `{fp:N}:<uuid>`
 /// into `(partition_index, uuid_bytes)` — SQLite stores the UUID as a
 /// 16-byte `BLOB` (§4.1) so we bind via `uuid::Uuid`.
-fn split_exec_id(
-    eid: &ff_core::types::ExecutionId,
-) -> Result<(i64, Uuid), EngineError> {
+fn split_exec_id(eid: &ff_core::types::ExecutionId) -> Result<(i64, Uuid), EngineError> {
     let s = eid.as_str();
-    let rest = s.strip_prefix("{fp:").ok_or_else(|| EngineError::Validation {
-        kind: ValidationKind::InvalidInput,
-        detail: format!("execution_id missing `{{fp:` prefix: {s}"),
-    })?;
+    let rest = s
+        .strip_prefix("{fp:")
+        .ok_or_else(|| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("execution_id missing `{{fp:` prefix: {s}"),
+        })?;
     let close = rest.find("}:").ok_or_else(|| EngineError::Validation {
         kind: ValidationKind::InvalidInput,
         detail: format!("execution_id missing `}}:`: {s}"),
     })?;
-    let part: i64 = rest[..close]
-        .parse()
-        .map_err(|_| EngineError::Validation {
-            kind: ValidationKind::InvalidInput,
-            detail: format!("execution_id partition index not u16: {s}"),
-        })?;
+    let part: i64 = rest[..close].parse().map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id partition index not u16: {s}"),
+    })?;
     let uuid = Uuid::parse_str(&rest[close + 2..]).map_err(|_| EngineError::Validation {
         kind: ValidationKind::InvalidInput,
         detail: format!("execution_id UUID invalid: {s}"),
@@ -567,6 +568,481 @@ async fn insert_lease_event(
     Ok(())
 }
 
+// ── Phase 2a.3 hot-path bodies ────────────────────────────────────────
+
+async fn renew_impl(pool: &SqlitePool, handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+    let payload = decode_handle(handle)?;
+    let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
+    let attempt_index = i64::from(payload.attempt_index.0);
+    let expected_epoch = payload.lease_epoch.0;
+    let lease_ttl_ms = i64::try_from(payload.lease_ttl_ms).unwrap_or(0);
+
+    let mut conn = begin_immediate(pool).await?;
+    let result = renew_inner(
+        &mut conn,
+        part,
+        exec_uuid,
+        attempt_index,
+        expected_epoch,
+        lease_ttl_ms,
+    )
+    .await;
+    match result {
+        Ok(renewal) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(renewal)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+async fn renew_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+    expected_epoch: u64,
+    lease_ttl_ms: i64,
+) -> Result<LeaseRenewal, EngineError> {
+    fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
+    let now = now_ms();
+    let new_expires = now.saturating_add(lease_ttl_ms);
+
+    sqlx::query(q_lease::UPDATE_ATTEMPT_RENEW_SQL)
+        .bind(new_expires)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // RFC-019 Stage B outbox parity: lease renewed event.
+    insert_lease_event(conn, part, exec_uuid, "renewed", now).await?;
+
+    Ok(LeaseRenewal::new(
+        u64::try_from(new_expires).unwrap_or(0),
+        expected_epoch,
+    ))
+}
+
+async fn progress_impl(
+    pool: &SqlitePool,
+    handle: &Handle,
+    percent: Option<u8>,
+    message: Option<String>,
+) -> Result<(), EngineError> {
+    let payload = decode_handle(handle)?;
+    let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
+    let attempt_index = i64::from(payload.attempt_index.0);
+    let expected_epoch = payload.lease_epoch.0;
+
+    let mut conn = begin_immediate(pool).await?;
+    let result = progress_inner(
+        &mut conn,
+        part,
+        exec_uuid,
+        attempt_index,
+        expected_epoch,
+        percent,
+        message,
+    )
+    .await;
+    match result {
+        Ok(()) => commit_or_rollback(&mut conn).await,
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+async fn progress_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+    expected_epoch: u64,
+    percent: Option<u8>,
+    message: Option<String>,
+) -> Result<(), EngineError> {
+    fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
+
+    // `coalesce(?, json_extract(raw_fields, '$.progress_pct'))` keeps
+    // any prior value when the caller passed None — mirrors the PG
+    // path's jsonb-partial-merge semantics. Binds: pct → i64 or NULL,
+    // msg → TEXT or NULL.
+    sqlx::query(q_exec::UPDATE_EXEC_CORE_PROGRESS_SQL)
+        .bind(percent.map(i64::from))
+        .bind(message)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+// ── append_frame (RFC-015 write surface) ──────────────────────────────
+
+/// Apply one RFC 7396 JSON Merge Patch in-place. Mirrors the PG helper
+/// at `ff-backend-postgres/src/stream.rs::apply_json_merge_patch`;
+/// both implementations must honour the [`SUMMARY_NULL_SENTINEL`]
+/// rewrite (leaf `"__ff_null__"` → JSON `null`) so the round-trip
+/// invariant holds across backends.
+fn apply_json_merge_patch(target: &mut serde_json::Value, patch: &serde_json::Value) {
+    use serde_json::Value;
+    if let Value::Object(patch_map) = patch {
+        if !target.is_object() {
+            *target = Value::Object(serde_json::Map::new());
+        }
+        let target_map = target.as_object_mut().expect("just ensured object");
+        for (k, v) in patch_map {
+            match v {
+                Value::Null => {
+                    target_map.remove(k);
+                }
+                Value::String(s) if s == SUMMARY_NULL_SENTINEL => {
+                    target_map.insert(k.clone(), Value::Null);
+                }
+                Value::Object(_) => {
+                    let entry = target_map.entry(k.clone()).or_insert(Value::Null);
+                    apply_json_merge_patch(entry, v);
+                }
+                other => {
+                    target_map.insert(k.clone(), other.clone());
+                }
+            }
+        }
+    } else {
+        *target = patch.clone();
+    }
+}
+
+/// Build the `fields` JSON TEXT blob for a frame — mirrors the PG
+/// helper at `ff-backend-postgres/src/stream.rs::build_fields_json`
+/// so downstream readers observe the same shape on both backends.
+fn build_fields_json(frame: &Frame) -> String {
+    use serde_json::{Map, Value};
+    let payload_str = String::from_utf8_lossy(&frame.bytes).into_owned();
+    let mut map = Map::new();
+    let frame_type = if frame.frame_type.is_empty() {
+        match frame.kind {
+            FrameKind::Stdout => "stdout",
+            FrameKind::Stderr => "stderr",
+            FrameKind::Event => "event",
+            FrameKind::Blob => "blob",
+            _ => "event",
+        }
+        .to_owned()
+    } else {
+        frame.frame_type.clone()
+    };
+    map.insert("frame_type".into(), Value::String(frame_type));
+    map.insert("payload".into(), Value::String(payload_str));
+    map.insert("encoding".into(), Value::String("utf8".into()));
+    map.insert("source".into(), Value::String("worker".into()));
+    if let Some(corr) = &frame.correlation_id {
+        map.insert("correlation_id".into(), Value::String(corr.clone()));
+    }
+    Value::Object(map).to_string()
+}
+
+async fn append_frame_impl(
+    pool: &SqlitePool,
+    handle: &Handle,
+    frame: Frame,
+) -> Result<AppendFrameOutcome, EngineError> {
+    let payload = decode_handle(handle)?;
+    let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
+    let attempt_index = i64::from(payload.attempt_index.0);
+    let expected_epoch = payload.lease_epoch.0;
+
+    let mut conn = begin_immediate(pool).await?;
+    let result = append_frame_inner(
+        &mut conn,
+        part,
+        exec_uuid,
+        attempt_index,
+        expected_epoch,
+        frame,
+    )
+    .await;
+    match result {
+        Ok(outcome) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(outcome)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+async fn append_frame_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+    expected_epoch: u64,
+    frame: Frame,
+) -> Result<AppendFrameOutcome, EngineError> {
+    fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
+
+    let ts_ms = now_ms();
+    let mode_wire = frame.mode.wire_str();
+    let fields_text = build_fields_json(&frame);
+
+    // Mint `seq` as MAX(seq) + 1 under the txn lock. `BEGIN IMMEDIATE`
+    // serializes writers so there is no need for an additional advisory
+    // lock (the PG path uses `pg_advisory_xact_lock` because READ
+    // COMMITTED isolates less strictly).
+    let max_seq: Option<i64> = sqlx::query_scalar(q_stream::SELECT_MAX_SEQ_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .bind(ts_ms)
+        .fetch_one(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let next_seq: i64 = max_seq.map(|s| s + 1).unwrap_or(0);
+
+    sqlx::query(q_stream::INSERT_STREAM_FRAME_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .bind(ts_ms)
+        .bind(next_seq)
+        .bind(&fields_text)
+        .bind(mode_wire)
+        .bind(ts_ms)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let mut summary_version: Option<u64> = None;
+
+    // DurableSummary: JSON Merge Patch applied in Rust, TEXT in/out.
+    if let StreamMode::DurableSummary { patch_kind } = &frame.mode {
+        let patch: serde_json::Value =
+            serde_json::from_slice(&frame.bytes).map_err(|e| EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!("summary patch not valid JSON: {e}"),
+            })?;
+
+        let existing: Option<(String, i64)> = sqlx::query_as(q_stream::SELECT_STREAM_SUMMARY_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .fetch_optional(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let (mut doc, prev_version): (serde_json::Value, i64) = match existing {
+            Some((text, v)) => {
+                let parsed = serde_json::from_str(&text)
+                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                (parsed, v)
+            }
+            None => (serde_json::Value::Object(serde_json::Map::new()), 0),
+        };
+
+        match patch_kind {
+            PatchKind::JsonMergePatch => apply_json_merge_patch(&mut doc, &patch),
+            _ => apply_json_merge_patch(&mut doc, &patch),
+        }
+
+        let new_version = prev_version + 1;
+        let patch_kind_wire = "json-merge-patch";
+        let doc_text = doc.to_string();
+        if prev_version == 0 {
+            sqlx::query(q_stream::INSERT_STREAM_SUMMARY_SQL)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(attempt_index)
+                .bind(&doc_text)
+                .bind(new_version)
+                .bind(patch_kind_wire)
+                .bind(ts_ms)
+                .bind(ts_ms)
+                .execute(&mut **conn)
+                .await
+                .map_err(map_sqlx_error)?;
+        } else {
+            sqlx::query(q_stream::UPDATE_STREAM_SUMMARY_SQL)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(attempt_index)
+                .bind(&doc_text)
+                .bind(new_version)
+                .bind(patch_kind_wire)
+                .bind(ts_ms)
+                .execute(&mut **conn)
+                .await
+                .map_err(map_sqlx_error)?;
+        }
+        summary_version = Some(u64::try_from(new_version).unwrap_or(0));
+    }
+
+    // BestEffortLive: EMA + trim. Computation ports from the PG helper
+    // at `ff-backend-postgres/src/stream.rs:272-339`.
+    if let StreamMode::BestEffortLive { config } = &frame.mode {
+        let meta: Option<(f64, i64)> = sqlx::query_as(q_stream::SELECT_STREAM_META_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .fetch_optional(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let (ema_prev, last_ts) = meta.unwrap_or((0.0, 0));
+        let inst_rate: f64 = if last_ts > 0 && ts_ms > last_ts {
+            1000.0 / ((ts_ms - last_ts) as f64)
+        } else {
+            0.0
+        };
+        let alpha = config.ema_alpha;
+        let ema_new = alpha * inst_rate + (1.0 - alpha) * ema_prev;
+        let k_raw = (ema_new * (f64::from(config.ttl_ms)) / 1000.0).ceil() as i64 * 2;
+        let k = k_raw
+            .max(i64::from(config.maxlen_floor))
+            .min(i64::from(config.maxlen_ceiling));
+
+        sqlx::query(q_stream::UPSERT_STREAM_META_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .bind(ema_new)
+            .bind(ts_ms)
+            .bind(k)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        sqlx::query(q_stream::TRIM_STREAM_FRAMES_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .bind(k)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+    }
+
+    let frame_count: i64 = sqlx::query_scalar(q_stream::COUNT_STREAM_FRAMES_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .fetch_one(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let stream_id = format!("{ts_ms}-{next_seq}");
+    let mut out = AppendFrameOutcome::new(stream_id, u64::try_from(frame_count).unwrap_or(0));
+    if let Some(v) = summary_version {
+        out = out.with_summary_version(v);
+    }
+    Ok(out)
+}
+
+// ── claim_from_reclaim ────────────────────────────────────────────────
+
+async fn claim_from_reclaim_impl(
+    pool: &SqlitePool,
+    token: &ReclaimToken,
+) -> Result<Option<Handle>, EngineError> {
+    let eid = &token.grant.execution_id;
+    let (part, exec_uuid) = split_exec_id(eid)?;
+
+    let mut conn = begin_immediate(pool).await?;
+    let result = claim_from_reclaim_inner(&mut conn, part, exec_uuid, token).await;
+    match result {
+        Ok(Some(handle)) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(Some(handle))
+        }
+        Ok(None) => {
+            rollback_quiet(&mut conn).await;
+            Ok(None)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+async fn claim_from_reclaim_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    token: &ReclaimToken,
+) -> Result<Option<Handle>, EngineError> {
+    // Latest attempt under the partition/exec. Mirror of PG at
+    // `ff-backend-postgres/src/attempt.rs:294-308`.
+    let row = sqlx::query(q_lease::SELECT_LATEST_ATTEMPT_FOR_RECLAIM_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let Some(row) = row else {
+        return Err(EngineError::NotFound { entity: "attempt" });
+    };
+    let attempt_index_i: i64 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    let current_epoch: i64 = row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+    let expires_at: Option<i64> = row
+        .try_get::<Option<i64>, _>("lease_expires_at_ms")
+        .map_err(map_sqlx_error)?;
+
+    let now = now_ms();
+    // Live-lease → grant no longer honour-able.
+    let live = matches!(expires_at, Some(exp) if exp > now);
+    if live {
+        return Ok(None);
+    }
+
+    let lease_ttl_ms = i64::from(token.lease_ttl_ms);
+    let new_expires = now.saturating_add(lease_ttl_ms);
+
+    sqlx::query(q_lease::UPDATE_ATTEMPT_RECLAIM_SQL)
+        .bind(token.worker_id.as_str())
+        .bind(token.worker_instance_id.as_str())
+        .bind(new_expires)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index_i)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    sqlx::query(q_lease::UPDATE_EXEC_CORE_RECLAIM_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    insert_lease_event(conn, part, exec_uuid, "reclaimed", now).await?;
+
+    let new_epoch = current_epoch.saturating_add(1);
+    let payload = HandlePayload::new(
+        token.grant.execution_id.clone(),
+        AttemptIndex::new(u32::try_from(attempt_index_i.max(0)).unwrap_or(0)),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(u64::try_from(new_epoch).unwrap_or(0)),
+        u64::from(token.lease_ttl_ms),
+        token.grant.lane_id.clone(),
+        token.worker_instance_id.clone(),
+    );
+    Ok(Some(encode_handle(&payload, HandleKind::Resumed)))
+}
 
 /// Internal shared state. `Arc<SqliteBackendInner>` is what the
 /// registry stores weak references to and what `SqliteBackend`
@@ -668,8 +1144,7 @@ impl SqliteBackend {
         // pool shares ONE in-memory database. Without this rewrite,
         // each pool connection opens its own private DB and tests see
         // schema mismatches silently.
-        let is_memory =
-            path == ":memory:" || path.starts_with("file::memory:");
+        let is_memory = path == ":memory:" || path.starts_with("file::memory:");
         let effective_path: std::borrow::Cow<'_, str> = if path == ":memory:" {
             std::borrow::Cow::Borrowed("file::memory:?cache=shared")
         } else {
@@ -730,9 +1205,7 @@ impl SqliteBackend {
             use sqlx::ConnectOptions;
             let conn = opts.connect().await.map_err(|e| BackendError::Valkey {
                 kind: ff_core::engine_error::BackendErrorKind::Transport,
-                message: format!(
-                    "sqlite sentinel connect for {path:?}: {e}"
-                ),
+                message: format!("sqlite sentinel connect for {path:?}: {e}"),
             })?;
             Some(std::sync::Mutex::new(Some(conn)))
         } else {
@@ -800,32 +1273,31 @@ impl EngineBackend for SqliteBackend {
         retry_serializable(|| claim_impl(pool, lane, capabilities, &policy)).await
     }
 
-    async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
-        unavailable("sqlite.renew")
+    async fn renew(&self, handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| renew_impl(pool, handle)).await
     }
 
     async fn progress(
         &self,
-        _handle: &Handle,
-        _percent: Option<u8>,
-        _message: Option<String>,
+        handle: &Handle,
+        percent: Option<u8>,
+        message: Option<String>,
     ) -> Result<(), EngineError> {
-        unavailable("sqlite.progress")
+        let pool = &self.inner.pool;
+        retry_serializable(|| progress_impl(pool, handle, percent, message.clone())).await
     }
 
     async fn append_frame(
         &self,
-        _handle: &Handle,
-        _frame: Frame,
+        handle: &Handle,
+        frame: Frame,
     ) -> Result<AppendFrameOutcome, EngineError> {
-        unavailable("sqlite.append_frame")
+        let pool = &self.inner.pool;
+        retry_serializable(|| append_frame_impl(pool, handle, frame.clone())).await
     }
 
-    async fn complete(
-        &self,
-        handle: &Handle,
-        payload: Option<Vec<u8>>,
-    ) -> Result<(), EngineError> {
+    async fn complete(&self, handle: &Handle, payload: Option<Vec<u8>>) -> Result<(), EngineError> {
         let pool = &self.inner.pool;
         retry_serializable(|| complete_impl(pool, handle, payload.clone())).await
     }
@@ -865,18 +1337,12 @@ impl EngineBackend for SqliteBackend {
         unavailable("sqlite.observe_signals")
     }
 
-    async fn claim_from_reclaim(
-        &self,
-        _token: ReclaimToken,
-    ) -> Result<Option<Handle>, EngineError> {
-        unavailable("sqlite.claim_from_reclaim")
+    async fn claim_from_reclaim(&self, token: ReclaimToken) -> Result<Option<Handle>, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| claim_from_reclaim_impl(pool, &token)).await
     }
 
-    async fn delay(
-        &self,
-        _handle: &Handle,
-        _delay_until: TimestampMs,
-    ) -> Result<(), EngineError> {
+    async fn delay(&self, _handle: &Handle, _delay_until: TimestampMs) -> Result<(), EngineError> {
         unavailable("sqlite.delay")
     }
 
@@ -893,10 +1359,7 @@ impl EngineBackend for SqliteBackend {
         unavailable("sqlite.describe_execution")
     }
 
-    async fn describe_flow(
-        &self,
-        _id: &FlowId,
-    ) -> Result<Option<FlowSnapshot>, EngineError> {
+    async fn describe_flow(&self, _id: &FlowId) -> Result<Option<FlowSnapshot>, EngineError> {
         unavailable("sqlite.describe_flow")
     }
 

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -671,10 +671,11 @@ async fn progress_inner(
 ) -> Result<(), EngineError> {
     fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
 
-    // `coalesce(?, json_extract(raw_fields, '$.progress_pct'))` keeps
-    // any prior value when the caller passed None — mirrors the PG
-    // path's jsonb-partial-merge semantics. Binds: pct → i64 or NULL,
-    // msg → TEXT or NULL.
+    // `UPDATE_EXEC_CORE_PROGRESS_SQL` is self-correct for any NULL/
+    // non-NULL combination of the two binds (PR #376 Copilot review) —
+    // its nested `CASE WHEN ? IS NULL` shape treats each field as
+    // independent and leaves the corresponding JSON path absent when
+    // the caller passed None. No Rust-side short-circuit needed.
     sqlx::query(q_exec::UPDATE_EXEC_CORE_PROGRESS_SQL)
         .bind(percent.map(i64::from))
         .bind(message)
@@ -844,8 +845,17 @@ async fn append_frame_inner(
 
         let (mut doc, prev_version): (serde_json::Value, i64) = match existing {
             Some((text, v)) => {
-                let parsed = serde_json::from_str(&text)
-                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                // Strict-parse posture (PR #376 gemini review): a stored
+                // `document_json` that no longer round-trips indicates
+                // DB corruption. Surface loudly via `Corruption` rather
+                // than silently overwriting with an empty object.
+                let parsed: serde_json::Value =
+                    serde_json::from_str(&text).map_err(|e| EngineError::Validation {
+                        kind: ValidationKind::Corruption,
+                        detail: format!(
+                            "corrupt summary document in ff_stream_summary: {e}"
+                        ),
+                    })?;
                 (parsed, v)
             }
             None => (serde_json::Value::Object(serde_json::Map::new()), 0),

--- a/crates/ff-backend-sqlite/src/queries/exec_core.rs
+++ b/crates/ff-backend-sqlite/src/queries/exec_core.rs
@@ -47,6 +47,31 @@ pub(crate) const UPDATE_EXEC_CORE_FAIL_RETRY_SQL: &str = r#"
      WHERE partition_key = ?2 AND execution_id = ?3
 "#;
 
+/// Merge `progress_pct` + `progress_message` into `ff_exec_core.raw_fields`
+/// (TEXT-encoded JSON). NULL binds leave the corresponding field untouched
+/// via `coalesce` — SQLite's `json_set` overwrites with NULL when passed
+/// a NULL argument, which would drop a previously-recorded value on a
+/// partial `progress` call. Mirror of PG at
+/// `ff-backend-postgres/src/attempt.rs:498-518`; PG uses `raw_fields ||`
+/// on a jsonb object, we re-express the same observable write shape via
+/// two nested `json_set` calls over a TEXT document.
+///
+/// Binds: `?1 = pct (nullable INT)`, `?2 = message (nullable TEXT)`,
+/// `?3 = partition_key`, `?4 = execution_id`.
+pub(crate) const UPDATE_EXEC_CORE_PROGRESS_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET raw_fields = json_set(
+               json_set(
+                   raw_fields,
+                   '$.progress_pct',
+                   coalesce(?1, json_extract(raw_fields, '$.progress_pct'))
+               ),
+               '$.progress_message',
+               coalesce(?2, json_extract(raw_fields, '$.progress_message'))
+           )
+     WHERE partition_key = ?3 AND execution_id = ?4
+"#;
+
 /// Flip exec_core to terminal failed — retry budget exhausted or
 /// classification was permanent. Mirror of PG at
 /// `ff-backend-postgres/src/attempt.rs:700-718`.

--- a/crates/ff-backend-sqlite/src/queries/exec_core.rs
+++ b/crates/ff-backend-sqlite/src/queries/exec_core.rs
@@ -48,27 +48,40 @@ pub(crate) const UPDATE_EXEC_CORE_FAIL_RETRY_SQL: &str = r#"
 "#;
 
 /// Merge `progress_pct` + `progress_message` into `ff_exec_core.raw_fields`
-/// (TEXT-encoded JSON). NULL binds leave the corresponding field untouched
-/// via `coalesce` — SQLite's `json_set` overwrites with NULL when passed
-/// a NULL argument, which would drop a previously-recorded value on a
-/// partial `progress` call. Mirror of PG at
-/// `ff-backend-postgres/src/attempt.rs:498-518`; PG uses `raw_fields ||`
-/// on a jsonb object, we re-express the same observable write shape via
-/// two nested `json_set` calls over a TEXT document.
+/// (TEXT-encoded JSON). NULL binds must leave the corresponding field
+/// untouched, INCLUDING when the JSON path is currently absent — a naive
+/// `json_set(x, '$.k', coalesce(NULL, json_extract(absent))) =
+/// json_set(x, '$.k', NULL)` materializes an explicit JSON `null`,
+/// which diverges from the PG `raw_fields ||` no-op semantics for an
+/// empty patch (PR #376 Copilot review).
+///
+/// The `CASE WHEN ? IS NULL THEN <inner> ELSE json_set(<inner>, '$.k', ?)`
+/// shape skips the `json_set` call entirely when the bind is NULL,
+/// preserving absent fields AND preserving prior non-NULL values.
+/// Mirror of PG at `ff-backend-postgres/src/attempt.rs:498-518`; PG
+/// uses `raw_fields ||` on a jsonb object, we re-express the same
+/// observable write shape via conditional `json_set` calls over a
+/// TEXT document.
 ///
 /// Binds: `?1 = pct (nullable INT)`, `?2 = message (nullable TEXT)`,
 /// `?3 = partition_key`, `?4 = execution_id`.
 pub(crate) const UPDATE_EXEC_CORE_PROGRESS_SQL: &str = r#"
     UPDATE ff_exec_core
-       SET raw_fields = json_set(
-               json_set(
-                   raw_fields,
-                   '$.progress_pct',
-                   coalesce(?1, json_extract(raw_fields, '$.progress_pct'))
-               ),
-               '$.progress_message',
-               coalesce(?2, json_extract(raw_fields, '$.progress_message'))
-           )
+       SET raw_fields = CASE
+               WHEN ?2 IS NULL THEN
+                   CASE
+                       WHEN ?1 IS NULL THEN raw_fields
+                       ELSE json_set(raw_fields, '$.progress_pct', ?1)
+                   END
+               ELSE json_set(
+                   CASE
+                       WHEN ?1 IS NULL THEN raw_fields
+                       ELSE json_set(raw_fields, '$.progress_pct', ?1)
+                   END,
+                   '$.progress_message',
+                   ?2
+               )
+           END
      WHERE partition_key = ?3 AND execution_id = ?4
 "#;
 

--- a/crates/ff-backend-sqlite/src/queries/lease.rs
+++ b/crates/ff-backend-sqlite/src/queries/lease.rs
@@ -1,5 +1,63 @@
-//! SQLite dialect-forked queries for lease lifecycle (acquire /
-//! renew / release).
+//! SQLite dialect-forked queries for lease lifecycle (renew / reclaim).
 //!
-//! Populated in Phase 2a.3 per RFC-023 §4.1. Phase 2a.1 lands the
-//! empty module as a layout-only placeholder.
+//! Populated in Phase 2a.3 per RFC-023 §4.1. The SQL strings are
+//! module-level `const`s so `backend.rs` call sites reference them
+//! by name and cross-dialect review lines them up against the PG
+//! reference at `ff-backend-postgres/src/attempt.rs` statement-by-
+//! statement.
+//!
+//! # Fence-triple contract
+//!
+//! Same as `queries/attempt.rs`: `BEGIN IMMEDIATE` on SQLite escalates
+//! the txn to RESERVED for the full read-modify-write window; the
+//! fence CAS is a plain SELECT of `ff_attempt.lease_epoch` (see
+//! `queries/attempt.rs::SELECT_ATTEMPT_EPOCH_SQL`).
+
+/// Advance the lease expiry for a live attempt. Caller has already
+/// fence-checked the handle's epoch against the row. The epoch is NOT
+/// bumped — renewal keeps the same epoch per the PG reference at
+/// `ff-backend-postgres/src/attempt.rs:446-461`.
+pub(crate) const UPDATE_ATTEMPT_RENEW_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET lease_expires_at_ms = ?1
+     WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4
+"#;
+
+/// Look up the latest attempt row for a reclaim. Returns
+/// `(attempt_index, lease_epoch, lease_expires_at_ms)`; the
+/// caller checks expiry (NULL or `<= now`) before minting a fresh
+/// handle. Mirror of PG at
+/// `ff-backend-postgres/src/attempt.rs:294-308` — without
+/// `FOR UPDATE` because `BEGIN IMMEDIATE` already holds RESERVED.
+pub(crate) const SELECT_LATEST_ATTEMPT_FOR_RECLAIM_SQL: &str = r#"
+    SELECT attempt_index, lease_epoch, lease_expires_at_ms
+      FROM ff_attempt
+     WHERE partition_key = ?1 AND execution_id = ?2
+     ORDER BY attempt_index DESC
+     LIMIT 1
+"#;
+
+/// Bump the epoch, rotate worker identity, install a fresh lease
+/// expiry, and clear the outcome so the attempt is live again.
+/// Mirror of PG at `ff-backend-postgres/src/attempt.rs:332-353`.
+pub(crate) const UPDATE_ATTEMPT_RECLAIM_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET worker_id = ?1,
+           worker_instance_id = ?2,
+           lease_epoch = lease_epoch + 1,
+           lease_expires_at_ms = ?3,
+           started_at_ms = ?4,
+           outcome = NULL
+     WHERE partition_key = ?5 AND execution_id = ?6 AND attempt_index = ?7
+"#;
+
+/// Flip `ff_exec_core` back to active/leased for a reclaimed attempt.
+/// Mirror of PG at `ff-backend-postgres/src/attempt.rs:355-369`.
+pub(crate) const UPDATE_EXEC_CORE_RECLAIM_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'active',
+           ownership_state = 'leased',
+           eligibility_state = 'not_applicable',
+           attempt_state = 'running_attempt'
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;

--- a/crates/ff-backend-sqlite/src/queries/mod.rs
+++ b/crates/ff-backend-sqlite/src/queries/mod.rs
@@ -13,3 +13,4 @@ pub mod attempt;
 pub mod dispatch;
 pub mod exec_core;
 pub mod lease;
+pub mod stream;

--- a/crates/ff-backend-sqlite/src/queries/stream.rs
+++ b/crates/ff-backend-sqlite/src/queries/stream.rs
@@ -11,8 +11,8 @@
 //!
 //! * `ff_stream_summary.document_json` is TEXT (not `jsonb`) in the
 //!   SQLite port; JSON Merge Patch is applied in Rust via
-//!   `apply_json_merge_patch_text` and written back whole. Same
-//!   observable behaviour as the PG `jsonb` path.
+//!   `crate::backend::apply_json_merge_patch` and written back whole.
+//!   Same observable behaviour as the PG `jsonb` path.
 //! * BestEffortLive trim uses a subquery-IN delete with the same
 //!   shape as PG — SQLite supports correlated subqueries in `DELETE`.
 //! * `pg_advisory_xact_lock` is replaced by the enclosing

--- a/crates/ff-backend-sqlite/src/queries/stream.rs
+++ b/crates/ff-backend-sqlite/src/queries/stream.rs
@@ -1,0 +1,111 @@
+//! SQLite dialect-forked queries for the RFC-015 stream append path.
+//!
+//! Populated in Phase 2a.3 per RFC-023 §4.1. Mirrors
+//! `ff-backend-postgres/src/stream.rs` statement-for-statement for the
+//! write surface (`append_frame`). The read surface
+//! (`read_stream` / `tail_stream` / `read_summary`) lands in a later
+//! phase — it needs in-Rust notifier wiring that replaces PG's
+//! `LISTEN/NOTIFY` plumbing.
+//!
+//! # Dialect notes
+//!
+//! * `ff_stream_summary.document_json` is TEXT (not `jsonb`) in the
+//!   SQLite port; JSON Merge Patch is applied in Rust via
+//!   `apply_json_merge_patch_text` and written back whole. Same
+//!   observable behaviour as the PG `jsonb` path.
+//! * BestEffortLive trim uses a subquery-IN delete with the same
+//!   shape as PG — SQLite supports correlated subqueries in `DELETE`.
+//! * `pg_advisory_xact_lock` is replaced by the enclosing
+//!   `BEGIN IMMEDIATE` lock (§4.1 A3 single-writer).
+
+/// Read `MAX(seq)` for the current `(pkey, eid, aidx, ts_ms)` tuple so
+/// the caller can mint the next sequence under the txn lock. Mirror of
+/// PG at `ff-backend-postgres/src/stream.rs:163-176`.
+pub(crate) const SELECT_MAX_SEQ_SQL: &str = r#"
+    SELECT MAX(seq) AS s FROM ff_stream_frame
+     WHERE partition_key = ?1 AND execution_id = ?2
+       AND attempt_index = ?3 AND ts_ms = ?4
+"#;
+
+/// Insert one frame row into `ff_stream_frame`. Mirror of PG at
+/// `ff-backend-postgres/src/stream.rs:178-193`.
+pub(crate) const INSERT_STREAM_FRAME_SQL: &str = r#"
+    INSERT INTO ff_stream_frame (
+        partition_key, execution_id, attempt_index,
+        ts_ms, seq, fields, mode, created_at_ms
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+"#;
+
+/// Fetch the current `ff_stream_summary` document + version for a
+/// given `(pkey, eid, aidx)`. Caller merges the patch in Rust.
+/// Mirror of PG's `FOR UPDATE` read at
+/// `ff-backend-postgres/src/stream.rs:210-220` — `BEGIN IMMEDIATE`
+/// already serializes writers on SQLite.
+pub(crate) const SELECT_STREAM_SUMMARY_SQL: &str = r#"
+    SELECT document_json, version
+      FROM ff_stream_summary
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+/// Insert a fresh `ff_stream_summary` row (first-time document). Mirror
+/// of PG at `ff-backend-postgres/src/stream.rs:234-251`.
+pub(crate) const INSERT_STREAM_SUMMARY_SQL: &str = r#"
+    INSERT INTO ff_stream_summary (
+        partition_key, execution_id, attempt_index,
+        document_json, version, patch_kind,
+        last_updated_ms, first_applied_ms
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+"#;
+
+/// Update an existing `ff_stream_summary` row with the merged document
+/// + bumped version. Mirror of PG at
+///   `ff-backend-postgres/src/stream.rs:253-267`.
+pub(crate) const UPDATE_STREAM_SUMMARY_SQL: &str = r#"
+    UPDATE ff_stream_summary
+       SET document_json = ?4,
+           version = ?5,
+           patch_kind = ?6,
+           last_updated_ms = ?7
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+/// Fetch the BestEffort EMA state (`ema_rate_hz`, `last_append_ts_ms`).
+/// Mirror of PG at `ff-backend-postgres/src/stream.rs:274-284`.
+pub(crate) const SELECT_STREAM_META_SQL: &str = r#"
+    SELECT ema_rate_hz, last_append_ts_ms
+      FROM ff_stream_meta
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+/// UPSERT the BestEffort EMA + last-append meta. Mirror of PG at
+/// `ff-backend-postgres/src/stream.rs:299-318`.
+pub(crate) const UPSERT_STREAM_META_SQL: &str = r#"
+    INSERT INTO ff_stream_meta (
+        partition_key, execution_id, attempt_index,
+        ema_rate_hz, last_append_ts_ms, maxlen_applied_last
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+    ON CONFLICT (partition_key, execution_id, attempt_index) DO UPDATE SET
+        ema_rate_hz = excluded.ema_rate_hz,
+        last_append_ts_ms = excluded.last_append_ts_ms,
+        maxlen_applied_last = excluded.maxlen_applied_last
+"#;
+
+/// Trim `ff_stream_frame` to the most-recent `?4` rows for the tuple.
+/// Mirror of PG at `ff-backend-postgres/src/stream.rs:322-331`.
+pub(crate) const TRIM_STREAM_FRAMES_SQL: &str = r#"
+    DELETE FROM ff_stream_frame
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+       AND (ts_ms, seq) NOT IN (
+           SELECT ts_ms, seq FROM ff_stream_frame
+            WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+            ORDER BY ts_ms DESC, seq DESC
+            LIMIT ?4
+       )
+"#;
+
+/// Count frames for a tuple post-append — returned via
+/// [`ff_core::backend::AppendFrameOutcome`].
+pub(crate) const COUNT_STREAM_FRAMES_SQL: &str = r#"
+    SELECT COUNT(*) AS c FROM ff_stream_frame
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -15,15 +15,17 @@
 
 use ff_backend_sqlite::SqliteBackend;
 use ff_core::backend::{
-    BackendTag, CapabilitySet, ClaimPolicy, FailureClass, FailureReason, Handle, HandleKind,
+    BackendTag, CapabilitySet, ClaimPolicy, FailureClass, FailureReason, Frame, FrameKind, Handle,
+    HandleKind, PatchKind, ReclaimToken, StreamMode,
 };
+use ff_core::contracts::ReclaimGrant;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
-use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
+use ff_core::handle_codec::{HandlePayload, encode as encode_opaque};
 use ff_core::partition::PartitionConfig;
+use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
 use ff_core::types::{
-    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, WorkerId,
-    WorkerInstanceId,
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, WorkerId, WorkerInstanceId,
 };
 use serial_test::serial;
 use std::sync::Arc;
@@ -68,8 +70,7 @@ async fn seed_runnable_execution(
     let pool = backend.pool_for_test();
     let exec_uuid = Uuid::new_v4();
     // Partition 0 per RFC-023 §4.1 A3 — num_flow_partitions = 1.
-    let exec_id = ExecutionId::parse(&format!("{{fp:0}}:{exec_uuid}"))
-        .expect("construct exec_id");
+    let exec_id = ExecutionId::parse(&format!("{{fp:0}}:{exec_uuid}")).expect("construct exec_id");
 
     sqlx::query(
         r#"
@@ -153,8 +154,7 @@ async fn read_exec_phase(backend: &SqliteBackend, exec_uuid: Uuid) -> String {
 #[serial(ff_dev_mode)]
 async fn claim_happy_path_mints_handle_and_transitions_state() {
     let backend = fresh_backend().await;
-    let (_exec_id, exec_uuid) =
-        seed_runnable_execution(&backend, "default", &["capA"]).await;
+    let (_exec_id, exec_uuid) = seed_runnable_execution(&backend, "default", &["capA"]).await;
 
     let caps = CapabilitySet::new(["capA"]);
     let h = backend
@@ -476,4 +476,447 @@ async fn fail_permanent_writes_terminal_failed() {
         read_attempt_outcome(&backend, exec_uuid, 0).await,
         Some("failed".into())
     );
+}
+
+// ── Phase 2a.3 — progress ───────────────────────────────────────────────
+
+/// Helper: read `progress_pct` + `progress_message` back from the
+/// raw_fields JSON document.
+async fn read_progress(backend: &SqliteBackend, exec_uuid: Uuid) -> (Option<i64>, Option<String>) {
+    let pool = backend.pool_for_test();
+    let row: (Option<i64>, Option<String>) = sqlx::query_as(
+        "SELECT json_extract(raw_fields, '$.progress_pct'), \
+                json_extract(raw_fields, '$.progress_message') \
+         FROM ff_exec_core WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read progress");
+    row
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn progress_writes_pct_and_message_to_raw_fields() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    backend
+        .progress(&h, Some(42), Some("halfway".into()))
+        .await
+        .expect("progress");
+
+    let (pct, msg) = read_progress(&backend, exec_uuid).await;
+    assert_eq!(pct, Some(42));
+    assert_eq!(msg, Some("halfway".into()));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn progress_preserves_prior_values_on_partial_update() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    backend
+        .progress(&h, Some(10), Some("starting".into()))
+        .await
+        .expect("progress-1");
+
+    // Second call only sets pct — message must remain "starting".
+    backend
+        .progress(&h, Some(75), None)
+        .await
+        .expect("progress-2");
+    let (pct, msg) = read_progress(&backend, exec_uuid).await;
+    assert_eq!(pct, Some(75));
+    assert_eq!(msg, Some("starting".into()));
+
+    // Third call only sets message — pct stays at 75.
+    backend
+        .progress(&h, None, Some("winding down".into()))
+        .await
+        .expect("progress-3");
+    let (pct, msg) = read_progress(&backend, exec_uuid).await;
+    assert_eq!(pct, Some(75));
+    assert_eq!(msg, Some("winding down".into()));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn progress_fence_mismatch_returns_contention() {
+    let backend = fresh_backend().await;
+    let (eid, _exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    let bad_payload = HandlePayload::new(
+        eid,
+        AttemptIndex::new(0),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(999),
+        30_000,
+        LaneId::new("default"),
+        WorkerInstanceId::new("test-worker-instance"),
+    );
+    let bad_opaque = encode_opaque(BackendTag::Sqlite, &bad_payload);
+    let bad_handle = Handle::new(BackendTag::Sqlite, HandleKind::Fresh, bad_opaque);
+
+    let err = backend
+        .progress(&bad_handle, Some(50), None)
+        .await
+        .expect_err("fence mismatch must surface");
+    assert!(
+        matches!(err, EngineError::Contention(ContentionKind::LeaseConflict)),
+        "expected LeaseConflict, got {err:?}"
+    );
+}
+
+// ── Phase 2a.3 — renew ─────────────────────────────────────────────────
+
+async fn read_lease_expiry(
+    backend: &SqliteBackend,
+    exec_uuid: Uuid,
+    attempt_index: i64,
+) -> Option<i64> {
+    let pool = backend.pool_for_test();
+    sqlx::query_scalar(
+        "SELECT lease_expires_at_ms FROM ff_attempt \
+         WHERE partition_key = 0 AND execution_id = ?1 AND attempt_index = ?2",
+    )
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_one(pool)
+    .await
+    .expect("read lease expiry")
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_advances_lease_expiry_and_emits_event() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    let expiry_before = read_lease_expiry(&backend, exec_uuid, 0).await.unwrap();
+    // Sleep 2ms so the re-computed `now + ttl` advances beyond the
+    // claim's `now + ttl` by a strictly positive amount.
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+
+    let renewal = backend.renew(&h).await.expect("renew");
+    assert!(
+        renewal.expires_at_ms as i64 > expiry_before,
+        "renew must advance lease expiry (before={expiry_before}, after={})",
+        renewal.expires_at_ms,
+    );
+
+    let expiry_after = read_lease_expiry(&backend, exec_uuid, 0).await.unwrap();
+    assert_eq!(expiry_after, renewal.expires_at_ms as i64);
+
+    let pool = backend.pool_for_test();
+    let events: Vec<String> = sqlx::query_scalar(
+        "SELECT event_type FROM ff_lease_event \
+         WHERE execution_id = ?1 ORDER BY event_id ASC",
+    )
+    .bind(exec_uuid.to_string())
+    .fetch_all(pool)
+    .await
+    .expect("read lease events");
+    assert_eq!(events, vec!["acquired", "renewed"]);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_fence_mismatch_returns_contention() {
+    let backend = fresh_backend().await;
+    let (eid, _exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    let bad_payload = HandlePayload::new(
+        eid,
+        AttemptIndex::new(0),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(999),
+        30_000,
+        LaneId::new("default"),
+        WorkerInstanceId::new("test-worker-instance"),
+    );
+    let bad_opaque = encode_opaque(BackendTag::Sqlite, &bad_payload);
+    let bad_handle = Handle::new(BackendTag::Sqlite, HandleKind::Fresh, bad_opaque);
+
+    let err = backend
+        .renew(&bad_handle)
+        .await
+        .expect_err("fence mismatch");
+    assert!(
+        matches!(err, EngineError::Contention(ContentionKind::LeaseConflict)),
+        "expected LeaseConflict, got {err:?}"
+    );
+}
+
+// ── Phase 2a.3 — append_frame ──────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn append_frame_durable_writes_frame_row() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    let frame = Frame::new(b"hello".to_vec(), FrameKind::Stdout);
+    let out = backend.append_frame(&h, frame).await.expect("append");
+    assert_eq!(out.frame_count, 1);
+    assert!(out.stream_id.contains('-'));
+    assert_eq!(out.summary_version, None);
+
+    let pool = backend.pool_for_test();
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_stream_frame \
+         WHERE partition_key = 0 AND execution_id = ?1 AND attempt_index = 0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("count");
+    assert_eq!(count, 1);
+
+    // Append a second frame → count=2.
+    let frame2 = Frame::new(b"world".to_vec(), FrameKind::Stdout);
+    let out2 = backend.append_frame(&h, frame2).await.expect("append 2");
+    assert_eq!(out2.frame_count, 2);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn append_frame_summary_merges_document_and_bumps_version() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    // First delta: {"a":1}
+    let f1 = Frame::new(br#"{"a":1}"#.to_vec(), FrameKind::Event).with_mode(
+        StreamMode::DurableSummary {
+            patch_kind: PatchKind::JsonMergePatch,
+        },
+    );
+    let out1 = backend.append_frame(&h, f1).await.expect("append 1");
+    assert_eq!(out1.summary_version, Some(1));
+
+    // Second delta: {"b":2} — merges with prior.
+    let f2 = Frame::new(br#"{"b":2}"#.to_vec(), FrameKind::Event).with_mode(
+        StreamMode::DurableSummary {
+            patch_kind: PatchKind::JsonMergePatch,
+        },
+    );
+    let out2 = backend.append_frame(&h, f2).await.expect("append 2");
+    assert_eq!(out2.summary_version, Some(2));
+
+    let pool = backend.pool_for_test();
+    let (doc, version): (String, i64) = sqlx::query_as(
+        "SELECT document_json, version FROM ff_stream_summary \
+         WHERE partition_key = 0 AND execution_id = ?1 AND attempt_index = 0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read summary");
+    assert_eq!(version, 2);
+    let doc_val: serde_json::Value = serde_json::from_str(&doc).expect("parse doc");
+    assert_eq!(doc_val["a"], serde_json::Value::from(1));
+    assert_eq!(doc_val["b"], serde_json::Value::from(2));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn append_frame_fence_mismatch_returns_contention() {
+    let backend = fresh_backend().await;
+    let (eid, _exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    let bad_payload = HandlePayload::new(
+        eid,
+        AttemptIndex::new(0),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(999),
+        30_000,
+        LaneId::new("default"),
+        WorkerInstanceId::new("test-worker-instance"),
+    );
+    let bad_opaque = encode_opaque(BackendTag::Sqlite, &bad_payload);
+    let bad_handle = Handle::new(BackendTag::Sqlite, HandleKind::Fresh, bad_opaque);
+
+    let frame = Frame::new(b"x".to_vec(), FrameKind::Stdout);
+    let err = backend
+        .append_frame(&bad_handle, frame)
+        .await
+        .expect_err("fence mismatch");
+    assert!(
+        matches!(err, EngineError::Contention(ContentionKind::LeaseConflict)),
+        "expected LeaseConflict, got {err:?}"
+    );
+}
+
+// ── Phase 2a.3 — claim_from_reclaim ────────────────────────────────────
+
+/// Set the current attempt's lease to expired (now - 1s) to simulate a
+/// stale lease eligible for reclaim.
+async fn expire_current_lease(backend: &SqliteBackend, exec_uuid: Uuid, attempt_index: i64) {
+    let pool = backend.pool_for_test();
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    sqlx::query(
+        "UPDATE ff_attempt SET lease_expires_at_ms = ?1 \
+         WHERE partition_key = 0 AND execution_id = ?2 AND attempt_index = ?3",
+    )
+    .bind(now_ms - 1_000)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .execute(pool)
+    .await
+    .expect("expire lease");
+}
+
+fn make_reclaim_token(exec_id: ExecutionId) -> ReclaimToken {
+    let partition = Partition {
+        family: PartitionFamily::Execution,
+        index: 0,
+    };
+    let grant = ReclaimGrant {
+        execution_id: exec_id,
+        partition_key: PartitionKey::from(&partition),
+        grant_key: "sqlite:test-grant".into(),
+        expires_at_ms: u64::MAX,
+        lane_id: LaneId::new("default"),
+    };
+    ReclaimToken::new(
+        grant,
+        WorkerId::new("reclaim-worker"),
+        WorkerInstanceId::new("reclaim-worker-instance"),
+        30_000,
+    )
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_from_reclaim_expired_lease_mints_resumed_handle() {
+    let backend = fresh_backend().await;
+    let (eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    // Fence forward: the lease is currently live. Expire it.
+    expire_current_lease(&backend, exec_uuid, 0).await;
+
+    let token = make_reclaim_token(eid);
+    let h = backend
+        .claim_from_reclaim(token)
+        .await
+        .expect("claim_from_reclaim")
+        .expect("Some(handle)");
+    assert_eq!(h.backend, BackendTag::Sqlite);
+    assert_eq!(h.kind, HandleKind::Resumed);
+
+    // The attempt row's epoch bumped to 2 (initial acquire was 1, the
+    // reclaim step adds 1 more).
+    let pool = backend.pool_for_test();
+    let epoch: i64 = sqlx::query_scalar(
+        "SELECT lease_epoch FROM ff_attempt \
+         WHERE partition_key = 0 AND execution_id = ?1 AND attempt_index = 0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read epoch");
+    assert_eq!(epoch, 2);
+
+    let events: Vec<String> = sqlx::query_scalar(
+        "SELECT event_type FROM ff_lease_event \
+         WHERE execution_id = ?1 ORDER BY event_id ASC",
+    )
+    .bind(exec_uuid.to_string())
+    .fetch_all(pool)
+    .await
+    .expect("read lease events");
+    assert_eq!(events, vec!["acquired", "reclaimed"]);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_from_reclaim_live_lease_returns_none() {
+    let backend = fresh_backend().await;
+    let (eid, _exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    // Do not expire — lease is still live. Reclaim must return None.
+    let token = make_reclaim_token(eid);
+    let res = backend
+        .claim_from_reclaim(token)
+        .await
+        .expect("claim_from_reclaim");
+    assert!(res.is_none(), "live lease must block reclaim");
 }

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -920,3 +920,73 @@ async fn claim_from_reclaim_live_lease_returns_none() {
         .expect("claim_from_reclaim");
     assert!(res.is_none(), "live lease must block reclaim");
 }
+
+/// PR #376 Copilot review — with the prior field absent + a NULL bind,
+/// SQLite's `json_set(x, '$.k', coalesce(NULL, NULL))` could
+/// materialize an explicit JSON `null`, diverging from the PG
+/// `raw_fields ||` no-op semantics. Assert that a partial `progress`
+/// on a fresh row leaves the un-set field ABSENT, not JSON null.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn progress_partial_update_leaves_absent_field_absent() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    // Set only pct; message has never been written.
+    backend
+        .progress(&h, Some(25), None)
+        .await
+        .expect("progress pct-only");
+
+    // `json_type('$.progress_message')` on an absent key returns NULL.
+    // If the write path materialized `"progress_message": null`,
+    // `json_type` would return `'null'` (the string literal).
+    let pool = backend.pool_for_test();
+    let msg_type: Option<String> = sqlx::query_scalar(
+        "SELECT json_type(raw_fields, '$.progress_message') \
+         FROM ff_exec_core WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read json_type");
+    assert_eq!(
+        msg_type, None,
+        "absent field must remain absent, got json_type = {msg_type:?}"
+    );
+}
+
+/// PR #376 Copilot review — `progress(None, None)` must be a no-op.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn progress_both_none_is_no_op() {
+    let backend = fresh_backend().await;
+    let (_eid, exec_uuid) = seed_runnable_execution(&backend, "default", &[]).await;
+
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, claim_policy())
+        .await
+        .expect("claim")
+        .expect("handle");
+
+    backend.progress(&h, None, None).await.expect("progress noop");
+
+    let pool = backend.pool_for_test();
+    let pct_type: Option<String> = sqlx::query_scalar(
+        "SELECT json_type(raw_fields, '$.progress_pct') \
+         FROM ff_exec_core WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read json_type");
+    assert_eq!(pct_type, None);
+}


### PR DESCRIPTION
## Summary

Replaces `Unavailable` stubs for four `EngineBackend` methods on
`SqliteBackend`, paralleling `ff-backend-postgres::attempt` +
`ff-backend-postgres::stream`. All four paths fence-check under
`BEGIN IMMEDIATE` (§4.1 A3) and wrap in `retry_serializable` (§4.3).

## Method surface (4)

- **`renew`** — advances `lease_expires_at_ms`, emits
  `ff_lease_event` `renewed`, returns `LeaseRenewal`.
- **`progress`** — merges `progress_pct` + `progress_message` into
  `ff_exec_core.raw_fields` via `json_set(coalesce(...))` so partial
  updates preserve prior values.
- **`append_frame`** — full RFC-015 **write** surface: Durable,
  DurableSummary (JSON Merge Patch in Rust, `__ff_null__` sentinel
  honoured), BestEffortLive (EMA MAXLEN + trim). Read surface
  (`read_stream`/`tail_stream`/`read_summary`) deferred to 2b — it
  depends on in-Rust notifier wiring to replace PG LISTEN/NOTIFY.
- **`claim_from_reclaim`** — expired-lease CAS, bumps epoch, flips
  `ff_exec_core` back to active/leased, emits `ff_lease_event`
  `reclaimed`, mints `HandleKind::Resumed`; live-lease → `Ok(None)`.

## append_frame scope decision

**Full RFC-015 write surface landed.** SQLite already has all three
stream tables migrated (`ff_stream_frame` / `ff_stream_summary` /
`ff_stream_meta` in migration 0001). JSON Merge Patch is applied in
Rust just as PG does, avoiding any `jsonb ||` dialect translation;
EMA MAXLEN computation ports unchanged. Read surface stays out of
scope because it requires the post-commit broadcast channel that
replaces PG's `LISTEN/NOTIFY` — scheduled alongside
`subscribe_lease_history` in Phase 2b/3.

## Query modules

- `queries/lease.rs` (populated): 4 SQL consts for renew + reclaim.
- `queries/stream.rs` (new): 9 SQL consts for append_frame.
- `queries/exec_core.rs`: `UPDATE_EXEC_CORE_PROGRESS_SQL` added.

## Non-deliverables (as specified)

- `create_execution` / `create_flow` / producer paths → Phase 2b
- `cancel` / `suspend` / `deliver_signal` → Phase 2b
- `subscribe_*` / read_stream / tail_stream / read_summary → Phase 3
- Wave 9 methods → Phase 3
- `Supports` flag flips → Phase 4 release PR atomic

## Test plan

- [x] `cargo test -p ff-backend-sqlite` — 20 tests pass (12 prior +
      8 new covering progress, renew, append_frame, reclaim incl.
      fence mismatch + live-lease-blocks-reclaim)
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p ff-backend-sqlite --all-targets` — 0 warnings
- [x] `cargo fmt --check -p ff-backend-sqlite` — only pre-existing
      fmt drift on untouched files; new code + edits clean
- [ ] Full CI (matrix + migration-parity) must pass before admin-merge
- [ ] Sweep every bot/reviewer inline comment before merging
- [ ] Phase 1a semver breaks still expected; Valkey cluster flake #369
      ignorable

## RFC/reality gaps

None. Trait signatures match; lease_event `renewed`/`reclaimed` wire
strings parity with PG `lease_event::EVENT_RENEWED`/`EVENT_RECLAIMED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new SQLite implementations for lease lifecycle and stream write paths, changing transactional write behavior and JSON/stream persistence logic. Main risk is correctness around fencing/lease conflicts and stream summary/trim semantics under concurrency.
> 
> **Overview**
> Implements Phase 2a.3 of the SQLite `EngineBackend` by replacing `Unavailable` stubs with real implementations for `renew`, `progress`, `append_frame`, and `claim_from_reclaim`, all guarded by `BEGIN IMMEDIATE` + lease-epoch fence checks.
> 
> `renew` now advances `lease_expires_at_ms` and emits `ff_lease_event` `renewed`; `progress` now partially updates `ff_exec_core.raw_fields` (`progress_pct`/`progress_message`) without clobbering existing values. `append_frame` now persists RFC-015 stream writes, including DurableSummary JSON Merge Patch application in Rust (honouring `SUMMARY_NULL_SENTINEL`) and BestEffortLive EMA-driven trimming, backed by a new `queries/stream.rs` module.
> 
> Adds SQLite query constants for renew/reclaim/progress/stream writes, adds a direct `serde_json` dependency, and expands `hot_path.rs` coverage for the new behaviors (including fence-mismatch and live-lease reclaim refusal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466199aa442637e940ff4032ac86842bc32b8633. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->