### PR TITLE
feat(backend-sqlite): v0.12 Phase 4c — atomic Supports flag flips (SQLite Wave 10 live)

### DIFF
--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2245,6 +2245,74 @@ pub(crate) struct SqliteBackendInner {
     pub(crate) scanner_handle: std::sync::OnceLock<crate::scanner_supervisor::SqliteScannerHandle>,
 }
 
+/// RFC-023 §6.3 — v0.12 atomic Supports flag flip for the SQLite
+/// dev-only backend.
+///
+/// Every flag whose backing trait method shipped in Phase 1-3 flips
+/// `true` here; two flags remain `false`:
+///
+/// - `claim_for_worker` — RFC-023 §5 permanent non-goal (scheduler
+///   routing is out of scope for the dev-only backend; SqliteBackend
+///   exposes `claim` via handle but not the scheduler-routed surface).
+/// - `subscribe_instance_tags` — #311 deferred on all backends;
+///   cairn's `instance_tag_backfill` is served by `list_executions`
+///   + `ScannerFilter::with_instance_tag`.
+///
+/// Mirrors the `postgres_supports_base()` shape in
+/// `ff-backend-postgres/src/lib.rs` for consumer-copy-paste parity
+/// per cairn #277. `Supports` is `#[non_exhaustive]` so we start from
+/// [`Supports::none`] and mutate named fields.
+fn sqlite_supports_base() -> Supports {
+    let mut s = Supports::none();
+
+    // ── Flow bulk cancel (Phase 2b.1 Group A) ──
+    // SqliteBackend::cancel_flow is always synchronous under the
+    // single-writer model: every member flips in the same transaction
+    // as the header. Both wait axes are callable (the `_wait` arg is
+    // ignored — the result is always `Cancelled {..}` immediately).
+    s.cancel_flow_wait_timeout = true;
+    s.cancel_flow_wait_indefinite = true;
+
+    // ── Admin seed + rotate HMAC (Phase 2b.1) ──
+    s.rotate_waitpoint_hmac_secret_all = true;
+    s.seed_waitpoint_hmac_secret = true;
+
+    // ── RFC-019 subscriptions (Phase 3.1) ──
+    s.subscribe_lease_history = true;
+    s.subscribe_completion = true;
+    s.subscribe_signal_delivery = true;
+
+    // ── Streaming (Phase 2b.2.2) ──
+    s.stream_durable_summary = true;
+    s.stream_best_effort_live = true;
+
+    // ── Boot ──
+    // SqliteBackend::prepare() returns NoOp (migrations run inside
+    // `SqliteBackend::new`, matching the PG posture); NoOp is a
+    // callable + correct outcome, not Unavailable.
+    s.prepare = true;
+
+    // ── Wave 9 (Phase 3.2-3.5) ──
+    s.cancel_execution = true;
+    s.change_priority = true;
+    s.replay_execution = true;
+    s.revoke_lease = true;
+    s.read_execution_state = true;
+    s.read_execution_info = true;
+    s.get_execution_result = true;
+    s.budget_admin = true;
+    s.quota_admin = true;
+    s.list_pending_waitpoints = true;
+    s.cancel_flow_header = true;
+    s.ack_cancel_member = true;
+
+    // ── Stay `false` (see struct-level rustdoc above) ──
+    // s.claim_for_worker — RFC-023 §5 non-goal
+    // s.subscribe_instance_tags — #311 all-backends
+
+    s
+}
+
 /// RFC-023 SQLite dev-only backend.
 ///
 /// Construction demands `FF_DEV_MODE=1` (§4.5). Identical paths
@@ -3097,11 +3165,14 @@ impl EngineBackend for SqliteBackend {
     }
 
     fn capabilities(&self) -> Capabilities {
-        // RFC-023 §4.3: Phase 1a exposes only the identity tuple; real
-        // `Supports::*` flags flip at the Phase 4 release PR when trait
-        // bodies ship. Consumers seeing `supports.*` all-false under
-        // "sqlite" know to expect `Unavailable` on every data-plane
-        // call until Phase 2+ lands.
+        // RFC-023 §6.3: atomic flag-flip at the v0.12 release PR.
+        // Phase 1-3 trait bodies shipped on `main` ahead of this PR; this
+        // capabilities() snapshot flips every `Supports::*` flag whose
+        // backing method ships (Wave 10 live), EXCEPT `claim_for_worker`
+        // (§5 permanent non-goal — scheduler routing is out of scope for
+        // the dev-only backend) and `subscribe_instance_tags` (#311 —
+        // deferred on all backends; cairn's `instance_tag_backfill` is
+        // served by `list_executions` + `ScannerFilter::with_instance_tag`).
         Capabilities::new(
             BackendIdentity::new(
                 "sqlite",
@@ -3110,9 +3181,9 @@ impl EngineBackend for SqliteBackend {
                     env!("CARGO_PKG_VERSION_MINOR").parse().unwrap_or(0),
                     env!("CARGO_PKG_VERSION_PATCH").parse().unwrap_or(0),
                 ),
-                "Phase-1a",
+                "Phase-4",
             ),
-            Supports::none(),
+            sqlite_supports_base(),
         )
     }
 

