### PR TITLE
feat(backend-sqlite): Phase 3.1 — subscribe_completion/lease_history/signal_delivery via OutboxCursorReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 3.1 subscribe methods (RFC-023
+  Wave 9 / RFC-019 Stage B/C).** Replaces the 3 `Unavailable` defaults
+  for `subscribe_completion`, `subscribe_lease_history`, and
+  `subscribe_signal_delivery` with real bodies built on the Phase
+  2b.2.2 `OutboxCursorReader` primitive: catch-up SELECT on subscribe,
+  park on the matching `pubsub` broadcast channel for post-commit
+  wakeups, re-SELECT on each wake, decode typed events via per-family
+  closures. Cursor encoding reuses the Postgres family prefix
+  (`0x02 ++ event_id(BE8)`) — SQLite's i64 event_ids are equivalent
+  in shape — so cursors are wire-stable across backends. `ScannerFilter`
+  is applied in the row decoder against the outbox's denormalised
+  `namespace` + `instance_tag` columns (matching the PG reference at
+  `ff-backend-postgres/src/lease_event_subscribe.rs`); NULL filter
+  columns silently drop under any non-noop filter, preserving the
+  cross-backend "filtered subscribers drop NULL-column rows"
+  invariant. `subscribe_instance_tags` remains on the trait default
+  (`Unavailable`) per RFC-020 §3.2 / the #311 deferral.
+- `crates/ff-backend-sqlite/src/completion_subscribe.rs`,
+  `src/lease_event_subscribe.rs`, `src/signal_delivery_subscribe.rs`
+  — one module per subscribe method; each owns its SELECT SQL, row
+  decoder, and typed-event mapping. Module naming mirrors the PG
+  reference for straight cross-backend diff.
+- `crates/ff-backend-sqlite/tests/subscribe.rs` — 10-test integration
+  harness covering tail happy-path, cursor-resume across subscribe
+  sessions, `ScannerFilter::instance_tag` behaviour (positive match
+  through the signal-delivery outbox where the producer populates
+  the column via `json_extract`; null-drop on lease/completion where
+  the producer writes NULL today), and lagged-broadcast recovery
+  (300 completions vs the 256-slot broadcast ring, verifying the
+  cursor-select fallback catches every durable row after a
+  `RecvError::Lagged`).
 - **`crates/ff-backend-sqlite` — Phase 2b.2.2 stream readers + outbox
   cursor-resume primitive (RFC-023 Group C + Group D.2; completes
   Phase 2).** Replaces the 3 Group C `Unavailable` stubs with real

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2737,6 +2737,49 @@ impl EngineBackend for SqliteBackend {
         retry_serializable(|| apply_dependency_to_child_impl(pool, &args)).await
     }
 
