### PR TITLE
feat(backend-sqlite): Phase 3.4 — Wave 9 budget/quota admin (5 methods) + report_usage_impl breach-counter extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 3.4 Wave 9 budget/quota admin
+  (RFC-023 Phase 3.4 / RFC-020 §4.4 Rev 6).** Replaces 5
+  `Unavailable` trait defaults with real SQLite bodies ported from
+  `ff-backend-postgres/src/budget.rs`: `create_budget` (INSERT
+  `ff_budget_policy` with 8 Rev-6 columns + idempotent
+  `ON CONFLICT DO NOTHING`), `reset_budget` (zero `ff_budget_usage` +
+  clear breach metadata + advance `next_reset_at_ms`),
+  `create_quota_policy` (INSERT `ff_quota_policy`;
+  `ff_quota_window` + `ff_quota_admitted` tables from migration 0012
+  exist and are written by the future admission path, matching PG's
+  `create_quota_policy_impl`), `get_budget_status` (two SELECTs —
+  policy row + usage rows), `report_usage_admin` (admin-path
+  shared-core entry; translates the parallel dim/delta vectors to
+  `UsageDimensions`).
+- `crates/ff-backend-sqlite/src/budget.rs` — new module hosting the
+  5 method bodies + `report_usage_and_check_core` shared hot-path.
+- `crates/ff-backend-sqlite/src/queries/budget.rs` +
+  `queries/quota.rs` — SQLite-dialect SQL constants (positional `?`
+  placeholders; shape-identical to the PG reference).
+
+### Changed
+
+- `ff-backend-sqlite::report_usage` — extended to maintain the 0013
+  breach-counter columns (`breach_count`, `soft_breach_count`,
+  `last_breach_at_ms`, `last_breach_dim`) incrementally in the same
+  write tx as the `ff_budget_usage` increments, matching Valkey
+  parity at `flowfabric.lua:6576-6580,6614` and the PG Rev-6 §7.2
+  pin-lift. Single-writer `BEGIN IMMEDIATE` + `retry_serializable`
+  replaces PG's `FOR NO KEY UPDATE` lock discipline per RFC-023
+  §4.3.
+
 - **`crates/ff-backend-sqlite` — Phase 3.3 Wave 9 read model +
   cancel-flow split + waitpoint read (RFC-023 Phase 3.3 / RFC-020 §4.1
   + §4.2.3 + §4.5).** Replaces 6 `Unavailable` trait defaults with

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -26,9 +26,11 @@ use ff_core::backend::{SummaryDocument, TailVisibility};
 use ff_core::capability::{BackendIdentity, Capabilities, Supports, Version};
 use ff_core::caps::{CapabilityRequirement, matches as caps_matches};
 use ff_core::contracts::{
-    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
-    RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SeedOutcome,
-    SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome,
+    BudgetStatus, CancelFlowResult, CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs,
+    CreateQuotaPolicyResult, ExecutionSnapshot, FlowSnapshot, ReportUsageAdminArgs,
+    ReportUsageResult, ResetBudgetArgs, ResetBudgetResult, RotateWaitpointHmacSecretAllArgs,
+    RotateWaitpointHmacSecretAllResult, SeedOutcome, SeedWaitpointHmacSecretArgs, SuspendArgs,
+    SuspendOutcome,
 };
 #[cfg(feature = "core")]
 use ff_core::contracts::{
@@ -2638,13 +2640,62 @@ impl EngineBackend for SqliteBackend {
         unavailable("sqlite.set_edge_group_policy")
     }
 
+    // ── RFC-020 Wave 9 — Budget + quota admin (Phase 3.4) ───────────
+    //
+    // Five admin methods (§4.4.1-§4.4.7) + `report_usage` hot-path are
+    // extended to maintain the 0013 breach-counter columns
+    // incrementally (RFC-020 Rev 6 §7.2 pin-lift). All write paths run
+    // under `BEGIN IMMEDIATE` + `retry_serializable`; the single-writer
+    // envelope replaces PG's `FOR NO KEY UPDATE` lock discipline.
+
     async fn report_usage(
         &self,
         _handle: &Handle,
-        _budget: &BudgetId,
-        _dimensions: UsageDimensions,
+        budget: &BudgetId,
+        dimensions: UsageDimensions,
     ) -> Result<ReportUsageResult, EngineError> {
-        unavailable("sqlite.report_usage")
+        crate::budget::report_usage_impl(&self.inner.pool, budget, dimensions).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn create_budget(
+        &self,
+        args: CreateBudgetArgs,
+    ) -> Result<CreateBudgetResult, EngineError> {
+        crate::budget::create_budget_impl(&self.inner.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn reset_budget(
+        &self,
+        args: ResetBudgetArgs,
+    ) -> Result<ResetBudgetResult, EngineError> {
+        crate::budget::reset_budget_impl(&self.inner.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn create_quota_policy(
+        &self,
+        args: CreateQuotaPolicyArgs,
+    ) -> Result<CreateQuotaPolicyResult, EngineError> {
+        crate::budget::create_quota_policy_impl(&self.inner.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn get_budget_status(
+        &self,
+        id: &BudgetId,
+    ) -> Result<BudgetStatus, EngineError> {
+        crate::budget::get_budget_status_impl(&self.inner.pool, id).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn report_usage_admin(
+        &self,
+        budget_id: &BudgetId,
+        args: ReportUsageAdminArgs,
+    ) -> Result<ReportUsageResult, EngineError> {
+        crate::budget::report_usage_admin_impl(&self.inner.pool, budget_id, args).await
     }
 
     #[cfg(feature = "streaming")]

--- a/crates/ff-backend-sqlite/src/budget.rs
+++ b/crates/ff-backend-sqlite/src/budget.rs
@@ -1,0 +1,718 @@
+//! Budget + quota family — SQLite impl.
+//!
+//! **RFC-023 Phase 3.4 / RFC-020 Wave 9 Standalone-1 (Revision 6).**
+//! Ports the five budget/quota admin methods + the shared
+//! `report_usage_and_check_core` hot-path from
+//! `ff-backend-postgres/src/budget.rs`:
+//!
+//!   * [`create_budget_impl`]           — §4.4.2
+//!   * [`reset_budget_impl`]            — §4.4.3
+//!   * [`create_quota_policy_impl`]     — §4.4.1
+//!   * [`get_budget_status_impl`]       — §4.4.7
+//!   * [`report_usage_admin_impl`]      — §4.4.6 admin entry
+//!   * [`report_usage_impl`]            — §4.4.6 hot-path entry
+//!   * [`report_usage_and_check_core`]  — shared body; maintains the
+//!     0013 breach-counter columns incrementally in the same tx as
+//!     the ff_budget_usage INSERTs (Valkey parity at
+//!     flowfabric.lua:6576-6580,6614).
+//!
+//! **Lock model.** PG uses `FOR NO KEY UPDATE` on the policy row to
+//! serialise the breach-UPDATE path; SQLite runs under a single-
+//! writer invariant (§4.1 A3), so `BEGIN IMMEDIATE` + the
+//! `retry_serializable` wrapper cover the same semantics. `reset_budget`
+//! and `report_usage*` are all write transactions and wrap in the
+//! retry helper for SQLITE_BUSY / SQLITE_LOCKED per §4.3.
+//!
+//! **`policy_json` encoding.** PG uses `jsonb`; SQLite stores it as
+//! TEXT (migration 0002). The same `{hard_limits, soft_limits,
+//! reset_interval_ms, on_hard_limit, on_soft_limit}` shape round-
+//! trips via `serde_json::Value::to_string` / `from_str`.
+//!
+//! **Partition key.** SQLite is single-partition (§4.1 —
+//! `num_budget_partitions = num_quota_partitions = 1` in
+//! `ff_partition_config`), so the `partition_key` column is always
+//! `0`. This matches the `budget_partition(..)` / `quota_partition(..)`
+//! result under `PartitionConfig { num_budget_partitions: 1, ..}`,
+//! and keeps the column shape identical to PG for cross-backend
+//! parity tooling that greps for `partition_key = ?`.
+
+use std::collections::{BTreeMap, HashMap};
+
+use ff_core::backend::UsageDimensions;
+use ff_core::contracts::{
+    BudgetStatus, CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs,
+    CreateQuotaPolicyResult, ReportUsageAdminArgs, ReportUsageResult, ResetBudgetArgs,
+    ResetBudgetResult,
+};
+use ff_core::engine_error::{backend_context, EngineError, ValidationKind};
+use ff_core::types::{BudgetId, TimestampMs};
+use serde_json::{json, Value as JsonValue};
+use sqlx::{Row, SqlitePool};
+
+use crate::errors::map_sqlx_error;
+use crate::queries::{budget as q_budget, quota as q_quota};
+use crate::retry::retry_serializable;
+use crate::tx_util::{begin_immediate, commit_or_rollback, now_ms, rollback_quiet};
+
+/// Dedup-expiry window. Matches RFC-012 §R7.2.3's "caller-supplied
+/// idempotency key" retention: 24h by default. Identical to the PG
+/// constant in `ff-backend-postgres/src/budget.rs`.
+const DEDUP_TTL_MS: i64 = 24 * 60 * 60 * 1_000;
+
+/// Canonical dimension-row key. Matches PG reference semantics: one
+/// ff_budget_usage row per dimension, keyed by dimension name.
+fn dim_row_key(name: &str) -> String {
+    name.to_string()
+}
+
+/// Serialize a `ReportUsageResult` to the JSON shape stored on
+/// `ff_budget_usage_dedup.outcome_json`. Same shape as PG.
+fn outcome_to_json(r: &ReportUsageResult) -> JsonValue {
+    match r {
+        ReportUsageResult::Ok => json!({"kind": "Ok"}),
+        ReportUsageResult::AlreadyApplied => json!({"kind": "AlreadyApplied"}),
+        ReportUsageResult::SoftBreach {
+            dimension,
+            current_usage,
+            soft_limit,
+        } => json!({
+            "kind": "SoftBreach",
+            "dimension": dimension,
+            "current_usage": current_usage,
+            "soft_limit": soft_limit,
+        }),
+        ReportUsageResult::HardBreach {
+            dimension,
+            current_usage,
+            hard_limit,
+        } => json!({
+            "kind": "HardBreach",
+            "dimension": dimension,
+            "current_usage": current_usage,
+            "hard_limit": hard_limit,
+        }),
+        // `#[non_exhaustive]`; future variants reach the backend via
+        // ff-core before landing an impl here, so emit a placeholder
+        // the replay path will reject rather than silently mis-decoding.
+        _ => json!({"kind": "Ok"}),
+    }
+}
+
+fn outcome_from_json(v: &JsonValue) -> Result<ReportUsageResult, EngineError> {
+    let kind = v.get("kind").and_then(|k| k.as_str()).ok_or_else(|| {
+        EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: "budget dedup outcome_json missing `kind`".into(),
+        }
+    })?;
+    match kind {
+        "Ok" => Ok(ReportUsageResult::Ok),
+        "AlreadyApplied" => Ok(ReportUsageResult::AlreadyApplied),
+        "SoftBreach" => Ok(ReportUsageResult::SoftBreach {
+            dimension: v
+                .get("dimension")
+                .and_then(|d| d.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            current_usage: v.get("current_usage").and_then(|d| d.as_u64()).unwrap_or(0),
+            soft_limit: v.get("soft_limit").and_then(|d| d.as_u64()).unwrap_or(0),
+        }),
+        "HardBreach" => Ok(ReportUsageResult::HardBreach {
+            dimension: v
+                .get("dimension")
+                .and_then(|d| d.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            current_usage: v.get("current_usage").and_then(|d| d.as_u64()).unwrap_or(0),
+            hard_limit: v.get("hard_limit").and_then(|d| d.as_u64()).unwrap_or(0),
+        }),
+        other => Err(EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("budget dedup outcome_json unknown kind: {other}"),
+        }),
+    }
+}
+
+/// Extract the dimension → limit map from a `policy_json` blob. Same
+/// shape as PG.
+fn limits_from_policy(policy: &JsonValue, key: &str) -> BTreeMap<String, u64> {
+    policy
+        .get(key)
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_u64().map(|n| (k.clone(), n)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Decode the TEXT `policy_json` column into a `serde_json::Value`.
+/// Empty / invalid → empty object (no limits defined), matching the
+/// "missing row / empty policy" branch in the PG reference.
+fn parse_policy_text(s: &str) -> JsonValue {
+    serde_json::from_str(s).unwrap_or_else(|_| JsonValue::Object(Default::default()))
+}
+
+/// Pack `CreateBudgetArgs` → `policy_json` shape.
+fn build_policy_json(args: &CreateBudgetArgs) -> JsonValue {
+    let mut hard = serde_json::Map::new();
+    let mut soft = serde_json::Map::new();
+    for (i, dim) in args.dimensions.iter().enumerate() {
+        if let Some(h) = args.hard_limits.get(i).copied() {
+            hard.insert(dim.clone(), json!(h));
+        }
+        if let Some(s) = args.soft_limits.get(i).copied() {
+            soft.insert(dim.clone(), json!(s));
+        }
+    }
+    json!({
+        "hard_limits": hard,
+        "soft_limits": soft,
+        "reset_interval_ms": args.reset_interval_ms,
+        "on_hard_limit": args.on_hard_limit,
+        "on_soft_limit": args.on_soft_limit,
+    })
+}
+
+// Single-partition constant — see module docs.
+const PART: i64 = 0;
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.6 — shared core for `report_usage` + `report_usage_admin`
+// ───────────────────────────────────────────────────────────────────
+
+/// `EngineBackend::report_usage` — SQLite hot-path entry. Thin retry
+/// wrapper around [`report_usage_and_check_core`].
+pub(crate) async fn report_usage_impl(
+    pool: &SqlitePool,
+    budget: &BudgetId,
+    dimensions: UsageDimensions,
+) -> Result<ReportUsageResult, EngineError> {
+    retry_serializable(|| report_usage_and_check_core(pool, budget, dimensions.clone())).await
+}
+
+/// Admin-path `report_usage_admin`. Translates the admin-shape
+/// `ReportUsageAdminArgs` to `UsageDimensions` and delegates to the
+/// shared core. Matches PG `report_usage_admin_impl`.
+pub(crate) async fn report_usage_admin_impl(
+    pool: &SqlitePool,
+    budget: &BudgetId,
+    args: ReportUsageAdminArgs,
+) -> Result<ReportUsageResult, EngineError> {
+    if args.dimensions.len() != args.deltas.len() {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "report_usage_admin: dimensions and deltas length mismatch".into(),
+        });
+    }
+    let mut custom: BTreeMap<String, u64> = BTreeMap::new();
+    for (d, v) in args.dimensions.into_iter().zip(args.deltas) {
+        custom.insert(d, v);
+    }
+    let mut ud = UsageDimensions::new();
+    ud.custom = custom;
+    ud.dedup_key = args.dedup_key;
+    retry_serializable(|| report_usage_and_check_core(pool, budget, ud.clone())).await
+}
+
+/// Shared body of `report_usage` + `report_usage_admin`. Tx steps:
+///
+///   1. `BEGIN IMMEDIATE` (single-writer escalation).
+///   2. Dedup reservation (INSERT-or-replay on
+///      `ff_budget_usage_dedup`).
+///   3. Load `policy_json` from `ff_budget_policy`.
+///   4. Compute per-dim new values; on hard-breach increment
+///      `breach_count` + `last_breach_*` and early-return.
+///   5. Apply increments to `ff_budget_usage`; on soft-breach
+///      increment `soft_breach_count`.
+///   6. Finalise dedup row + COMMIT.
+async fn report_usage_and_check_core(
+    pool: &SqlitePool,
+    budget: &BudgetId,
+    dimensions: UsageDimensions,
+) -> Result<ReportUsageResult, EngineError> {
+    let budget_id_str = budget.to_string();
+    let now = now_ms();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        // ── Dedup ──
+        let dedup_owned = match dimensions.dedup_key.as_deref().filter(|k| !k.is_empty()) {
+            Some(dk) => {
+                let inserted = sqlx::query(q_budget::INSERT_DEDUP_PLACEHOLDER_SQL)
+                    .bind(PART)
+                    .bind(dk)
+                    .bind(now)
+                    .bind(now + DEDUP_TTL_MS)
+                    .fetch_optional(&mut *conn)
+                    .await
+                    .map_err(map_sqlx_error)?;
+
+                if inserted.is_none() {
+                    let row = sqlx::query(q_budget::SELECT_DEDUP_OUTCOME_SQL)
+                        .bind(PART)
+                        .bind(dk)
+                        .fetch_one(&mut *conn)
+                        .await
+                        .map_err(map_sqlx_error)?;
+                    let outcome_text: String = row.try_get("outcome_json").map_err(map_sqlx_error)?;
+                    let outcome: JsonValue = serde_json::from_str(&outcome_text).map_err(|e| {
+                        EngineError::Validation {
+                            kind: ValidationKind::Corruption,
+                            detail: format!("dedup outcome_json decode: {e}"),
+                        }
+                    })?;
+                    // Empty placeholder ⇒ prior in-flight caller crashed
+                    // before writing outcome. Treat as AlreadyApplied.
+                    if outcome.as_object().map(|o| o.is_empty()).unwrap_or(false) {
+                        return Ok(ReplayOrFresh::Replay(ReportUsageResult::AlreadyApplied));
+                    }
+                    let parsed = outcome_from_json(&outcome)?;
+                    return Ok(ReplayOrFresh::Replay(parsed));
+                }
+                Some(dk.to_string())
+            }
+            None => None,
+        };
+
+        // ── Load policy row ──
+        let policy_row = sqlx::query(q_budget::SELECT_BUDGET_POLICY_ROW_SQL)
+            .bind(PART)
+            .bind(&budget_id_str)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let policy: JsonValue = match policy_row {
+            Some(r) => {
+                let text: String = r.try_get("policy_json").map_err(map_sqlx_error)?;
+                parse_policy_text(&text)
+            }
+            // No policy row ⇒ no limits defined. Treat all reports as
+            // Ok and still apply increments (Valkey parity).
+            None => JsonValue::Object(Default::default()),
+        };
+        let hard_limits = limits_from_policy(&policy, "hard_limits");
+        let soft_limits = limits_from_policy(&policy, "soft_limits");
+
+        // ── Per-dim admission ── Hard breach on ANY dim rejects the
+        //    whole report (no increments); soft breach is advisory.
+        //    Sorted-key iteration keeps the reported dim deterministic.
+        let mut per_dim_current: BTreeMap<String, u64> = BTreeMap::new();
+        for (dim, delta) in dimensions.custom.iter() {
+            let dim_key = dim_row_key(dim);
+
+            sqlx::query(q_budget::INSERT_USAGE_ROW_SQL)
+                .bind(PART)
+                .bind(&budget_id_str)
+                .bind(&dim_key)
+                .bind(now)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            let row = sqlx::query(q_budget::SELECT_USAGE_ROW_SQL)
+                .bind(PART)
+                .bind(&budget_id_str)
+                .bind(&dim_key)
+                .fetch_one(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+            let cur: i64 = row.try_get("current_value").map_err(map_sqlx_error)?;
+            let new_val = (cur as u64).saturating_add(*delta);
+
+            if let Some(hard) = hard_limits.get(dim)
+                && *hard > 0
+                && new_val > *hard
+            {
+                // Hard breach — no increments applied. Maintain
+                // `breach_count` + `last_breach_*` (Valkey parity at
+                // flowfabric.lua:6576-6580).
+                sqlx::query(q_budget::UPDATE_BUDGET_HARD_BREACH_SQL)
+                    .bind(now)
+                    .bind(dim)
+                    .bind(now)
+                    .bind(PART)
+                    .bind(&budget_id_str)
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(map_sqlx_error)?;
+
+                let outcome = ReportUsageResult::HardBreach {
+                    dimension: dim.clone(),
+                    current_usage: cur as u64,
+                    hard_limit: *hard,
+                };
+                if let Some(dk) = dedup_owned.as_deref() {
+                    finalize_dedup(&mut conn, dk, &outcome).await?;
+                }
+                return Ok(ReplayOrFresh::Fresh(outcome));
+            }
+            per_dim_current.insert(dim.clone(), new_val);
+        }
+
+        // ── Apply increments + check soft limits. Soft is first-dim-
+        //    wins (Valkey iteration-order semantics). ──
+        let mut soft_breach: Option<ReportUsageResult> = None;
+        for (dim, delta) in dimensions.custom.iter() {
+            let dim_key = dim_row_key(dim);
+            let new_val = per_dim_current[dim];
+
+            sqlx::query(q_budget::UPDATE_USAGE_INCREMENT_SQL)
+                .bind(*delta as i64)
+                .bind(now)
+                .bind(PART)
+                .bind(&budget_id_str)
+                .bind(&dim_key)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            if soft_breach.is_none()
+                && let Some(soft) = soft_limits.get(dim)
+                && *soft > 0
+                && new_val > *soft
+            {
+                soft_breach = Some(ReportUsageResult::SoftBreach {
+                    dimension: dim.clone(),
+                    current_usage: new_val,
+                    soft_limit: *soft,
+                });
+            }
+        }
+
+        // Soft breach ⇒ increment soft_breach_count (Valkey parity at
+        // flowfabric.lua:6614).
+        if soft_breach.is_some() {
+            sqlx::query(q_budget::UPDATE_BUDGET_SOFT_BREACH_SQL)
+                .bind(now)
+                .bind(PART)
+                .bind(&budget_id_str)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+        }
+
+        let outcome = soft_breach.unwrap_or(ReportUsageResult::Ok);
+        if let Some(dk) = dedup_owned.as_deref() {
+            finalize_dedup(&mut conn, dk, &outcome).await?;
+        }
+        Ok(ReplayOrFresh::Fresh(outcome))
+    }
+    .await;
+
+    match result {
+        Ok(outcome) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(outcome.into_inner())
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+/// Local tag so the inner closure can distinguish "dedup replay" from
+/// "fresh compute" cleanly — both commit the same tx, but replay paths
+/// short-circuit the mutation chain.
+enum ReplayOrFresh {
+    Replay(ReportUsageResult),
+    Fresh(ReportUsageResult),
+}
+
+impl ReplayOrFresh {
+    fn into_inner(self) -> ReportUsageResult {
+        match self {
+            ReplayOrFresh::Replay(r) | ReplayOrFresh::Fresh(r) => r,
+        }
+    }
+}
+
+async fn finalize_dedup(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    dedup_key: &str,
+    outcome: &ReportUsageResult,
+) -> Result<(), EngineError> {
+    let json = outcome_to_json(outcome).to_string();
+    sqlx::query(q_budget::UPDATE_DEDUP_OUTCOME_SQL)
+        .bind(json)
+        .bind(PART)
+        .bind(dedup_key)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.2 — `create_budget`
+// ───────────────────────────────────────────────────────────────────
+
+pub(crate) async fn create_budget_impl(
+    pool: &SqlitePool,
+    args: CreateBudgetArgs,
+) -> Result<CreateBudgetResult, EngineError> {
+    if args.dimensions.len() != args.hard_limits.len()
+        || args.dimensions.len() != args.soft_limits.len()
+    {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "create_budget: dimensions / hard_limits / soft_limits length mismatch"
+                .into(),
+        });
+    }
+
+    retry_serializable(|| create_budget_once(pool, &args)).await
+}
+
+async fn create_budget_once(
+    pool: &SqlitePool,
+    args: &CreateBudgetArgs,
+) -> Result<CreateBudgetResult, EngineError> {
+    let budget_id = args.budget_id.clone();
+    let now: i64 = args.now.0;
+    let policy_json = build_policy_json(args).to_string();
+    let reset_interval_ms = args.reset_interval_ms as i64;
+
+    let row = sqlx::query(q_budget::INSERT_BUDGET_POLICY_SQL)
+        .bind(PART)
+        .bind(budget_id.to_string())
+        .bind(policy_json)
+        .bind(&args.scope_type)
+        .bind(&args.scope_id)
+        .bind(&args.enforcement_mode)
+        // next_reset_at_ms CASE WHEN ? > 0 THEN ? + ? ELSE NULL END
+        .bind(reset_interval_ms)
+        .bind(now)
+        .bind(reset_interval_ms)
+        // created_at_ms, updated_at_ms
+        .bind(now)
+        .bind(now)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    Ok(match row {
+        Some(_) => CreateBudgetResult::Created { budget_id },
+        None => CreateBudgetResult::AlreadySatisfied { budget_id },
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.3 — `reset_budget`
+// ───────────────────────────────────────────────────────────────────
+
+pub(crate) async fn reset_budget_impl(
+    pool: &SqlitePool,
+    args: ResetBudgetArgs,
+) -> Result<ResetBudgetResult, EngineError> {
+    retry_serializable(|| reset_budget_once(pool, &args)).await
+}
+
+async fn reset_budget_once(
+    pool: &SqlitePool,
+    args: &ResetBudgetArgs,
+) -> Result<ResetBudgetResult, EngineError> {
+    let budget_id_str = args.budget_id.to_string();
+    let now: i64 = args.now.0;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let policy_row = sqlx::query(q_budget::SELECT_BUDGET_POLICY_ROW_SQL)
+            .bind(PART)
+            .bind(&budget_id_str)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let Some(policy_row) = policy_row else {
+            return Err(backend_context(
+                EngineError::NotFound { entity: "budget" },
+                format!("reset_budget: {}", args.budget_id),
+            ));
+        };
+        let policy_text: String = policy_row.try_get("policy_json").map_err(map_sqlx_error)?;
+        let policy_json = parse_policy_text(&policy_text);
+        let reset_interval_ms: i64 = policy_json
+            .get("reset_interval_ms")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+
+        // Zero all usage rows for this budget.
+        sqlx::query(q_budget::UPDATE_USAGE_ZERO_ALL_SQL)
+            .bind(now)
+            .bind(now)
+            .bind(PART)
+            .bind(&budget_id_str)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // Reset policy metadata + reschedule.
+        let row = sqlx::query(q_budget::UPDATE_BUDGET_RESET_SQL)
+            .bind(now)
+            .bind(reset_interval_ms)
+            .bind(now)
+            .bind(reset_interval_ms)
+            .bind(PART)
+            .bind(&budget_id_str)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        let next_reset: Option<i64> = row
+            .try_get::<Option<i64>, _>("next_reset_at_ms")
+            .map_err(map_sqlx_error)?;
+
+        Ok(next_reset)
+    }
+    .await;
+
+    match result {
+        Ok(next_reset) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(ResetBudgetResult::Reset {
+                next_reset_at: TimestampMs(next_reset.unwrap_or(0)),
+            })
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.1 — `create_quota_policy`
+// ───────────────────────────────────────────────────────────────────
+
+pub(crate) async fn create_quota_policy_impl(
+    pool: &SqlitePool,
+    args: CreateQuotaPolicyArgs,
+) -> Result<CreateQuotaPolicyResult, EngineError> {
+    retry_serializable(|| create_quota_policy_once(pool, &args)).await
+}
+
+async fn create_quota_policy_once(
+    pool: &SqlitePool,
+    args: &CreateQuotaPolicyArgs,
+) -> Result<CreateQuotaPolicyResult, EngineError> {
+    let qid = args.quota_policy_id.clone();
+    let now: i64 = args.now.0;
+
+    let row = sqlx::query(q_quota::INSERT_QUOTA_POLICY_SQL)
+        .bind(PART)
+        .bind(qid.to_string())
+        .bind(args.window_seconds as i64)
+        .bind(args.max_requests_per_window as i64)
+        .bind(args.max_concurrent as i64)
+        .bind(now)
+        .bind(now)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    Ok(match row {
+        Some(_) => CreateQuotaPolicyResult::Created {
+            quota_policy_id: qid,
+        },
+        None => CreateQuotaPolicyResult::AlreadySatisfied {
+            quota_policy_id: qid,
+        },
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────
+// §4.4.7 — `get_budget_status`
+// ───────────────────────────────────────────────────────────────────
+
+pub(crate) async fn get_budget_status_impl(
+    pool: &SqlitePool,
+    budget: &BudgetId,
+) -> Result<BudgetStatus, EngineError> {
+    let budget_id_str = budget.to_string();
+
+    // SELECT 1: policy row.
+    let policy_row = sqlx::query(q_budget::SELECT_BUDGET_STATUS_SQL)
+        .bind(PART)
+        .bind(&budget_id_str)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let Some(policy_row) = policy_row else {
+        return Err(backend_context(
+            EngineError::NotFound { entity: "budget" },
+            format!("get_budget_status: {budget}"),
+        ));
+    };
+
+    let scope_type: String = policy_row.try_get("scope_type").map_err(map_sqlx_error)?;
+    let scope_id: String = policy_row.try_get("scope_id").map_err(map_sqlx_error)?;
+    let enforcement_mode: String = policy_row
+        .try_get("enforcement_mode")
+        .map_err(map_sqlx_error)?;
+    let breach_count: i64 = policy_row.try_get("breach_count").map_err(map_sqlx_error)?;
+    let soft_breach_count: i64 = policy_row
+        .try_get("soft_breach_count")
+        .map_err(map_sqlx_error)?;
+    let last_breach_at_ms: Option<i64> = policy_row
+        .try_get::<Option<i64>, _>("last_breach_at_ms")
+        .map_err(map_sqlx_error)?;
+    let last_breach_dim: Option<String> = policy_row
+        .try_get::<Option<String>, _>("last_breach_dim")
+        .map_err(map_sqlx_error)?;
+    let next_reset_at_ms: Option<i64> = policy_row
+        .try_get::<Option<i64>, _>("next_reset_at_ms")
+        .map_err(map_sqlx_error)?;
+    let created_at_ms: i64 = policy_row.try_get("created_at_ms").map_err(map_sqlx_error)?;
+    let policy_text: String = policy_row.try_get("policy_json").map_err(map_sqlx_error)?;
+    let policy_json = parse_policy_text(&policy_text);
+
+    // SELECT 2: usage rows.
+    let usage_rows = sqlx::query(q_budget::SELECT_ALL_USAGE_ROWS_SQL)
+        .bind(PART)
+        .bind(&budget_id_str)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let mut usage: HashMap<String, u64> = HashMap::new();
+    for r in &usage_rows {
+        let key: String = r.try_get("dimensions_key").map_err(map_sqlx_error)?;
+        let val: i64 = r.try_get("current_value").map_err(map_sqlx_error)?;
+        if key == "_init" {
+            continue;
+        }
+        usage.insert(key, val.max(0) as u64);
+    }
+
+    let hard_limits: HashMap<String, u64> = limits_from_policy(&policy_json, "hard_limits")
+        .into_iter()
+        .collect();
+    let soft_limits: HashMap<String, u64> = limits_from_policy(&policy_json, "soft_limits")
+        .into_iter()
+        .collect();
+
+    let fmt_opt = |v: Option<i64>| -> Option<String> { v.map(|n| n.to_string()) };
+
+    Ok(BudgetStatus {
+        budget_id: budget.to_string(),
+        scope_type,
+        scope_id,
+        enforcement_mode,
+        usage,
+        hard_limits,
+        soft_limits,
+        breach_count: breach_count.max(0) as u64,
+        soft_breach_count: soft_breach_count.max(0) as u64,
+        last_breach_at: fmt_opt(last_breach_at_ms),
+        last_breach_dim,
+        next_reset_at: fmt_opt(next_reset_at_ms),
+        created_at: Some(created_at_ms.to_string()),
+    })
+}

--- a/crates/ff-backend-sqlite/src/budget.rs
+++ b/crates/ff-backend-sqlite/src/budget.rs
@@ -91,9 +91,16 @@ fn outcome_to_json(r: &ReportUsageResult) -> JsonValue {
             "current_usage": current_usage,
             "hard_limit": hard_limit,
         }),
-        // `#[non_exhaustive]`; future variants reach the backend via
-        // ff-core before landing an impl here, so emit a placeholder
-        // the replay path will reject rather than silently mis-decoding.
+        // `#[non_exhaustive]`; future `ReportUsageResult` variants
+        // reach the backend via ff-core before landing an impl here.
+        // Matches the PG reference fallback (`ff-backend-postgres/src/
+        // budget.rs:102`): a future variant round-trips as `Ok` on
+        // dedup replay rather than surfacing as `Corruption`. This
+        // is permissive-by-design for forward compatibility — the
+        // tradeoff is that a consumer running newer `ff-core` against
+        // an older backend binary sees `Ok` instead of the intended
+        // outcome on replay. Non-replay paths use the direct result,
+        // so the window is bounded to dedup-replay only.
         _ => json!({"kind": "Ok"}),
     }
 }
@@ -213,6 +220,13 @@ pub(crate) async fn report_usage_admin_impl(
     let mut ud = UsageDimensions::new();
     ud.custom = custom;
     ud.dedup_key = args.dedup_key;
+    // `args.now` is dropped here — matches PG reference
+    // (`ff-backend-postgres/src/budget.rs::report_usage_admin_impl`),
+    // which also delegates to the core and re-derives `now_ms()`.
+    // Server-clock authority is the cross-backend invariant:
+    // admins cannot back-date usage writes. Reviewer flag carried
+    // forward as a cross-backend design question; not a SQLite-only
+    // bug to fix here.
     retry_serializable(|| report_usage_and_check_core(pool, budget, ud.clone())).await
 }
 

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::result_large_err)]
 
 mod backend;
+mod budget;
 mod completion_subscribe;
 mod config;
 mod errors;

--- a/crates/ff-backend-sqlite/src/queries/budget.rs
+++ b/crates/ff-backend-sqlite/src/queries/budget.rs
@@ -1,0 +1,116 @@
+//! Budget-family SQL — SQLite dialect port of
+//! `ff-backend-postgres/src/budget.rs` raw-SQL constants.
+//!
+//! RFC-023 Phase 3.4 / RFC-020 Wave 9 Standalone-1.
+//!
+//! Placeholders are `?`-positional to match sqlx-sqlite; the PG
+//! reference uses `$1..$N`. Table shapes are identical (see
+//! `migrations/0002_budget.sql` + `migrations/0013_budget_policy_extensions.sql`).
+//!
+//! **Lock-mode note.** The PG reference uses `FOR NO KEY UPDATE` to
+//! serialise the breach-UPDATE path. SQLite's single-writer invariant
+//! (`BEGIN IMMEDIATE` acquires RESERVED) already serialises any two
+//! writers on the same connection pool, so no row-level locking hint
+//! is emitted. Write paths wrap in `retry_serializable` to absorb
+//! SQLITE_BUSY under contention per RFC-023 §4.3.
+
+// ── ff_budget_usage_dedup ──
+
+/// Idempotent dedup-row reservation. Inserts a placeholder row on
+/// first call; no-ops on replay. The `applied_at_ms` is returned by
+/// the caller via `RETURNING` for dedup-owned bookkeeping.
+pub(crate) const INSERT_DEDUP_PLACEHOLDER_SQL: &str = "\
+    INSERT INTO ff_budget_usage_dedup \
+        (partition_key, dedup_key, outcome_json, applied_at_ms, expires_at_ms) \
+    VALUES (?, ?, '{}', ?, ?) \
+    ON CONFLICT (partition_key, dedup_key) DO NOTHING \
+    RETURNING applied_at_ms";
+
+pub(crate) const SELECT_DEDUP_OUTCOME_SQL: &str = "\
+    SELECT outcome_json FROM ff_budget_usage_dedup \
+    WHERE partition_key = ? AND dedup_key = ?";
+
+pub(crate) const UPDATE_DEDUP_OUTCOME_SQL: &str = "\
+    UPDATE ff_budget_usage_dedup SET outcome_json = ? \
+    WHERE partition_key = ? AND dedup_key = ?";
+
+// ── ff_budget_policy ──
+
+/// `create_budget` upsert. Seeds `next_reset_at_ms = now + interval`
+/// when interval > 0 (matches Valkey `ZADD resets_zset` scheduling at
+/// flowfabric.lua:6522-6526). Idempotent on `(partition_key, budget_id)`.
+pub(crate) const INSERT_BUDGET_POLICY_SQL: &str = "\
+    INSERT INTO ff_budget_policy \
+        (partition_key, budget_id, policy_json, scope_type, scope_id, \
+         enforcement_mode, breach_count, soft_breach_count, \
+         last_breach_at_ms, last_breach_dim, next_reset_at_ms, \
+         created_at_ms, updated_at_ms) \
+    VALUES (?, ?, ?, ?, ?, ?, 0, 0, NULL, NULL, \
+            CASE WHEN ? > 0 THEN ? + ? ELSE NULL END, \
+            ?, ?) \
+    ON CONFLICT (partition_key, budget_id) DO NOTHING \
+    RETURNING created_at_ms";
+
+pub(crate) const SELECT_BUDGET_POLICY_ROW_SQL: &str = "\
+    SELECT policy_json FROM ff_budget_policy \
+    WHERE partition_key = ? AND budget_id = ?";
+
+pub(crate) const UPDATE_BUDGET_HARD_BREACH_SQL: &str = "\
+    UPDATE ff_budget_policy \
+    SET breach_count      = breach_count + 1, \
+        last_breach_at_ms = ?, \
+        last_breach_dim   = ?, \
+        updated_at_ms     = ? \
+    WHERE partition_key = ? AND budget_id = ?";
+
+pub(crate) const UPDATE_BUDGET_SOFT_BREACH_SQL: &str = "\
+    UPDATE ff_budget_policy \
+    SET soft_breach_count = soft_breach_count + 1, \
+        updated_at_ms     = ? \
+    WHERE partition_key = ? AND budget_id = ?";
+
+/// Zero breach metadata + reschedule `next_reset_at_ms` on reset.
+/// Returns the new `next_reset_at_ms` (possibly NULL when no interval).
+pub(crate) const UPDATE_BUDGET_RESET_SQL: &str = "\
+    UPDATE ff_budget_policy \
+    SET last_breach_at_ms = NULL, \
+        last_breach_dim   = NULL, \
+        updated_at_ms     = ?, \
+        next_reset_at_ms  = CASE WHEN ? > 0 THEN ? + ? ELSE NULL END \
+    WHERE partition_key = ? AND budget_id = ? \
+    RETURNING next_reset_at_ms";
+
+pub(crate) const SELECT_BUDGET_STATUS_SQL: &str = "\
+    SELECT scope_type, scope_id, enforcement_mode, \
+           breach_count, soft_breach_count, \
+           last_breach_at_ms, last_breach_dim, \
+           next_reset_at_ms, created_at_ms, \
+           policy_json \
+    FROM ff_budget_policy \
+    WHERE partition_key = ? AND budget_id = ?";
+
+// ── ff_budget_usage ──
+
+pub(crate) const INSERT_USAGE_ROW_SQL: &str = "\
+    INSERT INTO ff_budget_usage \
+        (partition_key, budget_id, dimensions_key, current_value, updated_at_ms) \
+    VALUES (?, ?, ?, 0, ?) \
+    ON CONFLICT (partition_key, budget_id, dimensions_key) DO NOTHING";
+
+pub(crate) const SELECT_USAGE_ROW_SQL: &str = "\
+    SELECT current_value FROM ff_budget_usage \
+    WHERE partition_key = ? AND budget_id = ? AND dimensions_key = ?";
+
+pub(crate) const UPDATE_USAGE_INCREMENT_SQL: &str = "\
+    UPDATE ff_budget_usage \
+    SET current_value = current_value + ?, updated_at_ms = ? \
+    WHERE partition_key = ? AND budget_id = ? AND dimensions_key = ?";
+
+pub(crate) const UPDATE_USAGE_ZERO_ALL_SQL: &str = "\
+    UPDATE ff_budget_usage \
+    SET current_value = 0, last_reset_at_ms = ?, updated_at_ms = ? \
+    WHERE partition_key = ? AND budget_id = ?";
+
+pub(crate) const SELECT_ALL_USAGE_ROWS_SQL: &str = "\
+    SELECT dimensions_key, current_value FROM ff_budget_usage \
+    WHERE partition_key = ? AND budget_id = ?";

--- a/crates/ff-backend-sqlite/src/queries/mod.rs
+++ b/crates/ff-backend-sqlite/src/queries/mod.rs
@@ -10,12 +10,14 @@
 //! Phase 2a.2 (attempt / exec_core) and Phase 2a.3 (lease / dispatch).
 
 pub mod attempt;
+pub mod budget;
 pub mod dispatch;
 pub mod exec_core;
 pub mod flow;
 pub mod flow_staging;
 pub mod lease;
 pub mod operator;
+pub mod quota;
 pub mod reads;
 pub mod signal;
 pub mod stream;

--- a/crates/ff-backend-sqlite/src/queries/quota.rs
+++ b/crates/ff-backend-sqlite/src/queries/quota.rs
@@ -1,0 +1,19 @@
+//! Quota-family SQL — SQLite dialect port of the quota-policy INSERT
+//! used by `create_quota_policy`. RFC-023 Phase 3.4 / RFC-020 Wave 9
+//! Standalone-1 §4.4.1.
+//!
+//! The `ff_quota_window` + `ff_quota_admitted` tables are defined by
+//! migration 0012 but not written on `create_quota_policy` — they are
+//! populated by the (future) admission path. The Rev 6 "3 tables"
+//! language covers schema availability, not per-write fan-out; the PG
+//! reference (`ff-backend-postgres/src/budget.rs::create_quota_policy_impl`)
+//! writes only the policy row on create, mirrored here.
+
+pub(crate) const INSERT_QUOTA_POLICY_SQL: &str = "\
+    INSERT INTO ff_quota_policy \
+        (partition_key, quota_policy_id, requests_per_window_seconds, \
+         max_requests_per_window, active_concurrency_cap, \
+         active_concurrency, created_at_ms, updated_at_ms) \
+    VALUES (?, ?, ?, ?, ?, 0, ?, ?) \
+    ON CONFLICT (partition_key, quota_policy_id) DO NOTHING \
+    RETURNING created_at_ms";

--- a/crates/ff-backend-sqlite/tests/wave9_budget.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_budget.rs
@@ -1,0 +1,397 @@
+//! RFC-023 Phase 3.4 — Wave 9 budget/quota admin integration tests.
+//!
+//! Covers the 5 admin methods + the `report_usage_impl` breach-counter
+//! extension on the SQLite backend:
+//!
+//!   * `create_budget` — happy path + idempotent second call.
+//!   * `reset_budget` — zeroes counters + advances `next_reset_at_ms`.
+//!   * `create_quota_policy` — writes `ff_quota_policy`; the two
+//!     companion tables (`ff_quota_window`, `ff_quota_admitted`) exist
+//!     from migration 0012 but are not populated on create (matches PG
+//!     reference).
+//!   * `get_budget_status` — returns limits + counters + `created_at`.
+//!   * `report_usage_admin` — increments usage + counters (Ok, soft
+//!     breach, hard breach branches).
+//!
+//! Hard-breach branch verifies that breach_count increments AND the
+//! increment is NOT applied (Valkey-canonical strict-mode semantics).
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{
+    CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
+    ReportUsageAdminArgs, ReportUsageResult, ResetBudgetArgs, ResetBudgetResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::EngineError;
+use ff_core::types::{BudgetId, QuotaPolicyId, TimestampMs};
+use serial_test::serial;
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    // SAFETY: test-only env; serial-gated.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:rfc-023-wave9-budget-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("backend")
+}
+
+fn budget_args(
+    id: &BudgetId,
+    reset_interval_ms: u64,
+    hard_tokens: u64,
+    soft_tokens: u64,
+) -> CreateBudgetArgs {
+    CreateBudgetArgs {
+        budget_id: id.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-1".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms,
+        dimensions: vec!["tokens".into()],
+        hard_limits: vec![hard_tokens],
+        soft_limits: vec![soft_tokens],
+        now: TimestampMs(now_ms()),
+    }
+}
+
+fn admin_args(dim: &str, delta: u64) -> ReportUsageAdminArgs {
+    ReportUsageAdminArgs::new(vec![dim.into()], vec![delta], TimestampMs(now_ms()))
+}
+
+// ── create_budget ──────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn create_budget_happy_path() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+
+    let r1 = b.create_budget(budget_args(&bid, 0, 100, 80)).await.unwrap();
+    assert!(matches!(r1, CreateBudgetResult::Created { .. }));
+
+    let r2 = b.create_budget(budget_args(&bid, 0, 100, 80)).await.unwrap();
+    assert!(matches!(r2, CreateBudgetResult::AlreadySatisfied { .. }));
+}
+
+#[tokio::test]
+#[serial]
+async fn create_budget_seeds_next_reset_with_interval() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+    let before = now_ms();
+
+    let interval_ms: u64 = 60_000;
+    b.create_budget(budget_args(&bid, interval_ms, 100, 80))
+        .await
+        .unwrap();
+
+    let status = b.get_budget_status(&bid).await.unwrap();
+    let next: i64 = status
+        .next_reset_at
+        .as_deref()
+        .expect("next_reset_at set when interval > 0")
+        .parse()
+        .expect("parseable");
+    assert!(
+        next >= before + interval_ms as i64,
+        "next_reset_at must be at least now + interval"
+    );
+}
+
+// ── reset_budget ───────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn reset_budget_clears_counters_advances_next_reset() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+    let interval_ms: u64 = 60_000;
+    b.create_budget(budget_args(&bid, interval_ms, 100, 80))
+        .await
+        .unwrap();
+    b.report_usage_admin(&bid, admin_args("tokens", 40))
+        .await
+        .unwrap();
+
+    let pre = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(pre.usage.get("tokens").copied(), Some(40));
+
+    let t = now_ms();
+    let r = b
+        .reset_budget(ResetBudgetArgs {
+            budget_id: bid.clone(),
+            now: TimestampMs(t),
+        })
+        .await
+        .unwrap();
+    let next = match r {
+        ResetBudgetResult::Reset { next_reset_at } => next_reset_at.0,
+        #[allow(unreachable_patterns)]
+        _ => panic!("unexpected reset result"),
+    };
+    assert!(next >= t + interval_ms as i64);
+
+    let post = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(post.usage.get("tokens").copied(), Some(0));
+    assert!(post.last_breach_at.is_none());
+    assert!(post.last_breach_dim.is_none());
+}
+
+#[tokio::test]
+#[serial]
+async fn reset_budget_not_found_returns_notfound() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+    let err = b
+        .reset_budget(ResetBudgetArgs {
+            budget_id: bid,
+            now: TimestampMs(now_ms()),
+        })
+        .await
+        .unwrap_err();
+    match err {
+        EngineError::NotFound { entity } => assert_eq!(entity, "budget"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+// ── create_quota_policy ────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn create_quota_policy_writes_policy_row_idempotent() {
+    let b = fresh_backend().await;
+    let qid = QuotaPolicyId::new();
+    let args = CreateQuotaPolicyArgs {
+        quota_policy_id: qid.clone(),
+        window_seconds: 60,
+        max_requests_per_window: 100,
+        max_concurrent: 10,
+        now: TimestampMs(now_ms()),
+    };
+    let r1 = b.create_quota_policy(args.clone()).await.unwrap();
+    assert!(matches!(r1, CreateQuotaPolicyResult::Created { .. }));
+    let r2 = b.create_quota_policy(args).await.unwrap();
+    assert!(matches!(r2, CreateQuotaPolicyResult::AlreadySatisfied { .. }));
+}
+
+// ── get_budget_status ──────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn get_budget_status_returns_limits_and_counters() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+
+    let missing = b.get_budget_status(&bid).await.unwrap_err();
+    match missing {
+        EngineError::NotFound { entity } => assert_eq!(entity, "budget"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+
+    b.create_budget(budget_args(&bid, 0, 100, 80)).await.unwrap();
+    let status = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(status.scope_type, "flow");
+    assert_eq!(status.scope_id, "flow-1");
+    assert_eq!(status.enforcement_mode, "strict");
+    assert_eq!(status.hard_limits.get("tokens").copied(), Some(100));
+    assert_eq!(status.soft_limits.get("tokens").copied(), Some(80));
+    assert_eq!(status.breach_count, 0);
+    assert_eq!(status.soft_breach_count, 0);
+    assert!(status.created_at.is_some());
+    assert!(status.next_reset_at.is_none(), "no reset scheduled");
+}
+
+// ── report_usage_admin ─────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn report_usage_admin_ok_increments_usage() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+    b.create_budget(budget_args(&bid, 0, 100, 80)).await.unwrap();
+
+    let r = b.report_usage_admin(&bid, admin_args("tokens", 30)).await.unwrap();
+    assert!(matches!(r, ReportUsageResult::Ok));
+    let status = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(status.usage.get("tokens").copied(), Some(30));
+    assert_eq!(status.breach_count, 0);
+    assert_eq!(status.soft_breach_count, 0);
+}
+
+#[tokio::test]
+#[serial]
+async fn report_usage_admin_soft_breach_increments_soft_count() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+    b.create_budget(budget_args(&bid, 0, 100, 50)).await.unwrap();
+
+    // 60 > soft 50, but <= hard 100 ⇒ soft breach, increment applied.
+    let r = b.report_usage_admin(&bid, admin_args("tokens", 60)).await.unwrap();
+    assert!(
+        matches!(r, ReportUsageResult::SoftBreach { .. }),
+        "expected SoftBreach, got {r:?}"
+    );
+    let status = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(status.usage.get("tokens").copied(), Some(60));
+    assert_eq!(status.soft_breach_count, 1);
+    assert_eq!(status.breach_count, 0);
+}
+
+#[tokio::test]
+#[serial]
+async fn report_usage_admin_hard_breach_rejects_and_increments_hard_count() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+    b.create_budget(budget_args(&bid, 0, 100, 50)).await.unwrap();
+
+    // First, 60 → soft breach (current 60).
+    b.report_usage_admin(&bid, admin_args("tokens", 60))
+        .await
+        .unwrap();
+
+    // Now 60 more would push to 120 > hard 100 ⇒ hard breach, reject.
+    let r = b.report_usage_admin(&bid, admin_args("tokens", 60)).await.unwrap();
+    assert!(
+        matches!(r, ReportUsageResult::HardBreach { .. }),
+        "expected HardBreach, got {r:?}"
+    );
+    let status = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(
+        status.usage.get("tokens").copied(),
+        Some(60),
+        "hard-breach must NOT apply the increment"
+    );
+    assert_eq!(status.breach_count, 1);
+    assert_eq!(status.last_breach_dim.as_deref(), Some("tokens"));
+}
+
+/// Token-budget-style scenario (mirrors `examples/token-budget`
+/// trip logic): batch of inferences reports usage; enforcement loop
+/// polls `get_budget_status` and trips on either `breach_count > 0`
+/// or hard-limit usage. Exercises the full Wave-9 admin surface
+/// end-to-end at the trait-level, standing in for the live-server
+/// run that Phase 3.5 (scanner supervisor + scheduler wiring) will
+/// unblock.
+#[tokio::test]
+#[serial]
+async fn token_budget_scenario_trips_hard_breach_via_counter() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+
+    // Mirror examples/token-budget parameters: two dims, strict mode.
+    let args = CreateBudgetArgs {
+        budget_id: bid.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-abc".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms: 0,
+        dimensions: vec!["tokens".into(), "cost_micros".into()],
+        hard_limits: vec![1_200, 15_000],
+        soft_limits: vec![800, 10_000],
+        now: TimestampMs(now_ms()),
+    };
+    b.create_budget(args).await.unwrap();
+
+    // Simulate a batch of 5 inferences at ~350 tokens each = 1750 tokens,
+    // which will soft-trip around batch 3 and hard-trip around batch 4.
+    let mut soft_seen = false;
+    let mut hard_seen = false;
+    for i in 0..5 {
+        let args = ReportUsageAdminArgs::new(
+            vec!["tokens".into(), "cost_micros".into()],
+            vec![350, 350 * 25 / 1000],
+            TimestampMs(now_ms()),
+        )
+        .with_dedup_key(format!("attempt-{i}"));
+        let r = b.report_usage_admin(&bid, args).await.unwrap();
+        match r {
+            ReportUsageResult::Ok => {}
+            ReportUsageResult::SoftBreach { .. } => soft_seen = true,
+            ReportUsageResult::HardBreach { .. } => {
+                hard_seen = true;
+                break;
+            }
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+    }
+    assert!(soft_seen, "expected at least one SoftBreach in the batch");
+    assert!(hard_seen, "expected a HardBreach to trip");
+
+    let status = b.get_budget_status(&bid).await.unwrap();
+    assert!(status.breach_count >= 1, "breach_count must increment");
+    assert!(
+        status.soft_breach_count >= 1,
+        "soft_breach_count must increment before hard trip"
+    );
+    // Token-budget example's enforcement loop trips on either hard-
+    // limit usage OR breach_count > 0. Assert the latter path works.
+    let tokens = status.usage.get("tokens").copied().unwrap_or(0);
+    assert!(
+        tokens < 1_200,
+        "hard breach must reject the triggering increment — got {tokens}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn report_usage_admin_dedup_replay_returns_cached_outcome() {
+    let b = fresh_backend().await;
+    let bid = BudgetId::new();
+    b.create_budget(budget_args(&bid, 0, 100, 80)).await.unwrap();
+
+    let dk = format!("dedup-{}", uuid_like());
+    let args = ReportUsageAdminArgs::new(
+        vec!["tokens".into()],
+        vec![10],
+        TimestampMs(now_ms()),
+    )
+    .with_dedup_key(dk.clone());
+
+    let r1 = b.report_usage_admin(&bid, args.clone()).await.unwrap();
+    assert!(matches!(r1, ReportUsageResult::Ok));
+
+    // Replay with the same dedup_key — the cached outcome returns and
+    // the increment is NOT applied again.
+    let r2 = b.report_usage_admin(&bid, args).await.unwrap();
+    assert!(matches!(r2, ReportUsageResult::Ok));
+
+    let status = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(
+        status.usage.get("tokens").copied(),
+        Some(10),
+        "dedup replay must not double-count"
+    );
+}

--- a/crates/ff-backend-sqlite/tests/wave9_budget.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_budget.rs
@@ -91,7 +91,7 @@ fn admin_args(dim: &str, delta: u64) -> ReportUsageAdminArgs {
 // ── create_budget ──────────────────────────────────────────────────
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn create_budget_happy_path() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -104,7 +104,7 @@ async fn create_budget_happy_path() {
 }
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn create_budget_seeds_next_reset_with_interval() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -131,7 +131,7 @@ async fn create_budget_seeds_next_reset_with_interval() {
 // ── reset_budget ───────────────────────────────────────────────────
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn reset_budget_clears_counters_advances_next_reset() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -168,7 +168,7 @@ async fn reset_budget_clears_counters_advances_next_reset() {
 }
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn reset_budget_not_found_returns_notfound() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -188,7 +188,7 @@ async fn reset_budget_not_found_returns_notfound() {
 // ── create_quota_policy ────────────────────────────────────────────
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn create_quota_policy_writes_policy_row_idempotent() {
     let b = fresh_backend().await;
     let qid = QuotaPolicyId::new();
@@ -208,7 +208,7 @@ async fn create_quota_policy_writes_policy_row_idempotent() {
 // ── get_budget_status ──────────────────────────────────────────────
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn get_budget_status_returns_limits_and_counters() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -235,7 +235,7 @@ async fn get_budget_status_returns_limits_and_counters() {
 // ── report_usage_admin ─────────────────────────────────────────────
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn report_usage_admin_ok_increments_usage() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -250,7 +250,7 @@ async fn report_usage_admin_ok_increments_usage() {
 }
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn report_usage_admin_soft_breach_increments_soft_count() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -269,7 +269,7 @@ async fn report_usage_admin_soft_breach_increments_soft_count() {
 }
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn report_usage_admin_hard_breach_rejects_and_increments_hard_count() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -304,7 +304,7 @@ async fn report_usage_admin_hard_breach_rejects_and_increments_hard_count() {
 /// run that Phase 3.5 (scanner supervisor + scheduler wiring) will
 /// unblock.
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn token_budget_scenario_trips_hard_breach_via_counter() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();
@@ -366,7 +366,7 @@ async fn token_budget_scenario_trips_hard_breach_via_counter() {
 }
 
 #[tokio::test]
-#[serial]
+#[serial(ff_dev_mode)]
 async fn report_usage_admin_dedup_replay_returns_cached_outcome() {
     let b = fresh_backend().await;
     let bid = BudgetId::new();


### PR DESCRIPTION
## Summary

RFC-023 Phase 3.4 / RFC-020 Wave 9 Standalone-1 §4.4 Rev 6 — replaces 5
`Unavailable` trait defaults on `ff-backend-sqlite` with real bodies ported
from `ff-backend-postgres/src/budget.rs`, and extends the existing
`report_usage` hot-path to maintain the 0013 breach-counter columns
incrementally per the Rev-6 §7.2 pin-lift.

## Methods (5)

| Method                 | RFC §   | Impl                                                     |
|------------------------|---------|----------------------------------------------------------|
| `create_budget`        | §4.4.2  | INSERT ff_budget_policy with 8 Rev-6 columns + idempotent ON CONFLICT DO NOTHING |
| `reset_budget`         | §4.4.3  | BEGIN IMMEDIATE + zero ff_budget_usage + clear breach metadata + advance `next_reset_at_ms` |
| `create_quota_policy`  | §4.4.1  | INSERT ff_quota_policy; ff_quota_window + ff_quota_admitted populated by future admission path (matches PG) |
| `get_budget_status`    | §4.4.7  | Two SELECTs (policy row + usage rows); limits parsed from policy_json TEXT |
| `report_usage_admin`   | §4.4.6  | Admin entry → shared `report_usage_and_check_core` |

## `report_usage_impl` extension

Shared `report_usage_and_check_core` function wraps both
`report_usage` (worker-path) and `report_usage_admin` (admin-path).
Hard-breach path increments `breach_count` + writes
`last_breach_at_ms`/`last_breach_dim` on the policy row in the same
tx as the (rejected) usage-row inspection. Soft-breach path
increments `soft_breach_count`. Matches Valkey parity at
`flowfabric.lua:6576-6580,6614` and the PG Rev-6 reference.

**Lock model.** SQLite single-writer (`BEGIN IMMEDIATE` +
`retry_serializable`) replaces PG's `FOR NO KEY UPDATE` lock
discipline per RFC-023 §4.3.

## Tests

11 new integration tests in `crates/ff-backend-sqlite/tests/wave9_budget.rs`:

- `create_budget_happy_path` (Created → AlreadySatisfied)
- `create_budget_seeds_next_reset_with_interval`
- `reset_budget_clears_counters_advances_next_reset`
- `reset_budget_not_found_returns_notfound`
- `create_quota_policy_writes_policy_row_idempotent`
- `get_budget_status_returns_limits_and_counters` (+ NotFound branch)
- `report_usage_admin_ok_increments_usage`
- `report_usage_admin_soft_breach_increments_soft_count`
- `report_usage_admin_hard_breach_rejects_and_increments_hard_count` — verifies increment is NOT applied on hard breach
- `report_usage_admin_dedup_replay_returns_cached_outcome`
- `token_budget_scenario_trips_hard_breach_via_counter` — mirrors `examples/token-budget` batch-breach shape at the trait level

## `examples/token-budget` live-run

Out-of-band for Phase 3.4. The example requires:
1. A running ff-server with `FF_BACKEND=sqlite` (supported), AND
2. A working scheduler/claim path on the SQLite branch.

The server's `start_sqlite_branch` wires `engine: None` (scheduler
lives in Phase 3.5's scanner supervisor), so the example's
`claim_via_server` loop cannot service workers end-to-end against
SQLite until 3.5. The `token_budget_scenario_trips_hard_breach_via_counter`
test stands in for the live run, exercising the full breach-trip
lifecycle (create → batch usage reports → soft breach → hard breach →
counter inspection) at the trait level.

RFC-020 §6.3 framed `examples/token-budget` as the Wave-9 release
gate; that gate binds on scheduler+admin together, not on admin alone,
so deferring the live-run to Phase 3.5 is consistent with the 3.4
"trait-only" scope. Flagged here for owner review.

## CI summary

- `cargo build -p ff-backend-sqlite`: clean
- `cargo clippy -p ff-backend-sqlite --all-targets`: clean (only
  unrelated pre-existing warning in `tests/producer_flow.rs`)
- `cargo test -p ff-backend-sqlite`: all test files pass (11 new,
  19 pre-existing full suite)
- Workspace clippy: only pre-existing `ff-test/tests/subscribe_filter_isolation.rs`
  "loop never actually loops" errors (on main before this PR)

## RFC-vs-reality gaps

1. **`examples/token-budget` live-run deferred to Phase 3.5** — see
   above. Recorded in PR body as explicit owner-visible deferral
   rather than silent omission.

2. **Quota on create writes one table, not three.** Phase 3.4 spec
   said "3 tables" per Rev-6 Gap-1; the PG reference writes only the
   policy row on `create_quota_policy_impl`. Window + admitted tables
   exist (migration 0012) and will be written by the admission path
   landing in Phase 3.5 or a subsequent phase. This matches PG's
   shape exactly; deviating would break parity.

## NOT in this PR

- Phase 3.5: scanner supervisor + `budget_reset` reconciler (manual
  `reset_budget` works today; scheduled resets don't fire)
- `Supports::*` flag flips (Phase 4 atomic)
- Docs sweep (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new SQLite implementations for budget/quota admin and modifies `report_usage` transactional write behavior to update breach counters and dedup rows, which could affect admission correctness and concurrency under load.
> 
> **Overview**
> Implements RFC-020 Wave 9 budget/quota admin support for the SQLite backend by replacing previously `Unavailable` trait methods with real bodies: `create_budget`, `reset_budget`, `create_quota_policy`, `get_budget_status`, and `report_usage_admin`.
> 
> Extends SQLite `report_usage` to run through a shared `report_usage_and_check_core` path that performs dedup/replay handling and updates the migration-0013 breach tracking fields (`breach_count`, `soft_breach_count`, `last_breach_at_ms`, `last_breach_dim`) within the same `BEGIN IMMEDIATE` write transaction as usage increments.
> 
> Adds new SQLite query modules (`queries/budget.rs`, `queries/quota.rs`) plus a comprehensive Wave 9 integration test suite (`tests/wave9_budget.rs`) covering idempotency, reset scheduling, soft/hard breach behavior, and dedup replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1987214f20d10ed3ece87eb600a174d5fbb3f332. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->