### PR TITLE
feat(ff-core+workspace): RFC-024 PR-B+C — trait method renames + new ReclaimGrant type + drop aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,76 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **RFC-024 PR-B+C — trait method renames + new `ReclaimGrant` type +
+  non_exhaustive constructors (closes partial of #371).** Folded PR-B
+  and PR-C of the RFC-024 series because the new trait method
+  signatures reference types introduced in PR-C; shipping them
+  separately would land trait methods referencing undefined types.
+  Scope spans `ff-core`, all three backends (Valkey, Postgres,
+  SQLite), `ff-sdk`, `ff-scheduler`, `ff-server`, and `ff-test`.
+  Backend impl bodies for the new methods are still
+  `EngineError::Unavailable` — PR-D (PG), PR-E (SQLite), PR-F
+  (Valkey) wire the real bodies.
+  - `crates/ff-core/src/contracts/mod.rs` — new distinct `ReclaimGrant`
+    type (lease-reclaim path, routes to `ff_reclaim_execution` /
+    PG+SQLite `reclaim_execution`). Distinct from the PR-A-renamed
+    `ResumeGrant`. `#[non_exhaustive]` with explicit `::new()`
+    constructor per `feedback_non_exhaustive_needs_constructor`.
+  - `crates/ff-core/src/contracts/mod.rs` — new
+    `IssueReclaimGrantOutcome` enum (`Granted(ReclaimGrant)` /
+    `NotReclaimable` / `ReclaimCapExceeded`) and new
+    `ReclaimExecutionOutcome` enum (`Claimed(Handle)` /
+    `NotReclaimable` / `ReclaimCapExceeded` / `GrantNotFound`). Both
+    `#[non_exhaustive]`; variants ARE the construction surface.
+  - `crates/ff-core/src/engine_backend.rs` — two new trait methods:
+    `issue_reclaim_grant(args) -> IssueReclaimGrantOutcome` and
+    `reclaim_execution(args) -> ReclaimExecutionOutcome`. Default
+    impls return `EngineError::Unavailable` so pre-RFC out-of-tree
+    backends keep compiling.
+
+### Changed
+
+- **RFC-024 PR-B+C — trait method rename + transitional aliases
+  dropped.** Compile-break wave that lands in the same PR as the new
+  surface above.
+  - `EngineBackend::claim_from_reclaim` → `claim_from_resume_grant`
+    across all three in-tree backends (Valkey, Postgres, SQLite) and
+    the SDK layer forwarders (`ff-sdk/src/layer/hooks.rs`,
+    `layer/test_support.rs`). Body unchanged; the method has always
+    driven `ff_claim_resumed_execution` / the PG+SQLite epoch-bump
+    reconciler — the old name advertised "reclaim" but delivered
+    resume.
+  - `FlowFabricWorker::claim_from_reclaim_grant` →
+    `claim_from_resume_grant` on the ff-sdk consumer surface. The
+    method retains its semantic (feeds the resume-grant path); the
+    new `claim_from_reclaim_grant` SDK method (distinct semantic,
+    feeds `reclaim_execution`) lands with PR-G.
+  - `ClaimGrant`, `ResumeGrant`, `IssueReclaimGrantArgs`, and
+    `ReclaimExecutionArgs` gain `#[non_exhaustive]` + explicit
+    `::new()` constructors per
+    `feedback_non_exhaustive_needs_constructor`. Struct-literal
+    construction from downstream crates migrates to the
+    constructors; in-crate tests unaffected.
+  - `IssueReclaimGrantArgs` gains a `worker_capabilities:
+    BTreeSet<String>` field (parity with `IssueClaimGrantArgs`; the
+    Lua `ff_issue_reclaim_grant` already reads ARGV[9]). Populated
+    by the SDK admin path in PR-G; `#[serde(default)]` preserves
+    wire compat.
+  - `ReclaimExecutionArgs::max_reclaim_count` flips from `u32` to
+    `Option<u32>` per RFC-024 §3.2. `None` ⇒ backend applies the
+    Rust-surface default of 1000 (RFC-024 §4.6); explicit `Some(n)`
+    preserves the per-call override. The Lua fallback remains 100
+    for pre-RFC ARGV-omitted callers; the two-default coexistence
+    is explicit by design.
+  - `crates/ff-core/src/contracts/mod.rs` — PR-A's transitional
+    `pub type ReclaimGrant = ResumeGrant` alias dropped. Call sites
+    semantically using a resume grant migrate to `ResumeGrant`; the
+    (distinct) new `ReclaimGrant` type in the `### Added` section
+    above covers the lease-reclaim path.
+  - `crates/ff-core/src/backend.rs` — PR-A's transitional
+    `pub type ReclaimToken = ResumeToken` alias dropped; all call
+    sites migrate to `ResumeToken`.
+
 - **RFC-024 PR-A — `ff-core` resume-path rename + `HandleKind::Reclaimed` variant.**
   First impl PR of the RFC-024 series (the series as a whole wires
   `ff_reclaim_execution` + `ff_issue_reclaim_grant` to the consumer

--- a/crates/ff-backend-postgres/src/attempt.rs
+++ b/crates/ff-backend-postgres/src/attempt.rs
@@ -1,6 +1,6 @@
 //! Attempt trait-method family — Postgres implementation.
 //!
-//! **RFC-v0.7 Wave 4b.** Bodies for `claim`, `claim_from_reclaim`,
+//! **RFC-v0.7 Wave 4b.** Bodies for `claim`, `claim_from_resume_grant`,
 //! `renew`, `progress`, `complete`, `fail`, `delay`, `wait_children`.
 //!
 //! # Fence-triple invariants (RFC-003)
@@ -35,7 +35,7 @@
 
 use ff_core::backend::{
     BackendTag, CapabilitySet, ClaimPolicy, FailOutcome, FailureClass, FailureReason, Handle,
-    HandleKind, LeaseRenewal, ReclaimToken,
+    HandleKind, LeaseRenewal, ResumeToken,
 };
 use ff_core::caps::{matches as caps_matches, CapabilityRequirement};
 use ff_core::engine_error::{ContentionKind, EngineError};
@@ -293,11 +293,11 @@ async fn try_claim_in_partition(
     Ok(Some(mint_handle(payload, HandleKind::Fresh)))
 }
 
-// ── claim_from_reclaim ──────────────────────────────────────────────────
+// ── claim_from_resume_grant ──────────────────────────────────────────────────
 
-pub(crate) async fn claim_from_reclaim(
+pub(crate) async fn claim_from_resume_grant(
     pool: &PgPool,
-    token: ReclaimToken,
+    token: ResumeToken,
 ) -> Result<Option<Handle>, EngineError> {
     let eid = &token.grant.execution_id;
     let (part, exec_uuid) = split_exec_id(eid)?;

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, BackendConfig, CancelFlowPolicy, CancelFlowWait, CapabilitySet,
     ClaimPolicy, FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal,
-    PendingWaitpoint, ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility,
+    PendingWaitpoint, ResumeToken, ResumeSignal, SummaryDocument, TailVisibility,
     UsageDimensions,
 };
 #[cfg(feature = "core")]
@@ -532,12 +532,12 @@ impl EngineBackend for PostgresBackend {
         suspend_ops::observe_signals_impl(&self.pool, handle).await
     }
 
-    #[tracing::instrument(name = "pg.claim_from_reclaim", skip_all)]
-    async fn claim_from_reclaim(
+    #[tracing::instrument(name = "pg.claim_from_resume_grant", skip_all)]
+    async fn claim_from_resume_grant(
         &self,
-        token: ReclaimToken,
+        token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        attempt::claim_from_reclaim(&self.pool, token).await
+        attempt::claim_from_resume_grant(&self.pool, token).await
     }
 
     #[tracing::instrument(name = "pg.delay", skip_all)]

--- a/crates/ff-backend-postgres/src/operator.rs
+++ b/crates/ff-backend-postgres/src/operator.rs
@@ -236,7 +236,7 @@ async fn cancel_execution_once(
 
     // Step 4b — clear lease on the current attempt row if one was
     // active. Zeroes `worker_instance_id` + `lease_expires_at_ms` so
-    // the `lease_expiry` reconciler + `claim_from_reclaim` path see a
+    // the `lease_expiry` reconciler + `claim_from_resume_grant` path see a
     // released slot. `lease_epoch` bumps by 1 to fence any in-flight
     // RMW (same pattern as `revoke_lease`).
     if lease_active {

--- a/crates/ff-backend-postgres/src/scheduler.rs
+++ b/crates/ff-backend-postgres/src/scheduler.rs
@@ -286,12 +286,12 @@ impl PostgresScheduler {
                 detail: format!("scheduler: reassembling exec id: {e}"),
             }
         })?;
-        Ok(Some(ClaimGrant {
-            execution_id: eid,
-            partition_key: PartitionKey::from(&partition),
+        Ok(Some(ClaimGrant::new(
+            eid,
+            PartitionKey::from(&partition),
             grant_key,
-            expires_at_ms: expires_at_ms as u64,
-        }))
+            expires_at_ms as u64,
+        )))
     }
 }
 

--- a/crates/ff-backend-postgres/tests/pg_engine_backend_attempt.rs
+++ b/crates/ff-backend-postgres/tests/pg_engine_backend_attempt.rs
@@ -1,6 +1,6 @@
 //! Wave 4b attempt-family integration tests.
 //!
-//! Exercises the `claim`, `claim_from_reclaim`, `renew`, `progress`,
+//! Exercises the `claim`, `claim_from_resume_grant`, `renew`, `progress`,
 //! `complete`, `fail`, `delay`, `wait_children` trait methods against
 //! a live Postgres with the Wave-3 schema applied.
 //!
@@ -16,11 +16,11 @@
 //!  --test pg_engine_backend_attempt -- --ignored`
 
 use ff_backend_postgres::PostgresBackend;
-use ff_core::backend::ReclaimToken;
+use ff_core::backend::ResumeToken;
 use ff_core::backend::{
     CapabilitySet, ClaimPolicy, FailOutcome, FailureClass, FailureReason,
 };
-use ff_core::contracts::ReclaimGrant;
+use ff_core::contracts::ResumeGrant;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::{ContentionKind, EngineError};
 use ff_core::partition::{PartitionConfig, PartitionKey};
@@ -223,18 +223,18 @@ async fn fail_permanent_terminal() {
     assert_eq!(completion_outbox_count(&pool, exec_uuid).await, 1);
 }
 
-fn reclaim_grant(eid: ff_core::types::ExecutionId, lane: LaneId, part_idx: u16) -> ReclaimGrant {
+fn reclaim_grant(eid: ff_core::types::ExecutionId, lane: LaneId, part_idx: u16) -> ResumeGrant {
     let pk = PartitionKey::from(&ff_core::partition::Partition {
         family: ff_core::partition::PartitionFamily::Flow,
         index: part_idx,
     });
-    ReclaimGrant {
-        execution_id: eid,
-        partition_key: pk,
-        grant_key: "gkey".into(),
-        expires_at_ms: (now_ms() as u64) + 60_000,
-        lane_id: lane,
-    }
+    ResumeGrant::new(
+        eid,
+        pk,
+        "gkey".into(),
+        (now_ms() as u64) + 60_000,
+        lane,
+    )
 }
 
 #[tokio::test]
@@ -251,9 +251,9 @@ async fn claim_from_reclaim_happy_path_bumps_epoch() {
         .bind(part).bind(exec_uuid).execute(&pool).await.unwrap();
     let eid = ff_core::types::ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
     let grant = reclaim_grant(eid, lane_id.clone(), part as u16);
-    let token = ReclaimToken::new(grant, WorkerId::new("w-rec"), WorkerInstanceId::new("w-rec-1"), 30_000);
+    let token = ResumeToken::new(grant, WorkerId::new("w-rec"), WorkerInstanceId::new("w-rec-1"), 30_000);
     let (epoch_before, _) = lease_row(&pool, part, exec_uuid).await;
-    let handle = backend.claim_from_reclaim(token).await.expect("reclaim").expect("Some");
+    let handle = backend.claim_from_resume_grant(token).await.expect("reclaim").expect("Some");
     let (epoch_after, _) = lease_row(&pool, part, exec_uuid).await;
     assert!(epoch_after > epoch_before, "epoch must bump: {epoch_before} -> {epoch_after}");
     backend.renew(&handle).await.expect("renew after reclaim");
@@ -271,8 +271,8 @@ async fn claim_from_reclaim_live_lease_returns_none() {
         .await.unwrap().unwrap();
     let eid = ff_core::types::ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
     let grant = reclaim_grant(eid, lane_id.clone(), part as u16);
-    let token = ReclaimToken::new(grant, WorkerId::new("w-thief"), WorkerInstanceId::new("w-thief-1"), 30_000);
-    let out = backend.claim_from_reclaim(token).await.expect("call ok");
+    let token = ResumeToken::new(grant, WorkerId::new("w-thief"), WorkerInstanceId::new("w-thief-1"), 30_000);
+    let out = backend.claim_from_resume_grant(token).await.expect("call ok");
     assert!(out.is_none(), "live lease must reject reclaim");
 }
 

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -18,7 +18,7 @@ use ff_core::backend::PrepareOutcome;
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy, FailOutcome,
     FailureClass, FailureReason, Frame, FrameKind, Handle, HandleKind, LeaseRenewal, PatchKind,
-    PendingWaitpoint, ReclaimToken, ResumeSignal, SUMMARY_NULL_SENTINEL, StreamMode,
+    PendingWaitpoint, ResumeToken, ResumeSignal, SUMMARY_NULL_SENTINEL, StreamMode,
     UsageDimensions,
 };
 #[cfg(feature = "streaming")]
@@ -1371,12 +1371,12 @@ async fn read_summary_impl(
     )))
 }
 