+    // ── RFC-019 Stage B/C — subscribe_* (Phase 3.1) ──────────────────
+    //
+    // Each method wraps the Phase 2b.2.2
+    // [`crate::outbox_cursor::OutboxCursorReader`] primitive against
+    // the matching outbox table + broadcast channel. Cursor encoding,
+    // `ScannerFilter` semantics, and event-type → typed-variant
+    // mapping all mirror the Postgres reference in
+    // `ff-backend-postgres/src/{lease,signal_delivery}_subscribe.rs`
+    // so cross-backend consumers see identical shapes.
+    //
+    // `subscribe_instance_tags` stays on the trait default
+    // (`Unavailable`) per RFC-020 §3.2 / the #311 deferral.
+
+    async fn subscribe_completion(
+        &self,
+        cursor: ff_core::stream_subscribe::StreamCursor,
+        filter: &ff_core::backend::ScannerFilter,
+    ) -> Result<ff_core::stream_events::CompletionSubscription, EngineError> {
+        let pool = self.inner.pool.clone();
+        let wakeup = self.inner.pubsub.completion.subscribe();
+        crate::completion_subscribe::subscribe(pool, wakeup, cursor, filter.clone()).await
+    }
+
+    async fn subscribe_lease_history(
+        &self,
+        cursor: ff_core::stream_subscribe::StreamCursor,
+        filter: &ff_core::backend::ScannerFilter,
+    ) -> Result<ff_core::stream_events::LeaseHistorySubscription, EngineError> {
+        let pool = self.inner.pool.clone();
+        let wakeup = self.inner.pubsub.lease_history.subscribe();
+        crate::lease_event_subscribe::subscribe(pool, wakeup, cursor, filter.clone()).await
+    }
+
+    async fn subscribe_signal_delivery(
+        &self,
+        cursor: ff_core::stream_subscribe::StreamCursor,
+        filter: &ff_core::backend::ScannerFilter,
+    ) -> Result<ff_core::stream_events::SignalDeliverySubscription, EngineError> {
+        let pool = self.inner.pool.clone();
+        let wakeup = self.inner.pubsub.signal_delivery.subscribe();
+        crate::signal_delivery_subscribe::subscribe(pool, wakeup, cursor, filter.clone()).await
+    }
+
     // ── HMAC secret management (RFC-023 Phase 2b.2.1) ──
 
     async fn seed_waitpoint_hmac_secret(

--- a/crates/ff-backend-sqlite/src/completion_subscribe.rs
+++ b/crates/ff-backend-sqlite/src/completion_subscribe.rs
@@ -1,0 +1,224 @@
+//! RFC-023 Phase 3.1 — `subscribe_completion` on SQLite.
+//!
+//! Tails the `ff_completion_event` outbox via the Phase 2b.2.2
+//! [`OutboxCursorReader`](crate::outbox_cursor) primitive: catch-up
+//! SELECT on subscribe, park on the `completion` broadcast channel
+//! for post-commit wakeups, re-SELECT on each wake. Mirrors
+//! `ff-backend-postgres/src/lib.rs::subscribe_completion` semantics
+//! (catch-up → NOTIFY-wake replay loop) but swaps `LISTEN/NOTIFY`
+//! for the in-process broadcast fan-out defined in
+//! [`crate::pubsub`].
+//!
+//! # Cursor encoding
+//!
+//! Reuses the Postgres family prefix (`0x02 ++ event_id(BE8)`) —
+//! per the RFC-023 autonomy note the SQLite event_id is i64 like PG,
+//! so sharing the codec keeps the cursor wire-stable.
+//!
+//! # Filter application
+//!
+//! `ScannerFilter` is evaluated in the row decoder (mirror of
+//! `ff-backend-postgres/src/lease_event_subscribe::passes_filter`):
+//! the outbox stores denormalised `namespace` + `instance_tag`
+//! columns; NULL columns never match a non-None filter dimension.
+//! This matches the "filtered subscribers silently drop NULL-column
+//! rows" invariant documented on migration 0008/0009.
+//!
+//! Note: the current SQLite `INSERT_COMPLETION_EVENT_SQL` writes
+//! NULL for both filter columns on the completion path (see
+//! `queries/attempt.rs`), so on a non-noop filter every completion
+//! row is dropped today. That mirrors the behaviour any PG
+//! deployment would see before the outbox is taught to populate
+//! those columns. Populating the columns is producer-side work
+//! outside Phase 3.1 scope.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::stream_events::{CompletionEvent, CompletionOutcome, CompletionSubscription};
+use ff_core::stream_subscribe::{
+    StreamCursor, decode_postgres_event_cursor, encode_postgres_event_cursor,
+};
+use ff_core::types::{ExecutionId, TimestampMs};
+
+use crate::outbox_cursor::{self, OutboxCursorConfig, OutboxCursorStream, RowDecoder};
+use crate::pubsub::OutboxEvent;
+
+/// Rows above `partition_key = ?1 AND event_id > ?2`, ASC, limited.
+/// Reads the denormalised filter columns so the row decoder can apply
+/// [`ScannerFilter`] without a per-row RTT.
+pub(crate) const SELECT_COMPLETION_EVENTS_SQL: &str = r#"
+    SELECT event_id, execution_id, outcome, occurred_at_ms,
+           partition_key, namespace, instance_tag
+      FROM ff_completion_event
+     WHERE partition_key = ?1 AND event_id > ?2
+  ORDER BY event_id ASC
+     LIMIT ?3
+"#;
+
+const PARTITION_KEY: i64 = 0;
+const REPLAY_BATCH: i64 = 256;
+
+pub(crate) async fn subscribe(
+    pool: SqlitePool,
+    wakeup: broadcast::Receiver<OutboxEvent>,
+    cursor: StreamCursor,
+    filter: ScannerFilter,
+) -> Result<CompletionSubscription, EngineError> {
+    let start = decode_postgres_event_cursor(&cursor).map_err(|msg| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: msg.to_string(),
+    })?;
+
+    // Empty cursor → tail from `max(event_id)` at subscribe time. This
+    // matches the PG `subscribe_completion` contract: a fresh
+    // subscription observes only events committed after the call
+    // returns, not historical events. A concrete cursor from a prior
+    // session replays strictly above that position.
+    let last_seen: i64 = match start {
+        Some(v) => v,
+        None => sqlx::query_scalar(
+            "SELECT COALESCE(MAX(event_id), 0) FROM ff_completion_event \
+             WHERE partition_key = ?1",
+        )
+        .bind(PARTITION_KEY)
+        .fetch_one(&pool)
+        .await
+        .map_err(|_| EngineError::Unavailable {
+            op: "sqlite.subscribe_completion",
+        })?,
+    };
+
+    let stream = outbox_cursor::spawn(OutboxCursorConfig {
+        pool,
+        select_sql: SELECT_COMPLETION_EVENTS_SQL,
+        partition_key: PARTITION_KEY,
+        cursor: last_seen,
+        batch_size: REPLAY_BATCH,
+        wakeup,
+        decoder: make_decoder(filter),
+        row_event_id: extract_event_id,
+    });
+
+    Ok(Box::pin(TypedStream { inner: stream }))
+}
+
+/// Wrap the untyped [`OutboxCursorStream`] in the
+/// `CompletionSubscription` return alias.
+struct TypedStream {
+    inner: OutboxCursorStream<CompletionEvent>,
+}
+
+impl Stream for TypedStream {
+    type Item = Result<CompletionEvent, EngineError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+fn extract_event_id(row: &sqlx::sqlite::SqliteRow) -> Result<i64, EngineError> {
+    row.try_get("event_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("ff_completion_event.event_id: {e}"),
+        })
+}
+
+fn make_decoder(filter: ScannerFilter) -> RowDecoder<CompletionEvent> {
+    Box::new(move |row| decode_row(row, &filter))
+}
+
+fn decode_row(
+    row: &sqlx::sqlite::SqliteRow,
+    filter: &ScannerFilter,
+) -> Result<Option<CompletionEvent>, EngineError> {
+    let event_id: i64 = row
+        .try_get("event_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("event_id: {e}"),
+        })?;
+
+    // Denormalised filter columns. NULL never matches a non-None
+    // filter dimension — parity with PG + Valkey.
+    let namespace: Option<String> = row
+        .try_get::<Option<String>, _>("namespace")
+        .unwrap_or(None);
+    let instance_tag: Option<String> = row
+        .try_get::<Option<String>, _>("instance_tag")
+        .unwrap_or(None);
+    if !passes_filter(filter, namespace.as_deref(), instance_tag.as_deref()) {
+        return Ok(None);
+    }
+
+    // Execution id is stored as a 16-byte BLOB in SQLite (diverges from
+    // PG's `Uuid`). Re-attach the `{fp:N}:<uuid>` hash-tag so downstream
+    // consumers see the canonical shape.
+    let partition_key: i64 = row
+        .try_get("partition_key")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("partition_key: {e}"),
+        })?;
+    let exec_uuid: Uuid = row
+        .try_get("execution_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("execution_id: {e}"),
+        })?;
+    let execution_id = ExecutionId::parse(&format!("{{fp:{partition_key}}}:{exec_uuid}"))
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("ff_completion_event.execution_id: {e}"),
+        })?;
+
+    let outcome: String = row.try_get("outcome").map_err(|e| EngineError::Validation {
+        kind: ValidationKind::Corruption,
+        detail: format!("outcome: {e}"),
+    })?;
+    let occurred_at_ms: i64 = row
+        .try_get("occurred_at_ms")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("occurred_at_ms: {e}"),
+        })?;
+
+    let cursor = encode_postgres_event_cursor(event_id);
+    Ok(Some(CompletionEvent::new(
+        cursor,
+        execution_id,
+        CompletionOutcome::from_wire(&outcome),
+        TimestampMs::from_millis(occurred_at_ms),
+    )))
+}
+
+/// Shared filter predicate — mirror of
+/// `ff-backend-postgres/src/lease_event_subscribe::passes_filter`.
+pub(crate) fn passes_filter(
+    filter: &ScannerFilter,
+    row_namespace: Option<&str>,
+    row_instance_tag: Option<&str>,
+) -> bool {
+    if let Some(ref want_ns) = filter.namespace {
+        match row_namespace {
+            Some(have) if have == want_ns.as_str() => {}
+            _ => return false,
+        }
+    }
+    if let Some((_, ref want_value)) = filter.instance_tag {
+        match row_instance_tag {
+            Some(have) if have == want_value.as_str() => {}
+            _ => return false,
+        }
+    }
+    true
+}

--- a/crates/ff-backend-sqlite/src/completion_subscribe.rs
+++ b/crates/ff-backend-sqlite/src/completion_subscribe.rs
@@ -73,9 +73,13 @@ pub(crate) async fn subscribe(
     cursor: StreamCursor,
     filter: ScannerFilter,
 ) -> Result<CompletionSubscription, EngineError> {
-    let start = decode_postgres_event_cursor(&cursor).map_err(|msg| EngineError::Validation {
+    // The underlying codec message names the Postgres family because
+    // SQLite reuses the `0x02` prefix; rewrite the detail so SQLite
+    // callers see a backend-appropriate hint instead of a confusing
+    // cross-backend name.
+    let start = decode_postgres_event_cursor(&cursor).map_err(|_| EngineError::Validation {
         kind: ValidationKind::InvalidInput,
-        detail: msg.to_string(),
+        detail: "invalid event_id cursor for sqlite.subscribe_completion".into(),
     })?;
 
     // Empty cursor → tail from `max(event_id)` at subscribe time. This
@@ -149,13 +153,21 @@ fn decode_row(
         })?;
 
     // Denormalised filter columns. NULL never matches a non-None
-    // filter dimension — parity with PG + Valkey.
+    // filter dimension — parity with PG + Valkey. A type-mismatch on
+    // these TEXT columns is a schema-level corruption surface, not a
+    // null; propagate as `Corruption` rather than silently defaulting.
     let namespace: Option<String> = row
         .try_get::<Option<String>, _>("namespace")
-        .unwrap_or(None);
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("namespace: {e}"),
+        })?;
     let instance_tag: Option<String> = row
         .try_get::<Option<String>, _>("instance_tag")
-        .unwrap_or(None);
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("instance_tag: {e}"),
+        })?;
     if !passes_filter(filter, namespace.as_deref(), instance_tag.as_deref()) {
         return Ok(None);
     }