--- a/crates/ff-backend-sqlite/tests/capabilities.rs
+++ b/crates/ff-backend-sqlite/tests/capabilities.rs
@@ -1,9 +1,18 @@
-//! RFC-023 §4.3 / §9 capability-matrix snapshot — Phase 1a subset.
+//! RFC-023 §4.3 / §6.3 / §9 capability-matrix snapshot — v0.12
+//! Phase 4c (Wave 10 live).
 //!
-//! Phase 1a asserts that `capabilities()` reports
-//! `identity.family == "sqlite"` and every `Supports::*` flag is
-//! `false`. Phase 4 release PR flips the flags in lockstep with
-//! trait body landings.
+//! Pre-v0.12 (Phase 1a) asserted every `Supports::*` flag `false` —
+//! the scaffolding shipped but no trait body did. v0.12 Phase 4c
+//! flips every flag whose backing method landed across Phase 1-3
+//! (hot path, flow, waitpoints, reads, Wave 9 operator/reads/budget/
+//! quota, RFC-019 subscriptions, streaming, admin HMAC). Two flags
+//! stay `false`:
+//!
+//! - `claim_for_worker` — RFC-023 §5 permanent non-goal.
+//! - `subscribe_instance_tags` — #311 deferred on all backends.
+//!
+//! Mirrors `crates/ff-backend-postgres/tests/capabilities.rs` for
+//! consumer copy-paste parity per cairn #277.
 
 use ff_backend_sqlite::SqliteBackend;
 use ff_core::engine_backend::EngineBackend;
@@ -23,12 +32,53 @@ async fn capabilities_identity_and_supports() {
 
     let caps = backend.capabilities();
     assert_eq!(caps.identity.family, "sqlite");
-    // Phase 1a rfc017_stage label.
-    assert_eq!(caps.identity.rfc017_stage, "Phase-1a");
+    // Phase 4 rfc017_stage label (flipped from "Phase-1a" at v0.12).
+    assert_eq!(caps.identity.rfc017_stage, "Phase-4");
 
-    // Every support flag must be false at Phase 1a — Phase 4 flips
-    // them when trait bodies ship.
-    assert_eq!(caps.supports, ff_core::capability::Supports::none());
+    // ── Flow bulk cancel (Phase 2b.1 Group A) ──
+    assert!(caps.supports.cancel_flow_wait_timeout);
+    assert!(caps.supports.cancel_flow_wait_indefinite);
+
+    // ── Admin seed + rotate HMAC (Phase 2b.1) ──
+    assert!(caps.supports.rotate_waitpoint_hmac_secret_all);
+    assert!(caps.supports.seed_waitpoint_hmac_secret);
+
+    // ── RFC-019 subscriptions (Phase 3.1) ──
+    assert!(caps.supports.subscribe_lease_history);
+    assert!(caps.supports.subscribe_completion);
+    assert!(caps.supports.subscribe_signal_delivery);
+
+    // ── Streaming (Phase 2b.2.2) ──
+    assert!(caps.supports.stream_durable_summary);
+    assert!(caps.supports.stream_best_effort_live);
+
+    // ── Wave 9 (Phase 3.2-3.5) ──
+    assert!(caps.supports.cancel_execution);
+    assert!(caps.supports.change_priority);
+    assert!(caps.supports.replay_execution);
+    assert!(caps.supports.revoke_lease);
+    assert!(caps.supports.read_execution_state);
+    assert!(caps.supports.read_execution_info);
+    assert!(caps.supports.get_execution_result);
+    assert!(caps.supports.budget_admin);
+    assert!(caps.supports.quota_admin);
+    assert!(caps.supports.list_pending_waitpoints);
+    assert!(caps.supports.cancel_flow_header);
+    assert!(caps.supports.ack_cancel_member);
+
+    // SqliteBackend::prepare() returns NoOp (migrations run inside
+    // `SqliteBackend::new`, matching PG's posture). NoOp is a callable
+    // + correct outcome, not Unavailable.
+    assert!(caps.supports.prepare);
+
+    // claim_for_worker: Unavailable on SQLite by RFC-023 §5 non-goal
+    // (scheduler routing is not in scope for the dev-only backend).
+    assert!(!caps.supports.claim_for_worker);
+
+    // subscribe_instance_tags: Deferred on all backends per RFC-020
+    // §3.2 / issue #311; served by list_executions +
+    // ScannerFilter::with_instance_tag.
+    assert!(!caps.supports.subscribe_instance_tags);
 
     assert_eq!(backend.backend_label(), "sqlite");
 }


