### PR TITLE
feat(ff-core): RFC-024 PR-A — ReclaimGrant→ResumeGrant + ReclaimToken→ResumeToken + HandleKind::Reclaimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **RFC-024 PR-A — `ff-core` resume-path rename + `HandleKind::Reclaimed` variant.**
+  First impl PR of the RFC-024 series (wires `ff_reclaim_execution` +
+  `ff_issue_reclaim_grant` to the consumer surface). Scope is
+  ff-core-only; no backend / SDK / server code touched.
+  - `crates/ff-core/src/contracts/mod.rs` — `ReclaimGrant` struct
+    renamed to `ResumeGrant` (the semantic has always been resume-
+    after-suspend; the routing FCALL is `ff_claim_resumed_execution`).
+    A transitional `pub type ReclaimGrant = ResumeGrant` alias is
+    retained so downstream backend / SDK / scheduler crates keep
+    compiling until the follow-up PR rewrites their call sites.
+  - `crates/ff-core/src/backend.rs` — `ReclaimToken` struct renamed
+    to `ResumeToken` (wraps a `ResumeGrant`; feeds the resume path).
+    Transitional `pub type ReclaimToken = ResumeToken` alias
+    retained on the same rationale.
+  - `crates/ff-core/src/backend.rs` — new `HandleKind::Reclaimed`
+    variant on the `#[non_exhaustive]` enum. Purely additive.
+    Reserved for the forthcoming `reclaim_execution` trait method
+    (RFC-024 PR-C onward) that mints a handle via the new
+    lease-reclaim path (distinct from the existing `Resumed`
+    suspend/resume path).
+  - Internal ff-core docs + the single `claim_from_reclaim` trait
+    method signature use the new names directly; no `#[allow(deprecated)]`
+    scatter. The aliases carry no `#[deprecated]` attribute (workspace
+    clippy runs with `-D warnings` and the downstream rename sweep
+    ships separately).
+  - Defers to the next PR in the series: the new `ReclaimGrant`
+    type (distinct semantic, lease-reclaim path), `#[non_exhaustive]` +
+    `new()` constructors on `ClaimGrant` / `ResumeGrant` /
+    `IssueReclaimGrantArgs` / `ReclaimExecutionArgs`,
+    `max_reclaim_count: u32` → `Option<u32>` flip, and the new
+    `IssueReclaimGrantOutcome` + `ReclaimExecutionOutcome` enums.
+    Those ride with the new trait-method introduction (PR-C) so the
+    constructor stabilisation lands alongside the surface that
+    requires it.
+
 - **`crates/ff-backend-sqlite` — Phase 3.5 scanner supervisor (N=1) +
   `budget_reset` reconciler (RFC-023 Phase 3.5 / RFC-020 Wave 9
   Standalone-1).** Ports the Postgres `scanner_supervisor` +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **RFC-024 PR-A — `ff-core` resume-path rename + `HandleKind::Reclaimed` variant.**
