### PR TITLE
fix(ferriskey+loader): FUNCTION LOAD cluster slot refresh between retries (closes #369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,32 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **ferriskey: expose `Client::force_cluster_slot_refresh` (closes
+  #369).** New `pub async fn force_cluster_slot_refresh(&self) ->
+  Result<()>` on `ferriskey::Client` (and on the internal
+  `ClientInner` + `cluster::ClusterConnection::force_slot_refresh`)
+  wraps the existing internal
+  `refresh_slots_and_subscriptions_with_retries` with
+  `RefreshPolicy::NotThrottable` +
+  `SlotRefreshTrigger::RuntimeRefresh`. Standalone mode is a no-op
+  returning `Ok(())` without a network round-trip. Intended for
+  consumers that have observed a stale-topology symptom (e.g.
+  `READONLY` on a write after failover) and want the next retry to
+  use a fresh slot map.
+- **`ff-script::loader` — force a cluster slot-map refresh between
+  `FUNCTION LOAD` retries.** The old retry loop slept blindly (1s /
+  2s / 4s / 8s … = ~39s total) without nudging ferriskey's slot
+  cache, so every attempt re-used the same stale routing and the
+  `READONLY` surface re-occurred until the background refresher
+  happened to fire. Each retry now calls
+  `client.force_cluster_slot_refresh().await` before the sleep,
+  making attempts productive. First attempt still skips the refresh
+  so the happy-path cluster has no extra RTT.
+- **`ff-script::loader` — shorten retry window from ~39s to ~15s
+  (6 attempts with 500ms/1s/2s/4s/7s backoff).** Retries are
+  productive now (each actually refreshes topology), so the blind
+  defense-in-depth padding is no longer needed.
+
 - **`crates/ff-backend-sqlite` — outbox producer tag back-fill
   (Phase 3.1-flagged regression, fixed in Phase 3.2).** Prior to
   Phase 3.2 the SQLite `ff_lease_event` + `ff_completion_event`

--- a/crates/ff-script/src/loader.rs
+++ b/crates/ff-script/src/loader.rs
@@ -53,19 +53,23 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
 
     // Load the library with retry for transient errors.
     //
-    // Cluster-topology race (issue #275): on a just-formed cluster,
-    // `FUNCTION LOAD` can route to a node that's a replica at dispatch
-    // time (gossip hasn't fully converged). Valkey rejects with
-    // `READONLY: You can't write against a read only replica.`
+    // Cluster-topology race (issues #275 / #369): on a just-formed
+    // cluster, `FUNCTION LOAD` can route to a node that's a replica
+    // at dispatch time (gossip hasn't fully converged, or ferriskey's
+    // cached slot map pre-dates the primary/replica swap). Valkey
+    // rejects with `READONLY: You can't write against a read only
+    // replica.`
     //
-    // Treat READONLY as transient: back off with exponential delay so
-    // slot-map refresh catches the settled topology. 8 attempts with
-    // 1s/2s/4s/8s/8s/8s/8s inter-attempt waits gives ~39s total window.
-    // On GHA hosted runners the race window has been observed past 15s
-    // under cgroup CPU throttling; 39s gives generous headroom. Real fix
-    // is ferriskey-side (tracked at issue #290).
-    const MAX_ATTEMPTS: u32 = 8;
-    let backoff_ms: [u64; 7] = [1_000, 2_000, 4_000, 8_000, 8_000, 8_000, 8_000];
+    // Mitigation: before each retry, force an unthrottled cluster
+    // slot-map refresh via ferriskey, then back off briefly. Each
+    // retry is productive (fresh topology), so the total window is
+    // ~14.5s (500ms + 1s + 2s + 4s + 7s between 6 attempts) instead
+    // of the earlier ~39s blind-sleep window.
+    //
+    // A deeper fix — ferriskey auto-refreshing on `READONLY` inside
+    // its cluster dispatch — is tracked as a follow-up to #290.
+    const MAX_ATTEMPTS: u32 = 6;
+    let backoff_ms: [u64; 5] = [500, 1_000, 2_000, 4_000, 7_000];
     let mut last_err = None;
     for attempt in 1..=MAX_ATTEMPTS {
         match client.function_load_replace(LIBRARY_SOURCE).await {
@@ -78,16 +82,32 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
                     tracing::error!(attempt, error = %e, "FUNCTION LOAD failed with permanent error");
                     return Err(LoadError::Valkey(e));
                 }
-                let backoff = backoff_ms.get((attempt as usize).saturating_sub(1)).copied().unwrap_or(4_000);
-                tracing::warn!(
-                    attempt,
-                    max_attempts = MAX_ATTEMPTS,
-                    backoff_ms = backoff,
-                    error = %e,
-                    "FUNCTION LOAD failed (transient), retrying"
-                );
                 last_err = Some(e);
                 if attempt < MAX_ATTEMPTS {
+                    // Before sleeping, force a slot-map refresh so the
+                    // next attempt routes against fresh topology. No-op
+                    // in standalone mode. A refresh failure is logged
+                    // but does not abort the retry loop — the sleep +
+                    // next attempt may still succeed (e.g. after a
+                    // background topology tick).
+                    if let Err(refresh_err) = client.force_cluster_slot_refresh().await {
+                        tracing::debug!(
+                            attempt,
+                            error = %refresh_err,
+                            "force_cluster_slot_refresh failed between FUNCTION LOAD retries"
+                        );
+                    }
+                    let backoff = backoff_ms
+                        .get((attempt as usize).saturating_sub(1))
+                        .copied()
+                        .unwrap_or(4_000);
+                    tracing::warn!(
+                        attempt,
+                        max_attempts = MAX_ATTEMPTS,
+                        backoff_ms = backoff,
+                        error = ?last_err.as_ref().map(|e| e.to_string()),
+                        "FUNCTION LOAD failed (transient), refreshed slot map, retrying"
+                    );
                     tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
                 }
             }

--- a/crates/ff-script/src/loader.rs
+++ b/crates/ff-script/src/loader.rs
@@ -82,8 +82,15 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
                     tracing::error!(attempt, error = %e, "FUNCTION LOAD failed with permanent error");
                     return Err(LoadError::Valkey(e));
                 }