### PR DESCRIPTION
## Summary

RFC-023 §6.3 atomic flag-flip at the v0.12 release PR. Phase 1-3 SQLite trait bodies shipped on `main` ahead of this PR; this flips `SqliteBackend::capabilities()` to report every `Supports` flag whose backing method lands as `true`. Identity `rfc017_stage` bumps `Phase-1a` → `Phase-4`.

Mirrors `postgres_supports_base()` in `crates/ff-backend-postgres/src/lib.rs` for consumer-copy-paste parity per cairn #277.

## Flags flipped (22)

| Group | Flags | Source |
| --- | --- | --- |
| Flow bulk cancel | `cancel_flow_wait_timeout`, `cancel_flow_wait_indefinite` | Phase 2b.1 Group A — synchronous under single-writer model; both wait axes callable (`_wait` arg ignored, always returns `Cancelled {..}`) |
| Admin HMAC | `rotate_waitpoint_hmac_secret_all`, `seed_waitpoint_hmac_secret` | Phase 2b.1 |
| RFC-019 subscriptions | `subscribe_lease_history`, `subscribe_completion`, `subscribe_signal_delivery` | Phase 3.1 |
| Streaming (RFC-015) | `stream_durable_summary` (`read_summary`), `stream_best_effort_live` (`tail_stream`) | Phase 2b.2.2 |
| Boot | `prepare` | NoOp is a callable + correct outcome, matching PG posture |
| Wave 9 | `cancel_execution`, `change_priority`, `replay_execution`, `revoke_lease`, `read_execution_state`, `read_execution_info`, `get_execution_result`, `budget_admin`, `quota_admin`, `list_pending_waitpoints`, `cancel_flow_header`, `ack_cancel_member` | Phase 3.2–3.5 |

## Flags NOT flipped (2)

- `claim_for_worker` — **RFC-023 §5 permanent non-goal**. Scheduler routing is out of scope for the dev-only backend; SqliteBackend exposes `claim` via handle but not the scheduler-routed surface. See memory note `project_sqlite_claim_for_worker_scope.md`.
- `subscribe_instance_tags` — **#311 deferred on all backends** (RFC-020 §3.2). Cairn's `instance_tag_backfill` is served by `list_executions` + `ScannerFilter::with_instance_tag`. PG also reports this as `false`.

No known gaps. Walked `ff_core::capability::Supports` field-by-field; every field maps cleanly to a Phase 1-3 landed method, a PG-parity group rollup (budget_admin / quota_admin), or one of the two documented permanent non-flips.

## Prerequisites met

Phase 1-3 complete on `main`:
- Last main merge: `66ab76b` (PG Wave 9 follow-ups)
- Last SQLite fix: `367fd7e` (public_state + is_memory detection, closes #372)
- Phase 3.5 upstream: `49eb179`

## Out of scope (handled by sibling Phase 4 PRs)

- Phase 4a — `examples/ff-dev/` + published-artifact smoke
- Phase 4b — `docs/BACKEND_PARITY_MATRIX.md` SQLite column
- Phase 4d — CHANGELOG finalization, version bump to `v0.12.0`, tag + publish

## Test plan

- [x] `cargo test -p ff-backend-sqlite --test capabilities` (1/1 pass)
- [x] `cargo test -p ff-backend-sqlite` (full suite — all green, 16/16 files pass, 147 tests)
- [x] `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` clean
- [ ] Full CI green; Phase 1a semver breaks still expected; Valkey cluster post-#369 fix should pass
- [ ] Admin-merge after matrix-green AND all bot review findings addressed

Must merge BEFORE the v0.12 release tag — this flag flip is the consumer-observable "Wave 10 ships" signal per RFC-023 §6.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the externally visible `capabilities()` contract for the SQLite backend, which can cause consumers to start calling newly-advertised APIs and surface latent implementation/compatibility issues. Logic changes are limited to capability reporting plus a focused test update.
> 
> **Overview**
> Updates `SqliteBackend::capabilities()` to report **Phase-4** (was **Phase-1a**) and to advertise a broad set of `Supports` flags as `true` via a new `sqlite_supports_base()` helper (bulk cancel wait axes, admin HMAC ops, RFC-019 subscriptions, streaming, `prepare`, and Wave 9 operator/read/admin features).
> 
> Keeps `claim_for_worker` and `subscribe_instance_tags` intentionally `false`, and updates the SQLite `capabilities` integration test to assert the new stage label and per-flag truth table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c107aa0bd5d15c63e8c318045dd2e3d59adaec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->