-  First impl PR of the RFC-024 series (wires `ff_reclaim_execution` +
-  `ff_issue_reclaim_grant` to the consumer surface). Scope is
-  ff-core-only; no backend / SDK / server code touched.
+  First impl PR of the RFC-024 series (the series as a whole wires
+  `ff_reclaim_execution` + `ff_issue_reclaim_grant` to the consumer
+  surface; this PR ships only the type renames + additive
+  `HandleKind::Reclaimed` variant — no new trait methods, no backend
+  wiring, no SDK endpoint). Scope is ff-core-only; no backend / SDK
+  / server code touched.
   - `crates/ff-core/src/contracts/mod.rs` — `ReclaimGrant` struct
     renamed to `ResumeGrant` (the semantic has always been resume-
     after-suspend; the routing FCALL is `ff_claim_resumed_execution`).

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -851,9 +851,10 @@ impl UsageDimensions {
 /// **Naming history (RFC-024).** This type was historically called
 /// `ReclaimToken`. Its semantic is resume-after-suspend (it wraps a
 /// `ResumeGrant` and feeds `ff_claim_resumed_execution`), so
-/// RFC-024 Rev 2 renames it. A deprecated type alias
+/// RFC-024 Rev 2 renames it. A transitional compatibility alias
 /// `ReclaimToken = ResumeToken` is retained for one release to ease
-/// consumer migration.
+/// consumer migration (no `#[deprecated]` marker — see the alias
+/// doc below for the rationale).
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ResumeToken {

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -20,7 +20,7 @@
 //! See `rfcs/RFC-012-engine-backend-trait.md` §3.3.0 for the authoritative
 //! type inventory and §4.1-§4.2 for the `Handle` / `EngineError` shapes.
 
-use crate::contracts::ReclaimGrant;
+use crate::contracts::ResumeGrant;
 use crate::types::{TimestampMs, WaitpointToken, WorkerId, WorkerInstanceId};
 
 // DX (HHH v0.3.4 re-smoke): `Namespace` lives in `ff_core::types` but
@@ -102,11 +102,18 @@ impl BackendTag {
 pub enum HandleKind {
     /// Fresh claim — returned by `claim` / `claim_from_grant`.
     Fresh,
-    /// Resumed from reclaim — returned by `claim_from_reclaim`.
+    /// Resumed from resume grant — returned by `claim_from_reclaim`
+    /// (renames to `claim_from_resume_grant` per RFC-024).
     Resumed,
     /// Suspended — returned by `suspend`. Terminal for the lease;
     /// resumption mints a new Handle via `claim_from_reclaim`.
     Suspended,
+    /// Reclaimed from a lease-reclaim grant — returned by the new
+    /// `reclaim_execution` trait method (RFC-024). Distinct from
+    /// [`HandleKind::Resumed`] (suspend/resume path) and
+    /// [`HandleKind::Fresh`] (first claim). The backing lifecycle
+    /// creates a new attempt row and bumps the reclaim counter.
+    Reclaimed,
 }
 
 /// Backend-private opaque payload carried inside a [`Handle`].
@@ -830,19 +837,27 @@ impl UsageDimensions {
     }
 }
 
-// ── §3.3.0 Reclaim / lease types ────────────────────────────────────────
+// ── §3.3.0 Resume / lease types ────────────────────────────────────────
 
 /// Opaque cookie returned by the reclaim scanner; consumed by
-/// `claim_from_reclaim` to mint a resumed Handle.
+/// `claim_from_reclaim` (renames to `claim_from_resume_grant` per
+/// RFC-024) to mint a resumed Handle.
 ///
-/// Wraps [`ReclaimGrant`] today (the scanner's existing product).
-/// Kept as a newtype so trait signatures name the reclaim-bound role
+/// Wraps [`ResumeGrant`] today (the scanner's existing product).
+/// Kept as a newtype so trait signatures name the resume-bound role
 /// explicitly and so the wrapped shape can evolve without breaking the
 /// trait.
+///
+/// **Naming history (RFC-024).** This type was historically called
+/// `ReclaimToken`. Its semantic is resume-after-suspend (it wraps a
+/// `ResumeGrant` and feeds `ff_claim_resumed_execution`), so
+/// RFC-024 Rev 2 renames it. A deprecated type alias
+/// `ReclaimToken = ResumeToken` is retained for one release to ease
+/// consumer migration.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct ReclaimToken {
-    pub grant: ReclaimGrant,
+pub struct ResumeToken {
+    pub grant: ResumeGrant,
     /// Worker identity that will claim the resumed execution.
     /// Wave 2 additive extension — mirrors the `ClaimPolicy`
     /// shape since `claim_from_reclaim` does not take a `ClaimPolicy`.
@@ -853,9 +868,9 @@ pub struct ReclaimToken {
     pub lease_ttl_ms: u32,
 }
 
-impl ReclaimToken {
+impl ResumeToken {
     pub fn new(
-        grant: ReclaimGrant,
+        grant: ResumeGrant,
         worker_id: WorkerId,
         worker_instance_id: WorkerInstanceId,
         lease_ttl_ms: u32,
@@ -868,6 +883,15 @@ impl ReclaimToken {
         }
     }
 }
+
+/// Transitional alias for [`ResumeToken`].
+///
+/// Retained for compile-time compatibility across the RFC-024 PR
+/// series. A follow-up PR rewrites downstream call sites to
+/// `ResumeToken` and removes this alias. No `#[deprecated]` marker
+/// here because workspace clippy runs with `-D warnings` and the
+/// downstream rename sweep ships separately.
+pub type ReclaimToken = ResumeToken;
 
 /// Result of a successful `renew` call.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1602,7 +1626,7 @@ mod tests {
 
     #[test]
     fn reclaim_token_wraps_grant() {
-        let grant = ReclaimGrant {
+        let grant = ResumeGrant {
             execution_id: ExecutionId::solo(&LaneId::new("default"), &Default::default()),
             partition_key: crate::partition::PartitionKey::from(&Partition {
                 family: PartitionFamily::Flow,
@@ -1612,7 +1636,7 @@ mod tests {
             expires_at_ms: 123,
             lane_id: LaneId::new("default"),
         };
-        let t = ReclaimToken::new(
+        let t = ResumeToken::new(
             grant.clone(),
             WorkerId::new("w"),
             WorkerInstanceId::new("w-1"),

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -158,10 +158,12 @@ impl ClaimGrant {
 /// `ReclaimGrant`, but its semantic has always been resume-after-
 /// suspend (the routing FCALL is `ff_claim_resumed_execution`, not
 /// `ff_reclaim_execution`). RFC-024 Rev 2 renames the type to
-/// `ResumeGrant` — the name now matches the semantic. A deprecated
-/// type alias `ReclaimGrant = ResumeGrant` is retained for one
-/// release to give consumers a `cargo fix`-compatible migration;
-/// the new lease-reclaim path uses a distinct (future) type.
+/// `ResumeGrant` — the name now matches the semantic. A transitional
+/// compatibility alias `ReclaimGrant = ResumeGrant` is retained for
+/// one release to give consumers a `cargo fix`-compatible migration
+/// (no `#[deprecated]` marker — see the alias doc below for the
+/// rationale); the new lease-reclaim path uses a distinct (future)
+/// type.
 ///
 /// Mirrors [`ClaimGrant`] for the resume path. Differences:
 ///

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -99,12 +99,12 @@ pub enum IssueClaimGrantResult {
 /// `ff-sdk` (consumer, via `FlowFabricWorker::claim_from_grant`).
 /// Lives in `ff-core` so neither crate needs a dep on the other.
 ///
-/// **Lane asymmetry with [`ReclaimGrant`]:** `ClaimGrant` does NOT
+/// **Lane asymmetry with [`ResumeGrant`]:** `ClaimGrant` does NOT
 /// carry `lane_id`. The issuing scheduler's caller already picked
 /// a lane (that's how admission reached this grant) and passes it
 /// through to `claim_from_grant` as a separate argument. The grant
 /// handle stays narrow to what uniquely identifies the admission
-/// decision. The matching field on [`ReclaimGrant`] is an
+/// decision. The matching field on [`ResumeGrant`] is an
 /// intentional divergence — see the note on that type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClaimGrant {
@@ -142,23 +142,32 @@ impl ClaimGrant {
     }
 }
 
-/// A reclaim grant issued for a resumed (attempt_interrupted) execution.
+/// A resume grant issued for a resumed (attempt_interrupted) execution.
 ///
 /// Issued by a producer (typically `ff-scheduler` once a Batch-C
 /// reclaim scanner is in place; test fixtures in the interim — no
 /// production Rust caller exists in-tree today). Consumed by
-/// [`FlowFabricWorker::claim_from_reclaim_grant`], which calls
+/// [`FlowFabricWorker::claim_from_resume_grant`], which calls
 /// `ff_claim_resumed_execution` atomically: that FCALL validates the
 /// grant, consumes it, and transitions `attempt_interrupted` →
 /// `started` while preserving the existing `attempt_index` +
 /// `attempt_id` (a resumed execution re-uses its attempt; it does
 /// not start a new one).
 ///
+/// **Naming history (RFC-024).** This type was historically called
+/// `ReclaimGrant`, but its semantic has always been resume-after-
+/// suspend (the routing FCALL is `ff_claim_resumed_execution`, not
+/// `ff_reclaim_execution`). RFC-024 Rev 2 renames the type to
+/// `ResumeGrant` — the name now matches the semantic. A deprecated
+/// type alias `ReclaimGrant = ResumeGrant` is retained for one
+/// release to give consumers a `cargo fix`-compatible migration;
+/// the new lease-reclaim path uses a distinct (future) type.
+///
 /// Mirrors [`ClaimGrant`] for the resume path. Differences:
 ///
 ///   * [`ClaimGrant`] is issued against a freshly-eligible
 ///     execution and `ff_claim_execution` creates a new attempt.
-///   * [`ReclaimGrant`] is issued against an `attempt_interrupted`
+///   * `ResumeGrant` is issued against an `attempt_interrupted`
 ///     execution; `ff_claim_resumed_execution` re-uses the existing
 ///     attempt and bumps the lease epoch.
 ///
@@ -167,7 +176,7 @@ impl ClaimGrant {
 /// consumes it (`ff_claim_execution` for new attempts,
 /// `ff_claim_resumed_execution` for resumes).
 ///
-/// **Lane asymmetry with [`ClaimGrant`]:** `ReclaimGrant` CARRIES
+/// **Lane asymmetry with [`ClaimGrant`]:** `ResumeGrant` CARRIES
 /// `lane_id` as a field. The issuing path already knows the lane
 /// (it's read from `exec_core` at grant time); carrying it here
 /// spares the consumer a `HGET exec_core lane_id` round trip on
@@ -178,12 +187,12 @@ impl ClaimGrant {
 /// Shared wire-level type between the eventual `ff-scheduler`
 /// producer (Batch-C reclaim scanner — not yet in-tree; test
 /// fixtures construct this type today) and `ff-sdk` (consumer, via
-/// `FlowFabricWorker::claim_from_reclaim_grant`). Lives in
+/// `FlowFabricWorker::claim_from_resume_grant`). Lives in
 /// `ff-core` so neither crate needs a dep on the other.
 ///
-/// [`FlowFabricWorker::claim_from_reclaim_grant`]: https://docs.rs/ff-sdk
+/// [`FlowFabricWorker::claim_from_resume_grant`]: https://docs.rs/ff-sdk
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ReclaimGrant {
+pub struct ResumeGrant {
     /// The execution granted for resumption.
     pub execution_id: ExecutionId,
     /// Opaque partition handle for this execution's hash-tag slot.
@@ -204,7 +213,7 @@ pub struct ReclaimGrant {
     pub lane_id: LaneId,
 }
 
-impl ReclaimGrant {
+impl ResumeGrant {
     /// Parse `partition_key` into a typed
     /// [`crate::partition::Partition`]. See [`ClaimGrant::partition`]
     /// for the alias-collapse note.
@@ -214,6 +223,17 @@ impl ReclaimGrant {
         self.partition_key.parse()
     }
 }
+
+/// Transitional alias for [`ResumeGrant`].
+///
+/// Retained for compile-time compatibility across the RFC-024 PR
+/// series. A follow-up PR rewrites downstream call sites to
+/// `ResumeGrant` and removes this alias; that same PR introduces a
+/// distinct new `ReclaimGrant` type for the lease-reclaim path
+/// (`reclaim_execution` / `ff_reclaim_execution`). No `#[deprecated]`
+/// marker on this PR because workspace clippy runs with `-D warnings`
+/// and the downstream rename sweep ships separately.
+pub type ReclaimGrant = ResumeGrant;
 
 // ─── claim_execution ───
 

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -50,7 +50,7 @@ use async_trait::async_trait;
 use crate::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
     FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
-    PrepareOutcome, ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility,
+    PrepareOutcome, ResumeSignal, ResumeToken, SummaryDocument, TailVisibility,
 };
 use crate::contracts::{
     CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
@@ -251,7 +251,7 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// Consume a reclaim grant to mint a resumed-kind handle. Returns
     /// `Ok(None)` when the grant's target execution is no longer
     /// resumable (already reclaimed, terminal, etc.).
-    async fn claim_from_reclaim(&self, token: ReclaimToken) -> Result<Option<Handle>, EngineError>;
+    async fn claim_from_reclaim(&self, token: ResumeToken) -> Result<Option<Handle>, EngineError>;
 
     // Round-5 amendment: lease-releasing peers of `suspend`.
 
@@ -1386,7 +1386,7 @@ mod tests {
         }
         async fn claim_from_reclaim(
             &self,
-            _token: ReclaimToken,
+            _token: ResumeToken,
         ) -> Result<Option<Handle>, EngineError> {
             unreachable!()
         }

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -248,9 +248,16 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// resume condition.
     async fn observe_signals(&self, handle: &Handle) -> Result<Vec<ResumeSignal>, EngineError>;
 
-    /// Consume a reclaim grant to mint a resumed-kind handle. Returns
+    /// Consume a resume grant (via [`ResumeToken`]) to mint a
+    /// resumed-kind handle. Routes to `ff_claim_resumed_execution` on
+    /// Valkey / the epoch-bump reconciler on PG/SQLite. Returns
     /// `Ok(None)` when the grant's target execution is no longer
     /// resumable (already reclaimed, terminal, etc.).
+    ///
+    /// **Naming history (RFC-024).** The method name + token name
+    /// historically said "reclaim" but the semantic has always been
+    /// resume-after-suspend. The token type is now `ResumeToken`; a
+    /// follow-up PR renames this method to `claim_from_resume_grant`.
     async fn claim_from_reclaim(&self, token: ResumeToken) -> Result<Option<Handle>, EngineError>;
 
     // Round-5 amendment: lease-releasing peers of `suspend`.

--- a/crates/ff-core/src/partition.rs
+++ b/crates/ff-core/src/partition.rs
@@ -39,7 +39,7 @@
 //!
 //! Consumers that need the parsed family/index call
 //! [`PartitionKey::parse`] (or [`crate::contracts::ClaimGrant::partition`] /
-//! [`crate::contracts::ReclaimGrant::partition`]) — these return a
+//! [`crate::contracts::ResumeGrant::partition`]) — these return a
 //! typed [`Partition`] so routing code stays unchanged.
 //!
 //! The `Execution` family label collapses to `Flow` on round-trip


### PR DESCRIPTION
## Summary

First impl PR of the RFC-024 series (wiring `ff_reclaim_execution` + `ff_issue_reclaim_grant` to the consumer surface; RFC accepted at Rev 2 via #391). Scope is **ff-core-only**; no backend / SDK / server code touched.

Aligns exactly with RFC-024 §9 PR-B (type renames only, backward-compat alias). Follow-up PRs land the new trait methods, backend wiring, migrations, and SDK admin endpoint per the §9 chain.

### Type renames (RFC-024 §3.1)

Per RFC-024 §2.3 + §3.1: the existing `ReclaimGrant` + `ReclaimToken` types have **always** represented resume-after-suspend semantics — their routing FCALL is `ff_claim_resumed_execution`, not `ff_reclaim_execution`. The name was the bug. This PR lands the honest names:

- `ReclaimGrant` struct → `ResumeGrant` (`crates/ff-core/src/contracts/mod.rs`)
- `ReclaimToken` struct → `ResumeToken` (`crates/ff-core/src/backend.rs`) — wraps a `ResumeGrant`, feeds the resume path
- Transitional `pub type ReclaimGrant = ResumeGrant` + `pub type ReclaimToken = ResumeToken` aliases retained so downstream crates (`ff-backend-valkey`, `ff-backend-postgres`, `ff-backend-sqlite`, `ff-scheduler`, `ff-sdk`, `ff-server`, `ff-test`) keep compiling. **No `#[deprecated]` marker** — workspace clippy runs with `-D warnings` and a deprecated alias would break CI on every dependent crate.
- Internal ff-core docs + the `claim_from_reclaim` trait method signature use the new names directly; no `#[allow(deprecated)]` scatter needed.

### Additive (`HandleKind::Reclaimed`)

- New `HandleKind::Reclaimed` variant on the `#[non_exhaustive]` enum (`crates/ff-core/src/backend.rs`). Reserved for the forthcoming `reclaim_execution` trait method (PR-C onward) that mints a handle via the new lease-reclaim path — distinct from `Resumed` (suspend/resume) and `Fresh` (first claim).

### Scope reconciliation with the task brief

The task brief combined two RFC-024 §9 PRs:
- PR-B (this PR): type renames, backward-compat alias.
- PR-C (next PR): new `ReclaimGrant` type (distinct lease-reclaim semantic), `#[non_exhaustive]` + `new()` constructors on `ClaimGrant` / `ResumeGrant` / `ReclaimGrant` / `IssueReclaimGrantArgs` / `ReclaimExecutionArgs`, `max_reclaim_count: u32` → `Option<u32>` flip, new `IssueReclaimGrantOutcome` + `ReclaimExecutionOutcome` enums, two new trait methods (`issue_reclaim_grant`, `reclaim_execution`) with `Unavailable` defaults.

The brief also mandated "ff-core-only, no backend code". Those constraints cannot all hold: introducing a new `ReclaimGrant` struct collides with the transitional alias that keeps downstream crates compiling, and adding `#[non_exhaustive]` to existing public structs without also landing `new()` constructors at every caller across the workspace is a wider cross-crate edit than the ff-core-only bound allows.

Cleanest resolution: ship this PR exactly aligned with RFC §9 PR-B (the renames only), move the new `ReclaimGrant` + constructors + enum additions to the next PR alongside the trait-method introductions they are surface-dependent on. Per task-brief autonomy: *"If a rename triggers unexpected compile breakage across workspace, DIAGNOSE + fix inline OR split into smaller PR"* — splitting is what's happening here.

### Follow-up PR chain (RFC-024 §9)

- **PR-C** — new `ReclaimGrant` type + `#[non_exhaustive]` + `new()` constructors + `Option<u32>` flip + outcome enums + two new trait methods with default-Unavailable impls.
- **PR-D** — Postgres migration 0015 (`ff_claim_grant` table + `lease_reclaim_count` column) + `scheduler.rs` table flip + new method impls.
- **PR-E** — SQLite migration 0015 + new method impls.
- **PR-F** — Valkey Lua ARGV[9] + new method impls.
- **PR-G** — SDK admin endpoint + consumer example + docs + RFC-018 capability flag.
- **PR-H** — cairn-rs consumer-side migration.

### Surprises during validation

- `ff-test/tests/subscribe_filter_isolation.rs` has **two pre-existing `clippy::never_loop` errors** on main (lines 190, 321). They surface only in `cargo clippy --all-targets` full-workspace runs. matrix.yml's clippy invocation doesn't pass `--all-targets` on the full workspace so CI stays green; flagged for a separate hygiene pass.

## Test plan

Verified locally before push:

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-sqlite --features ff-sdk/direct-valkey-claim -- -D warnings` (matrix.yml:213-218) — clean
- [x] `cargo test -p ff-core --lib` — 221 passed
- [x] `cargo test --workspace --no-run` — all tests compile
- [ ] CI matrix — pending push
- [ ] Admin-merge after CI green + all bot comments addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `ff-core` public API by renaming the resume-path grant/token types and updating the `EngineBackend::claim_from_reclaim` signature; transitional type aliases reduce but don’t eliminate downstream breakage risk. Adds a new `HandleKind` variant which is additive but may affect consumers persisting/serializing or matching on handle kinds.
> 
> **Overview**
> Aligns RFC-024 naming by renaming `ReclaimGrant`→`ResumeGrant` and `ReclaimToken`→`ResumeToken`, then updates `ff-core` docs/tests and the `EngineBackend::claim_from_reclaim` signature to use the new names while keeping transitional `pub type` aliases for downstream compilation.
> 
> Adds `HandleKind::Reclaimed` (additive on a `#[non_exhaustive]` enum) to reserve a distinct lifecycle kind for the forthcoming lease-reclaim path, separate from the existing suspend/resume `Resumed` kind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40c4c30d76150139cc5f26b00dc546da9c5c1bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->