### PR TITLE
feat(backend-sqlite): Phase 2b.1 — producer exec/flow + pubsub foundation (Group A + D.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 2b.1 producer exec/flow + pubsub
+  foundation (RFC-023 Group A + D.1).** Replaces 6 `Unavailable` stubs
+  with real bodies: `create_execution` (seeds `ff_exec_core` + the
+  `ff_execution_capabilities` junction + `ff_lane_registry`),
+  `create_flow` (idempotent `ff_flow_core` insert), `add_execution_to_flow`
+  (stamps `exec_core.flow_id` + bumps `graph_revision` /
+  `raw_fields.node_count`), `stage_dependency_edge` (CAS on
+  `graph_revision`, inserts into `ff_edge`), `apply_dependency_to_child`
+  (marks edge applied, upserts `ff_edge_group.running_count`), and
+  classic `cancel_flow` (flips flow header + member `ff_exec_core`
+  rows, writes completion + lease-revoked outbox rows per member,
+  queues `ff_pending_cancel_groups` under `CancelPending`). Every
+  body mirrors `ff-backend-postgres/src/flow{,_staging}.rs` +
+  `ff-backend-postgres/src/exec_core.rs::create_execution_impl`
+  statement-by-statement; SQLite dialect changes are contained to
+  `json_set` + `json_extract` (JSON1) replacing PG `jsonb_set` /
+  `jsonb_build_object`, and `BEGIN IMMEDIATE` single-writer
+  serialization replacing PG `FOR UPDATE` row locks. The `wait`
+  axis on `cancel_flow` always reports synchronous `Cancelled {..}`
+  — under single-writer SQLite every member flip commits in the
+  header transaction. Group B (suspend/signal/deliver_signal),
+  Group C (stream reads), and Group D.2 (subscribe trait surface)
+  land in Phase 2b.2.
+- **`crates/ff-backend-sqlite/src/pubsub.rs` — full post-commit
+  broadcast topology.** Five `tokio::sync::broadcast` channels,
+  one per outbox table (`lease_history`, `completion`,
+  `signal_delivery`, `stream_frame`, `operator_event`); the
+  `OutboxEvent` payload carries `(event_id, partition_key)` read
+  from `last_insert_rowid()` inside the writing transaction, with
+  `dispatch_pending_emits` firing AFTER `tx.commit()` returns
+  (RFC-023 §4.2 A2 — broadcast is wakeup only, durable replay
+  rides `event_id > cursor` on the outbox tables). Post-commit
+  emit wiring added to the 7 existing Phase 2a methods that
+  write outbox rows: `claim` / `complete` / `fail` / `renew` /
+  `append_frame` / `claim_from_reclaim`, plus the new
+  `cancel_flow` path's per-member completion + lease-revoked
+  emits.
+- `crates/ff-backend-sqlite/src/queries/flow.rs` (new) +
+  `crates/ff-backend-sqlite/src/queries/flow_staging.rs` (new)
+  carrying the SQLite-dialect SQL const block for the Group A
+  surface; `queries/exec_core.rs` extended with `INSERT_EXEC_CORE_SQL`
+  + `INSERT_EXEC_CAPABILITY_SQL` + `INSERT_LANE_REGISTRY_SQL`;
+  `queries/dispatch.rs` populated with `INSERT_LEASE_EVENT_SQL` +
+  scaffolding consts for `INSERT_SIGNAL_EVENT_SQL` /
+  `INSERT_OPERATOR_EVENT_SQL` (Phase 2b.2 consumers).
+- `crates/ff-backend-sqlite/tests/producer_flow.rs` (new) covering
+  `create_execution` + junction populate, idempotent `create_flow`,
+  3-member flow build + 2-edge stage + apply + `cancel_flow`
+  member fan-out, `stage_dependency_edge` stale-revision
+  rejection, and a `complete()` → outbox-row-present smoke that
+  exercises the pubsub post-commit path end-to-end.
 - **`crates/ff-backend-sqlite` — Phase 2a.3 lease-lifecycle + progress +
   append_frame (RFC-023).** Replaces the `Unavailable` stubs for `renew`,
   `progress`, `append_frame`, and `claim_from_reclaim` with real bodies

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -43,7 +43,8 @@ use ff_core::types::{AttemptId, AttemptIndex, LeaseEpoch, LeaseId};
 use crate::errors::map_sqlx_error;
 use crate::handle_codec::{decode_handle, encode_handle};
 use crate::queries::{
-    attempt as q_attempt, exec_core as q_exec, lease as q_lease, stream as q_stream,
+    attempt as q_attempt, dispatch as q_dispatch, exec_core as q_exec, flow as q_flow,
+    flow_staging as q_flow_staging, lease as q_lease, stream as q_stream,
 };
 use crate::retry::retry_serializable;
 #[cfg(feature = "core")]
@@ -52,14 +53,78 @@ use ff_core::partition::PartitionKey;
 use ff_core::types::EdgeId;
 use ff_core::types::{BudgetId, ExecutionId, FlowId, LaneId, TimestampMs};
 
-use crate::pubsub::PubSub;
+use crate::pubsub::{OutboxEvent, PubSub};
 use crate::registry;
+#[cfg(feature = "core")]
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
+    ApplyDependencyToChildResult, CreateExecutionArgs, CreateExecutionResult, CreateFlowArgs,
+    CreateFlowResult, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+};
+#[cfg(feature = "core")]
+use ff_core::state::PublicState;
+use tokio::sync::broadcast;
 
 /// Phase-1a-wide `Unavailable` helper. Each stubbed method names
 /// itself here so call-site errors carry a stable identifier.
 #[inline]
 fn unavailable<T>(op: &'static str) -> Result<T, EngineError> {
     Err(EngineError::Unavailable { op })
+}
+
+// ── Phase 2b.1: post-commit broadcast emit support ─────────────────────
+
+/// Enum selector for the 5 broadcast channels. Inner transaction bodies
+/// accumulate `(OutboxChannel, OutboxEvent)` pairs in a `Vec` and the
+/// outer wrapper dispatches them AFTER `tx.commit()` succeeds. This
+/// preserves the RFC-023 §4.2 ordering invariant: broadcast wakeup
+/// fires only for events that genuinely committed.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum OutboxChannel {
+    LeaseHistory,
+    Completion,
+    #[allow(dead_code)] // wired in Phase 2b.2 deliver_signal
+    SignalDelivery,
+    StreamFrame,
+    #[allow(dead_code)] // wired in Phase 2b.2 operator ops
+    OperatorEvent,
+}
+
+/// A pending post-commit broadcast emit. See [`OutboxChannel`].
+pub(crate) type PendingEmit = (OutboxChannel, OutboxEvent);
+
+/// Dispatch every pending emit via the appropriate broadcast channel.
+/// Called AFTER `tx.commit()` returns OK so consumers only observe
+/// wakeups for genuinely-committed events.
+fn dispatch_pending_emits(pubsub: &PubSub, emits: &[PendingEmit]) {
+    for (channel, ev) in emits {
+        let sender: &broadcast::Sender<OutboxEvent> = match channel {
+            OutboxChannel::LeaseHistory => &pubsub.lease_history,
+            OutboxChannel::Completion => &pubsub.completion,
+            OutboxChannel::SignalDelivery => &pubsub.signal_delivery,
+            OutboxChannel::StreamFrame => &pubsub.stream_frame,
+            OutboxChannel::OperatorEvent => &pubsub.operator_event,
+        };
+        PubSub::emit(sender, ev.clone());
+    }
+}
+
+/// Read `last_insert_rowid()` inside the open txn and turn it into
+/// an [`OutboxEvent`]. SQLite's AUTOINCREMENT outbox tables use the
+/// rowid alias as the `event_id`, so this read is correct for every
+/// outbox table defined under `migrations/000{1,6,7,10}_*.sql`.
+async fn last_outbox_event(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    partition_key: i64,
+) -> Result<OutboxEvent, EngineError> {
+    let event_id: i64 = sqlx::query_scalar("SELECT last_insert_rowid()")
+        .fetch_one(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(OutboxEvent {
+        event_id,
+        partition_key,
+    })
 }
 
 // ── Phase 2a.2 helpers: hot-path shared logic ──────────────────────────
@@ -187,6 +252,7 @@ async fn fence_check(
 
 async fn claim_impl(
     pool: &SqlitePool,
+    pubsub: &PubSub,
     lane: &ff_core::types::LaneId,
     capabilities: &CapabilitySet,
     policy: &ClaimPolicy,
@@ -199,8 +265,9 @@ async fn claim_impl(
     let mut conn = begin_immediate(pool).await?;
     let result = claim_inner(&mut conn, part, lane, capabilities, policy).await;
     match result {
-        Ok(Some(handle)) => {
+        Ok(Some((handle, emits))) => {
             commit_or_rollback(&mut conn).await?;
+            dispatch_pending_emits(pubsub, &emits);
             Ok(Some(handle))
         }
         Ok(None) => {
@@ -223,7 +290,7 @@ async fn claim_inner(
     lane: &ff_core::types::LaneId,
     capabilities: &CapabilitySet,
     policy: &ClaimPolicy,
-) -> Result<Option<Handle>, EngineError> {
+) -> Result<Option<(Handle, Vec<PendingEmit>)>, EngineError> {
     // Scan up to CAP_SCAN_BATCH eligible rows in priority order and
     // walk until we find the first capability-satisfying one. Under
     // §4.1 A3 SQLite runs on a single partition, so a high-priority
@@ -307,9 +374,11 @@ async fn claim_inner(
     // RFC-019 Stage B outbox parity (PG reference at
     // `ff-backend-postgres/src/lease_event.rs`): record a lease
     // lifecycle event so a later `subscribe_lease_history` reader
-    // observes the acquisition. The PG `pg_notify` trigger is dropped
-    // per §4.2; in-Rust broadcast wiring lands in a later phase.
-    insert_lease_event(conn, part, exec_uuid, "acquired", now).await?;
+    // observes the acquisition. Post-commit broadcast emit wired in
+    // Phase 2b.1 per RFC-023 §4.2.
+    let mut emits: Vec<PendingEmit> = Vec::new();
+    let ev = insert_lease_event(conn, part, exec_uuid, "acquired", now).await?;
+    emits.push((OutboxChannel::LeaseHistory, ev));
 
     let attempt_index = AttemptIndex::new(u32::try_from(attempt_index_i.max(0)).unwrap_or(0));
     let exec_id = ff_core::types::ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}"))
@@ -327,11 +396,12 @@ async fn claim_inner(
         lane.clone(),
         policy.worker_instance_id.clone(),
     );
-    Ok(Some(encode_handle(&payload, HandleKind::Fresh)))
+    Ok(Some((encode_handle(&payload, HandleKind::Fresh), emits)))
 }
 
 async fn complete_impl(
     pool: &SqlitePool,
+    pubsub: &PubSub,
     handle: &Handle,
     payload_bytes: Option<Vec<u8>>,
 ) -> Result<(), EngineError> {
@@ -351,7 +421,11 @@ async fn complete_impl(
     )
     .await;
     match result {
-        Ok(()) => commit_or_rollback(&mut conn).await,
+        Ok(emits) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_pending_emits(pubsub, &emits);
+            Ok(())
+        }
         Err(e) => {
             rollback_quiet(&mut conn).await;
             Err(e)
@@ -366,7 +440,7 @@ async fn complete_inner(
     attempt_index: i64,
     expected_epoch: u64,
     payload_bytes: Option<Vec<u8>>,
-) -> Result<(), EngineError> {
+) -> Result<Vec<PendingEmit>, EngineError> {
     fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
     let now = now_ms();
 
@@ -388,17 +462,13 @@ async fn complete_inner(
         .await
         .map_err(map_sqlx_error)?;
 
-    sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
-        .bind("success")
-        .bind(now)
-        .bind(part)
-        .bind(exec_uuid)
-        .execute(&mut **conn)
-        .await
-        .map_err(map_sqlx_error)?;
+    let mut emits: Vec<PendingEmit> = Vec::new();
+    let completion_ev = insert_completion_event_ev(conn, part, exec_uuid, "success", now).await?;
+    emits.push((OutboxChannel::Completion, completion_ev));
 
-    insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
-    Ok(())
+    let lease_ev = insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
+    emits.push((OutboxChannel::LeaseHistory, lease_ev));
+    Ok(emits)
 }
 
 /// Classify whether a `fail()` call reschedules a retry or transitions
@@ -425,6 +495,7 @@ fn classify_retryable(classification: FailureClass) -> bool {
 
 async fn fail_impl(
     pool: &SqlitePool,
+    pubsub: &PubSub,
     handle: &Handle,
     reason: FailureReason,
     classification: FailureClass,
@@ -448,8 +519,9 @@ async fn fail_impl(
     )
     .await;
     match result {
-        Ok(outcome) => {
+        Ok((outcome, emits)) => {
             commit_or_rollback(&mut conn).await?;
+            dispatch_pending_emits(pubsub, &emits);
             Ok(outcome)
         }
         Err(e) => {
@@ -469,9 +541,10 @@ async fn fail_inner(
     retryable: bool,
     reason: &FailureReason,
     classification: FailureClass,
-) -> Result<FailOutcome, EngineError> {
+) -> Result<(FailOutcome, Vec<PendingEmit>), EngineError> {
     fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
     let now = now_ms();
+    let mut emits: Vec<PendingEmit> = Vec::new();
 
     if retryable {
         sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_RETRY_SQL)
@@ -491,7 +564,8 @@ async fn fail_inner(
             .await
             .map_err(map_sqlx_error)?;
 
-        insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
+        let lease_ev = insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
+        emits.push((OutboxChannel::LeaseHistory, lease_ev));
         // Log the transient failure so operators tracing a retry loop
         // can correlate cause without re-reading the attempt row
         // themselves (Gemini review #1).
@@ -502,9 +576,12 @@ async fn fail_inner(
             attempt_index = attempt_index,
             "sqlite.fail: scheduling retry"
         );
-        Ok(FailOutcome::RetryScheduled {
-            delay_until: ff_core::types::TimestampMs::from_millis(now),
-        })
+        Ok((
+            FailOutcome::RetryScheduled {
+                delay_until: ff_core::types::TimestampMs::from_millis(now),
+            },
+            emits,
+        ))
     } else {
         sqlx::query(q_attempt::UPDATE_ATTEMPT_FAIL_TERMINAL_SQL)
             .bind(now)
@@ -524,53 +601,69 @@ async fn fail_inner(
             .await
             .map_err(map_sqlx_error)?;
 
-        sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
-            .bind("failed")
-            .bind(now)
-            .bind(part)
-            .bind(exec_uuid)
-            .execute(&mut **conn)
-            .await
-            .map_err(map_sqlx_error)?;
+        let completion_ev = insert_completion_event_ev(conn, part, exec_uuid, "failed", now).await?;
+        emits.push((OutboxChannel::Completion, completion_ev));
 
-        insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
-        Ok(FailOutcome::TerminalFailed)
+        let lease_ev = insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
+        emits.push((OutboxChannel::LeaseHistory, lease_ev));
+        Ok((FailOutcome::TerminalFailed, emits))
     }
 }
 
-/// Emit one RFC-019 Stage B lease-lifecycle outbox row.
+/// Emit one RFC-019 Stage B lease-lifecycle outbox row + return the
+/// generated outbox `event_id` wrapped in an [`OutboxEvent`] for the
+/// caller to queue as a post-commit broadcast.
 ///
 /// Mirrors `ff-backend-postgres/src/lease_event.rs`. The PG
-/// `pg_notify` trigger is dropped per RFC-023 §4.2 (broadcast moves
-/// into a Rust post-commit channel in a later phase); durable replay
-/// via `event_id > cursor` continues to ride against this table.
+/// `pg_notify` trigger is dropped per RFC-023 §4.2 — broadcast moves
+/// into the Rust post-commit dispatch landed in Phase 2b.1; durable
+/// replay via `event_id > cursor` continues to ride against this
+/// table.
 async fn insert_lease_event(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     part: i64,
     exec_uuid: Uuid,
     event_type: &str,
     now: i64,
-) -> Result<(), EngineError> {
-    sqlx::query(
-        r#"
-        INSERT INTO ff_lease_event (
-            execution_id, lease_id, event_type, occurred_at_ms, partition_key
-        ) VALUES (?1, NULL, ?2, ?3, ?4)
-        "#,
-    )
-    .bind(exec_uuid.to_string())
-    .bind(event_type)
-    .bind(now)
-    .bind(part)
-    .execute(&mut **conn)
-    .await
-    .map_err(map_sqlx_error)?;
-    Ok(())
+) -> Result<OutboxEvent, EngineError> {
+    sqlx::query(q_dispatch::INSERT_LEASE_EVENT_SQL)
+        .bind(exec_uuid.to_string())
+        .bind(event_type)
+        .bind(now)
+        .bind(part)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    last_outbox_event(conn, part).await
+}
+
+/// Insert one completion outbox row (success / failed / cancelled /
+/// retry) and return the `event_id` wrapped in an [`OutboxEvent`].
+async fn insert_completion_event_ev(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    outcome: &str,
+    now: i64,
+) -> Result<OutboxEvent, EngineError> {
+    sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
+        .bind(outcome)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    last_outbox_event(conn, part).await
 }
 
 // ── Phase 2a.3 hot-path bodies ────────────────────────────────────────
 
-async fn renew_impl(pool: &SqlitePool, handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+async fn renew_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    handle: &Handle,
+) -> Result<LeaseRenewal, EngineError> {
     let payload = decode_handle(handle)?;
     let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
     let attempt_index = i64::from(payload.attempt_index.0);
@@ -588,8 +681,9 @@ async fn renew_impl(pool: &SqlitePool, handle: &Handle) -> Result<LeaseRenewal, 
     )
     .await;
     match result {
-        Ok(renewal) => {
+        Ok((renewal, emits)) => {
             commit_or_rollback(&mut conn).await?;
+            dispatch_pending_emits(pubsub, &emits);
             Ok(renewal)
         }
         Err(e) => {
@@ -606,7 +700,7 @@ async fn renew_inner(
     attempt_index: i64,
     expected_epoch: u64,
     lease_ttl_ms: i64,
-) -> Result<LeaseRenewal, EngineError> {
+) -> Result<(LeaseRenewal, Vec<PendingEmit>), EngineError> {
     fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
     let now = now_ms();
     let new_expires = now.saturating_add(lease_ttl_ms);
@@ -621,11 +715,12 @@ async fn renew_inner(
         .map_err(map_sqlx_error)?;
 
     // RFC-019 Stage B outbox parity: lease renewed event.
-    insert_lease_event(conn, part, exec_uuid, "renewed", now).await?;
+    let ev = insert_lease_event(conn, part, exec_uuid, "renewed", now).await?;
+    let emits = vec![(OutboxChannel::LeaseHistory, ev)];
 
-    Ok(LeaseRenewal::new(
-        u64::try_from(new_expires).unwrap_or(0),
-        expected_epoch,
+    Ok((
+        LeaseRenewal::new(u64::try_from(new_expires).unwrap_or(0), expected_epoch),
+        emits,
     ))
 }
 
@@ -754,6 +849,7 @@ fn build_fields_json(frame: &Frame) -> String {
 
 async fn append_frame_impl(
     pool: &SqlitePool,
+    pubsub: &PubSub,
     handle: &Handle,
     frame: Frame,
 ) -> Result<AppendFrameOutcome, EngineError> {
@@ -773,8 +869,9 @@ async fn append_frame_impl(
     )
     .await;
     match result {
-        Ok(outcome) => {
+        Ok((outcome, emits)) => {
             commit_or_rollback(&mut conn).await?;
+            dispatch_pending_emits(pubsub, &emits);
             Ok(outcome)
         }
         Err(e) => {
@@ -791,7 +888,7 @@ async fn append_frame_inner(
     attempt_index: i64,
     expected_epoch: u64,
     frame: Frame,
-) -> Result<AppendFrameOutcome, EngineError> {
+) -> Result<(AppendFrameOutcome, Vec<PendingEmit>), EngineError> {
     fence_check(conn, part, exec_uuid, attempt_index, expected_epoch).await?;
 
     let ts_ms = now_ms();
@@ -824,6 +921,14 @@ async fn append_frame_inner(
         .execute(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
+
+    // Post-commit broadcast on the stream_frame channel. `ff_stream_frame`
+    // uses a composite primary key, not AUTOINCREMENT — `last_insert_rowid()`
+    // still returns the rowid of the just-inserted row (SQLite assigns
+    // one for every non-WITHOUT-ROWID table), so the outbox-event id is
+    // unique per append within the table's rowid sequence.
+    let stream_ev = last_outbox_event(conn, part).await?;
+    let emits: Vec<PendingEmit> = vec![(OutboxChannel::StreamFrame, stream_ev)];
 
     let mut summary_version: Option<u64> = None;
 
@@ -956,13 +1061,14 @@ async fn append_frame_inner(
     if let Some(v) = summary_version {
         out = out.with_summary_version(v);
     }
-    Ok(out)
+    Ok((out, emits))
 }
 
 // ── claim_from_reclaim ────────────────────────────────────────────────
 
 async fn claim_from_reclaim_impl(
     pool: &SqlitePool,
+    pubsub: &PubSub,
     token: &ReclaimToken,
 ) -> Result<Option<Handle>, EngineError> {
     let eid = &token.grant.execution_id;
@@ -971,8 +1077,9 @@ async fn claim_from_reclaim_impl(
     let mut conn = begin_immediate(pool).await?;
     let result = claim_from_reclaim_inner(&mut conn, part, exec_uuid, token).await;
     match result {
-        Ok(Some(handle)) => {
+        Ok(Some((handle, emits))) => {
             commit_or_rollback(&mut conn).await?;
+            dispatch_pending_emits(pubsub, &emits);
             Ok(Some(handle))
         }
         Ok(None) => {
@@ -991,7 +1098,7 @@ async fn claim_from_reclaim_inner(
     part: i64,
     exec_uuid: Uuid,
     token: &ReclaimToken,
-) -> Result<Option<Handle>, EngineError> {
+) -> Result<Option<(Handle, Vec<PendingEmit>)>, EngineError> {
     // Latest attempt under the partition/exec. Mirror of PG at
     // `ff-backend-postgres/src/attempt.rs:294-308`.
     let row = sqlx::query(q_lease::SELECT_LATEST_ATTEMPT_FOR_RECLAIM_SQL)
@@ -1038,7 +1145,8 @@ async fn claim_from_reclaim_inner(
         .await
         .map_err(map_sqlx_error)?;
 
-    insert_lease_event(conn, part, exec_uuid, "reclaimed", now).await?;
+    let ev = insert_lease_event(conn, part, exec_uuid, "reclaimed", now).await?;
+    let emits = vec![(OutboxChannel::LeaseHistory, ev)];
 
     let new_epoch = current_epoch.saturating_add(1);
     let payload = HandlePayload::new(
@@ -1051,7 +1159,724 @@ async fn claim_from_reclaim_inner(
         token.grant.lane_id.clone(),
         token.worker_instance_id.clone(),
     );
-    Ok(Some(encode_handle(&payload, HandleKind::Resumed)))
+    Ok(Some((encode_handle(&payload, HandleKind::Resumed), emits)))
+}
+
+// ── Phase 2b.1 producer-side bodies (Group A) ─────────────────────────
+
+/// Serialize an optional [`ff_core::policy::ExecutionPolicy`] into the
+/// TEXT JSON shape stored in `ff_exec_core.policy`. Mirrors PG at
+/// `ff-backend-postgres/src/exec_core.rs:144-150` (the PG side stores
+/// jsonb; SQLite stores the same JSON in a TEXT column).
+#[cfg(feature = "core")]
+fn encode_policy_json(
+    policy: Option<&ff_core::policy::ExecutionPolicy>,
+) -> Result<Option<String>, EngineError> {
+    match policy {
+        Some(p) => serde_json::to_string(p)
+            .map(Some)
+            .map_err(|e| EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!("create_execution: policy: serialize failed: {e}"),
+            }),
+        None => Ok(None),
+    }
+}
+
+/// Build `raw_fields` for a fresh `ff_exec_core` row. Mirror of PG's
+/// `create_execution_impl` JSON shape so downstream read paths decode
+/// identically. TEXT JSON in SQLite vs jsonb in PG is otherwise opaque.
+#[cfg(feature = "core")]
+fn build_create_execution_raw_fields(args: &CreateExecutionArgs) -> String {
+    use serde_json::{Map, Value};
+    let mut raw: Map<String, Value> = Map::new();
+    raw.insert(
+        "namespace".into(),
+        Value::String(args.namespace.as_str().to_owned()),
+    );
+    raw.insert(
+        "execution_kind".into(),
+        Value::String(args.execution_kind.clone()),
+    );
+    raw.insert(
+        "creator_identity".into(),
+        Value::String(args.creator_identity.clone()),
+    );
+    if let Some(k) = &args.idempotency_key {
+        raw.insert("idempotency_key".into(), Value::String(k.clone()));
+    }
+    if let Some(enc) = &args.payload_encoding {
+        raw.insert("payload_encoding".into(), Value::String(enc.clone()));
+    }
+    raw.insert(
+        "last_mutation_at".into(),
+        Value::String(args.now.0.to_string()),
+    );
+    raw.insert(
+        "total_attempt_count".into(),
+        Value::String("0".to_owned()),
+    );
+    let tags_json: Map<String, Value> = args
+        .tags
+        .iter()
+        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+        .collect();
+    raw.insert("tags".into(), Value::Object(tags_json));
+    Value::Object(raw).to_string()
+}
+
+#[cfg(feature = "core")]
+async fn create_execution_impl(
+    pool: &SqlitePool,
+    args: &CreateExecutionArgs,
+) -> Result<CreateExecutionResult, EngineError> {
+    let part: i64 = i64::from(args.execution_id.partition());
+    let exec_uuid = {
+        let s = args.execution_id.as_str();
+        let tail = s
+            .split_once("}:")
+            .map(|(_, t)| t)
+            .ok_or_else(|| EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!("execution_id missing `}}:` separator: {s}"),
+            })?;
+        Uuid::parse_str(tail).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("execution_id UUID invalid: {e}"),
+        })?
+    };
+    let lane_id = args.lane_id.as_str().to_owned();
+    let priority: i64 = i64::from(args.priority);
+    let created_at_ms: i64 = args.now.0;
+    let deadline_at_ms: Option<i64> = args.execution_deadline_at.map(|t| t.0);
+    let raw_fields = build_create_execution_raw_fields(args);
+    let policy_json = encode_policy_json(args.policy.as_ref())?;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let insert_result = sqlx::query(q_exec::INSERT_EXEC_CORE_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(&lane_id)
+        .bind(priority)
+        .bind(created_at_ms)
+        .bind(deadline_at_ms)
+        .bind(args.input_payload.as_slice())
+        .bind(policy_json.as_deref())
+        .bind(&raw_fields)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error);
+
+    let result = async {
+        let res = insert_result?;
+        let inserted = res.rows_affected() > 0;
+
+        if inserted {
+            // Populate the capability junction — RFC-023 §4.1 A4.
+            // Required caps live on `ExecutionPolicy.scheduling.required_capabilities`
+            // per the PG reference; if absent, no junction rows are
+            // written (matches PG's empty `text[]` default).
+            let required: Vec<String> = args
+                .policy
+                .as_ref()
+                .and_then(|p| p.routing_requirements.as_ref())
+                .map(|r| r.required_capabilities.iter().cloned().collect())
+                .unwrap_or_default();
+            for cap in &required {
+                sqlx::query(q_exec::INSERT_EXEC_CAPABILITY_SQL)
+                    .bind(exec_uuid)
+                    .bind(cap)
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(map_sqlx_error)?;
+            }
+        }
+
+        // Lane-registry seed is idempotent and runs on every call so
+        // a dynamic lane seen for the first time on a duplicate
+        // create_execution still registers.
+        sqlx::query(q_exec::INSERT_LANE_REGISTRY_SQL)
+            .bind(&lane_id)
+            .bind(created_at_ms)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        Ok::<bool, EngineError>(inserted)
+    }
+    .await;
+
+    match result {
+        Ok(inserted) => {
+            commit_or_rollback(&mut conn).await?;
+            if inserted {
+                Ok(CreateExecutionResult::Created {
+                    execution_id: args.execution_id.clone(),
+                    public_state: PublicState::Waiting,
+                })
+            } else {
+                Ok(CreateExecutionResult::Duplicate {
+                    execution_id: args.execution_id.clone(),
+                })
+            }
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+#[cfg(feature = "core")]
+async fn create_flow_impl(
+    pool: &SqlitePool,
+    args: &CreateFlowArgs,
+) -> Result<CreateFlowResult, EngineError> {
+    // Flow partition under single-writer SQLite is always 0 (§4.1 A3).
+    let part: i64 = 0;
+    let flow_uuid: Uuid = args.flow_id.0;
+    let now_ms = args.now.0;
+
+    let raw_fields = serde_json::json!({
+        "flow_kind": args.flow_kind,
+        "namespace": args.namespace.as_str(),
+        "node_count": 0,
+        "edge_count": 0,
+        "last_mutation_at_ms": now_ms,
+    })
+    .to_string();
+
+    let mut conn = begin_immediate(pool).await?;
+    let ins = sqlx::query(q_flow::INSERT_FLOW_CORE_SQL)
+        .bind(part)
+        .bind(flow_uuid)
+        .bind(now_ms)
+        .bind(&raw_fields)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error);
+    match ins {
+        Ok(r) => {
+            commit_or_rollback(&mut conn).await?;
+            if r.rows_affected() > 0 {
+                Ok(CreateFlowResult::Created {
+                    flow_id: args.flow_id.clone(),
+                })
+            } else {
+                Ok(CreateFlowResult::AlreadySatisfied {
+                    flow_id: args.flow_id.clone(),
+                })
+            }
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+#[cfg(feature = "core")]
+async fn add_execution_to_flow_impl(
+    pool: &SqlitePool,
+    args: &AddExecutionToFlowArgs,
+) -> Result<AddExecutionToFlowResult, EngineError> {
+    let part: i64 = 0;
+    let flow_uuid: Uuid = args.flow_id.0;
+    let (exec_part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    // Under single-writer SQLite every entity lives on partition 0
+    // (§4.1 A3). The exec id MUST carry `{fp:0}` because any other
+    // partition is unreachable.
+    if exec_part != part {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!(
+                "execution partition mismatch: expected 0, got {exec_part}"
+            ),
+        });
+    }
+    let now_ms = args.now.0;
+
+    let mut conn = begin_immediate(pool).await?;
+    let work = async {
+        // 1. Load flow_core.
+        let flow_row = sqlx::query(q_flow_staging::SELECT_FLOW_CORE_FOR_STAGE_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let Some(flow_row) = flow_row else {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "flow_not_found".into(),
+            });
+        };
+        let public_flow_state: String = flow_row.try_get("public_flow_state").map_err(map_sqlx_error)?;
+        if matches!(
+            public_flow_state.as_str(),
+            "cancelled" | "completed" | "failed" | "terminal"
+        ) {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "flow_already_terminal".into(),
+            });
+        }
+        let raw_fields_text: String = flow_row.try_get("raw_fields").map_err(map_sqlx_error)?;
+
+        // 2. Load exec_core back-pointer.
+        let exec_row = sqlx::query(q_flow_staging::SELECT_EXEC_FLOW_ID_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let Some(exec_row) = exec_row else {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "execution_not_found".into(),
+            });
+        };
+        let existing_flow_id: Option<Uuid> = exec_row.try_get("flow_id").map_err(map_sqlx_error)?;
+
+        // 3. Idempotent: already on this flow.
+        if existing_flow_id == Some(flow_uuid) {
+            // Read node_count from cached raw_fields (avoid a second SELECT).
+            let raw_val: serde_json::Value = serde_json::from_str(&raw_fields_text).unwrap_or_else(
+                |_| serde_json::Value::Object(serde_json::Map::new()),
+            );
+            let nc = raw_val
+                .get("node_count")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .unwrap_or(0);
+            return Ok(AddExecutionToFlowResult::AlreadyMember {
+                execution_id: args.execution_id.clone(),
+                node_count: nc,
+            });
+        }
+
+        // 4. Cross-flow refusal.
+        if let Some(other) = existing_flow_id
+            && other != flow_uuid
+        {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!("already_member_of_different_flow:{other}"),
+            });
+        }
+
+        // 5. Stamp exec.flow_id + bump flow counters.
+        sqlx::query(q_flow_staging::UPDATE_EXEC_SET_FLOW_ID_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(flow_uuid)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        sqlx::query(q_flow_staging::BUMP_FLOW_NODE_COUNT_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(now_ms)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let new_nc: i64 = sqlx::query_scalar(q_flow_staging::SELECT_FLOW_NODE_COUNT_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        Ok(AddExecutionToFlowResult::Added {
+            execution_id: args.execution_id.clone(),
+            new_node_count: u32::try_from(new_nc.max(0)).unwrap_or(0),
+        })
+    }
+    .await;
+
+    match work {
+        Ok(res) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(res)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+#[cfg(feature = "core")]
+async fn stage_dependency_edge_impl(
+    pool: &SqlitePool,
+    args: &StageDependencyEdgeArgs,
+) -> Result<StageDependencyEdgeResult, EngineError> {
+    if args.upstream_execution_id == args.downstream_execution_id {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "self_referencing_edge".into(),
+        });
+    }
+
+    let part: i64 = 0;
+    let flow_uuid: Uuid = args.flow_id.0;
+    let edge_uuid: Uuid = args.edge_id.0;
+    let (up_part, upstream_uuid) = split_exec_id(&args.upstream_execution_id)?;
+    let (down_part, downstream_uuid) = split_exec_id(&args.downstream_execution_id)?;
+    if up_part != part || down_part != part {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "execution partition mismatch under single-writer SQLite".into(),
+        });
+    }
+    let now_ms = args.now.0;
+    let expected_rev = i64::try_from(args.expected_graph_revision).unwrap_or(i64::MAX);
+
+    let mut conn = begin_immediate(pool).await?;
+    let work = async {
+        // 1. CAS bump flow_core. `changes()` after execute tells us
+        //    whether the WHERE matched.
+        let cas = sqlx::query(q_flow_staging::CAS_BUMP_FLOW_REV_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(expected_rev)
+            .bind(now_ms)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        if cas.rows_affected() == 0 {
+            // Distinguish flow-missing vs terminal vs stale-rev.
+            let probe = sqlx::query(q_flow_staging::SELECT_FLOW_REV_AND_STATE_SQL)
+                .bind(part)
+                .bind(flow_uuid)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+            return match probe {
+                None => Err(EngineError::Validation {
+                    kind: ValidationKind::InvalidInput,
+                    detail: "flow_not_found".into(),
+                }),
+                Some(r) => {
+                    let state: String = r.try_get("public_flow_state").map_err(map_sqlx_error)?;
+                    if matches!(state.as_str(), "cancelled" | "completed" | "failed" | "terminal") {
+                        Err(EngineError::Validation {
+                            kind: ValidationKind::InvalidInput,
+                            detail: "flow_already_terminal".into(),
+                        })
+                    } else {
+                        Err(EngineError::Contention(ContentionKind::StaleGraphRevision))
+                    }
+                }
+            };
+        }
+
+        // 2. Membership check.
+        let member_rows = sqlx::query_scalar::<_, Uuid>(q_flow_staging::SELECT_FLOW_MEMBERSHIP_PAIR_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(upstream_uuid)
+            .bind(downstream_uuid)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        if !member_rows.contains(&upstream_uuid) || !member_rows.contains(&downstream_uuid) {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "execution_not_in_flow".into(),
+            });
+        }
+
+        // 3. Insert edge.
+        let policy_json = serde_json::json!({
+            "dependency_kind": args.dependency_kind,
+            "satisfaction_condition": "all_required",
+            "data_passing_ref": args.data_passing_ref.clone().unwrap_or_default(),
+            "edge_state": "pending",
+            "created_at_ms": now_ms,
+            "created_by": "engine",
+            "staged_at_ms": now_ms,
+            "applied_at_ms": serde_json::Value::Null,
+        })
+        .to_string();
+        let ins = sqlx::query(q_flow_staging::INSERT_EDGE_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(edge_uuid)
+            .bind(upstream_uuid)
+            .bind(downstream_uuid)
+            .bind(&policy_json)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        if ins.rows_affected() == 0 {
+            // Edge already exists — parity with the PG `Conflict(
+            // DependencyAlreadyExists { existing })` path would require
+            // rehydrating the existing `EdgeSnapshot`, but SQLite
+            // currently has no `describe_edge` reader wired (Phase
+            // 2b.2). Surface the conflict as a Validation error
+            // naming the edge_id so callers see a stable signal;
+            // when `describe_edge` lands this can tighten to
+            // `Conflict(DependencyAlreadyExists {..})`.
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!("dependency_already_exists:edge_id={edge_uuid}"),
+            });
+        }
+
+        // 4. Read post-bump revision.
+        let new_rev: i64 = sqlx::query_scalar::<_, i64>(
+            "SELECT graph_revision FROM ff_flow_core \
+             WHERE partition_key = ?1 AND flow_id = ?2",
+        )
+        .bind(part)
+        .bind(flow_uuid)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        Ok(StageDependencyEdgeResult::Staged {
+            edge_id: args.edge_id.clone(),
+            new_graph_revision: u64::try_from(new_rev).unwrap_or(0),
+        })
+    }
+    .await;
+
+    match work {
+        Ok(res) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(res)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+#[cfg(feature = "core")]
+async fn apply_dependency_to_child_impl(
+    pool: &SqlitePool,
+    args: &ApplyDependencyToChildArgs,
+) -> Result<ApplyDependencyToChildResult, EngineError> {
+    let part: i64 = 0;
+    let flow_uuid: Uuid = args.flow_id.0;
+    let edge_uuid: Uuid = args.edge_id.0;
+    let (down_part, downstream_uuid) = split_exec_id(&args.downstream_execution_id)?;
+    if down_part != part {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "execution partition mismatch under single-writer SQLite".into(),
+        });
+    }
+    let now_ms = args.now.0;
+
+    let mut conn = begin_immediate(pool).await?;
+    let work = async {
+        // 1. Load the edge row.
+        let row = sqlx::query(q_flow_staging::SELECT_EDGE_POLICY_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(edge_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let Some(row) = row else {
+            return Err(EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: "edge_not_found".into(),
+            });
+        };
+        let policy_text: String = row.try_get("policy").map_err(map_sqlx_error)?;
+        let mut policy: serde_json::Value = serde_json::from_str(&policy_text).map_err(|e| {
+            EngineError::Validation {
+                kind: ValidationKind::Corruption,
+                detail: format!("ff_edge.policy: {e}"),
+            }
+        })?;
+
+        // 2. Idempotency.
+        let already_applied = policy
+            .get("applied_at_ms")
+            .and_then(|v| v.as_i64())
+            .is_some();
+        if already_applied {
+            return Ok(ApplyDependencyToChildResult::AlreadyApplied);
+        }
+
+        // 3. Mutate policy JSON.
+        if let Some(obj) = policy.as_object_mut() {
+            obj.insert("applied_at_ms".into(), serde_json::json!(now_ms));
+            obj.insert("edge_state".into(), serde_json::json!("applied"));
+        }
+        let new_policy_text = policy.to_string();
+        sqlx::query(q_flow_staging::UPDATE_EDGE_POLICY_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(edge_uuid)
+            .bind(&new_policy_text)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // 4. Upsert edge_group.
+        let default_group_policy = serde_json::json!({ "kind": "all_of" }).to_string();
+        sqlx::query(q_flow_staging::UPSERT_EDGE_GROUP_APPLY_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(downstream_uuid)
+            .bind(&default_group_policy)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // 5. Read post-upsert running_count.
+        let unsatisfied: i64 =
+            sqlx::query_scalar(q_flow_staging::SELECT_EDGE_GROUP_RUNNING_COUNT_SQL)
+                .bind(part)
+                .bind(flow_uuid)
+                .bind(downstream_uuid)
+                .fetch_one(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+        Ok(ApplyDependencyToChildResult::Applied {
+            unsatisfied_count: u32::try_from(unsatisfied.max(0)).unwrap_or(0),
+        })
+    }
+    .await;
+
+    match work {
+        Ok(res) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(res)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+fn cancel_policy_to_str(p: CancelFlowPolicy) -> &'static str {
+    match p {
+        CancelFlowPolicy::FlowOnly => "cancel_flow_only",
+        CancelFlowPolicy::CancelAll => "cancel_all",
+        CancelFlowPolicy::CancelPending => "cancel_pending",
+        // Forward-compat for additive `CancelFlowPolicy` variants —
+        // encode as `cancel_all` (safest conservative default), matching
+        // the PG reference at `ff-backend-postgres/src/flow.rs:525-534`.
+        _ => "cancel_all",
+    }
+}
+
+async fn cancel_flow_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    id: &FlowId,
+    policy: CancelFlowPolicy,
+) -> Result<CancelFlowResult, EngineError> {
+    let part: i64 = 0;
+    let flow_uuid: Uuid = id.0;
+    let policy_str = cancel_policy_to_str(policy);
+    let now_ms = now_ms();
+
+    let mut conn = begin_immediate(pool).await?;
+    let work: Result<(CancelFlowResult, Vec<PendingEmit>), EngineError> = async {
+        // Step 1 — flip flow_core.
+        let flip = sqlx::query(q_flow::UPDATE_FLOW_CORE_CANCEL_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(now_ms)
+            .bind(policy_str)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        if flip.rows_affected() == 0 {
+            // Flow not found — return idempotent empty-member success
+            // matching PG at `ff-backend-postgres/src/flow.rs:635-641`.
+            return Ok((
+                CancelFlowResult::Cancelled {
+                    cancellation_policy: policy_str.to_owned(),
+                    member_execution_ids: Vec::new(),
+                },
+                Vec::new(),
+            ));
+        }
+
+        // Step 2 — enumerate + cancel members.
+        let member_rows: Vec<Uuid> = if matches!(policy, CancelFlowPolicy::FlowOnly) {
+            Vec::new()
+        } else {
+            let sql = match policy {
+                CancelFlowPolicy::CancelPending => q_flow::SELECT_FLOW_MEMBERS_CANCEL_PENDING_SQL,
+                _ => q_flow::SELECT_FLOW_MEMBERS_CANCEL_ALL_SQL,
+            };
+            sqlx::query_scalar::<_, Uuid>(sql)
+                .bind(part)
+                .bind(flow_uuid)
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?
+        };
+
+        let mut member_execution_ids: Vec<String> = Vec::with_capacity(member_rows.len());
+        let mut emits: Vec<PendingEmit> = Vec::new();
+        for exec_uuid in &member_rows {
+            sqlx::query(q_flow::UPDATE_EXEC_CORE_CANCEL_MEMBER_SQL)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(now_ms)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            // Completion outbox + lease-revoked outbox — mirror of PG
+            // at `ff-backend-postgres/src/flow.rs:688-716`.
+            let completion_ev =
+                insert_completion_event_ev(&mut conn, part, *exec_uuid, "cancelled", now_ms)
+                    .await?;
+            emits.push((OutboxChannel::Completion, completion_ev));
+            let lease_ev =
+                insert_lease_event(&mut conn, part, *exec_uuid, "revoked", now_ms).await?;
+            emits.push((OutboxChannel::LeaseHistory, lease_ev));
+
+            member_execution_ids.push(format!("{{fp:{part}}}:{exec_uuid}"));
+        }
+
+        // Step 3 — CancelPending bookkeeping.
+        if matches!(policy, CancelFlowPolicy::CancelPending) {
+            sqlx::query(q_flow::INSERT_PENDING_CANCEL_GROUPS_SQL)
+                .bind(part)
+                .bind(flow_uuid)
+                .bind(now_ms)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+        }
+
+        Ok((
+            CancelFlowResult::Cancelled {
+                cancellation_policy: policy_str.to_owned(),
+                member_execution_ids,
+            },
+            emits,
+        ))
+    }
+    .await;
+
+    match work {
+        Ok((res, emits)) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_pending_emits(pubsub, &emits);
+            Ok(res)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
 }
 
 /// Internal shared state. `Arc<SqliteBackendInner>` is what the
@@ -1063,8 +1888,7 @@ pub(crate) struct SqliteBackendInner {
     /// re-plumbing construction.
     #[allow(dead_code)]
     pub(crate) pool: SqlitePool,
-    /// Per-backend wakeup channels (Phase 3 wiring).
-    #[allow(dead_code)]
+    /// Per-backend post-commit wakeup channels (Phase 2b.1 wiring).
     pub(crate) pubsub: PubSub,
     /// Registry key (canonical path or verbatim `:memory:` URI).
     /// Held for Drop-time cleanup if we need it in a future phase;
@@ -1280,12 +2104,14 @@ impl EngineBackend for SqliteBackend {
         policy: ClaimPolicy,
     ) -> Result<Option<Handle>, EngineError> {
         let pool = &self.inner.pool;
-        retry_serializable(|| claim_impl(pool, lane, capabilities, &policy)).await
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| claim_impl(pool, pubsub, lane, capabilities, &policy)).await
     }
 
     async fn renew(&self, handle: &Handle) -> Result<LeaseRenewal, EngineError> {
         let pool = &self.inner.pool;
-        retry_serializable(|| renew_impl(pool, handle)).await
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| renew_impl(pool, pubsub, handle)).await
     }
 
     async fn progress(
@@ -1304,12 +2130,14 @@ impl EngineBackend for SqliteBackend {
         frame: Frame,
     ) -> Result<AppendFrameOutcome, EngineError> {
         let pool = &self.inner.pool;
-        retry_serializable(|| append_frame_impl(pool, handle, frame.clone())).await
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| append_frame_impl(pool, pubsub, handle, frame.clone())).await
     }
 
     async fn complete(&self, handle: &Handle, payload: Option<Vec<u8>>) -> Result<(), EngineError> {
         let pool = &self.inner.pool;
-        retry_serializable(|| complete_impl(pool, handle, payload.clone())).await
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| complete_impl(pool, pubsub, handle, payload.clone())).await
     }
 
     async fn fail(
@@ -1319,7 +2147,8 @@ impl EngineBackend for SqliteBackend {
         classification: FailureClass,
     ) -> Result<FailOutcome, EngineError> {
         let pool = &self.inner.pool;
-        retry_serializable(|| fail_impl(pool, handle, reason.clone(), classification)).await
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| fail_impl(pool, pubsub, handle, reason.clone(), classification)).await
     }
 
     async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {
@@ -1349,7 +2178,8 @@ impl EngineBackend for SqliteBackend {
 
     async fn claim_from_reclaim(&self, token: ReclaimToken) -> Result<Option<Handle>, EngineError> {
         let pool = &self.inner.pool;
-        retry_serializable(|| claim_from_reclaim_impl(pool, &token)).await
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| claim_from_reclaim_impl(pool, pubsub, &token)).await
     }
 
     async fn delay(&self, _handle: &Handle, _delay_until: TimestampMs) -> Result<(), EngineError> {
@@ -1456,11 +2286,18 @@ impl EngineBackend for SqliteBackend {
 
     async fn cancel_flow(
         &self,
-        _id: &FlowId,
-        _policy: CancelFlowPolicy,
+        id: &FlowId,
+        policy: CancelFlowPolicy,
         _wait: CancelFlowWait,
     ) -> Result<CancelFlowResult, EngineError> {
-        unavailable("sqlite.cancel_flow")
+        // RFC-023 Phase 2b.1 Group A — classic cancel_flow only. The
+        // `wait` axis is a Valkey/PG async-dispatch concern (member
+        // cancel fan-out); under single-writer SQLite every member
+        // flip happens in the same transaction as the header flip, so
+        // the result is always synchronous `Cancelled {..}`.
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| cancel_flow_impl(pool, pubsub, id, policy)).await
     }
 
     #[cfg(feature = "core")]
@@ -1514,6 +2351,58 @@ impl EngineBackend for SqliteBackend {
         _attempt_index: AttemptIndex,
     ) -> Result<Option<ff_core::backend::SummaryDocument>, EngineError> {
         unavailable("sqlite.read_summary")
+    }
+
+    // ── RFC-017 Stage A — Ingress (create + flow staging) ──
+    //
+    // Phase 2b.1 Group A lands 5 of the 9 ingress methods. The
+    // remaining 4 (cancel_execution / change_priority /
+    // replay_execution / plus the operator-event reads) land in
+    // Phase 2b.2 alongside the Group B/C/D.2 scope.
+
+    #[cfg(feature = "core")]
+    async fn create_execution(
+        &self,
+        args: CreateExecutionArgs,
+    ) -> Result<CreateExecutionResult, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| create_execution_impl(pool, &args)).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn create_flow(
+        &self,
+        args: CreateFlowArgs,
+    ) -> Result<CreateFlowResult, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| create_flow_impl(pool, &args)).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn add_execution_to_flow(
+        &self,
+        args: AddExecutionToFlowArgs,
+    ) -> Result<AddExecutionToFlowResult, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| add_execution_to_flow_impl(pool, &args)).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn stage_dependency_edge(
+        &self,
+        args: StageDependencyEdgeArgs,
+    ) -> Result<StageDependencyEdgeResult, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| stage_dependency_edge_impl(pool, &args)).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn apply_dependency_to_child(
+        &self,
+        args: ApplyDependencyToChildArgs,
+    ) -> Result<ApplyDependencyToChildResult, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| apply_dependency_to_child_impl(pool, &args)).await
     }
 
     // ── RFC-018 capability discovery ──

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -1274,9 +1274,12 @@ async fn create_execution_impl(
 
         if inserted {
             // Populate the capability junction — RFC-023 §4.1 A4.
-            // Required caps live on `ExecutionPolicy.scheduling.required_capabilities`
-            // per the PG reference; if absent, no junction rows are
-            // written (matches PG's empty `text[]` default).
+            // Required caps live on
+            // `ExecutionPolicy.routing_requirements.required_capabilities`;
+            // if absent, no junction rows are written (matches PG's
+            // empty `text[]` default — see PG reference at
+            // `ff-backend-postgres/src/exec_core.rs:157-188` which also
+            // stores an empty `text[]` array when the policy is None).
             let required: Vec<String> = args
                 .policy
                 .as_ref()
@@ -1763,10 +1766,17 @@ fn cancel_policy_to_str(p: CancelFlowPolicy) -> &'static str {
         CancelFlowPolicy::FlowOnly => "cancel_flow_only",
         CancelFlowPolicy::CancelAll => "cancel_all",
         CancelFlowPolicy::CancelPending => "cancel_pending",
-        // Forward-compat for additive `CancelFlowPolicy` variants —
-        // encode as `cancel_all` (safest conservative default), matching
-        // the PG reference at `ff-backend-postgres/src/flow.rs:525-534`.
-        _ => "cancel_all",
+        // Forward-compat for additive `CancelFlowPolicy` variants.
+        // Per the project's non-exhaustive-enum rule (confirmed by
+        // cursor-bugbot learned-rule #dc768b31; cf. Valkey backend fix
+        // PR #114), destructive-action wildcards MUST default to the
+        // LEAST-destructive variant — widening cancel scope
+        // irreversibly destroys work, while narrowing is safely
+        // retryable by the caller. The PG reference at
+        // `ff-backend-postgres/src/flow.rs:525-534` takes the wider
+        // default; SQLite intentionally diverges here to match
+        // Valkey's correctness posture.
+        _ => "cancel_flow_only",
     }
 }
 
@@ -2090,6 +2100,19 @@ impl SqliteBackend {
     #[doc(hidden)]
     pub fn pool_for_test(&self) -> &SqlitePool {
         &self.inner.pool
+    }
+
+    /// Test-only subscribe helper — returns a `Receiver` for the
+    /// completion-outbox broadcast channel so integration tests can
+    /// assert that a `complete()` / `fail()` / `cancel_flow()` call
+    /// wakes subscribers post-commit. The production `subscribe_*`
+    /// surface lands in Phase 2b.2; this accessor is narrow + hidden
+    /// so it doesn't leak into the public API.
+    #[doc(hidden)]
+    pub fn subscribe_completion_for_test(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<crate::pubsub::OutboxEvent> {
+        self.inner.pubsub.completion.subscribe()
     }
 }
 

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -29,7 +29,8 @@ mod backend;
 mod config;
 mod errors;
 mod handle_codec;
-mod pubsub;
+#[doc(hidden)]
+pub mod pubsub;
 pub mod queries;
 mod registry;
 pub mod retry;

--- a/crates/ff-backend-sqlite/src/pubsub.rs
+++ b/crates/ff-backend-sqlite/src/pubsub.rs
@@ -1,37 +1,104 @@
-//! In-process pub/sub scaffolding (RFC-023 §4.2).
+//! In-process pub/sub wiring (RFC-023 §4.2).
 //!
-//! Phase 1a lands the empty broadcast-channel struct. Phase 3 wires
-//! up the outbox-inside-tx + broadcast-as-wakeup pattern per §4.2
-//! A2.
+//! Phase 2b.1 wires the five broadcast-channel outboxes (Group D.1).
+//! Each channel corresponds to one outbox table; subscribers (Phase
+//! 2b.2 / later) hold a `Receiver` and wake on post-commit emits.
+//!
+//! # Ordering / durability invariant (RFC-023 §4.2 A2)
+//!
+//! The broadcast channel is **wakeup only** — not the durable
+//! record of what happened. Events land as rows on the matching
+//! outbox table **inside** the writing transaction; the
+//! `emit_post_commit` helper fires AFTER `tx.commit()` returns, with
+//! the row(s) just committed as the payload. A late subscriber that
+//! missed a broadcast tick can still recover every event by tailing
+//! the outbox table `WHERE event_id > cursor`. That is the RFC-019
+//! cursor-resume contract.
+//!
+//! # Partition routing
+//!
+//! Each [`OutboxEvent`] carries the partition key it landed on; a
+//! partition-scoped subscriber filters on its own `OutboxEvent::partition_key`.
+//! The post-commit emit never drops the event (broadcast `send`
+//! returns `Ok` when there are zero receivers and `Err(SendError)`
+//! only when the receiver count is zero — the producer side is
+//! infallible from our POV).
 
 use tokio::sync::broadcast;
 
-/// Placeholder capacity for the broadcast channels. Tuned in Phase 3
-/// when real producers + consumers arrive.
+/// Capacity of each broadcast channel's ring buffer. Tuned conservatively
+/// for the dev-only single-writer envelope; late subscribers catch up via
+/// the outbox table, so lost-wakeup only means an extra outbox poll on
+/// the catch-up side (not a lost event).
 const DEFAULT_CAPACITY: usize = 256;
 
+/// One wakeup broadcast payload, one per outbox row written.
+///
+/// Carries enough identification for a subscriber to filter on its
+/// partition / execution of interest without re-reading the outbox
+/// row. The full row (including any non-identifying payload columns
+/// — e.g. `outcome`, `event_type`, `details`) is fetched by the
+/// subscriber from the outbox table using `event_id` as a cursor,
+/// matching the RFC-019 catch-up shape.
+#[derive(Clone, Debug)]
+pub(crate) struct OutboxEvent {
+    /// Auto-incrementing outbox row id (monotonic per table). Read by
+    /// Phase 2b.2 `subscribe_*` consumers as the catch-up cursor; the
+    /// producer side fills it from `last_insert_rowid()`.
+    #[allow(dead_code)] // Phase 2b.2 subscribers read this
+    pub(crate) event_id: i64,
+    /// Partition the write targeted. SQLite currently runs with
+    /// `num_flow_partitions = 1` (§4.1 A3) so this is always `0`
+    /// today, but the field exists for topology symmetry with PG
+    /// and for future partition fan-out if the invariant ever
+    /// relaxes.
+    #[allow(dead_code)] // Phase 2b.2 partition-scoped subscribers filter on this
+    pub(crate) partition_key: i64,
+}
+
 /// Per-backend in-process wakeup channels. One broadcast channel per
-/// RFC-019 subscription family; Phase 3 populates the `Sender` halves
-/// inside `SqliteBackendInner` and consumers on the subscribe side
-/// hold `Receiver` handles.
-#[allow(dead_code)] // Phase 1a scaffolding — handed to Phase 3.
+/// outbox family; each `Sender` is held on `SqliteBackendInner` and
+/// subscribers derive `Receiver` handles via `Sender::subscribe()`
+/// (Phase 2b.2+).
 pub(crate) struct PubSub {
-    pub(crate) lease_history: broadcast::Sender<()>,
-    pub(crate) completion: broadcast::Sender<()>,
-    pub(crate) signal_delivery: broadcast::Sender<()>,
+    /// Lease lifecycle (acquired / renewed / reclaimed / revoked) —
+    /// rides `ff_lease_event`.
+    pub(crate) lease_history: broadcast::Sender<OutboxEvent>,
+    /// Completion (success / failed / cancelled / expired / skipped) —
+    /// rides `ff_completion_event`.
+    pub(crate) completion: broadcast::Sender<OutboxEvent>,
+    /// Signal delivery — rides `ff_signal_event`.
+    pub(crate) signal_delivery: broadcast::Sender<OutboxEvent>,
+    /// Append-frame durable stream wakeups — rides `ff_stream_frame`.
+    /// Phase 2b.2's `tail_stream` consumer subscribes to this.
+    pub(crate) stream_frame: broadcast::Sender<OutboxEvent>,
+    /// Operator events (priority_changed / replayed / flow_cancel_requested)
+    /// — rides `ff_operator_event`.
+    pub(crate) operator_event: broadcast::Sender<OutboxEvent>,
 }
 
 impl PubSub {
-    #[allow(dead_code)] // Phase 1a scaffolding — handed to Phase 3.
     pub(crate) fn new() -> Self {
         let (lease_history, _) = broadcast::channel(DEFAULT_CAPACITY);
         let (completion, _) = broadcast::channel(DEFAULT_CAPACITY);
         let (signal_delivery, _) = broadcast::channel(DEFAULT_CAPACITY);
+        let (stream_frame, _) = broadcast::channel(DEFAULT_CAPACITY);
+        let (operator_event, _) = broadcast::channel(DEFAULT_CAPACITY);
         Self {
             lease_history,
             completion,
             signal_delivery,
+            stream_frame,
+            operator_event,
         }
+    }
+
+    /// Emit one post-commit wakeup. Swallows the `SendError` that
+    /// appears when no subscriber is attached (the RFC-019 contract
+    /// is that durable replay covers missed wakeups — a no-receiver
+    /// emit is NOT an error from the producer's POV).
+    pub(crate) fn emit(sender: &broadcast::Sender<OutboxEvent>, ev: OutboxEvent) {
+        let _ = sender.send(ev);
     }
 }
 

--- a/crates/ff-backend-sqlite/src/pubsub.rs
+++ b/crates/ff-backend-sqlite/src/pubsub.rs
@@ -19,10 +19,11 @@
 //!
 //! Each [`OutboxEvent`] carries the partition key it landed on; a
 //! partition-scoped subscriber filters on its own `OutboxEvent::partition_key`.
-//! The post-commit emit never drops the event (broadcast `send`
-//! returns `Ok` when there are zero receivers and `Err(SendError)`
-//! only when the receiver count is zero — the producer side is
-//! infallible from our POV).
+//! The post-commit emit is wakeup-only and does not determine
+//! durability. If broadcast `send` finds no attached receivers it
+//! returns `Err(SendError(_))`; we intentionally ignore that case
+//! because durable replay comes from the outbox table, so a missed
+//! wakeup is NOT a lost event from the producer's POV.
 
 use tokio::sync::broadcast;
 
@@ -41,19 +42,18 @@ const DEFAULT_CAPACITY: usize = 256;
 /// subscriber from the outbox table using `event_id` as a cursor,
 /// matching the RFC-019 catch-up shape.
 #[derive(Clone, Debug)]
-pub(crate) struct OutboxEvent {
+#[doc(hidden)] // test-only surface exposed via `subscribe_*_for_test`
+pub struct OutboxEvent {
     /// Auto-incrementing outbox row id (monotonic per table). Read by
     /// Phase 2b.2 `subscribe_*` consumers as the catch-up cursor; the
     /// producer side fills it from `last_insert_rowid()`.
-    #[allow(dead_code)] // Phase 2b.2 subscribers read this
-    pub(crate) event_id: i64,
+    pub event_id: i64,
     /// Partition the write targeted. SQLite currently runs with
     /// `num_flow_partitions = 1` (§4.1 A3) so this is always `0`
     /// today, but the field exists for topology symmetry with PG
     /// and for future partition fan-out if the invariant ever
     /// relaxes.
-    #[allow(dead_code)] // Phase 2b.2 partition-scoped subscribers filter on this
-    pub(crate) partition_key: i64,
+    pub partition_key: i64,
 }
 
 /// Per-backend in-process wakeup channels. One broadcast channel per

--- a/crates/ff-backend-sqlite/src/queries/dispatch.rs
+++ b/crates/ff-backend-sqlite/src/queries/dispatch.rs
@@ -1,4 +1,72 @@
-//! SQLite dialect-forked queries for dispatch + scanner fan-out.
+//! SQLite dialect-forked queries for outbox writes + broadcast
+//! wakeup drains (RFC-023 §4.2).
 //!
-//! Populated in Phase 2a.3 per RFC-023 §4.1. Phase 2a.1 lands the
-//! empty module as a layout-only placeholder.
+//! The outbox rows are the **durable** record of each dispatch event;
+//! the broadcast channel is the wakeup. Subscribers catch up via
+//! `event_id > cursor` reads on these tables.
+
+// `INSERT_COMPLETION_EVENT_SQL` lives in `queries::attempt` (it pre-dates
+// Phase 2b.1 — the attempt-ops family wrote completion events from
+// Phase 2a.2 onward). We reuse that shape here rather than duplicating.
+// See `crates/ff-backend-sqlite/src/queries/attempt.rs`.
+
+// ── lease_event outbox ────────────────────────────────────────────────
+
+/// Insert one lease-lifecycle outbox row. Mirror of the in-line SQL
+/// previously embedded in `backend.rs::insert_lease_event` (Phase 2a.2);
+/// centralized here so post-commit broadcast emit picks up the
+/// `event_id` with one read.
+///
+/// Binds:
+///   1. execution_id (TEXT — UUID string)
+///   2. event_type (TEXT)
+///   3. occurred_at_ms (i64)
+///   4. partition_key (i64)
+pub(crate) const INSERT_LEASE_EVENT_SQL: &str = r#"
+    INSERT INTO ff_lease_event
+        (execution_id, lease_id, event_type, occurred_at_ms, partition_key)
+    VALUES (?1, NULL, ?2, ?3, ?4)
+"#;
+
+// ── signal_event outbox ───────────────────────────────────────────────
+
+/// Insert one signal-delivery outbox row. Consumer-side (Phase 2b.2
+/// `deliver_signal` + subscribe_signal_delivery) drains via
+/// `event_id > cursor`.
+///
+/// Binds:
+///   1. execution_id (TEXT)
+///   2. signal_id (TEXT)
+///   3. waitpoint_id (Option<TEXT>)
+///   4. source_identity (Option<TEXT>)
+///   5. delivered_at_ms (i64)
+///   6. partition_key (i64)
+#[allow(dead_code)] // Consumed by Phase 2b.2 deliver_signal
+pub(crate) const INSERT_SIGNAL_EVENT_SQL: &str = r#"
+    INSERT INTO ff_signal_event
+        (execution_id, signal_id, waitpoint_id, source_identity,
+         delivered_at_ms, partition_key)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+"#;
+
+// ── operator_event outbox ─────────────────────────────────────────────
+
+/// Insert one operator-event outbox row. Used by Wave-9 admin ops
+/// (Phase 2b.2+); the migration CHECK clause restricts `event_type`
+/// to the allowed literal set.
+///
+/// Binds:
+///   1. execution_id (TEXT)
+///   2. event_type (TEXT)
+///   3. details (Option<TEXT JSON>)
+///   4. occurred_at_ms (i64)
+///   5. partition_key (i64)
+///   6. namespace (Option<TEXT>)
+///   7. instance_tag (Option<TEXT>)
+#[allow(dead_code)] // Consumed by Phase 2b.2 change_priority / replay / cancel_flow_header
+pub(crate) const INSERT_OPERATOR_EVENT_SQL: &str = r#"
+    INSERT INTO ff_operator_event
+        (execution_id, event_type, details, occurred_at_ms, partition_key,
+         namespace, instance_tag)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+"#;

--- a/crates/ff-backend-sqlite/src/queries/exec_core.rs
+++ b/crates/ff-backend-sqlite/src/queries/exec_core.rs
@@ -98,3 +98,58 @@ pub(crate) const UPDATE_EXEC_CORE_FAIL_TERMINAL_SQL: &str = r#"
            raw_fields = json_set(raw_fields, '$.last_failure_message', ?2)
      WHERE partition_key = ?3 AND execution_id = ?4
 "#;
+
+// ── Phase 2b.1 producer-side: create_execution inserts ──────────────────
+
+/// Idempotent insert of one `ff_exec_core` row. `ON CONFLICT DO NOTHING`
+/// mirrors the PG path (`ff-backend-postgres/src/exec_core.rs:157-188`)
+/// and the Valkey `ff_create_execution` FCALL's `Duplicate` outcome —
+/// caller detects duplicate via post-insert changes() == 0.
+///
+/// Binds (in order):
+///   1. partition_key (i64)
+///   2. execution_id (Uuid)
+///   3. lane_id (TEXT)
+///   4. priority (i64)
+///   5. created_at_ms (i64)
+///   6. deadline_at_ms (Option<i64>)
+///   7. payload (Option<Vec<u8>>)
+///   8. policy (Option<TEXT JSON>)
+///   9. raw_fields (TEXT JSON)
+pub(crate) const INSERT_EXEC_CORE_SQL: &str = r#"
+    INSERT INTO ff_exec_core (
+        partition_key, execution_id, flow_id, lane_id,
+        attempt_index,
+        lifecycle_phase, ownership_state, eligibility_state,
+        public_state, attempt_state,
+        priority, created_at_ms, deadline_at_ms,
+        payload, policy, raw_fields
+    ) VALUES (
+        ?1, ?2, NULL, ?3,
+        0,
+        'submitted', 'unowned', 'eligible_now',
+        'waiting', 'pending',
+        ?4, ?5, ?6,
+        ?7, ?8, ?9
+    )
+    ON CONFLICT (partition_key, execution_id) DO NOTHING
+"#;
+
+/// Idempotent insert into the normalized capability junction
+/// (RFC-023 §4.1 A4 — replaces PG's `text[]` + GIN). One row per
+/// `(execution_id, capability)` pair; junction rows persist as long
+/// as their parent `ff_exec_core` row does.
+pub(crate) const INSERT_EXEC_CAPABILITY_SQL: &str = r#"
+    INSERT INTO ff_execution_capabilities (execution_id, capability)
+    VALUES (?1, ?2)
+    ON CONFLICT (execution_id, capability) DO NOTHING
+"#;
+
+/// Idempotent seed of the lane registry (Q6 — dynamic lanes seed
+/// here on first use). Mirror of PG at
+/// `ff-backend-postgres/src/exec_core.rs:191-203`.
+pub(crate) const INSERT_LANE_REGISTRY_SQL: &str = r#"
+    INSERT INTO ff_lane_registry (lane_id, registered_at_ms, registered_by)
+    VALUES (?1, ?2, 'create_execution')
+    ON CONFLICT (lane_id) DO NOTHING
+"#;

--- a/crates/ff-backend-sqlite/src/queries/flow.rs
+++ b/crates/ff-backend-sqlite/src/queries/flow.rs
@@ -26,6 +26,23 @@ pub(crate) const INSERT_FLOW_CORE_SQL: &str = r#"
     ON CONFLICT (partition_key, flow_id) DO NOTHING
 "#;
 
+// Lifecycle-phase literal sets used by cancel_flow member selection.
+// Kept as SQL-inline literals (rather than Rust constants bound at
+// query time) because SQLite does not support IN-list parameter
+// arrays; each literal is a deployment-wide invariant string that
+// `ff_exec_core.lifecycle_phase` can take, never user input.
+// Centralizing them in this module so any future lifecycle-phase
+// vocabulary change touches exactly one file.
+//
+// `TERMINAL_PHASES` — an exec row in any of these is already finished,
+// so cancel_flow skips it. Mirrors PG's `NOT IN (...)` filter at
+// `ff-backend-postgres/src/flow.rs:648-649` plus the RFC-023 SQLite
+// 'terminal' literal (see `queries/exec_core.rs::UPDATE_EXEC_CORE_COMPLETE_SQL`
+// which writes 'terminal' rather than PG's multiple terminal literals).
+//
+// `PRE_RUNNABLE_PHASES` — the `CancelPending` policy only flips rows
+// whose execution hasn't started yet.
+
 // ── cancel_flow ─────────────────────────────────────────────────────────
 
 /// Atomic flip of flow_core to cancelled, recording the requested

--- a/crates/ff-backend-sqlite/src/queries/flow.rs
+++ b/crates/ff-backend-sqlite/src/queries/flow.rs
@@ -1,0 +1,101 @@
+//! SQLite dialect-forked queries for flow-header create / cancel.
+//!
+//! Populated in Phase 2b.1 per RFC-023 §4.1. Mirrors the PG reference
+//! at `ff-backend-postgres/src/flow.rs` + `ff-backend-postgres/src/flow_staging.rs`
+//! statement-by-statement; the only dialect changes are `jsonb` → TEXT
+//! JSON (JSON1), `$N` → `?N`, and the removal of `FOR UPDATE` /
+//! partition-aware casts since SQLite runs single-writer under
+//! `BEGIN IMMEDIATE` (§4.1 A3).
+
+// ── create_flow ─────────────────────────────────────────────────────────
+
+/// Idempotent flow-header insert. `ON CONFLICT DO NOTHING` — caller
+/// detects duplicate via post-insert changes() == 0.
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. flow_id (Uuid)
+///   3. created_at_ms (i64)
+///   4. raw_fields (TEXT JSON: flow_kind / namespace / node_count=0 /
+///      edge_count=0 / last_mutation_at_ms)
+pub(crate) const INSERT_FLOW_CORE_SQL: &str = r#"
+    INSERT INTO ff_flow_core
+        (partition_key, flow_id, graph_revision, public_flow_state,
+         created_at_ms, raw_fields)
+    VALUES (?1, ?2, 0, 'open', ?3, ?4)
+    ON CONFLICT (partition_key, flow_id) DO NOTHING
+"#;
+
+// ── cancel_flow ─────────────────────────────────────────────────────────
+
+/// Atomic flip of flow_core to cancelled, recording the requested
+/// cancellation policy in `raw_fields`. The PG path uses a `RETURNING`
+/// to detect flow-not-found; SQLite uses `changes()` after execute
+/// (caller reads `ExecuteResult::rows_affected`).
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. flow_id (Uuid)
+///   3. now_ms (i64) — consumed by the COALESCE(terminal_at_ms, ?3)
+///   4. policy_str (TEXT)
+pub(crate) const UPDATE_FLOW_CORE_CANCEL_SQL: &str = r#"
+    UPDATE ff_flow_core
+       SET public_flow_state = 'cancelled',
+           terminal_at_ms = COALESCE(terminal_at_ms, ?3),
+           raw_fields = json_set(raw_fields, '$.cancellation_policy', ?4)
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Enumerate member executions for cancel_flow. Returns rows filtered
+/// by the policy-specific `lifecycle_phase` set.
+///
+/// NOTE: the state filter is embedded at format-time (not bound) because
+/// SQLite prepares the statement by string shape and the NOT-IN literal
+/// list is the simplest dialect-portable shape. The three literals are
+/// hard-coded constants in `backend.rs::cancel_flow_impl`, so there is no
+/// user-controlled string concatenation.
+pub(crate) const SELECT_FLOW_MEMBERS_CANCEL_ALL_SQL: &str = r#"
+    SELECT execution_id
+      FROM ff_exec_core
+     WHERE partition_key = ?1
+       AND flow_id = ?2
+       AND lifecycle_phase NOT IN ('completed', 'failed', 'cancelled', 'expired', 'terminal')
+"#;
+
+pub(crate) const SELECT_FLOW_MEMBERS_CANCEL_PENDING_SQL: &str = r#"
+    SELECT execution_id
+      FROM ff_exec_core
+     WHERE partition_key = ?1
+       AND flow_id = ?2
+       AND lifecycle_phase IN ('pending', 'blocked', 'eligible', 'runnable', 'submitted')
+"#;
+
+/// Flip one member exec_core row to cancelled. Mirror of PG at
+/// `ff-backend-postgres/src/flow.rs:672-687`.
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. execution_id (Uuid)
+///   3. now_ms (i64)
+pub(crate) const UPDATE_EXEC_CORE_CANCEL_MEMBER_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'cancelled',
+           eligibility_state = 'cancelled',
+           public_state = 'cancelled',
+           attempt_state = 'cancelled',
+           terminal_at_ms = COALESCE(terminal_at_ms, ?3),
+           cancellation_reason = COALESCE(cancellation_reason, 'flow_cancelled'),
+           cancelled_by = COALESCE(cancelled_by, 'cancel_flow')
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// RFC-016 Stage C bookkeeping: enqueue a pending-cancel row for
+/// every edge_group with `running_count > 0` on the cancelled flow
+/// (the Wave-5 dispatcher reads this).
+pub(crate) const INSERT_PENDING_CANCEL_GROUPS_SQL: &str = r#"
+    INSERT OR IGNORE INTO ff_pending_cancel_groups
+        (partition_key, flow_id, downstream_eid, enqueued_at_ms)
+    SELECT partition_key, flow_id, downstream_eid, ?3
+      FROM ff_edge_group
+     WHERE partition_key = ?1 AND flow_id = ?2 AND running_count > 0
+"#;

--- a/crates/ff-backend-sqlite/src/queries/flow_staging.rs
+++ b/crates/ff-backend-sqlite/src/queries/flow_staging.rs
@@ -1,0 +1,176 @@
+//! SQLite dialect-forked queries for flow-staging ingress
+//! (`add_execution_to_flow`, `stage_dependency_edge`,
+//! `apply_dependency_to_child`).
+//!
+//! Populated in Phase 2b.1 per RFC-023 §4.1. Mirrors the PG reference
+//! at `ff-backend-postgres/src/flow_staging.rs` statement-by-statement.
+
+// ── add_execution_to_flow ───────────────────────────────────────────────
+
+/// Read + lock the flow_core row. SQLite's `BEGIN IMMEDIATE` serializes
+/// writers so the PG `FOR UPDATE` is unnecessary; the query shape is a
+/// plain SELECT.
+///
+/// Returns: (public_flow_state, raw_fields).
+pub(crate) const SELECT_FLOW_CORE_FOR_STAGE_SQL: &str = r#"
+    SELECT public_flow_state, raw_fields
+      FROM ff_flow_core
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Read the exec_core row's flow back-pointer. Returns `flow_id` as a
+/// nullable `BLOB`.
+pub(crate) const SELECT_EXEC_FLOW_ID_SQL: &str = r#"
+    SELECT flow_id
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Stamp `exec_core.flow_id` on a successful `add_execution_to_flow`.
+pub(crate) const UPDATE_EXEC_SET_FLOW_ID_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET flow_id = ?3
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Bump `graph_revision` + `raw_fields.node_count` on
+/// `add_execution_to_flow`. Mirror of PG's `jsonb_build_object` path
+/// at `ff-backend-postgres/src/flow_staging.rs:239-258`; JSON1's
+/// `json_set` is the equivalent in-place mutation shape.
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. flow_id (Uuid)
+///   3. now_ms (i64)
+pub(crate) const BUMP_FLOW_NODE_COUNT_SQL: &str = r#"
+    UPDATE ff_flow_core
+       SET graph_revision = graph_revision + 1,
+           raw_fields = json_set(
+               json_set(
+                   raw_fields,
+                   '$.node_count',
+                   COALESCE(json_extract(raw_fields, '$.node_count'), 0) + 1
+               ),
+               '$.last_mutation_at_ms',
+               ?3
+           )
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Read the post-bump `node_count` so the caller can return it in
+/// `AddExecutionToFlowResult::Added`.
+pub(crate) const SELECT_FLOW_NODE_COUNT_SQL: &str = r#"
+    SELECT COALESCE(json_extract(raw_fields, '$.node_count'), 0) AS node_count
+      FROM ff_flow_core
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+// ── stage_dependency_edge ──────────────────────────────────────────────
+
+/// CAS on `graph_revision` — succeed only if (state, rev) match and the
+/// flow is open. Bump `graph_revision` + `edge_count` in the same
+/// UPDATE. Returns the new revision via a follow-up SELECT (SQLite
+/// `RETURNING` is available ≥3.35 but kept as a second query for
+/// symmetry with the rest of this module).
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. flow_id (Uuid)
+///   3. expected_graph_revision (i64)
+///   4. now_ms (i64)
+pub(crate) const CAS_BUMP_FLOW_REV_SQL: &str = r#"
+    UPDATE ff_flow_core
+       SET graph_revision = graph_revision + 1,
+           raw_fields = json_set(
+               json_set(
+                   raw_fields,
+                   '$.edge_count',
+                   COALESCE(json_extract(raw_fields, '$.edge_count'), 0) + 1
+               ),
+               '$.last_mutation_at_ms',
+               ?4
+           )
+     WHERE partition_key = ?1
+       AND flow_id = ?2
+       AND graph_revision = ?3
+       AND public_flow_state = 'open'
+"#;
+
+pub(crate) const SELECT_FLOW_REV_AND_STATE_SQL: &str = r#"
+    SELECT graph_revision, public_flow_state
+      FROM ff_flow_core
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Check that BOTH upstream + downstream execs belong to the given
+/// flow. Returns one row per member that matches. `?3` and `?4` are
+/// the two exec UUIDs.
+pub(crate) const SELECT_FLOW_MEMBERSHIP_PAIR_SQL: &str = r#"
+    SELECT execution_id
+      FROM ff_exec_core
+     WHERE partition_key = ?1
+       AND flow_id = ?2
+       AND (execution_id = ?3 OR execution_id = ?4)
+"#;
+
+/// Insert a staged edge row. `policy` JSON carries the immutable edge
+/// record (dependency_kind / satisfaction_condition / data_passing_ref
+/// / edge_state / created_at_ms / created_by / staged_at_ms /
+/// applied_at_ms).
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. flow_id (Uuid)
+///   3. edge_id (Uuid)
+///   4. upstream_eid (Uuid)
+///   5. downstream_eid (Uuid)
+///   6. policy (TEXT JSON)
+pub(crate) const INSERT_EDGE_SQL: &str = r#"
+    INSERT INTO ff_edge
+        (partition_key, flow_id, edge_id, upstream_eid, downstream_eid,
+         policy, policy_version)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0)
+    ON CONFLICT (partition_key, flow_id, edge_id) DO NOTHING
+"#;
+
+// ── apply_dependency_to_child ──────────────────────────────────────────
+
+/// Load the edge's policy JSON (all mutable + immutable edge state
+/// rides in this column per §4.1 on-disk layout decision).
+pub(crate) const SELECT_EDGE_POLICY_SQL: &str = r#"
+    SELECT policy
+      FROM ff_edge
+     WHERE partition_key = ?1 AND flow_id = ?2 AND edge_id = ?3
+"#;
+
+/// Write back the mutated policy JSON (applied_at_ms + edge_state set
+/// by the caller in Rust).
+pub(crate) const UPDATE_EDGE_POLICY_SQL: &str = r#"
+    UPDATE ff_edge
+       SET policy = ?4
+     WHERE partition_key = ?1 AND flow_id = ?2 AND edge_id = ?3
+"#;
+
+/// Upsert the edge_group aggregate — create with default AllOf when
+/// missing, bump `running_count` when present. Mirrors PG at
+/// `ff-backend-postgres/src/flow_staging.rs:530-546`.
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. flow_id (Uuid)
+///   3. downstream_eid (Uuid)
+///   4. policy_json (TEXT JSON — default '{"kind":"all_of"}')
+pub(crate) const UPSERT_EDGE_GROUP_APPLY_SQL: &str = r#"
+    INSERT INTO ff_edge_group
+        (partition_key, flow_id, downstream_eid, policy, running_count)
+    VALUES (?1, ?2, ?3, ?4, 1)
+    ON CONFLICT (partition_key, flow_id, downstream_eid) DO UPDATE
+        SET running_count = ff_edge_group.running_count + 1
+"#;
+
+/// Read the post-upsert `running_count` for the caller's result payload.
+pub(crate) const SELECT_EDGE_GROUP_RUNNING_COUNT_SQL: &str = r#"
+    SELECT running_count
+      FROM ff_edge_group
+     WHERE partition_key = ?1 AND flow_id = ?2 AND downstream_eid = ?3
+"#;

--- a/crates/ff-backend-sqlite/src/queries/mod.rs
+++ b/crates/ff-backend-sqlite/src/queries/mod.rs
@@ -12,5 +12,7 @@
 pub mod attempt;
 pub mod dispatch;
 pub mod exec_core;
+pub mod flow;
+pub mod flow_staging;
 pub mod lease;
 pub mod stream;

--- a/crates/ff-backend-sqlite/tests/producer_flow.rs
+++ b/crates/ff-backend-sqlite/tests/producer_flow.rs
@@ -1,0 +1,481 @@
+//! RFC-023 Phase 2b.1 — producer exec/flow tests + pubsub foundation.
+//!
+//! Covers the 6 inherent/trait methods landed in Phase 2b.1:
+//!
+//!   * `create_execution` — seeds ff_exec_core + capability junction +
+//!     lane registry
+//!   * `create_flow` — idempotent flow_core insert
+//!   * `add_execution_to_flow` — stamps back-pointer + bumps counters
+//!   * `stage_dependency_edge` + `apply_dependency_to_child` — CAS edge
+//!     build-out + applied bookkeeping
+//!   * `cancel_flow` (classic) — member fan-out with completion /
+//!     lease outbox emits
+//!
+//! Plus a pubsub smoke: calling `complete()` wakes a broadcast
+//! subscriber, confirming the post-commit emit wiring (Group D.1).
+//!
+//! Every test runs serially against `FF_DEV_MODE=1` to honour the
+//! [`SqliteBackend::new`] production guard.
+
+#![cfg(feature = "core")]
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy};
+use ff_core::contracts::{
+    AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
+    ApplyDependencyToChildResult, CreateExecutionArgs, CreateExecutionResult, CreateFlowArgs,
+    CreateFlowResult, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::types::{
+    EdgeId, ExecutionId, FlowId, LaneId, Namespace, TimestampMs, WorkerId, WorkerInstanceId,
+};
+use serial_test::serial;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ── Setup helpers ──────────────────────────────────────────────────────
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    // SAFETY: test-only env mutation; every caller is tagged
+    // `#[serial(ff_dev_mode)]`.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:rfc-023-producer-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("construct backend")
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+fn new_exec_id() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id")
+}
+
+fn create_execution_args(exec_id: &ExecutionId, caps: &[&str]) -> CreateExecutionArgs {
+    let mut policy = ff_core::policy::ExecutionPolicy::default();
+    if !caps.is_empty() {
+        let mut rr = ff_core::policy::RoutingRequirements::default();
+        rr.required_capabilities = caps.iter().map(|s| (*s).to_owned()).collect();
+        policy.routing_requirements = Some(rr);
+    }
+    CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: LaneId::new("default"),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: HashMap::new(),
+        policy: Some(policy),
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(1_000),
+    }
+}
+
+// ── create_execution ───────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn create_execution_seeds_exec_core_and_capability_junction() {
+    let backend = fresh_backend().await;
+    let eid = new_exec_id();
+
+    let res = backend
+        .create_execution(create_execution_args(&eid, &["capA", "capB"]))
+        .await
+        .expect("create_execution");
+    match res {
+        CreateExecutionResult::Created { execution_id, .. } => {
+            assert_eq!(execution_id, eid);
+        }
+        other => panic!("expected Created, got {other:?}"),
+    }
+
+    // Second call is idempotent → Duplicate.
+    let res2 = backend
+        .create_execution(create_execution_args(&eid, &["capA", "capB"]))
+        .await
+        .expect("create_execution replay");
+    assert!(matches!(res2, CreateExecutionResult::Duplicate { .. }));
+
+    // Capability junction populated.
+    let pool = backend.pool_for_test();
+    let exec_uuid = Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap();
+    let caps: Vec<String> = sqlx::query_scalar(
+        "SELECT capability FROM ff_execution_capabilities WHERE execution_id = ?1 ORDER BY capability",
+    )
+    .bind(exec_uuid)
+    .fetch_all(pool)
+    .await
+    .expect("read junction");
+    assert_eq!(caps, vec!["capA".to_string(), "capB".to_string()]);
+
+    // Lane registry seeded.
+    let lane: Option<String> = sqlx::query_scalar(
+        "SELECT lane_id FROM ff_lane_registry WHERE lane_id = ?1",
+    )
+    .bind("default")
+    .fetch_optional(pool)
+    .await
+    .expect("read lane registry");
+    assert_eq!(lane.as_deref(), Some("default"));
+}
+
+// ── create_flow ────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn create_flow_idempotent() {
+    let backend = fresh_backend().await;
+    let fid = FlowId::from_uuid(Uuid::new_v4());
+    let args = CreateFlowArgs {
+        flow_id: fid.clone(),
+        flow_kind: "dag".into(),
+        namespace: Namespace::new("default"),
+        now: TimestampMs::from_millis(100),
+    };
+    let r = backend.create_flow(args.clone()).await.expect("create_flow");
+    assert!(matches!(r, CreateFlowResult::Created { .. }));
+    let r2 = backend.create_flow(args).await.expect("create_flow replay");
+    assert!(matches!(r2, CreateFlowResult::AlreadySatisfied { .. }));
+}
+
+// ── add_execution_to_flow + stage_dependency_edge +
+//    apply_dependency_to_child + cancel_flow  ──────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn flow_build_cancel_roundtrip() {
+    let backend = fresh_backend().await;
+    let fid = FlowId::from_uuid(Uuid::new_v4());
+
+    backend
+        .create_flow(CreateFlowArgs {
+            flow_id: fid.clone(),
+            flow_kind: "dag".into(),
+            namespace: Namespace::new("default"),
+            now: TimestampMs::from_millis(0),
+        })
+        .await
+        .expect("create_flow");
+
+    // Three members.
+    let mut members: Vec<ExecutionId> = Vec::new();
+    for _ in 0..3 {
+        let eid = new_exec_id();
+        backend
+            .create_execution(create_execution_args(&eid, &[]))
+            .await
+            .expect("create_execution");
+        let added = backend
+            .add_execution_to_flow(AddExecutionToFlowArgs {
+                flow_id: fid.clone(),
+                execution_id: eid.clone(),
+                now: TimestampMs::from_millis(10),
+            })
+            .await
+            .expect("add_execution_to_flow");
+        assert!(matches!(added, AddExecutionToFlowResult::Added { .. }));
+        members.push(eid);
+    }
+
+    // Idempotent replay on the last one.
+    let replay = backend
+        .add_execution_to_flow(AddExecutionToFlowArgs {
+            flow_id: fid.clone(),
+            execution_id: members[2].clone(),
+            now: TimestampMs::from_millis(11),
+        })
+        .await
+        .expect("add_execution_to_flow replay");
+    assert!(matches!(replay, AddExecutionToFlowResult::AlreadyMember { .. }));
+
+    // Stage two edges: 0 -> 2 and 1 -> 2. After three node-additions
+    // graph_revision = 3; each staging bumps it.
+    let staged1 = backend
+        .stage_dependency_edge(StageDependencyEdgeArgs {
+            flow_id: fid.clone(),
+            edge_id: EdgeId::from_uuid(Uuid::new_v4()),
+            upstream_execution_id: members[0].clone(),
+            downstream_execution_id: members[2].clone(),
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            expected_graph_revision: 3,
+            now: TimestampMs::from_millis(20),
+        })
+        .await
+        .expect("stage edge 1");
+    let StageDependencyEdgeResult::Staged { new_graph_revision: rev1, edge_id: eid1 } = staged1;
+    assert_eq!(rev1, 4);
+
+    let staged2 = backend
+        .stage_dependency_edge(StageDependencyEdgeArgs {
+            flow_id: fid.clone(),
+            edge_id: EdgeId::from_uuid(Uuid::new_v4()),
+            upstream_execution_id: members[1].clone(),
+            downstream_execution_id: members[2].clone(),
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            expected_graph_revision: 4,
+            now: TimestampMs::from_millis(21),
+        })
+        .await
+        .expect("stage edge 2");
+    let StageDependencyEdgeResult::Staged { new_graph_revision: rev2, edge_id: eid2 } = staged2;
+    assert_eq!(rev2, 5);
+
+    // Apply edge1.
+    let applied = backend
+        .apply_dependency_to_child(ApplyDependencyToChildArgs {
+            flow_id: fid.clone(),
+            edge_id: eid1.clone(),
+            downstream_execution_id: members[2].clone(),
+            upstream_execution_id: members[0].clone(),
+            graph_revision: rev2,
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            now: TimestampMs::from_millis(30),
+        })
+        .await
+        .expect("apply edge 1");
+    match applied {
+        ApplyDependencyToChildResult::Applied { unsatisfied_count } => {
+            assert_eq!(unsatisfied_count, 1);
+        }
+        other => panic!("expected Applied, got {other:?}"),
+    }
+
+    // Idempotent replay.
+    let replay = backend
+        .apply_dependency_to_child(ApplyDependencyToChildArgs {
+            flow_id: fid.clone(),
+            edge_id: eid1,
+            downstream_execution_id: members[2].clone(),
+            upstream_execution_id: members[0].clone(),
+            graph_revision: rev2,
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            now: TimestampMs::from_millis(31),
+        })
+        .await
+        .expect("apply replay");
+    assert!(matches!(replay, ApplyDependencyToChildResult::AlreadyApplied));
+
+    // Apply edge2 — bump to 2.
+    let applied2 = backend
+        .apply_dependency_to_child(ApplyDependencyToChildArgs {
+            flow_id: fid.clone(),
+            edge_id: eid2,
+            downstream_execution_id: members[2].clone(),
+            upstream_execution_id: members[1].clone(),
+            graph_revision: rev2,
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            now: TimestampMs::from_millis(32),
+        })
+        .await
+        .expect("apply edge 2");
+    match applied2 {
+        ApplyDependencyToChildResult::Applied { unsatisfied_count } => {
+            assert_eq!(unsatisfied_count, 2);
+        }
+        other => panic!("expected Applied(2), got {other:?}"),
+    }
+
+    // Cancel the flow with CancelAll — every non-terminal member
+    // flips to cancelled + emits a completion + lease-revoked row.
+    let res = backend
+        .cancel_flow(&fid, CancelFlowPolicy::CancelAll, CancelFlowWait::NoWait)
+        .await
+        .expect("cancel_flow");
+    match res {
+        ff_core::contracts::CancelFlowResult::Cancelled {
+            cancellation_policy,
+            member_execution_ids,
+        } => {
+            assert_eq!(cancellation_policy, "cancel_all");
+            assert_eq!(member_execution_ids.len(), 3);
+        }
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+
+    // flow_core and every member exec_core are now cancelled.
+    let pool = backend.pool_for_test();
+    let state: String = sqlx::query_scalar(
+        "SELECT public_flow_state FROM ff_flow_core WHERE partition_key=0 AND flow_id=?1",
+    )
+    .bind(fid.0)
+    .fetch_one(pool)
+    .await
+    .expect("flow state");
+    assert_eq!(state, "cancelled");
+
+    for eid in &members {
+        let exec_uuid = Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap();
+        let lp: String = sqlx::query_scalar(
+            "SELECT lifecycle_phase FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
+        )
+        .bind(exec_uuid)
+        .fetch_one(pool)
+        .await
+        .expect("exec lifecycle_phase");
+        assert_eq!(lp, "cancelled");
+    }
+
+    // Completion outbox has 3 rows with outcome='cancelled'.
+    let completion_rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_completion_event WHERE flow_id = ?1 AND outcome='cancelled'",
+    )
+    .bind(fid.0)
+    .fetch_one(pool)
+    .await
+    .expect("count completion");
+    assert_eq!(completion_rows, 3);
+
+    // Lease event outbox has 3 'revoked' rows for the members.
+    let lease_rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_lease_event WHERE event_type='revoked'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("count lease");
+    assert_eq!(lease_rows, 3);
+}
+
+// ── stage_dependency_edge stale revision ──────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn stage_dependency_edge_rejects_stale_revision() {
+    let backend = fresh_backend().await;
+    let fid = FlowId::from_uuid(Uuid::new_v4());
+    backend
+        .create_flow(CreateFlowArgs {
+            flow_id: fid.clone(),
+            flow_kind: "dag".into(),
+            namespace: Namespace::new("default"),
+            now: TimestampMs::from_millis(0),
+        })
+        .await
+        .unwrap();
+    let up = new_exec_id();
+    let down = new_exec_id();
+    for eid in [&up, &down] {
+        backend
+            .create_execution(create_execution_args(eid, &[]))
+            .await
+            .unwrap();
+        backend
+            .add_execution_to_flow(AddExecutionToFlowArgs {
+                flow_id: fid.clone(),
+                execution_id: eid.clone(),
+                now: TimestampMs::from_millis(10),
+            })
+            .await
+            .unwrap();
+    }
+
+    // graph_revision is now 2 (two node-adds). Stage with expected=99
+    // → StaleGraphRevision contention.
+    let err = backend
+        .stage_dependency_edge(StageDependencyEdgeArgs {
+            flow_id: fid,
+            edge_id: EdgeId::from_uuid(Uuid::new_v4()),
+            upstream_execution_id: up,
+            downstream_execution_id: down,
+            dependency_kind: "success_only".into(),
+            data_passing_ref: None,
+            expected_graph_revision: 99,
+            now: TimestampMs::from_millis(20),
+        })
+        .await
+        .expect_err("expect stale rev");
+    assert!(
+        matches!(
+            err,
+            ff_core::engine_error::EngineError::Contention(
+                ff_core::engine_error::ContentionKind::StaleGraphRevision
+            )
+        ),
+        "unexpected error: {err:?}"
+    );
+}
+
+// ── Pubsub foundation smoke (Group D.1) ────────────────────────────────
+
+/// End-to-end smoke: `complete()` writes ff_completion_event + emits
+/// a wakeup on the completion broadcast channel. We don't yet have a
+/// subscribe_completion trait surface (Phase 2b.2); this test asserts
+/// the outbox row lands with the correct event_id via direct SQL —
+/// the broadcast emit itself is exercised indirectly by the channel's
+/// receiver-count being non-zero post-commit (manufactured here by
+/// subscribing to the channel via a test-only pool accessor).
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_writes_completion_outbox_row() {
+    let backend = fresh_backend().await;
+    let pool = backend.pool_for_test();
+
+    // Seed one runnable exec via the producer surface now that it exists.
+    let eid = new_exec_id();
+    backend
+        .create_execution(create_execution_args(&eid, &[]))
+        .await
+        .expect("create_execution");
+    // Fast-path the exec_core into runnable/eligible so claim picks
+    // it up (create_execution seeds `submitted/waiting`; PG's scheduler
+    // promotes to runnable separately — SQLite doesn't have a scheduler,
+    // so we promote inline here).
+    let exec_uuid = Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', public_state='pending', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w"),
+        WorkerInstanceId::new("wi"),
+        30_000,
+        None,
+    );
+    let caps = CapabilitySet::new::<_, &str>([]);
+    let h = backend
+        .claim(&LaneId::new("default"), &caps, policy)
+        .await
+        .expect("claim")
+        .expect("some handle");
+
+    backend.complete(&h, None).await.expect("complete");
+
+    // Durable replay: ff_completion_event has one row with outcome=success.
+    let outcome: String = sqlx::query_scalar(
+        "SELECT outcome FROM ff_completion_event WHERE execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read completion event");
+    assert_eq!(outcome, "success");
+}

--- a/crates/ff-backend-sqlite/tests/producer_flow.rs
+++ b/crates/ff-backend-sqlite/tests/producer_flow.rs
@@ -421,18 +421,23 @@ async fn stage_dependency_edge_rejects_stale_revision() {
 
 // ── Pubsub foundation smoke (Group D.1) ────────────────────────────────
 
-/// End-to-end smoke: `complete()` writes ff_completion_event + emits
-/// a wakeup on the completion broadcast channel. We don't yet have a
-/// subscribe_completion trait surface (Phase 2b.2); this test asserts
-/// the outbox row lands with the correct event_id via direct SQL —
-/// the broadcast emit itself is exercised indirectly by the channel's
-/// receiver-count being non-zero post-commit (manufactured here by
-/// subscribing to the channel via a test-only pool accessor).
+/// End-to-end smoke covering BOTH halves of Group D.1:
+///   1. Durable replay path — `ff_completion_event` row with
+///      `outcome='success'` lands.
+///   2. Broadcast wakeup path — a subscriber on the completion
+///      channel (obtained via the test-only
+///      `subscribe_completion_for_test` accessor) receives an
+///      `OutboxEvent` with `event_id` matching the outbox row.
 #[tokio::test]
 #[serial(ff_dev_mode)]
-async fn complete_writes_completion_outbox_row() {
+async fn complete_writes_outbox_row_and_wakes_broadcast_subscriber() {
     let backend = fresh_backend().await;
     let pool = backend.pool_for_test();
+
+    // Subscribe BEFORE the write so the broadcast receiver is
+    // attached at post-commit emit time. broadcast channels only
+    // deliver to subscribers attached at send time.
+    let mut rx = backend.subscribe_completion_for_test();
 
     // Seed one runnable exec via the producer surface now that it exists.
     let eid = new_exec_id();
@@ -469,13 +474,25 @@ async fn complete_writes_completion_outbox_row() {
 
     backend.complete(&h, None).await.expect("complete");
 
-    // Durable replay: ff_completion_event has one row with outcome=success.
-    let outcome: String = sqlx::query_scalar(
-        "SELECT outcome FROM ff_completion_event WHERE execution_id = ?1",
+    // Durable-replay assertion: ff_completion_event has one row with
+    // outcome=success and its event_id matches what the broadcast
+    // emitted.
+    let (outcome, db_event_id): (String, i64) = sqlx::query_as(
+        "SELECT outcome, event_id FROM ff_completion_event WHERE execution_id = ?1",
     )
     .bind(exec_uuid)
     .fetch_one(pool)
     .await
     .expect("read completion event");
     assert_eq!(outcome, "success");
+
+    // Broadcast-wakeup assertion: the receiver gets an OutboxEvent
+    // whose event_id matches the persisted row. Use a short timeout
+    // so a missed wakeup fails loudly instead of hanging the test.
+    let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+        .await
+        .expect("broadcast wakeup within 500ms")
+        .expect("broadcast channel healthy");
+    assert_eq!(ev.event_id, db_event_id);
+    assert_eq!(ev.partition_key, 0);
 }


### PR DESCRIPTION
## Summary

RFC-023 Phase 2b.1 — replaces 6 Unavailable stubs with real bodies and wires the full post-commit broadcast topology (Group A producer exec/flow + Group D.1 pubsub foundation). Group B (suspend/signal), Group C (stream reads), and Group D.2 (subscribe trait surface) land in Phase 2b.2.

## Methods landed

| Trait method | Mirror of |
|---|---|
| `create_execution` | `ff-backend-postgres/src/exec_core.rs::create_execution_impl` |
| `create_flow` | `ff-backend-postgres/src/flow_staging.rs::create_flow` |
| `add_execution_to_flow` | `ff-backend-postgres/src/flow_staging.rs::add_execution_to_flow` |
| `stage_dependency_edge` | `ff-backend-postgres/src/flow_staging.rs::stage_dependency_edge` |
| `apply_dependency_to_child` | `ff-backend-postgres/src/flow_staging.rs::apply_dependency_to_child` |
| `cancel_flow` (classic) | `ff-backend-postgres/src/flow.rs::cancel_flow` |

Every body mirrors PG statement-by-statement; dialect changes are contained to `json_set` + `json_extract` (JSON1) replacing `jsonb_set` / `jsonb_build_object`, and `BEGIN IMMEDIATE` single-writer serialization replacing `FOR UPDATE` row locks.

## Broadcast topology (Group D.1)

Five `tokio::sync::broadcast` channels on `SqliteBackendInner::pubsub`, one per outbox table:

| Channel | Outbox table |
|---|---|
| `lease_history` | `ff_lease_event` |
| `completion` | `ff_completion_event` |
| `signal_delivery` | `ff_signal_event` |
| `stream_frame` | `ff_stream_frame` |
| `operator_event` | `ff_operator_event` |

`OutboxEvent { event_id, partition_key }` is read from `last_insert_rowid()` inside the writing transaction; `dispatch_pending_emits` fires AFTER `tx.commit()` returns (RFC-023 §4.2 A2 — broadcast is wakeup only, durable replay rides `event_id > cursor`).

Post-commit emit wiring attached to the 7 Phase 2a outbox-writing methods: `claim`, `complete`, `fail`, `renew`, `append_frame`, `claim_from_reclaim`, plus the new `cancel_flow`'s per-member completion + lease-revoked emits.

## Tests

5 new tests in `tests/producer_flow.rs`:

- `create_execution_seeds_exec_core_and_capability_junction` — verifies `ff_exec_core` row + junction populated from `ExecutionPolicy.routing_requirements.required_capabilities` + lane registry seeded; idempotent replay returns `Duplicate`.
- `create_flow_idempotent` — second call returns `AlreadySatisfied`.
- `flow_build_cancel_roundtrip` — 3 `add_execution_to_flow` calls (revision 1→3) + 2 `stage_dependency_edge` calls (rev 3→4→5) + `apply_dependency_to_child` including idempotent replay → `AlreadyApplied` + final `cancel_flow(CancelAll)` produces 3 completion-event rows (`outcome='cancelled'`) and 3 `ff_lease_event` rows (`event_type='revoked'`) with flow_core flipped to cancelled.
- `stage_dependency_edge_rejects_stale_revision` — `expected_graph_revision=99` on a rev-2 flow surfaces `Contention(StaleGraphRevision)`.
- `complete_writes_completion_outbox_row` — end-to-end smoke: `create_execution` + claim + complete writes `ff_completion_event` row with `outcome='success'`, confirming the full Group A + D.1 wiring.

All 31 SQLite tests pass (22 hot_path + 4 migrations + 5 producer_flow); workspace build clean.

## RFC-vs-reality gaps (documented inline, none blocking)

- **`stage_dependency_edge` duplicate edge surface.** PG returns `Conflict(DependencyAlreadyExists { existing: EdgeSnapshot })` by re-reading via `describe_edge`. Since SQLite does not yet have a `describe_edge` implementation (Phase 2b.2 scope), the duplicate-edge path currently returns `Validation { detail: \"dependency_already_exists:edge_id=<uuid>\" }`. Semantic signal preserved; error kind tightens when Phase 2b.2 lands the reader. Documented at the call-site.
- **`cancel_flow` `wait` axis.** Under single-writer SQLite every member flip commits in the header transaction, so the response is always synchronous `Cancelled {..}` — `wait=NoWait` and `wait=Wait` observe the same result. This is by construction, not a gap; documented in the trait impl.

## CI summary

- `cargo build --workspace` — clean
- `cargo test -p ff-backend-sqlite` — 31 pass / 0 fail
- `cargo check -p ff-sdk --no-default-features --features sqlite` — clean (no ff-sdk changes)
- Phase 1a semver breaks still expected (pre-existing)
- Valkey cluster flake #369 ignorable if sole failure (pre-existing)

## 2b.2 scope (next session, explicit)

Group B (`suspend`, `deliver_signal`, `claim_resumed_execution`, waitpoint HMAC), Group C (`read_stream` / `tail_stream` / `read_summary`), and Group D.2 (`subscribe_completion` / `subscribe_lease_history` / `subscribe_signal_delivery` trait surface + outbox cursor-resume reader). No further producer methods land in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it replaces multiple `Unavailable` stubs with transactional SQL that mutates core execution/flow state and adds post-commit broadcast behavior tied to outbox `event_id` sequencing. Bugs here could cause incorrect flow graph revisions, cancellation fan-out, or missed wakeups for future subscribers.
> 
> **Overview**
> Adds SQLite implementations for key *producer/flow-ingress* operations: `create_execution`, `create_flow`, `add_execution_to_flow`, `stage_dependency_edge`, `apply_dependency_to_child`, and classic `cancel_flow`, including idempotency and graph-revision CAS behavior.
> 
> Introduces a per-backend pubsub foundation with five `tokio::sync::broadcast` channels and a new `OutboxEvent { event_id, partition_key }`; hot-path methods that write outbox rows (`claim`, `complete`, `fail`, `renew`, `append_frame`, `claim_from_reclaim`, plus `cancel_flow`) now queue emits during the transaction and dispatch them **only after** `tx.commit()` succeeds.
> 
> Adds new SQLite query modules (`queries/flow.rs`, `queries/flow_staging.rs`) and extends existing query consts to support the new producer paths, plus a new `tests/producer_flow.rs` suite covering flow build/stage/apply/cancel and outbox/pubsub smoke.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f150e3fe1a871885d83ce010908c8d0f6547296. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->