-// ── claim_from_reclaim ────────────────────────────────────────────────
+// ── claim_from_resume_grant ────────────────────────────────────────────────
 
 async fn claim_from_reclaim_impl(
     pool: &SqlitePool,
     pubsub: &PubSub,
-    token: &ReclaimToken,
+    token: &ResumeToken,
 ) -> Result<Option<Handle>, EngineError> {
     let eid = &token.grant.execution_id;
     let (part, exec_uuid) = split_exec_id(eid)?;
@@ -1404,7 +1404,7 @@ async fn claim_from_reclaim_inner(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     part: i64,
     exec_uuid: Uuid,
-    token: &ReclaimToken,
+    token: &ResumeToken,
 ) -> Result<Option<(Handle, Vec<PendingEmit>)>, EngineError> {
     // Latest attempt under the partition/exec. Mirror of PG at
     // `ff-backend-postgres/src/attempt.rs:294-308`.
@@ -2614,7 +2614,7 @@ impl EngineBackend for SqliteBackend {
         retry_serializable(|| crate::suspend_ops::observe_signals_impl(pool, handle)).await
     }
 
-    async fn claim_from_reclaim(&self, token: ReclaimToken) -> Result<Option<Handle>, EngineError> {
+    async fn claim_from_resume_grant(&self, token: ResumeToken) -> Result<Option<Handle>, EngineError> {
         let pool = &self.inner.pool;
         let pubsub = &self.inner.pubsub;
         retry_serializable(|| claim_from_reclaim_impl(pool, pubsub, &token)).await

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -16,9 +16,9 @@
 use ff_backend_sqlite::SqliteBackend;
 use ff_core::backend::{
     BackendTag, CapabilitySet, ClaimPolicy, FailureClass, FailureReason, Frame, FrameKind, Handle,
-    HandleKind, PatchKind, ReclaimToken, StreamMode,
+    HandleKind, PatchKind, ResumeToken, StreamMode,
 };
-use ff_core::contracts::ReclaimGrant;
+use ff_core::contracts::ResumeGrant;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
 use ff_core::handle_codec::{HandlePayload, encode as encode_opaque};
@@ -834,7 +834,7 @@ async fn append_frame_fence_mismatch_returns_contention() {
     );
 }
 
-// ── Phase 2a.3 — claim_from_reclaim ────────────────────────────────────
+// ── Phase 2a.3 — claim_from_resume_grant ────────────────────────────────────
 
 /// Set the current attempt's lease to expired (now - 1s) to simulate a
 /// stale lease eligible for reclaim.
@@ -856,19 +856,19 @@ async fn expire_current_lease(backend: &SqliteBackend, exec_uuid: Uuid, attempt_
     .expect("expire lease");
 }
 
-fn make_reclaim_token(exec_id: ExecutionId) -> ReclaimToken {
+fn make_reclaim_token(exec_id: ExecutionId) -> ResumeToken {
     let partition = Partition {
         family: PartitionFamily::Execution,
         index: 0,
     };
-    let grant = ReclaimGrant {
-        execution_id: exec_id,
-        partition_key: PartitionKey::from(&partition),
-        grant_key: "sqlite:test-grant".into(),
-        expires_at_ms: u64::MAX,
-        lane_id: LaneId::new("default"),
-    };
-    ReclaimToken::new(
+    let grant = ResumeGrant::new(
+        exec_id,
+        PartitionKey::from(&partition),
+        "sqlite:test-grant".into(),
+        u64::MAX,
+        LaneId::new("default"),
+    );
+    ResumeToken::new(
         grant,
         WorkerId::new("reclaim-worker"),
         WorkerInstanceId::new("reclaim-worker-instance"),
@@ -894,9 +894,9 @@ async fn claim_from_reclaim_expired_lease_mints_resumed_handle() {
 
     let token = make_reclaim_token(eid);
     let h = backend
-        .claim_from_reclaim(token)
+        .claim_from_resume_grant(token)
         .await
-        .expect("claim_from_reclaim")
+        .expect("claim_from_resume_grant")
         .expect("Some(handle)");
     assert_eq!(h.backend, BackendTag::Sqlite);
     assert_eq!(h.kind, HandleKind::Resumed);
@@ -941,9 +941,9 @@ async fn claim_from_reclaim_live_lease_returns_none() {
     // Do not expire — lease is still live. Reclaim must return None.
     let token = make_reclaim_token(eid);
     let res = backend
-        .claim_from_reclaim(token)
+        .claim_from_resume_grant(token)
         .await
-        .expect("claim_from_reclaim");
+        .expect("claim_from_resume_grant");
     assert!(res.is_none(), "live lease must block reclaim");
 }
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -31,7 +31,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, BackendConnection, CancelFlowPolicy, CancelFlowWait,
     CapabilitySet, ClaimPolicy, FailOutcome, FailureClass, FailureReason, Frame, Handle,
-    HandleKind, LeaseRenewal, PatchKind, PendingWaitpoint, ReclaimToken, ResumeSignal,
+    HandleKind, LeaseRenewal, PatchKind, PendingWaitpoint, ResumeSignal, ResumeToken,
     StreamMode, SummaryDocument, TailVisibility, UsageDimensions, WaitpointHmac,
 };
 use ff_core::contracts::decode::{
@@ -3624,7 +3624,7 @@ async fn suspend_impl(
             // execution identity. The new handle has the same fence
             // triple as the caller's pre-suspend handle — its purpose
             // is to carry a `HandleKind::Suspended` tag for
-            // `observe_signals` / `claim_from_reclaim` routing.
+            // `observe_signals` / `claim_from_resume_grant` routing.
             let suspended_handle = handle_codec::encode_handle(f, HandleKind::Suspended);
             Ok(SuspendOutcome::Suspended {
                 details,
@@ -3914,11 +3914,11 @@ async fn claim_impl(
     Ok(None)
 }
 
-/// Resume-claim implementation — consumes a `ReclaimToken` and routes
+/// Resume-claim implementation — consumes a `ResumeToken` and routes
 /// through `ff_claim_resumed_execution`. Worker identity + lease TTL
 /// ride on the token (Wave 2 additive extension).
 #[tracing::instrument(
-    name = "ff.claim_from_reclaim",
+    name = "ff.claim_from_resume_grant",
     skip_all,
     fields(
         backend = "valkey",
@@ -3926,10 +3926,10 @@ async fn claim_impl(
         worker_instance_id = %token.worker_instance_id,
     )
 )]
-async fn claim_from_reclaim_impl(
+async fn claim_from_resume_grant_impl(
     client: &ferriskey::Client,
     partition_config: &PartitionConfig,
-    token: ReclaimToken,
+    token: ResumeToken,
 ) -> Result<Option<Handle>, EngineError> {
     let execution_id = token.grant.execution_id.clone();
     let lane_id = token.grant.lane_id.clone();
@@ -4320,16 +4320,16 @@ impl EngineBackend for ValkeyBackend {
             })
     }
 
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        token: ReclaimToken,
+        token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        claim_from_reclaim_impl(&self.client, &self.partition_config, token)
+        claim_from_resume_grant_impl(&self.client, &self.partition_config, token)
             .await
             .map_err(|e| {
                 ff_core::engine_error::backend_context(
                     e,
-                    "claim_from_reclaim: FCALL ff_claim_resumed_execution",
+                    "claim_from_resume_grant: FCALL ff_claim_resumed_execution",
                 )
             })
     }

--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -102,11 +102,11 @@ impl BackendTag {
 pub enum HandleKind {
     /// Fresh claim — returned by `claim` / `claim_from_grant`.
     Fresh,
-    /// Resumed from resume grant — returned by `claim_from_reclaim`
-    /// (renames to `claim_from_resume_grant` per RFC-024).
+    /// Resumed from resume grant — returned by `claim_from_resume_grant`
+    /// (renamed from `claim_from_reclaim` per RFC-024 PR-B+C).
     Resumed,
     /// Suspended — returned by `suspend`. Terminal for the lease;
-    /// resumption mints a new Handle via `claim_from_reclaim`.
+    /// resumption mints a new Handle via `claim_from_resume_grant`.
     Suspended,
     /// Reclaimed from a lease-reclaim grant — returned by the new
     /// `reclaim_execution` trait method (RFC-024). Distinct from
@@ -141,7 +141,7 @@ impl HandleOpaque {
 }
 
 /// Opaque attempt cookie held by the worker for the duration of an
-/// attempt. Produced by `claim` / `claim_from_reclaim` / `suspend`;
+/// attempt. Produced by `claim` / `claim_from_resume_grant` / `suspend`;
 /// borrowed by every op (renew, progress, append_frame, complete, fail,
 /// cancel, suspend, delay, wait_children, observe_signals, report_usage).
 ///
@@ -157,7 +157,7 @@ pub struct Handle {
 
 impl Handle {
     /// Construct a new Handle. Called by backend impls only; consumer
-    /// code receives Handles from `claim` / `suspend` / `claim_from_reclaim`.
+    /// code receives Handles from `claim` / `suspend` / `claim_from_resume_grant`.
     pub fn new(backend: BackendTag, kind: HandleKind, opaque: HandleOpaque) -> Self {
         Self {
             backend,
@@ -840,8 +840,8 @@ impl UsageDimensions {
 // ── §3.3.0 Resume / lease types ────────────────────────────────────────
 
 /// Opaque cookie returned by the reclaim scanner; consumed by
-/// `claim_from_reclaim` (renames to `claim_from_resume_grant` per
-/// RFC-024) to mint a resumed Handle.
+/// [`crate::engine_backend::EngineBackend::claim_from_resume_grant`]
+/// to mint a resumed Handle.
 ///
 /// Wraps [`ResumeGrant`] today (the scanner's existing product).
 /// Kept as a newtype so trait signatures name the resume-bound role
@@ -851,17 +851,17 @@ impl UsageDimensions {
 /// **Naming history (RFC-024).** This type was historically called
 /// `ReclaimToken`. Its semantic is resume-after-suspend (it wraps a
 /// `ResumeGrant` and feeds `ff_claim_resumed_execution`), so
-/// RFC-024 Rev 2 renames it. A transitional compatibility alias
-/// `ReclaimToken = ResumeToken` is retained for one release to ease
-/// consumer migration (no `#[deprecated]` marker — see the alias
-/// doc below for the rationale).
+/// RFC-024 Rev 2 renamed it to `ResumeToken`. The transitional
+/// `ReclaimToken` alias lived for one PR and was dropped in PR-B+C;
+/// downstream call sites migrate to `ResumeToken`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ResumeToken {
     pub grant: ResumeGrant,
     /// Worker identity that will claim the resumed execution.
     /// Wave 2 additive extension — mirrors the `ClaimPolicy`
-    /// shape since `claim_from_reclaim` does not take a `ClaimPolicy`.
+    /// shape since `claim_from_resume_grant` does not take a
+    /// `ClaimPolicy`.
     pub worker_id: WorkerId,
     /// Worker instance identity.
     pub worker_instance_id: WorkerInstanceId,
@@ -884,15 +884,6 @@ impl ResumeToken {
         }
     }
 }
-
-/// Transitional alias for [`ResumeToken`].
-///
-/// Retained for compile-time compatibility across the RFC-024 PR
-/// series. A follow-up PR rewrites downstream call sites to
-/// `ResumeToken` and removes this alias. No `#[deprecated]` marker
-/// here because workspace clippy runs with `-D warnings` and the
-/// downstream rename sweep ships separately.
-pub type ReclaimToken = ResumeToken;
 
 /// Result of a successful `renew` call.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -107,6 +107,7 @@ pub enum IssueClaimGrantResult {
 /// decision. The matching field on [`ResumeGrant`] is an
 /// intentional divergence — see the note on that type.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ClaimGrant {
     /// The execution that was granted.
     pub execution_id: ExecutionId,
@@ -125,6 +126,22 @@ pub struct ClaimGrant {
 }
 
 impl ClaimGrant {
+    /// Construct a fresh-claim grant. Added alongside `#[non_exhaustive]`
+    /// per RFC-024 §3.1 + `feedback_non_exhaustive_needs_constructor`.
+    pub fn new(
+        execution_id: ExecutionId,
+        partition_key: crate::partition::PartitionKey,
+        grant_key: String,
+        expires_at_ms: u64,
+    ) -> Self {
+        Self {
+            execution_id,
+            partition_key,
+            grant_key,
+            expires_at_ms,
+        }
+    }
+
     /// Parse `partition_key` into a typed
     /// [`crate::partition::Partition`]. Intended for internal
     /// consumers (scheduler emitter, SDK worker claim path) that
@@ -157,13 +174,11 @@ impl ClaimGrant {
 /// **Naming history (RFC-024).** This type was historically called
 /// `ReclaimGrant`, but its semantic has always been resume-after-
 /// suspend (the routing FCALL is `ff_claim_resumed_execution`, not
-/// `ff_reclaim_execution`). RFC-024 Rev 2 renames the type to
-/// `ResumeGrant` — the name now matches the semantic. A transitional
-/// compatibility alias `ReclaimGrant = ResumeGrant` is retained for
-/// one release to give consumers a `cargo fix`-compatible migration
-/// (no `#[deprecated]` marker — see the alias doc below for the
-/// rationale); the new lease-reclaim path uses a distinct (future)
-/// type.
+/// `ff_reclaim_execution`). RFC-024 PR-A renamed the type to
+/// `ResumeGrant` — the name now matches the semantic. RFC-024 PR-B+C
+/// dropped the transitional `ReclaimGrant = ResumeGrant` alias and
+/// introduced a distinct new [`ReclaimGrant`] for the lease-reclaim
+/// path (`reclaim_execution` / `ff_reclaim_execution`).
 ///
 /// Mirrors [`ClaimGrant`] for the resume path. Differences:
 ///
@@ -194,6 +209,7 @@ impl ClaimGrant {
 ///
 /// [`FlowFabricWorker::claim_from_resume_grant`]: https://docs.rs/ff-sdk
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ResumeGrant {
     /// The execution granted for resumption.
     pub execution_id: ExecutionId,
@@ -216,6 +232,24 @@ pub struct ResumeGrant {
 }
 
 impl ResumeGrant {
+    /// Construct a resume grant. Added alongside `#[non_exhaustive]`
+    /// per RFC-024 §3.1 + `feedback_non_exhaustive_needs_constructor`.
+    pub fn new(
+        execution_id: ExecutionId,
+        partition_key: crate::partition::PartitionKey,
+        grant_key: String,
+        expires_at_ms: u64,
+        lane_id: LaneId,
+    ) -> Self {
+        Self {
+            execution_id,
+            partition_key,
+            grant_key,
+            expires_at_ms,
+            lane_id,
+        }
+    }
+
     /// Parse `partition_key` into a typed
     /// [`crate::partition::Partition`]. See [`ClaimGrant::partition`]
     /// for the alias-collapse note.
@@ -226,16 +260,70 @@ impl ResumeGrant {
     }
 }
 
-/// Transitional alias for [`ResumeGrant`].
+/// A lease-reclaim grant issued for an execution in
+/// `lease_expired_reclaimable` or `lease_revoked` state (RFC-024 §3.1).
 ///
-/// Retained for compile-time compatibility across the RFC-024 PR
-/// series. A follow-up PR rewrites downstream call sites to
-/// `ResumeGrant` and removes this alias; that same PR introduces a
-/// distinct new `ReclaimGrant` type for the lease-reclaim path
-/// (`reclaim_execution` / `ff_reclaim_execution`). No `#[deprecated]`
-/// marker on this PR because workspace clippy runs with `-D warnings`
-/// and the downstream rename sweep ships separately.
-pub type ReclaimGrant = ResumeGrant;
+/// Distinct from [`ResumeGrant`]: the reclaim grant routes to
+/// `ff_reclaim_execution` (Valkey) / the new-attempt reclaim impl
+/// (PG/SQLite), which creates a NEW attempt row and bumps the
+/// execution's `lease_reclaim_count`. The resume grant, by contrast,
+/// re-uses the existing attempt under `ff_claim_resumed_execution`.
+///
+/// Carries `lane_id` for symmetry with [`ResumeGrant`] — the Lua
+/// `ff_reclaim_execution` needs the lane for key construction, and
+/// the consuming worker would otherwise pay a round-trip to recover
+/// it from `exec_core`.
+///
+/// Backend impl bodies ship under PR-D (PG) / PR-E (SQLite) / PR-F
+/// (Valkey). This PR lands only the type + trait surface; default
+/// [`crate::engine_backend::EngineBackend::issue_reclaim_grant`] and
+/// [`crate::engine_backend::EngineBackend::reclaim_execution`] return
+/// [`crate::engine_error::EngineError::Unavailable`] until each
+/// backend PR wires its real body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ReclaimGrant {
+    /// The execution granted for lease-reclaim.
+    pub execution_id: ExecutionId,
+    /// Opaque partition handle for this execution's hash-tag slot.
+    pub partition_key: crate::partition::PartitionKey,
+    /// Backend-scoped grant key (Valkey key / PG+SQLite
+    /// `ff_claim_grant.grant_id`).
+    pub grant_key: String,
+    /// Monotonic ms when the grant expires; unconsumed grants vanish.
+    pub expires_at_ms: u64,
+    /// Lane the execution belongs to — needed by
+    /// `ff_reclaim_execution` for `KEYS[*]` construction.
+    pub lane_id: LaneId,
+}
+
+impl ReclaimGrant {
+    /// Construct a reclaim grant. Added alongside `#[non_exhaustive]`
+    /// per RFC-024 §3.1 + `feedback_non_exhaustive_needs_constructor`.
+    pub fn new(
+        execution_id: ExecutionId,
+        partition_key: crate::partition::PartitionKey,
+        grant_key: String,
+        expires_at_ms: u64,
+        lane_id: LaneId,
+    ) -> Self {
+        Self {
+            execution_id,
+            partition_key,
+            grant_key,
+            expires_at_ms,
+            lane_id,
+        }
+    }
+
+    /// Parse `partition_key` into a typed
+    /// [`crate::partition::Partition`].
+    pub fn partition(
+        &self,
+    ) -> Result<crate::partition::Partition, crate::partition::PartitionKeyParseError> {
+        self.partition_key.parse()
+    }
+}
 
 // ─── claim_execution ───
 
@@ -531,6 +619,7 @@ pub enum FailExecutionResult {
 // ─── issue_reclaim_grant ───
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct IssueReclaimGrantArgs {
     pub execution_id: ExecutionId,
     pub worker_id: WorkerId,
@@ -543,11 +632,49 @@ pub struct IssueReclaimGrantArgs {
     pub route_snapshot_json: Option<String>,
     #[serde(default)]
     pub admission_summary: Option<String>,
+    /// Worker capabilities (parity with `IssueClaimGrantArgs`). The
+    /// Lua primitive `ff_issue_reclaim_grant` reads these at ARGV[9].
+    /// Populated by the SDK admin path from the registered worker's
+    /// `WorkerRegistration::capabilities` per RFC-024 §3.2 (B-2).
+    #[serde(default)]
+    pub worker_capabilities: BTreeSet<String>,
     /// Caller-side timestamp for bookkeeping. NOT passed to the Lua FCALL —
     /// ff_issue_reclaim_grant uses `redis.call("TIME")` for grant_expires_at
     /// (same as ff_issue_claim_grant). Kept for contract symmetry with
     /// IssueClaimGrantArgs and scheduler audit logging.
     pub now: TimestampMs,
+}
+
+impl IssueReclaimGrantArgs {
+    /// Construct an `IssueReclaimGrantArgs`. Added alongside
+    /// `#[non_exhaustive]` per RFC-024 §3.2 +
+    /// `feedback_non_exhaustive_needs_constructor`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        execution_id: ExecutionId,
+        worker_id: WorkerId,
+        worker_instance_id: WorkerInstanceId,
+        lane_id: LaneId,
+        capability_hash: Option<String>,
+        grant_ttl_ms: u64,
+        route_snapshot_json: Option<String>,
+        admission_summary: Option<String>,
+        worker_capabilities: BTreeSet<String>,
+        now: TimestampMs,
+    ) -> Self {
+        Self {
+            execution_id,
+            worker_id,
+            worker_instance_id,
+            lane_id,
+            capability_hash,
+            grant_ttl_ms,
+            route_snapshot_json,
+            admission_summary,
+            worker_capabilities,
+            now,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -556,9 +683,35 @@ pub enum IssueReclaimGrantResult {
     Granted { expires_at_ms: TimestampMs },
 }
 
+/// Typed outcome of [`crate::engine_backend::EngineBackend::issue_reclaim_grant`]
+/// (RFC-024 §3.2).
+///
+/// Construction surface: backends produce variants; consumers match
+/// on variants. No `::new()` — variants ARE the surface.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IssueReclaimGrantOutcome {
+    /// Grant issued — hand the carried [`ReclaimGrant`] to
+    /// [`crate::engine_backend::EngineBackend::reclaim_execution`].
+    Granted(ReclaimGrant),
+    /// Execution is not in a reclaimable state (not
+    /// `lease_expired_reclaimable` / `lease_revoked`).
+    NotReclaimable {
+        execution_id: ExecutionId,
+        detail: String,
+    },
+    /// `max_reclaim_count` exceeded; execution transitioned to
+    /// terminal_failed by the backend primitive.
+    ReclaimCapExceeded {
+        execution_id: ExecutionId,
+        reclaim_count: u32,
+    },
+}
+
 // ─── reclaim_execution ───
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ReclaimExecutionArgs {
     pub execution_id: ExecutionId,
     pub worker_id: WorkerId,
@@ -572,17 +725,78 @@ pub struct ReclaimExecutionArgs {
     /// JSON-encoded attempt policy for the reclaim attempt.
     #[serde(default)]
     pub attempt_policy_json: String,
-    /// Maximum reclaim count before terminal failure. Default: 100.
-    #[serde(default = "default_max_reclaim_count")]
-    pub max_reclaim_count: u32,
+    /// Maximum reclaim count before terminal failure. `None` ⇒ backend
+    /// applies the Rust-surface default of 1000 per RFC-024 §4.6. The
+    /// Lua fallback remains 100 for pre-RFC ARGV-omitted call sites;
+    /// the two-default coexistence is explicit by design.
+    #[serde(default)]
+    pub max_reclaim_count: Option<u32>,
     /// Old worker instance (for old_worker_leases key construction).
     pub old_worker_instance_id: WorkerInstanceId,
     /// Current attempt index (for old_attempt/old_stream_meta key construction).
     pub current_attempt_index: AttemptIndex,
 }
 
-fn default_max_reclaim_count() -> u32 {
-    100
+impl ReclaimExecutionArgs {
+    /// Construct a `ReclaimExecutionArgs`. Added alongside
+    /// `#[non_exhaustive]` per RFC-024 §3.2 +
+    /// `feedback_non_exhaustive_needs_constructor`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        execution_id: ExecutionId,
+        worker_id: WorkerId,
+        worker_instance_id: WorkerInstanceId,
+        lane_id: LaneId,
+        capability_hash: Option<String>,
+        lease_id: LeaseId,
+        lease_ttl_ms: u64,
+        attempt_id: AttemptId,
+        attempt_policy_json: String,
+        max_reclaim_count: Option<u32>,
+        old_worker_instance_id: WorkerInstanceId,
+        current_attempt_index: AttemptIndex,
+    ) -> Self {
+        Self {
+            execution_id,
+            worker_id,
+            worker_instance_id,
+            lane_id,
+            capability_hash,
+            lease_id,
+            lease_ttl_ms,
+            attempt_id,
+            attempt_policy_json,
+            max_reclaim_count,
+            old_worker_instance_id,
+            current_attempt_index,
+        }
+    }
+}
+
+/// Typed outcome of [`crate::engine_backend::EngineBackend::reclaim_execution`]
+/// (RFC-024 §3.2).
+///
+/// Distinct from the wire-level [`ReclaimExecutionResult`]; this enum
+/// is the trait-surface shape consumers match on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReclaimExecutionOutcome {
+    /// Execution reclaimed — carries the new-attempt
+    /// [`crate::backend::Handle`] (kind = `Reclaimed`).
+    Claimed(crate::backend::Handle),
+    /// Execution is not in a reclaimable state.
+    NotReclaimable {
+        execution_id: ExecutionId,
+        detail: String,
+    },
+    /// `max_reclaim_count` exceeded; execution transitioned to
+    /// terminal_failed.
+    ReclaimCapExceeded {
+        execution_id: ExecutionId,
+        reclaim_count: u32,
+    },
+    /// The supplied grant was not found / already consumed / expired.
+    GrantNotFound { execution_id: ExecutionId },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -53,7 +53,8 @@ use crate::backend::{
     PrepareOutcome, ResumeSignal, ResumeToken, SummaryDocument, TailVisibility,
 };
 use crate::contracts::{
-    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
+    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, IssueReclaimGrantArgs,
+    IssueReclaimGrantOutcome, ReclaimExecutionArgs, ReclaimExecutionOutcome, ReportUsageResult,
     RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SeedOutcome,
     SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome,
 };
@@ -254,11 +255,48 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// `Ok(None)` when the grant's target execution is no longer
     /// resumable (already reclaimed, terminal, etc.).
     ///
-    /// **Naming history (RFC-024).** The method name + token name
-    /// historically said "reclaim" but the semantic has always been
-    /// resume-after-suspend. The token type is now `ResumeToken`; a
-    /// follow-up PR renames this method to `claim_from_resume_grant`.
-    async fn claim_from_reclaim(&self, token: ResumeToken) -> Result<Option<Handle>, EngineError>;
+    /// **Renamed from `claim_from_reclaim` (RFC-024 PR-B+C).** The
+    /// pre-rename name advertised "reclaim" but the semantic has
+    /// always been resume-after-suspend. The new lease-reclaim path
+    /// lives on [`Self::reclaim_execution`].
+    async fn claim_from_resume_grant(
+        &self,
+        token: ResumeToken,
+    ) -> Result<Option<Handle>, EngineError>;
+
+    /// Issue a lease-reclaim grant (RFC-024 §3.2). Admits executions
+    /// in `lease_expired_reclaimable` or `lease_revoked` state to the
+    /// reclaim path; the returned [`IssueReclaimGrantOutcome::Granted`]
+    /// carries a [`crate::contracts::ReclaimGrant`] which is then fed
+    /// to [`Self::reclaim_execution`] to mint a fresh attempt.
+    ///
+    /// Default impl returns [`EngineError::Unavailable`] — PR-D (PG),
+    /// PR-E (SQLite), and PR-F (Valkey) override with real bodies.
+    async fn issue_reclaim_grant(
+        &self,
+        _args: IssueReclaimGrantArgs,
+    ) -> Result<IssueReclaimGrantOutcome, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "issue_reclaim_grant",
+        })
+    }
+
+    /// Consume a [`crate::contracts::ReclaimGrant`] to mint a fresh
+    /// attempt for a previously lease-expired / lease-revoked
+    /// execution (RFC-024 §3.2). Creates a new attempt row, bumps the
+    /// execution's `lease_reclaim_count`, and mints a
+    /// [`crate::backend::HandleKind::Reclaimed`] handle.
+    ///
+    /// Default impl returns [`EngineError::Unavailable`] — PR-D (PG),
+    /// PR-E (SQLite), and PR-F (Valkey) override with real bodies.
+    async fn reclaim_execution(
+        &self,
+        _args: ReclaimExecutionArgs,
+    ) -> Result<ReclaimExecutionOutcome, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "reclaim_execution",
+        })
+    }
 
     // Round-5 amendment: lease-releasing peers of `suspend`.
 
@@ -532,7 +570,7 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// same attempt index.
     ///
     /// Distinct from [`Self::claim`] (fresh work) and
-    /// [`Self::claim_from_reclaim`] (grant-based ownership transfer
+    /// [`Self::claim_from_resume_grant`] (grant-based ownership transfer
     /// after a crash): the resumed-claim path re-binds an existing
     /// attempt rather than minting a new one. The backend issues a
     /// fresh `lease_id` + bumps the `lease_epoch`, preserving
@@ -1391,7 +1429,7 @@ mod tests {
         ) -> Result<Vec<ResumeSignal>, EngineError> {
             unreachable!()
         }
-        async fn claim_from_reclaim(
+        async fn claim_from_resume_grant(
             &self,
             _token: ResumeToken,
         ) -> Result<Option<Handle>, EngineError> {

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -42,14 +42,14 @@ fn worker_caps_digest(csv: &str) -> String {
 /// share one wire-level type without a cross-dep between them.
 pub use ff_core::contracts::ClaimGrant;
 
-/// A reclaim grant for a resumed (attempt_interrupted) execution.
+/// A resume grant for a resumed (attempt_interrupted) execution.
 ///
-/// Re-export of [`ff_core::contracts::ReclaimGrant`] for symmetry
+/// Re-export of [`ff_core::contracts::ResumeGrant`] for symmetry
 /// with [`ClaimGrant`]. `ff-scheduler` will be the canonical
 /// producer once the Batch-C reclaim scanner lands; today only
 /// test fixtures construct this type. Consumed by
-/// `FlowFabricWorker::claim_from_reclaim_grant`.
-pub use ff_core::contracts::ReclaimGrant;
+/// `FlowFabricWorker::claim_from_resume_grant`.
+pub use ff_core::contracts::ResumeGrant;
 
 /// Budget check result from a cross-partition budget read.
 #[derive(Debug)]
@@ -800,12 +800,12 @@ impl Scheduler {
                         elapsed_ms = call_start.elapsed().as_millis() as u64,
                         "scheduler: claim call completed (hit)"
                     );
-                    return Ok(Some(ClaimGrant {
-                        execution_id: eid,
-                        partition_key: ff_core::partition::PartitionKey::from(&partition),
-                        grant_key: grant_key.clone(),
-                        expires_at_ms: now_ms + grant_ttl_ms,
-                    }));
+                    return Ok(Some(ClaimGrant::new(
+                        eid,
+                        ff_core::partition::PartitionKey::from(&partition),
+                        grant_key.clone(),
+                        now_ms + grant_ttl_ms,
+                    )));
                 }
                 Err(script_err) => {
                     if matches!(script_err, ScriptError::CapabilityMismatch(_)) {

--- a/crates/ff-scheduler/src/lib.rs
+++ b/crates/ff-scheduler/src/lib.rs
@@ -2,4 +2,4 @@
 
 pub mod claim;
 
-pub use claim::{ClaimGrant, ReclaimGrant, Scheduler, SchedulerConfig, SchedulerError};
+pub use claim::{ClaimGrant, ResumeGrant, Scheduler, SchedulerConfig, SchedulerError};

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -380,12 +380,12 @@ impl ClaimForWorkerResponse {
                 retryable: Some(false),
                 raw_body: String::new(),
             })?;
-        Ok(ff_core::contracts::ClaimGrant {
+        Ok(ff_core::contracts::ClaimGrant::new(
             execution_id,
-            partition_key: self.partition_key,
-            grant_key: self.grant_key,
-            expires_at_ms: self.expires_at_ms,
-        })
+            self.partition_key,
+            self.grant_key,
+            self.expires_at_ms,
+        ))
     }
 }
 

--- a/crates/ff-sdk/src/layer/hooks.rs
+++ b/crates/ff-sdk/src/layer/hooks.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy, FailOutcome,
-    FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint, ReclaimToken,
+    FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint, ResumeToken,
     ResumeSignal,
 };
 use ff_core::contracts::{
@@ -230,11 +230,11 @@ impl<H: LayerHooks> EngineBackend for HookedBackend<H> {
         )
     }
 
-    async fn claim_from_reclaim(&self, token: ReclaimToken) -> Result<Option<Handle>, EngineError> {
+    async fn claim_from_resume_grant(&self, token: ResumeToken) -> Result<Option<Handle>, EngineError> {
         with_hooks!(
             self,
-            "claim_from_reclaim",
-            self.inner.claim_from_reclaim(token).await
+            "claim_from_resume_grant",
+            self.inner.claim_from_resume_grant(token).await
         )
     }
 

--- a/crates/ff-sdk/src/layer/test_support.rs
+++ b/crates/ff-sdk/src/layer/test_support.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, BackendTag, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
     FailOutcome, FailureClass, FailureReason, Frame, Handle, HandleKind, HandleOpaque,
-    LeaseRenewal, PendingWaitpoint, ReclaimToken, ResumeSignal, UsageDimensions, WaitpointHmac,
+    LeaseRenewal, PendingWaitpoint, ResumeToken, ResumeSignal, UsageDimensions, WaitpointHmac,
 };
 use ff_core::contracts::{
     CancelFlowResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
@@ -187,11 +187,11 @@ impl EngineBackend for PassthroughBackend {
         Ok(Vec::new())
     }
 
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        _token: ReclaimToken,
+        _token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        self.record("claim_from_reclaim")?;
+        self.record("claim_from_resume_grant")?;
         Ok(None)
     }
 

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -59,21 +59,21 @@
 //! * [`FlowFabricWorker::claim_from_grant`] — fresh claims. Use
 //!   `ff_scheduler::Scheduler::claim_for_worker` to obtain the
 //!   [`ClaimGrant`], then hand it to the SDK.
-//! * [`FlowFabricWorker::claim_from_reclaim_grant`] — resumed claims
+//! * [`FlowFabricWorker::claim_from_resume_grant`] — resumed claims
 //!   for an `attempt_interrupted` execution. Wraps a
-//!   [`ReclaimGrant`].
+//!   [`ResumeGrant`].
 //!
 //! `claim_next` bypasses budget and quota admission control; the
 //! grant-based path does not. See each method's rustdoc for the
 //! exact migration recipe.
 //!
-//! `ClaimGrant` / `ReclaimGrant` (and the `ClaimPolicy` /
-//! `ReclaimToken` wire types on the scheduler-owner side) are
-//! re-exported from `ff-sdk` (#283) so consumers do not need a
-//! direct `ff-scheduler` dep just to type these signatures.
+//! `ClaimGrant` / `ResumeGrant` / `ReclaimGrant` (and the
+//! `ClaimPolicy` / `ResumeToken` wire types on the scheduler-owner
+//! side) are re-exported from `ff-sdk` (#283) so consumers do not need
+//! a direct `ff-scheduler` dep just to type these signatures.
 //!
 //! [`ClaimGrant`]: crate::ClaimGrant
-//! [`ReclaimGrant`]: crate::ReclaimGrant
+//! [`ResumeGrant`]: crate::ResumeGrant
 
 #[cfg(feature = "valkey-default")]
 pub mod admin;
@@ -149,13 +149,13 @@ pub use ff_core::contracts::{
     SuspensionRequester, TimeoutBehavior, WaitpointBinding,
 };
 // #283 — Claim-flow wire types. Consumers typing `claim_from_grant` /
-// `claim_from_reclaim_grant` signatures (or wrapping
-// `EngineBackend::claim_for_worker`) can name these as
+// `claim_from_resume_grant` / `claim_from_reclaim_grant` signatures (or
+// wrapping `EngineBackend::claim_for_worker`) can name these as
 // `ff_sdk::ClaimGrant` etc. without pinning `ff-scheduler` directly.
 // `Scheduler` itself is intentionally not re-exported: implementing a
 // scheduler is specialized and stays behind the `ff-scheduler` dep.
-pub use ff_core::backend::{ClaimPolicy, ReclaimToken};
-pub use ff_core::contracts::{ClaimGrant, ReclaimGrant};
+pub use ff_core::backend::{ClaimPolicy, ResumeToken};
+pub use ff_core::contracts::{ClaimGrant, ReclaimGrant, ResumeGrant};
 // RFC-023 Phase 1a (§4.4 item 10): re-export always reachable. The
 // Valkey-specific methods (`connect`, `claim_*`, `deliver_signal`)
 // are item-level cfg-gated; under sqlite-only features the type
@@ -214,7 +214,7 @@ pub enum SdkError {
     /// [`FlowFabricWorker::claim_from_grant`] and
     /// [`FlowFabricWorker::claim_from_reclaim_grant`] when the
     /// concurrency semaphore is saturated. Distinct from `Ok(None)`:
-    /// a `ClaimGrant`/`ReclaimGrant` represents real work already
+    /// a `ClaimGrant`/`ResumeGrant` represents real work already
     /// selected by the scheduler, so silently dropping it would waste
     /// the grant and let the grant TTL elapse. Surfacing the
     /// saturation lets the caller release the grant (or wait +

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -961,7 +961,7 @@ impl ClaimedTask {
             SuspendOutcome::Suspended { details, handle: new_handle } => {
                 // Renewal is stopped only AFTER a successful Suspended
                 // outcome. The suspended-kind handle is what the caller
-                // will later hand to `observe_signals` / `claim_from_reclaim`.
+                // will later hand to `observe_signals` / `claim_from_resume_grant`.
                 self.stop_renewal();
                 Ok(TrySuspendOutcome::Suspended(SuspendedHandle {
                     handle: new_handle,

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1432,10 +1432,15 @@ impl FlowFabricWorker {
         self.claim_from_grant(lane.clone(), grant).await.map(Some)
     }
 
-    /// Consume a [`ReclaimGrant`] and transition the granted
+    /// Consume a [`ResumeGrant`] and transition the granted
     /// `attempt_interrupted` execution into a `started` state on this
     /// worker. Symmetric partner to [`claim_from_grant`] for the
     /// resume path.
+    ///
+    /// **Renamed from `claim_from_reclaim_grant` (RFC-024 PR-B+C).**
+    /// The new `claim_from_reclaim_grant` method lands with PR-G and
+    /// dispatches to [`EngineBackend::reclaim_execution`] for the
+    /// lease-reclaim path (distinct semantic, distinct grant type).
     ///
     /// The grant must have been issued to THIS worker (matching
     /// `worker_id` at grant time). A mismatch returns
@@ -1474,12 +1479,12 @@ impl FlowFabricWorker {
     /// * [`SdkError::Backend`] / [`SdkError::BackendContext`] —
     ///   transport.
     ///
-    /// [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
+    /// [`ResumeGrant`]: ff_core::contracts::ResumeGrant
     /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
     #[cfg(feature = "valkey-default")]
-    pub async fn claim_from_reclaim_grant(
+    pub async fn claim_from_resume_grant(
         &self,
-        grant: ff_core::contracts::ReclaimGrant,
+        grant: ff_core::contracts::ResumeGrant,
     ) -> Result<ClaimedTask, SdkError> {
         // Semaphore check FIRST — same load-bearing ordering as
         // `claim_from_grant`. If the worker is saturated, surface
@@ -1496,7 +1501,7 @@ impl FlowFabricWorker {
         // Grant carries partition + lane_id so no round-trip is needed
         // to resolve them before the FCALL.
         let partition = grant.partition().map_err(|e| SdkError::Config {
-            context: "claim_from_reclaim_grant".to_owned(),
+            context: "claim_from_resume_grant".to_owned(),
             field: Some("partition_key".to_owned()),
             message: e.to_string(),
         })?;
@@ -1517,9 +1522,9 @@ impl FlowFabricWorker {
     /// returns a [`ClaimedTask`] bound to the resumed attempt.
     ///
     /// The method stays private; external callers use
-    /// [`claim_from_reclaim_grant`].
+    /// [`claim_from_resume_grant`].
     ///
-    /// [`claim_from_reclaim_grant`]: FlowFabricWorker::claim_from_reclaim_grant
+    /// [`claim_from_resume_grant`]: FlowFabricWorker::claim_from_resume_grant
     #[cfg(feature = "valkey-default")]
     async fn claim_resumed_execution(
         &self,

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -1785,12 +1785,12 @@ mod claim_grant_dto_tests {
         let fid = FlowId::new();
         let eid = ExecutionId::for_flow(&fid, &config);
         let p = Partition { family, index: 7 };
-        ClaimGrant {
-            execution_id: eid,
-            partition_key: PartitionKey::from(&p),
-            grant_key: "ff:exec:{fp:7}:deadbeef:claim_grant".to_owned(),
-            expires_at_ms: 1_700_000_000_000,
-        }
+        ClaimGrant::new(
+            eid,
+            PartitionKey::from(&p),
+            "ff:exec:{fp:7}:deadbeef:claim_grant".to_owned(),
+            1_700_000_000_000,
+        )
     }
 
     #[test]

--- a/crates/ff-server/tests/parity_stage_a.rs
+++ b/crates/ff-server/tests/parity_stage_a.rs
@@ -32,7 +32,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
     FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
-    ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
+    ResumeToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
 };
 use ff_core::contracts::{
     CancelFlowResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
@@ -166,11 +166,11 @@ impl EngineBackend for MockBackend {
         Err(unavailable("mock::observe_signals"))
     }
 
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        _token: ReclaimToken,
+        _token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        Err(unavailable("mock::claim_from_reclaim"))
+        Err(unavailable("mock::claim_from_resume_grant"))
     }
 
     async fn delay(

--- a/crates/ff-server/tests/parity_stage_a_backfill.rs
+++ b/crates/ff-server/tests/parity_stage_a_backfill.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
     FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
-    ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
+    ResumeToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
 };
 use ff_core::contracts::{
     AddExecutionToFlowArgs, ApplyDependencyToChildArgs, CancelExecutionArgs, CancelFlowResult,
@@ -111,9 +111,9 @@ impl EngineBackend for DefaultsOnlyBackend {
     ) -> Result<Vec<ResumeSignal>, EngineError> {
         Ok(vec![])
     }
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        _t: ReclaimToken,
+        _t: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
         Ok(None)
     }

--- a/crates/ff-server/tests/parity_stage_b.rs
+++ b/crates/ff-server/tests/parity_stage_b.rs
@@ -34,7 +34,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
     FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
-    ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
+    ResumeToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
 };
 use ff_core::contracts::{
     CancelFlowResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
@@ -140,11 +140,11 @@ impl EngineBackend for MockBackend {
     ) -> Result<Vec<ResumeSignal>, EngineError> {
         Err(unavailable("mock::observe_signals"))
     }
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        _token: ReclaimToken,
+        _token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        Err(unavailable("mock::claim_from_reclaim"))
+        Err(unavailable("mock::claim_from_resume_grant"))
     }
     async fn delay(
         &self,
@@ -400,11 +400,11 @@ impl EngineBackend for DefaultsBackend {
     ) -> Result<Vec<ResumeSignal>, EngineError> {
         Err(unavailable("defaults::observe_signals"))
     }
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        _token: ReclaimToken,
+        _token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        Err(unavailable("defaults::claim_from_reclaim"))
+        Err(unavailable("defaults::claim_from_resume_grant"))
     }
     async fn delay(
         &self,

--- a/crates/ff-server/tests/parity_stage_c.rs
+++ b/crates/ff-server/tests/parity_stage_c.rs
@@ -31,7 +31,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
     FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
-    ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
+    ResumeToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
 };
 use ff_core::contracts::{
     AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
@@ -161,11 +161,11 @@ impl EngineBackend for MockBackend {
     ) -> Result<Vec<ResumeSignal>, EngineError> {
         Err(unavailable("mock::observe_signals"))
     }
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        _token: ReclaimToken,
+        _token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        Err(unavailable("mock::claim_from_reclaim"))
+        Err(unavailable("mock::claim_from_resume_grant"))
     }
     async fn delay(
         &self,
@@ -981,12 +981,12 @@ async fn claim_for_worker_granted_returns_grant_shape() {
     let partition = PartitionConfig::default();
     let eid = ExecutionId::for_flow(&FlowId::new(), &partition);
     let part = ff_core::partition::execution_partition(&eid, &partition);
-    let grant = ClaimGrant {
-        execution_id: eid.clone(),
-        partition_key: PartitionKey::from(&part),
-        grant_key: "ff:exec:{p:0}:xxx:claim_grant".into(),
-        expires_at_ms: 30_000,
-    };
+    let grant = ClaimGrant::new(
+        eid.clone(),
+        PartitionKey::from(&part),
+        "ff:exec:{p:0}:xxx:claim_grant".into(),
+        30_000,
+    );
     {
         let mut g = mock.scripted.lock().unwrap();
         g.claim_for_worker = Some(Ok(ClaimForWorkerOutcome::granted(grant.clone())));

--- a/crates/ff-server/tests/parity_stage_d1.rs
+++ b/crates/ff-server/tests/parity_stage_d1.rs
@@ -32,7 +32,7 @@ use async_trait::async_trait;
 use ff_core::backend::{
     AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy,
     FailOutcome, FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint,
-    ReclaimToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
+    ResumeToken, ResumeSignal, SummaryDocument, TailVisibility, UsageDimensions,
 };
 use ff_core::contracts::{
     AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
@@ -159,11 +159,11 @@ impl EngineBackend for MockBackend {
     ) -> Result<Vec<ResumeSignal>, EngineError> {
         Err(unavailable("mock::observe_signals"))
     }
-    async fn claim_from_reclaim(
+    async fn claim_from_resume_grant(
         &self,
-        _token: ReclaimToken,
+        _token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
-        Err(unavailable("mock::claim_from_reclaim"))
+        Err(unavailable("mock::claim_from_resume_grant"))
     }
     async fn delay(
         &self,

--- a/crates/ff-test/tests/claim_grant_wire.rs
+++ b/crates/ff-test/tests/claim_grant_wire.rs
@@ -31,12 +31,12 @@ fn sample_grant(family: PartitionFamily) -> ClaimGrant {
     let fid = FlowId::new();
     let eid = ExecutionId::for_flow(&fid, &config);
     let p = Partition { family, index: 42 };
-    ClaimGrant {
-        execution_id: eid,
-        partition_key: PartitionKey::from(&p),
-        grant_key: "ff:exec:{fp:42}:00000000-0000-0000-0000-000000000000:claim_grant".to_owned(),
-        expires_at_ms: 1_700_000_000_000,
-    }
+    ClaimGrant::new(
+        eid,
+        PartitionKey::from(&p),
+        "ff:exec:{fp:42}:00000000-0000-0000-0000-000000000000:claim_grant".to_owned(),
+        1_700_000_000_000,
+    )
 }
 
 /// Manually construct the JSON the server emits (ClaimGrantDto is

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -5058,17 +5058,17 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     // moved into the saturated call. The grant values are
     // unchanged; we just rebuild the Rust wrapper around the same
     // Valkey key.
-    let rebuilt_g2 = ff_core::contracts::ClaimGrant {
-        execution_id: eid_b.clone(),
-        partition_key: ff_core::partition::PartitionKey::from(
+    // expires_at_ms is advisory on the consumer side; Lua enforces the
+    // real expiry via its own TIME read, so copying any value from the
+    // pre-rejection grant is fine.
+    let rebuilt_g2 = ff_core::contracts::ClaimGrant::new(
+        eid_b.clone(),
+        ff_core::partition::PartitionKey::from(
             &ff_core::partition::execution_partition(&eid_b, &test_config()),
         ),
-        grant_key: g2_key.clone(),
-        // expires_at_ms is advisory on the consumer side; Lua
-        // enforces the real expiry via its own TIME read, so
-        // copying any value from the pre-rejection grant is fine.
-        expires_at_ms: u64::MAX,
-    };
+        g2_key.clone(),
+        u64::MAX,
+    );
 
     let task2 = second_worker
         .claim_from_grant(lane_id.clone(), rebuilt_g2)
@@ -8826,7 +8826,7 @@ async fn test_capable_worker_unblocks_on_get_error_failopen() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// FlowFabricWorker::claim_from_reclaim_grant (cairn-fabric P1B)
+// FlowFabricWorker::claim_from_resume_grant (cairn-fabric P1B)
 // ═══════════════════════════════════════════════════════════════════════
 
 /// Write the test partition config into Valkey so the SDK's worker
@@ -8873,7 +8873,7 @@ async fn build_reclaim_test_worker(
 /// Drive an execution through create → claim → suspend → deliver-signal,
 /// leaving it in `attempt_interrupted` with the suspended/runnable
 /// transition already completed. Returns the eid plus the `ReclaimGrant`
-/// a caller can pass to `claim_from_reclaim_grant`.
+/// a caller can pass to `claim_from_resume_grant`.
 ///
 /// `grant_ttl_ms` is the TTL for the claim-grant the resumed-path
 /// consumer reads. Short TTL = fast expiry test; long TTL = happy path.
@@ -8883,7 +8883,7 @@ async fn suspend_resume_setup_with_grant(
     grant_ttl_ms: u64,
     grant_worker_id: &str,
     grant_worker_instance_id: &str,
-) -> ff_core::contracts::ReclaimGrant {
+) -> ff_core::contracts::ResumeGrant {
     // 1. create + claim the initial attempt
     fcall_create_execution(tc, eid, NS, LANE, "reclaim_grant_test", 0).await;
     fcall_issue_claim_grant(tc, eid, LANE, WORKER, WORKER_INST).await;
@@ -8951,23 +8951,23 @@ async fn suspend_resume_setup_with_grant(
         .and_then(|s| s.parse().ok())
         .expect("grant_expires_at should be numeric");
 
-    ff_core::contracts::ReclaimGrant {
-        execution_id: eid.clone(),
-        partition_key: ff_core::partition::PartitionKey::from(&partition),
+    ff_core::contracts::ResumeGrant::new(
+        eid.clone(),
+        ff_core::partition::PartitionKey::from(&partition),
         grant_key,
         expires_at_ms,
         lane_id,
-    }
+    )
 }
 
-/// Happy path + control: `claim_from_reclaim_grant` resumes the
+/// Happy path + control: `claim_from_resume_grant` resumes the
 /// suspended execution cleanly. Paired with the expiry test — both use
 /// the same setup; this one consumes the grant immediately to prove
 /// the flow works, the other waits out the TTL to prove the expiry
 /// check fires.
 #[tokio::test]
 #[serial_test::serial]
-async fn test_claim_from_reclaim_grant_happy_path() {
+async fn test_claim_from_resume_grant_happy_path() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     write_test_partition_config(&tc).await;
@@ -8981,7 +8981,7 @@ async fn test_claim_from_reclaim_grant_happy_path() {
 
     let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
     let claimed = worker
-        .claim_from_reclaim_grant(grant)
+        .claim_from_resume_grant(grant)
         .await
         .expect("happy path should succeed");
 
@@ -9009,7 +9009,7 @@ async fn test_claim_from_reclaim_grant_happy_path() {
 /// real TTL check.
 #[tokio::test]
 #[serial_test::serial]
-async fn test_claim_from_reclaim_grant_immediate_control() {
+async fn test_claim_from_resume_grant_immediate_control() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     write_test_partition_config(&tc).await;
@@ -9023,7 +9023,7 @@ async fn test_claim_from_reclaim_grant_immediate_control() {
 
     let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
     let claimed = worker
-        .claim_from_reclaim_grant(grant)
+        .claim_from_resume_grant(grant)
         .await
         .expect("control: short-TTL grant claimed immediately should still succeed");
 
@@ -9035,7 +9035,7 @@ async fn test_claim_from_reclaim_grant_immediate_control() {
 /// "short TTL always fails" flakiness.
 #[tokio::test]
 #[serial_test::serial]
-async fn test_claim_from_reclaim_grant_expired() {
+async fn test_claim_from_resume_grant_expired() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     write_test_partition_config(&tc).await;
@@ -9051,7 +9051,7 @@ async fn test_claim_from_reclaim_grant_expired() {
     tokio::time::sleep(std::time::Duration::from_millis(600)).await;
 
     let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
-    match worker.claim_from_reclaim_grant(grant).await {
+    match worker.claim_from_resume_grant(grant).await {
         // Either error is acceptable:
         //   * `ClaimGrantExpired` fires when the FCALL observes the
         //     grant key still present but `grant_expires_at < now_ms`
@@ -9071,11 +9071,11 @@ async fn test_claim_from_reclaim_grant_expired() {
     }
 }
 
-/// Grant issued to worker A → worker B calls `claim_from_reclaim_grant`
+/// Grant issued to worker A → worker B calls `claim_from_resume_grant`
 /// → `ScriptError::InvalidClaimGrant`.
 #[tokio::test]
 #[serial_test::serial]
-async fn test_claim_from_reclaim_grant_wrong_worker() {
+async fn test_claim_from_resume_grant_wrong_worker() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     write_test_partition_config(&tc).await;
@@ -9088,7 +9088,7 @@ async fn test_claim_from_reclaim_grant_wrong_worker() {
 
     // Build a FlowFabricWorker with a DIFFERENT worker_id.
     let worker = build_reclaim_test_worker("worker-b", "worker-b-inst").await;
-    match worker.claim_from_reclaim_grant(grant).await {
+    match worker.claim_from_resume_grant(grant).await {
         Err(ff_sdk::SdkError::Engine(ref _b))
             if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::InvalidClaimGrant)) =>
         {}
@@ -9103,7 +9103,7 @@ async fn test_claim_from_reclaim_grant_wrong_worker() {
 /// path instead of the normal claim path.
 #[tokio::test]
 #[serial_test::serial]
-async fn test_claim_from_reclaim_grant_not_resumed() {
+async fn test_claim_from_resume_grant_not_resumed() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     write_test_partition_config(&tc).await;
@@ -9123,16 +9123,16 @@ async fn test_claim_from_reclaim_grant_not_resumed() {
     let expires_at_str: Option<String> = tc.hget(&grant_key, "grant_expires_at").await;
     let expires_at_ms: u64 = expires_at_str.as_deref().and_then(|s| s.parse().ok()).unwrap();
 
-    let grant = ff_core::contracts::ReclaimGrant {
-        execution_id: eid.clone(),
-        partition_key: ff_core::partition::PartitionKey::from(&partition),
+    let grant = ff_core::contracts::ResumeGrant::new(
+        eid.clone(),
+        ff_core::partition::PartitionKey::from(&partition),
         grant_key,
         expires_at_ms,
-        lane_id: LaneId::new(LANE),
-    };
+        LaneId::new(LANE),
+    );
 
     let worker = build_reclaim_test_worker(WORKER, WORKER_INST).await;
-    match worker.claim_from_reclaim_grant(grant).await {
+    match worker.claim_from_resume_grant(grant).await {
         Err(ff_sdk::SdkError::Engine(ref _b))
             if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::NotAResumedExecution)) =>
         {}
@@ -9153,7 +9153,7 @@ async fn test_claim_from_reclaim_grant_not_resumed() {
 /// fails with `InvalidClaimGrant`.
 #[tokio::test]
 #[serial_test::serial]
-async fn test_claim_from_reclaim_grant_double_consume() {
+async fn test_claim_from_resume_grant_double_consume() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     write_test_partition_config(&tc).await;
@@ -9167,7 +9167,7 @@ async fn test_claim_from_reclaim_grant_double_consume() {
 
     // First consumption succeeds.
     let claimed = worker
-        .claim_from_reclaim_grant(grant.clone())
+        .claim_from_resume_grant(grant.clone())
         .await
         .expect("first consume should succeed");
 
@@ -9180,7 +9180,7 @@ async fn test_claim_from_reclaim_grant_double_consume() {
     // `ExecutionNotLeaseable`. If an attacker/race ordered calls
     // differently we'd also see `InvalidClaimGrant` — accept either
     // as proof the second consume was rejected.
-    match worker.claim_from_reclaim_grant(grant).await {
+    match worker.claim_from_resume_grant(grant).await {
         Err(ff_sdk::SdkError::Engine(ref _b))
             if matches!(**_b, ff_sdk::EngineError::Contention(ff_sdk::ContentionKind::ExecutionNotLeaseable)) =>
         {}
@@ -9196,7 +9196,7 @@ async fn test_claim_from_reclaim_grant_double_consume() {
     claimed.complete(None).await.unwrap();
 }
 
-/// Saturation guard for `claim_from_reclaim_grant` — mirrors
+/// Saturation guard for `claim_from_resume_grant` — mirrors
 /// `test_claim_from_grant_rejects_at_capacity`. A worker at
 /// `max_concurrent_tasks=1` with its single permit in flight must
 /// refuse a second reclaim grant with `SdkError::WorkerAtCapacity`
@@ -9204,7 +9204,7 @@ async fn test_claim_from_reclaim_grant_double_consume() {
 /// is not atomically consumed).
 ///
 /// Caught during cross-review round 2: the original
-/// `claim_from_reclaim_grant` did NOT acquire a concurrency permit,
+/// `claim_from_resume_grant` did NOT acquire a concurrency permit,
 /// which on a saturated worker silently exceeded
 /// `max_concurrent_tasks` and handed back a `ClaimedTask` without a
 /// permit to release — violating the concurrency contract the user
@@ -9212,7 +9212,7 @@ async fn test_claim_from_reclaim_grant_double_consume() {
 /// pattern exactly.
 #[tokio::test]
 #[serial_test::serial]
-async fn test_claim_from_reclaim_grant_rejects_at_capacity() {
+async fn test_claim_from_resume_grant_rejects_at_capacity() {
     let tc = TestCluster::connect().await;
     tc.cleanup().await;
     write_test_partition_config(&tc).await;
@@ -9248,13 +9248,13 @@ async fn test_claim_from_reclaim_grant_rejects_at_capacity() {
 
     // 1st reclaim takes the sole permit.
     let task_a = worker
-        .claim_from_reclaim_grant(grant_a)
+        .claim_from_resume_grant(grant_a)
         .await
         .expect("first reclaim should take the permit");
 
     // 2nd reclaim must refuse at capacity, BEFORE invoking the Lua
     // FCALL that would atomically consume the grant key.
-    match worker.claim_from_reclaim_grant(grant_b).await {
+    match worker.claim_from_resume_grant(grant_b).await {
         Err(ff_sdk::SdkError::WorkerAtCapacity) => {}
         Err(other) => panic!("expected WorkerAtCapacity, got {other:?}"),
         Ok(_) => panic!("saturated worker should not claim"),
@@ -9277,7 +9277,7 @@ async fn test_claim_from_reclaim_grant_rejects_at_capacity() {
         .expect("EXISTS on grant_key");
     assert_eq!(exists, 1,
         "reclaim grant_key must still exist after capacity reject — \
-         claim_from_reclaim_grant must not fire ff_claim_resumed_execution \
+         claim_from_resume_grant must not fire ff_claim_resumed_execution \
          when the semaphore is drained");
 
     // Cleanup so the lease from task_a doesn't linger into the next

--- a/crates/ff-test/tests/engine_backend_claim.rs
+++ b/crates/ff-test/tests/engine_backend_claim.rs
@@ -1,6 +1,6 @@
 //! Integration coverage for
 //! [`ff_core::engine_backend::EngineBackend::claim`] and
-//! [`ff_core::engine_backend::EngineBackend::claim_from_reclaim`] on
+//! [`ff_core::engine_backend::EngineBackend::claim_from_resume_grant`] on
 //! the Valkey-backed impl (v0.7 Wave 2).
 //!
 //! Covers:
@@ -11,7 +11,7 @@
 //!     worker's CapabilitySet doesn't cover required_capabilities, so
 //!     `claim` returns `Ok(None)`.
 //!   * Empty eligible set — nothing to claim, `Ok(None)`.
-//!   * claim_from_reclaim happy path — consumes a `ReclaimToken`
+//!   * claim_from_resume_grant happy path — consumes a `ResumeToken`
 //!     (Wave 2 extended shape with worker identity) and mints a
 //!     `HandleKind::Resumed` handle with a bumped lease_epoch.
 //!
@@ -23,9 +23,9 @@ use std::sync::Arc;
 use ferriskey::Value;
 use ff_backend_valkey::ValkeyBackend;
 use ff_core::backend::{
-    BackendTag, CapabilitySet, ClaimPolicy, HandleKind, ReclaimToken,
+    BackendTag, CapabilitySet, ClaimPolicy, HandleKind, ResumeToken,
 };
-use ff_core::contracts::{DeliverSignalArgs, ReclaimGrant};
+use ff_core::contracts::{DeliverSignalArgs, ResumeGrant};
 use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::{ExecKeyContext, IndexKeys};
 use ff_core::partition::{execution_partition, PartitionConfig, PartitionKey};
@@ -203,10 +203,10 @@ async fn claim_capability_mismatch_returns_none() {
     assert!(out.is_none(), "expected Ok(None), got {out:?}");
 }
 
-// ───────────────────────── claim_from_reclaim ─────────────────────────
+// ───────────────────────── claim_from_resume_grant ─────────────────────────
 
 /// Seed an execution, claim it, suspend it, deliver a resuming signal,
-/// and leave the exec ready for `claim_from_reclaim`. Returns
+/// and leave the exec ready for `claim_from_resume_grant`. Returns
 /// `(exec_id, lease_epoch_before_reclaim)`.
 async fn seed_resumable(tc: &TestCluster, eid: &ExecutionId) -> u64 {
     let partition = execution_partition(eid, &config());
@@ -379,22 +379,22 @@ async fn seed_resumable(tc: &TestCluster, eid: &ExecutionId) -> u64 {
         .await
         .expect("deliver_signal should resume");
 
-    // A fresh grant is required before claim_from_reclaim consumes it.
+    // A fresh grant is required before claim_from_resume_grant consumes it.
     issue_grant(tc, eid, "").await;
 
     epoch_before
 }
 
-fn synthetic_reclaim_grant(eid: &ExecutionId) -> ReclaimGrant {
+fn synthetic_reclaim_grant(eid: &ExecutionId) -> ResumeGrant {
     let partition = execution_partition(eid, &config());
     let ctx = ExecKeyContext::new(&partition, eid);
-    ReclaimGrant {
-        execution_id: eid.clone(),
-        partition_key: PartitionKey::from(&partition),
-        grant_key: ctx.claim_grant(),
-        expires_at_ms: 0, // unused by the Valkey resume path
-        lane_id: LaneId::new(LANE),
-    }
+    ResumeGrant::new(
+        eid.clone(),
+        PartitionKey::from(&partition),
+        ctx.claim_grant(),
+        0, // unused by the Valkey resume path
+        LaneId::new(LANE),
+    )
 }
 
 #[tokio::test]
@@ -407,7 +407,7 @@ async fn claim_from_reclaim_happy_path_bumps_epoch() {
     let epoch_before = seed_resumable(&tc, &eid).await;
 
     let grant = synthetic_reclaim_grant(&eid);
-    let token = ReclaimToken::new(
+    let token = ResumeToken::new(
         grant,
         WorkerId::new(WORKER),
         WorkerInstanceId::new(WORKER_INST),
@@ -416,10 +416,10 @@ async fn claim_from_reclaim_happy_path_bumps_epoch() {
 
     let backend = build_backend(&tc).await;
     let handle = backend
-        .claim_from_reclaim(token)
+        .claim_from_resume_grant(token)
         .await
-        .expect("claim_from_reclaim should succeed")
-        .expect("claim_from_reclaim should return Some on resumed exec");
+        .expect("claim_from_resume_grant should succeed")
+        .expect("claim_from_resume_grant should return Some on resumed exec");
 
     assert_eq!(handle.backend, BackendTag::Valkey);
     assert_eq!(handle.kind, HandleKind::Resumed);
@@ -456,7 +456,7 @@ async fn claim_from_reclaim_double_consume_surfaces_typed_error() {
     let _ = seed_resumable(&tc, &eid).await;
 
     let grant = synthetic_reclaim_grant(&eid);
-    let token = ReclaimToken::new(
+    let token = ResumeToken::new(
         grant,
         WorkerId::new(WORKER),
         WorkerInstanceId::new(WORKER_INST),
@@ -465,19 +465,19 @@ async fn claim_from_reclaim_double_consume_surfaces_typed_error() {
 
     let backend = build_backend(&tc).await;
     let _first = backend
-        .claim_from_reclaim(token.clone())
+        .claim_from_resume_grant(token.clone())
         .await
-        .expect("first claim_from_reclaim should succeed")
-        .expect("first claim_from_reclaim should return Some");
+        .expect("first claim_from_resume_grant should succeed")
+        .expect("first claim_from_resume_grant should return Some");
 
     // Second consume on the same grant: the grant key was consumed by
     // the first FCALL and the lease is now held by the first claim, so
     // the FCALL surfaces a typed ScriptError (invalid_claim_grant /
     // claim_grant_consumed / lease_conflict depending on wire state).
     let err = backend
-        .claim_from_reclaim(token)
+        .claim_from_resume_grant(token)
         .await
-        .expect_err("second claim_from_reclaim should fail");
+        .expect_err("second claim_from_resume_grant should fail");
     let s = err.to_string();
     assert!(
         s.contains("invalid_claim_grant")

--- a/crates/ff-test/tests/pg_reconciler_timeouts.rs
+++ b/crates/ff-test/tests/pg_reconciler_timeouts.rs
@@ -6,7 +6,7 @@
 //!     attempt interrupted + execution re-eligible. Same with retries
 //!     exhausted → terminal + completion event emitted.
 //!   * `lease_expiry` — orphaned lease → reclaim becomes redeemable
-//!     via `claim_from_reclaim`.
+//!     via `claim_from_resume_grant`.
 //!   * `suspension_timeout` — `Fail` behavior → terminal; `Signal`
 //!     behavior → synthetic timeout entry in member_map + timeout
 //!     cleared so the scanner doesn't re-fire.


### PR DESCRIPTION
## Summary

Implements RFC-024 PR-B+C folded. Renames `EngineBackend::claim_from_reclaim` to `claim_from_resume_grant` (honest name — the method has always driven the resume path), adds two new trait methods (`issue_reclaim_grant`, `reclaim_execution`) with default `Unavailable` impls, introduces the new distinct `ReclaimGrant` type for the lease-reclaim path, and drops PR-A's transitional `ReclaimGrant = ResumeGrant` / `ReclaimToken = ResumeToken` aliases.

See RFC-024 §3.1-§3.3 + §9 PR partitioning. PR-B and PR-C are folded because the new trait method signatures reference types that PR-C introduces; shipping them separately would land trait methods with undefined return types. RFC §9 partitioning was overly granular on this point.

### Trait surface (`crates/ff-core/src/engine_backend.rs`)
- `claim_from_reclaim` → `claim_from_resume_grant` (rename; semantics unchanged).
- New `issue_reclaim_grant(args) -> IssueReclaimGrantOutcome` (default `Unavailable`).
- New `reclaim_execution(args) -> ReclaimExecutionOutcome` (default `Unavailable`).

### Types (`crates/ff-core/src/contracts/mod.rs`)
- New distinct `ReclaimGrant` (lease-reclaim path), `#[non_exhaustive]` + `::new()`.
- New `IssueReclaimGrantOutcome` + `ReclaimExecutionOutcome` enums, `#[non_exhaustive]`.
- `ClaimGrant` / `ResumeGrant` / `IssueReclaimGrantArgs` / `ReclaimExecutionArgs` gain `#[non_exhaustive]` + `::new()` per `feedback_non_exhaustive_needs_constructor`.
- `IssueReclaimGrantArgs` gains `worker_capabilities: BTreeSet<String>` (parity with `IssueClaimGrantArgs`).
- `ReclaimExecutionArgs::max_reclaim_count` flips `u32` → `Option<u32>`; `None` ⇒ Rust-surface default 1000 (RFC-024 §4.6).

### Transitional aliases dropped
- `pub type ReclaimGrant = ResumeGrant` (contracts/mod.rs) — dropped; new `ReclaimGrant` type occupies the name with different semantics (lease-reclaim, not resume).
- `pub type ReclaimToken = ResumeToken` (backend.rs) — dropped.

### Workspace-wide migration

Every `ReclaimGrant` / `ReclaimToken` alias consumer migrates to `ResumeGrant` / `ResumeToken` (all existing consumers semantically held resume grants; the new lease-reclaim `ReclaimGrant` is referenced only by the new trait methods' future impl bodies). Crates touched: `ff-core`, `ff-backend-valkey`, `ff-backend-postgres`, `ff-backend-sqlite`, `ff-scheduler`, `ff-sdk`, `ff-server`, `ff-test`.

SDK `FlowFabricWorker::claim_from_reclaim_grant` renamed to `claim_from_resume_grant`. The new `claim_from_reclaim_grant` SDK method (distinct semantic — feeds `reclaim_execution`) lands with PR-G.

### Backend impl bodies NOT in this PR

All three backends return `EngineError::Unavailable` from the new trait methods via the trait default. PR-D (Postgres migration 0015 + impl), PR-E (SQLite migration 0015 + impl), PR-F (Valkey Lua ARGV[9] + impl) wire real bodies.

### Semver breaks

cargo-semver-checks WILL flag:
- Trait method rename (removal of `claim_from_reclaim`, addition of `claim_from_resume_grant`).
- Alias removals (`ReclaimGrant`, `ReclaimToken`).
- `max_reclaim_count` type flip.
- `#[non_exhaustive]` additions on `ClaimGrant` / `ResumeGrant` / `IssueReclaimGrantArgs` / `ReclaimExecutionArgs`.

All documented breaks per RFC-024 §8.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo check --workspace --all-features --tests` clean
- [x] `cargo test -p ff-core --all-features --lib` — 222 pass
- [x] `cargo test --workspace --all-features --lib` — all pass
- [ ] CI matrix green
- [ ] cargo-semver-checks output documented before admin-merge

Pre-existing clippy errors in `crates/ff-test/tests/subscribe_filter_isolation.rs` (`this loop never actually loops`) are on main, not introduced here (verified via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to semver-breaking public API changes (trait method rename, alias removals, `#[non_exhaustive]` additions, and argument type changes) across multiple crates; runtime behavior is largely unchanged because new reclaim methods default to `EngineError::Unavailable`.
> 
> **Overview**
> Implements RFC-024 PR-B+C by **renaming the resume-claim surface**: `EngineBackend::claim_from_reclaim` (and SDK `FlowFabricWorker::claim_from_reclaim_grant`) become `claim_from_resume_grant`, and all in-tree backends/tests/forwarders are updated to use `ResumeGrant`/`ResumeToken`.
> 
> Adds the **lease-reclaim API surface** in `ff-core`: a distinct `ReclaimGrant` type plus new trait methods `issue_reclaim_grant` and `reclaim_execution` returning typed outcome enums; these methods have default implementations that return `EngineError::Unavailable` until backend PRs wire them.
> 
> Hardens and evolves wire types by marking several structs `#[non_exhaustive]` and adding `::new()` constructors (migrating call sites away from struct literals), adding `worker_capabilities` to `IssueReclaimGrantArgs`, and changing `ReclaimExecutionArgs::max_reclaim_count` from `u32` to `Option<u32>`; transitional `ReclaimGrant`/`ReclaimToken` aliases are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b501833b10ebebbcdd937a568fa6a0273344cac4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->