-                last_err = Some(e);
                 if attempt < MAX_ATTEMPTS {
+                    // Log the transient error's Display before moving
+                    // `e` into `last_err` so the structured field is
+                    // a real error reference, not a post-hoc
+                    // `Option<String>` round-trip.
+                    let backoff = backoff_ms
+                        .get((attempt as usize).saturating_sub(1))
+                        .copied()
+                        .unwrap_or(4_000);
                     // Before sleeping, force a slot-map refresh so the
                     // next attempt routes against fresh topology. No-op
                     // in standalone mode. A refresh failure is logged
@@ -97,18 +104,17 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
                             "force_cluster_slot_refresh failed between FUNCTION LOAD retries"
                         );
                     }
-                    let backoff = backoff_ms
-                        .get((attempt as usize).saturating_sub(1))
-                        .copied()
-                        .unwrap_or(4_000);
                     tracing::warn!(
                         attempt,
                         max_attempts = MAX_ATTEMPTS,
                         backoff_ms = backoff,
-                        error = ?last_err.as_ref().map(|e| e.to_string()),
+                        error = %e,
                         "FUNCTION LOAD failed (transient), refreshed slot map, retrying"
                     );
+                    last_err = Some(e);
                     tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
+                } else {
+                    last_err = Some(e);
                 }
             }
         }

--- a/ferriskey/src/client/mod.rs
+++ b/ferriskey/src/client/mod.rs
@@ -887,6 +887,20 @@ impl Client {
         matches!(&*guard, ClientWrapper::Cluster { .. })
     }
 
+    /// Force an immediate refresh of the cluster slot map.
+    ///
+    /// No-op in standalone mode; callers typically dispatch this
+    /// after observing a stale-topology symptom (e.g. a `READONLY`
+    /// error from a write that was routed to a former-primary that
+    /// has been demoted to a replica) before retrying the command.
+    pub async fn force_cluster_slot_refresh(&self) -> Result<()> {
+        let guard = self.internal_client.read().await;
+        match &*guard {
+            ClientWrapper::Standalone(_) => Ok(()),
+            ClientWrapper::Cluster { client } => client.force_slot_refresh().await,
+        }
+    }
+
     /// Typed-tuple variant of [`Self::cluster_scan`] for Rust
     /// callers that want direct access to the next scan state and
     /// key list without the language-binding cursor-id container

