### PR TITLE
feat(backend-sqlite): Phase 3.2 — Wave 9 operator control (4 methods) + producer tag backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 3.2 Wave 9 operator control
+  (RFC-023 Phase 3.2 / RFC-020 §4.2.1-5).** Replaces the 4 `Unavailable`
+  trait defaults for `cancel_execution`, `revoke_lease`,
+  `change_priority`, and `replay_execution` with real SQLite bodies
+  ported from the Postgres reference (`ff-backend-postgres/src/operator.rs`
+  v0.11.0). Each method runs under the §4.2 shared spine adapted for
+  SQLite (`BEGIN IMMEDIATE` RESERVED-lock for the RMW window, WHERE-
+  clause CAS fencing, `rows_affected()`-driven contention branches,
+  outbox INSERT in-tx + post-commit broadcast wakeup) and rides the
+  Phase 2a.1 `retry::retry_serializable` wrapper for SQLITE_BUSY /
+  SQLITE_LOCKED absorption. Semantics match PG Revision 7 exactly:
+  `cancel_execution` emits `ff_lease_event revoked` only (no
+  operator_event — the migration 0010 CHECK allow-list gates on
+  `priority_changed` / `replayed` / `flow_cancel_requested`);
+  `revoke_lease` returns `AlreadySatisfied` on `no_active_lease` /
+  `different_worker_instance_id` / `lease_id_mismatch` / `epoch_moved`;
+  `change_priority` surfaces `Contention(ExecutionNotEligible)` on the
+  Valkey-canonical gate (`lifecycle_phase='runnable' AND
+  eligibility_state='eligible_now'`) failing; `replay_execution` picks
+  the skipped-flow-member branch iff the current attempt's
+  `outcome='skipped' AND exec_core.flow_id IS NOT NULL` (Valkey
+  `flowfabric.lua:8555`) and resets downstream `ff_edge_group`
+  skip/fail/running counters to 0 while preserving `success_count` per
+  Revision 7 Option A. Replay bumps `raw_fields.replay_count` via a
+  nested `json_set(json_set(...))` (SQLite JSON1 analogue of PG's
+  `jsonb_set(..., to_jsonb(... + 1))`).
+- `crates/ff-backend-sqlite/src/operator.rs` — 4 `_once` bodies + 4
+  `_impl` retry wrappers + in-file helpers (`split_eid`,
+  `synthetic_lease_id`, `insert_lease_event`, `insert_operator_event`,
+  post-commit broadcast dispatchers).
+- `crates/ff-backend-sqlite/src/queries/operator.rs` — dialect-forked
+  SQL for the 4 methods (pre-reads, CAS UPDATEs, edge-group reset,
+  co-transactional `INSERT_OPERATOR_EVENT_SQL` that back-fills
+  `namespace` + `instance_tag` from `ff_exec_core.raw_fields`).
+- `crates/ff-backend-sqlite/tests/wave9_operator.rs` — 13-test
+  integration harness: happy-path + fence-failure + gate-failure +
+  outbox-verify for each method, the two replay branches (normal
+  resumes to `Waiting`, skipped-flow-member resumes to
+  `WaitingChildren` and resets edge-group counters with
+  `success_count` preserved), and a concurrent-cancel serialization
+  test that verifies SERIALIZABLE-retry absorbs cross-tx SQLITE_BUSY
+  under the single-writer envelope.
 - **`crates/ff-backend-sqlite` — Phase 3.1 subscribe methods (RFC-023
   Wave 9 / RFC-019 Stage B/C).** Replaces the 3 `Unavailable` defaults
   for `subscribe_completion`, `subscribe_lease_history`, and
@@ -123,6 +165,34 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   single Rust implementation (Valkey continues to sign inside Lua).
   The PG `signal.rs` re-exports from ff-core for backward
   compatibility of internal call sites.
+
+### Fixed
+
+- **`crates/ff-backend-sqlite` — outbox producer tag back-fill
+  (Phase 3.1-flagged regression, fixed in Phase 3.2).** Prior to
+  Phase 3.2 the SQLite `ff_lease_event` + `ff_completion_event`
+  producers hard-coded `namespace` + `instance_tag` to `NULL` on every
+  insert, causing any `ScannerFilter::instance_tag(...)` subscriber
+  to silently drop every lease + completion event (the
+  `subscribe_*_filter_drops_null_tag_rows` tests pinned this shape;
+  the signal producer had already been ported correctly in Phase
+  2b.2.1). Phase 3.2 replaces the hard-coded NULLs with a
+  co-transactional `SELECT ... FROM ff_exec_core UNION ALL SELECT ...
+  WHERE NOT EXISTS (...)` (mirror of
+  `queries/signal.rs::INSERT_SIGNAL_EVENT_SQL`) so every outbox row
+  carries the denormalised tag columns. Touched producers:
+  `queries/dispatch.rs::INSERT_LEASE_EVENT_SQL`,
+  `queries/attempt.rs::INSERT_COMPLETION_EVENT_SQL`,
+  `queries/signal.rs::INSERT_COMPLETION_RESUMABLE_SQL`. The 3
+  call-sites on `INSERT_LEASE_EVENT_SQL`
+  (`backend::insert_lease_event`,
+  `suspend_ops::claim_resumed_execution_impl`, new
+  `operator::insert_lease_event`) now bind the exec UUID twice: once
+  stringified for the outbox row and once as the 16-byte BLOB for the
+  exec_core lookup. The two previously-xfailing subscribe tests
+  (`subscribe_*_filter_drops_null_tag_rows`) flip to positive
+  filter-through
+  (`subscribe_*_filter_by_instance_tag_receives_events`).
 
 ### Changed
 

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -61,8 +61,10 @@ use crate::registry;
 #[cfg(feature = "core")]
 use ff_core::contracts::{
     AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
-    ApplyDependencyToChildResult, CreateExecutionArgs, CreateExecutionResult, CreateFlowArgs,
-    CreateFlowResult, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+    ApplyDependencyToChildResult, CancelExecutionArgs, CancelExecutionResult,
+    ChangePriorityArgs, ChangePriorityResult, CreateExecutionArgs, CreateExecutionResult,
+    CreateFlowArgs, CreateFlowResult, ReplayExecutionArgs, ReplayExecutionResult,
+    RevokeLeaseArgs, RevokeLeaseResult, StageDependencyEdgeArgs, StageDependencyEdgeResult,
 };
 #[cfg(feature = "core")]
 use ff_core::state::PublicState;
