### PR TITLE
feat(backend-sqlite): Phase 3.3 — Wave 9 read model + cancel-flow split + list_pending_waitpoints (6 methods)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 3.3 Wave 9 read model +
+  cancel-flow split + waitpoint read (RFC-023 Phase 3.3 / RFC-020 §4.1
+  + §4.2.3 + §4.5).** Replaces 6 `Unavailable` trait defaults with
+  real SQLite bodies ported from the Postgres reference
+  (`ff-backend-postgres/src/exec_core.rs` + `operator.rs` +
+  `suspend_ops.rs`). Read model: `read_execution_state` (single-column
+  projection of `public_state`), `read_execution_info` (multi-column
+  projection + correlated attempt subqueries → `ExecutionInfo`), and
+  `get_execution_result` (current-attempt semantics per Rev 7 Fork 3).
+  Cancel-flow split: `cancel_flow_header` (atomic flip of flow_core +
+  backlog header + member rows + per-member exec_core flip + outbox
+  `flow_cancel_requested`; idempotent replay returns
+  `AlreadyTerminal { stored_* }`), and `ack_cancel_member` (member
+  drain + conditional parent delete; NO outbox emit per §4.2.7
+  Valkey-parity). Waitpoint read: `list_pending_waitpoints`
+  (cursor-paginated scan of `ff_waitpoint_pending` with `state IN
+  ('pending','active')` filter, `NotFound` on missing execution,
+  `(token_kid, token_fingerprint)` parsed from the stored token).
+  Storage-tier literal normalisation reuses the PG helper shapes:
+  `cancelled`/`terminal` → Terminal; `running` → Active; `pending`/
+  `pending_claim` → PendingFirstAttempt; unknown tokens surface as
+  `EngineError::Validation(Corruption)` via `json_enum!`.
+- `crates/ff-backend-sqlite/src/reads.rs` — new module hosting the 3
+  read bodies + 5 `normalise_*` helpers + `derive_terminal_outcome`.
+- `crates/ff-backend-sqlite/src/queries/reads.rs` — SQL for the 3 read
+  paths. SQLite `LEFT JOIN LATERAL` lowered to correlated subqueries
+  in the SELECT list.
+- `crates/ff-backend-sqlite/src/operator.rs` — extended with
+  `cancel_flow_header_impl` + `ack_cancel_member_impl` + helper
+  `insert_operator_event_flow` (back-fills namespace from
+  `ff_flow_core.raw_fields`).
+- `crates/ff-backend-sqlite/src/queries/operator.rs` — extended with
+  cancel-flow-header SQL set (`SELECT_FLOW_CORE_FOR_CANCEL_SQL`,
+  `UPDATE_FLOW_CORE_CANCEL_WITH_REASON_SQL`, `INSERT_CANCEL_BACKLOG_SQL`,
+  `SELECT_FLOW_INFLIGHT_MEMBERS_SQL`, `INSERT_CANCEL_BACKLOG_MEMBER_SQL`,
+  `UPDATE_EXEC_CORE_CANCEL_FROM_HEADER_SQL`,
+  `DELETE_CANCEL_BACKLOG_MEMBER_SQL`,
+  `DELETE_CANCEL_BACKLOG_IF_EMPTY_SQL`) plus
+  `INSERT_OPERATOR_EVENT_FLOW_SQL` for flow-keyed operator events.
+- `crates/ff-backend-sqlite/src/queries/waitpoint.rs` — extended with
+  `SELECT_EXEC_EXISTS_SQL` + `SELECT_PENDING_WAITPOINTS_PAGE_SQL` for
+  the paginated pending-waitpoint scan.
+- `crates/ff-backend-sqlite/src/suspend_ops.rs` — extended with
+  `list_pending_waitpoints_impl` + `parse_waitpoint_token_kid_fp`
+  (mirrors the PG reference shape).
+- `crates/ff-backend-sqlite/tests/wave9_reads.rs` — 9 integration
+  tests covering the read model (missing → None, post-create,
+  post-claim, normalisation, terminal-outcome derivation, active/
+  terminal result semantics).
+- `crates/ff-backend-sqlite/tests/wave9_waitpoints.rs` — 5 integration
+  tests covering `list_pending_waitpoints` (empty, happy path with all
+  10 `PendingWaitpointInfo` fields populated, cursor pagination across
+  3 pages, `NotFound` on missing execution, `state='closed'` filter).
+- `crates/ff-backend-sqlite/tests/wave9_operator.rs` — extended with
+  4 integration tests for `cancel_flow_header` (happy path with
+  backlog + member + operator_event + exec_core verification,
+  idempotent `AlreadyTerminal` replay) and `ack_cancel_member`
+  (member-drain + final-ack parent-delete, idempotent no-op on missing).
+
 - **`crates/ff-backend-sqlite` — Phase 3.2 Wave 9 operator control
   (RFC-023 Phase 3.2 / RFC-020 §4.2.1-5).** Replaces the 4 `Unavailable`
   trait defaults for `cancel_execution`, `revoke_lease`,

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -61,10 +61,12 @@ use crate::registry;
 #[cfg(feature = "core")]
 use ff_core::contracts::{
     AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
-    ApplyDependencyToChildResult, CancelExecutionArgs, CancelExecutionResult,
-    ChangePriorityArgs, ChangePriorityResult, CreateExecutionArgs, CreateExecutionResult,
-    CreateFlowArgs, CreateFlowResult, ReplayExecutionArgs, ReplayExecutionResult,
-    RevokeLeaseArgs, RevokeLeaseResult, StageDependencyEdgeArgs, StageDependencyEdgeResult,
+    ApplyDependencyToChildResult, CancelExecutionArgs, CancelExecutionResult, CancelFlowArgs,
+    CancelFlowHeader, ChangePriorityArgs, ChangePriorityResult, CreateExecutionArgs,
+    CreateExecutionResult, CreateFlowArgs, CreateFlowResult, ExecutionInfo,
+    ListPendingWaitpointsArgs, ListPendingWaitpointsResult, ReplayExecutionArgs,
+    ReplayExecutionResult, RevokeLeaseArgs, RevokeLeaseResult, StageDependencyEdgeArgs,
+    StageDependencyEdgeResult,
 };
 #[cfg(feature = "core")]
 use ff_core::state::PublicState;