--- a/crates/ff-backend-sqlite/src/lease_event_subscribe.rs
+++ b/crates/ff-backend-sqlite/src/lease_event_subscribe.rs
@@ -1,0 +1,235 @@
+//! RFC-023 Phase 3.1 — `subscribe_lease_history` on SQLite.
+//!
+//! Tails `ff_lease_event` via [`OutboxCursorReader`](crate::outbox_cursor).
+//! Mirror of `ff-backend-postgres/src/lease_event_subscribe.rs`.
+//! Cursor encoding, filter semantics, and event-type → typed-variant
+//! mapping all match the PG reference so cross-backend consumer code
+//! is identical.
+//!
+//! Notes on SQLite producer shape (current as of Phase 2b.1):
+//!  * `execution_id` column is TEXT (UUID string), not BLOB.
+//!  * `lease_id` is always NULL on insert (PG reference is likewise
+//!    NULL in most paths).
+//!  * `namespace` + `instance_tag` are always NULL on insert today —
+//!    populating them is producer-side follow-up work; filtered
+//!    subscribers silently drop NULL-column rows, which matches the
+//!    cross-backend invariant on migrations 0008.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::stream_events::{LeaseHistoryEvent, LeaseHistorySubscription};
+use ff_core::stream_subscribe::{
+    StreamCursor, decode_postgres_event_cursor, encode_postgres_event_cursor,
+};
+use ff_core::types::{ExecutionId, LeaseId, TimestampMs};
+
+use crate::completion_subscribe::passes_filter;
+use crate::outbox_cursor::{self, OutboxCursorConfig, OutboxCursorStream, RowDecoder};
+use crate::pubsub::OutboxEvent;
+
+pub(crate) const SELECT_LEASE_EVENTS_SQL: &str = r#"
+    SELECT event_id, execution_id, lease_id, event_type, occurred_at_ms,
+           partition_key, namespace, instance_tag
+      FROM ff_lease_event
+     WHERE partition_key = ?1 AND event_id > ?2
+  ORDER BY event_id ASC
+     LIMIT ?3
+"#;
+
+const PARTITION_KEY: i64 = 0;
+const REPLAY_BATCH: i64 = 256;
+
+pub(crate) async fn subscribe(
+    pool: SqlitePool,
+    wakeup: broadcast::Receiver<OutboxEvent>,
+    cursor: StreamCursor,
+    filter: ScannerFilter,
+) -> Result<LeaseHistorySubscription, EngineError> {
+    let start = decode_postgres_event_cursor(&cursor).map_err(|msg| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: msg.to_string(),
+    })?;
+
+    let last_seen: i64 = match start {
+        Some(v) => v,
+        None => sqlx::query_scalar(
+            "SELECT COALESCE(MAX(event_id), 0) FROM ff_lease_event \
+             WHERE partition_key = ?1",
+        )
+        .bind(PARTITION_KEY)
+        .fetch_one(&pool)
+        .await
+        .map_err(|_| EngineError::Unavailable {
+            op: "sqlite.subscribe_lease_history",
+        })?,
+    };
+
+    let stream = outbox_cursor::spawn(OutboxCursorConfig {
+        pool,
+        select_sql: SELECT_LEASE_EVENTS_SQL,
+        partition_key: PARTITION_KEY,
+        cursor: last_seen,
+        batch_size: REPLAY_BATCH,
+        wakeup,
+        decoder: make_decoder(filter),
+        row_event_id: extract_event_id,
+    });
+
+    Ok(Box::pin(TypedStream { inner: stream }))
+}
+
+struct TypedStream {
+    inner: OutboxCursorStream<LeaseHistoryEvent>,
+}
+
+impl Stream for TypedStream {
+    type Item = Result<LeaseHistoryEvent, EngineError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+fn extract_event_id(row: &sqlx::sqlite::SqliteRow) -> Result<i64, EngineError> {
+    row.try_get("event_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("ff_lease_event.event_id: {e}"),
+        })
+}
+
+fn make_decoder(filter: ScannerFilter) -> RowDecoder<LeaseHistoryEvent> {
+    Box::new(move |row| decode_row(row, &filter))
+}
+
+fn decode_row(
+    row: &sqlx::sqlite::SqliteRow,
+    filter: &ScannerFilter,
+) -> Result<Option<LeaseHistoryEvent>, EngineError> {
+    let event_id: i64 = row
+        .try_get("event_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("event_id: {e}"),
+        })?;
+
+    let namespace: Option<String> = row
+        .try_get::<Option<String>, _>("namespace")
+        .unwrap_or(None);
+    let instance_tag: Option<String> = row
+        .try_get::<Option<String>, _>("instance_tag")
+        .unwrap_or(None);
+    if !passes_filter(filter, namespace.as_deref(), instance_tag.as_deref()) {
+        return Ok(None);
+    }
+
+    let exec_text: String = row
+        .try_get("execution_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("execution_id: {e}"),
+        })?;
+    let partition_key: i64 = row
+        .try_get("partition_key")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("partition_key: {e}"),
+        })?;
+    let exec_uuid = match Uuid::parse_str(&exec_text) {
+        Ok(u) => u,
+        Err(_) => {
+            tracing::warn!(
+                execution_id = %exec_text,
+                event_id = event_id,
+                "sqlite.lease_history: skipping row with unparseable execution_id"
+            );
+            return Ok(None);
+        }
+    };
+    let execution_id = ExecutionId::parse(&format!("{{fp:{partition_key}}}:{exec_uuid}"))
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("ff_lease_event.execution_id: {e}"),
+        })?;
+
+    let lease_id_str: Option<String> = row
+        .try_get::<Option<String>, _>("lease_id")
+        .unwrap_or(None);
+    let lease_id = lease_id_str
+        .as_deref()
+        .and_then(|s| LeaseId::parse(s).ok());
+
+    let event_type: String = row
+        .try_get("event_type")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("event_type: {e}"),
+        })?;
+    let occurred_at_ms: i64 =
+        row.try_get("occurred_at_ms")
+            .map_err(|e| EngineError::Validation {
+                kind: ValidationKind::Corruption,
+                detail: format!("occurred_at_ms: {e}"),
+            })?;
+
+    let cursor = encode_postgres_event_cursor(event_id);
+    let at = TimestampMs::from_millis(occurred_at_ms);
+    // SQLite outbox does not yet persist the owning worker instance
+    // or the revoke source — mirror the PG reference's `None` /
+    // `"operator"` defaults.
+    let event = match event_type.as_str() {
+        "acquired" => LeaseHistoryEvent::Acquired {
+            cursor,
+            execution_id,
+            lease_id,
+            worker_instance_id: None,
+            at,
+        },
+        "renewed" => LeaseHistoryEvent::Renewed {
+            cursor,
+            execution_id,
+            lease_id,
+            worker_instance_id: None,
+            at,
+        },
+        "expired" => LeaseHistoryEvent::Expired {
+            cursor,
+            execution_id,
+            lease_id,
+            prev_owner: None,
+            at,
+        },
+        "reclaimed" => LeaseHistoryEvent::Reclaimed {
+            cursor,
+            execution_id,
+            new_lease_id: lease_id,
+            new_owner: None,
+            at,
+        },
+        "revoked" => LeaseHistoryEvent::Revoked {
+            cursor,
+            execution_id,
+            lease_id,
+            revoked_by: "operator".to_string(),
+            at,
+        },
+        other => {
+            tracing::warn!(
+                event_id = event_id,
+                event_type = %other,
+                "sqlite.lease_history: unknown event_type, skipping"
+            );
+            return Ok(None);
+        }
+    };
+    Ok(Some(event))
+}

