### PR TITLE
rfcs: promote RFC-024 to accepted (Round 2 unanimous)

### DIFF
--- a/rfcs/RFC-024-reclaim-wiring.md
+++ b/rfcs/RFC-024-reclaim-wiring.md
@@ -1,9 +1,10 @@
 # RFC-024: Wire `ff_reclaim_execution` + `ff_issue_reclaim_grant` to the consumer surface
 
-**Status:** DRAFT
+**Status:** ACCEPTED
 **Revision:** 2
 **Author:** FlowFabric Team (manager single-agent draft)
 **Proposed:** 2026-04-26
+**Accepted:** 2026-04-28
 **Target release:** v0.12.0 (joint wave with RFC-023 SQLite; all three backends folded)
 **Related RFCs:** RFC-012 (EngineBackend trait), RFC-017 (ff-server backend abstraction), RFC-018 (capability discovery), RFC-019 (lease events), RFC-020 (Postgres Wave 9), RFC-023 (SQLite dev-only backend)
 **Tracking issue:** #371


### PR DESCRIPTION
## Summary
- Promote RFC-024 (reclaim wiring for pull-mode deadlock) from DRAFT to ACCEPTED after Round 2 unanimous ACCEPT.
- Move `rfcs/drafts/RFC-024-reclaim-wiring.md` → `rfcs/RFC-024-reclaim-wiring.md`.
- Header: `Status: DRAFT` → `Status: ACCEPTED`; retain `Proposed: 2026-04-26`, `Revision: 2`; add `Accepted: 2026-04-28`.

No other content changes — Round 2 polish items are tracked for impl PRs.

Same pattern as RFC-020 and RFC-023 promotion PRs. Doc-only trivial change; admin-merge after CI green.

## Test plan
- [x] File moved out of drafts/
- [x] Status flipped to ACCEPTED with Accepted date added
- [x] No other content changes (diff is 2 insertions / 1 deletion in the header)
- [ ] CI green
- [ ] Admin merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only change (file move + header metadata update) with no production code impact.
> 
> **Overview**
> Promotes `RFC-024-reclaim-wiring` from *DRAFT* to **ACCEPTED** by relocating it into `rfcs/` and updating the header (`Status` flip and adding an `Accepted` date).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5f8a278aed2c5de6826073127ec3e847d3ecb3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->