### PR TITLE
fix(backend-sqlite): claim writes public_state + is_memory detects mode=memory URIs (closes #372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,24 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **ff-backend-sqlite: claim path writes `public_state = 'running'` to
+  `ff_exec_core`.** Matches the Postgres parity write at
+  `ff-backend-postgres/src/suspend_ops.rs:958-960`. Before the fix the
+  column stayed at its create-time `'pending'` literal on claimed
+  executions; the Spine-B read normaliser inferred the correct
+  `PublicState::Active` from lifecycle + ownership so downstream
+  consumers were unaffected, but direct SQL reads against
+  `ff_exec_core.public_state` observed the wrong state.
+- **ff-backend-sqlite: `SqliteBackend::new` `is_memory` detection now
+  catches `file:*?mode=memory*` URIs (closes #372).** The prior
+  detector (`path == ":memory:" || path.starts_with("file::memory:")`)
+  missed the RFC-023 §4.6 recommended test-isolation form
+  (`file:ff-test-<uuid>?mode=memory&cache=shared`), so WAL mode was
+  applied inappropriately and no sentinel connection was held — a
+  pool-idle cycle dropped the shared cache mid-test and risked data
+  loss under parallel test harnesses. Detection is extracted into a
+  dedicated `is_memory_uri` helper with a unit test covering all three
+  supported forms.
 - **ferriskey: expose `Client::force_cluster_slot_refresh` (closes
   #369).** New `pub async fn force_cluster_slot_refresh(&self) ->
   Result<()>` on `ferriskey::Client` (and on the internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,8 +280,9 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **ff-backend-sqlite: claim path writes `public_state = 'running'` to
   `ff_exec_core`.** Matches the Postgres parity write at
   `ff-backend-postgres/src/suspend_ops.rs:958-960`. Before the fix the
-  column stayed at its create-time `'pending'` literal on claimed
-  executions; the Spine-B read normaliser inferred the correct
+  column stayed at its create-time `'waiting'` literal on claimed
+  executions (`'pending'` is the sibling `attempt_state` literal, not
+  `public_state`); the Spine-B read normaliser inferred the correct
   `PublicState::Active` from lifecycle + ownership so downstream
   consumers were unaffected, but direct SQL reads against
   `ff_exec_core.public_state` observed the wrong state.

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -146,6 +146,11 @@ async fn last_outbox_event(
 ///   - `"file:<name>?...mode=memory..."` (the §4.6-recommended named
 ///     form, e.g. `file:ff-test-<uuid>?mode=memory&cache=shared`)
 ///
+/// The `mode=memory` check requires the query-parameter delimiter
+/// (`?` or `&`) so filesystem paths whose filename happens to contain
+/// the substring (e.g. `file:my_mode=memory_db.sqlite`) are not
+/// misclassified as in-memory.
+///
 /// A #372 miss on the third form caused `is_memory = false` for the
 /// §4.6 test-isolation URIs: WAL mode was applied inappropriately
 /// and no sentinel connection was held, so pool-idle cycles dropped
@@ -153,7 +158,8 @@ async fn last_outbox_event(
 fn is_memory_uri(path: &str) -> bool {
     path == ":memory:"
         || path.starts_with("file::memory:")
-        || (path.starts_with("file:") && path.contains("mode=memory"))
+        || (path.starts_with("file:")
+            && (path.contains("?mode=memory") || path.contains("&mode=memory")))
 }
 
 /// Unix-millis wall clock. Matches the PG reference shape
@@ -3114,5 +3120,11 @@ mod tests {
         assert!(!is_memory_uri("./ff.sqlite"));
         assert!(!is_memory_uri("file:/tmp/ff.sqlite"));
         assert!(!is_memory_uri("file:ff-test?cache=shared"));
+        // Filename happens to contain the substring `mode=memory`
+        // but it is not a query parameter — MUST NOT match.
+        assert!(!is_memory_uri("file:my_mode=memory_db.sqlite"));
+        // Query-parameter form with `&` delimiter (mode is not the
+        // first parameter) — MUST match.
+        assert!(is_memory_uri("file:ff-test?cache=shared&mode=memory"));
     }
 }

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -138,6 +138,24 @@ async fn last_outbox_event(
 
 // ── Phase 2a.2 helpers: hot-path shared logic ──────────────────────────
 
+/// Classify a sqlite path/URI as in-memory (RFC-023 §4.6).
+///
+/// Matches the three on-disk-free forms the backend supports:
+///   - bare `":memory:"` (rewritten internally to a shared-cache URI)
+///   - `"file::memory:..."` (the short-form shared-cache URI)
+///   - `"file:<name>?...mode=memory..."` (the §4.6-recommended named
+///     form, e.g. `file:ff-test-<uuid>?mode=memory&cache=shared`)
+///
+/// A #372 miss on the third form caused `is_memory = false` for the
+/// §4.6 test-isolation URIs: WAL mode was applied inappropriately
+/// and no sentinel connection was held, so pool-idle cycles dropped
+/// the shared cache mid-test.
+fn is_memory_uri(path: &str) -> bool {
+    path == ":memory:"
+        || path.starts_with("file::memory:")
+        || (path.starts_with("file:") && path.contains("mode=memory"))
+}
+
 /// Unix-millis wall clock. Matches the PG reference shape
 /// (`ff-backend-postgres/src/attempt.rs:55-63`); SQLite stores the
 /// same `*_ms` fields so the value is directly comparable.
@@ -2254,7 +2272,7 @@ impl SqliteBackend {
         // pool shares ONE in-memory database. Without this rewrite,
         // each pool connection opens its own private DB and tests see
         // schema mismatches silently.
-        let is_memory = path == ":memory:" || path.starts_with("file::memory:");
+        let is_memory = is_memory_uri(path);
         let effective_path: std::borrow::Cow<'_, str> = if path == ":memory:" {
             std::borrow::Cow::Borrowed("file::memory:?cache=shared")
         } else {
@@ -3064,5 +3082,37 @@ impl EngineBackend for SqliteBackend {
         // applies the migrations inside `SqliteBackend::new` itself
         // rather than here, matching the PG posture.
         Ok(PrepareOutcome::NoOp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_memory_uri;
+
+    /// #372 regression: `is_memory_uri` must detect the three in-memory
+    /// URI forms the backend supports, including the RFC-023 §4.6
+    /// recommended `file:<name>?mode=memory&cache=shared` test-
+    /// isolation form. A miss on the third form caused WAL to be
+    /// applied inappropriately and no sentinel connection to be held,
+    /// so pool-idle cycles dropped the shared cache mid-test.
+    #[test]
+    fn is_memory_detects_all_uri_forms() {
+        // Bare.
+        assert!(is_memory_uri(":memory:"));
+        // Short-form shared-cache URI.
+        assert!(is_memory_uri("file::memory:"));
+        assert!(is_memory_uri("file::memory:?cache=shared"));
+        // §4.6 named form (the one #372 missed).
+        assert!(is_memory_uri(
+            "file:ff-test-abc123?mode=memory&cache=shared"
+        ));
+        assert!(is_memory_uri(
+            "file:ff-test-00000000-0000-0000-0000-000000000000?mode=memory&cache=shared"
+        ));
+        // Filesystem paths and unrelated URIs must not match.
+        assert!(!is_memory_uri("/tmp/ff.sqlite"));
+        assert!(!is_memory_uri("./ff.sqlite"));
+        assert!(!is_memory_uri("file:/tmp/ff.sqlite"));
+        assert!(!is_memory_uri("file:ff-test?cache=shared"));
     }
 }

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -146,20 +146,37 @@ async fn last_outbox_event(
 ///   - `"file:<name>?...mode=memory..."` (the §4.6-recommended named
 ///     form, e.g. `file:ff-test-<uuid>?mode=memory&cache=shared`)
 ///
-/// The `mode=memory` check requires the query-parameter delimiter
-/// (`?` or `&`) so filesystem paths whose filename happens to contain
-/// the substring (e.g. `file:my_mode=memory_db.sqlite`) are not
-/// misclassified as in-memory.
+/// The `mode=memory` check parses the URI query string and requires
+/// an exact `mode=memory` `key=value` pair (delimited by `?`/`&`,
+/// terminated by `&`/`#`/end-of-string). A substring-only check
+/// would mis-classify filesystem paths whose filename happens to
+/// contain the substring (e.g. `file:my_mode=memory_db.sqlite`) or
+/// a longer value (`?mode=memory_extra`) as in-memory.
 ///
 /// A #372 miss on the third form caused `is_memory = false` for the
 /// §4.6 test-isolation URIs: WAL mode was applied inappropriately
 /// and no sentinel connection was held, so pool-idle cycles dropped
 /// the shared cache mid-test.
 fn is_memory_uri(path: &str) -> bool {
-    path == ":memory:"
-        || path.starts_with("file::memory:")
-        || (path.starts_with("file:")
-            && (path.contains("?mode=memory") || path.contains("&mode=memory")))
+    if path == ":memory:" || path.starts_with("file::memory:") {
+        return true;
+    }
+    if !path.starts_with("file:") {
+        return false;
+    }
+    // Require `mode=memory` to appear as a real URI query parameter —
+    // a `key=value` pair delimited by `?` or `&`, ending at `&`, `#`,
+    // or end-of-string. A substring-only check would mis-classify
+    // filesystem paths whose filename happens to contain
+    // `mode=memory` (e.g. `file:my_mode=memory_db.sqlite`) or a
+    // longer value like `?mode=memory_extra`.
+    let Some(query_start) = path.find('?') else {
+        return false;
+    };
+    let query = &path[query_start + 1..];
+    // Strip URI fragment before splitting pairs.
+    let query = query.split('#').next().unwrap_or("");
+    query.split('&').any(|kv| kv == "mode=memory")
 }
 
 /// Unix-millis wall clock. Matches the PG reference shape
@@ -3126,5 +3143,38 @@ mod tests {
         // Query-parameter form with `&` delimiter (mode is not the
         // first parameter) — MUST match.
         assert!(is_memory_uri("file:ff-test?cache=shared&mode=memory"));
+    }
+
+    /// Filename that happens to contain the substring `mode=memory`
+    /// must NOT be classified as in-memory — it is a persistent file
+    /// path, not a URI query parameter.
+    #[test]
+    fn is_memory_uri_rejects_filename_with_mode_memory() {
+        assert!(!is_memory_uri("file:my_mode=memory_db.sqlite"));
+        // Also guard against a value-prefix mismatch: a query
+        // parameter whose value starts with `memory` but isn't
+        // exactly `memory` must not match.
+        assert!(!is_memory_uri("file:foo?mode=memory_extra"));
+    }
+
+    /// Simple `?mode=memory` query parameter — the canonical form.
+    #[test]
+    fn is_memory_uri_accepts_query_param() {
+        assert!(is_memory_uri("file:test?mode=memory"));
+    }
+
+    /// RFC-023 §4.6 recommended test-isolation form — the original
+    /// #372 regression case.
+    #[test]
+    fn is_memory_uri_accepts_shared_cache_form() {
+        assert!(is_memory_uri(
+            "file:ff-test-00000000-0000-0000-0000-000000000000?mode=memory&cache=shared"
+        ));
+    }
+
+    /// Plain file path (no query string) must not match.
+    #[test]
+    fn is_memory_uri_rejects_plain_file() {
+        assert!(!is_memory_uri("file:./data.db"));
     }
 }

--- a/crates/ff-backend-sqlite/src/queries/exec_core.rs
+++ b/crates/ff-backend-sqlite/src/queries/exec_core.rs
@@ -9,11 +9,20 @@
 /// Flip exec_core to `active/leased/running` on a successful claim
 /// (mirror of PG's claim-path UPDATE at
 /// `ff-backend-postgres/src/attempt.rs:236-250`).
+///
+/// `public_state = 'running'` mirrors the Postgres resume-claim write
+/// at `ff-backend-postgres/src/suspend_ops.rs:958-960` and normalises
+/// to [`ff_core::types::PublicState::Active`] via
+/// [`crate::reads::normalise_public_state`]. Without this write the
+/// column remained at its create-time `'waiting'` literal on SQLite
+/// while Spine-B consumers (and any direct `SELECT public_state`)
+/// expected the claimed-execution literal.
 pub(crate) const UPDATE_EXEC_CORE_CLAIM_SQL: &str = r#"
     UPDATE ff_exec_core
        SET lifecycle_phase = 'active',
            ownership_state = 'leased',
            eligibility_state = 'not_applicable',
+           public_state = 'running',
            attempt_state = 'running_attempt'
      WHERE partition_key = ?1 AND execution_id = ?2
 "#;

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -148,6 +148,19 @@ async fn read_exec_phase(backend: &SqliteBackend, exec_uuid: Uuid) -> String {
     .expect("read lifecycle_phase")
 }
 
+/// Read one exec_core row's `public_state`.
+async fn read_exec_public_state(backend: &SqliteBackend, exec_uuid: Uuid) -> String {
+    let pool = backend.pool_for_test();
+    sqlx::query_scalar::<_, String>(
+        "SELECT public_state FROM ff_exec_core \
+          WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read public_state")
+}
+
 // ── claim ──────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -169,6 +182,18 @@ async fn claim_happy_path_mints_handle_and_transitions_state() {
 
     // exec_core flipped to active.
     assert_eq!(read_exec_phase(&backend, exec_uuid).await, "active");
+
+    // `public_state = 'running'` parity write with Postgres
+    // (`ff-backend-postgres/src/suspend_ops.rs:958-960`). The
+    // Spine-B normaliser maps the raw literal back to
+    // `PublicState::Active`; before the fix the column remained
+    // at its create-time `'pending'` literal (#sqlite claim
+    // public_state gap) and direct SQL readers observed the wrong
+    // state even though the inferred enum was correct.
+    assert_eq!(
+        read_exec_public_state(&backend, exec_uuid).await,
+        "running"
+    );
 
     // Attempt row created with no terminal outcome yet.
     assert_eq!(read_attempt_outcome(&backend, exec_uuid, 0).await, None);

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -186,10 +186,11 @@ async fn claim_happy_path_mints_handle_and_transitions_state() {
     // `public_state = 'running'` parity write with Postgres
     // (`ff-backend-postgres/src/suspend_ops.rs:958-960`). The
     // Spine-B normaliser maps the raw literal back to
-    // `PublicState::Active`; before the fix the column remained
-    // at its create-time `'pending'` literal (#sqlite claim
-    // public_state gap) and direct SQL readers observed the wrong
-    // state even though the inferred enum was correct.
+    // `PublicState::Active`; before the fix the `public_state`
+    // column remained at its create-time `'waiting'` literal
+    // (`'pending'` is the sibling `attempt_state` literal, not
+    // `public_state`) and direct SQL readers observed the wrong
+    // public state even though the inferred enum was correct.
     assert_eq!(
         read_exec_public_state(&backend, exec_uuid).await,
         "running"

--- a/crates/ff-backend-sqlite/tests/wave9_reads.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_reads.rs
@@ -199,10 +199,10 @@ async fn read_execution_info_happy_path_post_claim() {
     assert_eq!(info.execution_id, exec_id);
     assert_eq!(info.namespace, "default");
     assert_eq!(info.execution_kind, "op");
-    // Note: SQLite's claim path does not write public_state today
-    // (parity gap with PG); post-claim row retains the INSERT literal
-    // 'waiting' until a future Phase flips it.
-    assert_eq!(info.public_state, PublicState::Waiting);
+    // SQLite's claim path writes `public_state = 'running'` (the
+    // Postgres-parity literal from `suspend_ops.rs:958-960`), which
+    // the Spine-B normaliser maps to `PublicState::Active`.
+    assert_eq!(info.public_state, PublicState::Active);
     assert_eq!(info.state_vector.lifecycle_phase, LifecyclePhase::Active);
     assert_eq!(
         info.state_vector.terminal_outcome,


### PR DESCRIPTION
## Summary

Two coherent SQLite backend fixes bundled in one PR.

### A. SQLite claim path now writes `public_state = 'running'`

`crates/ff-backend-sqlite/src/queries/exec_core.rs::UPDATE_EXEC_CORE_CLAIM_SQL` now sets `public_state = 'running'` alongside the existing lifecycle / ownership / eligibility / attempt flips. Mirrors the Postgres parity write at `ff-backend-postgres/src/suspend_ops.rs:958-960`; the Spine-B read normaliser (`reads.rs::normalise_public_state`) maps the raw `'running'` literal to `PublicState::Active`, so downstream consumers are unchanged but direct `SELECT public_state` queries now return the expected literal instead of the create-time `'waiting'` value.

- Surfaced in Phase 3.3 review (project memory `project_sqlite_claim_public_state_gap.md`, now marked FIXED).
- Not consumer-visible through trait reads (normaliser inferred correctly); visible to any future subscribe filter or direct-SQL operator tool.

### B. `is_memory` URI detection catches `mode=memory` form (closes #372)

`SqliteBackend::new`'s inline detector missed the RFC-023 §4.6 recommended test-isolation form (`file:ff-test-<uuid>?mode=memory&cache=shared`): WAL was applied inappropriately and no sentinel connection was held, so pool-idle cycles dropped the shared cache between pool connections and risked data loss under parallel tests.

Detection is extracted into a dedicated module-level `is_memory_uri(path)` helper:

```rust
fn is_memory_uri(path: &str) -> bool {
    path == ":memory:"
        || path.starts_with("file::memory:")
        || (path.starts_with("file:") && path.contains("mode=memory"))
}
```

## Test coverage

- `crates/ff-backend-sqlite/src/backend.rs::tests::is_memory_detects_all_uri_forms` — new unit test; three positive forms (`:memory:`, `file::memory:*`, `file:*?mode=memory*`) + four negative cases (filesystem paths, unrelated URIs).
- `crates/ff-backend-sqlite/tests/hot_path.rs::claim_happy_path_mints_handle_and_transitions_state` — extended with new `read_exec_public_state` helper; asserts `public_state = 'running'` post-claim.
- `crates/ff-backend-sqlite/tests/wave9_reads.rs::read_execution_info_happy_path_post_claim` — expectation flipped from `PublicState::Waiting` → `PublicState::Active`; the prior expectation documented the gap this PR closes.

## Local CI

- `cargo build -p ff-backend-sqlite` — clean.
- `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` — clean.
- `FF_DEV_MODE=1 cargo test -p ff-backend-sqlite` — 133 tests passing (unit + all integration tests), no failures.

## Test plan

- [x] Unit test for `is_memory_uri` covers all three positive forms + negative cases
- [x] Integration test in `hot_path.rs` asserts `public_state = 'running'` after claim
- [x] Existing `wave9_reads.rs` post-claim assertion updated to reflect the fix
- [x] `cargo test -p ff-backend-sqlite` green locally
- [x] `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` clean
- [ ] Full matrix CI green (Valkey + Postgres + SQLite)
- [ ] Address any bot review findings before merge

Closes #372.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: targeted SQLite-only fixes (one SQL UPDATE field and URI classification) with added unit/integration coverage; main risk is subtle behavior change for direct SQL readers and test-only in-memory DB handling.
> 
> **Overview**
> Fixes two SQLite backend parity/issues.
> 
> The claim path now updates `ff_exec_core.public_state` to `'running'` alongside the existing claim state flips, matching Postgres and making direct SQL reads reflect the expected post-claim state; related integration expectations were updated.
> 
> `SqliteBackend::new` now correctly treats `file:*?mode=memory*` URIs as in-memory via a new `is_memory_uri` helper (preventing WAL/sentinel misconfiguration in tests), with a focused unit test covering supported and non-supported URI forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437c7b5de68ea98eb1f4237cc9b61d87af73b2c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->