@@ -2780,6 +2782,78 @@ impl EngineBackend for SqliteBackend {
         args: ReplayExecutionArgs,
     ) -> Result<ReplayExecutionResult, EngineError> {
         crate::operator::replay_execution_impl(&self.inner.pool, &self.inner.pubsub, args).await
+    }
+
+    // ── RFC-020 Wave 9 — Read model (Phase 3.3) ──────────────────────
+    //
+    // Three read-only methods paralleling PG §4.1. Normalisation
+    // helpers collapse storage-tier lifecycle/state literals to the
+    // `serde_snake_case` wire form; unknown tokens surface
+    // `Corruption`. `get_execution_result` has current-attempt
+    // semantics per RFC-020 Rev 7 Fork 3.
+
+    #[cfg(feature = "core")]
+    async fn read_execution_state(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<PublicState>, EngineError> {
+        crate::reads::read_execution_state_impl(&self.inner.pool, id).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn read_execution_info(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<ExecutionInfo>, EngineError> {
+        crate::reads::read_execution_info_impl(&self.inner.pool, id).await
+    }
+
+    async fn get_execution_result(
+        &self,
+        id: &ExecutionId,
+    ) -> Result<Option<Vec<u8>>, EngineError> {
+        crate::reads::get_execution_result_impl(&self.inner.pool, id).await
+    }
+
+    // ── RFC-020 Wave 9 — Cancel-flow split (Phase 3.3) ───────────────
+    //
+    // `cancel_flow_header` is the atomic flow-state flip + member
+    // enumeration; `ack_cancel_member` is the drain of one member +
+    // parent-delete when empty. The Server composes these with its
+    // wait/async machinery to build the wire-level
+    // [`CancelFlowResult`]. `ack_cancel_member` is silent on the
+    // outbox (RFC-020 §4.2.7 Valkey-parity).
+
+    #[cfg(feature = "core")]
+    async fn cancel_flow_header(
+        &self,
+        args: CancelFlowArgs,
+    ) -> Result<CancelFlowHeader, EngineError> {
+        crate::operator::cancel_flow_header_impl(&self.inner.pool, &self.inner.pubsub, args).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn ack_cancel_member(
+        &self,
+        flow_id: &FlowId,
+        execution_id: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        crate::operator::ack_cancel_member_impl(
+            &self.inner.pool,
+            flow_id.clone(),
+            execution_id.clone(),
+        )
+        .await
+    }
+
+    // ── RFC-020 Wave 9 — list_pending_waitpoints (Phase 3.3) ─────────
+
+    #[cfg(feature = "core")]
+    async fn list_pending_waitpoints(
+        &self,
+        args: ListPendingWaitpointsArgs,
+    ) -> Result<ListPendingWaitpointsResult, EngineError> {
+        crate::suspend_ops::list_pending_waitpoints_impl(&self.inner.pool, args).await
     }
 
     // ── RFC-019 Stage B/C — subscribe_* (Phase 3.1) ──────────────────

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -33,6 +33,7 @@ mod handle_codec;
 mod lease_event_subscribe;
 mod operator;
 mod outbox_cursor;
+mod reads;
 mod signal_delivery_subscribe;
 #[doc(hidden)]
 pub mod pubsub;

--- a/crates/ff-backend-sqlite/src/operator.rs
+++ b/crates/ff-backend-sqlite/src/operator.rs
@@ -672,6 +672,8 @@ fn member_wire_id(partition_key: i64, exec_uuid: Uuid) -> String {
 
 /// Insert one operator-event row keyed on a flow_id (not
 /// execution_id). Used by `flow_cancel_requested` per RFC-020 §4.2.3.
+/// Reuses `last_outbox_event` for consistency with the other outbox
+/// insertion helpers in this module (gemini review).
 async fn insert_operator_event_flow(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     part: i64,
@@ -679,7 +681,7 @@ async fn insert_operator_event_flow(
     event_type: &str,
     details: Option<String>,
     now: i64,
-) -> Result<OutboxEvent, OutboxInsertErr> {
+) -> Result<OutboxEvent, EngineError> {
     sqlx::query(q_op::INSERT_OPERATOR_EVENT_FLOW_SQL)
         .bind(flow_uuid.to_string())
         .bind(event_type)
@@ -689,22 +691,8 @@ async fn insert_operator_event_flow(
         .bind(flow_uuid)
         .execute(&mut **conn)
         .await
-        .map_err(|e| OutboxInsertErr(map_sqlx_error(e)))?;
-    let event_id: i64 = sqlx::query_scalar("SELECT last_insert_rowid()")
-        .fetch_one(&mut **conn)
-        .await
-        .map_err(|e| OutboxInsertErr(map_sqlx_error(e)))?;
-    Ok(OutboxEvent {
-        event_id,
-        partition_key: part,
-    })
-}
-
-struct OutboxInsertErr(EngineError);
-impl From<OutboxInsertErr> for EngineError {
-    fn from(e: OutboxInsertErr) -> Self {
-        e.0
-    }
+        .map_err(map_sqlx_error)?;
+    last_outbox_event(conn, part).await
 }
 
 async fn cancel_flow_header_once(
@@ -738,8 +726,12 @@ async fn cancel_flow_header_once(
         // Idempotent-replay path — already terminal. Return stored
         // policy / reason + enumerated members. Mirrors PG.
         if matches!(public_flow_state.as_str(), "cancelled" | "completed" | "failed") {
-            let raw: serde_json::Value =
-                serde_json::from_str(&raw_fields_str).unwrap_or(serde_json::Value::Null);
+            let raw: serde_json::Value = serde_json::from_str(&raw_fields_str).map_err(|e| {
+                EngineError::Validation {
+                    kind: ValidationKind::Corruption,
+                    detail: format!("flow_core: raw_fields not valid JSON: {e}"),
+                }
+            })?;
             let stored_cancellation_policy = raw
                 .get("cancellation_policy")
                 .and_then(|v| v.as_str())

--- a/crates/ff-backend-sqlite/src/operator.rs
+++ b/crates/ff-backend-sqlite/src/operator.rs
@@ -36,12 +36,13 @@ use sqlx::{Row, SqlitePool};
 use uuid::Uuid;
 
 use ff_core::contracts::{
-    CancelExecutionArgs, CancelExecutionResult, ChangePriorityArgs, ChangePriorityResult,
-    ReplayExecutionArgs, ReplayExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
+    CancelExecutionArgs, CancelExecutionResult, CancelFlowArgs, CancelFlowHeader,
+    ChangePriorityArgs, ChangePriorityResult, ReplayExecutionArgs, ReplayExecutionResult,
+    RevokeLeaseArgs, RevokeLeaseResult,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
 use ff_core::state::PublicState;
-use ff_core::types::CancelSource;
+use ff_core::types::{CancelSource, ExecutionId, FlowId};
 
 use crate::errors::map_sqlx_error;
 use crate::pubsub::{OutboxEvent, PubSub};
@@ -658,4 +659,291 @@ pub(crate) async fn replay_execution_impl(
     args: ReplayExecutionArgs,
 ) -> Result<ReplayExecutionResult, EngineError> {
     retry_serializable(|| replay_execution_once(pool, pubsub, &args)).await
+}
+
+// ─── cancel_flow_header (§4.2.3, Phase 3.3) ─────────────────────────
+
+/// Format a member execution UUID as the wire-form `ExecutionId`
+/// string (`{fp:N}:<uuid>`). SQLite uses `part=0` for all flows
+/// (single-writer, no partitioning).
+fn member_wire_id(partition_key: i64, exec_uuid: Uuid) -> String {
+    format!("{{fp:{partition_key}}}:{exec_uuid}")
+}
+
+/// Insert one operator-event row keyed on a flow_id (not
+/// execution_id). Used by `flow_cancel_requested` per RFC-020 §4.2.3.
+async fn insert_operator_event_flow(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    flow_uuid: Uuid,
+    event_type: &str,
+    details: Option<String>,
+    now: i64,
+) -> Result<OutboxEvent, OutboxInsertErr> {
+    sqlx::query(q_op::INSERT_OPERATOR_EVENT_FLOW_SQL)
+        .bind(flow_uuid.to_string())
+        .bind(event_type)
+        .bind(details)
+        .bind(now)
+        .bind(part)
+        .bind(flow_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(|e| OutboxInsertErr(map_sqlx_error(e)))?;
+    let event_id: i64 = sqlx::query_scalar("SELECT last_insert_rowid()")
+        .fetch_one(&mut **conn)
+        .await
+        .map_err(|e| OutboxInsertErr(map_sqlx_error(e)))?;
+    Ok(OutboxEvent {
+        event_id,
+        partition_key: part,
+    })
+}
+
+struct OutboxInsertErr(EngineError);
+impl From<OutboxInsertErr> for EngineError {
+    fn from(e: OutboxInsertErr) -> Self {
+        e.0
+    }
+}
+
+async fn cancel_flow_header_once(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: &CancelFlowArgs,
+) -> Result<CancelFlowHeader, EngineError> {
+    let part: i64 = 0; // SQLite single-partition (mirrors cancel_flow_impl).
+    let flow_uuid: Uuid = args.flow_id.0;
+    let now = args.now.0;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let flow_row = sqlx::query(q_op::SELECT_FLOW_CORE_FOR_CANCEL_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let Some(flow_row) = flow_row else {
+            return Err(EngineError::NotFound { entity: "flow" });
+        };
+
+        let public_flow_state: String = flow_row
+            .try_get("public_flow_state")
+            .map_err(map_sqlx_error)?;
+        let raw_fields_str: String = flow_row.try_get("raw_fields").map_err(map_sqlx_error)?;
+
+        // Idempotent-replay path — already terminal. Return stored
+        // policy / reason + enumerated members. Mirrors PG.
+        if matches!(public_flow_state.as_str(), "cancelled" | "completed" | "failed") {
+            let raw: serde_json::Value =
+                serde_json::from_str(&raw_fields_str).unwrap_or(serde_json::Value::Null);
+            let stored_cancellation_policy = raw
+                .get("cancellation_policy")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+            let stored_cancel_reason = raw
+                .get("cancel_reason")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+
+            let backlog_members: Vec<String> =
+                sqlx::query_scalar::<_, String>(q_op::SELECT_CANCEL_BACKLOG_MEMBERS_SQL)
+                    .bind(part)
+                    .bind(flow_uuid)
+                    .fetch_all(&mut *conn)
+                    .await
+                    .map_err(map_sqlx_error)?;
+
+            let members: Vec<String> = if backlog_members.is_empty() {
+                // Pre-E2-shape flow: enumerate live exec_core rows.
+                let live = sqlx::query_scalar::<_, Uuid>(q_op::SELECT_FLOW_ALL_MEMBERS_SQL)
+                    .bind(part)
+                    .bind(flow_uuid)
+                    .fetch_all(&mut *conn)
+                    .await
+                    .map_err(map_sqlx_error)?;
+                live.into_iter().map(|u| member_wire_id(part, u)).collect()
+            } else {
+                backlog_members
+            };
+
+            return Ok((
+                CancelFlowHeader::AlreadyTerminal {
+                    stored_cancellation_policy,
+                    stored_cancel_reason,
+                    member_execution_ids: members,
+                },
+                None,
+            ));
+        }
+
+        // Fresh cancel path.
+        sqlx::query(q_op::UPDATE_FLOW_CORE_CANCEL_WITH_REASON_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(now)
+            .bind(&args.cancellation_policy)
+            .bind(&args.reason)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        sqlx::query(q_op::INSERT_CANCEL_BACKLOG_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(now)
+            .bind(&args.reason)
+            .bind(&args.cancellation_policy)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let member_uuids: Vec<Uuid> =
+            sqlx::query_scalar::<_, Uuid>(q_op::SELECT_FLOW_INFLIGHT_MEMBERS_SQL)
+                .bind(part)
+                .bind(flow_uuid)
+                .fetch_all(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+        let member_execution_ids: Vec<String> = member_uuids
+            .iter()
+            .map(|u| member_wire_id(part, *u))
+            .collect();
+
+        // SQLite has no bulk UNNEST — loop. Under single-writer
+        // BEGIN IMMEDIATE each statement is cheap and membership is
+        // bounded; matches `cancel_flow_impl` shape at backend.rs:2090.
+        for (wire_id, exec_uuid) in member_execution_ids.iter().zip(member_uuids.iter()) {
+            sqlx::query(q_op::INSERT_CANCEL_BACKLOG_MEMBER_SQL)
+                .bind(part)
+                .bind(flow_uuid)
+                .bind(wire_id)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            sqlx::query(q_op::UPDATE_EXEC_CORE_CANCEL_FROM_HEADER_SQL)
+                .bind(part)
+                .bind(exec_uuid)
+                .bind(now)
+                .bind(&args.reason)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+        }
+
+        // Outbox emit — flow-level `flow_cancel_requested`.
+        let details = json!({
+            "flow_id": flow_uuid.to_string(),
+            "cancellation_policy": &args.cancellation_policy,
+            "reason": &args.reason,
+            "member_count": member_execution_ids.len(),
+        });
+        let ev = insert_operator_event_flow(
+            &mut conn,
+            part,
+            flow_uuid,
+            "flow_cancel_requested",
+            Some(details.to_string()),
+            now,
+        )
+        .await?;
+
+        Ok((
+            CancelFlowHeader::Cancelled {
+                cancellation_policy: args.cancellation_policy.clone(),
+                member_execution_ids,
+            },
+            Some(ev),
+        ))
+    }
+    .await;
+
+    match result {
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+        Ok((ret, ev)) => {
+            commit_or_rollback(&mut conn).await?;
+            if let Some(ev) = ev {
+                dispatch_operator(pubsub, ev);
+            }
+            Ok(ret)
+        }
+    }
+}
+
+pub(crate) async fn cancel_flow_header_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: CancelFlowArgs,
+) -> Result<CancelFlowHeader, EngineError> {
+    retry_serializable(|| cancel_flow_header_once(pool, pubsub, &args)).await
+}
+
+// ─── ack_cancel_member (§4.2.3, Phase 3.3) ──────────────────────────
+
+async fn ack_cancel_member_once(
+    pool: &SqlitePool,
+    flow_id: &FlowId,
+    execution_id: &ExecutionId,
+) -> Result<(), EngineError> {
+    let part: i64 = 0;
+    let flow_uuid: Uuid = flow_id.0;
+    let member_wire = execution_id.as_str();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    // Intra-ack drain: delete the member row, then delete the parent
+    // iff empty. Under SQLite single-writer (BEGIN IMMEDIATE) the two
+    // statements share a serialised window, so the final-ack path
+    // observes post-delete state; concurrent acks from other processes
+    // race at BEGIN IMMEDIATE and are re-sequenced by
+    // `retry_serializable` — matches PG SERIALIZABLE CTE shape.
+    //
+    // NO outbox emit — RFC-020 §4.2.7 matrix marks this path silent
+    // for Valkey parity.
+    let result = async {
+        sqlx::query(q_op::DELETE_CANCEL_BACKLOG_MEMBER_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .bind(member_wire)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        sqlx::query(q_op::DELETE_CANCEL_BACKLOG_IF_EMPTY_SQL)
+            .bind(part)
+            .bind(flow_uuid)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        Ok::<(), EngineError>(())
+    }
+    .await;
+
+    match result {
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+        Ok(()) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(())
+        }
+    }
+}
+
+pub(crate) async fn ack_cancel_member_impl(
+    pool: &SqlitePool,
+    flow_id: FlowId,
+    execution_id: ExecutionId,
+) -> Result<(), EngineError> {
+    retry_serializable(|| ack_cancel_member_once(pool, &flow_id, &execution_id)).await
 }

--- a/crates/ff-backend-sqlite/src/queries/mod.rs
+++ b/crates/ff-backend-sqlite/src/queries/mod.rs
@@ -16,6 +16,7 @@ pub mod flow;
 pub mod flow_staging;
 pub mod lease;
 pub mod operator;
+pub mod reads;
 pub mod signal;
 pub mod stream;
 pub mod suspend;

--- a/crates/ff-backend-sqlite/src/queries/operator.rs
+++ b/crates/ff-backend-sqlite/src/queries/operator.rs
@@ -294,11 +294,19 @@ pub(crate) const INSERT_CANCEL_BACKLOG_MEMBER_SQL: &str = r#"
 
 /// Flip one member exec_core row to cancelled for the `cancel_flow_header`
 /// fan-out. Binds: ?1 part, ?2 execution_id BLOB, ?3 now, ?4 reason.
+///
+/// Also clears `ownership_state` + `attempt_state` to their terminal
+/// forms so the `StateVector` assembled by `read_execution_info` is
+/// internally consistent (cursor bugbot: a live-running member would
+/// otherwise retain `ownership_state='leased'` + `attempt_state=
+/// 'running_attempt'` alongside `lifecycle_phase='cancelled'`).
 pub(crate) const UPDATE_EXEC_CORE_CANCEL_FROM_HEADER_SQL: &str = r#"
     UPDATE ff_exec_core
        SET lifecycle_phase     = 'cancelled',
+           ownership_state     = 'unowned',
            eligibility_state   = 'cancelled',
            public_state        = 'cancelled',
+           attempt_state       = 'cancelled',
            terminal_at_ms      = COALESCE(terminal_at_ms, ?3),
            cancellation_reason = COALESCE(cancellation_reason, ?4),
            cancelled_by        = COALESCE(cancelled_by, 'cancel_flow_header')

--- a/crates/ff-backend-sqlite/src/queries/operator.rs
+++ b/crates/ff-backend-sqlite/src/queries/operator.rs
@@ -221,6 +221,116 @@ pub(crate) const UPDATE_ATTEMPT_REPLAY_RESET_SQL: &str = r#"
      WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3
 "#;
 
+// ── cancel_flow_header (§4.2.3, Phase 3.3) ─────────────────────────
+
+/// Pre-read flow core row under the write lock (`BEGIN IMMEDIATE`).
+/// Binds: ?1 partition_key, ?2 flow_id BLOB.
+pub(crate) const SELECT_FLOW_CORE_FOR_CANCEL_SQL: &str = r#"
+    SELECT public_flow_state, raw_fields
+      FROM ff_flow_core
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Flip `ff_flow_core` to cancelled + merge `cancellation_policy` +
+/// `cancel_reason` into `raw_fields`. SQLite has no `jsonb ||` merge;
+/// we nest two `json_set` calls. Binds: ?1 part, ?2 flow_id, ?3 now,
+/// ?4 cancellation_policy, ?5 reason.
+pub(crate) const UPDATE_FLOW_CORE_CANCEL_WITH_REASON_SQL: &str = r#"
+    UPDATE ff_flow_core
+       SET public_flow_state = 'cancelled',
+           terminal_at_ms    = COALESCE(terminal_at_ms, ?3),
+           raw_fields        = json_set(
+                                 json_set(raw_fields,
+                                          '$.cancellation_policy', ?4),
+                                 '$.cancel_reason', ?5)
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Idempotent insert of the backlog header. Binds: ?1 part, ?2
+/// flow_id, ?3 requested_at_ms, ?4 reason, ?5 cancellation_policy.
+pub(crate) const INSERT_CANCEL_BACKLOG_SQL: &str = r#"
+    INSERT INTO ff_cancel_backlog
+        (partition_key, flow_id, requested_at_ms, requester, reason,
+         cancellation_policy, status)
+    VALUES (?1, ?2, ?3, '', ?4, ?5, 'pending')
+    ON CONFLICT (partition_key, flow_id) DO NOTHING
+"#;
+
+/// Enumerate in-flight member executions for a flow. Binds: ?1 part,
+/// ?2 flow_id BLOB.
+pub(crate) const SELECT_FLOW_INFLIGHT_MEMBERS_SQL: &str = r#"
+    SELECT execution_id
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND flow_id = ?2
+       AND lifecycle_phase NOT IN ('terminal','cancelled')
+"#;
+
+/// Enumerate all members (used for idempotent-replay when a backlog
+/// row doesn't exist yet). Binds: ?1 part, ?2 flow_id.
+pub(crate) const SELECT_FLOW_ALL_MEMBERS_SQL: &str = r#"
+    SELECT execution_id
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Enumerate already-enumerated backlog members (idempotent-replay
+/// path). Binds: ?1 part, ?2 flow_id.
+pub(crate) const SELECT_CANCEL_BACKLOG_MEMBERS_SQL: &str = r#"
+    SELECT execution_id
+      FROM ff_cancel_backlog_member
+     WHERE partition_key = ?1 AND flow_id = ?2
+"#;
+
+/// Insert one backlog member row. Binds: ?1 part, ?2 flow_id, ?3
+/// execution_id wire-string. SQLite has no bulk UNNEST — the caller
+/// loops; under single-writer with BEGIN IMMEDIATE each statement is
+/// cheap and the membership cardinality is bounded.
+pub(crate) const INSERT_CANCEL_BACKLOG_MEMBER_SQL: &str = r#"
+    INSERT INTO ff_cancel_backlog_member
+        (partition_key, flow_id, execution_id)
+    VALUES (?1, ?2, ?3)
+    ON CONFLICT (partition_key, flow_id, execution_id) DO NOTHING
+"#;
+
+/// Flip one member exec_core row to cancelled for the `cancel_flow_header`
+/// fan-out. Binds: ?1 part, ?2 execution_id BLOB, ?3 now, ?4 reason.
+pub(crate) const UPDATE_EXEC_CORE_CANCEL_FROM_HEADER_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase     = 'cancelled',
+           eligibility_state   = 'cancelled',
+           public_state        = 'cancelled',
+           terminal_at_ms      = COALESCE(terminal_at_ms, ?3),
+           cancellation_reason = COALESCE(cancellation_reason, ?4),
+           cancelled_by        = COALESCE(cancelled_by, 'cancel_flow_header')
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+// ── ack_cancel_member (§4.2.3, Phase 3.3) ──────────────────────────
+
+/// Delete one backlog member row. Binds: ?1 part, ?2 flow_id, ?3
+/// execution_id wire-string.
+pub(crate) const DELETE_CANCEL_BACKLOG_MEMBER_SQL: &str = r#"
+    DELETE FROM ff_cancel_backlog_member
+     WHERE partition_key = ?1
+       AND flow_id       = ?2
+       AND execution_id  = ?3
+"#;
+
+/// Delete backlog header IFF no members remain. Binds: ?1 part, ?2
+/// flow_id. Note: the NOT EXISTS subquery re-checks member_map
+/// post-member-delete in the same statement window, so a last-member
+/// ack drops both in a single logical step. Concurrent acks race at
+/// commit time and the loser retries through `retry_serializable`.
+pub(crate) const DELETE_CANCEL_BACKLOG_IF_EMPTY_SQL: &str = r#"
+    DELETE FROM ff_cancel_backlog
+     WHERE partition_key = ?1
+       AND flow_id       = ?2
+       AND NOT EXISTS (
+         SELECT 1 FROM ff_cancel_backlog_member
+          WHERE partition_key = ?1 AND flow_id = ?2
+       )
+"#;
+
 // ── operator_event outbox (co-transactional) ───────────────────────
 
 /// Insert one operator-event outbox row, back-filling `namespace` +
@@ -249,5 +359,36 @@ pub(crate) const INSERT_OPERATOR_EVENT_SQL: &str = r#"
      WHERE NOT EXISTS (
          SELECT 1 FROM ff_exec_core
           WHERE partition_key = ?5 AND execution_id = ?6
+     )
+"#;
+
+/// Insert one operator-event outbox row, back-filling `namespace`
+/// from the co-transactional `ff_flow_core.raw_fields` row. Used by
+/// `flow_cancel_requested` where the `execution_id` column on the
+/// outbox carries the FLOW id (Phase 3.3 parity with PG reference
+/// `ff-backend-postgres/src/operator.rs:1118-1132`). `instance_tag`
+/// is left NULL — flows don't carry `cairn.instance_id` tags today.
+///
+/// Binds:
+///   1. flow_id TEXT (stringified UUID) — written on outbox row.
+///   2. event_type TEXT ('flow_cancel_requested').
+///   3. details TEXT (nullable JSON).
+///   4. occurred_at_ms (i64).
+///   5. partition_key (i64).
+///   6. flow_id BLOB — for the co-transactional flow_core lookup.
+pub(crate) const INSERT_OPERATOR_EVENT_FLOW_SQL: &str = r#"
+    INSERT INTO ff_operator_event
+        (execution_id, event_type, details, occurred_at_ms, partition_key,
+         namespace, instance_tag)
+    SELECT ?1, ?2, ?3, ?4, ?5,
+           json_extract(raw_fields, '$.namespace'),
+           NULL
+      FROM ff_flow_core
+     WHERE partition_key = ?5 AND flow_id = ?6
+    UNION ALL
+    SELECT ?1, ?2, ?3, ?4, ?5, NULL, NULL
+     WHERE NOT EXISTS (
+         SELECT 1 FROM ff_flow_core
+          WHERE partition_key = ?5 AND flow_id = ?6
      )
 "#;

--- a/crates/ff-backend-sqlite/src/queries/reads.rs
+++ b/crates/ff-backend-sqlite/src/queries/reads.rs
@@ -1,0 +1,70 @@
+//! SQL statements for Wave 9 read-model methods (RFC-023 Phase 3.3).
+//!
+//! Mirrors `ff-backend-postgres/src/exec_core.rs` §4.1 read impls at
+//! the statement level. SQLite translations:
+//!
+//! * `LEFT JOIN LATERAL (... LIMIT 1)` → `LEFT JOIN` on a correlated
+//!   subquery expression. SQLite executes the subquery per-outer-row
+//!   which is equivalent for LIMIT 1 projections.
+//! * `FOR UPDATE` — no-op under `BEGIN IMMEDIATE` single-writer.
+//! * `BYTEA` → `BLOB`. `uuid` column bound as 16-byte BLOB.
+//! * JSON extraction via `json_extract` (JSON1) instead of `->>`.
+
+// ── read_execution_state (§4.1) ────────────────────────────────────
+
+/// Single-column point read on `ff_exec_core.public_state`. Binds:
+/// ?1 partition_key, ?2 execution_id BLOB.
+pub(crate) const SELECT_PUBLIC_STATE_SQL: &str = r#"
+    SELECT public_state
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+// ── read_execution_info (§4.1) ─────────────────────────────────────
+
+/// Multi-column projection of `ff_exec_core` joined with the current
+/// attempt row (for `outcome`) + the earliest started attempt row
+/// (for `started_at`). Mirrors PG's LATERAL joins with SQLite
+/// correlated subqueries in the SELECT list.
+///
+/// Binds: ?1 partition_key, ?2 execution_id BLOB.
+pub(crate) const SELECT_EXECUTION_INFO_SQL: &str = r#"
+    SELECT ec.flow_id,
+           ec.lane_id,
+           ec.priority,
+           ec.lifecycle_phase,
+           ec.ownership_state,
+           ec.eligibility_state,
+           ec.public_state,
+           ec.attempt_state,
+           ec.blocking_reason,
+           ec.attempt_index,
+           ec.created_at_ms,
+           ec.terminal_at_ms,
+           ec.raw_fields,
+           (SELECT outcome
+              FROM ff_attempt a
+             WHERE a.partition_key = ec.partition_key
+               AND a.execution_id  = ec.execution_id
+               AND a.attempt_index = ec.attempt_index) AS attempt_outcome,
+           (SELECT started_at_ms
+              FROM ff_attempt a
+             WHERE a.partition_key = ec.partition_key
+               AND a.execution_id  = ec.execution_id
+               AND a.started_at_ms IS NOT NULL
+             ORDER BY a.attempt_index ASC
+             LIMIT 1) AS first_started_at_ms
+      FROM ff_exec_core ec
+     WHERE ec.partition_key = ?1 AND ec.execution_id = ?2
+"#;
+
+// ── get_execution_result (§4.1 + §7.8) ─────────────────────────────
+
+/// `result` BLOB point read from `ff_exec_core`. Current-attempt
+/// semantics per RFC-020 Rev 7 Fork 3. Binds: ?1 partition_key, ?2
+/// execution_id BLOB.
+pub(crate) const SELECT_EXECUTION_RESULT_SQL: &str = r#"
+    SELECT result
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;

--- a/crates/ff-backend-sqlite/src/queries/waitpoint.rs
+++ b/crates/ff-backend-sqlite/src/queries/waitpoint.rs
@@ -70,3 +70,32 @@ pub const SELECT_WAITPOINT_FOR_DELIVER_SQL: &str =
 pub const DELETE_WAITPOINTS_BY_EXEC_SQL: &str =
     "DELETE FROM ff_waitpoint_pending \
       WHERE partition_key = ?1 AND execution_id = ?2";
+
+// ── list_pending_waitpoints (RFC-020 §4.5, Phase 3.3) ──────────────
+
+/// Existence probe — matches PG reference's `EXISTS exec_core`
+/// pre-check so a non-existent execution surfaces `NotFound` rather
+/// than an empty page. Binds: ?1 partition_key, ?2 execution_id BLOB.
+pub const SELECT_EXEC_EXISTS_SQL: &str =
+    "SELECT 1 FROM ff_exec_core WHERE partition_key = ?1 AND execution_id = ?2";
+
+/// Cursor-paginated scan of `ff_waitpoint_pending` for one execution.
+/// Filters to `state IN ('pending','active')` (matches Valkey's
+/// client-side keep filter). Fetches `limit + 1` to detect "more to
+/// come" without a second round-trip.
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. execution_id BLOB
+///   3. after_waitpoint_id BLOB — NULL → no cursor
+///   4. limit_plus_one (i64)
+pub const SELECT_PENDING_WAITPOINTS_PAGE_SQL: &str =
+    "SELECT waitpoint_id, waitpoint_key, state, required_signal_names, \
+            created_at_ms, activated_at_ms, expires_at_ms, token_kid, token \
+       FROM ff_waitpoint_pending \
+      WHERE partition_key = ?1 \
+        AND execution_id  = ?2 \
+        AND state IN ('pending', 'active') \
+        AND (?3 IS NULL OR waitpoint_id > ?3) \
+      ORDER BY waitpoint_id \
+      LIMIT ?4";

--- a/crates/ff-backend-sqlite/src/reads.rs
+++ b/crates/ff-backend-sqlite/src/reads.rs
@@ -266,18 +266,33 @@ pub(crate) async fn read_execution_info_impl(
         .and_then(|bytes| Uuid::from_slice(bytes).ok())
         .map(|u| u.to_string());
 
+    // Checked integer conversions — surface storage-tier corruption
+    // loudly instead of silently truncating (copilot review).
+    let priority_i32: i32 = i32::try_from(priority).map_err(|e| EngineError::Validation {
+        kind: ValidationKind::Corruption,
+        detail: format!("exec_core: priority out of i32 range: {priority}: {e}"),
+    })?;
+    let attempt_index_u32: u32 = u32::try_from(attempt_index.max(0)).map_err(|e| {
+        EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!(
+                "exec_core: attempt_index out of u32 range: {attempt_index}: {e}"
+            ),
+        }
+    })?;
+
     Ok(Some(ExecutionInfo {
         execution_id: id.clone(),
         namespace,
         lane_id,
-        priority: priority as i32,
+        priority: priority_i32,
         execution_kind,
         state_vector,
         public_state,
         created_at: created_at_ms.to_string(),
         started_at: first_started_at_ms_opt.map(|v| v.to_string()),
         completed_at: terminal_at_ms_opt.map(|v| v.to_string()),
-        current_attempt_index: attempt_index.max(0) as u32,
+        current_attempt_index: attempt_index_u32,
         flow_id,
         blocking_detail,
     }))

--- a/crates/ff-backend-sqlite/src/reads.rs
+++ b/crates/ff-backend-sqlite/src/reads.rs
@@ -1,0 +1,308 @@
+//! RFC-020 Wave 9 Spine-B read-model — SQLite port (RFC-023 Phase 3.3).
+//!
+//! Three read-only methods paralleling
+//! `ff-backend-postgres/src/exec_core.rs` §4.1:
+//!
+//!   * [`read_execution_state_impl`] — single-column projection of
+//!     `ff_exec_core.public_state`.
+//!   * [`read_execution_info_impl`] — multi-column `ff_exec_core` +
+//!     correlated-subquery attempt join into [`ExecutionInfo`].
+//!   * [`get_execution_result_impl`] — `ff_exec_core.result` BLOB.
+//!
+//! Storage literals are a superset of the in-core enum variants
+//! (Postgres and SQLite ports share the same authoring sites); the
+//! `normalise_*` helpers collapse them to the `serde_snake_case`
+//! wire-form expected by `json_enum!`. Unknown tokens surface as
+//! `EngineError::Validation(Corruption)` — the `json_enum!` macro
+//! deserialise from a quoted literal, so any mismatch is loud.
+//!
+//! All three paths are read-only; no `BEGIN IMMEDIATE` needed — we
+//! execute directly on the pool. Mirrors PG's READ COMMITTED posture
+//! for these three methods (§4.1).
+
+use ff_core::contracts::ExecutionInfo;
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::state::{
+    AttemptState, BlockingReason, EligibilityState, LifecyclePhase, OwnershipState, PublicState,
+    StateVector, TerminalOutcome,
+};
+use ff_core::types::ExecutionId;
+use serde_json::Value as JsonValue;
+use sqlx::{Row, SqlitePool};
+use uuid::Uuid;
+
+use crate::errors::map_sqlx_error;
+use crate::queries::reads as q_read;
+use crate::tx_util::split_exec_id;
+
+// ─── normalisation helpers (parity with PG exec_core) ──────────────
+//
+// Match arms are grounded in actual write sites in this crate + PG
+// reference; unknown tokens fall through so `json_enum!` surfaces
+// `Corruption` loudly per RFC-020 Rev 7 §4.1.
+
+fn normalise_lifecycle_phase(raw: &str) -> &str {
+    match raw {
+        "cancelled" | "terminal" => "terminal",
+        "pending" | "runnable" | "eligible" | "blocked" => "runnable",
+        "active" => "active",
+        "suspended" => "suspended",
+        "submitted" => "submitted",
+        other => other,
+    }
+}
+
+fn normalise_ownership_state(raw: &str) -> &str {
+    match raw {
+        "released" | "unowned" => "unowned",
+        "leased" => "leased",
+        "lease_expired_reclaimable" => "lease_expired_reclaimable",
+        "lease_revoked" => "lease_revoked",
+        other => other,
+    }
+}
+
+fn normalise_eligibility_state(raw: &str) -> &str {
+    match raw {
+        "cancelled" => "not_applicable",
+        "pending_claim" => "eligible_now",
+        other => other,
+    }
+}
+
+fn normalise_attempt_state(raw: &str) -> &str {
+    match raw {
+        "pending" | "pending_claim" => "pending_first_attempt",
+        "running" => "running_attempt",
+        "cancelled" => "attempt_terminal",
+        other => other,
+    }
+}
+
+fn normalise_public_state(raw: &str) -> &str {
+    match raw {
+        "running" => "active",
+        other => other,
+    }
+}
+
+macro_rules! json_enum {
+    ($ty:ty, $field:expr, $raw:expr) => {{
+        let quoted = format!("\"{}\"", $raw);
+        serde_json::from_str::<$ty>(&quoted).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!(
+                "exec_core: {}: '{}' is not a known value: {}",
+                $field, $raw, e
+            ),
+        })
+    }};
+}
+
+fn derive_terminal_outcome(
+    phase_norm: &str,
+    phase_raw: &str,
+    attempt_outcome: Option<&str>,
+) -> TerminalOutcome {
+    if phase_norm != "terminal" {
+        return TerminalOutcome::None;
+    }
+    if phase_raw == "cancelled" {
+        return TerminalOutcome::Cancelled;
+    }
+    match attempt_outcome {
+        Some("success") => TerminalOutcome::Success,
+        Some("failed") => TerminalOutcome::Failed,
+        Some("cancelled") => TerminalOutcome::Cancelled,
+        Some("expired") => TerminalOutcome::Expired,
+        Some("skipped") => TerminalOutcome::Skipped,
+        _ => TerminalOutcome::None,
+    }
+}
+
+// ─── read_execution_state ──────────────────────────────────────────
+
+/// RFC-020 §4.1 — point read of `public_state`. `Ok(None)` when the
+/// execution is missing.
+pub(crate) async fn read_execution_state_impl(
+    pool: &SqlitePool,
+    id: &ExecutionId,
+) -> Result<Option<PublicState>, EngineError> {
+    let (part, exec_uuid) = split_exec_id(id)?;
+
+    let row: Option<(String,)> = sqlx::query_as(q_read::SELECT_PUBLIC_STATE_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let Some((raw,)) = row else {
+        return Ok(None);
+    };
+    let parsed: PublicState =
+        json_enum!(PublicState, "public_state", normalise_public_state(&raw))?;
+    Ok(Some(parsed))
+}
+
+// ─── read_execution_info ───────────────────────────────────────────
+
+/// RFC-020 §4.1 — multi-column projection + current-attempt /
+/// first-attempt joins into [`ExecutionInfo`]. `Ok(None)` when the
+/// execution is missing.
+pub(crate) async fn read_execution_info_impl(
+    pool: &SqlitePool,
+    id: &ExecutionId,
+) -> Result<Option<ExecutionInfo>, EngineError> {
+    let (part, exec_uuid) = split_exec_id(id)?;
+
+    let row = sqlx::query(q_read::SELECT_EXECUTION_INFO_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let flow_id_blob: Option<Vec<u8>> = row.try_get("flow_id").map_err(map_sqlx_error)?;
+    let lane_id: String = row.try_get("lane_id").map_err(map_sqlx_error)?;
+    let priority: i64 = row.try_get("priority").map_err(map_sqlx_error)?;
+    let lifecycle_phase_raw: String =
+        row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let ownership_state_raw: String =
+        row.try_get("ownership_state").map_err(map_sqlx_error)?;
+    let eligibility_state_raw: String =
+        row.try_get("eligibility_state").map_err(map_sqlx_error)?;
+    let public_state_raw: String = row.try_get("public_state").map_err(map_sqlx_error)?;
+    let attempt_state_raw: String = row.try_get("attempt_state").map_err(map_sqlx_error)?;
+    let blocking_reason_opt: Option<String> =
+        row.try_get("blocking_reason").map_err(map_sqlx_error)?;
+    let attempt_index: i64 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    let created_at_ms: i64 = row.try_get("created_at_ms").map_err(map_sqlx_error)?;
+    let terminal_at_ms_opt: Option<i64> =
+        row.try_get("terminal_at_ms").map_err(map_sqlx_error)?;
+    let raw_fields_str: String = row.try_get("raw_fields").map_err(map_sqlx_error)?;
+    let attempt_outcome_opt: Option<String> =
+        row.try_get("attempt_outcome").map_err(map_sqlx_error)?;
+    let first_started_at_ms_opt: Option<i64> =
+        row.try_get("first_started_at_ms").map_err(map_sqlx_error)?;
+
+    let raw_fields: JsonValue =
+        serde_json::from_str(&raw_fields_str).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("exec_core: raw_fields not valid JSON: {e}"),
+        })?;
+
+    let lifecycle_phase: LifecyclePhase = json_enum!(
+        LifecyclePhase,
+        "lifecycle_phase",
+        normalise_lifecycle_phase(&lifecycle_phase_raw)
+    )?;
+    let ownership_state: OwnershipState = json_enum!(
+        OwnershipState,
+        "ownership_state",
+        normalise_ownership_state(&ownership_state_raw)
+    )?;
+    let eligibility_state: EligibilityState = json_enum!(
+        EligibilityState,
+        "eligibility_state",
+        normalise_eligibility_state(&eligibility_state_raw)
+    )?;
+    let public_state: PublicState = json_enum!(
+        PublicState,
+        "public_state",
+        normalise_public_state(&public_state_raw)
+    )?;
+    let attempt_state: AttemptState = json_enum!(
+        AttemptState,
+        "attempt_state",
+        normalise_attempt_state(&attempt_state_raw)
+    )?;
+    let blocking_reason: BlockingReason = match blocking_reason_opt
+        .as_deref()
+        .filter(|s| !s.is_empty())
+    {
+        None => BlockingReason::None,
+        Some(raw) => json_enum!(BlockingReason, "blocking_reason", raw)?,
+    };
+    let terminal_outcome = derive_terminal_outcome(
+        normalise_lifecycle_phase(&lifecycle_phase_raw),
+        &lifecycle_phase_raw,
+        attempt_outcome_opt.as_deref(),
+    );
+
+    let state_vector = StateVector {
+        lifecycle_phase,
+        ownership_state,
+        eligibility_state,
+        blocking_reason,
+        terminal_outcome,
+        attempt_state,
+        public_state,
+    };
+
+    // Scalar raw_fields fields (namespace, execution_kind, blocking_detail).
+    let mut namespace = String::new();
+    let mut execution_kind = String::new();
+    let mut blocking_detail = String::new();
+    if let JsonValue::Object(map) = &raw_fields {
+        if let Some(JsonValue::String(s)) = map.get("namespace") {
+            namespace = s.clone();
+        }
+        if let Some(JsonValue::String(s)) = map.get("execution_kind") {
+            execution_kind = s.clone();
+        }
+        if let Some(JsonValue::String(s)) = map.get("blocking_detail") {
+            blocking_detail = s.clone();
+        }
+    }
+
+    // `ExecutionInfo::flow_id` is the bare UUID wire form (per PG impl).
+    let flow_id = flow_id_blob
+        .as_deref()
+        .and_then(|bytes| Uuid::from_slice(bytes).ok())
+        .map(|u| u.to_string());
+
+    Ok(Some(ExecutionInfo {
+        execution_id: id.clone(),
+        namespace,
+        lane_id,
+        priority: priority as i32,
+        execution_kind,
+        state_vector,
+        public_state,
+        created_at: created_at_ms.to_string(),
+        started_at: first_started_at_ms_opt.map(|v| v.to_string()),
+        completed_at: terminal_at_ms_opt.map(|v| v.to_string()),
+        current_attempt_index: attempt_index.max(0) as u32,
+        flow_id,
+        blocking_detail,
+    }))
+}
+
+// ─── get_execution_result ──────────────────────────────────────────
+
+/// RFC-020 §4.1 + §7.8 — `ff_exec_core.result` BLOB point read.
+/// Current-attempt semantics (Fork 3 Rev 7). `Ok(None)` when the
+/// execution is missing or `result` is NULL.
+pub(crate) async fn get_execution_result_impl(
+    pool: &SqlitePool,
+    id: &ExecutionId,
+) -> Result<Option<Vec<u8>>, EngineError> {
+    let (part, exec_uuid) = split_exec_id(id)?;
+
+    let row: Option<(Option<Vec<u8>>,)> = sqlx::query_as(q_read::SELECT_EXECUTION_RESULT_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    match row {
+        None => Ok(None),
+        Some((payload,)) => Ok(payload),
+    }
+}

--- a/crates/ff-backend-sqlite/src/suspend_ops.rs
+++ b/crates/ff-backend-sqlite/src/suspend_ops.rs
@@ -1303,10 +1303,15 @@ pub(crate) async fn list_pending_waitpoints_impl(
         let (token_kid, token_fingerprint) = parse_waitpoint_token_kid_fp(&token);
 
         // Decode JSON array literal into Vec<String>. Malformed JSON
-        // collapses to empty (wildcard) per the
-        // `PendingWaitpointInfo::required_signal_names` contract.
+        // surfaces `Corruption` loudly rather than silently collapsing
+        // to empty (gemini review — data-integrity guard).
         let req_names: Vec<String> =
-            serde_json::from_str(&req_names_json).unwrap_or_default();
+            serde_json::from_str(&req_names_json).map_err(|e| EngineError::Validation {
+                kind: ValidationKind::Corruption,
+                detail: format!(
+                    "waitpoint_pending: required_signal_names not valid JSON: {e}"
+                ),
+            })?;
 
         let mut info = PendingWaitpointInfo::new(
             wp_id,

--- a/crates/ff-backend-sqlite/src/suspend_ops.rs
+++ b/crates/ff-backend-sqlite/src/suspend_ops.rs
@@ -24,7 +24,8 @@ use ff_core::backend::{
 };
 use ff_core::contracts::{
     AdditionalWaitpointBinding, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
-    ClaimedResumedExecution, DeliverSignalArgs, DeliverSignalResult, ResumeCondition,
+    ClaimedResumedExecution, DeliverSignalArgs, DeliverSignalResult,
+    ListPendingWaitpointsArgs, ListPendingWaitpointsResult, PendingWaitpointInfo, ResumeCondition,
     RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllEntry,
     RotateWaitpointHmacSecretAllResult, RotateWaitpointHmacSecretOutcome, SeedOutcome,
     SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome, SuspendOutcomeDetails,
@@ -1216,4 +1217,126 @@ pub(crate) async fn rotate_waitpoint_hmac_secret_all_impl(
     Ok(RotateWaitpointHmacSecretAllResult::new(vec![
         RotateWaitpointHmacSecretAllEntry::new(0, outcome_res),
     ]))
+}
+
+// ── list_pending_waitpoints (RFC-020 §4.5, Phase 3.3) ──────────────────
+
+/// RFC-017 §8 / RFC-020 §4.5 — parse the stored `<kid>:<hex>` waitpoint
+/// token into a `(token_kid, token_fingerprint)` pair. The fingerprint
+/// is the first 16 hex chars (8 bytes) of the HMAC digest — the §8
+/// audit-safe handle. Malformed input collapses to `("", "")` so
+/// callers skip / log without surfacing a typed error. Mirrors the PG
+/// reference at `ff-backend-postgres/src/suspend_ops.rs`.
+fn parse_waitpoint_token_kid_fp(raw: &str) -> (String, String) {
+    match raw.split_once(':') {
+        Some((kid, hex)) if !kid.is_empty() && !hex.is_empty() => {
+            let fp_len = hex.len().min(16);
+            (kid.to_owned(), hex[..fp_len].to_owned())
+        }
+        _ => (String::new(), String::new()),
+    }
+}
+
+/// RFC-020 §4.5 — read-only projection of pending-or-active waitpoints
+/// for one execution. Cursor-paginated SELECT against
+/// `ff_waitpoint_pending`. Pre-check `ff_exec_core` existence so a
+/// non-existent execution surfaces `NotFound` rather than an empty
+/// page (mirrors PG + Valkey). `token_fingerprint` is parsed from the
+/// stored `<kid>:<hex>` token — the raw token never crosses the trait
+/// boundary per RFC-017 Stage D1 / §8.
+pub(crate) async fn list_pending_waitpoints_impl(
+    pool: &SqlitePool,
+    args: ListPendingWaitpointsArgs,
+) -> Result<ListPendingWaitpointsResult, EngineError> {
+    const DEFAULT_LIMIT: u32 = 100;
+    const MAX_LIMIT: u32 = 1000;
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as i64;
+    let after_uuid = match args.after.as_ref() {
+        Some(wp) => Some(wp_uuid(wp)?),
+        None => None,
+    };
+
+    // Existence probe.
+    let exists: Option<(i64,)> = sqlx::query_as(q_wp::SELECT_EXEC_EXISTS_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+    if exists.is_none() {
+        return Err(EngineError::NotFound { entity: "execution" });
+    }
+
+    // Page: request `limit + 1` for "has more" detection.
+    // `required_signal_names` is stored as a TEXT JSON array literal
+    // (SQLite has no native text[] — see migration 0011 default).
+    type Row = (
+        Uuid,
+        String,
+        String,
+        String,
+        i64,
+        Option<i64>,
+        Option<i64>,
+        String,
+        String,
+    );
+    let rows: Vec<Row> = sqlx::query_as(q_wp::SELECT_PENDING_WAITPOINTS_PAGE_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(after_uuid)
+        .bind(limit + 1)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let has_more = rows.len() as i64 > limit;
+    let take_n = if has_more { limit as usize } else { rows.len() };
+
+    let mut entries: Vec<PendingWaitpointInfo> = Vec::with_capacity(take_n);
+    for (wp_uid, wp_key, state, req_names_json, created_ms, activated_ms, expires_ms, _kid, token)
+        in rows.into_iter().take(take_n)
+    {
+        let wp_id = WaitpointId::from_uuid(wp_uid);
+        let (token_kid, token_fingerprint) = parse_waitpoint_token_kid_fp(&token);
+
+        // Decode JSON array literal into Vec<String>. Malformed JSON
+        // collapses to empty (wildcard) per the
+        // `PendingWaitpointInfo::required_signal_names` contract.
+        let req_names: Vec<String> =
+            serde_json::from_str(&req_names_json).unwrap_or_default();
+
+        let mut info = PendingWaitpointInfo::new(
+            wp_id,
+            wp_key,
+            state,
+            TimestampMs(created_ms),
+            args.execution_id.clone(),
+            token_kid,
+            token_fingerprint,
+        );
+        if !req_names.is_empty() {
+            info = info.with_required_signal_names(req_names);
+        }
+        if let Some(ms) = activated_ms {
+            info = info.with_activated_at(TimestampMs(ms));
+        }
+        if let Some(ms) = expires_ms {
+            info = info.with_expires_at(TimestampMs(ms));
+        }
+        entries.push(info);
+    }
+
+    let next_cursor = if has_more {
+        entries.last().map(|e| e.waitpoint_id.clone())
+    } else {
+        None
+    };
+    let mut result = ListPendingWaitpointsResult::new(entries);
+    if let Some(cursor) = next_cursor {
+        result = result.with_next_cursor(cursor);
+    }
+    Ok(result)
 }

--- a/crates/ff-backend-sqlite/tests/wave9_operator.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_operator.rs
@@ -13,10 +13,11 @@ use std::time::Duration;
 use ff_backend_sqlite::SqliteBackend;
 use ff_core::backend::{CapabilitySet, ClaimPolicy};
 use ff_core::contracts::{
-    CancelExecutionArgs, CancelExecutionResult, ChangePriorityArgs, ChangePriorityResult,
-    CreateExecutionArgs, CreateExecutionResult, ReplayExecutionArgs, ReplayExecutionResult,
-    RevokeLeaseArgs, RevokeLeaseResult,
+    CancelExecutionArgs, CancelExecutionResult, CancelFlowArgs, CancelFlowHeader,
+    ChangePriorityArgs, ChangePriorityResult, CreateExecutionArgs, CreateExecutionResult,
+    ReplayExecutionArgs, ReplayExecutionResult, RevokeLeaseArgs, RevokeLeaseResult,
 };
+use ff_core::types::FlowId;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind};
 use ff_core::state::PublicState;
@@ -598,4 +599,257 @@ async fn concurrent_cancel_serialization() {
     // Small delay to let any broadcast emits settle before the backend
     // drops (avoids a noisy test-teardown race on the wakeup channel).
     tokio::time::sleep(Duration::from_millis(20)).await;
+}
+
+// ── cancel_flow_header + ack_cancel_member (Phase 3.3) ─────────────
+
+/// Seed a flow with N in-flight members on partition 0. Bypasses the
+/// `create_flow` ingress since Phase 3.3 only ships cancel-path
+/// glue — matching the PG reference test style at
+/// `spine_a_pt2_mutations.rs`.
+async fn seed_flow_with_members(
+    b: &Arc<SqliteBackend>,
+    flow_id: &FlowId,
+    n: usize,
+) -> Vec<Uuid> {
+    let flow_uuid = flow_id.0;
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+           (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms, raw_fields) \
+         VALUES (0, ?1, 0, 'open', ?2, '{}')",
+    )
+    .bind(flow_uuid)
+    .bind(now_ms())
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let mut members = Vec::with_capacity(n);
+    for _ in 0..n {
+        let m = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO ff_exec_core \
+               (partition_key, execution_id, flow_id, lane_id, attempt_index, \
+                lifecycle_phase, ownership_state, eligibility_state, \
+                public_state, attempt_state, priority, created_at_ms, raw_fields) \
+             VALUES (0, ?1, ?2, 'default', 0, \
+                     'active', 'leased', 'eligible_now', 'running', 'running_attempt', \
+                     0, ?3, '{}')",
+        )
+        .bind(m)
+        .bind(flow_uuid)
+        .bind(now_ms())
+        .execute(b.pool_for_test())
+        .await
+        .unwrap();
+        members.push(m);
+    }
+    members
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn cancel_flow_header_happy_path_creates_backlog_and_flips_members() {
+    let b = fresh_backend().await;
+    let flow_id = FlowId::new();
+    let members = seed_flow_with_members(&b, &flow_id, 3).await;
+
+    let r = b
+        .cancel_flow_header(CancelFlowArgs {
+            flow_id: flow_id.clone(),
+            reason: "op-shutdown".into(),
+            cancellation_policy: "cancel_all".into(),
+            now: TimestampMs::from_millis(now_ms()),
+        })
+        .await
+        .expect("cancel_flow_header ok");
+    match r {
+        CancelFlowHeader::Cancelled {
+            cancellation_policy,
+            member_execution_ids,
+        } => {
+            assert_eq!(cancellation_policy, "cancel_all");
+            assert_eq!(member_execution_ids.len(), 3);
+        }
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+
+    // ff_cancel_backlog has one row.
+    let header_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_cancel_backlog WHERE flow_id=?1",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(header_count, 1);
+
+    // ff_cancel_backlog_member has 3 rows.
+    let member_rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_cancel_backlog_member WHERE flow_id=?1",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(member_rows, 3);
+
+    // Members flipped to cancelled on ff_exec_core.
+    let cancelled: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_exec_core \
+         WHERE flow_id=?1 AND lifecycle_phase='cancelled'",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(cancelled, 3);
+
+    // flow_core flipped.
+    let fstate: String = sqlx::query_scalar(
+        "SELECT public_flow_state FROM ff_flow_core WHERE flow_id=?1",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(fstate, "cancelled");
+
+    // Operator event emitted.
+    let op_events: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_operator_event \
+         WHERE event_type='flow_cancel_requested' AND execution_id=?1",
+    )
+    .bind(flow_id.0.to_string())
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(op_events, 1);
+
+    let _ = members;
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn cancel_flow_header_already_terminal_is_idempotent() {
+    let b = fresh_backend().await;
+    let flow_id = FlowId::new();
+    // Seed a pre-cancelled flow directly.
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+           (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms, raw_fields) \
+         VALUES (0, ?1, 0, 'cancelled', ?2, \
+           '{\"cancellation_policy\":\"flow_only\",\"cancel_reason\":\"prior\"}')",
+    )
+    .bind(flow_id.0)
+    .bind(now_ms())
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let r = b
+        .cancel_flow_header(CancelFlowArgs {
+            flow_id: flow_id.clone(),
+            reason: "retry".into(),
+            cancellation_policy: "cancel_all".into(),
+            now: TimestampMs::from_millis(now_ms()),
+        })
+        .await
+        .expect("idempotent ok");
+    match r {
+        CancelFlowHeader::AlreadyTerminal {
+            stored_cancellation_policy,
+            stored_cancel_reason,
+            member_execution_ids,
+        } => {
+            assert_eq!(stored_cancellation_policy.as_deref(), Some("flow_only"));
+            assert_eq!(stored_cancel_reason.as_deref(), Some("prior"));
+            assert!(member_execution_ids.is_empty());
+        }
+        other => panic!("expected AlreadyTerminal, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn ack_cancel_member_drains_and_deletes_parent_when_last() {
+    let b = fresh_backend().await;
+    let flow_id = FlowId::new();
+    let _members = seed_flow_with_members(&b, &flow_id, 2).await;
+
+    let r = b
+        .cancel_flow_header(CancelFlowArgs {
+            flow_id: flow_id.clone(),
+            reason: "test".into(),
+            cancellation_policy: "cancel_all".into(),
+            now: TimestampMs::from_millis(now_ms()),
+        })
+        .await
+        .expect("cancel ok");
+    let member_ids = match r {
+        CancelFlowHeader::Cancelled {
+            member_execution_ids,
+            ..
+        } => member_execution_ids,
+        other => panic!("expected Cancelled, got {other:?}"),
+    };
+    assert_eq!(member_ids.len(), 2);
+
+    // Ack first member.
+    let eid_a = ExecutionId::parse(&member_ids[0]).expect("parse");
+    b.ack_cancel_member(&flow_id, &eid_a)
+        .await
+        .expect("ack 1");
+
+    // Parent still present (one member remains).
+    let header_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_cancel_backlog WHERE flow_id=?1",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(header_count, 1);
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_cancel_backlog_member WHERE flow_id=?1",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(remaining, 1);
+
+    // Ack second member — final ack should drop both child + parent.
+    let eid_b = ExecutionId::parse(&member_ids[1]).expect("parse");
+    b.ack_cancel_member(&flow_id, &eid_b)
+        .await
+        .expect("ack 2");
+    let header_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_cancel_backlog WHERE flow_id=?1",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(header_after, 0, "parent backlog row dropped on final ack");
+    let members_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ff_cancel_backlog_member WHERE flow_id=?1",
+    )
+    .bind(flow_id.0)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(members_after, 0);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn ack_cancel_member_idempotent_on_missing() {
+    let b = fresh_backend().await;
+    let flow_id = FlowId::new();
+    let missing_eid = new_exec_id();
+    // No backlog row exists — ack is a no-op.
+    b.ack_cancel_member(&flow_id, &missing_eid)
+        .await
+        .expect("idempotent no-op");
 }

--- a/crates/ff-backend-sqlite/tests/wave9_reads.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_reads.rs
@@ -1,0 +1,300 @@
+//! RFC-023 Phase 3.3 — Wave 9 read-model integration tests.
+//!
+//! Covers `read_execution_state`, `read_execution_info`, and
+//! `get_execution_result` on the SQLite backend: happy path, missing
+//! row → `Ok(None)`, lifecycle_phase normalisation, terminal-outcome
+//! derivation, current-attempt semantics for `get_execution_result`.
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CapabilitySet, ClaimPolicy};
+use ff_core::contracts::{CreateExecutionArgs, CreateExecutionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::state::{LifecyclePhase, PublicState, TerminalOutcome};
+use ff_core::types::{
+    ExecutionId, LaneId, Namespace, TimestampMs, WorkerId, WorkerInstanceId,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+// ── Shared setup ───────────────────────────────────────────────────
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:rfc-023-wave9-reads-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("backend")
+}
+
+fn new_exec_id() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id")
+}
+
+fn uuid_of(eid: &ExecutionId) -> Uuid {
+    Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap()
+}
+
+async fn create_runnable(b: &Arc<SqliteBackend>, lane: &LaneId) -> ExecutionId {
+    let exec_id = new_exec_id();
+    let args = CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: lane.clone(),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let r = b.create_execution(args).await.expect("create");
+    assert!(matches!(r, CreateExecutionResult::Created { .. }));
+    // Promote to runnable so claim() picks it up.
+    let exec_uuid = uuid_of(&exec_id);
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    exec_id
+}
+
+async fn create_and_claim(b: &Arc<SqliteBackend>) -> ExecutionId {
+    let lane = LaneId::new(format!("lane-{}", Uuid::new_v4()));
+    let exec_id = create_runnable(b, &lane).await;
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i1"),
+        30_000,
+        None,
+    );
+    let _ = b
+        .claim(&lane, &CapabilitySet::default(), policy)
+        .await
+        .expect("claim")
+        .expect("handle");
+    exec_id
+}
+
+// ── read_execution_state ───────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn read_execution_state_missing_returns_none() {
+    let b = fresh_backend().await;
+    let missing = new_exec_id();
+    let got = b.read_execution_state(&missing).await.expect("ok");
+    assert!(got.is_none());
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn read_execution_state_happy_path_submitted() {
+    // Fresh create → public_state='waiting' (per INSERT_EXEC_CORE_SQL).
+    let b = fresh_backend().await;
+    let lane = LaneId::new(format!("lane-{}", Uuid::new_v4()));
+    let exec_id = {
+        let id = new_exec_id();
+        let args = CreateExecutionArgs {
+            execution_id: id.clone(),
+            namespace: Namespace::new("default"),
+            lane_id: lane,
+            execution_kind: "op".into(),
+            input_payload: vec![],
+            payload_encoding: None,
+            priority: 0,
+            creator_identity: "test".into(),
+            idempotency_key: None,
+            tags: Default::default(),
+            policy: None,
+            delay_until: None,
+            execution_deadline_at: None,
+            partition_id: 0,
+            now: TimestampMs::from_millis(now_ms()),
+        };
+        let _ = b.create_execution(args).await.expect("create");
+        id
+    };
+    let got = b.read_execution_state(&exec_id).await.expect("ok").expect("some");
+    assert_eq!(got, PublicState::Waiting);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn read_execution_state_normalizes_running_to_active() {
+    // Verify the normaliser collapses the storage-tier `running`
+    // literal to `PublicState::Active` (matches PG exec_core
+    // normalisation). SQLite's claim path does not itself write
+    // public_state='running' today; seed the literal directly so the
+    // test exercises the normaliser regardless of the write-site gap.
+    let b = fresh_backend().await;
+    let exec_id = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    sqlx::query(
+        "UPDATE ff_exec_core SET public_state='running' \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    let got = b.read_execution_state(&exec_id).await.expect("ok").expect("some");
+    assert_eq!(got, PublicState::Active);
+}
+
+// ── read_execution_info ────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn read_execution_info_missing_returns_none() {
+    let b = fresh_backend().await;
+    let missing = new_exec_id();
+    assert!(b.read_execution_info(&missing).await.expect("ok").is_none());
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn read_execution_info_happy_path_post_claim() {
+    let b = fresh_backend().await;
+    let exec_id = create_and_claim(&b).await;
+    let info = b
+        .read_execution_info(&exec_id)
+        .await
+        .expect("ok")
+        .expect("some");
+    assert_eq!(info.execution_id, exec_id);
+    assert_eq!(info.namespace, "default");
+    assert_eq!(info.execution_kind, "op");
+    // Note: SQLite's claim path does not write public_state today
+    // (parity gap with PG); post-claim row retains the INSERT literal
+    // 'waiting' until a future Phase flips it.
+    assert_eq!(info.public_state, PublicState::Waiting);
+    assert_eq!(info.state_vector.lifecycle_phase, LifecyclePhase::Active);
+    assert_eq!(
+        info.state_vector.terminal_outcome,
+        TerminalOutcome::None,
+        "active row is not terminal"
+    );
+    assert!(info.started_at.is_some(), "claim set started_at on attempt 0");
+    assert!(info.completed_at.is_none());
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn read_execution_info_terminal_cancelled_derives_outcome() {
+    use ff_core::contracts::{CancelExecutionArgs, CancelExecutionResult};
+    use ff_core::types::CancelSource;
+
+    let b = fresh_backend().await;
+    let exec_id = create_and_claim(&b).await;
+    let _ = b
+        .cancel_execution(CancelExecutionArgs {
+            execution_id: exec_id.clone(),
+            reason: "test".into(),
+            source: CancelSource::OperatorOverride,
+            lease_id: None,
+            lease_epoch: None,
+            attempt_id: None,
+            now: TimestampMs::from_millis(now_ms()),
+        })
+        .await
+        .expect("cancel");
+
+    let info = b
+        .read_execution_info(&exec_id)
+        .await
+        .expect("ok")
+        .expect("some");
+    assert_eq!(info.state_vector.lifecycle_phase, LifecyclePhase::Terminal);
+    assert_eq!(info.public_state, PublicState::Cancelled);
+    assert_eq!(
+        info.state_vector.terminal_outcome,
+        TerminalOutcome::Cancelled,
+        "lifecycle_phase='cancelled' → TerminalOutcome::Cancelled",
+    );
+    assert!(info.completed_at.is_some(), "terminal_at_ms populated by cancel");
+    let _ = matches!(info.state_vector.lifecycle_phase, LifecyclePhase::Terminal);
+    let _ = CancelExecutionResult::Cancelled {
+        execution_id: exec_id.clone(),
+        public_state: PublicState::Cancelled,
+    };
+}
+
+// ── get_execution_result ───────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn get_execution_result_missing_returns_none() {
+    let b = fresh_backend().await;
+    let missing = new_exec_id();
+    let got = b.get_execution_result(&missing).await.expect("ok");
+    assert!(got.is_none());
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn get_execution_result_active_returns_none() {
+    // An active execution has no stored result yet.
+    let b = fresh_backend().await;
+    let exec_id = create_and_claim(&b).await;
+    let got = b.get_execution_result(&exec_id).await.expect("ok");
+    assert!(got.is_none(), "active exec has no result payload");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn get_execution_result_terminal_returns_payload() {
+    // Seed the `result` column directly (matches the PG reference
+    // test's style — the real write path is `complete()` which Phase
+    // 3.3 is not scoped to exercise).
+    let b = fresh_backend().await;
+    let exec_id = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    let payload = b"the-result-bytes".to_vec();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='terminal', public_state='completed', \
+         result=?1 WHERE partition_key=0 AND execution_id=?2",
+    )
+    .bind(&payload)
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let got = b.get_execution_result(&exec_id).await.expect("ok").expect("some");
+    assert_eq!(got, payload);
+}

--- a/crates/ff-backend-sqlite/tests/wave9_waitpoints.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_waitpoints.rs
@@ -1,0 +1,302 @@
+//! RFC-023 Phase 3.3 — Wave 9 `list_pending_waitpoints` integration
+//! tests. Covers the happy path, cursor pagination, empty result,
+//! closed-state filtering, and the missing-execution NotFound gate.
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CapabilitySet, ClaimPolicy};
+use ff_core::contracts::{
+    CreateExecutionArgs, CreateExecutionResult, ListPendingWaitpointsArgs, ResumeCondition,
+    ResumePolicy, SeedWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs, SuspensionReasonCode,
+    WaitpointBinding,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::EngineError;
+use ff_core::types::{
+    ExecutionId, LaneId, Namespace, SuspensionId, TimestampMs, WaitpointId, WorkerId,
+    WorkerInstanceId,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+// ── Setup ──────────────────────────────────────────────────────────
+
+const KID: &str = "kid-test";
+fn secret_hex() -> String {
+    "cafebabe".repeat(8)
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:rfc-023-wave9-wp-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    let b = SqliteBackend::new(&uri).await.expect("backend");
+    b.seed_waitpoint_hmac_secret(SeedWaitpointHmacSecretArgs::new(KID, secret_hex()))
+        .await
+        .expect("seed kid");
+    b
+}
+
+fn new_exec_id() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id")
+}
+
+async fn create_and_claim(
+    b: &Arc<SqliteBackend>,
+) -> (ExecutionId, ff_core::backend::Handle) {
+    let exec_id = new_exec_id();
+    let args = CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: LaneId::new("default"),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let r = b.create_execution(args).await.expect("create");
+    assert!(matches!(r, CreateExecutionResult::Created { .. }));
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', public_state='pending', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i1"),
+        30_000,
+        None,
+    );
+    let handle = b
+        .claim(&LaneId::new("default"), &CapabilitySet::default(), policy)
+        .await
+        .expect("claim")
+        .expect("handle");
+    (exec_id, handle)
+}
+
+/// Suspend on a bundle of N waitpoints so each one lands a
+/// `ff_waitpoint_pending` row.
+async fn suspend_n(
+    b: &Arc<SqliteBackend>,
+    handle: &ff_core::backend::Handle,
+    n: usize,
+) -> Vec<(WaitpointId, String)> {
+    let mut bindings = Vec::with_capacity(n);
+    for i in 0..n {
+        bindings.push(WaitpointBinding::Fresh {
+            waitpoint_id: WaitpointId::new(),
+            waitpoint_key: format!("wpk:{i}"),
+        });
+    }
+    let primary_key = match &bindings[0] {
+        WaitpointBinding::Fresh { waitpoint_key, .. } => waitpoint_key.clone(),
+        _ => unreachable!(),
+    };
+    let mut args = SuspendArgs::new(
+        SuspensionId::new(),
+        bindings[0].clone(),
+        ResumeCondition::Single {
+            waitpoint_key: primary_key,
+            matcher: SignalMatcher::Wildcard,
+        },
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::from_millis(now_ms()),
+    );
+    // Additional waitpoints go on via `waitpoints` vec (SuspendArgs
+    // carries them directly).
+    args.waitpoints = bindings.clone();
+
+    let _ = b.suspend(handle, args).await.expect("suspend");
+    bindings
+        .into_iter()
+        .map(|b| match b {
+            WaitpointBinding::Fresh {
+                waitpoint_id,
+                waitpoint_key,
+            } => (waitpoint_id, waitpoint_key),
+            _ => unreachable!(),
+        })
+        .collect()
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn list_pending_waitpoints_empty_for_no_suspension() {
+    let b = fresh_backend().await;
+    let (exec_id, _h) = create_and_claim(&b).await;
+    let r = b
+        .list_pending_waitpoints(ListPendingWaitpointsArgs::new(exec_id.clone()))
+        .await
+        .expect("ok");
+    assert!(r.entries.is_empty());
+    assert!(r.next_cursor.is_none());
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn list_pending_waitpoints_happy_path_returns_all_fields() {
+    let b = fresh_backend().await;
+    let (exec_id, handle) = create_and_claim(&b).await;
+    let seeded = suspend_n(&b, &handle, 3).await;
+
+    let r = b
+        .list_pending_waitpoints(ListPendingWaitpointsArgs::new(exec_id.clone()))
+        .await
+        .expect("ok");
+    assert_eq!(r.entries.len(), 3);
+    assert!(r.next_cursor.is_none());
+
+    for entry in &r.entries {
+        assert_eq!(entry.execution_id, exec_id);
+        assert_eq!(entry.state, "active", "suspend lands state='active'");
+        assert!(!entry.waitpoint_key.is_empty());
+        assert!(entry.activated_at.is_some());
+        assert!(!entry.token_kid.is_empty(), "token_kid populated");
+        assert!(!entry.token_fingerprint.is_empty(), "fingerprint populated");
+        assert_eq!(
+            entry.token_fingerprint.len(),
+            16,
+            "fingerprint is 16 hex chars = 8 bytes"
+        );
+    }
+
+    // Every seeded waitpoint surfaces in the result.
+    let returned: std::collections::HashSet<_> =
+        r.entries.iter().map(|e| e.waitpoint_id.clone()).collect();
+    for (wp_id, _) in &seeded {
+        assert!(returned.contains(wp_id), "wp {wp_id:?} not in result");
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn list_pending_waitpoints_cursor_pagination() {
+    let b = fresh_backend().await;
+    let (exec_id, handle) = create_and_claim(&b).await;
+    let _seeded = suspend_n(&b, &handle, 5).await;
+
+    let page1 = b
+        .list_pending_waitpoints(
+            ListPendingWaitpointsArgs::new(exec_id.clone()).with_limit(2),
+        )
+        .await
+        .expect("page 1");
+    assert_eq!(page1.entries.len(), 2);
+    let cursor = page1.next_cursor.expect("more rows remain");
+
+    let page2 = b
+        .list_pending_waitpoints(
+            ListPendingWaitpointsArgs::new(exec_id.clone())
+                .with_after(cursor.clone())
+                .with_limit(2),
+        )
+        .await
+        .expect("page 2");
+    assert_eq!(page2.entries.len(), 2);
+    let cursor2 = page2.next_cursor.expect("one more row remains");
+
+    let page3 = b
+        .list_pending_waitpoints(
+            ListPendingWaitpointsArgs::new(exec_id.clone())
+                .with_after(cursor2)
+                .with_limit(2),
+        )
+        .await
+        .expect("page 3");
+    assert_eq!(page3.entries.len(), 1);
+    assert!(page3.next_cursor.is_none());
+
+    // Pages are distinct.
+    let all_ids: Vec<_> = page1
+        .entries
+        .iter()
+        .chain(page2.entries.iter())
+        .chain(page3.entries.iter())
+        .map(|e| e.waitpoint_id.clone())
+        .collect();
+    let set: std::collections::HashSet<_> = all_ids.iter().cloned().collect();
+    assert_eq!(set.len(), 5, "5 distinct waitpoints across 3 pages");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn list_pending_waitpoints_missing_execution_returns_not_found() {
+    let b = fresh_backend().await;
+    let missing = new_exec_id();
+    let err = b
+        .list_pending_waitpoints(ListPendingWaitpointsArgs::new(missing))
+        .await
+        .expect_err("missing exec is NotFound");
+    assert!(matches!(err, EngineError::NotFound { entity: "execution" }));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn list_pending_waitpoints_filters_closed_state() {
+    let b = fresh_backend().await;
+    let (exec_id, handle) = create_and_claim(&b).await;
+    let seeded = suspend_n(&b, &handle, 2).await;
+
+    // Flip one waitpoint to state='closed' directly — simulates a
+    // satisfied/expired row the impl should hide.
+    let target: Uuid = seeded[0].0.0;
+    sqlx::query("UPDATE ff_waitpoint_pending SET state='closed' WHERE waitpoint_id=?1")
+        .bind(target)
+        .execute(b.pool_for_test())
+        .await
+        .unwrap();
+
+    let r = b
+        .list_pending_waitpoints(ListPendingWaitpointsArgs::new(exec_id.clone()))
+        .await
+        .expect("ok");
+    assert_eq!(r.entries.len(), 1, "closed row filtered");
+    assert_ne!(
+        r.entries[0].waitpoint_id.0, target,
+        "remaining entry is the non-closed one"
+    );
+}


### PR DESCRIPTION
## Summary

RFC-023 Phase 3.3 — lands 6 Wave 9 trait methods on the SQLite
backend, replacing `Unavailable` stubs with real bodies ported from
the Postgres reference. Closes out the read-only + cancel-flow-split
halves of Wave 9 under RFC-020 §4.1, §4.2.3, and §4.5.

### Methods

**Read model (§4.1)**
- `read_execution_state` — point read of `public_state` via the PG
  normaliser helpers (`running` → `Active`, `cancelled`/`terminal` →
  `Terminal`, unknown → `Corruption`).
- `read_execution_info` — `ff_exec_core` projection + correlated
  attempt subqueries (SQLite analogue of PG's `LEFT JOIN LATERAL`)
  into `ExecutionInfo`. Derives `TerminalOutcome` from attempt
  outcome + lifecycle literal.
- `get_execution_result` — `result` BLOB point read, current-attempt
  semantics (RFC-020 Rev 7 Fork 3).

**Cancel-flow split (§4.2.3)**
- `cancel_flow_header` — atomic flow_core flip + `ff_cancel_backlog`
  header + in-flight member enumeration + `ff_cancel_backlog_member`
  per-member rows + per-member `ff_exec_core` flip + outbox
  `ff_operator_event event_type='flow_cancel_requested'`. Idempotent
  replay returns `AlreadyTerminal { stored_cancellation_policy,
  stored_cancel_reason, member_execution_ids }`.
- `ack_cancel_member` — member-row DELETE + parent-row DELETE iff
  empty. NO outbox emit (§4.2.7 Valkey-parity). Final-ack drop of
  both rows runs in a single BEGIN IMMEDIATE window.

**Waitpoint read (§4.5)**
- `list_pending_waitpoints` — cursor-paginated scan of
  `ff_waitpoint_pending` with `state IN ('pending','active')` filter,
  `(limit + 1)` fetch for has-more detection, `NotFound` on missing
  execution, `(token_kid, token_fingerprint)` parsed from stored
  `<kid>:<hex>` token — raw token never crosses the trait boundary
  (RFC-017 Stage D1 / §8). Populates all 10 `PendingWaitpointInfo`
  fields including `activated_at_ms` from the Phase 1b 0011 extension.

### Module-layout decisions

- New `src/reads.rs` (rather than extending `exec_core.rs`) so the
  read model has its own home paralleling PG's §4.1 section structure.
- New `src/queries/reads.rs` for the 3 SQL strings.
- Extended `src/operator.rs` + `src/queries/operator.rs` for the
  cancel-flow-split SQL and a new flow-keyed operator-event insert
  helper (`INSERT_OPERATOR_EVENT_FLOW_SQL` back-fills `namespace`
  from `ff_flow_core.raw_fields` since flow events don't have an
  exec_core row).
- Extended `src/suspend_ops.rs` + `src/queries/waitpoint.rs` for the
  pending-waitpoint list.

### SQLite dialect notes

- `LATERAL` joins → correlated subqueries in the SELECT list (for
  `read_execution_info`).
- Bulk `UNNEST` → per-member INSERT loop under single-writer
  `BEGIN IMMEDIATE` (membership cardinality is bounded; each stmt is
  cheap; matches existing `cancel_flow_impl` pattern).
- `SERIALIZABLE` tx wrap → `retry::retry_serializable` wrapper on
  top of `BEGIN IMMEDIATE` with SQLITE_BUSY/SQLITE_LOCKED absorption.
- `text[]` columns → TEXT holding a JSON array literal, decoded at
  the Rust boundary with `serde_json::from_str`.

### Gaps + notes

- SQLite's claim path does not write `public_state='running'` today
  (parity gap with PG). Tests verify the normaliser works correctly
  by seeding the literal directly; the write-site gap is out of
  Phase 3.3 scope.
- `Supports.*` flag flips stay `false` until the Phase 4 atomic
  release PR per RFC-023 §6.3.

## Tests

- **New `tests/wave9_reads.rs`** — 9 tests: missing → None (×3),
  post-create, post-claim, `running` → `Active` normalisation,
  terminal-cancelled → `TerminalOutcome::Cancelled`, active/terminal
  `get_execution_result` semantics.
- **New `tests/wave9_waitpoints.rs`** — 5 tests: empty, happy path
  with all 10 `PendingWaitpointInfo` fields populated, 3-page cursor
  pagination, `NotFound` on missing execution, `state='closed'`
  filter excludes.
- **Extended `tests/wave9_operator.rs`** — 4 new tests:
  `cancel_flow_header` happy path (backlog + member + operator_event
  + exec_core verified), idempotent `AlreadyTerminal` replay,
  `ack_cancel_member` member-drain + final-ack parent-delete,
  idempotent no-op on missing row.

## CI summary

- `cargo build -p ff-backend-sqlite --all-features` — clean.
- `cargo build --workspace --all-features` — clean (only pre-existing
  warnings in ferriskey crate).
- `cargo test -p ff-backend-sqlite --all-features` — all 117 tests
  pass (17 wave9_operator, 9 wave9_reads, 5 wave9_waitpoints, + 86
  pre-existing).
- `cargo clippy -p ff-backend-sqlite --all-features --tests` — clean
  on new code (one pre-existing warning in `tests/producer_flow.rs`
  untouched).
- Valkey cluster flake #369 ignorable per project conventions.

## Test plan

- [x] `cargo build -p ff-backend-sqlite --all-features`
- [x] `cargo test -p ff-backend-sqlite --all-features`
- [x] `cargo build --workspace --all-features`
- [x] `cargo clippy -p ff-backend-sqlite --all-features --tests`

Following Phase 3.1 precedent, this PR is admin-merged after CI is
green and bot comments are cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new transactional cancellation and read-model logic against SQLite tables (including outbox emission and state normalization), which could affect correctness of flow cancellation and execution status reporting if SQL/normalization mismatches exist.
> 
> **Overview**
> Implements RFC-020 Wave 9 Phase 3.3 support in the SQLite backend by replacing previously `Unavailable` stubs with concrete behavior for the read model (`read_execution_state`, `read_execution_info`, `get_execution_result`), flow-cancel split (`cancel_flow_header`, `ack_cancel_member`), and waitpoint introspection (`list_pending_waitpoints`).
> 
> This adds a new `reads` module and query set with state/enum normalization and terminal-outcome derivation, extends operator SQL and logic to create/drain `ff_cancel_backlog*` rows and emit a `flow_cancel_requested` operator event, and adds paginated pending-waitpoint scanning with execution-existence gating and token fingerprint parsing. Integration test coverage is expanded with new suites for reads and waitpoints and additional operator tests for cancel-flow header/ack behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299436d21eb3c516a6cc29ca327b090bb43fd3ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->