--- a/ferriskey/src/client/mod.rs
+++ b/ferriskey/src/client/mod.rs
@@ -894,11 +894,21 @@ impl Client {
     /// error from a write that was routed to a former-primary that
     /// has been demoted to a replica) before retrying the command.
     pub async fn force_cluster_slot_refresh(&self) -> Result<()> {
-        let guard = self.internal_client.read().await;
-        match &*guard {
-            ClientWrapper::Standalone(_) => Ok(()),
-            ClientWrapper::Cluster { client } => client.force_slot_refresh().await,
-        }
+        // Clone the `ClusterConnection` under the lock so we don't
+        // hold the `internal_client` read guard across the network
+        // refresh: a writer (e.g. `update_connection_password`) that
+        // queues during the refresh would otherwise starve every
+        // subsequent reader until topology resolution completes.
+        // `ClusterConnection` is `Clone` and the clone is cheap (mpsc
+        // sender + `Arc<InnerCore>`).
+        let cluster = {
+            let guard = self.internal_client.read().await;
+            match &*guard {
+                ClientWrapper::Standalone(_) => return Ok(()),
+                ClientWrapper::Cluster { client } => client.clone(),
+            }
+        };
+        cluster.force_slot_refresh().await
     }
 
     /// Typed-tuple variant of [`Self::cluster_scan`] for Rust

--- a/ferriskey/src/cluster/mod.rs
+++ b/ferriskey/src/cluster/mod.rs
@@ -295,6 +295,26 @@ where
         self.route_cluster_scan(cluster_scan_args).await
     }
 
+    /// Force an immediate, unthrottled refresh of the cluster slot map.
+    ///
+    /// Intended for callers that have just observed a stale-topology
+    /// symptom (e.g. a write command routed to a replica returning
+    /// `READONLY You can't write against a read only replica`) and want
+    /// to drive a fresh CLUSTER SLOTS query before retrying. Uses the
+    /// `NotThrottable` policy so the refresh runs even if one was
+    /// recently attempted.
+    ///
+    /// Serialized behind the same topology-refresh lock as the
+    /// background refresher; concurrent callers coalesce.
+    pub async fn force_slot_refresh(&self) -> Result<()> {
+        ClusterConnInner::<C>::refresh_slots_and_subscriptions_with_retries(
+            self.inner.clone(),
+            &RefreshPolicy::NotThrottable,
+            SlotRefreshTrigger::RuntimeRefresh,
+        )
+        .await
+    }
+
     /// Route cluster scan to be handled by internal cluster_scan command
     async fn route_cluster_scan(
         &mut self,

--- a/ferriskey/src/ferriskey_client.rs
+++ b/ferriskey/src/ferriskey_client.rs
@@ -354,6 +354,25 @@ impl Client {
         self.inner.is_cluster().await
     }
 
+    /// Force an immediate refresh of the cluster slot map.
+    ///
+    /// In standalone mode this is a no-op and returns `Ok(())`
+    /// without a network round-trip. In cluster mode it drives an
+    /// unthrottled `CLUSTER SLOTS` query and updates the internal
+    /// routing table; concurrent callers coalesce behind the same
+    /// refresh lock used by ferriskey's background topology checker.
+    ///
+    /// Intended for consumers that have just observed a stale-
+    /// topology symptom on a cluster command (e.g. a `READONLY`
+    /// error after a failover moved the target slot to a new
+    /// primary) and want the next retry to use a fresh slot map.
+    /// Normal command dispatch already refreshes on `MOVED`/`ASK`;
+    /// this entry point exists for the `READONLY` case, which
+    /// ferriskey does not yet auto-refresh on (tracked separately).
+    pub async fn force_cluster_slot_refresh(&self) -> Result<()> {
+        self.inner.force_cluster_slot_refresh().await
+    }
+
     /// Dial a second, independent multiplexed connection using the
     /// same configuration (addresses, TLS, auth, cluster mode,
     /// timeouts, retry strategy, ...) that produced this client.


### PR DESCRIPTION
## Summary

Fixes #369 — the intermittent `ubuntu-latest · valkey 8 · cluster` CI flake where `Server::start` → `FUNCTION LOAD` rejects with `READONLY You can't write against a read only replica`.

### Root cause

ferriskey's cluster slot map can be stale when `FUNCTION LOAD` dispatches (just-formed cluster, or a primary/replica swap the client hasn't observed yet). The write routes to what is now a replica; Valkey rejects.