@@ -635,6 +637,9 @@ async fn insert_lease_event(
         .bind(event_type)
         .bind(now)
         .bind(part)
+        // BLOB bind for the co-transactional exec_core lookup that
+        // back-fills namespace + instance_tag (Phase 3.2 fix).
+        .bind(exec_uuid)
         .execute(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
@@ -2735,6 +2740,46 @@ impl EngineBackend for SqliteBackend {
     ) -> Result<ApplyDependencyToChildResult, EngineError> {
         let pool = &self.inner.pool;
         retry_serializable(|| apply_dependency_to_child_impl(pool, &args)).await
+    }
+
+    // ── RFC-020 Wave 9 — Operator control (Phase 3.2) ────────────────
+    //
+    // Each body lives in `crate::operator` and follows the §4.2 shared
+    // spine adapted for SQLite (BEGIN IMMEDIATE + WHERE-clause CAS +
+    // post-commit broadcast). Outbox rows populate namespace +
+    // instance_tag via co-transactional SELECT so tag-filtered
+    // subscribers do not silently drop events.
+
+    #[cfg(feature = "core")]
+    async fn cancel_execution(
+        &self,
+        args: CancelExecutionArgs,
+    ) -> Result<CancelExecutionResult, EngineError> {
+        crate::operator::cancel_execution_impl(&self.inner.pool, &self.inner.pubsub, args).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn revoke_lease(
+        &self,
+        args: RevokeLeaseArgs,
+    ) -> Result<RevokeLeaseResult, EngineError> {
+        crate::operator::revoke_lease_impl(&self.inner.pool, &self.inner.pubsub, args).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn change_priority(
+        &self,
+        args: ChangePriorityArgs,
+    ) -> Result<ChangePriorityResult, EngineError> {
+        crate::operator::change_priority_impl(&self.inner.pool, &self.inner.pubsub, args).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn replay_execution(
+        &self,
+        args: ReplayExecutionArgs,
+    ) -> Result<ReplayExecutionResult, EngineError> {
+        crate::operator::replay_execution_impl(&self.inner.pool, &self.inner.pubsub, args).await
     }
 
     // ── RFC-019 Stage B/C — subscribe_* (Phase 3.1) ──────────────────

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -31,6 +31,7 @@ mod config;
 mod errors;
 mod handle_codec;
 mod lease_event_subscribe;
+mod operator;
 mod outbox_cursor;
 mod signal_delivery_subscribe;
 #[doc(hidden)]

--- a/crates/ff-backend-sqlite/src/operator.rs
+++ b/crates/ff-backend-sqlite/src/operator.rs
@@ -4,7 +4,10 @@
 //! mutating ops:
 //!
 //!   * [`cancel_execution_impl`] — §4.2.1 + §4.2.7 outbox matrix
-//!     (ff_operator_event + ff_lease_event if lease active).
+//!     (ff_lease_event `revoked` iff a lease was active; NO
+//!     operator_event — the migration 0010 CHECK allow-list excludes
+//!     a `cancelled` event_type and the PG reference does not emit
+//!     one).
 //!   * [`revoke_lease_impl`] — §4.2.2 (ff_lease_event revoked).
 //!   * [`change_priority_impl`] — §4.2.4 Rev 7 Fork 3 Option C
 //!     (ff_operator_event priority_changed).
@@ -44,39 +47,11 @@ use crate::errors::map_sqlx_error;
 use crate::pubsub::{OutboxEvent, PubSub};
 use crate::queries::operator as q_op;
 use crate::retry::retry_serializable;
+use crate::tx_util::{
+    begin_immediate, commit_or_rollback, now_ms, rollback_quiet, split_exec_id,
+};
 
 // ─── shared helpers ────────────────────────────────────────────────
-
-/// Decompose an `ExecutionId` into `(partition_key, uuid_blob)`.
-/// SQLite stores `execution_id` as a 16-byte BLOB (see `backend::split_exec_id`).
-fn split_eid(
-    eid: &ff_core::types::ExecutionId,
-) -> Result<(i64, Uuid), EngineError> {
-    let s = eid.as_str();
-    let tail = s
-        .split_once("}:")
-        .map(|(_, t)| t)
-        .ok_or_else(|| EngineError::Validation {
-            kind: ValidationKind::InvalidInput,
-            detail: format!("execution_id missing `}}:`: {s}"),
-        })?;
-    let part_str = s
-        .strip_prefix("{fp:")
-        .and_then(|r| r.find("}:").map(|i| &r[..i]))
-        .ok_or_else(|| EngineError::Validation {
-            kind: ValidationKind::InvalidInput,
-            detail: format!("execution_id missing `{{fp:`: {s}"),
-        })?;
-    let part: i64 = part_str.parse().map_err(|_| EngineError::Validation {
-        kind: ValidationKind::InvalidInput,
-        detail: format!("execution_id partition index not u16: {s}"),
-    })?;
-    let uuid = Uuid::parse_str(tail).map_err(|_| EngineError::Validation {
-        kind: ValidationKind::InvalidInput,
-        detail: format!("execution_id UUID invalid: {s}"),
-    })?;
-    Ok((part, uuid))
-}
 
 /// Synthetic lease identity for the SQLite backend — same shape as
 /// the PG synthetic (`pg:<uuid>:<attempt>:<epoch>`) but tagged
@@ -84,31 +59,6 @@ fn split_eid(
 /// logs / traces.
 fn synthetic_lease_id(exec_uuid: Uuid, attempt_index: i32, lease_epoch: i64) -> String {
     format!("sqlite:{exec_uuid}:{attempt_index}:{lease_epoch}")
-}
-
-async fn begin_immediate(
-    pool: &SqlitePool,
-) -> Result<sqlx::pool::PoolConnection<sqlx::Sqlite>, EngineError> {
-    let mut conn = pool.acquire().await.map_err(map_sqlx_error)?;
-    sqlx::query("BEGIN IMMEDIATE")
-        .execute(&mut *conn)
-        .await
-        .map_err(map_sqlx_error)?;
-    Ok(conn)
-}
-
-async fn commit_or_rollback(
-    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
-) -> Result<(), EngineError> {
-    if let Err(e) = sqlx::query("COMMIT").execute(&mut **conn).await.map_err(map_sqlx_error) {
-        let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
-        return Err(e);
-    }
-    Ok(())
-}
-
-async fn rollback_quiet(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
-    let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
 }
 
 /// Co-transactional `last_insert_rowid()` → `OutboxEvent` for the
@@ -185,7 +135,7 @@ async fn cancel_execution_once(
     pubsub: &PubSub,
     args: &CancelExecutionArgs,
 ) -> Result<CancelExecutionResult, EngineError> {
-    let (part, exec_uuid) = split_eid(&args.execution_id)?;
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
     let now = args.now.0;
 
     let mut conn = begin_immediate(pool).await?;
@@ -327,14 +277,8 @@ async fn revoke_lease_once(
     pubsub: &PubSub,
     args: &RevokeLeaseArgs,
 ) -> Result<RevokeLeaseResult, EngineError> {
-    let (part, exec_uuid) = split_eid(&args.execution_id)?;
-    let now: i64 = i64::try_from(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis())
-            .unwrap_or(0),
-    )
-    .unwrap_or(i64::MAX);
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let now = now_ms();
 
     let mut conn = begin_immediate(pool).await?;
 
@@ -483,7 +427,7 @@ async fn change_priority_once(
     pubsub: &PubSub,
     args: &ChangePriorityArgs,
 ) -> Result<ChangePriorityResult, EngineError> {
-    let (part, exec_uuid) = split_eid(&args.execution_id)?;
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
     let now = args.now.0;
 
     let mut conn = begin_immediate(pool).await?;
@@ -579,7 +523,7 @@ async fn replay_execution_once(
     pubsub: &PubSub,
     args: &ReplayExecutionArgs,
 ) -> Result<ReplayExecutionResult, EngineError> {
-    let (part, exec_uuid) = split_eid(&args.execution_id)?;
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
     let now = args.now.0;
 
     let mut conn = begin_immediate(pool).await?;

--- a/crates/ff-backend-sqlite/src/operator.rs
+++ b/crates/ff-backend-sqlite/src/operator.rs
@@ -1,0 +1,717 @@
+//! Wave 9 operator-control methods — SQLite port (RFC-023 Phase 3.2).
+//!
+//! Mirrors `ff-backend-postgres/src/operator.rs` Revision 7. Four
+//! mutating ops:
+//!
+//!   * [`cancel_execution_impl`] — §4.2.1 + §4.2.7 outbox matrix
+//!     (ff_operator_event + ff_lease_event if lease active).
+//!   * [`revoke_lease_impl`] — §4.2.2 (ff_lease_event revoked).
+//!   * [`change_priority_impl`] — §4.2.4 Rev 7 Fork 3 Option C
+//!     (ff_operator_event priority_changed).
+//!   * [`replay_execution_impl`] — §4.2.5 Rev 7 Forks 1 + 2 (two
+//!     branches: normal vs skipped_flow_member; ff_operator_event
+//!     replayed).
+//!
+//! Each follows the §4.2 shared spine adapted for SQLite:
+//!
+//!   1. `BEGIN IMMEDIATE` (RESERVED write lock — single-writer §4.1 A3).
+//!   2. Pre-read gates + identity fields (no `FOR UPDATE` — the write
+//!      lock already covers us).
+//!   3. Validate against Valkey-canonical semantics (§5.2 PG parity).
+//!   4. Mutate with WHERE-clause CAS fencing + `rows_affected()` check.
+//!   5. Emit the outbox row per §4.2.7 matrix via the co-transactional
+//!      `INSERT_*_EVENT_SQL` producer that back-fills
+//!      namespace + instance_tag.
+//!   6. `COMMIT`. The `retry::retry_serializable` wrapper retries up to
+//!      3× on SQLITE_BUSY / SQLITE_LOCKED (§4.3).
+//!
+//! Lifecycle_phase enum literals are lowercase per RFC-020 Rev 4
+//! (`'cancelled'`, `'runnable'`, `'terminal'`, `'active'`).
+
+use serde_json::json;
+use sqlx::{Row, SqlitePool};
+use uuid::Uuid;
+
+use ff_core::contracts::{
+    CancelExecutionArgs, CancelExecutionResult, ChangePriorityArgs, ChangePriorityResult,
+    ReplayExecutionArgs, ReplayExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
+};
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::state::PublicState;
+use ff_core::types::CancelSource;
+
+use crate::errors::map_sqlx_error;
+use crate::pubsub::{OutboxEvent, PubSub};
+use crate::queries::operator as q_op;
+use crate::retry::retry_serializable;
+
+// ─── shared helpers ────────────────────────────────────────────────
+
+/// Decompose an `ExecutionId` into `(partition_key, uuid_blob)`.
+/// SQLite stores `execution_id` as a 16-byte BLOB (see `backend::split_exec_id`).
+fn split_eid(
+    eid: &ff_core::types::ExecutionId,
+) -> Result<(i64, Uuid), EngineError> {
+    let s = eid.as_str();
+    let tail = s
+        .split_once("}:")
+        .map(|(_, t)| t)
+        .ok_or_else(|| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("execution_id missing `}}:`: {s}"),
+        })?;
+    let part_str = s
+        .strip_prefix("{fp:")
+        .and_then(|r| r.find("}:").map(|i| &r[..i]))
+        .ok_or_else(|| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("execution_id missing `{{fp:`: {s}"),
+        })?;
+    let part: i64 = part_str.parse().map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id partition index not u16: {s}"),
+    })?;
+    let uuid = Uuid::parse_str(tail).map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id UUID invalid: {s}"),
+    })?;
+    Ok((part, uuid))
+}
+
+/// Synthetic lease identity for the SQLite backend — same shape as
+/// the PG synthetic (`pg:<uuid>:<attempt>:<epoch>`) but tagged
+/// `sqlite` so consumers can tell the producer backend apart from
+/// logs / traces.
+fn synthetic_lease_id(exec_uuid: Uuid, attempt_index: i32, lease_epoch: i64) -> String {
+    format!("sqlite:{exec_uuid}:{attempt_index}:{lease_epoch}")
+}
+
+async fn begin_immediate(
+    pool: &SqlitePool,
+) -> Result<sqlx::pool::PoolConnection<sqlx::Sqlite>, EngineError> {
+    let mut conn = pool.acquire().await.map_err(map_sqlx_error)?;
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(conn)
+}
+
+async fn commit_or_rollback(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+) -> Result<(), EngineError> {
+    if let Err(e) = sqlx::query("COMMIT").execute(&mut **conn).await.map_err(map_sqlx_error) {
+        let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
+        return Err(e);
+    }
+    Ok(())
+}
+
+async fn rollback_quiet(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
+    let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
+}
+
+/// Co-transactional `last_insert_rowid()` → `OutboxEvent` for the
+/// post-commit broadcast fan-out.
+async fn last_outbox_event(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+) -> Result<OutboxEvent, EngineError> {
+    let event_id: i64 = sqlx::query_scalar("SELECT last_insert_rowid()")
+        .fetch_one(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(OutboxEvent {
+        event_id,
+        partition_key: part,
+    })
+}
+
+/// Insert one `ff_lease_event` outbox row + return the event_id. Uses
+/// the co-transactional INSERT that back-fills namespace + instance_tag
+/// from exec_core.raw_fields (Phase 3.2 fix).
+async fn insert_lease_event(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    event_type: &str,
+    now: i64,
+) -> Result<OutboxEvent, EngineError> {
+    sqlx::query(crate::queries::dispatch::INSERT_LEASE_EVENT_SQL)
+        .bind(exec_uuid.to_string())
+        .bind(event_type)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    last_outbox_event(conn, part).await
+}
+
+/// Insert one `ff_operator_event` outbox row + return the event_id.
+async fn insert_operator_event(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    event_type: &str,
+    details: Option<String>,
+    now: i64,
+) -> Result<OutboxEvent, EngineError> {
+    sqlx::query(q_op::INSERT_OPERATOR_EVENT_SQL)
+        .bind(exec_uuid.to_string())
+        .bind(event_type)
+        .bind(details)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    last_outbox_event(conn, part).await
+}
+
+fn dispatch_lease(pubsub: &PubSub, ev: OutboxEvent) {
+    PubSub::emit(&pubsub.lease_history, ev);
+}
+fn dispatch_operator(pubsub: &PubSub, ev: OutboxEvent) {
+    PubSub::emit(&pubsub.operator_event, ev);
+}
+
+// ─── cancel_execution ──────────────────────────────────────────────
+
+async fn cancel_execution_once(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: &CancelExecutionArgs,
+) -> Result<CancelExecutionResult, EngineError> {
+    let (part, exec_uuid) = split_eid(&args.execution_id)?;
+    let now = args.now.0;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    // Inline body — on any error, rollback + bail. On success, commit +
+    // emit wakeup. Mirrors PG `cancel_execution_once`.
+    let result = async {
+        let row = sqlx::query(q_op::SELECT_CANCEL_PRE_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let Some(row) = row else {
+            return Err(EngineError::NotFound {
+                entity: "execution",
+            });
+        };
+
+        let lifecycle_phase: String = row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+        let public_state: String = row.try_get("public_state").map_err(map_sqlx_error)?;
+        let attempt_index: i64 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+        let worker_instance_id: Option<String> =
+            row.try_get("worker_instance_id").map_err(map_sqlx_error)?;
+        let lease_epoch: Option<i64> = row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+
+        // Terminal handling — idempotent if already cancelled; hard
+        // conflict otherwise.
+        if matches!(lifecycle_phase.as_str(), "terminal" | "cancelled") {
+            return if public_state == "cancelled" {
+                Ok((
+                    CancelExecutionResult::Cancelled {
+                        execution_id: args.execution_id.clone(),
+                        public_state: PublicState::Cancelled,
+                    },
+                    None,
+                ))
+            } else {
+                Err(EngineError::Validation {
+                    kind: ValidationKind::InvalidInput,
+                    detail: format!(
+                        "cancel_execution: execution_id={}: already terminal in state '{}'",
+                        args.execution_id, public_state
+                    ),
+                })
+            };
+        }
+
+        // Lease fence validation.
+        let lease_active = worker_instance_id
+            .as_deref()
+            .is_some_and(|s| !s.is_empty());
+        if !matches!(args.source, CancelSource::OperatorOverride) && lease_active {
+            let Some(expected_epoch) = args.lease_epoch.as_ref() else {
+                return Err(EngineError::Validation {
+                    kind: ValidationKind::InvalidInput,
+                    detail: format!(
+                        "cancel_execution: execution_id={}: lease_epoch required when source != operator_override and execution is active",
+                        args.execution_id
+                    ),
+                });
+            };
+            let expected = i64::try_from(expected_epoch.0).unwrap_or(i64::MAX);
+            if lease_epoch.unwrap_or(0) != expected {
+                return Err(EngineError::State(StateKind::StaleLease));
+            }
+        }
+
+        // Flip exec_core → cancelled.
+        sqlx::query(q_op::UPDATE_EXEC_CORE_CANCELLED_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(now)
+            .bind(&args.reason)
+            .bind(args.source.as_str())
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // If a lease was active, clear it and emit lease_event revoked.
+        // Per RFC-020 §4.2.7 matrix, `cancel_execution` emits ONLY
+        // `ff_lease_event` (if lease active) — no `ff_operator_event`
+        // row (the migration 0010 CHECK allow-list does not include a
+        // `cancelled` event_type). Valkey parity: the `released`
+        // history event rides the lease stream too.
+        let lease_ev = if lease_active {
+            sqlx::query(q_op::UPDATE_ATTEMPT_CANCELLED_SQL)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(attempt_index)
+                .bind(now)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            Some(insert_lease_event(&mut conn, part, exec_uuid, "revoked", now).await?)
+        } else {
+            None
+        };
+
+        Ok((
+            CancelExecutionResult::Cancelled {
+                execution_id: args.execution_id.clone(),
+                public_state: PublicState::Cancelled,
+            },
+            lease_ev,
+        ))
+    }
+    .await;
+
+    match result {
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+        Ok((ret, lease_ev)) => {
+            commit_or_rollback(&mut conn).await?;
+            if let Some(ev) = lease_ev {
+                dispatch_lease(pubsub, ev);
+            }
+            Ok(ret)
+        }
+    }
+}
+
+pub(crate) async fn cancel_execution_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: CancelExecutionArgs,
+) -> Result<CancelExecutionResult, EngineError> {
+    retry_serializable(|| cancel_execution_once(pool, pubsub, &args)).await
+}
+
+// ─── revoke_lease ──────────────────────────────────────────────────
+
+async fn revoke_lease_once(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: &RevokeLeaseArgs,
+) -> Result<RevokeLeaseResult, EngineError> {
+    let (part, exec_uuid) = split_eid(&args.execution_id)?;
+    let now: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let ec_row = sqlx::query(q_op::SELECT_EXEC_ATTEMPT_INDEX_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let Some(ec_row) = ec_row else {
+            return Err(EngineError::NotFound {
+                entity: "execution",
+            });
+        };
+        let attempt_index: i64 = ec_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+        let att_row = sqlx::query(q_op::SELECT_ATTEMPT_OWNER_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let (worker_instance_id, lease_epoch): (Option<String>, Option<i64>) = match att_row {
+            Some(r) => (
+                r.try_get("worker_instance_id").map_err(map_sqlx_error)?,
+                r.try_get("lease_epoch").map_err(map_sqlx_error)?,
+            ),
+            None => (None, None),
+        };
+
+        let lease_active = worker_instance_id
+            .as_deref()
+            .is_some_and(|s| !s.is_empty());
+        if !lease_active {
+            return Ok((
+                RevokeLeaseResult::AlreadySatisfied {
+                    reason: "no_active_lease".to_owned(),
+                },
+                None,
+            ));
+        }
+
+        // Targeted-revoke fence (Valkey parity).
+        let caller_wiid = args.worker_instance_id.as_str();
+        if !caller_wiid.is_empty() && worker_instance_id.as_deref() != Some(caller_wiid) {
+            return Ok((
+                RevokeLeaseResult::AlreadySatisfied {
+                    reason: "different_worker_instance_id".to_owned(),
+                },
+                None,
+            ));
+        }
+
+        let prior_epoch = lease_epoch.unwrap_or(0);
+
+        // Optional expected_lease_id fence.
+        if let Some(expected) = args
+            .expected_lease_id
+            .as_ref()
+            .filter(|s| !s.is_empty())
+        {
+            let current_id =
+                synthetic_lease_id(exec_uuid, attempt_index as i32, prior_epoch);
+            if expected != &current_id {
+                return Ok((
+                    RevokeLeaseResult::AlreadySatisfied {
+                        reason: "lease_id_mismatch".to_owned(),
+                    },
+                    None,
+                ));
+            }
+        }
+
+        // CAS on lease_epoch.
+        let affected = sqlx::query(q_op::UPDATE_ATTEMPT_REVOKE_CAS_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .bind(prior_epoch)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?
+            .rows_affected();
+
+        if affected == 0 {
+            return Ok((
+                RevokeLeaseResult::AlreadySatisfied {
+                    reason: "epoch_moved".to_owned(),
+                },
+                None,
+            ));
+        }
+
+        // Flip exec_core back to reclaimable-runnable.
+        sqlx::query(q_op::UPDATE_EXEC_CORE_RECLAIMABLE_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(now)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let lease_ev = insert_lease_event(&mut conn, part, exec_uuid, "revoked", now).await?;
+
+        Ok((
+            RevokeLeaseResult::Revoked {
+                lease_id: synthetic_lease_id(exec_uuid, attempt_index as i32, prior_epoch),
+                lease_epoch: (prior_epoch + 1).to_string(),
+            },
+            Some(lease_ev),
+        ))
+    }
+    .await;
+
+    match result {
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+        Ok((ret, lease_ev)) => {
+            commit_or_rollback(&mut conn).await?;
+            if let Some(ev) = lease_ev {
+                dispatch_lease(pubsub, ev);
+            }
+            Ok(ret)
+        }
+    }
+}
+
+pub(crate) async fn revoke_lease_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: RevokeLeaseArgs,
+) -> Result<RevokeLeaseResult, EngineError> {
+    retry_serializable(|| revoke_lease_once(pool, pubsub, &args)).await
+}
+
+// ─── change_priority ───────────────────────────────────────────────
+
+async fn change_priority_once(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: &ChangePriorityArgs,
+) -> Result<ChangePriorityResult, EngineError> {
+    let (part, exec_uuid) = split_eid(&args.execution_id)?;
+    let now = args.now.0;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let row = sqlx::query(q_op::SELECT_CHANGE_PRIORITY_PRE_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let Some(row) = row else {
+            return Err(EngineError::NotFound {
+                entity: "execution",
+            });
+        };
+
+        let lifecycle_phase: String = row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+        let eligibility_state: String =
+            row.try_get("eligibility_state").map_err(map_sqlx_error)?;
+        let old_priority: i64 = row.try_get("priority").map_err(map_sqlx_error)?;
+
+        if lifecycle_phase != "runnable" || eligibility_state != "eligible_now" {
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotEligible));
+        }
+
+        // Clamp to [0, 9000] per Valkey `ff_change_priority`.
+        let new_priority = args.new_priority.clamp(0, 9000);
+
+        let affected = sqlx::query(q_op::UPDATE_EXEC_CORE_PRIORITY_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(new_priority)
+            .bind(now)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?
+            .rows_affected();
+
+        if affected == 0 {
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotEligible));
+        }
+
+        let details = json!({
+            "old_priority": old_priority,
+            "new_priority": new_priority,
+        });
+        let ev = insert_operator_event(
+            &mut conn,
+            part,
+            exec_uuid,
+            "priority_changed",
+            Some(details.to_string()),
+            now,
+        )
+        .await?;
+
+        Ok((
+            ChangePriorityResult::Changed {
+                execution_id: args.execution_id.clone(),
+            },
+            ev,
+        ))
+    }
+    .await;
+
+    match result {
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+        Ok((ret, ev)) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_operator(pubsub, ev);
+            Ok(ret)
+        }
+    }
+}
+
+pub(crate) async fn change_priority_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: ChangePriorityArgs,
+) -> Result<ChangePriorityResult, EngineError> {
+    retry_serializable(|| change_priority_once(pool, pubsub, &args)).await
+}
+
+// ─── replay_execution ──────────────────────────────────────────────
+
+async fn replay_execution_once(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: &ReplayExecutionArgs,
+) -> Result<ReplayExecutionResult, EngineError> {
+    let (part, exec_uuid) = split_eid(&args.execution_id)?;
+    let now = args.now.0;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let ec_row = sqlx::query(q_op::SELECT_REPLAY_PRE_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let Some(ec_row) = ec_row else {
+            return Err(EngineError::NotFound {
+                entity: "execution",
+            });
+        };
+
+        let lifecycle_phase: String = ec_row
+            .try_get("lifecycle_phase")
+            .map_err(map_sqlx_error)?;
+        let flow_id: Option<Vec<u8>> = ec_row.try_get("flow_id").map_err(map_sqlx_error)?;
+        let attempt_index: i64 = ec_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+        // Gate: lifecycle_phase = 'terminal' (Valkey canonical).
+        if lifecycle_phase != "terminal" {
+            return Err(EngineError::State(StateKind::ExecutionNotTerminal));
+        }
+
+        let att_row = sqlx::query(q_op::SELECT_ATTEMPT_OUTCOME_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let attempt_outcome: Option<String> = match att_row.as_ref() {
+            Some(r) => r.try_get("outcome").map_err(map_sqlx_error)?,
+            None => None,
+        };
+        let has_attempt_row = att_row.is_some();
+
+        // Branch: skipped flow member (Valkey `flowfabric.lua:8555`).
+        let is_skipped_flow_member =
+            attempt_outcome.as_deref() == Some("skipped") && flow_id.is_some();
+
+        // Reset downstream edge-group counters for skipped-flow-member.
+        let groups_reset: i64 = if is_skipped_flow_member {
+            sqlx::query(q_op::RESET_EDGE_GROUP_COUNTERS_SQL)
+                .bind(part)
+                .bind(exec_uuid)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?
+                .rows_affected() as i64
+        } else {
+            0
+        };
+
+        let (eligibility_state, public_state) = if is_skipped_flow_member {
+            ("blocked_by_dependencies", "waiting_children")
+        } else {
+            ("eligible_now", "waiting")
+        };
+
+        sqlx::query(q_op::UPDATE_EXEC_CORE_REPLAY_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(eligibility_state)
+            .bind(public_state)
+            .bind(now)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        if has_attempt_row {
+            sqlx::query(q_op::UPDATE_ATTEMPT_REPLAY_RESET_SQL)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(attempt_index)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+        }
+
+        let details = if is_skipped_flow_member {
+            json!({
+                "branch": "skipped_flow_member",
+                "groups_reset": groups_reset,
+            })
+        } else {
+            json!({
+                "branch": "normal",
+            })
+        };
+        let ev = insert_operator_event(
+            &mut conn,
+            part,
+            exec_uuid,
+            "replayed",
+            Some(details.to_string()),
+            now,
+        )
+        .await?;
+
+        let ps = if is_skipped_flow_member {
+            PublicState::WaitingChildren
+        } else {
+            PublicState::Waiting
+        };
+        Ok((ReplayExecutionResult::Replayed { public_state: ps }, ev))
+    }
+    .await;
+
+    match result {
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+        Ok((ret, ev)) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_operator(pubsub, ev);
+            Ok(ret)
+        }
+    }
+}
+
+pub(crate) async fn replay_execution_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: ReplayExecutionArgs,
+) -> Result<ReplayExecutionResult, EngineError> {
+    retry_serializable(|| replay_execution_once(pool, pubsub, &args)).await
+}

--- a/crates/ff-backend-sqlite/src/queries/attempt.rs
+++ b/crates/ff-backend-sqlite/src/queries/attempt.rs
@@ -141,7 +141,9 @@ pub(crate) const INSERT_COMPLETION_EVENT_SQL: &str = r#"
         namespace, instance_tag, occurred_at_ms
     )
     SELECT partition_key, execution_id, flow_id, ?1,
-           NULL, NULL, ?2
+           json_extract(raw_fields, '$.namespace'),
+           json_extract(raw_fields, '$.tags."cairn.instance_id"'),
+           ?2
       FROM ff_exec_core
      WHERE partition_key = ?3 AND execution_id = ?4
 "#;

--- a/crates/ff-backend-sqlite/src/queries/dispatch.rs
+++ b/crates/ff-backend-sqlite/src/queries/dispatch.rs
@@ -12,20 +12,40 @@
 
 // ── lease_event outbox ────────────────────────────────────────────────
 
-/// Insert one lease-lifecycle outbox row. Mirror of the in-line SQL
-/// previously embedded in `backend.rs::insert_lease_event` (Phase 2a.2);
-/// centralized here so post-commit broadcast emit picks up the
-/// `event_id` with one read.
+/// Insert one lease-lifecycle outbox row, back-filling `namespace` +
+/// `instance_tag` from the co-transactional `ff_exec_core.raw_fields`
+/// row so tag-filtered subscribers do not silently drop the event
+/// (Phase 3.2 fix — pre-fix, both columns landed NULL and a filter
+/// with `instance_tag=...` matched zero rows). Mirrors the
+/// `INSERT_SIGNAL_EVENT_SQL` SELECT+UNION-ALL shape from
+/// `queries/signal.rs`: the first branch reads exec_core (usual
+/// path); the second branch fires only when the exec row does not
+/// exist so the insert is still guaranteed by the 4 shipped binds
+/// and never lost.
 ///
 /// Binds:
-///   1. execution_id (TEXT — UUID string)
+///   1. execution_id (TEXT — UUID string) — emitted on the outbox row
 ///   2. event_type (TEXT)
 ///   3. occurred_at_ms (i64)
-///   4. partition_key (i64)
+///   4. partition_key (i64) — used both on the outbox row and the
+///      co-transactional exec_core lookup
+///   5. execution_id (BLOB) — `ff_exec_core.execution_id` is BLOB, so
+///      the lookup binds the Uuid-as-bytes form
 pub(crate) const INSERT_LEASE_EVENT_SQL: &str = r#"
     INSERT INTO ff_lease_event
-        (execution_id, lease_id, event_type, occurred_at_ms, partition_key)
-    VALUES (?1, NULL, ?2, ?3, ?4)
+        (execution_id, lease_id, event_type, occurred_at_ms, partition_key,
+         namespace, instance_tag)
+    SELECT ?1, NULL, ?2, ?3, ?4,
+           json_extract(raw_fields, '$.namespace'),
+           json_extract(raw_fields, '$.tags."cairn.instance_id"')
+      FROM ff_exec_core
+     WHERE partition_key = ?4 AND execution_id = ?5
+    UNION ALL
+    SELECT ?1, NULL, ?2, ?3, ?4, NULL, NULL
+     WHERE NOT EXISTS (
+         SELECT 1 FROM ff_exec_core
+          WHERE partition_key = ?4 AND execution_id = ?5
+     )
 "#;
 
 // ── signal_event outbox ───────────────────────────────────────────────
@@ -49,24 +69,8 @@ pub(crate) const INSERT_SIGNAL_EVENT_SQL: &str = r#"
     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
 "#;
 
-// ── operator_event outbox ─────────────────────────────────────────────
-
-/// Insert one operator-event outbox row. Used by Wave-9 admin ops
-/// (Phase 2b.2+); the migration CHECK clause restricts `event_type`
-/// to the allowed literal set.
-///
-/// Binds:
-///   1. execution_id (TEXT)
-///   2. event_type (TEXT)
-///   3. details (Option<TEXT JSON>)
-///   4. occurred_at_ms (i64)
-///   5. partition_key (i64)
-///   6. namespace (Option<TEXT>)
-///   7. instance_tag (Option<TEXT>)
-#[allow(dead_code)] // Consumed by Phase 2b.2 change_priority / replay / cancel_flow_header
-pub(crate) const INSERT_OPERATOR_EVENT_SQL: &str = r#"
-    INSERT INTO ff_operator_event
-        (execution_id, event_type, details, occurred_at_ms, partition_key,
-         namespace, instance_tag)
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-"#;
+// Operator-event outbox inserts live in `queries::operator`
+// (Phase 3.2). See `queries/operator.rs::INSERT_OPERATOR_EVENT_SQL` —
+// the Wave-9 producer back-fills namespace + instance_tag from
+// exec_core.raw_fields via co-transactional SELECT, matching the
+// lease/completion/signal producer shape.

--- a/crates/ff-backend-sqlite/src/queries/mod.rs
+++ b/crates/ff-backend-sqlite/src/queries/mod.rs
@@ -15,6 +15,7 @@ pub mod exec_core;
 pub mod flow;
 pub mod flow_staging;
 pub mod lease;
+pub mod operator;
 pub mod signal;
 pub mod stream;
 pub mod suspend;

--- a/crates/ff-backend-sqlite/src/queries/operator.rs
+++ b/crates/ff-backend-sqlite/src/queries/operator.rs
@@ -1,0 +1,246 @@
+//! SQL statements for Wave 9 operator-control ops (RFC-023 Phase 3.2).
+//!
+//! Mirrors `ff-backend-postgres/src/operator.rs`. SQLite-specific
+//! translations:
+//!
+//! * `jsonb_set(raw_fields, '{k}', to_jsonb($::text))` →
+//!   `json_set(raw_fields, '$.k', ?)`. `raw_fields` is TEXT JSON
+//!   (JSON1), not JSONB.
+//! * `raw_fields->>'replay_count'` → `json_extract(raw_fields,
+//!   '$.replay_count')`. Cast to INTEGER happens via SQLite's implicit
+//!   numeric coercion inside arithmetic.
+//! * `FOR NO KEY UPDATE` / `FOR UPDATE` are no-ops — the enclosing
+//!   `BEGIN IMMEDIATE` holds the RESERVED lock for the full
+//!   read-modify-write window.
+//! * `ExecutionId` UUIDs are bound as 16-byte `BLOB`s (see
+//!   `backend::split_exec_id`), not stringified UUIDs as on PG.
+
+// ── cancel_execution ───────────────────────────────────────────────
+
+/// Pre-read: pin `exec_core` + current-attempt lease identity.
+/// Binds: ?1 partition_key, ?2 execution_id BLOB, ?3 attempt_index
+/// is re-bound separately on the attempt row via `attempt_index` from
+/// this read.
+pub(crate) const SELECT_CANCEL_PRE_SQL: &str = r#"
+    SELECT ec.lifecycle_phase  AS lifecycle_phase,
+           ec.public_state     AS public_state,
+           ec.attempt_index    AS attempt_index,
+           a.worker_instance_id AS worker_instance_id,
+           a.lease_epoch       AS lease_epoch
+      FROM ff_exec_core ec
+      LEFT JOIN ff_attempt a
+        ON a.partition_key = ec.partition_key
+       AND a.execution_id  = ec.execution_id
+       AND a.attempt_index = ec.attempt_index
+     WHERE ec.partition_key = ?1 AND ec.execution_id = ?2
+"#;
+
+/// Flip `ff_exec_core` into the terminal `cancelled` state. Matches
+/// `ff-backend-postgres/src/operator.rs:211-236`. Binds: ?1 part, ?2
+/// exec_uuid BLOB, ?3 now_ms, ?4 reason, ?5 source_str.
+pub(crate) const UPDATE_EXEC_CORE_CANCELLED_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase     = 'cancelled',
+           ownership_state     = 'unowned',
+           eligibility_state   = 'not_applicable',
+           public_state        = 'cancelled',
+           attempt_state       = 'cancelled',
+           terminal_at_ms      = COALESCE(terminal_at_ms, ?3),
+           cancellation_reason = COALESCE(cancellation_reason, ?4),
+           cancelled_by        = COALESCE(cancelled_by, ?5),
+           raw_fields          = json_set(raw_fields, '$.last_mutation_at', CAST(?3 AS TEXT))
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Clear the current attempt's lease fields, bump lease_epoch, mark
+/// outcome='cancelled'. Binds: ?1 part, ?2 exec_uuid BLOB, ?3
+/// attempt_index, ?4 now_ms.
+pub(crate) const UPDATE_ATTEMPT_CANCELLED_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET worker_instance_id   = NULL,
+           lease_expires_at_ms  = NULL,
+           lease_epoch          = lease_epoch + 1,
+           terminal_at_ms       = ?4,
+           outcome              = 'cancelled'
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+// ── revoke_lease ───────────────────────────────────────────────────
+
+/// Pre-read: exec_core.attempt_index.
+pub(crate) const SELECT_EXEC_ATTEMPT_INDEX_SQL: &str = r#"
+    SELECT attempt_index
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Pre-read: attempt's current owner + epoch.
+pub(crate) const SELECT_ATTEMPT_OWNER_SQL: &str = r#"
+    SELECT worker_instance_id, lease_epoch
+      FROM ff_attempt
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+/// CAS on lease_epoch — clears the lease + bumps the epoch. Row-count
+/// = 0 → concurrent revoker won, surface `AlreadySatisfied
+/// (epoch_moved)`. Binds: ?1 part, ?2 exec_uuid, ?3 attempt_index, ?4
+/// prior_epoch.
+pub(crate) const UPDATE_ATTEMPT_REVOKE_CAS_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET worker_instance_id   = NULL,
+           lease_expires_at_ms  = NULL,
+           lease_epoch          = lease_epoch + 1
+     WHERE partition_key = ?1
+       AND execution_id  = ?2
+       AND attempt_index = ?3
+       AND lease_epoch   = ?4
+"#;
+
+/// Flip exec_core back to runnable (reclaimable) — gated on
+/// lifecycle_phase='active' so a concurrent cancel/complete is not
+/// overwritten. Binds: ?1 part, ?2 exec_uuid, ?3 now_ms.
+pub(crate) const UPDATE_EXEC_CORE_RECLAIMABLE_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase   = 'runnable',
+           ownership_state   = 'unowned',
+           eligibility_state = 'eligible_now',
+           attempt_state     = 'attempt_interrupted',
+           raw_fields        = json_set(raw_fields, '$.last_mutation_at', CAST(?3 AS TEXT))
+     WHERE partition_key = ?1 AND execution_id = ?2
+       AND lifecycle_phase = 'active'
+"#;
+
+// ── change_priority ────────────────────────────────────────────────
+
+/// Pre-read: gate fields + current priority. Binds: ?1 part, ?2
+/// exec_uuid BLOB.
+pub(crate) const SELECT_CHANGE_PRIORITY_PRE_SQL: &str = r#"
+    SELECT lifecycle_phase, eligibility_state, priority
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Update priority — gated on lifecycle_phase='runnable' AND
+/// eligibility_state='eligible_now' (Valkey-canonical gate from
+/// `flowfabric.lua:3683-3688`). Row-count = 0 on concurrent transition
+/// surfaces `ExecutionNotEligible`. Binds: ?1 part, ?2 exec_uuid, ?3
+/// new_priority, ?4 now_ms.
+pub(crate) const UPDATE_EXEC_CORE_PRIORITY_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET priority   = ?3,
+           raw_fields = json_set(raw_fields, '$.last_mutation_at', CAST(?4 AS TEXT))
+     WHERE partition_key = ?1 AND execution_id = ?2
+       AND lifecycle_phase   = 'runnable'
+       AND eligibility_state = 'eligible_now'
+"#;
+
+// ── replay_execution ───────────────────────────────────────────────
+
+/// Pre-read: lifecycle gate + flow membership + attempt index for
+/// deriving the skipped-flow-member branch.
+pub(crate) const SELECT_REPLAY_PRE_SQL: &str = r#"
+    SELECT lifecycle_phase, flow_id, attempt_index
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Read current attempt's outcome for the skipped-branch selector.
+pub(crate) const SELECT_ATTEMPT_OUTCOME_SQL: &str = r#"
+    SELECT outcome
+      FROM ff_attempt
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+/// Reset downstream edge-group counters for the skipped-flow-member
+/// replay branch. skip/fail/running → 0; success_count preserved per
+/// Valkey ground-truth at `flowfabric.lua:8580`. Binds: ?1 part, ?2
+/// exec_uuid_blob (downstream_eid).
+pub(crate) const RESET_EDGE_GROUP_COUNTERS_SQL: &str = r#"
+    UPDATE ff_edge_group
+       SET skip_count    = 0,
+           fail_count    = 0,
+           running_count = 0
+     WHERE (partition_key, flow_id, downstream_eid) IN (
+       SELECT DISTINCT e.partition_key, e.flow_id, e.downstream_eid
+         FROM ff_edge e
+        WHERE e.partition_key   = ?1
+          AND e.downstream_eid  = ?2
+     )
+"#;
+
+/// Flip exec_core back to runnable + bump `replay_count`. Binds: ?1
+/// part, ?2 exec_uuid BLOB, ?3 eligibility_state, ?4 public_state, ?5
+/// now_ms.
+///
+/// SQLite's `json_set` doesn't support JSON-pointer arithmetic in a
+/// single call the way PG's `jsonb_set(..., to_jsonb(... + 1))` does.
+/// We nest two `json_set` calls: the inner one bumps
+/// `replay_count`, the outer stamps `last_mutation_at`. The bump
+/// reads the current value via `json_extract` + `COALESCE(..., 0)`
+/// so the first replay initializes it from 0 → 1.
+pub(crate) const UPDATE_EXEC_CORE_REPLAY_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase      = 'runnable',
+           ownership_state      = 'unowned',
+           eligibility_state    = ?3,
+           public_state         = ?4,
+           attempt_state        = 'pending_replay_attempt',
+           terminal_at_ms       = NULL,
+           result               = NULL,
+           cancellation_reason  = NULL,
+           cancelled_by         = NULL,
+           raw_fields           = json_set(
+               json_set(
+                   raw_fields,
+                   '$.replay_count',
+                   CAST(COALESCE(CAST(json_extract(raw_fields, '$.replay_count') AS INTEGER), 0) + 1 AS TEXT)
+               ),
+               '$.last_mutation_at',
+               CAST(?5 AS TEXT)
+           )
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Reset current attempt row in-place (Rev 7 Fork 2 Option A — no new
+/// attempt row). Binds: ?1 part, ?2 exec_uuid, ?3 attempt_index.
+pub(crate) const UPDATE_ATTEMPT_REPLAY_RESET_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET outcome              = NULL,
+           terminal_at_ms       = NULL,
+           worker_id            = NULL,
+           worker_instance_id   = NULL,
+           lease_expires_at_ms  = NULL,
+           lease_epoch          = lease_epoch + 1
+     WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
+"#;
+
+// ── operator_event outbox (co-transactional) ───────────────────────
+
+/// Insert one operator-event outbox row, back-filling `namespace` +
+/// `instance_tag` from the co-transactional `ff_exec_core.raw_fields`
+/// row (Phase 3.2 fix — mirrors the lease_event / completion_event
+/// back-fill). Binds:
+///
+///   1. execution_id TEXT — emitted on the outbox row.
+///   2. event_type TEXT.
+///   3. details TEXT (nullable JSON).
+///   4. occurred_at_ms (i64).
+///   5. partition_key (i64) — used on both the outbox row and the
+///      co-transactional exec_core lookup.
+///   6. execution_id BLOB — `ff_exec_core.execution_id` is BLOB.
+pub(crate) const INSERT_OPERATOR_EVENT_SQL: &str = r#"
+    INSERT INTO ff_operator_event
+        (execution_id, event_type, details, occurred_at_ms, partition_key,
+         namespace, instance_tag)
+    SELECT ?1, ?2, ?3, ?4, ?5,
+           json_extract(raw_fields, '$.namespace'),
+           json_extract(raw_fields, '$.tags."cairn.instance_id"')
+      FROM ff_exec_core
+     WHERE partition_key = ?5 AND execution_id = ?6
+    UNION ALL
+    SELECT ?1, ?2, ?3, ?4, ?5, NULL, NULL
+     WHERE NOT EXISTS (
+         SELECT 1 FROM ff_exec_core
+          WHERE partition_key = ?5 AND execution_id = ?6
+     )
+"#;

--- a/crates/ff-backend-sqlite/src/queries/operator.rs
+++ b/crates/ff-backend-sqlite/src/queries/operator.rs
@@ -18,9 +18,9 @@
 // ── cancel_execution ───────────────────────────────────────────────
 
 /// Pre-read: pin `exec_core` + current-attempt lease identity.
-/// Binds: ?1 partition_key, ?2 execution_id BLOB, ?3 attempt_index
-/// is re-bound separately on the attempt row via `attempt_index` from
-/// this read.
+/// Binds: ?1 partition_key, ?2 execution_id BLOB. `attempt_index` is
+/// returned by this read (not bound) and is re-bound separately on
+/// the attempt-row follow-up statements.
 pub(crate) const SELECT_CANCEL_PRE_SQL: &str = r#"
     SELECT ec.lifecycle_phase  AS lifecycle_phase,
            ec.public_state     AS public_state,
@@ -178,6 +178,13 @@ pub(crate) const RESET_EDGE_GROUP_COUNTERS_SQL: &str = r#"
 /// `replay_count`, the outer stamps `last_mutation_at`. The bump
 /// reads the current value via `json_extract` + `COALESCE(..., 0)`
 /// so the first replay initializes it from 0 → 1.
+///
+/// `replay_count` is stored as a JSON **number** (not a string): the
+/// SQLite integer result of the arithmetic flows directly into
+/// `json_set(...)` without a `CAST ... AS TEXT` wrapper, matching the
+/// PG reference's `to_jsonb(... + 1)` shape. `last_mutation_at` stays
+/// a JSON string to match how it is written elsewhere (e.g.
+/// `build_create_execution_raw_fields`).
 pub(crate) const UPDATE_EXEC_CORE_REPLAY_SQL: &str = r#"
     UPDATE ff_exec_core
        SET lifecycle_phase      = 'runnable',
@@ -193,7 +200,7 @@ pub(crate) const UPDATE_EXEC_CORE_REPLAY_SQL: &str = r#"
                json_set(
                    raw_fields,
                    '$.replay_count',
-                   CAST(COALESCE(CAST(json_extract(raw_fields, '$.replay_count') AS INTEGER), 0) + 1 AS TEXT)
+                   COALESCE(CAST(json_extract(raw_fields, '$.replay_count') AS INTEGER), 0) + 1
                ),
                '$.last_mutation_at',
                CAST(?5 AS TEXT)

--- a/crates/ff-backend-sqlite/src/queries/signal.rs
+++ b/crates/ff-backend-sqlite/src/queries/signal.rs
@@ -39,10 +39,25 @@ pub const INSERT_SIGNAL_EVENT_SQL: &str = "INSERT INTO ff_signal_event \
       )";
 
 /// Completion outbox insert for the `resumable` transition when a
-/// signal satisfies a waitpoint. `flow_id` + `namespace` + `instance_tag`
-/// columns on `ff_completion_event` default to NULL when not provided —
-/// matches the PG path's minimal insert shape at
-/// `ff-backend-postgres/src/suspend_ops.rs:845-854`.
+/// signal satisfies a waitpoint. Back-fills `namespace` +
+/// `instance_tag` from `ff_exec_core.raw_fields` via a
+/// co-transactional SELECT so tag-filtered subscribers receive the
+/// event (Phase 3.2 fix — pre-fix both columns landed NULL).
+/// `flow_id` stays NULL here (matches the PG minimal insert shape at
+/// `ff-backend-postgres/src/suspend_ops.rs:845-854`).
+///
+/// Binds: ?1 partition_key, ?2 execution_id (BLOB — reused for the
+/// exec_core lookup), ?3 occurred_at_ms.
 pub const INSERT_COMPLETION_RESUMABLE_SQL: &str = "INSERT INTO ff_completion_event \
-     (partition_key, execution_id, outcome, occurred_at_ms) \
-     VALUES (?1, ?2, 'resumable', ?3)";
+     (partition_key, execution_id, outcome, occurred_at_ms, namespace, instance_tag) \
+     SELECT ?1, ?2, 'resumable', ?3, \
+            json_extract(raw_fields, '$.namespace'), \
+            json_extract(raw_fields, '$.tags.\"cairn.instance_id\"') \
+       FROM ff_exec_core \
+      WHERE partition_key = ?1 AND execution_id = ?2 \
+     UNION ALL \
+     SELECT ?1, ?2, 'resumable', ?3, NULL, NULL \
+      WHERE NOT EXISTS ( \
+          SELECT 1 FROM ff_exec_core \
+           WHERE partition_key = ?1 AND execution_id = ?2 \
+      )";

--- a/crates/ff-backend-sqlite/src/queries/signal.rs
+++ b/crates/ff-backend-sqlite/src/queries/signal.rs
@@ -48,16 +48,18 @@ pub const INSERT_SIGNAL_EVENT_SQL: &str = "INSERT INTO ff_signal_event \
 ///
 /// Binds: ?1 partition_key, ?2 execution_id (BLOB — reused for the
 /// exec_core lookup), ?3 occurred_at_ms.
-pub const INSERT_COMPLETION_RESUMABLE_SQL: &str = "INSERT INTO ff_completion_event \
-     (partition_key, execution_id, outcome, occurred_at_ms, namespace, instance_tag) \
-     SELECT ?1, ?2, 'resumable', ?3, \
-            json_extract(raw_fields, '$.namespace'), \
-            json_extract(raw_fields, '$.tags.\"cairn.instance_id\"') \
-       FROM ff_exec_core \
-      WHERE partition_key = ?1 AND execution_id = ?2 \
-     UNION ALL \
-     SELECT ?1, ?2, 'resumable', ?3, NULL, NULL \
-      WHERE NOT EXISTS ( \
-          SELECT 1 FROM ff_exec_core \
-           WHERE partition_key = ?1 AND execution_id = ?2 \
-      )";
+pub const INSERT_COMPLETION_RESUMABLE_SQL: &str = r#"
+    INSERT INTO ff_completion_event
+        (partition_key, execution_id, outcome, occurred_at_ms, namespace, instance_tag)
+    SELECT ?1, ?2, 'resumable', ?3,
+           json_extract(raw_fields, '$.namespace'),
+           json_extract(raw_fields, '$.tags."cairn.instance_id"')
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+    UNION ALL
+    SELECT ?1, ?2, 'resumable', ?3, NULL, NULL
+     WHERE NOT EXISTS (
+         SELECT 1 FROM ff_exec_core
+          WHERE partition_key = ?1 AND execution_id = ?2
+     )
+"#;

--- a/crates/ff-backend-sqlite/src/suspend_ops.rs
+++ b/crates/ff-backend-sqlite/src/suspend_ops.rs
@@ -1042,6 +1042,9 @@ pub(crate) async fn claim_resumed_execution_impl(
             .bind("acquired")
             .bind(now)
             .bind(part)
+            // BLOB bind for the co-transactional exec_core lookup that
+            // back-fills namespace + instance_tag (Phase 3.2 fix).
+            .bind(exec_uuid)
             .execute(&mut *conn)
             .await
             .map_err(map_sqlx_error)?;

--- a/crates/ff-backend-sqlite/tests/subscribe.rs
+++ b/crates/ff-backend-sqlite/tests/subscribe.rs
@@ -300,28 +300,35 @@ async fn subscribe_completion_cursor_resume() {
 
 #[tokio::test]
 #[serial(ff_dev_mode)]
-async fn subscribe_completion_filter_drops_null_tag_rows() {
+async fn subscribe_completion_filter_by_instance_tag_receives_events() {
+    // Phase 3.2 fix: the SQLite completion producer now populates
+    // `instance_tag` from `ff_exec_core.raw_fields.tags."cairn.instance_id"`
+    // via a co-transactional SELECT (see
+    // `queries/attempt.rs::INSERT_COMPLETION_EVENT_SQL`). A subscriber
+    // filtering on a matching tag MUST observe the event; a subscriber
+    // with a non-matching filter MUST drop it.
     let b = fresh_backend().await;
-    // The SQLite completion outbox writes NULL `instance_tag` on every
-    // row today, so a non-noop filter drops every event. This mirrors
-    // the Postgres "filtered subscribers silently drop NULL-column
-    // rows" invariant. The assertion below is the visible shape of
-    // that invariant — once the producer is taught to populate the
-    // column, this test updates to positive filter-through.
-    let filter = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-nope");
+    let filter = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-42");
     let mut stream = b
         .subscribe_completion(StreamCursor::empty(), &filter)
         .await
         .expect("subscribe");
     tokio::time::sleep(Duration::from_millis(20)).await;
 
+    // Untagged completion — filter drops it.
     let (_e, h) = create_and_claim(&b).await;
-    b.complete(&h, None).await.expect("complete");
+    b.complete(&h, None).await.expect("complete untagged");
 
-    let events = drain_n::<CompletionEvent>(&mut stream, 1, Duration::from_millis(400)).await;
-    assert!(
-        events.is_empty(),
-        "filter with instance_tag must drop NULL-column completion rows"
+    // Tagged completion — filter passes it through.
+    let (_e, h) = create_and_claim_tagged(&b, Some(("cairn.instance_id", "i-42"))).await;
+    b.complete(&h, None).await.expect("complete tagged");
+
+    let events =
+        drain_n::<CompletionEvent>(&mut stream, 1, Duration::from_millis(2000)).await;
+    assert_eq!(
+        events.len(),
+        1,
+        "filter should pass through exactly one tagged completion event"
     );
 }
 
@@ -383,19 +390,40 @@ async fn subscribe_lease_history_cursor_resume() {
 
 #[tokio::test]
 #[serial(ff_dev_mode)]
-async fn subscribe_lease_history_filter_drops_null_tag_rows() {
+async fn subscribe_lease_history_filter_by_instance_tag_receives_events() {
+    // Phase 3.2 fix: the SQLite lease_event producer now populates
+    // `instance_tag` from `ff_exec_core.raw_fields.tags."cairn.instance_id"`
+    // via a co-transactional SELECT (see
+    // `queries/dispatch.rs::INSERT_LEASE_EVENT_SQL`). A subscriber
+    // filtering on a matching tag MUST observe the full lease
+    // lifecycle (acquired + revoked); a non-matching filter MUST drop.
     let b = fresh_backend().await;
-    let filter = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-nope");
+    let filter = ScannerFilter::new().with_instance_tag("cairn.instance_id", "i-42");
     let mut stream = b
         .subscribe_lease_history(StreamCursor::empty(), &filter)
         .await
         .expect("subscribe");
     tokio::time::sleep(Duration::from_millis(20)).await;
-    let (_eid, handle) = create_and_claim(&b).await;
-    b.complete(&handle, None).await.expect("complete");
+
+    // Untagged — filter drops every event.
+    let (_eid, h_untagged) = create_and_claim(&b).await;
+    b.complete(&h_untagged, None).await.expect("complete untagged");
+
+    // Tagged — acquired + revoked both land with instance_tag=i-42,
+    // both pass the filter.
+    let (_eid, h_tagged) =
+        create_and_claim_tagged(&b, Some(("cairn.instance_id", "i-42"))).await;
+    b.complete(&h_tagged, None).await.expect("complete tagged");
+
     let events =
-        drain_n::<LeaseHistoryEvent>(&mut stream, 1, Duration::from_millis(400)).await;
-    assert!(events.is_empty(), "filtered lease-history drops NULL rows");
+        drain_n::<LeaseHistoryEvent>(&mut stream, 2, Duration::from_millis(2000)).await;
+    assert_eq!(
+        events.len(),
+        2,
+        "tagged acquired + revoked should both pass the filter, got {events:?}"
+    );
+    assert!(matches!(events[0], LeaseHistoryEvent::Acquired { .. }));
+    assert!(matches!(events[1], LeaseHistoryEvent::Revoked { .. }));
 }
 
 // ── subscribe_signal_delivery ─────────────────────────────────────────

--- a/crates/ff-backend-sqlite/tests/wave9_operator.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_operator.rs
@@ -430,8 +430,8 @@ async fn replay_execution_normal_branch() {
 
     // lifecycle_phase flipped back to runnable.
     assert_eq!(read_lifecycle_phase(&b, exec_uuid).await, "runnable");
-    // raw_fields.replay_count bumped to 1.
-    let replay_count: String = sqlx::query_scalar(
+    // raw_fields.replay_count bumped to 1 (stored as JSON number).
+    let replay_count: i64 = sqlx::query_scalar(
         "SELECT json_extract(raw_fields, '$.replay_count') \
          FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
     )
@@ -439,7 +439,7 @@ async fn replay_execution_normal_branch() {
     .fetch_one(b.pool_for_test())
     .await
     .unwrap();
-    assert_eq!(replay_count, "1");
+    assert_eq!(replay_count, 1);
     // operator_event 'replayed' emitted.
     assert_eq!(count_outbox(&b, "ff_operator_event", exec_uuid).await, 1);
 }

--- a/crates/ff-backend-sqlite/tests/wave9_operator.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_operator.rs
@@ -1,0 +1,601 @@
+//! RFC-023 Phase 3.2 — Wave 9 operator-control integration tests.
+//!
+//! Covers `cancel_execution`, `revoke_lease`, `change_priority`, and
+//! `replay_execution` on the SQLite backend: happy path, fence /
+//! gate failures, outbox emission, and the replay branch selector
+//! (normal vs skipped_flow_member).
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CapabilitySet, ClaimPolicy};
+use ff_core::contracts::{
+    CancelExecutionArgs, CancelExecutionResult, ChangePriorityArgs, ChangePriorityResult,
+    CreateExecutionArgs, CreateExecutionResult, ReplayExecutionArgs, ReplayExecutionResult,
+    RevokeLeaseArgs, RevokeLeaseResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind};
+use ff_core::state::PublicState;
+use ff_core::types::{
+    CancelSource, ExecutionId, LaneId, LeaseEpoch, Namespace, TimestampMs, WorkerId,
+    WorkerInstanceId,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+// ── Setup helpers ──────────────────────────────────────────────────
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    // SAFETY: test-only env; all callers are serial-gated.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:rfc-023-wave9-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("construct backend")
+}
+
+fn new_exec_id() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id")
+}
+
+fn create_args(exec_id: &ExecutionId, lane_id: &LaneId) -> CreateExecutionArgs {
+    CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: lane_id.clone(),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(now_ms()),
+    }
+}
+
+/// Create a runnable exec. Mirrors the claim-path pre-setup used by
+/// `tests/subscribe.rs`: after create_execution the row is in a
+/// `pending`/`initial` shape that `claim()` does not yet route; force
+/// it to `runnable` + `pending` so a claim call finds it.
+async fn create_runnable(b: &Arc<SqliteBackend>) -> (ExecutionId, LaneId) {
+    let lane_id = LaneId::new(format!("lane-{}", Uuid::new_v4()));
+    let exec_id = new_exec_id();
+    let args = create_args(&exec_id, &lane_id);
+    let r = b.create_execution(args).await.expect("create");
+    assert!(matches!(r, CreateExecutionResult::Created { .. }));
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', public_state='pending', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    (exec_id, lane_id)
+}
+
+async fn create_and_claim(
+    b: &Arc<SqliteBackend>,
+) -> (ExecutionId, ff_core::backend::Handle) {
+    let (exec_id, lane_id) = create_runnable(b).await;
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i1"),
+        30_000,
+        None,
+    );
+    let handle = b
+        .claim(&lane_id, &CapabilitySet::default(), policy)
+        .await
+        .expect("claim")
+        .expect("handle");
+    (exec_id, handle)
+}
+
+fn uuid_of(eid: &ExecutionId) -> Uuid {
+    Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap()
+}
+
+async fn count_outbox(
+    b: &Arc<SqliteBackend>,
+    table: &str,
+    exec_uuid: Uuid,
+) -> i64 {
+    let sql = format!(
+        "SELECT COUNT(*) FROM {table} WHERE execution_id = ?1 AND partition_key = 0"
+    );
+    sqlx::query_scalar::<_, i64>(&sql)
+        .bind(exec_uuid.to_string())
+        .fetch_one(b.pool_for_test())
+        .await
+        .unwrap()
+}
+
+async fn read_lifecycle_phase(b: &Arc<SqliteBackend>, exec_uuid: Uuid) -> String {
+    sqlx::query_scalar::<_, String>(
+        "SELECT lifecycle_phase FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap()
+}
+
+// ── cancel_execution ───────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn cancel_execution_happy_path() {
+    let b = fresh_backend().await;
+    let (exec_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+
+    let args = CancelExecutionArgs {
+        execution_id: exec_id.clone(),
+        reason: "operator test".into(),
+        source: CancelSource::OperatorOverride,
+        lease_id: None,
+        lease_epoch: None,
+        attempt_id: None,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let r = b.cancel_execution(args).await.expect("cancel");
+    assert!(matches!(
+        r,
+        CancelExecutionResult::Cancelled {
+            public_state: PublicState::Cancelled,
+            ..
+        }
+    ));
+
+    // exec_core flipped to cancelled.
+    assert_eq!(read_lifecycle_phase(&b, exec_uuid).await, "cancelled");
+
+    // Per RFC-020 §4.2.7 matrix, cancel_execution emits ONLY the
+    // lease_event (`revoked`) when a lease was active — no
+    // ff_operator_event row. acquired (from claim) + revoked (from
+    // cancel) = 2 lease_event rows.
+    assert_eq!(count_outbox(&b, "ff_operator_event", exec_uuid).await, 0);
+    assert_eq!(count_outbox(&b, "ff_lease_event", exec_uuid).await, 2,
+        "acquired + revoked lease events expected");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn cancel_execution_idempotent_when_already_cancelled() {
+    let b = fresh_backend().await;
+    let (exec_id, _handle) = create_and_claim(&b).await;
+
+    let args = CancelExecutionArgs {
+        execution_id: exec_id.clone(),
+        reason: "first".into(),
+        source: CancelSource::OperatorOverride,
+        lease_id: None,
+        lease_epoch: None,
+        attempt_id: None,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let _ = b.cancel_execution(args.clone()).await.expect("cancel 1");
+    // Second call — idempotent replay.
+    let r = b.cancel_execution(args).await.expect("cancel 2");
+    assert!(matches!(r, CancelExecutionResult::Cancelled { .. }));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn cancel_execution_lease_fence_required_when_not_operator_override() {
+    let b = fresh_backend().await;
+    let (exec_id, _handle) = create_and_claim(&b).await;
+
+    // source != OperatorOverride + lease active + missing lease_epoch ⇒
+    // Validation error per RFC-020 §4.2.1.
+    let args = CancelExecutionArgs {
+        execution_id: exec_id.clone(),
+        reason: "no fence".into(),
+        source: CancelSource::LeaseHolder,
+        lease_id: None,
+        lease_epoch: None,
+        attempt_id: None,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let err = b.cancel_execution(args).await.unwrap_err();
+    assert!(matches!(err, EngineError::Validation { .. }), "got {err:?}");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn cancel_execution_stale_lease_fence_rejects() {
+    let b = fresh_backend().await;
+    let (exec_id, _handle) = create_and_claim(&b).await;
+
+    // Wrong lease_epoch — triggers StaleLease.
+    let args = CancelExecutionArgs {
+        execution_id: exec_id.clone(),
+        reason: "bad fence".into(),
+        source: CancelSource::LeaseHolder,
+        lease_id: None,
+        lease_epoch: Some(LeaseEpoch(999_999)),
+        attempt_id: None,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let err = b.cancel_execution(args).await.unwrap_err();
+    assert!(
+        matches!(err, EngineError::State(StateKind::StaleLease)),
+        "got {err:?}"
+    );
+}
+
+// ── revoke_lease ───────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn revoke_lease_happy_path() {
+    let b = fresh_backend().await;
+    let (exec_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+
+    let args = RevokeLeaseArgs {
+        execution_id: exec_id.clone(),
+        expected_lease_id: None,
+        worker_instance_id: WorkerInstanceId::new("w1-i1"),
+        reason: "operator revoke".into(),
+    };
+    let r = b.revoke_lease(args).await.expect("revoke");
+    assert!(matches!(r, RevokeLeaseResult::Revoked { .. }), "got {r:?}");
+
+    // Lease cleared — another acquired + revoked pair in the outbox.
+    assert_eq!(
+        count_outbox(&b, "ff_lease_event", exec_uuid).await,
+        2,
+        "expected acquired (from claim) + revoked (from revoke_lease)"
+    );
+
+    // exec_core back to runnable (reclaimable).
+    assert_eq!(read_lifecycle_phase(&b, exec_uuid).await, "runnable");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn revoke_lease_no_active_lease_returns_already_satisfied() {
+    let b = fresh_backend().await;
+    let (exec_id, _lane) = create_runnable(&b).await;
+
+    let args = RevokeLeaseArgs {
+        execution_id: exec_id.clone(),
+        expected_lease_id: None,
+        worker_instance_id: WorkerInstanceId::new("w1-i1"),
+        reason: "no lease".into(),
+    };
+    let r = b.revoke_lease(args).await.expect("revoke");
+    match r {
+        RevokeLeaseResult::AlreadySatisfied { reason } => {
+            assert_eq!(reason, "no_active_lease");
+        }
+        other => panic!("expected AlreadySatisfied, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn revoke_lease_different_worker_returns_already_satisfied() {
+    let b = fresh_backend().await;
+    let (exec_id, _handle) = create_and_claim(&b).await;
+
+    // Caller targets a different wiid — idempotent skip.
+    let args = RevokeLeaseArgs {
+        execution_id: exec_id.clone(),
+        expected_lease_id: None,
+        worker_instance_id: WorkerInstanceId::new("w2-i1"),
+        reason: "wrong worker".into(),
+    };
+    let r = b.revoke_lease(args).await.expect("revoke");
+    match r {
+        RevokeLeaseResult::AlreadySatisfied { reason } => {
+            assert_eq!(reason, "different_worker_instance_id");
+        }
+        other => panic!("expected AlreadySatisfied, got {other:?}"),
+    }
+}
+
+// ── change_priority ────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn change_priority_happy_path() {
+    let b = fresh_backend().await;
+    let (exec_id, _lane) = create_runnable(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    // eligible_now requires a secondary flip — mimic the Valkey-canonical
+    // state the RFC gates on. create_runnable flips to runnable + pending;
+    // set eligibility_state = 'eligible_now' directly.
+    sqlx::query(
+        "UPDATE ff_exec_core SET eligibility_state='eligible_now' \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let args = ChangePriorityArgs {
+        execution_id: exec_id.clone(),
+        new_priority: 42,
+        lane_id: LaneId::new("lane-ignored-on-sqlite"),
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let r = b.change_priority(args).await.expect("change_priority");
+    assert!(matches!(r, ChangePriorityResult::Changed { .. }));
+
+    let p: i64 = sqlx::query_scalar(
+        "SELECT priority FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(p, 42);
+
+    assert_eq!(count_outbox(&b, "ff_operator_event", exec_uuid).await, 1);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn change_priority_ineligible_execution_returns_not_eligible() {
+    let b = fresh_backend().await;
+    // Create exec but leave it in the default state (pending, not
+    // eligible_now). Expect ExecutionNotEligible.
+    let lane = LaneId::new(format!("lane-{}", Uuid::new_v4()));
+    let exec_id = new_exec_id();
+    b.create_execution(create_args(&exec_id, &lane)).await.expect("create");
+
+    let args = ChangePriorityArgs {
+        execution_id: exec_id.clone(),
+        new_priority: 10,
+        lane_id: lane,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let err = b.change_priority(args).await.unwrap_err();
+    assert!(
+        matches!(err, EngineError::Contention(ContentionKind::ExecutionNotEligible)),
+        "got {err:?}"
+    );
+}
+
+// ── replay_execution ───────────────────────────────────────────────
+
+/// Helper: drive an exec all the way to terminal so replay has
+/// something to lift back to runnable.
+async fn create_complete_terminal(
+    b: &Arc<SqliteBackend>,
+) -> (ExecutionId, Uuid) {
+    let (exec_id, handle) = create_and_claim(b).await;
+    b.complete(&handle, None).await.expect("complete");
+    // complete sets lifecycle_phase='terminal'; confirm.
+    let exec_uuid = uuid_of(&exec_id);
+    assert_eq!(read_lifecycle_phase(b, exec_uuid).await, "terminal");
+    (exec_id, exec_uuid)
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn replay_execution_normal_branch() {
+    let b = fresh_backend().await;
+    let (exec_id, exec_uuid) = create_complete_terminal(&b).await;
+
+    let args = ReplayExecutionArgs {
+        execution_id: exec_id.clone(),
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let r = b.replay_execution(args).await.expect("replay");
+    assert!(
+        matches!(
+            r,
+            ReplayExecutionResult::Replayed {
+                public_state: PublicState::Waiting,
+            }
+        ),
+        "normal branch must resume to Waiting, got {r:?}"
+    );
+
+    // lifecycle_phase flipped back to runnable.
+    assert_eq!(read_lifecycle_phase(&b, exec_uuid).await, "runnable");
+    // raw_fields.replay_count bumped to 1.
+    let replay_count: String = sqlx::query_scalar(
+        "SELECT json_extract(raw_fields, '$.replay_count') \
+         FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(replay_count, "1");
+    // operator_event 'replayed' emitted.
+    assert_eq!(count_outbox(&b, "ff_operator_event", exec_uuid).await, 1);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn replay_execution_skipped_flow_member_resets_edge_group_counters() {
+    let b = fresh_backend().await;
+    let (exec_id, exec_uuid) = create_complete_terminal(&b).await;
+
+    // Force the skipped-flow-member branch: mark the attempt outcome
+    // as 'skipped' and attach a flow_id. Pre-populate ff_edge +
+    // ff_edge_group with non-zero skip/fail/running counts so the
+    // reset is observable.
+    let fake_flow = Uuid::new_v4();
+    sqlx::query(
+        "UPDATE ff_exec_core SET flow_id=?1 \
+         WHERE partition_key=0 AND execution_id=?2",
+    )
+    .bind(fake_flow)
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE ff_attempt SET outcome='skipped' \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    let edge_id = Uuid::new_v4();
+    let upstream = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_edge (partition_key, flow_id, edge_id, upstream_eid, \
+         downstream_eid, policy, policy_version) \
+         VALUES (0, ?1, ?2, ?3, ?4, '{}', 0)",
+    )
+    .bind(fake_flow)
+    .bind(edge_id)
+    .bind(upstream)
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ff_edge_group (partition_key, flow_id, downstream_eid, \
+         policy, k_target, success_count, fail_count, skip_count, running_count) \
+         VALUES (0, ?1, ?2, '{}', 1, 3, 5, 7, 2)",
+    )
+    .bind(fake_flow)
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let args = ReplayExecutionArgs {
+        execution_id: exec_id.clone(),
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let r = b.replay_execution(args).await.expect("replay");
+    assert!(
+        matches!(
+            r,
+            ReplayExecutionResult::Replayed {
+                public_state: PublicState::WaitingChildren,
+            }
+        ),
+        "skipped-flow-member branch resumes to WaitingChildren, got {r:?}"
+    );
+
+    // Counters reset — success preserved (Option A: satisfied edges
+    // remain satisfied).
+    let row: (i64, i64, i64, i64) = sqlx::query_as(
+        "SELECT success_count, fail_count, skip_count, running_count \
+         FROM ff_edge_group WHERE partition_key=0 AND flow_id=?1 AND downstream_eid=?2",
+    )
+    .bind(fake_flow)
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(row.0, 3, "success_count preserved");
+    assert_eq!(row.1, 0, "fail_count reset");
+    assert_eq!(row.2, 0, "skip_count reset");
+    assert_eq!(row.3, 0, "running_count reset");
+
+    // operator_event `replayed` emitted with branch=skipped_flow_member.
+    let details: String = sqlx::query_scalar(
+        "SELECT details FROM ff_operator_event \
+         WHERE execution_id=?1 AND event_type='replayed'",
+    )
+    .bind(exec_uuid.to_string())
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert!(
+        details.contains("skipped_flow_member"),
+        "details should mark skipped_flow_member branch: {details}"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn replay_execution_non_terminal_returns_not_terminal() {
+    let b = fresh_backend().await;
+    let (exec_id, _lane) = create_runnable(&b).await;
+
+    let args = ReplayExecutionArgs {
+        execution_id: exec_id.clone(),
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let err = b.replay_execution(args).await.unwrap_err();
+    assert!(
+        matches!(err, EngineError::State(StateKind::ExecutionNotTerminal)),
+        "got {err:?}"
+    );
+}
+
+// ── concurrent cancel retry ────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn concurrent_cancel_serialization() {
+    let b = fresh_backend().await;
+    let (exec_id, _handle) = create_and_claim(&b).await;
+
+    let args = CancelExecutionArgs {
+        execution_id: exec_id.clone(),
+        reason: "concurrent".into(),
+        source: CancelSource::OperatorOverride,
+        lease_id: None,
+        lease_epoch: None,
+        attempt_id: None,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    // Two concurrent cancels — both must resolve OK (one wins the
+    // first-cancel path, the second observes the terminal state and
+    // returns Cancelled idempotently). SQLite's BEGIN IMMEDIATE
+    // serializes; the retry wrapper absorbs any SQLITE_BUSY under load.
+    let b2 = b.clone();
+    let args2 = args.clone();
+    let (r1, r2) = tokio::join!(
+        b.cancel_execution(args),
+        b2.cancel_execution(args2),
+    );
+    assert!(
+        matches!(r1, Ok(CancelExecutionResult::Cancelled { .. })),
+        "first cancel must succeed: {r1:?}"
+    );
+    assert!(
+        matches!(r2, Ok(CancelExecutionResult::Cancelled { .. })),
+        "second cancel must idempotently succeed: {r2:?}"
+    );
+    // Small delay to let any broadcast emits settle before the backend
+    // drops (avoids a noisy test-teardown race on the wakeup channel).
+    tokio::time::sleep(Duration::from_millis(20)).await;
+}


### PR DESCRIPTION
## Summary

- **Wave 9 operator control (4 methods)** — Replaces the 4 `Unavailable` trait defaults on `ff-backend-sqlite` for `cancel_execution`, `revoke_lease`, `change_priority`, `replay_execution` with real SQLite bodies ported from `ff-backend-postgres/src/operator.rs` Revision 7. Matches PG §4.2.7 outbox matrix exactly.
- **Producer tag back-fill fix** — SQLite `ff_lease_event` + `ff_completion_event` producers previously hard-coded `namespace` + `instance_tag` to NULL on every insert, silently dropping every tag-filtered subscriber. Phase 3.2 folds in the fix by rewriting the 3 producer INSERTs to use a co-transactional `SELECT ... FROM ff_exec_core UNION ALL SELECT ... WHERE NOT EXISTS (...)` (mirror of the existing signal producer shape).

## Method enumeration

Each follows the RFC-023 §4.2 shared spine adapted for SQLite: `BEGIN IMMEDIATE` RESERVED-lock for the RMW window, WHERE-clause CAS fencing, `rows_affected()`-driven contention branches, outbox INSERT in-tx, post-commit broadcast wakeup via `PubSub::emit`. All four ride `retry::retry_serializable` for SQLITE_BUSY / SQLITE_LOCKED absorption (§4.3).

| Method | Outbox emits (§4.2.7 matrix) | Key branches |
| --- | --- | --- |
| `cancel_execution` | `ff_lease_event` `revoked` (iff lease active). **No operator_event** — the migration 0010 CHECK allow-list gates on `priority_changed` / `replayed` / `flow_cancel_requested`; a `cancelled` type is not allowed and the PG reference does not emit one. | Idempotent replay on `public_state='cancelled'`; `Validation` on terminal-but-different; `State(StaleLease)` on lease-epoch mismatch; `Validation` on missing lease_epoch when source ≠ `OperatorOverride` and exec is active. |
| `revoke_lease` | `ff_lease_event` `revoked` | `AlreadySatisfied { reason: "no_active_lease" / "different_worker_instance_id" / "lease_id_mismatch" / "epoch_moved" }`; CAS on `lease_epoch`; reclaim-path `exec_core` flip gated on `lifecycle_phase='active'`. |
| `change_priority` | `ff_operator_event` `priority_changed` (details `{old_priority, new_priority}`) | `Contention(ExecutionNotEligible)` on Valkey gate failure (`lifecycle_phase='runnable' AND eligibility_state='eligible_now'`). New priority clamped to `[0, 9000]` per Valkey `ff_change_priority`. |
| `replay_execution` | `ff_operator_event` `replayed` (details `{branch: "normal"\|"skipped_flow_member", groups_reset?: N}`) | `State(ExecutionNotTerminal)` when not terminal. Skipped-flow-member iff current attempt's `outcome='skipped' AND exec_core.flow_id IS NOT NULL` (Valkey `flowfabric.lua:8555`) — resets downstream `ff_edge_group` skip/fail/running to 0 while preserving `success_count` per RFC-020 Rev 7 Option A. Both branches flip exec_core to `runnable` + bump `raw_fields.replay_count` via nested `json_set(json_set(...))` (SQLite JSON1 analogue of PG's `jsonb_set(..., to_jsonb(... + 1))`). |

## Producer tag back-fill fix details

Pre-Phase-3.2 state: `INSERT_LEASE_EVENT_SQL` had no namespace/instance_tag columns in its VALUES list (SQLite added them in migration 0008 but the SQL was never updated); `INSERT_COMPLETION_EVENT_SQL` hard-coded `NULL, NULL`. The subscribe filter drops silently drop every row under `ScannerFilter::instance_tag(...)`, pinned by the two `subscribe_*_filter_drops_null_tag_rows` tests in `tests/subscribe.rs`.

Phase 3.2 fix:
- `queries/dispatch.rs::INSERT_LEASE_EVENT_SQL` — rewritten to `INSERT ... SELECT ... FROM ff_exec_core WHERE partition_key=? AND execution_id=? UNION ALL SELECT ?,?,...,NULL,NULL WHERE NOT EXISTS (...)`. Extracts `namespace` + `cairn.instance_id` tag via `json_extract`. Adds a 5th bind (exec UUID as BLOB) for the exec_core lookup. Fallback UNION branch guarantees the row is written even if exec_core is absent (edge case).
- `queries/attempt.rs::INSERT_COMPLETION_EVENT_SQL` — swap `NULL, NULL` for `json_extract(raw_fields, '$.namespace'), json_extract(raw_fields, '$.tags."cairn.instance_id"')`. Bind count unchanged.
- `queries/signal.rs::INSERT_COMPLETION_RESUMABLE_SQL` — same UNION-ALL rewrite as lease_event; bind count unchanged (reuses `?2` for both the outbox BLOB column and the exec_core BLOB lookup).
- 3 call sites on `INSERT_LEASE_EVENT_SQL` updated: `backend::insert_lease_event`, `suspend_ops::claim_resumed_execution_impl`, new `operator::insert_lease_event`. All bind the exec UUID twice (stringified TEXT for the outbox row + `Uuid` BLOB for the exec_core lookup).
- The two `subscribe_*_filter_drops_null_tag_rows` tests flip to positive filter-through (`subscribe_*_filter_by_instance_tag_receives_events`).

## `cancel_execution` outbox deviation from RFC §4.2.7 matrix header

The initial port emitted an `ff_operator_event cancelled` row alongside the lease_event revoke. First test run failed with `SqliteError 275 CHECK constraint failed: event_type IN ('priority_changed', 'replayed', 'flow_cancel_requested')`. Rechecked: PG `operator.rs::cancel_execution_once` (the canonical reference) emits **only** `lease_event::EVENT_REVOKED`, no operator_event. RFC-020 §4.2.7 matrix line 143 + 653 corroborates: `cancel_execution` → `ff_lease_event` only. Reverted to match PG exactly. Test assertion updated to `count(ff_operator_event) == 0`.

## Tests

New: `crates/ff-backend-sqlite/tests/wave9_operator.rs` — 13 tests:

- `cancel_execution_happy_path` / `cancel_execution_idempotent_when_already_cancelled` / `cancel_execution_lease_fence_required_when_not_operator_override` / `cancel_execution_stale_lease_fence_rejects` / `concurrent_cancel_serialization`
- `revoke_lease_happy_path` / `revoke_lease_no_active_lease_returns_already_satisfied` / `revoke_lease_different_worker_returns_already_satisfied`
- `change_priority_happy_path` / `change_priority_ineligible_execution_returns_not_eligible`
- `replay_execution_normal_branch` / `replay_execution_skipped_flow_member_resets_edge_group_counters` / `replay_execution_non_terminal_returns_not_terminal`

Updated: `crates/ff-backend-sqlite/tests/subscribe.rs` — `subscribe_completion_filter_drops_null_tag_rows` → `subscribe_completion_filter_by_instance_tag_receives_events`; `subscribe_lease_history_filter_drops_null_tag_rows` → `subscribe_lease_history_filter_by_instance_tag_receives_events`. Positive filter-through: tagged completion / tagged acquired+revoked pairs observed by the filtered subscriber; untagged events dropped.

All 97 ff-backend-sqlite tests pass locally. `cargo clippy -p ff-backend-sqlite -- -D warnings` clean.

## RFC-vs-reality gaps

- None structural. `cancel_execution` outbox shape (lease_event only, no operator_event) was already specified correctly in §4.2.7 matrix line 143/653; the task description's "emits ff_operator_event" was imprecise.
- Pre-existing clippy warning in `tests/producer_flow.rs` (field_reassign_with_default, landed in #377) — not touched; CI clippy stage runs lib-only (`cargo clippy -p ff-backend-sqlite -- -D warnings`, no `--tests`), so it does not gate this PR. Recommend cleaning up in a follow-up adjacency PR.

## Test plan

- [x] `cargo build -p ff-backend-sqlite --tests` clean
- [x] `FF_DEV_MODE=1 cargo test -p ff-backend-sqlite` — all 97 tests pass
- [x] `cargo clippy -p ff-backend-sqlite -- -D warnings` clean
- [ ] Workspace CI (matrix.yml) green
- [ ] Migration parity job green
- [ ] Valkey cluster suite (known flake #369 ignorable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds and rewires SQLite operator-control mutations and changes outbox insert SQL to back-fill `namespace`/`instance_tag`, which impacts execution state transitions and subscriber filtering behavior.
> 
> **Overview**
> Implements SQLite Wave 9 operator-control methods (`cancel_execution`, `revoke_lease`, `change_priority`, `replay_execution`) by replacing prior `Unavailable` stubs with real transactional bodies that update `ff_exec_core`/`ff_attempt`, emit the appropriate outbox rows, and trigger post-commit pubsub wakeups.
> 
> Fixes a SQLite outbox regression where `ff_lease_event` and `ff_completion_event` rows were written with `NULL` tag columns by rewriting the relevant INSERTs to co-transactionally back-fill `namespace`/`instance_tag` from `ff_exec_core.raw_fields` (and updating call sites/binds accordingly), then updates subscribe tests to assert positive tag-filter pass-through. Adds a new integration test suite covering the four operator-control methods, including replay branching and concurrency/serialization retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d0fc8ac15d765104351c2d555f546dba2e1d232. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->