### PR TITLE
fix(pg-backend+docs): Wave 9 follow-ups — lifecycle_phase adapter doc (#354) + attempt.outcome on cancel (#355) + ff_exec_core.started_at_ms (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `ff-backend-postgres`: `ff_attempt.outcome` is now cleared on the
+  exec-cancel paths that previously left it stale — `cancel_flow`
+  member loop (`src/flow.rs`) and `exec_core::cancel` (the
+  `Handle`-level cancel). The existing `operator::cancel_execution`
+  path already cleared outcome on live leases; this extends the
+  invariant to the remaining cancel sites so a post-cancel
+  `read_execution_info` never surfaces a stale `retry` /
+  `interrupted` terminal-outcome on a cancelled row.
+  `ff-backend-sqlite` gets the parallel fix on the `cancel_flow`
+  member loop. Closes #355.
+- `ff-backend-postgres`, `ff-backend-sqlite`: added
+  `ff_exec_core.started_at_ms` (migration 0016) as a set-once
+  first-claim timestamp column. Populated by the claim + resume-claim
+  paths via `COALESCE(started_at_ms, now)` so reclaim + retry never
+  overwrite the original value. The Wave-9 Spine-B
+  `read_execution_info` read path drops the LATERAL join (Postgres) /
+  correlated subquery (SQLite) on `ff_attempt.started_at_ms` and reads
+  the column directly. Migration 0016 backfills existing rows from
+  `MIN(ff_attempt.started_at_ms)` per execution. Migration number
+  0015 is reserved for RFC-024 (claim-grant table); if the RFC-024
+  impl PR lands first the two renumber independently — 0016 stays
+  additive and safe. Closes #356.
+
+### Documentation
+
+- `rfcs/RFC-020-postgres-wave-9.md` §4.1 (Revision 8): corrected the
+  earlier "maps directly" claim for `ff_exec_core.lifecycle_phase` +
+  sibling state columns. Postgres legitimately encodes
+  `(phase × eligibility × terminal-outcome)` in a richer private
+  alphabet than the canonical `ff_core::state` enums (`cancelled`,
+  `released`, `pending_claim`, bare `running`, `blocked` are valid
+  column literals but not enum members). The `normalise_*` shim in
+  `crates/ff-backend-postgres/src/exec_core.rs` is now documented as
+  the read-boundary adapter (Option B per owner decision on #354),
+  not a transient inconsistency; a corresponding module-level doc on
+  `exec_core.rs` spells out the invariant for new read + write paths.
+  Closes #354.
+
 ### Added
 
 - **`crates/ff-backend-sqlite` — Phase 3.5 scanner supervisor (N=1) +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   0015 is reserved for RFC-024 (claim-grant table); if the RFC-024
   impl PR lands first the two renumber independently — 0016 stays
   additive and safe. Closes #356.
+- `ff-backend-postgres`: first-claim path now writes
+  `public_state = 'running'` on `ff_exec_core` for parity with the
+  resume-claim path (`src/suspend_ops.rs`) and the SQLite first-claim
+  write landed in PR #392. Prior to this fix the column remained at its
+  create-time `'waiting'` literal after a PG first-claim, so Spine-B
+  `read_execution_info` readers (and any direct `SELECT public_state`)
+  saw the wrong column state until the read-boundary
+  `normalise_public_state` adapter masked it. Regression coverage in
+  `crates/ff-backend-postgres/tests/wave9_followups.rs`
+  (`first_claim_writes_public_state_running`).
 
 ### Documentation
 

--- a/crates/ff-backend-postgres/migrations/0016_started_at_ms.sql
+++ b/crates/ff-backend-postgres/migrations/0016_started_at_ms.sql
@@ -11,12 +11,12 @@
 -- This migration adds `ff_exec_core.started_at_ms BIGINT` as a
 -- set-once column populated on first claim (see
 -- `attempt.rs::claim` — post-0016 writes use
--- `started_at_ms = COALESCE(ff_exec_core.started_at_ms, excluded)` so
--- reclaim and retry paths never overwrite the original first-claim
--- timestamp). Existing rows are backfilled from
--- `ff_attempt.started_at_ms` (earliest non-NULL attempt) so the
--- Spine-B read path can drop the LATERAL join without regressing
--- pre-existing executions.
+-- `started_at_ms = COALESCE(started_at_ms, $now)` so reclaim and retry
+-- paths never overwrite the original first-claim timestamp). Existing
+-- rows are backfilled from `ff_attempt.started_at_ms` (earliest
+-- non-NULL attempt by `attempt_index ASC`) so the Spine-B read path
+-- can drop the LATERAL join without regressing pre-existing
+-- executions.
 --
 -- Migration numbering: 0015 is reserved for RFC-024 (claim-grant
 -- table) which is queued but not yet shipped. This migration claims
@@ -31,21 +31,24 @@ ALTER TABLE ff_exec_core
     ADD COLUMN IF NOT EXISTS started_at_ms BIGINT;
 
 -- Section 2 — Backfill from existing `ff_attempt.started_at_ms`.
--- Uses the earliest attempt with a non-NULL started_at_ms (matches
--- the pre-0016 LATERAL-join selection: `ORDER BY attempt_index ASC
--- LIMIT 1` over rows where `started_at_ms IS NOT NULL`). Rows whose
--- executions never reached claim (pure submit / cancel-before-claim)
--- leave `started_at_ms` NULL, which the read path already tolerates
--- (`first_started_at_ms_opt.map(...)` → `Option<String>`).
+-- Uses DISTINCT ON to pick the earliest attempt row by
+-- `attempt_index ASC` with a non-NULL started_at_ms, matching the
+-- pre-0016 LATERAL-join selection exactly (`ORDER BY attempt_index
+-- ASC LIMIT 1`). MIN(started_at_ms) would drift if timestamps were
+-- ever non-monotonic. Rows whose executions never reached claim
+-- (pure submit / cancel-before-claim) leave `started_at_ms` NULL,
+-- which the read path already tolerates
+-- (`started_at_ms_opt.map(...)` → `Option<String>`).
 UPDATE ff_exec_core ec
    SET started_at_ms = sub.first_started_at_ms
   FROM (
-    SELECT a.partition_key,
+    SELECT DISTINCT ON (a.partition_key, a.execution_id)
+           a.partition_key,
            a.execution_id,
-           MIN(a.started_at_ms) AS first_started_at_ms
+           a.started_at_ms AS first_started_at_ms
       FROM ff_attempt a
      WHERE a.started_at_ms IS NOT NULL
-     GROUP BY a.partition_key, a.execution_id
+     ORDER BY a.partition_key, a.execution_id, a.attempt_index ASC
   ) sub
  WHERE ec.partition_key = sub.partition_key
    AND ec.execution_id  = sub.execution_id

--- a/crates/ff-backend-postgres/migrations/0016_started_at_ms.sql
+++ b/crates/ff-backend-postgres/migrations/0016_started_at_ms.sql
@@ -1,0 +1,61 @@
+-- RFC-020 Wave 9 follow-up (#356) — promote first-claim timestamp
+-- to a typed column on `ff_exec_core`.
+--
+-- Pre-0016 the Spine-B `read_execution_info` path recovered
+-- `ExecutionInfo.started_at` via a LATERAL join on `ff_attempt` —
+-- `SELECT started_at_ms FROM ff_attempt WHERE ... AND
+-- started_at_ms IS NOT NULL ORDER BY attempt_index ASC LIMIT 1`.
+-- That matched Valkey semantics (first-claim, preserved across
+-- retries) but cost a correlated subquery per read.
+--
+-- This migration adds `ff_exec_core.started_at_ms BIGINT` as a
+-- set-once column populated on first claim (see
+-- `attempt.rs::claim` — post-0016 writes use
+-- `started_at_ms = COALESCE(ff_exec_core.started_at_ms, excluded)` so
+-- reclaim and retry paths never overwrite the original first-claim
+-- timestamp). Existing rows are backfilled from
+-- `ff_attempt.started_at_ms` (earliest non-NULL attempt) so the
+-- Spine-B read path can drop the LATERAL join without regressing
+-- pre-existing executions.
+--
+-- Migration numbering: 0015 is reserved for RFC-024 (claim-grant
+-- table) which is queued but not yet shipped. This migration claims
+-- 0016 to avoid collision; if the RFC-024 impl PR lands first it
+-- takes 0015 and this file continues to apply cleanly. If this PR
+-- lands first, the RFC-024 migration PR adjusts.
+--
+-- Additive (`backward_compatible = true`). No destructive DDL.
+
+-- Section 1 — Add the column.
+ALTER TABLE ff_exec_core
+    ADD COLUMN IF NOT EXISTS started_at_ms BIGINT;
+
+-- Section 2 — Backfill from existing `ff_attempt.started_at_ms`.
+-- Uses the earliest attempt with a non-NULL started_at_ms (matches
+-- the pre-0016 LATERAL-join selection: `ORDER BY attempt_index ASC
+-- LIMIT 1` over rows where `started_at_ms IS NOT NULL`). Rows whose
+-- executions never reached claim (pure submit / cancel-before-claim)
+-- leave `started_at_ms` NULL, which the read path already tolerates
+-- (`first_started_at_ms_opt.map(...)` → `Option<String>`).
+UPDATE ff_exec_core ec
+   SET started_at_ms = sub.first_started_at_ms
+  FROM (
+    SELECT a.partition_key,
+           a.execution_id,
+           MIN(a.started_at_ms) AS first_started_at_ms
+      FROM ff_attempt a
+     WHERE a.started_at_ms IS NOT NULL
+     GROUP BY a.partition_key, a.execution_id
+  ) sub
+ WHERE ec.partition_key = sub.partition_key
+   AND ec.execution_id  = sub.execution_id
+   AND ec.started_at_ms IS NULL;
+
+-- Section 3 — Migration annotation.
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    16,
+    '0016_started_at_ms',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/src/attempt.rs
+++ b/crates/ff-backend-postgres/src/attempt.rs
@@ -232,19 +232,24 @@ async fn try_claim_in_partition(
     .map_err(map_sqlx_error)?;
     let epoch_i: i64 = epoch_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
 
-    // Flip exec_core to active.
+    // Flip exec_core to active. #356: `started_at_ms` is set-once —
+    // `COALESCE(started_at_ms, $3)` preserves the original first-claim
+    // timestamp across reclaim + retry attempts, matching Valkey's
+    // dedicated set-once `exec_core["started_at"]` field.
     sqlx::query(
         r#"
         UPDATE ff_exec_core
            SET lifecycle_phase = 'active',
                ownership_state = 'leased',
                eligibility_state = 'not_applicable',
-               attempt_state = 'running_attempt'
+               attempt_state = 'running_attempt',
+               started_at_ms = COALESCE(started_at_ms, $3)
          WHERE partition_key = $1 AND execution_id = $2
         "#,
     )
     .bind(part)
     .bind(exec_uuid)
+    .bind(now)
     .execute(&mut *tx)
     .await
     .map_err(map_sqlx_error)?;

--- a/crates/ff-backend-postgres/src/attempt.rs
+++ b/crates/ff-backend-postgres/src/attempt.rs
@@ -236,12 +236,19 @@ async fn try_claim_in_partition(
     // `COALESCE(started_at_ms, $3)` preserves the original first-claim
     // timestamp across reclaim + retry attempts, matching Valkey's
     // dedicated set-once `exec_core["started_at"]` field.
+    //
+    // `public_state = 'running'` mirrors the resume-claim write in
+    // `suspend_ops.rs` and the SQLite first-claim write in
+    // `ff-backend-sqlite/src/queries/exec_core.rs`. Without this field
+    // the row stayed at its create-time `'waiting'` literal on PG
+    // while Spine-B readers expected the claimed-execution literal.
     sqlx::query(
         r#"
         UPDATE ff_exec_core
            SET lifecycle_phase = 'active',
                ownership_state = 'leased',
                eligibility_state = 'not_applicable',
+               public_state = 'running',
                attempt_state = 'running_attempt',
                started_at_ms = COALESCE(started_at_ms, $3)
          WHERE partition_key = $1 AND execution_id = $2

--- a/crates/ff-backend-postgres/src/exec_core.rs
+++ b/crates/ff-backend-postgres/src/exec_core.rs
@@ -442,6 +442,27 @@ pub(super) async fn cancel_impl(
     .await
     .map_err(map_sqlx_error)?;
 
+    // #355: clear the current attempt's `outcome` so a later
+    // `read_execution_info` doesn't surface a stale
+    // `retry`/`interrupted` terminal-outcome on a cancelled row.
+    // Mirrors the equivalent clear on the `cancel_flow` member loop
+    // (`flow.rs`).
+    sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET outcome = NULL
+         WHERE partition_key = $1
+           AND execution_id  = $2
+           AND attempt_index = (SELECT attempt_index FROM ff_exec_core
+                                 WHERE partition_key = $1 AND execution_id = $2)
+        "#,
+    )
+    .bind(partition_key)
+    .bind(eid_uuid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
     tx.commit().await.map_err(map_sqlx_error)?;
     Ok(())
 }
@@ -507,10 +528,14 @@ pub(super) async fn resolve_execution_flow_id_impl(
 // produce Postgres-specific literals that are **not** members of the
 // public enums:
 //
-//   * `flow.rs:672-687` (cancel-member loop) writes `cancelled` to all
-//     five columns on flow-cancel.
+//   * `flow.rs:672-687` (cancel-member loop) writes `cancelled` to
+//     `lifecycle_phase`, `eligibility_state`, and `public_state` on
+//     flow-cancel.
 //   * `operator.rs:211-235` (`cancel_execution`) likewise writes
 //     `cancelled`.
+//   * `exec_core::cancel_impl` writes `cancelled` to `public_state` +
+//     `attempt_state` and the sentinel `terminal` to `lifecycle_phase`
+//     (the Handle-level single-exec cancel path).
 //   * `suspend_ops.rs:958` (resume-claim) writes bare `running` to
 //     `public_state` (canonical form is `active`).
 //   * `suspend_ops.rs:585` writes `released` to `ownership_state`
@@ -764,7 +789,7 @@ pub(super) async fn read_execution_info_impl(
     let raw_fields: JsonValue = row.try_get("raw_fields").map_err(map_sqlx_error)?;
     let attempt_outcome_opt: Option<String> =
         row.try_get("attempt_outcome").map_err(map_sqlx_error)?;
-    let first_started_at_ms_opt: Option<i64> =
+    let started_at_ms_opt: Option<i64> =
         row.try_get("started_at_ms").map_err(map_sqlx_error)?;
 
     let lifecycle_phase: LifecyclePhase = json_enum!(
@@ -846,7 +871,7 @@ pub(super) async fn read_execution_info_impl(
         state_vector,
         public_state,
         created_at: created_at_ms.to_string(),
-        started_at: first_started_at_ms_opt.map(|v| v.to_string()),
+        started_at: started_at_ms_opt.map(|v| v.to_string()),
         completed_at: terminal_at_ms_opt.map(|v| v.to_string()),
         current_attempt_index: attempt_index.max(0) as u32,
         flow_id,

--- a/crates/ff-backend-postgres/src/exec_core.rs
+++ b/crates/ff-backend-postgres/src/exec_core.rs
@@ -490,19 +490,59 @@ pub(super) async fn resolve_execution_flow_id_impl(
 //
 // All three reads project from the `ff_exec_core` row for the target
 // `(partition_key, execution_id)`; `read_execution_info` additionally
-// LATERAL-joins `ff_attempt` for the current-attempt row (outcome +
-// started_at). READ COMMITTED is sufficient — all three are
-// single-query, read-only, no CAS. Per RFC §4.1 + §7.8,
-// `get_execution_result` is current-attempt semantics (matches Valkey's
-// `GET ctx.result()` primitive; `result` column on `ff_exec_core`).
+// LATERAL-joins `ff_attempt` for the current-attempt row (outcome).
+// READ COMMITTED is sufficient — all three are single-query, read-only,
+// no CAS. Per RFC §4.1 + §7.8, `get_execution_result` is
+// current-attempt semantics (matches Valkey's `GET ctx.result()`
+// primitive; `result` column on `ff_exec_core`).
 //
-// Postgres storage strings for the 6 state-vector dimensions are a
-// superset of the in-core enum literals (`cancelled`, `blocked`,
-// `eligible`, `pending`, `released`, `running`, `pending_claim`, …).
-// These Postgres-specific literals are collapsed to the closest
-// user-facing enum variant by the normalisation helpers below before
-// JSON-deserialising; unknown tokens surface as `Corruption` errors
-// rather than silently defaulting.
+// ── Column-literal alphabet: the read-boundary adapter (#354) ────
+//
+// The Postgres `ff_exec_core` state columns — `lifecycle_phase`,
+// `ownership_state`, `eligibility_state`, `public_state`,
+// `attempt_state` — encode `(phase × eligibility × terminal-outcome)`
+// in a **richer private alphabet** than the canonical `ff_core::state`
+// enums (`LifecyclePhase`, `OwnershipState`, `EligibilityState`,
+// `PublicState`, `AttemptState`). Write sites in this crate legitimately
+// produce Postgres-specific literals that are **not** members of the
+// public enums:
+//
+//   * `flow.rs:672-687` (cancel-member loop) writes `cancelled` to all
+//     five columns on flow-cancel.
+//   * `operator.rs:211-235` (`cancel_execution`) likewise writes
+//     `cancelled`.
+//   * `suspend_ops.rs:958` (resume-claim) writes bare `running` to
+//     `public_state` (canonical form is `active`).
+//   * `suspend_ops.rs:585` writes `released` to `ownership_state`
+//     (canonical form is `unowned`).
+//   * Scheduler-transitional paths write `pending_claim` to
+//     `eligibility_state` and `attempt_state`; legacy dispatch paths
+//     write `blocked` to `lifecycle_phase`.
+//
+// **This module is the documented read-boundary adapter** (Option B
+// per owner decision on #354 / RFC-020 §4.1 Revision 8). The
+// `normalise_*` helpers below collapse each column literal to the
+// closest public-enum variant before `json_enum!` deserialises the
+// string into the enum type; unknown tokens fall through the match arm
+// unchanged and `json_enum!` surfaces them as
+// `ValidationKind::Corruption` rather than silently defaulting.
+//
+// **Invariant for new code:**
+//
+//   * New read paths against these columns MUST call through the
+//     `normalise_*` helpers before constructing a public enum.
+//   * New write paths MAY introduce new column literals (the column is
+//     the authoritative audit trail of which backend phase produced the
+//     row), but MUST update the corresponding `normalise_*` arm in the
+//     same PR so the read path stays total.
+//   * Option A — migrating write paths to canonical literals only —
+//     was considered and rejected (RFC-020 §4.1 Revision 8): it would
+//     relocate the `(phase × eligibility × terminal-outcome)` encoding
+//     from SQL columns into per-write computation without reducing
+//     mapping-layer complexity, and would lose the column-level
+//     distinction between e.g. `cancelled` (terminal-by-cancel) and
+//     `terminal` (terminal-by-success/fail/expire/skip) that the
+//     `derive_terminal_outcome` helper below depends on.
 
 // Normalisation maps: `ff_exec_core` literal → closest
 // serde-snake_case enum variant. Each arm is grounded in an actual
@@ -660,11 +700,12 @@ pub(super) async fn read_execution_info_impl(
     let partition_key: i16 = id.partition() as i16;
     let execution_id = eid_uuid(id);
 
-    // LATERAL joins: `cur` pins to the current attempt (for
-    // `outcome` — drives `TerminalOutcome`); `first` pins to the
-    // earliest attempt row on the execution (attempt_index ASC — drives
-    // `started_at`, which per `ExecutionInfo` contract is the
-    // first-claim timestamp preserved across retries — Valkey parity).
+    // LATERAL join: `cur` pins to the current attempt (for
+    // `outcome` — drives `TerminalOutcome`). Since migration 0016
+    // (#356) `ff_exec_core.started_at_ms` is a set-once column
+    // populated on first claim, so the `ExecutionInfo.started_at`
+    // field reads directly from the base row — the second LATERAL
+    // join on `ff_attempt.started_at_ms` (earliest non-NULL) is gone.
     let row = sqlx::query(
         r#"
         SELECT ec.flow_id,
@@ -679,9 +720,9 @@ pub(super) async fn read_execution_info_impl(
                ec.attempt_index,
                ec.created_at_ms,
                ec.terminal_at_ms,
+               ec.started_at_ms,
                ec.raw_fields,
-               cur.outcome       AS attempt_outcome,
-               first_att.started_at_ms AS first_started_at_ms
+               cur.outcome       AS attempt_outcome
         FROM ff_exec_core ec
         LEFT JOIN LATERAL (
             SELECT outcome
@@ -690,15 +731,6 @@ pub(super) async fn read_execution_info_impl(
               AND execution_id  = ec.execution_id
               AND attempt_index = ec.attempt_index
         ) cur ON TRUE
-        LEFT JOIN LATERAL (
-            SELECT started_at_ms
-            FROM ff_attempt
-            WHERE partition_key = ec.partition_key
-              AND execution_id  = ec.execution_id
-              AND started_at_ms IS NOT NULL
-            ORDER BY attempt_index ASC
-            LIMIT 1
-        ) first_att ON TRUE
         WHERE ec.partition_key = $1 AND ec.execution_id = $2
         "#,
     )
@@ -733,7 +765,7 @@ pub(super) async fn read_execution_info_impl(
     let attempt_outcome_opt: Option<String> =
         row.try_get("attempt_outcome").map_err(map_sqlx_error)?;
     let first_started_at_ms_opt: Option<i64> =
-        row.try_get("first_started_at_ms").map_err(map_sqlx_error)?;
+        row.try_get("started_at_ms").map_err(map_sqlx_error)?;
 
     let lifecycle_phase: LifecyclePhase = json_enum!(
         LifecyclePhase,

--- a/crates/ff-backend-postgres/src/flow.rs
+++ b/crates/ff-backend-postgres/src/flow.rs
@@ -686,6 +686,26 @@ async fn cancel_flow_once(
         .await
         .map_err(map_sqlx_error)?;
 
+        // #355: clear the current attempt's `outcome` so a later
+        // `read_execution_info` doesn't surface a stale
+        // `retry`/`interrupted` terminal-outcome on the cancelled row.
+        // Mirror of the SQLite companion statement in
+        // `ff-backend-sqlite/src/queries/flow.rs`
+        // (`UPDATE_ATTEMPT_CLEAR_OUTCOME_FOR_CURRENT_SQL`).
+        sqlx::query(
+            "UPDATE ff_attempt \
+                SET outcome = NULL \
+              WHERE partition_key = $1 \
+                AND execution_id  = $2 \
+                AND attempt_index = (SELECT attempt_index FROM ff_exec_core \
+                                      WHERE partition_key = $1 AND execution_id = $2)",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
         // Emit a completion outbox row (trigger fires NOTIFY).
         sqlx::query(
             "INSERT INTO ff_completion_event \

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -953,15 +953,23 @@ pub(crate) async fn claim_resumed_execution_impl(
     .await
     .map_err(map_sqlx_error)?;
 
+    // #356: started_at_ms is set-once on ff_exec_core; the resume-claim
+    // path preserves the original first-claim timestamp via COALESCE.
+    // On a suspended exec that was resumed before 0016 backfill, the
+    // column may be NULL here — we seed it with `now` as a defensible
+    // fallback (post-suspension resume is as close to "first observable
+    // claim" as the column can get in that edge case).
     sqlx::query(
         "UPDATE ff_exec_core \
             SET lifecycle_phase = 'active', ownership_state = 'leased', \
                 eligibility_state = 'not_applicable', \
-                public_state = 'running', attempt_state = 'running_attempt' \
+                public_state = 'running', attempt_state = 'running_attempt', \
+                started_at_ms = COALESCE(started_at_ms, $3) \
           WHERE partition_key = $1 AND execution_id = $2",
     )
     .bind(part)
     .bind(exec_uuid)
+    .bind(now)
     .execute(&mut *tx)
     .await
     .map_err(map_sqlx_error)?;

--- a/crates/ff-backend-postgres/tests/spine_b_reads.rs
+++ b/crates/ff-backend-postgres/tests/spine_b_reads.rs
@@ -99,13 +99,55 @@ async fn insert_exec_core(
     result_payload: Option<Vec<u8>>,
     raw_fields: serde_json::Value,
 ) {
+    insert_exec_core_with_started(
+        pool,
+        part,
+        exec_uuid,
+        lane_id,
+        lifecycle_phase,
+        ownership_state,
+        eligibility_state,
+        public_state,
+        attempt_state,
+        attempt_index,
+        now_ms,
+        terminal_at_ms,
+        result_payload,
+        raw_fields,
+        None,
+    )
+    .await;
+}
+
+/// Variant that seeds `ff_exec_core.started_at_ms` (#356). The existing
+/// `insert_exec_core` wraps this with `started_at_ms = None` for
+/// pre-0016 test semantics.
+#[allow(clippy::too_many_arguments)]
+async fn insert_exec_core_with_started(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    lane_id: &str,
+    lifecycle_phase: &str,
+    ownership_state: &str,
+    eligibility_state: &str,
+    public_state: &str,
+    attempt_state: &str,
+    attempt_index: i32,
+    now_ms: i64,
+    terminal_at_ms: Option<i64>,
+    result_payload: Option<Vec<u8>>,
+    raw_fields: serde_json::Value,
+    started_at_ms: Option<i64>,
+) {
     sqlx::query(
         "INSERT INTO ff_exec_core \
            (partition_key, execution_id, lane_id, attempt_index, \
             lifecycle_phase, ownership_state, eligibility_state, \
             public_state, attempt_state, \
-            priority, created_at_ms, terminal_at_ms, result, raw_fields) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, $10, $11, $12, $13)",
+            priority, created_at_ms, terminal_at_ms, started_at_ms, \
+            result, raw_fields) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, $10, $11, $12, $13, $14)",
     )
     .bind(part)
     .bind(exec_uuid)
@@ -118,6 +160,7 @@ async fn insert_exec_core(
     .bind(attempt_state)
     .bind(now_ms)
     .bind(terminal_at_ms)
+    .bind(started_at_ms)
     .bind(result_payload)
     .bind(raw_fields)
     .execute(pool)
@@ -210,19 +253,19 @@ async fn read_execution_info_missing_returns_none() {
 #[tokio::test]
 #[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
 async fn read_execution_info_lateral_joins_both_attempts() {
-    // Two LATERAL joins in `read_execution_info`:
-    //   * current-attempt (attempt_index = ec.attempt_index) drives
-    //     `outcome` → `TerminalOutcome`;
-    //   * first-attempt (earliest started_at_ms) drives
-    //     `ExecutionInfo.started_at` (first-claim timestamp, preserved
-    //     across retries — Valkey-parity contract).
+    // Since migration 0016 (#356) `started_at` is read directly from
+    // `ff_exec_core.started_at_ms`; the `outcome` LATERAL still pins
+    // to the current attempt.
     //
-    // Seed two attempts:
+    // Seed two attempts + set `ff_exec_core.started_at_ms = first_start`
+    // (the value the set-once claim-path would have written at
+    // first-claim):
     //   * attempt 0 started at `first_start` (old first-claim);
     //   * attempt 1 started at `later_start` (current attempt);
     // then bump `ec.attempt_index = 1`.
     // The read must surface
-    //   * `started_at = first_start` (NOT later_start)
+    //   * `started_at = first_start` (NOT later_start — the set-once
+    //     semantics mean a retry attempt never overwrites the column)
     //   * `outcome`-derived state from attempt_index=1 (NULL → None)
     let Some(fx) = seed_backend().await else {
         return;
@@ -230,7 +273,7 @@ async fn read_execution_info_lateral_joins_both_attempts() {
     let now = TimestampMs::now().0;
     let first_start = now - 10_000;
     let later_start = now - 100;
-    insert_exec_core(
+    insert_exec_core_with_started(
         &fx.pool,
         fx.part,
         fx.exec_uuid,
@@ -249,9 +292,10 @@ async fn read_execution_info_lateral_joins_both_attempts() {
             "execution_kind": "task",
             "blocking_detail": "",
         }),
+        Some(first_start),
     )
     .await;
-    // Attempt 0: first-claim row; drives `started_at`.
+    // Attempt 0: first-claim row.
     insert_attempt(&fx.pool, fx.part, fx.exec_uuid, 0, Some("failed"), Some(first_start))
         .await;
     // Attempt 1: current attempt; drives `outcome` (no terminal outcome yet).

--- a/crates/ff-backend-postgres/tests/wave9_followups.rs
+++ b/crates/ff-backend-postgres/tests/wave9_followups.rs
@@ -293,3 +293,70 @@ async fn first_claim_populates_started_at_ms_set_once() {
         "set-once: reclaim/retry must not overwrite started_at_ms (#356)"
     );
 }
+
+async fn read_exec_public_state(pool: &PgPool, part: i16, exec_uuid: Uuid) -> String {
+    sqlx::query(
+        "SELECT public_state FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("read public_state")
+    .try_get::<String, _>("public_state")
+    .expect("public_state column")
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn first_claim_writes_public_state_running() {
+    // PG parity with SQLite (PR #392) + PG resume-claim path
+    // (`suspend_ops.rs`): first-claim must flip `public_state` from
+    // the create-time `'waiting'` literal to `'running'`.
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+
+    let lane = LaneId::new(format!("wave9-followup-pubstate-{}", Uuid::new_v4()).as_str());
+    let eid = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let (part, exec_uuid) = split_exec(&eid);
+    let now = TimestampMs::now().0;
+
+    insert_exec_core(
+        &pool,
+        part,
+        exec_uuid,
+        None,
+        lane.as_str(),
+        "runnable",
+        "waiting",
+        0,
+        now,
+    )
+    .await;
+
+    assert_eq!(
+        read_exec_public_state(&pool, part, exec_uuid).await,
+        "waiting",
+        "pre-condition: seeded as waiting"
+    );
+
+    let _h = backend
+        .claim(
+            &lane,
+            &CapabilitySet::default(),
+            claim_policy_for("w-pubstate", 60_000),
+        )
+        .await
+        .expect("first claim ok")
+        .expect("first claim Some");
+
+    assert_eq!(
+        read_exec_public_state(&pool, part, exec_uuid).await,
+        "running",
+        "first-claim must flip ff_exec_core.public_state to 'running' for Spine-B parity"
+    );
+}

--- a/crates/ff-backend-postgres/tests/wave9_followups.rs
+++ b/crates/ff-backend-postgres/tests/wave9_followups.rs
@@ -1,0 +1,295 @@
+//! RFC-020 Wave 9 follow-ups (#354, #355, #356) — regression coverage.
+//!
+//! * #354 is doc-only (RFC-020 §4.1 + exec_core.rs module comment).
+//! * #355 — `ff_attempt.outcome` must be cleared on `cancel_flow` member
+//!   loop.
+//! * #356 — `ff_exec_core.started_at_ms` is set-once on first claim.
+//!   Reclaim + retry must not overwrite.
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::backend::{CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy};
+use ff_core::contracts::CancelFlowResult;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::{flow_partition, PartitionConfig};
+use ff_core::types::{ExecutionId, FlowId, LaneId, TimestampMs, WorkerId, WorkerInstanceId};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let bootstrap = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&bootstrap)
+        .await
+        .expect("apply_migrations clean");
+    bootstrap.close().await;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect pool");
+    Some(pool)
+}
+
+fn split_exec(eid: &ExecutionId) -> (i16, Uuid) {
+    let (_, u) = eid.as_str().split_once("}:").unwrap();
+    (eid.partition() as i16, Uuid::parse_str(u).unwrap())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_exec_core(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    flow_id: Option<Uuid>,
+    lane_id: &str,
+    lifecycle_phase: &str,
+    public_state: &str,
+    attempt_index: i32,
+    now: i64,
+) {
+    sqlx::query(
+        "INSERT INTO ff_exec_core \
+           (partition_key, execution_id, flow_id, lane_id, attempt_index, \
+            lifecycle_phase, ownership_state, eligibility_state, \
+            public_state, attempt_state, \
+            priority, created_at_ms, raw_fields) \
+         VALUES ($1, $2, $3, $4, $5, $6, 'unowned', 'eligible_now', \
+                 $7, 'running_attempt', 0, $8, '{}'::jsonb)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(flow_id)
+    .bind(lane_id)
+    .bind(attempt_index)
+    .bind(lifecycle_phase)
+    .bind(public_state)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("insert ff_exec_core");
+}
+
+async fn insert_attempt_with_outcome(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    attempt_index: i32,
+    outcome: Option<&str>,
+) {
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, lease_epoch, outcome) \
+         VALUES ($1, $2, $3, 1, $4)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .bind(outcome)
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+}
+
+async fn read_attempt_outcome(
+    pool: &PgPool,
+    part: i16,
+    exec_uuid: Uuid,
+    attempt_index: i32,
+) -> Option<String> {
+    let row = sqlx::query(
+        "SELECT outcome FROM ff_attempt \
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_one(pool)
+    .await
+    .expect("select outcome");
+    row.try_get::<Option<String>, _>("outcome").expect("outcome")
+}
+
+async fn read_exec_started_at(pool: &PgPool, part: i16, exec_uuid: Uuid) -> Option<i64> {
+    let row = sqlx::query(
+        "SELECT started_at_ms FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("select started_at_ms");
+    row.try_get::<Option<i64>, _>("started_at_ms").expect("col")
+}
+
+fn claim_policy_for(worker: &str, ttl_ms: u32) -> ClaimPolicy {
+    ClaimPolicy::new(
+        WorkerId::new(worker),
+        WorkerInstanceId::new(format!("{worker}-1")),
+        ttl_ms,
+        Some(Duration::from_millis(100)),
+    )
+}
+
+// ── #355 — cancel_flow clears member attempt outcome ─────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn cancel_flow_clears_member_attempt_outcome() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+
+    // Seed a flow + member execution. `flow_partition` and
+    // `ExecutionId::solo` hash independently; the cancel_flow member
+    // scan is partition-local against the flow's partition, so seed
+    // the member onto the flow's partition_key directly.
+    let flow_id = FlowId::new();
+    let flow_uuid = flow_id.0;
+    let part = flow_partition(&flow_id, &PartitionConfig::default()).index as i16;
+    let now = TimestampMs::now().0;
+
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+           (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms) \
+         VALUES ($1, $2, 0, 'open', $3)",
+    )
+    .bind(part)
+    .bind(flow_uuid)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert ff_flow_core");
+
+    // Mint a fresh UUID for the member, co-partitioned with the flow.
+    let m_uuid = Uuid::new_v4();
+    insert_exec_core(
+        &pool,
+        part,
+        m_uuid,
+        Some(flow_uuid),
+        "default",
+        "runnable",
+        "waiting",
+        0,
+        now,
+    )
+    .await;
+    insert_attempt_with_outcome(&pool, part, m_uuid, 0, Some("retry")).await;
+
+    // Pre: stale outcome observable.
+    assert_eq!(
+        read_attempt_outcome(&pool, part, m_uuid, 0).await.as_deref(),
+        Some("retry"),
+        "pre-cancel: stale retry outcome seeded"
+    );
+
+    let r = backend
+        .cancel_flow(&flow_id, CancelFlowPolicy::CancelAll, CancelFlowWait::NoWait)
+        .await
+        .expect("cancel_flow ok");
+    assert!(
+        matches!(r, CancelFlowResult::Cancelled { .. }),
+        "got {r:?}"
+    );
+
+    // Post: outcome nulled (#355).
+    assert_eq!(
+        read_attempt_outcome(&pool, part, m_uuid, 0).await,
+        None,
+        "post-cancel: attempt.outcome must be NULL (#355 regression)"
+    );
+}
+
+// ── #356 — started_at_ms set-once on ff_exec_core ───────────────────
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn first_claim_populates_started_at_ms_set_once() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+
+    let lane = LaneId::new(format!("wave9-followup-356-{}", Uuid::new_v4()).as_str());
+    let eid = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let (part, exec_uuid) = split_exec(&eid);
+    let now = TimestampMs::now().0;
+
+    insert_exec_core(
+        &pool,
+        part,
+        exec_uuid,
+        None,
+        lane.as_str(),
+        "runnable",
+        "waiting",
+        0,
+        now,
+    )
+    .await;
+
+    // Pre: column NULL.
+    assert_eq!(read_exec_started_at(&pool, part, exec_uuid).await, None);
+
+    let _h1 = backend
+        .claim(
+            &lane,
+            &CapabilitySet::default(),
+            claim_policy_for("w356", 60_000),
+        )
+        .await
+        .expect("first claim ok")
+        .expect("first claim Some");
+
+    let first_val = read_exec_started_at(&pool, part, exec_uuid).await;
+    assert!(
+        first_val.is_some(),
+        "first claim must populate ff_exec_core.started_at_ms"
+    );
+    let first_ts = first_val.unwrap();
+
+    // Force exec back to runnable/eligible + bump attempt_index so the
+    // scanner reselects it. Second claim must NOT overwrite started_at_ms.
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', ownership_state='unowned', \
+            eligibility_state='eligible_now', attempt_index = attempt_index + 1 \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .expect("reset to runnable for retry-claim");
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    let _h2 = backend
+        .claim(
+            &lane,
+            &CapabilitySet::default(),
+            claim_policy_for("w356", 60_000),
+        )
+        .await
+        .expect("second claim ok")
+        .expect("second claim Some");
+
+    let second_val = read_exec_started_at(&pool, part, exec_uuid)
+        .await
+        .expect("second claim leaves column populated");
+    assert_eq!(
+        second_val, first_ts,
+        "set-once: reclaim/retry must not overwrite started_at_ms (#356)"
+    );
+}

--- a/crates/ff-backend-sqlite/migrations/0016_started_at_ms.sql
+++ b/crates/ff-backend-sqlite/migrations/0016_started_at_ms.sql
@@ -1,0 +1,34 @@
+-- RFC-023 SQLite port of
+-- `crates/ff-backend-postgres/migrations/0016_started_at_ms.sql`
+-- (RFC-020 Wave 9 follow-up #356).
+--
+-- Adds `ff_exec_core.started_at_ms INTEGER` as a set-once column
+-- populated on first claim; backfills from
+-- `ff_attempt.started_at_ms` so the Spine-B read path can drop the
+-- correlated-subquery LATERAL-equivalent.
+--
+-- Additive.
+
+ALTER TABLE ff_exec_core
+    ADD COLUMN started_at_ms INTEGER;
+
+-- Backfill. `MIN(started_at_ms)` over non-NULL attempts per execution
+-- matches the pre-0016 read path's `ORDER BY attempt_index ASC
+-- LIMIT 1` over `started_at_ms IS NOT NULL`.
+UPDATE ff_exec_core
+   SET started_at_ms = (
+        SELECT MIN(a.started_at_ms)
+          FROM ff_attempt a
+         WHERE a.partition_key = ff_exec_core.partition_key
+           AND a.execution_id  = ff_exec_core.execution_id
+           AND a.started_at_ms IS NOT NULL
+   )
+ WHERE started_at_ms IS NULL;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    16,
+    '0016_started_at_ms',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/migrations/0016_started_at_ms.sql
+++ b/crates/ff-backend-sqlite/migrations/0016_started_at_ms.sql
@@ -12,18 +12,31 @@
 ALTER TABLE ff_exec_core
     ADD COLUMN started_at_ms INTEGER;
 
--- Backfill. `MIN(started_at_ms)` over non-NULL attempts per execution
--- matches the pre-0016 read path's `ORDER BY attempt_index ASC
--- LIMIT 1` over `started_at_ms IS NOT NULL`.
+-- Backfill using the same semantics as the pre-0016 read path:
+-- pick `started_at_ms` from the earliest attempt row by
+-- `attempt_index ASC` with a non-NULL `started_at_ms`. MIN over the
+-- timestamp would drift if values are ever non-monotonic; ordering on
+-- `attempt_index` preserves the exact prior behaviour. The EXISTS
+-- guard skips exec rows without any matching attempt so the UPDATE
+-- doesn't touch (and re-NULL) submit-but-never-claimed rows on large
+-- tables.
 UPDATE ff_exec_core
    SET started_at_ms = (
-        SELECT MIN(a.started_at_ms)
+        SELECT a.started_at_ms
           FROM ff_attempt a
          WHERE a.partition_key = ff_exec_core.partition_key
            AND a.execution_id  = ff_exec_core.execution_id
            AND a.started_at_ms IS NOT NULL
+         ORDER BY a.attempt_index ASC
+         LIMIT 1
    )
- WHERE started_at_ms IS NULL;
+ WHERE started_at_ms IS NULL
+   AND EXISTS (
+        SELECT 1 FROM ff_attempt a
+         WHERE a.partition_key = ff_exec_core.partition_key
+           AND a.execution_id  = ff_exec_core.execution_id
+           AND a.started_at_ms IS NOT NULL
+   );
 
 INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
 VALUES (

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -414,9 +414,14 @@ async fn claim_inner(
         .map_err(map_sqlx_error)?;
     let epoch_i: i64 = epoch_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
 
+    // #356: `started_at_ms` is set-once on ff_exec_core (migration
+    // 0016); COALESCE preserves the first-claim timestamp across
+    // reclaim + retry attempts, matching Valkey's dedicated
+    // `exec_core["started_at"]` semantics.
     sqlx::query(q_exec::UPDATE_EXEC_CORE_CLAIM_SQL)
         .bind(part)
         .bind(exec_uuid)
+        .bind(now)
         .execute(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
@@ -2139,6 +2144,17 @@ async fn cancel_flow_impl(
                 .bind(part)
                 .bind(exec_uuid)
                 .bind(now_ms)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+            // #355: clear the current attempt's `outcome` so a later
+            // `read_execution_info` doesn't surface a stale
+            // terminal-outcome on a cancelled row. PG parallel in
+            // `ff-backend-postgres/src/flow.rs` cancel-member loop.
+            sqlx::query(q_flow::UPDATE_ATTEMPT_CLEAR_OUTCOME_FOR_CURRENT_SQL)
+                .bind(part)
+                .bind(exec_uuid)
                 .execute(&mut *conn)
                 .await
                 .map_err(map_sqlx_error)?;

--- a/crates/ff-backend-sqlite/src/queries/exec_core.rs
+++ b/crates/ff-backend-sqlite/src/queries/exec_core.rs
@@ -23,7 +23,8 @@ pub(crate) const UPDATE_EXEC_CORE_CLAIM_SQL: &str = r#"
            ownership_state = 'leased',
            eligibility_state = 'not_applicable',
            public_state = 'running',
-           attempt_state = 'running_attempt'
+           attempt_state = 'running_attempt',
+           started_at_ms = COALESCE(started_at_ms, ?3)
      WHERE partition_key = ?1 AND execution_id = ?2
 "#;
 

--- a/crates/ff-backend-sqlite/src/queries/flow.rs
+++ b/crates/ff-backend-sqlite/src/queries/flow.rs
@@ -106,6 +106,24 @@ pub(crate) const UPDATE_EXEC_CORE_CANCEL_MEMBER_SQL: &str = r#"
      WHERE partition_key = ?1 AND execution_id = ?2
 "#;
 
+/// Clear the current attempt's `outcome` on cancel-member so a later
+/// `read_execution_info` doesn't surface a stale `retry`/`interrupted`
+/// terminal-outcome on a cancelled row (#355). Mirror of the PG
+/// companion statement added on the cancel-member loop in
+/// `ff-backend-postgres/src/flow.rs`.
+///
+/// Binds:
+///   1. partition_key (i64)
+///   2. execution_id (Uuid)
+pub(crate) const UPDATE_ATTEMPT_CLEAR_OUTCOME_FOR_CURRENT_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET outcome = NULL
+     WHERE partition_key = ?1
+       AND execution_id  = ?2
+       AND attempt_index = (SELECT attempt_index FROM ff_exec_core
+                             WHERE partition_key = ?1 AND execution_id = ?2)
+"#;
+
 /// RFC-016 Stage C bookkeeping: enqueue a pending-cancel row for
 /// every edge_group with `running_count > 0` on the cancelled flow
 /// (the Wave-5 dispatcher reads this).

--- a/crates/ff-backend-sqlite/src/queries/reads.rs
+++ b/crates/ff-backend-sqlite/src/queries/reads.rs
@@ -23,9 +23,12 @@ pub(crate) const SELECT_PUBLIC_STATE_SQL: &str = r#"
 // ── read_execution_info (§4.1) ─────────────────────────────────────
 
 /// Multi-column projection of `ff_exec_core` joined with the current
-/// attempt row (for `outcome`) + the earliest started attempt row
-/// (for `started_at`). Mirrors PG's LATERAL joins with SQLite
-/// correlated subqueries in the SELECT list.
+/// attempt row (for `outcome`). Mirrors PG's single remaining LATERAL
+/// join with a SQLite correlated subquery in the SELECT list. Since
+/// migration 0016 (#356) `ff_exec_core.started_at_ms` is a set-once
+/// column populated on first claim, so the earlier "earliest attempt
+/// started_at_ms" subquery is gone — `ExecutionInfo.started_at` reads
+/// directly from the base row.
 ///
 /// Binds: ?1 partition_key, ?2 execution_id BLOB.
 pub(crate) const SELECT_EXECUTION_INFO_SQL: &str = r#"
@@ -41,19 +44,13 @@ pub(crate) const SELECT_EXECUTION_INFO_SQL: &str = r#"
            ec.attempt_index,
            ec.created_at_ms,
            ec.terminal_at_ms,
+           ec.started_at_ms,
            ec.raw_fields,
            (SELECT outcome
               FROM ff_attempt a
              WHERE a.partition_key = ec.partition_key
                AND a.execution_id  = ec.execution_id
-               AND a.attempt_index = ec.attempt_index) AS attempt_outcome,
-           (SELECT started_at_ms
-              FROM ff_attempt a
-             WHERE a.partition_key = ec.partition_key
-               AND a.execution_id  = ec.execution_id
-               AND a.started_at_ms IS NOT NULL
-             ORDER BY a.attempt_index ASC
-             LIMIT 1) AS first_started_at_ms
+               AND a.attempt_index = ec.attempt_index) AS attempt_outcome
       FROM ff_exec_core ec
      WHERE ec.partition_key = ?1 AND ec.execution_id = ?2
 "#;

--- a/crates/ff-backend-sqlite/src/queries/suspend.rs
+++ b/crates/ff-backend-sqlite/src/queries/suspend.rs
@@ -69,10 +69,17 @@ pub const UPDATE_EXEC_CORE_RESUMABLE_SQL: &str = "UPDATE ff_exec_core \
          eligibility_state = 'eligible_now' \
      WHERE partition_key = ?1 AND execution_id = ?2";
 
+// #356: `started_at_ms` is set-once on ff_exec_core via migration
+// 0016; the resume-claim path preserves the original first-claim
+// timestamp via COALESCE (seeds `?3 = now` as a defensible fallback
+// for any pre-0016-backfill exec that resumes before a first-claim
+// column-write — structurally the same as the PG sibling in
+// `ff-backend-postgres/src/suspend_ops.rs`).
 pub const UPDATE_EXEC_CORE_RUNNING_SQL: &str = "UPDATE ff_exec_core \
      SET lifecycle_phase = 'active', ownership_state = 'leased', \
          eligibility_state = 'not_applicable', \
-         public_state = 'running', attempt_state = 'running_attempt' \
+         public_state = 'running', attempt_state = 'running_attempt', \
+         started_at_ms = COALESCE(started_at_ms, ?3) \
      WHERE partition_key = ?1 AND execution_id = ?2";
 
 pub const SELECT_EXEC_STATE_FOR_RESUME_SQL: &str =

--- a/crates/ff-backend-sqlite/src/reads.rs
+++ b/crates/ff-backend-sqlite/src/reads.rs
@@ -187,7 +187,7 @@ pub(crate) async fn read_execution_info_impl(
     let raw_fields_str: String = row.try_get("raw_fields").map_err(map_sqlx_error)?;
     let attempt_outcome_opt: Option<String> =
         row.try_get("attempt_outcome").map_err(map_sqlx_error)?;
-    let first_started_at_ms_opt: Option<i64> =
+    let started_at_ms_opt: Option<i64> =
         row.try_get("started_at_ms").map_err(map_sqlx_error)?;
 
     let raw_fields: JsonValue =
@@ -290,7 +290,7 @@ pub(crate) async fn read_execution_info_impl(
         state_vector,
         public_state,
         created_at: created_at_ms.to_string(),
-        started_at: first_started_at_ms_opt.map(|v| v.to_string()),
+        started_at: started_at_ms_opt.map(|v| v.to_string()),
         completed_at: terminal_at_ms_opt.map(|v| v.to_string()),
         current_attempt_index: attempt_index_u32,
         flow_id,

--- a/crates/ff-backend-sqlite/src/reads.rs
+++ b/crates/ff-backend-sqlite/src/reads.rs
@@ -188,7 +188,7 @@ pub(crate) async fn read_execution_info_impl(
     let attempt_outcome_opt: Option<String> =
         row.try_get("attempt_outcome").map_err(map_sqlx_error)?;
     let first_started_at_ms_opt: Option<i64> =
-        row.try_get("first_started_at_ms").map_err(map_sqlx_error)?;
+        row.try_get("started_at_ms").map_err(map_sqlx_error)?;
 
     let raw_fields: JsonValue =
         serde_json::from_str(&raw_fields_str).map_err(|e| EngineError::Validation {

--- a/crates/ff-backend-sqlite/src/suspend_ops.rs
+++ b/crates/ff-backend-sqlite/src/suspend_ops.rs
@@ -1023,6 +1023,7 @@ pub(crate) async fn claim_resumed_execution_impl(
         sqlx::query(q_suspend::UPDATE_EXEC_CORE_RUNNING_SQL)
             .bind(part)
             .bind(exec_uuid)
+            .bind(now)
             .execute(&mut *conn)
             .await
             .map_err(map_sqlx_error)?;

--- a/crates/ff-backend-sqlite/tests/migrations.rs
+++ b/crates/ff-backend-sqlite/tests/migrations.rs
@@ -111,6 +111,9 @@ async fn migrations_apply_and_schema_is_present() {
 #[tokio::test]
 #[serial(ff_dev_mode)]
 async fn sqlx_migration_ledger_records_all_14() {
+    // Naming kept for git-diff continuity; the real count floats as
+    // new migrations land. Current set: 0001..=0014 + 0016 (RFC-020
+    // Wave 9 follow-up #356; 0015 reserved for RFC-024 claim-grant).
     let backend = fresh_backend().await;
     let pool = backend.pool_for_test();
 
@@ -119,7 +122,7 @@ async fn sqlx_migration_ledger_records_all_14() {
             .fetch_one(pool)
             .await
             .expect("query _sqlx_migrations");
-    assert_eq!(count, 14, "expected 14 successful migrations, got {count}");
+    assert_eq!(count, 15, "expected 15 successful migrations (0001..=0014 + 0016), got {count}");
 }
 
 #[tokio::test]
@@ -169,7 +172,9 @@ async fn ff_execution_capabilities_junction_schema() {
 #[serial(ff_dev_mode)]
 async fn migration_annotation_ledger_populated() {
     // Every migration INSERTs a row into `ff_migration_annotation`;
-    // verify all 14 versions landed.
+    // verify the expected set landed. 0015 is reserved for RFC-024
+    // (claim-grant table) and not yet shipped, so the current ledger
+    // is 0001..=0014 + 0016.
     let backend = fresh_backend().await;
     let pool = backend.pool_for_test();
 
@@ -179,5 +184,7 @@ async fn migration_annotation_ledger_populated() {
             .await
             .expect("query annotations");
     let versions: Vec<i64> = rows.into_iter().map(|(v,)| v).collect();
-    assert_eq!(versions, (1..=14).collect::<Vec<i64>>());
+    let mut expected: Vec<i64> = (1..=14).collect();
+    expected.push(16);
+    assert_eq!(versions, expected);
 }

--- a/crates/ff-backend-sqlite/tests/wave9_followups.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_followups.rs
@@ -1,0 +1,229 @@
+//! RFC-020 Wave 9 follow-ups (#355, #356) — SQLite regression coverage.
+//!
+//! PG parallels live in
+//! `crates/ff-backend-postgres/tests/wave9_followups.rs`. #354 is
+//! doc-only.
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy};
+use ff_core::contracts::{CancelFlowResult, CreateExecutionArgs};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::types::{
+    ExecutionId, FlowId, LaneId, Namespace, TimestampMs, WorkerId, WorkerInstanceId,
+};
+use serial_test::serial;
+use sqlx::Row;
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:rfc-023-wave9-followups-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("backend")
+}
+
+fn new_exec_id() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id")
+}
+
+fn uuid_of(eid: &ExecutionId) -> Uuid {
+    Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap()
+}
+
+async fn create_runnable(b: &Arc<SqliteBackend>, lane: &LaneId) -> ExecutionId {
+    let exec_id = new_exec_id();
+    let args = CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: lane.clone(),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    b.create_execution(args).await.expect("create");
+
+    // Force the row into claimable state (mirrors wave9_operator's helper).
+    let exec_uuid = uuid_of(&exec_id);
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', eligibility_state='eligible_now', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    exec_id
+}
+
+async fn read_started_at_ms(b: &Arc<SqliteBackend>, exec_uuid: Uuid) -> Option<i64> {
+    let row = sqlx::query(
+        "SELECT started_at_ms FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    row.try_get::<Option<i64>, _>("started_at_ms").unwrap()
+}
+
+// ── #356 — started_at_ms set-once ────────────────────────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn sqlite_first_claim_populates_started_at_ms_set_once() {
+    let b = fresh_backend().await;
+    let lane_id = LaneId::new(format!("wave9-355-{}", uuid_like()).as_str());
+    let exec_id = create_runnable(&b, &lane_id).await;
+    let exec_uuid = uuid_of(&exec_id);
+
+    // Pre: column is NULL on freshly created rows.
+    assert_eq!(read_started_at_ms(&b, exec_uuid).await, None);
+
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w356"),
+        WorkerInstanceId::new("w356-i1"),
+        30_000,
+        None,
+    );
+
+    let _h1 = b
+        .claim(&lane_id, &CapabilitySet::default(), policy.clone())
+        .await
+        .expect("claim 1")
+        .expect("handle 1");
+    let first = read_started_at_ms(&b, exec_uuid).await.expect("populated");
+
+    // Force a reclaim-like cycle: put the row back to runnable + bump
+    // attempt_index, reclaim, and verify started_at_ms is unchanged.
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', ownership_state='unowned', \
+         eligibility_state='eligible_now', attempt_state='initial', \
+         attempt_index=attempt_index+1 \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    let _h2 = b
+        .claim(&lane_id, &CapabilitySet::default(), policy)
+        .await
+        .expect("claim 2")
+        .expect("handle 2");
+    let second = read_started_at_ms(&b, exec_uuid).await.expect("populated");
+
+    assert_eq!(first, second, "set-once: reclaim must not overwrite started_at_ms (#356)");
+}
+
+// ── #355 — cancel_flow clears member attempt.outcome ─────────────────
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn sqlite_cancel_flow_clears_member_attempt_outcome() {
+    let b = fresh_backend().await;
+    let lane_id = LaneId::new("wave9-356-cancel-flow");
+    let exec_id = create_runnable(&b, &lane_id).await;
+    let exec_uuid = uuid_of(&exec_id);
+
+    // Seed a flow header + bind the exec to it.
+    let flow_id = FlowId::new();
+    let flow_uuid = flow_id.0;
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+           (partition_key, flow_id, graph_revision, public_flow_state, created_at_ms) \
+         VALUES (0, ?1, 0, 'open', ?2)",
+    )
+    .bind(flow_uuid)
+    .bind(now_ms())
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    sqlx::query("UPDATE ff_exec_core SET flow_id=?1 WHERE partition_key=0 AND execution_id=?2")
+        .bind(flow_uuid)
+        .bind(exec_uuid)
+        .execute(b.pool_for_test())
+        .await
+        .unwrap();
+
+    // Seed a stale `retry` outcome on the current attempt.
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, lease_epoch, outcome) \
+         VALUES (0, ?1, 0, 1, 'retry')",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    // Pre: stale outcome is observable.
+    let pre: Option<String> = sqlx::query_scalar(
+        "SELECT outcome FROM ff_attempt WHERE partition_key=0 AND execution_id=?1 AND attempt_index=0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(pre.as_deref(), Some("retry"));
+
+    let r = b
+        .cancel_flow(&flow_id, CancelFlowPolicy::CancelAll, CancelFlowWait::NoWait)
+        .await
+        .expect("cancel_flow ok");
+    assert!(
+        matches!(r, CancelFlowResult::Cancelled { .. }),
+        "got {r:?}"
+    );
+
+    // Post: outcome nulled (#355).
+    let post: Option<String> = sqlx::query_scalar(
+        "SELECT outcome FROM ff_attempt WHERE partition_key=0 AND execution_id=?1 AND attempt_index=0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(post, None, "post-cancel: attempt.outcome must be NULL (#355)");
+}

--- a/crates/ff-backend-sqlite/tests/wave9_followups.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_followups.rs
@@ -110,7 +110,7 @@ async fn read_started_at_ms(b: &Arc<SqliteBackend>, exec_uuid: Uuid) -> Option<i
 #[serial(ff_dev_mode)]
 async fn sqlite_first_claim_populates_started_at_ms_set_once() {
     let b = fresh_backend().await;
-    let lane_id = LaneId::new(format!("wave9-355-{}", uuid_like()).as_str());
+    let lane_id = LaneId::new(format!("wave9-356-{}", uuid_like()).as_str());
     let exec_id = create_runnable(&b, &lane_id).await;
     let exec_uuid = uuid_of(&exec_id);
 
@@ -162,7 +162,7 @@ async fn sqlite_first_claim_populates_started_at_ms_set_once() {
 #[serial(ff_dev_mode)]
 async fn sqlite_cancel_flow_clears_member_attempt_outcome() {
     let b = fresh_backend().await;
-    let lane_id = LaneId::new("wave9-356-cancel-flow");
+    let lane_id = LaneId::new("wave9-355-cancel-flow");
     let exec_id = create_runnable(&b, &lane_id).await;
     let exec_uuid = uuid_of(&exec_id);
 

--- a/rfcs/RFC-020-postgres-wave-9.md
+++ b/rfcs/RFC-020-postgres-wave-9.md
@@ -1,9 +1,10 @@
 # RFC-020: Postgres Wave 9 — deferred backend impls
 
-**Status:** ACCEPTED — Revision 7
+**Status:** ACCEPTED — Revision 8
 **Author:** FlowFabric Team (manager single-agent draft)
 **Proposed:** 2026-04-26
 **Accepted:** 2026-04-26
+**Revision 8:** 2026-04-26 — Wave 9 follow-up findings (#354, #355, #356) landed. **(#354)** §4.1 "maps directly" claim for `ff_exec_core.lifecycle_phase` + sibling state columns corrected to acknowledge the richer private alphabet encoded at the column level (Postgres writes `cancelled`, `released`, `pending_claim`, bare `running`, `blocked` as legitimate literals); the `normalise_*` shim in `crates/ff-backend-postgres/src/exec_core.rs` is documented as the boundary adapter, not a transient inconsistency — Option B (bless the adapter) per owner decision. **(#355)** `ff_attempt.outcome` now cleared on the two cancel paths that previously left it stale (`flow.rs` cancel-member loop; `exec_core::cancel_impl`); the existing `operator::cancel_execution_once` path already cleared it on live leases. **(#356)** Additive migration 0016 promotes first-claim timestamp from a LATERAL join on `ff_attempt.started_at_ms` to a typed `ff_exec_core.started_at_ms` column, set-once on first claim; Spine-B read path drops the LATERAL join. Parallel SQLite migration. Scope grows by one additive migration (0016 — 0015 reserved for RFC-024 claim-grant table) on each backend; method count unchanged.
 **Revision 2:** 2026-04-26 — Round-1 reviewer findings addressed (schema-ground-truth, design-spine reframe, drop G6, full-parity + coherent-wave directive)
 **Revision 3:** 2026-04-26 — Round-2 reviewer findings addressed: (A1/A2) new `ff_operator_event` channel (migration 0010) instead of repurposing `ff_signal_event`; (A3) `PendingWaitpointInfo` contract aligned, additive migration 0011 adds `waitpoint_key`/`state`/`required_signal_names`/`activated_at_ms` (**Revision 5 correction: `waitpoint_key` already shipped via migration 0004; 0011 adds 3 columns, not 4**); (A4) reconciler per-attempt scoping audited; (A5) `outcome`/`lifecycle_phase` column-binding clarified; (B1–B4) release-PR line items tightened; (C1) per-release-risk engagement in §8.7; (C2) intra-ack race traced to SERIALIZABLE retry; (C3a–d) resolved in §4.2.4/§4.2.7/§4.1/§6.3. Scope grows by two additive migrations (0010 + 0011); method count unchanged at 13.
 **Revision 4:** 2026-04-26 — Round-3 reviewer-A findings addressed: (NEW-1) `lifecycle_phase` enum literals corrected to lowercase real-enum values (`cancelled` / `runnable` / `NOT IN ('terminal','cancelled')`) across §4.2.1, §4.2.4, §4.2.5, §4.2.6; (NEW-4) stray `FOR UPDATE` removed from UPDATE in §4.2.4; (NEW-5) `waitpoint_key` pre-0011 projection behavior pinned in §4.5 (COALESCE to `''` + degraded-row counter) — **superseded by Revision 5 (moot: column already exists from 0004)**; (NEW-2) SERIALIZABLE retry budget pinned to 3 (matches `CANCEL_FLOW_MAX_ATTEMPTS` in `flow.rs:52`) in §4.2.3; (B-1) scope note for the producer-side `suspend_*` write-path change added to §3; (B-2) rollback-forward-only caveat added to §6.2; (C-polish) §8 adds a one-liner pointing at §4.2.4 for the repurpose-`ff_signal_event` rejection. No scope, alternatives, or new forks re-opened.
@@ -220,6 +221,36 @@ across every method in the spine.
 **Decision: join-on-read against the real schema.** A denormalised
 `ff_execution_view` projection was considered and rejected (§7.1
 owner-resolve).
+
+**Column-literal alphabet (Revision 8 correction, closes #354).** The
+Postgres `ff_exec_core` state columns (`lifecycle_phase`,
+`ownership_state`, `eligibility_state`, `public_state`,
+`attempt_state`) encode `(phase × eligibility × terminal-outcome)` in
+a **richer private alphabet** than the canonical `LifecyclePhase` /
+`OwnershipState` / `EligibilityState` / `PublicState` / `AttemptState`
+enums in `ff_core::state`. Earlier revisions described this mapping as
+"maps directly"; that claim was wrong. Write-paths in this crate
+(`flow.rs:674` cancel-member, `suspend_ops.rs` suspension-resume
+claim, `exec_core.rs` initial insert, scheduler-transitional claim
+paths) legitimately write Postgres-specific literals such as
+`cancelled`, `released`, `pending_claim`, bare `running`, `blocked`
+that are not members of the public enums. Read-paths call through a
+normalisation shim (`normalise_lifecycle_phase`,
+`normalise_ownership_state`, `normalise_eligibility_state`,
+`normalise_public_state`, `normalise_attempt_state` in
+`crates/ff-backend-postgres/src/exec_core.rs`) that collapses the
+column literals to the closest public-enum variant before
+`serde_json::from_str` deserialises into the enum type. **This
+adapter-at-the-read-boundary is the documented architecture, not a
+transient shim.** Option A (migrating the write-paths to canonical
+literals) was considered and rejected: it would relocate the
+encoding of terminal-outcome + scheduler-transitional state from SQL
+columns into per-write computation, which does not simplify the
+codebase — it just moves the mapping layer and loses the column-level
+audit trail of which backend phase produced each row. New read paths
+against these columns MUST call through the `normalise_*` helpers;
+new write paths MAY introduce new column literals, but MUST update
+the corresponding `normalise_*` arm in the same PR.
 
 The three reads project from the same column set:
 


### PR DESCRIPTION
## Summary

Three Wave-9 follow-up fixes in one PR.

### #354 — bless the read-boundary adapter (Option B per owner decision)

RFC-020 §4.1 earlier claimed `ff_exec_core.lifecycle_phase` "maps directly" to the `LifecyclePhase` enum. Ground-truth: the column (and its four sibling state columns — `ownership_state`, `eligibility_state`, `public_state`, `attempt_state`) encode `(phase × eligibility × terminal-outcome)` in a **richer private alphabet** than the canonical `ff_core::state` enums. Write sites in this crate legitimately produce Postgres-specific literals (`cancelled`, `released`, `pending_claim`, bare `running`, `blocked`) that are not members of the public enums.

The `normalise_*` shim in `crates/ff-backend-postgres/src/exec_core.rs` IS the documented read-boundary adapter. Option A (migrating writes to canonical literals) would relocate the mapping layer into per-write computation without reducing complexity, and would lose the column-level `cancelled` ↔ `terminal` distinction that `derive_terminal_outcome` depends on.

Revision 8 of RFC-020 corrects the "maps directly" claim; a new module-level doc comment on `exec_core.rs` pins the invariant for new read + write paths.

### #355 — clear ff_attempt.outcome on remaining cancel paths

Pre-fix, `cancel_flow` member loop and `exec_core::cancel_impl` both wrote `lifecycle_phase='cancelled'` / `public_state='cancelled'` but left `ff_attempt.outcome` at its prior value (possibly stale `retry` or `interrupted`). The existing `operator::cancel_execution_once` path already cleared outcome on live leases; this PR extends the invariant to the two remaining cancel sites. SQLite gets the parallel fix on the `cancel_flow` member loop.

### #356 — add ff_exec_core.started_at_ms as a set-once column

Additive migration **0016** on both backends. Populated by the claim + resume-claim paths via `COALESCE(started_at_ms, now)` so reclaim + retry never overwrite the original first-claim timestamp. Backfills existing rows from `MIN(ff_attempt.started_at_ms)` per execution. Wave-9 Spine-B `read_execution_info` read path drops the LATERAL join (Postgres) / correlated subquery (SQLite) on `ff_attempt.started_at_ms` and reads the column directly.

**Migration numbering coordination:** 0015 is reserved for RFC-024 (claim-grant table) which is queued but not yet shipped. This PR claims 0016 to avoid collision. If the RFC-024 impl PR lands first it takes 0015 and this migration continues to apply cleanly. If this PR lands first, the RFC-024 migration adjusts at its PR-E (migrations) stage.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p ff-backend-sqlite` — all green locally (new regression tests pass; migrations count assertion updated)
- [x] `cargo check -p ff-backend-postgres --tests` clean (PG integration tests gated on `FF_PG_TEST_URL`; CI provides live DB)
- [ ] Full CI matrix green (Phase 1a semver breaks expected — schema shape changed with new column)
- [ ] `migration-parity` job green (0016 applied on both backends)
- [ ] All bot review comments addressed before admin-merge

Closes #354, #355, #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DB migrations and changes Postgres/SQLite claim, cancel, and read paths; mistakes could affect execution state visibility or upgrade/migration behavior. Changes are additive but touch core engine persistence semantics.
> 
> **Overview**
> Fixes cancellation semantics so `ff_attempt.outcome` is cleared on previously-missed cancel paths (Postgres `cancel_flow` member loop and handle-level `exec_core::cancel`, plus the parallel SQLite `cancel_flow` loop) to prevent stale terminal outcomes from appearing after cancel.
> 
> Introduces additive migration `0016` on Postgres and SQLite to add `ff_exec_core.started_at_ms` as a **set-once first-claim timestamp** (written via `COALESCE(started_at_ms, now)` on claim/resume-claim and backfilled from the earliest attempt), and updates `read_execution_info` to read this column directly (dropping the prior LATERAL/correlated subquery on `ff_attempt.started_at_ms`).
> 
> Updates Wave-9 documentation to explicitly document the Postgres state-column “private alphabet” and the `normalise_*` read-boundary adapter, and adds/adjusts regression tests and SQLite migration-ledger assertions accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a6065a24050beb876ddaef43a52cdf574fd0c01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->