### PR TITLE
feat(backend-sqlite): Phase 3.5 — scanner supervisor (N=1) + budget_reset reconciler (completes Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`crates/ff-backend-sqlite` — Phase 3.5 scanner supervisor (N=1) +
+  `budget_reset` reconciler (RFC-023 Phase 3.5 / RFC-020 Wave 9
+  Standalone-1).** Ports the Postgres `scanner_supervisor` +
+  `reconcilers::budget_reset` to SQLite, collapsed to N=1 per §4.1
+  (SQLite is single-writer / single-process → no partition
+  fan-out). Supervisor = one `tokio::time::interval` tick task per
+  reconciler with a `watch` shutdown channel; drained on
+  `EngineBackend::shutdown_prepare`. `ff-server::start_sqlite_branch`
+  installs the supervisor using the same `budget_reset_interval`
+  env knob that drives the Valkey + Postgres backends.
+- `crates/ff-backend-sqlite/src/scanner_supervisor.rs` — supervisor
+  handle + tick loop + `shutdown(grace)` API.
+- `crates/ff-backend-sqlite/src/reconcilers/{mod,budget_reset}.rs` —
+  `budget_reset` reconciler body (partial-index-backed bounded batch
+  scan at `BATCH_SIZE = 20`; delegates per-row to the shared
+  `budget::budget_reset_reconciler_apply` helper).
+- `SqliteBackend::with_scanners(cfg) -> bool` — idempotent
+  supervisor install; `shutdown_prepare(grace)` override to drain.
+
 - **`crates/ff-backend-sqlite` — Phase 3.4 Wave 9 budget/quota admin
   (RFC-023 Phase 3.4 / RFC-020 §4.4 Rev 6).** Replaces 5
   `Unavailable` trait defaults with real SQLite bodies ported from

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2180,6 +2180,12 @@ pub(crate) struct SqliteBackendInner {
     /// shared cache alive.
     #[allow(dead_code)]
     pub(crate) memory_sentinel: Option<std::sync::Mutex<Option<sqlx::SqliteConnection>>>,
+    /// RFC-023 Phase 3.5: scanner supervisor handle. Installed at
+    /// most once per backend instance (registry-shared inner) via
+    /// [`SqliteBackend::with_scanners`]; drained on
+    /// `EngineBackend::shutdown_prepare`. `OnceLock` so dedup clones
+    /// that race on `with_scanners` produce at most one supervisor.
+    pub(crate) scanner_handle: std::sync::OnceLock<crate::scanner_supervisor::SqliteScannerHandle>,
 }
 
 /// RFC-023 SQLite dev-only backend.
@@ -2341,6 +2347,7 @@ impl SqliteBackend {
             pubsub: PubSub::new(),
             key: key.clone(),
             memory_sentinel,
+            scanner_handle: std::sync::OnceLock::new(),
         });
         let inner = registry::insert(key, inner);
         Ok(Arc::new(Self { inner }))