--- a/crates/ff-backend-sqlite/src/lease_event_subscribe.rs
+++ b/crates/ff-backend-sqlite/src/lease_event_subscribe.rs
@@ -54,9 +54,12 @@ pub(crate) async fn subscribe(
     cursor: StreamCursor,
     filter: ScannerFilter,
 ) -> Result<LeaseHistorySubscription, EngineError> {
-    let start = decode_postgres_event_cursor(&cursor).map_err(|msg| EngineError::Validation {
+    // See completion_subscribe::subscribe — rewrite the underlying
+    // Postgres-branded detail so SQLite callers see a backend-fit
+    // message.
+    let start = decode_postgres_event_cursor(&cursor).map_err(|_| EngineError::Validation {
         kind: ValidationKind::InvalidInput,
-        detail: msg.to_string(),
+        detail: "invalid event_id cursor for sqlite.subscribe_lease_history".into(),
     })?;
 
     let last_seen: i64 = match start {
@@ -122,12 +125,20 @@ fn decode_row(
             detail: format!("event_id: {e}"),
         })?;
 
+    // Type-mismatch on denormalised filter columns is schema
+    // corruption, not a legitimate NULL; surface loudly.
     let namespace: Option<String> = row
         .try_get::<Option<String>, _>("namespace")
-        .unwrap_or(None);
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("namespace: {e}"),
+        })?;
     let instance_tag: Option<String> = row
         .try_get::<Option<String>, _>("instance_tag")
-        .unwrap_or(None);
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("instance_tag: {e}"),
+        })?;
     if !passes_filter(filter, namespace.as_deref(), instance_tag.as_deref()) {
         return Ok(None);
     }
@@ -144,17 +155,14 @@ fn decode_row(
             kind: ValidationKind::Corruption,
             detail: format!("partition_key: {e}"),
         })?;
-    let exec_uuid = match Uuid::parse_str(&exec_text) {
-        Ok(u) => u,
-        Err(_) => {
-            tracing::warn!(
-                execution_id = %exec_text,
-                event_id = event_id,
-                "sqlite.lease_history: skipping row with unparseable execution_id"
-            );
-            return Ok(None);
-        }
-    };
+    // Producers always write a parseable UUID into `execution_id`; an
+    // unparseable value is storage-level corruption, not an
+    // operational skip. Surface `Corruption` so the subscriber fails
+    // loudly rather than silently dropping state transitions.
+    let exec_uuid = Uuid::parse_str(&exec_text).map_err(|e| EngineError::Validation {
+        kind: ValidationKind::Corruption,
+        detail: format!("ff_lease_event.execution_id parse '{exec_text}': {e}"),
+    })?;
     let execution_id = ExecutionId::parse(&format!("{{fp:{partition_key}}}:{exec_uuid}"))
         .map_err(|e| EngineError::Validation {
             kind: ValidationKind::Corruption,
@@ -163,10 +171,20 @@ fn decode_row(
 
     let lease_id_str: Option<String> = row
         .try_get::<Option<String>, _>("lease_id")
-        .unwrap_or(None);
-    let lease_id = lease_id_str
-        .as_deref()
-        .and_then(|s| LeaseId::parse(s).ok());
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("lease_id column: {e}"),
+        })?;
+    // A present-but-malformed `lease_id` is schema corruption, not a
+    // legitimate absent value — surface via `?` instead of dropping
+    // the parse error.
+    let lease_id = match lease_id_str.as_deref() {
+        Some(s) => Some(LeaseId::parse(s).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("lease_id parse '{s}': {e}"),
+        })?),
+        None => None,
+    };
 
     let event_type: String = row
         .try_get("event_type")

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -26,10 +26,13 @@
 #![allow(clippy::result_large_err)]
 
 mod backend;
+mod completion_subscribe;
 mod config;
 mod errors;
 mod handle_codec;
+mod lease_event_subscribe;
 mod outbox_cursor;
+mod signal_delivery_subscribe;
 #[doc(hidden)]
 pub mod pubsub;
 pub mod queries;

--- a/crates/ff-backend-sqlite/src/signal_delivery_subscribe.rs
+++ b/crates/ff-backend-sqlite/src/signal_delivery_subscribe.rs
@@ -1,0 +1,204 @@
+//! RFC-023 Phase 3.1 — `subscribe_signal_delivery` on SQLite.
+//!
+//! Tails `ff_signal_event` via the
+//! [`OutboxCursorReader`](crate::outbox_cursor) primitive.
+//! Mirror of `ff-backend-postgres/src/signal_delivery_subscribe.rs`.
+//!
+//! Unlike the lease/completion producers, the SQLite signal producer
+//! DOES populate `namespace` + `instance_tag` from `ff_exec_core`
+//! via `json_extract` (see `queries/signal.rs::INSERT_SIGNAL_EVENT_SQL`),
+//! so `ScannerFilter::instance_tag` is observable end-to-end.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use ff_core::backend::ScannerFilter;
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::stream_events::{SignalDeliveryEffect, SignalDeliveryEvent, SignalDeliverySubscription};
+use ff_core::stream_subscribe::{
+    StreamCursor, decode_postgres_event_cursor, encode_postgres_event_cursor,
+};
+use ff_core::types::{ExecutionId, SignalId, TimestampMs, WaitpointId};
+
+use crate::completion_subscribe::passes_filter;
+use crate::outbox_cursor::{self, OutboxCursorConfig, OutboxCursorStream, RowDecoder};
+use crate::pubsub::OutboxEvent;
+
+pub(crate) const SELECT_SIGNAL_EVENTS_SQL: &str = r#"
+    SELECT event_id, execution_id, signal_id, waitpoint_id,
+           source_identity, delivered_at_ms, partition_key,
+           namespace, instance_tag
+      FROM ff_signal_event
+     WHERE partition_key = ?1 AND event_id > ?2
+  ORDER BY event_id ASC
+     LIMIT ?3
+"#;
+
+const PARTITION_KEY: i64 = 0;
+const REPLAY_BATCH: i64 = 256;
+
+pub(crate) async fn subscribe(
+    pool: SqlitePool,
+    wakeup: broadcast::Receiver<OutboxEvent>,
+    cursor: StreamCursor,
+    filter: ScannerFilter,
+) -> Result<SignalDeliverySubscription, EngineError> {
+    let start = decode_postgres_event_cursor(&cursor).map_err(|msg| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: msg.to_string(),
+    })?;
+
+    let last_seen: i64 = match start {
+        Some(v) => v,
+        None => sqlx::query_scalar(
+            "SELECT COALESCE(MAX(event_id), 0) FROM ff_signal_event \
+             WHERE partition_key = ?1",
+        )
+        .bind(PARTITION_KEY)
+        .fetch_one(&pool)
+        .await
+        .map_err(|_| EngineError::Unavailable {
+            op: "sqlite.subscribe_signal_delivery",
+        })?,
+    };
+
+    let stream = outbox_cursor::spawn(OutboxCursorConfig {
+        pool,
+        select_sql: SELECT_SIGNAL_EVENTS_SQL,
+        partition_key: PARTITION_KEY,
+        cursor: last_seen,
+        batch_size: REPLAY_BATCH,
+        wakeup,
+        decoder: make_decoder(filter),
+        row_event_id: extract_event_id,
+    });
+
+    Ok(Box::pin(TypedStream { inner: stream }))
+}
+
+struct TypedStream {
+    inner: OutboxCursorStream<SignalDeliveryEvent>,
+}
+
+impl Stream for TypedStream {
+    type Item = Result<SignalDeliveryEvent, EngineError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+fn extract_event_id(row: &sqlx::sqlite::SqliteRow) -> Result<i64, EngineError> {
+    row.try_get("event_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("ff_signal_event.event_id: {e}"),
+        })
+}
+
+fn make_decoder(filter: ScannerFilter) -> RowDecoder<SignalDeliveryEvent> {
+    Box::new(move |row| decode_row(row, &filter))
+}
+
+fn decode_row(
+    row: &sqlx::sqlite::SqliteRow,
+    filter: &ScannerFilter,
+) -> Result<Option<SignalDeliveryEvent>, EngineError> {
+    let event_id: i64 = row
+        .try_get("event_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("event_id: {e}"),
+        })?;
+
+    let namespace: Option<String> = row
+        .try_get::<Option<String>, _>("namespace")
+        .unwrap_or(None);
+    let instance_tag: Option<String> = row
+        .try_get::<Option<String>, _>("instance_tag")
+        .unwrap_or(None);
+    if !passes_filter(filter, namespace.as_deref(), instance_tag.as_deref()) {
+        return Ok(None);
+    }
+
+    let exec_text: String = row
+        .try_get("execution_id")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("execution_id: {e}"),
+        })?;
+    let partition_key: i64 = row
+        .try_get("partition_key")
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("partition_key: {e}"),
+        })?;
+    let exec_uuid = match Uuid::parse_str(&exec_text) {
+        Ok(u) => u,
+        Err(_) => {
+            tracing::warn!(
+                execution_id = %exec_text,
+                event_id = event_id,
+                "sqlite.signal_delivery: skipping row with unparseable execution_id"
+            );
+            return Ok(None);
+        }
+    };
+    let execution_id = ExecutionId::parse(&format!("{{fp:{partition_key}}}:{exec_uuid}"))
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("ff_signal_event.execution_id: {e}"),
+        })?;
+
+    let signal_id_text: String =
+        row.try_get("signal_id").map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("signal_id: {e}"),
+        })?;
+    let signal_id = match SignalId::parse(&signal_id_text) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                event_id = event_id,
+                "sqlite.signal_delivery: skipping row with bad signal_id"
+            );
+            return Ok(None);
+        }
+    };
+
+    let waitpoint_text: Option<String> = row
+        .try_get::<Option<String>, _>("waitpoint_id")
+        .unwrap_or(None);
+    let waitpoint_id = waitpoint_text
+        .as_deref()
+        .and_then(|s| WaitpointId::parse(s).ok());
+    let source_identity: Option<String> = row
+        .try_get::<Option<String>, _>("source_identity")
+        .unwrap_or(None);
+    let delivered_at_ms: i64 =
+        row.try_get("delivered_at_ms")
+            .map_err(|e| EngineError::Validation {
+                kind: ValidationKind::Corruption,
+                detail: format!("delivered_at_ms: {e}"),
+            })?;
+
+    let cursor = encode_postgres_event_cursor(event_id);
+    // SQLite outbox does not yet persist the delivery effect; surface
+    // `Satisfied` as the PG reference does.
+    Ok(Some(SignalDeliveryEvent::new(
+        cursor,
+        execution_id,
+        signal_id,
+        waitpoint_id,
+        source_identity,
+        SignalDeliveryEffect::Satisfied,
+        TimestampMs::from_millis(delivered_at_ms),
+    )))
+}