The loader's retry loop was blind sleeps totalling ~39s without prodding ferriskey to refresh its cached slot map. Every attempt re-used the same stale routing until the background topology checker happened to fire.

### Fix (Option C from the #369 investigation)

1. **ferriskey** — new `pub async fn force_cluster_slot_refresh(&self) -> Result<()>` on `Client` (and on `ClientInner` + `cluster::ClusterConnection::force_slot_refresh`). Wraps the existing internal `refresh_slots_and_subscriptions_with_retries` with `RefreshPolicy::NotThrottable` + `SlotRefreshTrigger::RuntimeRefresh`. Standalone mode is a no-op returning `Ok(())` without a network round-trip.
2. **ff-script loader** — calls `force_cluster_slot_refresh()` before each retry's backoff sleep (skipped on the first attempt, so the happy-path has no extra RTT).
3. **Retry window** — shortened from ~39s (8 attempts × blind sleeps) to ~14.5s (6 attempts with 500ms/1s/2s/4s/7s backoffs). Productive retries, no defense-in-depth padding needed.

### Decisions applied

- **Option C**, not Option A — `Option A` (ferriskey auto-refresh on `READONLY` in the cluster dispatch layer) is the deeper fix and is filed as a follow-up to #290.
- Backoff schedule chosen to hit the ~15s budget: 5 inter-attempt backoffs summing to 14.5s, requiring 6 attempts.
- `force_cluster_slot_refresh` uses `RefreshPolicy::NotThrottable` so repeated calls during the retry loop each actually trigger a refresh (consumers opt in to this behaviour by calling the method).

## Verification

- `cargo build --workspace` clean
- `cargo test -p ferriskey --lib` → 262 passed / 0 failed
- `cargo test -p ff-script` → 25 passed / 0 failed
- Dedicated mock-cluster unit test for `force_cluster_slot_refresh` would require fabricating a `CLUSTER SLOTS` response against ferriskey's internal `MockConn` harness (private); deferred per scope guidance, real cluster soak is the verification path.

### Post-merge CI soak plan

Since the flake is non-deterministic on CI, post-merge verification is soak-based:

- After merge: rerun the matrix lane ~20 times
- Assert 0 READONLY surfaces across all reruns
- If the fix is correct and the underlying cluster refresh itself is healthy, the flake should not reproduce — first retry after the refresh should see the settled topology.

### Follow-up

A new tracking issue will be filed post-merge: "ferriskey: ReadOnly errors should auto-trigger topology refresh in cluster dispatch (follow-up to #369)", referencing #290.

## Test plan

- [ ] CI matrix green (Phase 1a semver breaks expected on ferriskey; cluster lane is the one that must pass)
- [ ] Migration-parity job green
- [ ] Bot review comments addressed before admin-merge
- [ ] Post-merge matrix soak (~20 reruns) shows 0 READONLY surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public cluster-topology refresh API and changes the Valkey Lua library loader retry behavior; risk is moderate because it affects cluster routing/refresh timing and could impact retry patterns under load.
> 
> **Overview**
> Improves resilience to Valkey cluster topology churn by exposing `Client::force_cluster_slot_refresh()` in ferriskey (no-op in standalone, unthrottled `CLUSTER SLOTS` refresh in cluster mode).
> 
> Updates `ff-script`’s `FUNCTION LOAD` retry loop to call this refresh between transient failures and shortens the retry/backoff window (~39s → ~15s), making retries route against fresh slot maps to avoid repeated `READONLY` failures after failover or early cluster formation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e7d60664ec9ae2a19000f78ad8b8b6e28699e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->