@@ -2351,6 +2358,38 @@ impl SqliteBackend {
     #[allow(dead_code)]
     pub(crate) fn pool(&self) -> &SqlitePool {
         &self.inner.pool
+    }
+
+    /// RFC-023 Phase 3.5: spawn the N=1 scanner supervisor
+    /// (currently `budget_reset` only) as a background tick loop.
+    /// Idempotent: the first caller wins; subsequent calls on the
+    /// same registry-shared backend no-op. Drained on
+    /// [`EngineBackend::shutdown_prepare`].
+    ///
+    /// Returns `true` if this call installed the supervisor,
+    /// `false` if a supervisor was already present.
+    pub fn with_scanners(&self, cfg: crate::scanner_supervisor::SqliteScannerConfig) -> bool {
+        // Build outside the `OnceLock::set` call so we only spawn
+        // tasks if we actually win the race to install.
+        let mut result = false;
+        let _ = self.inner.scanner_handle.get_or_init(|| {
+            result = true;
+            crate::scanner_supervisor::spawn_scanners(self.inner.pool.clone(), cfg)
+        });
+        result
+    }
+
+    /// Test-only hook to drive the `budget_reset` reconciler
+    /// synchronously against a fixed `now`. Hidden from rustdoc;
+    /// exists so Phase 3.5 integration tests can verify reconciler
+    /// semantics without waiting on wall-clock cadence ticks.
+    #[doc(hidden)]
+    pub async fn budget_reset_scan_tick_for_test(
+        &self,
+        now_ms: i64,
+    ) -> Result<(u32, u32), EngineError> {
+        let report = crate::reconcilers::budget_reset::scan_tick(&self.inner.pool, now_ms).await?;
+        Ok((report.processed, report.errors))
     }
 
     /// Test-only pool accessor. Hidden from rustdoc; not a stable
@@ -2389,6 +2428,26 @@ impl SqliteBackend {
 
 #[async_trait]
 impl EngineBackend for SqliteBackend {
+    // ── Lifecycle ──
+
+    /// RFC-023 Phase 3.5: drain the scanner supervisor (if
+    /// installed) up to `grace`. Matches the PG backend's
+    /// `shutdown_prepare` contract — bounded best-effort drain,
+    /// never returns an error.
+    async fn shutdown_prepare(&self, grace: Duration) -> Result<(), EngineError> {
+        if let Some(handle) = self.inner.scanner_handle.get() {
+            let timed_out = handle.shutdown(grace).await;
+            if timed_out > 0 {
+                tracing::warn!(
+                    timed_out,
+                    ?grace,
+                    "sqlite scanner supervisor exceeded grace on shutdown"
+                );
+            }
+        }
+        Ok(())
+    }
+
     // ── Claim + lifecycle ──
 
     async fn claim(

--- a/crates/ff-backend-sqlite/src/budget.rs
+++ b/crates/ff-backend-sqlite/src/budget.rs
@@ -601,6 +601,111 @@ async fn reset_budget_once(
 }
 
 // ───────────────────────────────────────────────────────────────────
+// §4.4.3 — `budget_reset` reconciler entry point (RFC-023 Phase 3.5)
+// ───────────────────────────────────────────────────────────────────
+
+/// Called per row returned by the SQLite `budget_reset` reconciler
+/// scan. Looks up the policy's `reset_interval_ms` from
+/// `policy_json`, zeroes usage rows + clears `last_breach_*` +
+/// reschedules `next_reset_at_ms`, all under a single
+/// `BEGIN IMMEDIATE` txn wrapped in [`retry_serializable`] (§4.3).
+///
+/// Matches the PG twin `budget_reset_reconciler_apply` at
+/// `ff-backend-postgres/src/budget.rs`:
+///   * defensive re-read of `next_reset_at_ms` — a concurrent
+///     `reset_budget` admin call may have already advanced the
+///     schedule past `now`; if so this tick is a no-op.
+///   * breach counters (`breach_count`, `soft_breach_count`) are
+///     NOT zeroed — they are lifetime totals (PG parity +
+///     `reset_budget_impl` parity).
+pub(crate) async fn budget_reset_reconciler_apply(
+    pool: &SqlitePool,
+    budget_id: &str,
+    now: i64,
+) -> Result<(), EngineError> {
+    retry_serializable(|| budget_reset_reconciler_once(pool, budget_id, now)).await
+}
+
+async fn budget_reset_reconciler_once(
+    pool: &SqlitePool,
+    budget_id: &str,
+    now: i64,
+) -> Result<(), EngineError> {
+    let mut conn = begin_immediate(pool).await?;
+
+    let result: Result<(), EngineError> = async {
+        let policy_row = sqlx::query(
+            "SELECT policy_json, next_reset_at_ms \
+               FROM ff_budget_policy \
+              WHERE partition_key = ? AND budget_id = ?",
+        )
+        .bind(PART)
+        .bind(budget_id)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let Some(policy_row) = policy_row else {
+            return Ok(());
+        };
+
+        // Defensive re-check: skip if a concurrent admin reset
+        // already advanced `next_reset_at_ms` past `now`.
+        let next_reset: Option<i64> = policy_row
+            .try_get::<Option<i64>, _>("next_reset_at_ms")
+            .map_err(map_sqlx_error)?;
+        if !matches!(next_reset, Some(n) if n <= now) {
+            return Ok(());
+        }
+
+        let policy_text: String = policy_row.try_get("policy_json").map_err(map_sqlx_error)?;
+        let policy_json = parse_policy_text(&policy_text);
+        let reset_interval_ms: i64 = policy_json
+            .get("reset_interval_ms")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+
+        // Zero all usage rows for this budget.
+        sqlx::query(q_budget::UPDATE_USAGE_ZERO_ALL_SQL)
+            .bind(now)
+            .bind(now)
+            .bind(PART)
+            .bind(budget_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // Reset policy metadata + reschedule. Uses the same
+        // `UPDATE_BUDGET_RESET_SQL` as `reset_budget_impl` so the
+        // admin + reconciler paths produce identical rows.
+        sqlx::query(q_budget::UPDATE_BUDGET_RESET_SQL)
+            .bind(now)
+            .bind(reset_interval_ms)
+            .bind(now)
+            .bind(reset_interval_ms)
+            .bind(PART)
+            .bind(budget_id)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        Ok(())
+    }
+    .await;
+
+    match result {
+        Ok(()) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(())
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────
 // §4.4.1 — `create_quota_policy`
 // ───────────────────────────────────────────────────────────────────
 

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -35,6 +35,8 @@ mod lease_event_subscribe;
 mod operator;
 mod outbox_cursor;
 mod reads;
+mod reconcilers;
+mod scanner_supervisor;
 mod signal_delivery_subscribe;
 #[doc(hidden)]
 pub mod pubsub;
@@ -47,3 +49,4 @@ mod tx_util;
 pub use backend::SqliteBackend;
 pub use errors::{MAX_ATTEMPTS, is_retryable_sqlite_busy};
 pub use retry::{IsRetryableBusy, retry_serializable};
+pub use scanner_supervisor::{SqliteScannerConfig, SqliteScannerHandle};

--- a/crates/ff-backend-sqlite/src/reconcilers/budget_reset.rs
+++ b/crates/ff-backend-sqlite/src/reconcilers/budget_reset.rs
@@ -1,0 +1,78 @@
+//! SQLite `budget_reset` reconciler (RFC-023 Phase 3.5 /
+//! RFC-020 Wave 9 Standalone-1, §4.4.3 Gap 2 Option B).
+//!
+//! Ports `ff-backend-postgres::reconcilers::budget_reset` to SQLite.
+//! Scans `ff_budget_policy` for rows whose `next_reset_at_ms` has
+//! lapsed (backed by the `ff_budget_policy_reset_due_idx` partial
+//! index from migration 0013) and invokes the shared
+//! [`crate::budget::budget_reset_reconciler_apply`] helper — same
+//! code path as the admin `reset_budget` FCALL's body.
+//!
+//! Fan-out: N=1. SQLite has one (logical) partition (§4.1
+//! `num_budget_partitions = 1`), so there is no outer partition
+//! loop — the supervisor calls `scan_tick(pool)` once per cadence
+//! tick.
+//!
+//! Race discipline: a manual `reset_budget` + the reconciler's
+//! reset resolve identically. Both run under `BEGIN IMMEDIATE` and
+//! re-read `next_reset_at_ms` inside the tx; the second commit
+//! zeroes the already-zeroed usage (no-op) and overwrites
+//! `next_reset_at_ms` with the later `now + interval`, which the
+//! next tick will re-process. Deterministic under the single-
+//! writer invariant.
+
+use sqlx::{Row, SqlitePool};
+
+use ff_core::engine_error::EngineError;
+
+use crate::budget;
+use crate::errors::map_sqlx_error;
+use crate::reconcilers::ScanReport;
+
+/// Partial-index-backed bounded batch. Matches the PG reference
+/// (`BATCH_SIZE = 20`).
+const BATCH_SIZE: i64 = 20;
+
+/// Single-partition constant — see `crate::budget` module docs.
+const PART: i64 = 0;
+
+/// Scan for budgets with a lapsed `next_reset_at_ms` and apply the
+/// reset transaction per hit. `now_ms` is the wall-clock supplied by
+/// the supervisor tick (so tests can drive a fixed `now`).
+pub async fn scan_tick(pool: &SqlitePool, now_ms: i64) -> Result<ScanReport, EngineError> {
+    // Bounded batch scan. Backed by `ff_budget_policy_reset_due_idx`
+    // (partial). `ORDER BY next_reset_at_ms` keeps earliest-due
+    // first, matching the PG reference + Valkey ZRANGEBYSCORE order.
+    let rows = sqlx::query(
+        "SELECT budget_id \
+           FROM ff_budget_policy \
+          WHERE partition_key = ? \
+            AND next_reset_at_ms IS NOT NULL \
+            AND next_reset_at_ms <= ? \
+          ORDER BY next_reset_at_ms ASC \
+          LIMIT ?",
+    )
+    .bind(PART)
+    .bind(now_ms)
+    .bind(BATCH_SIZE)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut report = ScanReport::default();
+    for row in rows {
+        let budget_id: String = row.try_get("budget_id").map_err(map_sqlx_error)?;
+        match budget::budget_reset_reconciler_apply(pool, &budget_id, now_ms).await {
+            Ok(()) => report.processed += 1,
+            Err(e) => {
+                tracing::warn!(
+                    budget_id = %budget_id,
+                    error = %e,
+                    "sqlite budget_reset reconciler: reset failed",
+                );
+                report.errors += 1;
+            }
+        }
+    }
+    Ok(report)
+}

--- a/crates/ff-backend-sqlite/src/reconcilers/budget_reset.rs
+++ b/crates/ff-backend-sqlite/src/reconcilers/budget_reset.rs
@@ -10,16 +10,17 @@
 //!
 //! Fan-out: N=1. SQLite has one (logical) partition (§4.1
 //! `num_budget_partitions = 1`), so there is no outer partition
-//! loop — the supervisor calls `scan_tick(pool)` once per cadence
-//! tick.
+//! loop — the supervisor calls `scan_tick(pool, now_ms)` once per
+//! cadence tick.
 //!
-//! Race discipline: a manual `reset_budget` + the reconciler's
-//! reset resolve identically. Both run under `BEGIN IMMEDIATE` and
-//! re-read `next_reset_at_ms` inside the tx; the second commit
-//! zeroes the already-zeroed usage (no-op) and overwrites
-//! `next_reset_at_ms` with the later `now + interval`, which the
-//! next tick will re-process. Deterministic under the single-
-//! writer invariant.
+//! Race discipline: a manual `reset_budget` and the reconciler may
+//! target the same budget concurrently. Both run under
+//! `BEGIN IMMEDIATE` and re-read `next_reset_at_ms` inside the tx.
+//! If a concurrent admin reset has already advanced the schedule
+//! past `now`, [`crate::budget::budget_reset_reconciler_apply`]
+//! skips applying another reset; otherwise it performs the same
+//! reset transition as the admin path. Deterministic under the
+//! single-writer invariant.
 
 use sqlx::{Row, SqlitePool};
 

--- a/crates/ff-backend-sqlite/src/reconcilers/mod.rs
+++ b/crates/ff-backend-sqlite/src/reconcilers/mod.rs
@@ -1,0 +1,25 @@
+//! SQLite-backend scanner reconcilers (RFC-023 Phase 3.5).
+//!
+//! Mirrors `ff-backend-postgres::reconcilers` in shape, but at N=1
+//! partition fan-out per RFC-023 §4.1: SQLite is single-writer /
+//! single-process, so there is no partition to iterate over. Each
+//! reconciler is a single `scan_tick(pool, ...)` function the
+//! [`scanner_supervisor`](crate::scanner_supervisor) drives on a
+//! fixed cadence.
+//!
+//! Phase 3.5 ships only `budget_reset` — the scheduled-reset
+//! backstop for Wave 9 budgets. `attempt_timeout` / `lease_expiry`
+//! / `suspension_timeout` are intentionally NOT ported: SQLite's
+//! single-writer invariant + manual admin ops cover that ground
+//! under the dev-only envelope (§4.1 A3).
+
+pub mod budget_reset;
+
+/// Result of scanning one tick. Mirrors
+/// `ff-backend-postgres::reconcilers::ScanReport` for supervisor-
+/// side aggregation parity across backends.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScanReport {
+    pub processed: u32,
+    pub errors: u32,
+}

--- a/crates/ff-backend-sqlite/src/scanner_supervisor.rs
+++ b/crates/ff-backend-sqlite/src/scanner_supervisor.rs
@@ -1,0 +1,183 @@
+//! SQLite scanner supervisor (RFC-023 Phase 3.5).
+//!
+//! SQLite collapses the Postgres per-partition fan-out to N=1
+//! (§4.1): one process, one writer, one logical partition. The
+//! supervisor is therefore just a tokio task per reconciler type
+//! running a `tokio::time::interval` tick loop with a `watch`
+//! shutdown channel — no partition iteration.
+//!
+//! Phase 3.5 ships only `budget_reset`. Future reconcilers (if the
+//! §4.1 A3 single-writer envelope ever needs them) drop in as
+//! additional `spawn_reconciler` calls here.
+//!
+//! # Shutdown
+//!
+//! [`SqliteScannerHandle::shutdown`] flips the `watch` channel and
+//! awaits the underlying [`JoinSet`] up to `grace`. Ticks observe
+//! the signal at the next `select!` and exit. Mirrors the
+//! `PostgresScannerHandle::shutdown` shape so `ff-server`'s
+//! `Server::shutdown` drain logic stays backend-agnostic.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use sqlx::SqlitePool;
+use tokio::sync::{Mutex, watch};
+use tokio::task::JoinSet;
+
+use crate::reconcilers;
+
+/// Subset of `EngineConfig`'s interval knobs that the SQLite
+/// reconcilers honour. Only `budget_reset_interval` is wired today;
+/// kept as a struct (not a bare `Duration`) so additional cadences
+/// are additive, matching [`ff_backend_postgres::PostgresScannerConfig`].
+#[derive(Clone, Debug)]
+pub struct SqliteScannerConfig {
+    /// RFC-020 Wave 9 Standalone-1 cadence. Matches the Valkey side's
+    /// `ff-server::config::budget_reset_interval` knob so one env
+    /// value drives all three backends.
+    pub budget_reset_interval: Duration,
+}
+
+/// Spawned scanner supervisor. Holding this handle keeps the
+/// reconciler tasks alive; drop-on-backend or explicit shutdown
+/// drains them. Returned by [`spawn_scanners`]; stored inside
+/// `SqliteBackendInner` so `EngineBackend::shutdown_prepare` can
+/// drain on server shutdown.
+pub struct SqliteScannerHandle {
+    shutdown_tx: watch::Sender<bool>,
+    join_set: Arc<Mutex<JoinSet<()>>>,
+}
+
+impl SqliteScannerHandle {
+    /// Signal shutdown and await drain up to `grace`. Returns the
+    /// number of tasks that did not exit cleanly within the grace
+    /// window (for operator logging). Subsequent calls are no-ops.
+    pub async fn shutdown(&self, grace: Duration) -> usize {
+        let _ = self.shutdown_tx.send(true);
+        let mut js = self.join_set.lock().await;
+        let deadline = tokio::time::Instant::now() + grace;
+        let mut timed_out = 0usize;
+        while !js.is_empty() {
+            let remaining = deadline
+                .checked_duration_since(tokio::time::Instant::now())
+                .unwrap_or(Duration::ZERO);
+            if remaining.is_zero() {
+                timed_out = js.len();
+                js.abort_all();
+                break;
+            }
+            match tokio::time::timeout(remaining, js.join_next()).await {
+                Ok(Some(_res)) => continue,
+                Ok(None) => break,
+                Err(_) => {
+                    timed_out = js.len();
+                    js.abort_all();
+                    break;
+                }
+            }
+        }
+        timed_out
+    }
+}
+
+impl Drop for SqliteScannerHandle {
+    /// Best-effort signal on drop. Tasks exit at their next tick; if
+    /// the caller wants a bounded drain they must call
+    /// [`Self::shutdown`] explicitly (per PG parity).
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+}
+
+/// Spawn all SQLite reconcilers as long-lived tick loops. Phase 3.5
+/// ships one: `budget_reset`.
+pub fn spawn_scanners(pool: SqlitePool, cfg: SqliteScannerConfig) -> SqliteScannerHandle {
+    let (tx, rx) = watch::channel(false);
+    let js = Arc::new(Mutex::new(JoinSet::new()));
+
+    spawn_reconciler(
+        &js,
+        rx,
+        pool,
+        cfg.budget_reset_interval,
+        "sqlite.budget_reset",
+        |pool| {
+            Box::pin(async move {
+                let now = now_ms();
+                reconcilers::budget_reset::scan_tick(&pool, now)
+                    .await
+                    .map(|_| ())
+            })
+        },
+    );
+
+    tracing::info!(
+        scanners = 1,
+        "sqlite scanner supervisor spawned (RFC-023 Phase 3.5 — budget_reset N=1)"
+    );
+
+    SqliteScannerHandle {
+        shutdown_tx: tx,
+        join_set: js,
+    }
+}
+
+type TickFut =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ff_core::engine_error::EngineError>> + Send>>;
+
+fn spawn_reconciler<F>(
+    js: &Arc<Mutex<JoinSet<()>>>,
+    mut shutdown: watch::Receiver<bool>,
+    pool: SqlitePool,
+    interval: Duration,
+    name: &'static str,
+    tick: F,
+) where
+    F: Fn(SqlitePool) -> TickFut + Send + Sync + 'static + Clone,
+{
+    let js_clone = js.clone();
+    tokio::spawn(async move {
+        let mut guard = js_clone.lock().await;
+        guard.spawn(async move {
+            let mut tk = tokio::time::interval(interval);
+            tk.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // First tick fires immediately; skip it so the first
+            // observable reconciler run happens `interval` after
+            // spawn. Matches the PG supervisor shape (which uses the
+            // same default interval behaviour).
+            tk.tick().await;
+            loop {
+                tokio::select! {
+                    _ = shutdown.changed() => {
+                        if *shutdown.borrow() {
+                            return;
+                        }
+                    }
+                    _ = tk.tick() => {
+                        if *shutdown.borrow() {
+                            return;
+                        }
+                        if let Err(e) = tick(pool.clone()).await {
+                            tracing::warn!(
+                                scanner = name,
+                                error = %e,
+                                "sqlite reconciler tick failed"
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    });
+}
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX)
+}

--- a/crates/ff-backend-sqlite/src/scanner_supervisor.rs
+++ b/crates/ff-backend-sqlite/src/scanner_supervisor.rs
@@ -13,8 +13,10 @@
 //! # Shutdown
 //!
 //! [`SqliteScannerHandle::shutdown`] flips the `watch` channel and
-//! awaits the underlying [`JoinSet`] up to `grace`. Ticks observe
-//! the signal at the next `select!` and exit. Mirrors the
+//! awaits the underlying [`JoinSet`] up to `grace`. Tasks are
+//! registered synchronously during [`spawn_scanners`] (before the
+//! handle is returned), so the drain contract holds even for an
+//! immediate shutdown after `with_scanners`. Mirrors the
 //! `PostgresScannerHandle::shutdown` shape so `ff-server`'s
 //! `Server::shutdown` drain logic stays backend-agnostic.
 
@@ -26,6 +28,7 @@ use tokio::sync::{Mutex, watch};
 use tokio::task::JoinSet;
 
 use crate::reconcilers;
+use crate::tx_util::now_ms;
 
 /// Subset of `EngineConfig`'s interval knobs that the SQLite
 /// reconcilers honour. Only `budget_reset_interval` is wired today;
@@ -36,6 +39,10 @@ pub struct SqliteScannerConfig {
     /// RFC-020 Wave 9 Standalone-1 cadence. Matches the Valkey side's
     /// `ff-server::config::budget_reset_interval` knob so one env
     /// value drives all three backends.
+    ///
+    /// If set to zero (`FF_BUDGET_RESET_INTERVAL_S=0`) the reconciler
+    /// is treated as disabled and not spawned, mirroring
+    /// `tokio::time::interval`'s zero-duration panic safety.
     pub budget_reset_interval: Duration,
 }
 
@@ -91,93 +98,94 @@ impl Drop for SqliteScannerHandle {
 }
 
 /// Spawn all SQLite reconcilers as long-lived tick loops. Phase 3.5
-/// ships one: `budget_reset`.
+/// ships one: `budget_reset`. Tasks are registered into the
+/// `JoinSet` synchronously — the handle returned is always drainable
+/// via [`SqliteScannerHandle::shutdown`].
 pub fn spawn_scanners(pool: SqlitePool, cfg: SqliteScannerConfig) -> SqliteScannerHandle {
     let (tx, rx) = watch::channel(false);
-    let js = Arc::new(Mutex::new(JoinSet::new()));
+    let mut js = JoinSet::new();
 
-    spawn_reconciler(
-        &js,
-        rx,
-        pool,
-        cfg.budget_reset_interval,
-        "sqlite.budget_reset",
-        |pool| {
-            Box::pin(async move {
-                let now = now_ms();
-                reconcilers::budget_reset::scan_tick(&pool, now)
-                    .await
-                    .map(|_| ())
-            })
-        },
-    );
+    // Zero-interval guard: treat as disabled rather than panicking
+    // in `tokio::time::interval`. Matches `FF_BUDGET_RESET_INTERVAL_S=0`
+    // as an opt-out.
+    if !cfg.budget_reset_interval.is_zero() {
+        spawn_reconciler(
+            &mut js,
+            rx.clone(),
+            pool.clone(),
+            cfg.budget_reset_interval,
+            "sqlite.budget_reset",
+            |pool| {
+                Box::pin(async move {
+                    reconcilers::budget_reset::scan_tick(&pool, now_ms())
+                        .await
+                        .map(|_| ())
+                })
+            },
+        );
+    }
 
+    let scanners = js.len();
     tracing::info!(
-        scanners = 1,
+        scanners,
         "sqlite scanner supervisor spawned (RFC-023 Phase 3.5 — budget_reset N=1)"
     );
 
     SqliteScannerHandle {
         shutdown_tx: tx,
-        join_set: js,
+        join_set: Arc::new(Mutex::new(js)),
     }
 }
 
-type TickFut =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ff_core::engine_error::EngineError>> + Send>>;
+type TickFut = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<(), ff_core::engine_error::EngineError>> + Send>,
+>;
 
+/// Register one reconciler tick task synchronously into the
+/// supervisor's [`JoinSet`]. Tasks exit at the next `select!` once
+/// `shutdown` fires (or the watch channel is closed).
 fn spawn_reconciler<F>(
-    js: &Arc<Mutex<JoinSet<()>>>,
+    js: &mut JoinSet<()>,
     mut shutdown: watch::Receiver<bool>,
     pool: SqlitePool,
     interval: Duration,
     name: &'static str,
     tick: F,
 ) where
-    F: Fn(SqlitePool) -> TickFut + Send + Sync + 'static + Clone,
+    F: Fn(SqlitePool) -> TickFut + Send + Sync + 'static,
 {
-    let js_clone = js.clone();
-    tokio::spawn(async move {
-        let mut guard = js_clone.lock().await;
-        guard.spawn(async move {
-            let mut tk = tokio::time::interval(interval);
-            tk.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            // First tick fires immediately; skip it so the first
-            // observable reconciler run happens `interval` after
-            // spawn. Matches the PG supervisor shape (which uses the
-            // same default interval behaviour).
-            tk.tick().await;
-            loop {
-                tokio::select! {
-                    _ = shutdown.changed() => {
-                        if *shutdown.borrow() {
-                            return;
-                        }
+    js.spawn(async move {
+        let mut tk = tokio::time::interval(interval);
+        tk.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // `tokio::time::interval` yields an immediate first tick;
+        // drain it so the first observable reconciler run happens
+        // `interval` after spawn. Intentional SQLite startup-timing
+        // difference from the Postgres supervisor, which lets the
+        // first immediate tick fire. Safe: the watch shutdown signal
+        // is only delivered via `changed()`, so skipping this
+        // pre-drain tick has no shutdown-observability cost.
+        tk.tick().await;
+        loop {
+            tokio::select! {
+                res = shutdown.changed() => {
+                    // Channel closed (sender dropped) OR shutdown=true → exit.
+                    if res.is_err() || *shutdown.borrow() {
+                        return;
                     }
-                    _ = tk.tick() => {
-                        if *shutdown.borrow() {
-                            return;
-                        }
-                        if let Err(e) = tick(pool.clone()).await {
-                            tracing::warn!(
-                                scanner = name,
-                                error = %e,
-                                "sqlite reconciler tick failed"
-                            );
-                        }
+                }
+                _ = tk.tick() => {
+                    if *shutdown.borrow() {
+                        return;
+                    }
+                    if let Err(e) = tick(pool.clone()).await {
+                        tracing::warn!(
+                            scanner = name,
+                            error = %e,
+                            "sqlite reconciler tick failed"
+                        );
                     }
                 }
             }
-        });
+        }
     });
-}
-
-fn now_ms() -> i64 {
-    i64::try_from(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis())
-            .unwrap_or(0),
-    )
-    .unwrap_or(i64::MAX)
 }

--- a/crates/ff-backend-sqlite/tests/producer_flow.rs
+++ b/crates/ff-backend-sqlite/tests/producer_flow.rs
@@ -67,8 +67,10 @@ fn new_exec_id() -> ExecutionId {
 fn create_execution_args(exec_id: &ExecutionId, caps: &[&str]) -> CreateExecutionArgs {
     let mut policy = ff_core::policy::ExecutionPolicy::default();
     if !caps.is_empty() {
-        let mut rr = ff_core::policy::RoutingRequirements::default();
-        rr.required_capabilities = caps.iter().map(|s| (*s).to_owned()).collect();
+        let rr = ff_core::policy::RoutingRequirements {
+            required_capabilities: caps.iter().map(|s| (*s).to_owned()).collect(),
+            ..Default::default()
+        };
         policy.routing_requirements = Some(rr);
     }
     CreateExecutionArgs {

--- a/crates/ff-backend-sqlite/tests/wave9_reconciler.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_reconciler.rs
@@ -230,6 +230,41 @@ async fn supervisor_starts_and_stops_cleanly() {
 
 #[tokio::test]
 #[serial(ff_dev_mode)]
+async fn supervisor_shutdown_drains_immediately_after_install() {
+    // Regression guard: earlier drafts spawned tick tasks from a
+    // detached `tokio::spawn` acquiring an async mutex, which left a
+    // window where `shutdown()` could observe an empty JoinSet while
+    // the task was still queued. The final shape spawns synchronously
+    // during `spawn_scanners`, so an immediate shutdown MUST drain
+    // the task (timed_out == 0).
+    let b = fresh_backend("immediate-shutdown").await;
+    b.with_scanners(SqliteScannerConfig {
+        // 1h cadence — the task is parked at `select!`, not doing work.
+        budget_reset_interval: Duration::from_secs(3600),
+    });
+    b.shutdown_prepare(Duration::from_secs(2))
+        .await
+        .expect("shutdown_prepare drains registered tasks");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn supervisor_zero_interval_is_disabled_not_panic() {
+    // `tokio::time::interval(Duration::ZERO)` panics; the supervisor
+    // must treat zero as "reconciler disabled" per
+    // FF_BUDGET_RESET_INTERVAL_S=0 semantics.
+    let b = fresh_backend("zero-interval").await;
+    b.with_scanners(SqliteScannerConfig {
+        budget_reset_interval: Duration::from_millis(0),
+    });
+    // Shutdown should still work and report zero timed-out tasks.
+    b.shutdown_prepare(Duration::from_secs(1))
+        .await
+        .expect("zero-interval supervisor must shut down cleanly");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
 async fn supervisor_tick_advances_on_cadence() {
     let b = fresh_backend("cadence").await;
     let bid = BudgetId::new();

--- a/crates/ff-backend-sqlite/tests/wave9_reconciler.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_reconciler.rs
@@ -1,0 +1,269 @@
+//! RFC-023 Phase 3.5 — scanner supervisor (N=1) + budget_reset
+//! reconciler integration tests.
+//!
+//! Covers:
+//!   * `budget_reset` reconciler fires on a past-due row and
+//!     zeroes usage + advances `next_reset_at_ms`.
+//!   * `budget_reset` reconciler skips rows whose
+//!     `next_reset_at_ms` is still in the future.
+//!   * Supervisor spawn + explicit `shutdown()` returns cleanly
+//!     (no timed-out tasks under the default grace).
+//!   * Supervisor drives the reconciler on cadence — after
+//!     several short ticks a past-due row becomes reset.
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ff_backend_sqlite::{SqliteBackend, SqliteScannerConfig};
+use ff_core::contracts::{CreateBudgetArgs, ReportUsageAdminArgs};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::types::{BudgetId, TimestampMs};
+use serial_test::serial;
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend(tag: &str) -> Arc<SqliteBackend> {
+    // SAFETY: test-only env; serial-gated.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:rfc-023-wave9-reconciler-{tag}-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("backend")
+}
+
+fn budget_args(id: &BudgetId, reset_interval_ms: u64) -> CreateBudgetArgs {
+    CreateBudgetArgs {
+        budget_id: id.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-1".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms,
+        dimensions: vec!["tokens".into()],
+        hard_limits: vec![1000],
+        soft_limits: vec![800],
+        now: TimestampMs(now_ms()),
+    }
+}
+
+fn admin_args(dim: &str, delta: u64) -> ReportUsageAdminArgs {
+    ReportUsageAdminArgs::new(vec![dim.into()], vec![delta], TimestampMs(now_ms()))
+}
+
+/// Force a budget's `next_reset_at_ms` to a specific value — emulates
+/// "time passed" without requiring wall-clock sleep. Reaches through
+/// the test-only pool accessor.
+async fn force_next_reset(b: &SqliteBackend, budget_id: &BudgetId, next_reset_at_ms: Option<i64>) {
+    let pool = b.pool_for_test();
+    sqlx::query("UPDATE ff_budget_policy SET next_reset_at_ms = ? WHERE partition_key = 0 AND budget_id = ?")
+        .bind(next_reset_at_ms)
+        .bind(budget_id.to_string())
+        .execute(pool)
+        .await
+        .expect("force next_reset_at_ms");
+}
+
+// ── Reconciler behaviour ───────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn budget_reset_reconciler_fires_on_due_row() {
+    let b = fresh_backend("fires").await;
+    let bid = BudgetId::new();
+    let interval_ms: u64 = 60_000;
+
+    b.create_budget(budget_args(&bid, interval_ms))
+        .await
+        .unwrap();
+    b.report_usage_admin(&bid, admin_args("tokens", 200))
+        .await
+        .unwrap();
+
+    // Pull the budget's schedule "into the past" so the reconciler
+    // treats it as due.
+    let t_now = now_ms();
+    force_next_reset(&b, &bid, Some(t_now - 1_000)).await;
+
+    let pre = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(pre.usage.get("tokens").copied(), Some(200));
+
+    // Drive one reconciler tick at `t_now`.
+    let (processed, errors) = b
+        .budget_reset_scan_tick_for_test(t_now)
+        .await
+        .expect("scan_tick");
+    assert_eq!(errors, 0, "no reconciler errors expected");
+    assert_eq!(processed, 1, "one due row processed");
+
+    let post = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(
+        post.usage.get("tokens").copied(),
+        Some(0),
+        "usage zeroed by reconciler"
+    );
+    let next_post: i64 = post
+        .next_reset_at
+        .as_deref()
+        .expect("reconciler must reschedule next_reset_at")
+        .parse()
+        .expect("parseable");
+    assert!(
+        next_post >= t_now + interval_ms as i64,
+        "next_reset_at advanced by at least one interval (got {next_post}, expected >= {})",
+        t_now + interval_ms as i64
+    );
+    assert!(post.last_breach_at.is_none(), "last_breach_at cleared");
+    assert!(post.last_breach_dim.is_none(), "last_breach_dim cleared");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn budget_reset_reconciler_skips_not_due() {
+    let b = fresh_backend("skips").await;
+    let bid = BudgetId::new();
+    let interval_ms: u64 = 60_000;
+
+    b.create_budget(budget_args(&bid, interval_ms))
+        .await
+        .unwrap();
+    b.report_usage_admin(&bid, admin_args("tokens", 150))
+        .await
+        .unwrap();
+
+    // Force the schedule well into the future.
+    let t_now = now_ms();
+    let future = t_now + 10 * interval_ms as i64;
+    force_next_reset(&b, &bid, Some(future)).await;
+
+    let (processed, errors) = b
+        .budget_reset_scan_tick_for_test(t_now)
+        .await
+        .expect("scan_tick");
+    assert_eq!(errors, 0);
+    assert_eq!(processed, 0, "future-due row must not be processed");
+
+    let post = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(
+        post.usage.get("tokens").copied(),
+        Some(150),
+        "usage unchanged when not due"
+    );
+    assert_eq!(
+        post.next_reset_at.as_deref().map(|s| s.parse::<i64>().unwrap()),
+        Some(future),
+        "next_reset_at unchanged when not due"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn budget_reset_reconciler_skips_null_schedule() {
+    // Budgets with `reset_interval_ms = 0` carry NULL
+    // `next_reset_at_ms` — the partial index excludes them; the
+    // reconciler must not touch them.
+    let b = fresh_backend("null-schedule").await;
+    let bid = BudgetId::new();
+    b.create_budget(budget_args(&bid, 0)).await.unwrap();
+    b.report_usage_admin(&bid, admin_args("tokens", 42))
+        .await
+        .unwrap();
+
+    let (processed, errors) = b
+        .budget_reset_scan_tick_for_test(now_ms() + 10_000_000)
+        .await
+        .expect("scan_tick");
+    assert_eq!(errors, 0);
+    assert_eq!(processed, 0, "NULL-scheduled row never due");
+
+    let post = b.get_budget_status(&bid).await.unwrap();
+    assert_eq!(post.usage.get("tokens").copied(), Some(42));
+    assert!(post.next_reset_at.is_none());
+}
+
+// ── Supervisor lifecycle ────────────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn supervisor_starts_and_stops_cleanly() {
+    let b = fresh_backend("start-stop").await;
+    let installed = b.with_scanners(SqliteScannerConfig {
+        budget_reset_interval: Duration::from_millis(100),
+    });
+    assert!(installed, "first with_scanners call installs supervisor");
+
+    // Second call is a no-op (idempotent).
+    let again = b.with_scanners(SqliteScannerConfig {
+        budget_reset_interval: Duration::from_millis(100),
+    });
+    assert!(!again, "second with_scanners call must be a no-op");
+
+    // Graceful drain.
+    b.shutdown_prepare(Duration::from_secs(2))
+        .await
+        .expect("shutdown_prepare");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn supervisor_tick_advances_on_cadence() {
+    let b = fresh_backend("cadence").await;
+    let bid = BudgetId::new();
+    let interval_ms: u64 = 60_000;
+    b.create_budget(budget_args(&bid, interval_ms))
+        .await
+        .unwrap();
+    b.report_usage_admin(&bid, admin_args("tokens", 300))
+        .await
+        .unwrap();
+    force_next_reset(&b, &bid, Some(now_ms() - 1_000)).await;
+
+    // Short cadence to force at least one tick inside the test.
+    b.with_scanners(SqliteScannerConfig {
+        budget_reset_interval: Duration::from_millis(50),
+    });
+
+    // Wait up to ~3s for the supervisor to notice the due row.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let mut observed_reset = false;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let s = b.get_budget_status(&bid).await.unwrap();
+        if s.usage.get("tokens").copied() == Some(0) {
+            observed_reset = true;
+            break;
+        }
+    }
+    assert!(
+        observed_reset,
+        "supervisor must reset the due budget within the cadence window"
+    );
+
+    b.shutdown_prepare(Duration::from_secs(2))
+        .await
+        .expect("shutdown_prepare");
+}

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -708,6 +708,14 @@ impl Server {
                 }
                 other => ServerError::Backend(other),
             })?;
+
+        // RFC-023 Phase 3.5: install the N=1 scanner supervisor
+        // (`budget_reset` today). Drained via `shutdown_prepare`.
+        let scanner_cfg = ff_backend_sqlite::SqliteScannerConfig {
+            budget_reset_interval: config.engine_config.budget_reset_interval,
+        };
+        sqlite_arc.with_scanners(scanner_cfg);
+
         let backend: Arc<dyn EngineBackend> = sqlite_arc;
 
         tracing::info!(


### PR DESCRIPTION
## Summary

RFC-023 Phase 3.5 — the final implementation phase of the SQLite dev-only backend. Phase 4 (release) follows.

- **Scanner supervisor (N=1).** SQLite is single-writer / single-process per §4.1 → no partition fan-out. One `tokio::time::interval` tick task per reconciler, `watch` shutdown channel, bounded `shutdown(grace)` drain, `OnceLock`-guarded install so registry-deduped clones spawn at most one supervisor per DB path.
- **`budget_reset` reconciler.** Partial-index-backed bounded batch scan (`BATCH_SIZE = 20`) over `ff_budget_policy WHERE next_reset_at_ms <= now` (migration 0013 `ff_budget_policy_reset_due_idx`). Per-row delegates to the shared `budget::budget_reset_reconciler_apply` helper — same body shape as `reset_budget_impl` (zero usage + clear `last_breach_*` + advance `next_reset_at_ms`). Defensive in-tx re-check skips rows a concurrent admin reset already advanced.
- **Wiring.** `SqliteBackend::with_scanners(cfg)` installs idempotently; `shutdown_prepare(grace)` drains on server shutdown. `ff-server::start_sqlite_branch` spawns the supervisor using the same `budget_reset_interval` env knob that drives Valkey + Postgres.

### Out of scope (intentional)

`attempt_timeout`, `lease_expiry`, `suspension_timeout` reconcilers are NOT ported. SQLite's single-writer invariant + manual admin ops cover that ground under the dev-only envelope (§4.1 A3). Matches RFC-023 Revision 6 scope.

### Token-budget live-run — structural gap

Per task: "If token-budget live-run reveals a scheduler gap (claim path needed for example), try to fix inline; if structural, STOP + report."

`examples/token-budget` is driven via `FlowFabricWorker::connect`'s `claim_via_server` path, which routes through `EngineBackend::claim_for_worker`. That trait method returns `Unavailable` on the SQLite backend today: it would require a SQLite scheduler twin (mirroring `ff-scheduler` / `PostgresScheduler`). That's a structural gap explicitly outside RFC-023's dev-only envelope and outside Phase 3.5.

**Validation substitute.** A scratch binary against the backend directly exercises the full Phase 3.4 + 3.5 surface end-to-end. Transcript:

```
=== RFC-023 Phase 3.5 live-run ===
FF_SQLITE_PATH = file:rfc023-phase35-liverun?mode=memory&cache=shared
WARN: FlowFabric SQLite backend active (FF_DEV_MODE=1). This backend is dev-only; single-writer, single-process, not supported in production. See RFC-023.
[1] create_budget → Created { budget_id: BudgetId(fca14f48-304e-42de-a393-eb4cdda1ebc4) }
[2a] report_usage_admin(30) → Ok
[2b] report_usage_admin(55, cumulative 85) → SoftBreach { dimension: "tokens", current_usage: 85, soft_limit: 80 }
[3] get_budget_status → usage={"tokens": 85} breach_count=0 soft_breach_count=1
[4a] report_usage_admin(50, cumulative 135) → HardBreach { dimension: "tokens", current_usage: 85, hard_limit: 100 }
[4b] post-hard-breach: usage={"tokens": 85} breach_count=1
INFO: sqlite scanner supervisor spawned (RFC-023 Phase 3.5 — budget_reset N=1) scanners=1
[5] supervisor installed = true
[6] forced next_reset_at_ms = 1777327510403 (past). Waiting for reconciler tick...
[7] reconciler fired. usage={"tokens": 0} next_reset_at=Some("1777327512604")
[8] shutting down supervisor...
    shutdown OK

=== PASS ===
```

Observed:
- `create_budget` (Phase 3.4) — Created
- `report_usage_admin` (Phase 3.4 + extension) — Ok → SoftBreach → HardBreach; breach counters incremented correctly; hard-breach increment NOT applied (Valkey-canonical strict-mode parity).
- `get_budget_status` (Phase 3.4) — returned live counters.
- **Scheduled reset fires via reconciler (Phase 3.5 — THE thing this phase validates).** Forced `next_reset_at_ms` into the past; supervisor at 200ms cadence picked up the row; usage zeroed; `next_reset_at_ms` advanced to `now + 1s` (the budget's `reset_interval_ms`).
- `shutdown_prepare` drained the supervisor cleanly.

## CI summary

- `cargo build -p ff-backend-sqlite` — clean.
- `cargo build -p ff-server` — clean.
- `cargo test -p ff-backend-sqlite` — **all 15 test files pass** (new `wave9_reconciler.rs`: 5 tests; all existing wave9 / hot-path / subscribe / producer_* / capabilities / guard / migrations / stream_reader suites green).
- `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-sqlite --features ff-sdk/direct-valkey-claim -- -D warnings` (CI-equivalent) — clean.
- Bonus: pre-existing `field-reassign-with-default` in `tests/producer_flow.rs` fixed inline (per `feedback_no_preexisting_excuse.md`); `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` now passes.
- Phase 1a semver breaks expected; Valkey cluster flake #369 ignorable.

## Test plan

- [x] New `tests/wave9_reconciler.rs` — 5 tests, all passing.
- [x] Full `ff-backend-sqlite` test suite green.
- [x] Live-run against the backend: create_budget + report_usage_admin + forced past-due schedule + supervisor-driven reset + shutdown.
- [x] CI-equivalent clippy clean.
- [ ] Matrix CI green (will update after push).
- [ ] Postgres migration-parity green (no schema changes in this phase).

## After merge

Phase 3 is complete. Phase 4 = release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new background scanner tasks to the SQLite backend and wires them into server startup/shutdown, which could affect lifecycle behavior and budget reset correctness/timing if misconfigured.
> 
> **Overview**
> **Adds Phase 3.5 scheduled scanning to the SQLite dev backend.** A new N=1 `scanner_supervisor` spawns tokio interval-driven reconciler tasks with watch-based shutdown, is installed idempotently via `SqliteBackend::with_scanners`, and is drained during `EngineBackend::shutdown_prepare`.
> 
> **Implements the SQLite `budget_reset` reconciler.** It batch-scans due rows in `ff_budget_policy` and applies resets via a shared transactional helper that zeroes usage, clears breach metadata, and advances `next_reset_at_ms`, with defensive re-checks for concurrent admin resets.
> 
> `ff-server` now enables the SQLite supervisor at startup using the existing `budget_reset_interval` config, and new integration tests cover reconciler behavior plus supervisor lifecycle/cadence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7845b6bc71c2b22dcc28b911cfc2ee462e0fecf7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->