--- a/crates/ff-backend-sqlite/src/signal_delivery_subscribe.rs
+++ b/crates/ff-backend-sqlite/src/signal_delivery_subscribe.rs
@@ -49,9 +49,11 @@ pub(crate) async fn subscribe(
     cursor: StreamCursor,
     filter: ScannerFilter,
 ) -> Result<SignalDeliverySubscription, EngineError> {
-    let start = decode_postgres_event_cursor(&cursor).map_err(|msg| EngineError::Validation {
+    // Rewrite the underlying Postgres-branded cursor-decode detail so
+    // SQLite callers see a backend-appropriate message.
+    let start = decode_postgres_event_cursor(&cursor).map_err(|_| EngineError::Validation {
         kind: ValidationKind::InvalidInput,
-        detail: msg.to_string(),
+        detail: "invalid event_id cursor for sqlite.subscribe_signal_delivery".into(),
     })?;
 
     let last_seen: i64 = match start {
@@ -117,12 +119,20 @@ fn decode_row(
             detail: format!("event_id: {e}"),
         })?;
 
+    // Type-mismatch on denormalised filter columns is schema
+    // corruption, not a legitimate NULL — surface loudly.
     let namespace: Option<String> = row
         .try_get::<Option<String>, _>("namespace")
-        .unwrap_or(None);
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("namespace: {e}"),
+        })?;
     let instance_tag: Option<String> = row
         .try_get::<Option<String>, _>("instance_tag")
-        .unwrap_or(None);
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("instance_tag: {e}"),
+        })?;
     if !passes_filter(filter, namespace.as_deref(), instance_tag.as_deref()) {
         return Ok(None);
     }
@@ -139,17 +149,12 @@ fn decode_row(
             kind: ValidationKind::Corruption,
             detail: format!("partition_key: {e}"),
         })?;
-    let exec_uuid = match Uuid::parse_str(&exec_text) {
-        Ok(u) => u,
-        Err(_) => {
-            tracing::warn!(
-                execution_id = %exec_text,
-                event_id = event_id,
-                "sqlite.signal_delivery: skipping row with unparseable execution_id"
-            );
-            return Ok(None);
-        }
-    };
+    // Unparseable execution_id is storage-level corruption — fail
+    // loudly rather than silently skip the state transition.
+    let exec_uuid = Uuid::parse_str(&exec_text).map_err(|e| EngineError::Validation {
+        kind: ValidationKind::Corruption,
+        detail: format!("ff_signal_event.execution_id parse '{exec_text}': {e}"),
+    })?;
     let execution_id = ExecutionId::parse(&format!("{{fp:{partition_key}}}:{exec_uuid}"))
         .map_err(|e| EngineError::Validation {
             kind: ValidationKind::Corruption,
@@ -161,27 +166,31 @@ fn decode_row(
             kind: ValidationKind::Corruption,
             detail: format!("signal_id: {e}"),
         })?;
-    let signal_id = match SignalId::parse(&signal_id_text) {
-        Ok(id) => id,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                event_id = event_id,
-                "sqlite.signal_delivery: skipping row with bad signal_id"
-            );
-            return Ok(None);
-        }
-    };
+    let signal_id = SignalId::parse(&signal_id_text).map_err(|e| EngineError::Validation {
+        kind: ValidationKind::Corruption,
+        detail: format!("signal_id parse '{signal_id_text}': {e}"),
+    })?;
 
     let waitpoint_text: Option<String> = row
         .try_get::<Option<String>, _>("waitpoint_id")
-        .unwrap_or(None);
-    let waitpoint_id = waitpoint_text
-        .as_deref()
-        .and_then(|s| WaitpointId::parse(s).ok());
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("waitpoint_id column: {e}"),
+        })?;
+    // Present-but-malformed waitpoint_id is corruption, not absence.
+    let waitpoint_id = match waitpoint_text.as_deref() {
+        Some(s) => Some(WaitpointId::parse(s).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("waitpoint_id parse '{s}': {e}"),
+        })?),
+        None => None,
+    };
     let source_identity: Option<String> = row
         .try_get::<Option<String>, _>("source_identity")
-        .unwrap_or(None);
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("source_identity: {e}"),
+        })?;
     let delivered_at_ms: i64 =
         row.try_get("delivered_at_ms")
             .map_err(|e| EngineError::Validation {

--- a/crates/ff-backend-sqlite/tests/subscribe.rs
+++ b/crates/ff-backend-sqlite/tests/subscribe.rs
@@ -496,11 +496,13 @@ async fn subscribe_signal_delivery_filter_by_instance_tag() {
 // ── lagged-broadcast recovery (shared) ────────────────────────────────
 //
 // Overwhelm the broadcast channel's 256-slot ring by producing a batch
-// of events with the subscriber task stalled; when it polls, `RecvError::Lagged`
-// fires and the cursor-select fallback catches every missed row via the
-// durable outbox. `subscribe_signal_delivery` is exercised because the
-// producer path is self-contained (no ff_exec_core hot-path dependence
-// beyond what `create_and_claim_tagged` sets up).
+// of events with the subscriber task stalled; when it polls,
+// `RecvError::Lagged` fires and the cursor-select fallback catches
+// every missed row via the durable outbox. `subscribe_completion` is
+// exercised because the producer path is the simplest end-to-end:
+// `create_and_claim` + `complete` in a tight loop — no suspend /
+// waitpoint setup needed per event — so saturating the 256-slot
+// broadcast ring takes a minimal number of iterations.
 
 #[tokio::test]
 #[serial(ff_dev_mode)]

--- a/crates/ff-backend-sqlite/tests/subscribe.rs
+++ b/crates/ff-backend-sqlite/tests/subscribe.rs
@@ -1,0 +1,536 @@
+//! RFC-023 Phase 3.1 — subscribe_completion / subscribe_lease_history /
+//! subscribe_signal_delivery integration tests.
+//!
+//! Covers for each method:
+//!   * tail + live-wake happy path (subscriber observes an event
+//!     produced after subscribe returns)
+//!   * cursor-resume (resubscribe with the last observed cursor,
+//!     skip already-seen events)
+//!   * `ScannerFilter::instance_tag` filtering (where the producer
+//!     populates the denormalised column; lease/completion producers
+//!     write NULL today, so only signal_delivery has an end-to-end
+//!     filter test — documented in the test comment)
+//!   * lagged-broadcast recovery (force the broadcast ring to
+//!     overflow via many back-pressured emits; the cursor-select
+//!     fallback catches the drops)
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CapabilitySet, ClaimPolicy, ScannerFilter};
+use ff_core::contracts::{
+    CreateExecutionArgs, CreateExecutionResult, DeliverSignalArgs, DeliverSignalResult,
+    ResumeCondition, ResumePolicy, SeedWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs,
+    SuspensionReasonCode, WaitpointBinding,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::stream_events::{
+    CompletionEvent, CompletionOutcome, LeaseHistoryEvent, SignalDeliveryEvent,
+};
+use ff_core::stream_subscribe::StreamCursor;
+use ff_core::types::{
+    ExecutionId, LaneId, Namespace, SignalId, SuspensionId, TimestampMs, WaitpointId, WorkerId,
+    WorkerInstanceId,
+};
+use futures_core::Stream;
+use serial_test::serial;
+use std::future::poll_fn;
+use std::pin::Pin;
+use uuid::Uuid;
+
+// ── Setup helpers ─────────────────────────────────────────────────────
+
+const KID: &str = "kid-test";
+
+fn secret_hex() -> String {
+    "cafebabe".repeat(8)
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    // SAFETY: test-only env mutation; every caller is serial-gated.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:rfc-023-subscribe-{}?mode=memory&cache=shared", uuid_like());
+    let b = SqliteBackend::new(&uri).await.expect("construct backend");
+    b.seed_waitpoint_hmac_secret(SeedWaitpointHmacSecretArgs::new(KID, secret_hex()))
+        .await
+        .expect("seed kid");
+    b
+}
+
+fn new_exec_id() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id")
+}
+
+/// Build a `CreateExecutionArgs` with optional `(tag_key, tag_value)`
+/// so filter tests can pass `cairn.instance_id = ...` and observe
+/// the denormalised column on `ff_signal_event`.
+fn create_args(exec_id: &ExecutionId, tag: Option<(&str, &str)>) -> CreateExecutionArgs {
+    let mut tags = std::collections::HashMap::new();
+    if let Some((k, v)) = tag {
+        tags.insert(k.to_owned(), v.to_owned());
+    }
+    CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: LaneId::new("default"),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags,
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(now_ms()),
+    }
+}
+
+async fn create_and_claim_tagged(
+    backend: &Arc<SqliteBackend>,
+    tag: Option<(&str, &str)>,
+) -> (ExecutionId, ff_core::backend::Handle) {
+    // Each call uses a unique lane so that re-eligible executions from
+    // earlier calls (e.g. a signalled-but-not-completed resumable exec)
+    // cannot be picked up by this claim. Without this, `claim()` would
+    // happily return a stale handle bound to a PRIOR exec (same lane
+    // pool) whose fence triple no longer matches the fresh exec id we
+    // just created.
+    let lane_id = LaneId::new(format!("lane-{}", Uuid::new_v4()));
+    let exec_id = new_exec_id();
+    let mut args = create_args(&exec_id, tag);
+    args.lane_id = lane_id.clone();
+    let r = backend.create_execution(args).await.expect("create");
+    assert!(matches!(r, CreateExecutionResult::Created { .. }));
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', public_state='pending', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .unwrap();
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i1"),
+        30_000,
+        None,
+    );
+    let handle = backend
+        .claim(&lane_id, &CapabilitySet::default(), policy)
+        .await
+        .expect("claim")
+        .expect("handle");
+    (exec_id, handle)
+}
+
+async fn create_and_claim(
+    backend: &Arc<SqliteBackend>,
+) -> (ExecutionId, ff_core::backend::Handle) {
+    create_and_claim_tagged(backend, None).await
+}
+
+/// Collect up to `n` items from a boxed stream with an overall timeout.
+async fn drain_n<T>(
+    stream: &mut Pin<Box<dyn Stream<Item = Result<T, ff_core::engine_error::EngineError>> + Send>>,
+    n: usize,
+    timeout: Duration,
+) -> Vec<T>
+where
+    T: 'static,
+{
+    let mut out = Vec::with_capacity(n);
+    let deadline = tokio::time::Instant::now() + timeout;
+    while out.len() < n {
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if remaining.is_zero() {
+            break;
+        }
+        let poll_once = poll_fn(|cx| stream.as_mut().poll_next(cx));
+        match tokio::time::timeout(remaining, poll_once).await {
+            Ok(Some(Ok(ev))) => out.push(ev),
+            Ok(Some(Err(e))) => panic!("stream yielded error: {e:?}"),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    out
+}
+
+fn suspend_args_wildcard(wp_key: &str) -> SuspendArgs {
+    let binding = WaitpointBinding::Fresh {
+        waitpoint_id: WaitpointId::new(),
+        waitpoint_key: wp_key.to_owned(),
+    };
+    SuspendArgs::new(
+        SuspensionId::new(),
+        binding,
+        ResumeCondition::Single {
+            waitpoint_key: wp_key.to_owned(),
+            matcher: SignalMatcher::Wildcard,
+        },
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::from_millis(now_ms()),
+    )
+}
+
+fn deliver_args(
+    exec_id: &ExecutionId,
+    waitpoint_id: WaitpointId,
+    waitpoint_token: &str,
+) -> DeliverSignalArgs {
+    DeliverSignalArgs {
+        execution_id: exec_id.clone(),
+        waitpoint_id,
+        signal_id: SignalId::new(),
+        signal_name: "ready".into(),
+        signal_category: "external".into(),
+        source_type: "operator".into(),
+        source_identity: "op-1".into(),
+        payload: None,
+        payload_encoding: None,
+        correlation_id: None,
+        idempotency_key: None,
+        target_scope: "execution".into(),
+        created_at: None,
+        dedup_ttl_ms: None,
+        resume_delay_ms: None,
+        max_signals_per_execution: None,
+        signal_maxlen: None,
+        waitpoint_token: ff_core::types::WaitpointToken::from(waitpoint_token.to_owned()),
+        now: TimestampMs::from_millis(now_ms()),
+    }
+}
+
+// ── subscribe_completion ──────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_completion_tail_happy_path() {
+    let b = fresh_backend().await;
+    // Subscribe FIRST so the catch-up SELECT starts from an empty
+    // max-event_id; then produce one completion via `complete()`.
+    let mut stream = b
+        .subscribe_completion(StreamCursor::empty(), &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe");
+
+    // Give the background task a moment to resolve the tail cursor.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let (_eid, handle) = create_and_claim(&b).await;
+    b.complete(&handle, None).await.expect("complete");
+
+    let events = drain_n::<CompletionEvent>(&mut stream, 1, Duration::from_millis(1500)).await;
+    assert_eq!(events.len(), 1, "expected one completion");
+    assert!(matches!(events[0].outcome, CompletionOutcome::Success));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_completion_cursor_resume() {
+    let b = fresh_backend().await;
+
+    // Produce completion #1 BEFORE any subscriber — catch-up path.
+    let (_e1, h1) = create_and_claim(&b).await;
+    b.complete(&h1, None).await.expect("complete 1");
+
+    // Subscribe from empty cursor; since completion #1 is already past
+    // max, the tail subscriber sees NOTHING of event #1 (empty cursor
+    // == tail-from-now). Complete #2 after subscribe.
+    let mut stream = b
+        .subscribe_completion(StreamCursor::empty(), &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe 1");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let (_e2, h2) = create_and_claim(&b).await;
+    b.complete(&h2, None).await.expect("complete 2");
+
+    let events = drain_n::<CompletionEvent>(&mut stream, 1, Duration::from_millis(1500)).await;
+    assert_eq!(events.len(), 1, "tail subscriber should only see #2");
+    let cursor_after_2 = events[0].cursor.clone();
+    drop(stream); // shut down the subscriber task
+
+    // Reconnect with the cursor after completion #2; produce #3.
+    let mut stream2 = b
+        .subscribe_completion(cursor_after_2, &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe 2");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let (_e3, h3) = create_and_claim(&b).await;
+    b.complete(&h3, None).await.expect("complete 3");
+
+    let events = drain_n::<CompletionEvent>(&mut stream2, 1, Duration::from_millis(1500)).await;
+    assert_eq!(events.len(), 1, "resume should yield #3 only");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_completion_filter_drops_null_tag_rows() {
+    let b = fresh_backend().await;
+    // The SQLite completion outbox writes NULL `instance_tag` on every
+    // row today, so a non-noop filter drops every event. This mirrors
+    // the Postgres "filtered subscribers silently drop NULL-column
+    // rows" invariant. The assertion below is the visible shape of
+    // that invariant — once the producer is taught to populate the
+    // column, this test updates to positive filter-through.
+    let filter = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-nope");
+    let mut stream = b
+        .subscribe_completion(StreamCursor::empty(), &filter)
+        .await
+        .expect("subscribe");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let (_e, h) = create_and_claim(&b).await;
+    b.complete(&h, None).await.expect("complete");
+
+    let events = drain_n::<CompletionEvent>(&mut stream, 1, Duration::from_millis(400)).await;
+    assert!(
+        events.is_empty(),
+        "filter with instance_tag must drop NULL-column completion rows"
+    );
+}
+
+// ── subscribe_lease_history ───────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_lease_history_tail_happy_path() {
+    let b = fresh_backend().await;
+    let mut stream = b
+        .subscribe_lease_history(StreamCursor::empty(), &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let (_eid, handle) = create_and_claim(&b).await;
+    b.renew(&handle).await.expect("renew");
+    b.complete(&handle, None).await.expect("complete");
+
+    // create_and_claim emits "acquired"; renew emits "renewed";
+    // complete emits "revoked". Three lease-history rows total.
+    let events = drain_n::<LeaseHistoryEvent>(&mut stream, 3, Duration::from_millis(2000)).await;
+    assert_eq!(events.len(), 3, "expected acquired+renewed+revoked, got {events:?}");
+    assert!(matches!(events[0], LeaseHistoryEvent::Acquired { .. }));
+    assert!(matches!(events[1], LeaseHistoryEvent::Renewed { .. }));
+    assert!(matches!(events[2], LeaseHistoryEvent::Revoked { .. }));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_lease_history_cursor_resume() {
+    let b = fresh_backend().await;
+    let mut stream = b
+        .subscribe_lease_history(StreamCursor::empty(), &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe 1");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let (_eid, handle) = create_and_claim(&b).await;
+    let events =
+        drain_n::<LeaseHistoryEvent>(&mut stream, 1, Duration::from_millis(1500)).await;
+    assert_eq!(events.len(), 1);
+    let cursor_after_1 = events[0].cursor().clone();
+    drop(stream);
+
+    // Renew on the same handle — produces "renewed". Resume from
+    // `cursor_after_1` must yield "renewed" only, skipping the
+    // already-seen "acquired".
+    let mut stream2 = b
+        .subscribe_lease_history(cursor_after_1, &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe 2");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    b.renew(&handle).await.expect("renew");
+    let events =
+        drain_n::<LeaseHistoryEvent>(&mut stream2, 1, Duration::from_millis(1500)).await;
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], LeaseHistoryEvent::Renewed { .. }));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_lease_history_filter_drops_null_tag_rows() {
+    let b = fresh_backend().await;
+    let filter = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-nope");
+    let mut stream = b
+        .subscribe_lease_history(StreamCursor::empty(), &filter)
+        .await
+        .expect("subscribe");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let (_eid, handle) = create_and_claim(&b).await;
+    b.complete(&handle, None).await.expect("complete");
+    let events =
+        drain_n::<LeaseHistoryEvent>(&mut stream, 1, Duration::from_millis(400)).await;
+    assert!(events.is_empty(), "filtered lease-history drops NULL rows");
+}
+
+// ── subscribe_signal_delivery ─────────────────────────────────────────
+
+async fn suspend_and_deliver(
+    b: &Arc<SqliteBackend>,
+    tag: Option<(&str, &str)>,
+) -> ExecutionId {
+    let (exec_id, handle) = create_and_claim_tagged(b, tag).await;
+    let outcome = b
+        .suspend(&handle, suspend_args_wildcard("wpk:sd"))
+        .await
+        .expect("suspend");
+    let details = outcome.details().clone();
+    let r = b
+        .deliver_signal(deliver_args(
+            &exec_id,
+            details.waitpoint_id.clone(),
+            details.waitpoint_token.as_str(),
+        ))
+        .await
+        .expect("deliver");
+    assert!(matches!(r, DeliverSignalResult::Accepted { .. }));
+    exec_id
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_signal_delivery_tail_happy_path() {
+    let b = fresh_backend().await;
+    let mut stream = b
+        .subscribe_signal_delivery(StreamCursor::empty(), &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    suspend_and_deliver(&b, None).await;
+
+    let events =
+        drain_n::<SignalDeliveryEvent>(&mut stream, 1, Duration::from_millis(2000)).await;
+    assert_eq!(events.len(), 1, "expected one signal-delivery event");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_signal_delivery_cursor_resume() {
+    let b = fresh_backend().await;
+    let mut stream = b
+        .subscribe_signal_delivery(StreamCursor::empty(), &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe 1");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    suspend_and_deliver(&b, None).await;
+    let events =
+        drain_n::<SignalDeliveryEvent>(&mut stream, 1, Duration::from_millis(1500)).await;
+    assert_eq!(events.len(), 1);
+    let cursor_after_1 = events[0].cursor.clone();
+    drop(stream);
+
+    // Resume: produce a second signal; observer must see only #2.
+    let mut stream2 = b
+        .subscribe_signal_delivery(cursor_after_1, &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe 2");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    suspend_and_deliver(&b, None).await;
+    let events =
+        drain_n::<SignalDeliveryEvent>(&mut stream2, 1, Duration::from_millis(1500)).await;
+    assert_eq!(events.len(), 1, "resume should yield only the second signal");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_signal_delivery_filter_by_instance_tag() {
+    // Signal producer DOES populate `instance_tag` from the exec's
+    // `tags["cairn.instance_id"]` via json_extract (see
+    // `queries/signal.rs::INSERT_SIGNAL_EVENT_SQL`), so an end-to-end
+    // positive filter is observable here even though lease/completion
+    // rows currently land with NULL filter columns.
+    let b = fresh_backend().await;
+    let filter = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-42");
+    let mut stream = b
+        .subscribe_signal_delivery(StreamCursor::empty(), &filter)
+        .await
+        .expect("subscribe");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Produce a non-matching signal (no tag) — filter must drop it.
+    suspend_and_deliver(&b, None).await;
+    // Then a matching signal — filter passes it through.
+    suspend_and_deliver(&b, Some(("cairn.instance_id", "i-42"))).await;
+
+    let events =
+        drain_n::<SignalDeliveryEvent>(&mut stream, 1, Duration::from_millis(2000)).await;
+    assert_eq!(events.len(), 1, "only the tagged signal should pass the filter");
+}
+
+// ── lagged-broadcast recovery (shared) ────────────────────────────────
+//
+// Overwhelm the broadcast channel's 256-slot ring by producing a batch
+// of events with the subscriber task stalled; when it polls, `RecvError::Lagged`
+// fires and the cursor-select fallback catches every missed row via the
+// durable outbox. `subscribe_signal_delivery` is exercised because the
+// producer path is self-contained (no ff_exec_core hot-path dependence
+// beyond what `create_and_claim_tagged` sets up).
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn subscribe_completion_lagged_recovery() {
+    let b = fresh_backend().await;
+    let mut stream = b
+        .subscribe_completion(StreamCursor::empty(), &ScannerFilter::NOOP)
+        .await
+        .expect("subscribe");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Produce more completions than the broadcast ring can hold
+    // (DEFAULT_CAPACITY = 256). We sprint 300 completions; the
+    // subscriber will observe a broadcast `Lagged` error the first
+    // time it wakes, but the outbox-cursor fallback replays every
+    // durable row from the last cursor.
+    const N: usize = 300;
+    for _ in 0..N {
+        let (_e, h) = create_and_claim(&b).await;
+        b.complete(&h, None).await.expect("complete");
+    }
+
+    let events =
+        drain_n::<CompletionEvent>(&mut stream, N, Duration::from_millis(10_000)).await;
+    assert_eq!(events.len(), N, "lagged-recovery must yield every durable event");
+    // Cursors are monotonic.
+    for pair in events.windows(2) {
+        assert!(
+            pair[1].cursor.as_bytes() > pair[0].cursor.as_bytes(),
+            "cursors not monotonic across lagged-recovery window"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

RFC-023 Phase 3.1. Replaces the 3 trait `Unavailable` defaults on the SQLite backend with real bodies built on the Phase 2b.2.2 `OutboxCursorReader` primitive.

### Methods landed (3 / 3)

- `subscribe_completion` — tails `ff_completion_event` via the `completion` broadcast channel.
- `subscribe_lease_history` — tails `ff_lease_event` via the `lease_history` broadcast channel.
- `subscribe_signal_delivery` — tails `ff_signal_event` via the `signal_delivery` broadcast channel.

`subscribe_instance_tags` stays on the trait default (`Unavailable`) per RFC-020 §3.2 / the #311 deferral.

### `OutboxCursorReader` consumption pattern

Each subscribe body:

1. Decodes the caller's `StreamCursor` (empty → tail from `max(event_id)` at subscribe time, matching PG's `LISTEN/max(event_id)` handshake).
2. Builds a `RowDecoder<T>` closure that materialises one typed event per row and applies `ScannerFilter` against the outbox's denormalised `namespace` + `instance_tag` columns.
3. `outbox_cursor::spawn(OutboxCursorConfig { pool, select_sql, partition_key: 0, cursor: last_seen, batch_size: 256, wakeup: pubsub.<family>.subscribe(), decoder, row_event_id })`.
4. Boxes the returned `OutboxCursorStream<T>` as the trait's family-specific `Pin<Box<dyn Stream<Item=Result<Event, EngineError>>>>` alias.

Cursor encoding reuses the PG family prefix (`0x02 ++ event_id(BE8)`) — SQLite's i64 event_ids share the shape, so cursors stay wire-stable across backends (per the autonomy note in the Phase 3.1 brief).

### ScannerFilter decision

Filter applied in the **row decoder**, not via a `WHERE` clause — matches the PG reference at `ff-backend-postgres/src/lease_event_subscribe::passes_filter`. Rationale: the outbox SELECT is already index-scanning on `(partition_key, event_id)`, and the filter columns are sparse + nullable. Decode-side predicate keeps `last_seen` advancing past dropped rows so a subsequent catch-up doesn't re-scan them.

Behaviour parity with PG: NULL filter columns silently drop under any non-noop filter (SQLite lease + completion producers write NULL today; signal-delivery producer populates via `json_extract` of `raw_fields.tags["cairn.instance_id"]`, so filter tests are positive for signal-delivery).

### Tests (10)

`crates/ff-backend-sqlite/tests/subscribe.rs`:

- `subscribe_completion_{tail_happy_path, cursor_resume, filter_drops_null_tag_rows, lagged_recovery}` — 4 cases
- `subscribe_lease_history_{tail_happy_path, cursor_resume, filter_drops_null_tag_rows}` — 3 cases
- `subscribe_signal_delivery_{tail_happy_path, cursor_resume, filter_by_instance_tag}` — 3 cases

The `lagged_recovery` test sprints 300 completions against the 256-slot broadcast ring, verifying the cursor-select fallback catches every durable row after `RecvError::Lagged`.

### Gaps / follow-ups

- SQLite `INSERT_COMPLETION_EVENT_SQL` and `INSERT_LEASE_EVENT_SQL` write NULL for the denormalised `namespace` + `instance_tag` columns today. On a non-noop filter every row is dropped — matches PG's "filtered subscribers silently drop NULL-column rows" invariant. Populating these columns is producer-side follow-up work (outside Phase 3.1 scope).
- Cursor encoding deliberately shares the PG `0x02` prefix; if we ever want to distinguish SQLite cursors from PG cursors (e.g. for a cross-backend merge consumer), a new family byte would land in a dedicated RFC amendment.

### CI summary (local)

- `cargo build -p ff-backend-sqlite --tests` — clean.
- `cargo test -p ff-backend-sqlite` — 29 / 29 pass (19 lib, 10 new subscribe integration).
- `cargo clippy -p ff-backend-sqlite --lib --test subscribe -- -D warnings` — clean.
- `cargo check --workspace` — clean.

One pre-existing clippy warning in `tests/producer_flow.rs` (field_reassign_with_default, unrelated to this PR) left untouched per surgical-changes rule.

## Test plan

- [x] `cargo test -p ff-backend-sqlite` green locally
- [x] `cargo clippy -p ff-backend-sqlite --lib --test subscribe -- -D warnings` clean
- [x] `cargo check --workspace` clean
- [ ] Matrix CI green
- [ ] Migration-parity CI green
- [ ] Bot review comments swept

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new SQLite implementations for three `subscribe_*` streaming APIs using cursor resume + broadcast wakeups; correctness issues could surface as missed/duplicated events or filtering mismatches under load.
> 
> **Overview**
> Implements SQLite support for RFC-019 Phase 3.1 event subscriptions by replacing the `Unavailable` defaults for `subscribe_completion`, `subscribe_lease_history`, and `subscribe_signal_delivery` with real stream implementations built on the `OutboxCursorReader` pattern (catch-up SELECT on subscribe, then re-SELECT on broadcast wakeups with cursor advancement).
> 
> Adds per-family subscribe modules that define the outbox SELECT, cursor encoding compatible with Postgres (`0x02 ++ event_id`), row decoding into typed events, and decode-side `ScannerFilter` handling (including dropping rows with NULL filter columns under non-noop filters). Includes a new SQLite integration test suite covering tailing, cursor resume, filter behavior, and broadcast lag recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff61987154a809bd8891aeec3fd3354fc7fdbc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->