### PR TITLE
feat(backend-sqlite): RFC-024 PR-E — issue_reclaim_grant + reclaim_execution + migration 0017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,43 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     TTL-expired grant, cap-exceeded at reclaim, scheduler
     write-through verification).
 
+- **RFC-024 PR-E — SQLite `issue_reclaim_grant` + `reclaim_execution`
+  impls + migration 0017 (advances closure of #371).** SQLite wiring
+  for the RFC-024 lease-reclaim path — the PR-B+C trait defaults are
+  replaced with real bodies on the SQLite backend. Parallel to PR-D
+  (Postgres); different backend crate, disjoint.
+  - `crates/ff-backend-sqlite/migrations/0017_claim_grant_table.sql`
+    — new `ff_claim_grant` table (SQLite-dialect port of PR-D's
+    Postgres migration; BLOB for raw bytes, TEXT JSON for
+    capabilities, no partitioning per RFC-023 §4.1 N=1 supervisor).
+    Additive column `ff_exec_core.lease_reclaim_count INTEGER NOT NULL
+    DEFAULT 0`. No JSON backfill: SQLite never shipped the PG scheduler
+    `claim_grant` JSON stash (RFC-023 §5 `claim_for_worker` non-goal).
+  - `crates/ff-backend-sqlite/src/queries/claim_grant.rs` — new
+    dialect-forked SQL strings (INSERT / SELECT / DELETE / UPDATE)
+    mirroring the PG reference one-for-one.
+  - `crates/ff-backend-sqlite/src/reclaim.rs` — new module carrying
+    `issue_reclaim_grant_impl` + `reclaim_execution_impl`. Both run
+    inside a single `BEGIN IMMEDIATE` txn (RFC-023 §4.3 RESERVED
+    write-lock substitute for PG `FOR UPDATE`). `reclaim_execution_impl`
+    marks the prior attempt `interrupted_reclaimed`, inserts a fresh
+    `ff_attempt` row (new attempt_index), bumps `lease_reclaim_count`,
+    consumes the grant row, emits an RFC-019 `reclaimed` lease event
+    via the post-commit `PubSub::lease_history` broadcast, and mints
+    a `HandleKind::Reclaimed` handle. Cap exceeded branch transitions
+    the execution to `terminal_failed` matching the Valkey Lua at
+    `flowfabric.lua:3049-3080`.
+  - `crates/ff-backend-sqlite/src/backend.rs` — `EngineBackend::issue_reclaim_grant`
+    + `EngineBackend::reclaim_execution` trait methods overridden
+    (wrapped in `retry_serializable`).
+  - `crates/ff-backend-sqlite/tests/rfc024_reclaim.rs` — 10 new
+    integration tests covering happy path, wrong-phase rejection,
+    `lease_revoked` admission, new-attempt semantics,
+    prior-attempt-interrupted marker, worker-id mismatch,
+    grant-not-found, grant-TTL-expired, cap-exceeded terminal
+    transition, and `HandleKind::Reclaimed` handle kind.
+  - Default max_reclaim_count: 1000 on the Rust surface (per RFC-024
+    §4.6); per-call override via `ReclaimExecutionArgs.max_reclaim_count`.
 - **RFC-024 PR-B+C — trait method renames + new `ReclaimGrant` type +
   non_exhaustive constructors (closes partial of #371).** Folded PR-B
   and PR-C of the RFC-024 series because the new trait method

--- a/crates/ff-backend-sqlite/migrations/.sqlite-skip
+++ b/crates/ff-backend-sqlite/migrations/.sqlite-skip
@@ -14,7 +14,3 @@
 # The parity-drift lint (`scripts/lint-migrations.sh`) parses this
 # format directly.
 
-# RFC-024 PR-D (Postgres) is landing ahead of PR-E (SQLite). The
-# SQLite sibling for `0017_claim_grant_table.sql` lands in PR-E
-# and this skip-entry is removed then.
-0017_claim_grant_table.sql # issue:371

--- a/crates/ff-backend-sqlite/migrations/0017_claim_grant_table.sql
+++ b/crates/ff-backend-sqlite/migrations/0017_claim_grant_table.sql
@@ -1,0 +1,51 @@
+-- RFC-024 PR-E — SQLite `ff_claim_grant` table + `ff_exec_core.lease_reclaim_count`
+--
+-- SQLite-dialect port of PR-D's Postgres migration. RFC-023 §4.1: no
+-- partitioning (N=1 supervisor), BLOB for raw bytes, TEXT JSON for
+-- capabilities (SQLite has no JSONB + no array type).
+--
+-- Unlike the PG migration this port does NOT backfill JSON-stashed
+-- grants: SQLite never shipped a scheduler.rs `claim_grant` JSON stash
+-- (RFC-023 §5 — `claim_for_worker` is a permanent non-goal on the
+-- dev-only backend). Fresh DBs + existing DBs alike start with an
+-- empty `ff_claim_grant` table.
+--
+-- `lease_reclaim_count` on `ff_exec_core` tracks how many times the
+-- execution has been reclaimed via `reclaim_execution` (RFC-024 §3.3).
+-- Required for the §9 release-gate test (cap exceeded at 1000).
+
+CREATE TABLE ff_claim_grant (
+    partition_key        INTEGER NOT NULL,
+    grant_id             BLOB    NOT NULL,
+    execution_id         BLOB    NOT NULL,
+    kind                 TEXT    NOT NULL
+        CHECK (kind IN ('claim', 'reclaim')),
+    worker_id            TEXT    NOT NULL,
+    worker_instance_id   TEXT    NOT NULL,
+    lane_id              TEXT,
+    capability_hash      TEXT,
+    worker_capabilities  TEXT    NOT NULL DEFAULT '[]',
+    route_snapshot_json  TEXT,
+    admission_summary    TEXT,
+    grant_ttl_ms         INTEGER NOT NULL,
+    issued_at_ms         INTEGER NOT NULL,
+    expires_at_ms        INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, grant_id)
+);
+
+CREATE INDEX ff_claim_grant_execution_idx
+    ON ff_claim_grant (partition_key, execution_id);
+
+CREATE INDEX ff_claim_grant_expiry_idx
+    ON ff_claim_grant (expires_at_ms);
+
+ALTER TABLE ff_exec_core
+    ADD COLUMN lease_reclaim_count INTEGER NOT NULL DEFAULT 0;
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    17,
+    '0017_claim_grant_table',
+    CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    1
+);

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -27,7 +27,8 @@ use ff_core::capability::{BackendIdentity, Capabilities, Supports, Version};
 use ff_core::caps::{CapabilityRequirement, matches as caps_matches};
 use ff_core::contracts::{
     BudgetStatus, CancelFlowResult, CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs,
-    CreateQuotaPolicyResult, ExecutionSnapshot, FlowSnapshot, ReportUsageAdminArgs,
+    CreateQuotaPolicyResult, ExecutionSnapshot, FlowSnapshot, IssueReclaimGrantArgs,
+    IssueReclaimGrantOutcome, ReclaimExecutionArgs, ReclaimExecutionOutcome, ReportUsageAdminArgs,
     ReportUsageResult, ResetBudgetArgs, ResetBudgetResult, RotateWaitpointHmacSecretAllArgs,
     RotateWaitpointHmacSecretAllResult, SeedOutcome, SeedWaitpointHmacSecretArgs, SuspendArgs,
     SuspendOutcome,
@@ -2686,6 +2687,23 @@ impl EngineBackend for SqliteBackend {
         let pool = &self.inner.pool;
         let pubsub = &self.inner.pubsub;
         retry_serializable(|| claim_from_reclaim_impl(pool, pubsub, &token)).await
+    }
+
+    async fn issue_reclaim_grant(
+        &self,
+        args: IssueReclaimGrantArgs,
+    ) -> Result<IssueReclaimGrantOutcome, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| crate::reclaim::issue_reclaim_grant_impl(pool, &args)).await
+    }
+
+    async fn reclaim_execution(
+        &self,
+        args: ReclaimExecutionArgs,
+    ) -> Result<ReclaimExecutionOutcome, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| crate::reclaim::reclaim_execution_impl(pool, pubsub, &args)).await
     }
 
     async fn delay(&self, _handle: &Handle, _delay_until: TimestampMs) -> Result<(), EngineError> {

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -35,6 +35,7 @@ mod lease_event_subscribe;
 mod operator;
 mod outbox_cursor;
 mod reads;
+mod reclaim;
 mod reconcilers;
 mod scanner_supervisor;
 mod signal_delivery_subscribe;

--- a/crates/ff-backend-sqlite/src/queries/claim_grant.rs
+++ b/crates/ff-backend-sqlite/src/queries/claim_grant.rs
@@ -1,0 +1,129 @@
+//! SQLite dialect-forked queries for RFC-024 `ff_claim_grant` table.
+//!
+//! Landed by PR-E of the RFC-024 series (SQLite lease-reclaim wiring).
+//! The SQL strings are module-level `const`s so `reclaim.rs` call
+//! sites reference them by name and cross-dialect review lines them
+//! up against the PG reference.
+//!
+//! # Transaction contract
+//!
+//! All callers wrap these statements in a `BEGIN IMMEDIATE` txn per
+//! RFC-023 §4.3 — SQLite's RESERVED lock covers the full read-modify-
+//! write window, so no explicit `FOR UPDATE` equivalent is needed.
+
+/// Read the execution's ownership + phase fields plus the current
+/// reclaim counter. Used by `issue_reclaim_grant_impl` to validate
+/// that the target execution is in a reclaimable state
+/// (`lifecycle_phase = 'active'` AND
+/// `ownership_state IN ('lease_expired_reclaimable', 'lease_revoked')`).
+pub(crate) const SELECT_EXEC_CORE_FOR_RECLAIM_SQL: &str = r#"
+    SELECT lifecycle_phase,
+           ownership_state,
+           eligibility_state,
+           attempt_state,
+           attempt_index,
+           lane_id,
+           lease_reclaim_count
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Insert a reclaim-kind grant row.
+pub(crate) const INSERT_RECLAIM_GRANT_SQL: &str = r#"
+    INSERT INTO ff_claim_grant (
+        partition_key,
+        grant_id,
+        execution_id,
+        kind,
+        worker_id,
+        worker_instance_id,
+        lane_id,
+        capability_hash,
+        worker_capabilities,
+        route_snapshot_json,
+        admission_summary,
+        grant_ttl_ms,
+        issued_at_ms,
+        expires_at_ms
+    ) VALUES (?1, ?2, ?3, 'reclaim', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+"#;
+
+/// Read the reclaim-kind grant row for an execution under a partition.
+pub(crate) const SELECT_RECLAIM_GRANT_BY_EXEC_SQL: &str = r#"
+    SELECT grant_id,
+           worker_id,
+           worker_instance_id,
+           lane_id,
+           expires_at_ms
+      FROM ff_claim_grant
+     WHERE partition_key = ?1 AND execution_id = ?2 AND kind = 'reclaim'
+     ORDER BY issued_at_ms DESC
+     LIMIT 1
+"#;
+
+/// Consume (DELETE) a reclaim grant row.
+pub(crate) const DELETE_RECLAIM_GRANT_SQL: &str = r#"
+    DELETE FROM ff_claim_grant
+     WHERE partition_key = ?1 AND grant_id = ?2
+"#;
+
+/// Read the current `lease_reclaim_count` under the txn.
+pub(crate) const SELECT_LEASE_RECLAIM_COUNT_SQL: &str = r#"
+    SELECT lease_reclaim_count
+      FROM ff_exec_core
+     WHERE partition_key = ?1 AND execution_id = ?2
+"#;
+
+/// Bump `lease_reclaim_count` and flip `ff_exec_core` to the
+/// new-attempt active/leased posture. Mirrors `UPDATE_EXEC_CORE_RECLAIM_SQL`
+/// in `queries/lease.rs` but also bumps `attempt_index` (new attempt)
+/// and `lease_reclaim_count` (RFC-024 §3.3 counter).
+pub(crate) const UPDATE_EXEC_CORE_FOR_NEW_RECLAIM_ATTEMPT_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'active',
+           ownership_state = 'leased',
+           eligibility_state = 'not_applicable',
+           attempt_state = 'running_attempt',
+           attempt_index = ?1,
+           lease_reclaim_count = lease_reclaim_count + 1
+     WHERE partition_key = ?2 AND execution_id = ?3
+"#;
+
+/// Transition `ff_exec_core` to `terminal_failed` on reclaim-cap
+/// exceeded. Mirrors the Lua `max_reclaims_exceeded` branch at
+/// `flowfabric.lua:3049-3080`.
+pub(crate) const UPDATE_EXEC_CORE_RECLAIM_CAP_EXCEEDED_SQL: &str = r#"
+    UPDATE ff_exec_core
+       SET lifecycle_phase = 'terminal',
+           ownership_state = 'unowned',
+           eligibility_state = 'not_applicable',
+           attempt_state = 'attempt_terminal',
+           public_state = 'failed',
+           terminal_at_ms = ?1
+     WHERE partition_key = ?2 AND execution_id = ?3
+"#;
+
+/// Mark the prior attempt as `interrupted_reclaimed`. Mirrors the
+/// Valkey Lua at `flowfabric.lua:3112`.
+pub(crate) const UPDATE_PRIOR_ATTEMPT_INTERRUPTED_RECLAIMED_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET outcome = 'interrupted_reclaimed',
+           terminal_at_ms = ?1
+     WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4
+"#;
+
+/// Insert a fresh `ff_attempt` row for the reclaimed attempt. The new
+/// row starts with `lease_epoch = 0` (new attempt = new epoch line).
+pub(crate) const INSERT_NEW_RECLAIM_ATTEMPT_SQL: &str = r#"
+    INSERT INTO ff_attempt (
+        partition_key,
+        execution_id,
+        attempt_index,
+        worker_id,
+        worker_instance_id,
+        lease_epoch,
+        lease_expires_at_ms,
+        started_at_ms,
+        policy
+    ) VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?7, ?8)
+"#;

--- a/crates/ff-backend-sqlite/src/queries/claim_grant.rs
+++ b/crates/ff-backend-sqlite/src/queries/claim_grant.rs
@@ -67,11 +67,38 @@ pub(crate) const DELETE_RECLAIM_GRANT_SQL: &str = r#"
      WHERE partition_key = ?1 AND grant_id = ?2
 "#;
 
-/// Read the current `lease_reclaim_count` under the txn.
-pub(crate) const SELECT_LEASE_RECLAIM_COUNT_SQL: &str = r#"
-    SELECT lease_reclaim_count
-      FROM ff_exec_core
-     WHERE partition_key = ?1 AND execution_id = ?2
+/// Reclaim-time re-validation read. Used by
+/// `reclaim_execution_inner` after the grant has been located but
+/// before any state mutation, to defend against:
+///
+/// 1. **Lifecycle/ownership drift between grant issuance and grant
+///    consumption.** The exec may have transitioned to
+///    `terminal`/`cancelled` through another path (e.g. operator
+///    cancel) while the grant was in-flight. Mirrors PG PR-D
+///    `claim_grant.rs::reclaim_execution_once` and Lua
+///    `flowfabric.lua:3049+` gate.
+/// 2. **Caller-supplied stale `current_attempt_index`.** The Rust
+///    API takes this from caller args; a stale value could backward-
+///    pin `attempt_index` or PK-collide with an existing row.
+///    Returning the authoritative value lets the caller derive
+///    `new_attempt_index = stored + 1` server-side.
+/// 3. **Lease-epoch monotonicity.** The prior attempt row's
+///    `lease_epoch` is the floor for the new attempt's epoch
+///    (Lua `next_epoch = current_lease_epoch + 1`). The joined
+///    `ff_attempt.lease_epoch` covers the first-reclaim case where
+///    the `ff_exec_core` lease fields may already be cleared.
+pub(crate) const SELECT_EXEC_CORE_RECLAIM_GATE_SQL: &str = r#"
+    SELECT ec.lease_reclaim_count,
+           ec.lifecycle_phase,
+           ec.ownership_state,
+           ec.attempt_index,
+           COALESCE(a.lease_epoch, 0) AS prior_lease_epoch
+      FROM ff_exec_core ec
+      LEFT JOIN ff_attempt a
+        ON a.partition_key = ec.partition_key
+       AND a.execution_id  = ec.execution_id
+       AND a.attempt_index = ec.attempt_index
+     WHERE ec.partition_key = ?1 AND ec.execution_id = ?2
 "#;
 
 /// Bump `lease_reclaim_count` and flip `ff_exec_core` to the
@@ -112,8 +139,12 @@ pub(crate) const UPDATE_PRIOR_ATTEMPT_INTERRUPTED_RECLAIMED_SQL: &str = r#"
      WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4
 "#;
 
-/// Insert a fresh `ff_attempt` row for the reclaimed attempt. The new
-/// row starts with `lease_epoch = 0` (new attempt = new epoch line).
+/// Insert a fresh `ff_attempt` row for the reclaimed attempt. The
+/// `lease_epoch` bind is the caller-derived `prior_lease_epoch + 1`
+/// (see `SELECT_EXEC_CORE_RECLAIM_GATE_SQL`), matching Lua
+/// `flowfabric.lua:3106` (`next_epoch = current_lease_epoch + 1`).
+/// Previous PR-E had this hard-coded to `0`; that broke epoch
+/// monotonicity for lease fencing across the distributed system.
 pub(crate) const INSERT_NEW_RECLAIM_ATTEMPT_SQL: &str = r#"
     INSERT INTO ff_attempt (
         partition_key,
@@ -125,5 +156,22 @@ pub(crate) const INSERT_NEW_RECLAIM_ATTEMPT_SQL: &str = r#"
         lease_expires_at_ms,
         started_at_ms,
         policy
-    ) VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?7, ?8)
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+"#;
+
+/// Clear lease fields on the prior attempt row when reclaim
+/// cap-exceeded fires. Mirrors Lua `flowfabric.lua:3064-3079`
+/// (clears `current_lease_id`/`current_worker_*` on exec_core +
+/// DEL on lease_current_key). On SQLite the lease-fencing fields
+/// live on the attempt row, so we clear there and leave the prior
+/// outcome = 'interrupted_reclaimed' for parity with the
+/// successful-reclaim branch.
+pub(crate) const CLEAR_PRIOR_ATTEMPT_LEASE_ON_CAP_EXCEEDED_SQL: &str = r#"
+    UPDATE ff_attempt
+       SET outcome = 'interrupted_reclaimed',
+           terminal_at_ms = ?1,
+           worker_id = NULL,
+           worker_instance_id = NULL,
+           lease_expires_at_ms = NULL
+     WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4
 "#;

--- a/crates/ff-backend-sqlite/src/queries/mod.rs
+++ b/crates/ff-backend-sqlite/src/queries/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod attempt;
 pub mod budget;
+pub mod claim_grant;
 pub mod dispatch;
 pub mod exec_core;
 pub mod flow;

--- a/crates/ff-backend-sqlite/src/reclaim.rs
+++ b/crates/ff-backend-sqlite/src/reclaim.rs
@@ -1,0 +1,390 @@
+//! RFC-024 PR-E — SQLite `issue_reclaim_grant` + `reclaim_execution`
+//! impls.
+//!
+//! Mirrors the Valkey `ff_issue_reclaim_grant` + `ff_reclaim_execution`
+//! FCALL semantics (`flowfabric.lua:2985`, `:3898`) on SQLite's flat
+//! schema. Both impls run inside a single `BEGIN IMMEDIATE` txn per
+//! RFC-023 §4.3 — SQLite's RESERVED lock covers the full read-modify-
+//! write window, so no explicit `FOR UPDATE` is needed.
+//!
+//! Outbox semantics (RFC-019): successful `reclaim_execution` emits a
+//! `ff_lease_event` row with event_type `reclaimed`, dispatched via
+//! the post-commit broadcast to `PubSub::lease_history`. The
+//! `ff_operator_event` CHECK constraint (migration 0010) does not
+//! admit a `reclaimed` event type, matching PG's RFC-020 matrix
+//! where reclaim fires only on the lease channel.
+
+use sqlx::{Row, SqlitePool};
+use uuid::Uuid;
+
+use ff_core::backend::HandleKind;
+use ff_core::contracts::{
+    IssueReclaimGrantArgs, IssueReclaimGrantOutcome, ReclaimExecutionArgs,
+    ReclaimExecutionOutcome, ReclaimGrant,
+};
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::handle_codec::HandlePayload;
+use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
+use ff_core::types::{AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseId};
+
+use crate::errors::map_sqlx_error;
+use crate::handle_codec::encode_handle;
+use crate::pubsub::{OutboxEvent, PubSub};
+use crate::queries::claim_grant as q_grant;
+use crate::queries::dispatch as q_dispatch;
+use crate::tx_util::{begin_immediate, commit_or_rollback, now_ms, rollback_quiet, split_exec_id};
+
+/// Rust-surface default for `max_reclaim_count` per RFC-024 §4.6. The
+/// Lua fallback is 100 (scheduler-scanner ceiling); the Rust surface
+/// is 1000 (pull-mode consumer ceiling). The two-default coexistence
+/// is documented in the RFC.
+const DEFAULT_MAX_RECLAIM_COUNT: u32 = 1000;
+
+/// Build the `PartitionKey` for an execution from its hash-tag
+/// partition index.
+fn partition_key_for_exec(execution_id: &ExecutionId) -> PartitionKey {
+    PartitionKey::from(Partition {
+        family: PartitionFamily::Flow,
+        index: execution_id.partition(),
+    })
+}
+
+/// Co-transactional `last_insert_rowid()` to `OutboxEvent` for the
+/// post-commit broadcast fan-out. Mirrors `operator.rs::last_outbox_event`.
+async fn last_outbox_event(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+) -> Result<OutboxEvent, EngineError> {
+    let event_id: i64 = sqlx::query_scalar("SELECT last_insert_rowid()")
+        .fetch_one(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(OutboxEvent {
+        event_id,
+        partition_key: part,
+    })
+}
+
+/// Insert one `ff_lease_event` outbox row + return the event_id.
+async fn insert_lease_event(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    event_type: &str,
+    now: i64,
+) -> Result<OutboxEvent, EngineError> {
+    sqlx::query(q_dispatch::INSERT_LEASE_EVENT_SQL)
+        .bind(exec_uuid.to_string())
+        .bind(event_type)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    last_outbox_event(conn, part).await
+}
+
+fn dispatch_lease(pubsub: &PubSub, ev: OutboxEvent) {
+    PubSub::emit(&pubsub.lease_history, ev);
+}
+
+// -- issue_reclaim_grant -------------------------------------------------
+
+pub(crate) async fn issue_reclaim_grant_impl(
+    pool: &SqlitePool,
+    args: &IssueReclaimGrantArgs,
+) -> Result<IssueReclaimGrantOutcome, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+
+    let mut conn = begin_immediate(pool).await?;
+    let result = issue_reclaim_grant_inner(&mut conn, part, exec_uuid, args).await;
+    match result {
+        Ok(outcome) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(outcome)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+async fn issue_reclaim_grant_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    args: &IssueReclaimGrantArgs,
+) -> Result<IssueReclaimGrantOutcome, EngineError> {
+    let row = sqlx::query(q_grant::SELECT_EXEC_CORE_FOR_RECLAIM_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let Some(row) = row else {
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+
+    let lifecycle_phase: String = row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let ownership_state: String = row.try_get("ownership_state").map_err(map_sqlx_error)?;
+
+    if lifecycle_phase != "active" {
+        return Ok(IssueReclaimGrantOutcome::NotReclaimable {
+            execution_id: args.execution_id.clone(),
+            detail: format!("lifecycle_phase={lifecycle_phase} (expected active)"),
+        });
+    }
+    if ownership_state != "lease_expired_reclaimable" && ownership_state != "lease_revoked" {
+        return Ok(IssueReclaimGrantOutcome::NotReclaimable {
+            execution_id: args.execution_id.clone(),
+            detail: format!(
+                "ownership_state={ownership_state} (expected lease_expired_reclaimable | lease_revoked)"
+            ),
+        });
+    }
+
+    let now = now_ms();
+    let ttl = i64::try_from(args.grant_ttl_ms).unwrap_or(i64::MAX);
+    let expires_at = now.saturating_add(ttl);
+
+    let grant_uuid = Uuid::new_v4();
+    let worker_caps_json = serde_json::to_string(&args.worker_capabilities).map_err(|e| {
+        EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("issue_reclaim_grant: worker_capabilities serialize failed: {e}"),
+        }
+    })?;
+
+    sqlx::query(q_grant::INSERT_RECLAIM_GRANT_SQL)
+        .bind(part)
+        .bind(grant_uuid)
+        .bind(exec_uuid)
+        .bind(args.worker_id.as_str())
+        .bind(args.worker_instance_id.as_str())
+        .bind(args.lane_id.as_str())
+        .bind(args.capability_hash.as_deref())
+        .bind(&worker_caps_json)
+        .bind(args.route_snapshot_json.as_deref())
+        .bind(args.admission_summary.as_deref())
+        .bind(ttl)
+        .bind(now)
+        .bind(expires_at)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    let partition_key = partition_key_for_exec(&args.execution_id);
+    let expires_at_u64 = u64::try_from(expires_at).unwrap_or(0);
+
+    Ok(IssueReclaimGrantOutcome::Granted(ReclaimGrant::new(
+        args.execution_id.clone(),
+        partition_key,
+        grant_uuid.to_string(),
+        expires_at_u64,
+        args.lane_id.clone(),
+    )))
+}
+
+// -- reclaim_execution ---------------------------------------------------
+
+pub(crate) async fn reclaim_execution_impl(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: &ReclaimExecutionArgs,
+) -> Result<ReclaimExecutionOutcome, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+
+    let mut conn = begin_immediate(pool).await?;
+    let result = reclaim_execution_inner(&mut conn, part, exec_uuid, args).await;
+    match result {
+        Ok((outcome, lease_ev)) => {
+            commit_or_rollback(&mut conn).await?;
+            if let Some(ev) = lease_ev {
+                dispatch_lease(pubsub, ev);
+            }
+            Ok(outcome)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+async fn reclaim_execution_inner(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    part: i64,
+    exec_uuid: Uuid,
+    args: &ReclaimExecutionArgs,
+) -> Result<(ReclaimExecutionOutcome, Option<OutboxEvent>), EngineError> {
+    // 1. Locate + validate the reclaim grant for this execution.
+    let grant_row = sqlx::query(q_grant::SELECT_RECLAIM_GRANT_BY_EXEC_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let Some(grant_row) = grant_row else {
+        return Ok((
+            ReclaimExecutionOutcome::GrantNotFound {
+                execution_id: args.execution_id.clone(),
+            },
+            None,
+        ));
+    };
+
+    let grant_id: Vec<u8> = grant_row.try_get("grant_id").map_err(map_sqlx_error)?;
+    let grant_uuid = Uuid::from_slice(&grant_id).map_err(|e| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("reclaim_execution: grant_id invalid UUID bytes: {e}"),
+    })?;
+
+    let grant_worker: String = grant_row.try_get("worker_id").map_err(map_sqlx_error)?;
+    // Lua (flowfabric.lua:3088): grant.worker_id == args.worker_id.
+    // worker_instance_id is NOT checked (cairn per-request-spawn).
+    if grant_worker != args.worker_id.as_str() {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!(
+                "reclaim_execution: grant worker_id={grant_worker} mismatches caller {}",
+                args.worker_id
+            ),
+        });
+    }
+
+    let grant_expires_at: i64 = grant_row.try_get("expires_at_ms").map_err(map_sqlx_error)?;
+    let now = now_ms();
+    if grant_expires_at <= now {
+        // Expired grant: consume it so retries do not hit the same
+        // stale row, then report GrantNotFound.
+        sqlx::query(q_grant::DELETE_RECLAIM_GRANT_SQL)
+            .bind(part)
+            .bind(grant_uuid)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        return Ok((
+            ReclaimExecutionOutcome::GrantNotFound {
+                execution_id: args.execution_id.clone(),
+            },
+            None,
+        ));
+    }
+
+    let grant_lane: Option<String> = grant_row.try_get("lane_id").map_err(map_sqlx_error)?;
+
+    // 2. Read current reclaim counter + cap check BEFORE new attempt.
+    let count_row = sqlx::query(q_grant::SELECT_LEASE_RECLAIM_COUNT_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    let Some(count_row) = count_row else {
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+    let current_count_i: i64 = count_row
+        .try_get("lease_reclaim_count")
+        .map_err(map_sqlx_error)?;
+    let current_count = u32::try_from(current_count_i.max(0)).unwrap_or(0);
+
+    let cap = args.max_reclaim_count.unwrap_or(DEFAULT_MAX_RECLAIM_COUNT);
+    // Lua (flowfabric.lua:3049): fires terminal_failed when
+    // `reclaim_count >= max_reclaim` BEFORE the bump.
+    if current_count >= cap {
+        sqlx::query(q_grant::UPDATE_EXEC_CORE_RECLAIM_CAP_EXCEEDED_SQL)
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        sqlx::query(q_grant::DELETE_RECLAIM_GRANT_SQL)
+            .bind(part)
+            .bind(grant_uuid)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        return Ok((
+            ReclaimExecutionOutcome::ReclaimCapExceeded {
+                execution_id: args.execution_id.clone(),
+                reclaim_count: current_count,
+            },
+            None,
+        ));
+    }
+
+    // 3. Mark prior attempt `interrupted_reclaimed`.
+    let prior_attempt_index = i64::from(args.current_attempt_index.0);
+    sqlx::query(q_grant::UPDATE_PRIOR_ATTEMPT_INTERRUPTED_RECLAIMED_SQL)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(prior_attempt_index)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // 4. Insert new attempt row (new attempt_index = prior + 1).
+    let new_attempt_index_i = prior_attempt_index.saturating_add(1);
+    let lease_ttl_ms_i = i64::try_from(args.lease_ttl_ms).unwrap_or(0);
+    let new_expires_at = now.saturating_add(lease_ttl_ms_i);
+    sqlx::query(q_grant::INSERT_NEW_RECLAIM_ATTEMPT_SQL)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(new_attempt_index_i)
+        .bind(args.worker_id.as_str())
+        .bind(args.worker_instance_id.as_str())
+        .bind(new_expires_at)
+        .bind(now)
+        .bind(&args.attempt_policy_json)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // 5. Flip `ff_exec_core` to active/leased + bump reclaim counter +
+    //    pin `attempt_index` to the new attempt.
+    sqlx::query(q_grant::UPDATE_EXEC_CORE_FOR_NEW_RECLAIM_ATTEMPT_SQL)
+        .bind(new_attempt_index_i)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // 6. Consume the grant row.
+    sqlx::query(q_grant::DELETE_RECLAIM_GRANT_SQL)
+        .bind(part)
+        .bind(grant_uuid)
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // 7. Emit RFC-019 `reclaimed` lease event.
+    let ev = insert_lease_event(conn, part, exec_uuid, "reclaimed", now).await?;
+
+    // 8. Mint the Reclaimed-kind handle.
+    let lane_id = grant_lane
+        .map(ff_core::types::LaneId::new)
+        .unwrap_or_else(|| args.lane_id.clone());
+    let payload = HandlePayload::new(
+        args.execution_id.clone(),
+        AttemptIndex::new(u32::try_from(new_attempt_index_i.max(0)).unwrap_or(0)),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(0),
+        args.lease_ttl_ms,
+        lane_id,
+        args.worker_instance_id.clone(),
+    );
+    Ok((
+        ReclaimExecutionOutcome::Claimed(encode_handle(&payload, HandleKind::Reclaimed)),
+        Some(ev),
+    ))
+}

--- a/crates/ff-backend-sqlite/src/reclaim.rs
+++ b/crates/ff-backend-sqlite/src/reclaim.rs
@@ -25,11 +25,12 @@ use ff_core::contracts::{
 use ff_core::engine_error::{EngineError, ValidationKind};
 use ff_core::handle_codec::HandlePayload;
 use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
-use ff_core::types::{AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseId};
+use ff_core::types::{AttemptIndex, ExecutionId, LeaseEpoch};
 
 use crate::errors::map_sqlx_error;
 use crate::handle_codec::encode_handle;
 use crate::pubsub::{OutboxEvent, PubSub};
+use crate::queries::attempt as q_attempt;
 use crate::queries::claim_grant as q_grant;
 use crate::queries::dispatch as q_dispatch;
 use crate::tx_util::{begin_immediate, commit_or_rollback, now_ms, rollback_quiet, split_exec_id};
@@ -277,27 +278,72 @@ async fn reclaim_execution_inner(
 
     let grant_lane: Option<String> = grant_row.try_get("lane_id").map_err(map_sqlx_error)?;
 
-    // 2. Read current reclaim counter + cap check BEFORE new attempt.
-    let count_row = sqlx::query(q_grant::SELECT_LEASE_RECLAIM_COUNT_SQL)
+    // 2. Reclaim-time re-validation: read authoritative exec_core
+    //    fields under the tx (lifecycle/ownership gate + server-
+    //    derived attempt_index + prior lease_epoch for monotonic
+    //    bump). Mirrors PG PR-D `claim_grant.rs::reclaim_execution_once`
+    //    lines 463-484 and Lua `flowfabric.lua:3049+`.
+    let gate_row = sqlx::query(q_grant::SELECT_EXEC_CORE_RECLAIM_GATE_SQL)
         .bind(part)
         .bind(exec_uuid)
         .fetch_optional(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
-    let Some(count_row) = count_row else {
+    let Some(gate_row) = gate_row else {
         return Err(EngineError::NotFound {
             entity: "execution",
         });
     };
-    let current_count_i: i64 = count_row
+    let current_count_i: i64 = gate_row
         .try_get("lease_reclaim_count")
         .map_err(map_sqlx_error)?;
     let current_count = u32::try_from(current_count_i.max(0)).unwrap_or(0);
+    let lifecycle_phase: String = gate_row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let ownership_state: String = gate_row.try_get("ownership_state").map_err(map_sqlx_error)?;
+    // Authoritative attempt_index: ignore caller-supplied
+    // `args.current_attempt_index` (F7). Caller arg is informational
+    // only; the server-side value is the truth used for both prior-
+    // attempt targeting and new_attempt_index derivation.
+    let stored_attempt_index_i: i64 = gate_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    let prior_lease_epoch_i: i64 = gate_row
+        .try_get("prior_lease_epoch")
+        .map_err(map_sqlx_error)?;
 
+    // 2a. Gate: lifecycle must be `active` + ownership must still be
+    //     reclaimable. Between grant issuance and consumption the
+    //     exec could have gone terminal/cancelled via another path.
+    if lifecycle_phase != "active" {
+        return Ok((
+            ReclaimExecutionOutcome::NotReclaimable {
+                execution_id: args.execution_id.clone(),
+                detail: format!(
+                    "lifecycle_phase={lifecycle_phase} (expected active); exec transitioned \
+                     after grant issuance"
+                ),
+            },
+            None,
+        ));
+    }
+    if ownership_state != "lease_expired_reclaimable" && ownership_state != "lease_revoked" {
+        return Ok((
+            ReclaimExecutionOutcome::NotReclaimable {
+                execution_id: args.execution_id.clone(),
+                detail: format!(
+                    "ownership_state={ownership_state} (expected \
+                     lease_expired_reclaimable | lease_revoked); exec transitioned after \
+                     grant issuance"
+                ),
+            },
+            None,
+        ));
+    }
+
+    // 3. Cap check BEFORE new attempt. Lua (`flowfabric.lua:3049`)
+    //    fires terminal_failed when `reclaim_count >= max_reclaim`
+    //    BEFORE the bump.
     let cap = args.max_reclaim_count.unwrap_or(DEFAULT_MAX_RECLAIM_COUNT);
-    // Lua (flowfabric.lua:3049): fires terminal_failed when
-    // `reclaim_count >= max_reclaim` BEFORE the bump.
     if current_count >= cap {
+        // Flip exec_core to terminal_failed.
         sqlx::query(q_grant::UPDATE_EXEC_CORE_RECLAIM_CAP_EXCEEDED_SQL)
             .bind(now)
             .bind(part)
@@ -305,34 +351,63 @@ async fn reclaim_execution_inner(
             .execute(&mut **conn)
             .await
             .map_err(map_sqlx_error)?;
+        // Clear the prior attempt's lease fields + mark interrupted.
+        // Mirrors Lua :3064-3079 (clears current_lease_id /
+        // current_worker_* on exec_core + DEL lease_current). On
+        // SQLite the lease-fencing fields live on the attempt row.
+        sqlx::query(q_grant::CLEAR_PRIOR_ATTEMPT_LEASE_ON_CAP_EXCEEDED_SQL)
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(stored_attempt_index_i)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        // Consume the grant.
         sqlx::query(q_grant::DELETE_RECLAIM_GRANT_SQL)
             .bind(part)
             .bind(grant_uuid)
             .execute(&mut **conn)
             .await
             .map_err(map_sqlx_error)?;
+        // RFC-019 §4.2.7 outbox matrix: every terminal transition
+        // emits both a completion_event and a lease_event. Cap-
+        // exceeded is terminal_failed, so both fire.
+        sqlx::query(q_attempt::INSERT_COMPLETION_EVENT_SQL)
+            .bind("failed")
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut **conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let ev = insert_lease_event(conn, part, exec_uuid, "revoked", now).await?;
         return Ok((
             ReclaimExecutionOutcome::ReclaimCapExceeded {
                 execution_id: args.execution_id.clone(),
                 reclaim_count: current_count,
             },
-            None,
+            Some(ev),
         ));
     }
 
-    // 3. Mark prior attempt `interrupted_reclaimed`.
-    let prior_attempt_index = i64::from(args.current_attempt_index.0);
+    // 4. Mark prior attempt `interrupted_reclaimed` using the
+    //    server-authoritative prior index.
     sqlx::query(q_grant::UPDATE_PRIOR_ATTEMPT_INTERRUPTED_RECLAIMED_SQL)
         .bind(now)
         .bind(part)
         .bind(exec_uuid)
-        .bind(prior_attempt_index)
+        .bind(stored_attempt_index_i)
         .execute(&mut **conn)
         .await
         .map_err(map_sqlx_error)?;
 
-    // 4. Insert new attempt row (new attempt_index = prior + 1).
-    let new_attempt_index_i = prior_attempt_index.saturating_add(1);
+    // 5. Insert new attempt row. `new_attempt_index = stored + 1`
+    //    (F7: ignore caller arg). `new_lease_epoch = prior + 1`
+    //    (F4/F5: matches Lua :3106, preserves fencing monotonicity).
+    let new_attempt_index_i = stored_attempt_index_i.saturating_add(1);
+    let new_lease_epoch_i = prior_lease_epoch_i.saturating_add(1);
+    let new_lease_epoch_u = u64::try_from(new_lease_epoch_i.max(0)).unwrap_or(0);
     let lease_ttl_ms_i = i64::try_from(args.lease_ttl_ms).unwrap_or(0);
     let new_expires_at = now.saturating_add(lease_ttl_ms_i);
     sqlx::query(q_grant::INSERT_NEW_RECLAIM_ATTEMPT_SQL)
@@ -341,6 +416,7 @@ async fn reclaim_execution_inner(
         .bind(new_attempt_index_i)
         .bind(args.worker_id.as_str())
         .bind(args.worker_instance_id.as_str())
+        .bind(new_lease_epoch_i)
         .bind(new_expires_at)
         .bind(now)
         .bind(&args.attempt_policy_json)
@@ -348,7 +424,7 @@ async fn reclaim_execution_inner(
         .await
         .map_err(map_sqlx_error)?;
 
-    // 5. Flip `ff_exec_core` to active/leased + bump reclaim counter +
+    // 6. Flip `ff_exec_core` to active/leased + bump reclaim counter +
     //    pin `attempt_index` to the new attempt.
     sqlx::query(q_grant::UPDATE_EXEC_CORE_FOR_NEW_RECLAIM_ATTEMPT_SQL)
         .bind(new_attempt_index_i)
@@ -358,7 +434,7 @@ async fn reclaim_execution_inner(
         .await
         .map_err(map_sqlx_error)?;
 
-    // 6. Consume the grant row.
+    // 7. Consume the grant row.
     sqlx::query(q_grant::DELETE_RECLAIM_GRANT_SQL)
         .bind(part)
         .bind(grant_uuid)
@@ -366,19 +442,23 @@ async fn reclaim_execution_inner(
         .await
         .map_err(map_sqlx_error)?;
 
-    // 7. Emit RFC-019 `reclaimed` lease event.
+    // 8. Emit RFC-019 `reclaimed` lease event.
     let ev = insert_lease_event(conn, part, exec_uuid, "reclaimed", now).await?;
 
-    // 8. Mint the Reclaimed-kind handle.
+    // 9. Mint the Reclaimed-kind handle. F4: use caller-supplied
+    //    `attempt_id` + `lease_id` (PR-D parity @ PG
+    //    `claim_grant.rs:633-652` — Valkey PR-F Lua round-trips these
+    //    same identifiers via ARGV[5]/[7]). LeaseEpoch is the newly
+    //    derived monotonic value, NOT 0.
     let lane_id = grant_lane
         .map(ff_core::types::LaneId::new)
         .unwrap_or_else(|| args.lane_id.clone());
     let payload = HandlePayload::new(
         args.execution_id.clone(),
         AttemptIndex::new(u32::try_from(new_attempt_index_i.max(0)).unwrap_or(0)),
-        AttemptId::new(),
-        LeaseId::new(),
-        LeaseEpoch(0),
+        args.attempt_id.clone(),
+        args.lease_id.clone(),
+        LeaseEpoch(new_lease_epoch_u),
         args.lease_ttl_ms,
         lane_id,
         args.worker_instance_id.clone(),

--- a/crates/ff-backend-sqlite/tests/migrations.rs
+++ b/crates/ff-backend-sqlite/tests/migrations.rs
@@ -94,6 +94,8 @@ async fn migrations_apply_and_schema_is_present() {
         // 0014 — cancel backlog
         "ff_cancel_backlog",
         "ff_cancel_backlog_member",
+        // 0017 — RFC-024 PR-E claim-grant table
+        "ff_claim_grant",
     ] {
         assert!(
             names.iter().any(|n| n == expected),
@@ -113,7 +115,9 @@ async fn migrations_apply_and_schema_is_present() {
 async fn sqlx_migration_ledger_records_all_14() {
     // Naming kept for git-diff continuity; the real count floats as
     // new migrations land. Current set: 0001..=0014 + 0016 (RFC-020
-    // Wave 9 follow-up #356; 0015 reserved for RFC-024 claim-grant).
+    // Wave 9 follow-up #356) + 0017 (RFC-024 PR-E claim-grant table).
+    // 0015 was reserved for RFC-024 but 0016 landed first; RFC-024
+    // PR-E lands on 0017 to avoid sequence collisions.
     let backend = fresh_backend().await;
     let pool = backend.pool_for_test();
 
@@ -122,7 +126,10 @@ async fn sqlx_migration_ledger_records_all_14() {
             .fetch_one(pool)
             .await
             .expect("query _sqlx_migrations");
-    assert_eq!(count, 15, "expected 15 successful migrations (0001..=0014 + 0016), got {count}");
+    assert_eq!(
+        count, 16,
+        "expected 16 successful migrations (0001..=0014 + 0016 + 0017), got {count}"
+    );
 }
 
 #[tokio::test]
@@ -172,9 +179,8 @@ async fn ff_execution_capabilities_junction_schema() {
 #[serial(ff_dev_mode)]
 async fn migration_annotation_ledger_populated() {
     // Every migration INSERTs a row into `ff_migration_annotation`;
-    // verify the expected set landed. 0015 is reserved for RFC-024
-    // (claim-grant table) and not yet shipped, so the current ledger
-    // is 0001..=0014 + 0016.
+    // verify the expected set landed. Current ledger is 0001..=0014
+    // + 0016 + 0017 (RFC-024 PR-E claim-grant table).
     let backend = fresh_backend().await;
     let pool = backend.pool_for_test();
 
@@ -186,5 +192,6 @@ async fn migration_annotation_ledger_populated() {
     let versions: Vec<i64> = rows.into_iter().map(|(v,)| v).collect();
     let mut expected: Vec<i64> = (1..=14).collect();
     expected.push(16);
+    expected.push(17);
     assert_eq!(versions, expected);
 }

--- a/crates/ff-backend-sqlite/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-sqlite/tests/rfc024_reclaim.rs
@@ -1,0 +1,474 @@
+//! RFC-024 PR-E — SQLite `issue_reclaim_grant` + `reclaim_execution`
+//! integration tests.
+//!
+//! Mirrors the shape of `tests/wave9_operator.rs` (FF_DEV_MODE=1
+//! shared-cache in-memory backend, `#[serial(ff_dev_mode)]` gating).
+//! Parallel to `ff-backend-postgres/tests/rfc024_reclaim.rs` (PR-D).
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CapabilitySet, ClaimPolicy, HandleKind};
+use ff_core::contracts::{
+    CreateExecutionArgs, CreateExecutionResult, IssueReclaimGrantArgs, IssueReclaimGrantOutcome,
+    ReclaimExecutionArgs, ReclaimExecutionOutcome,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseId, Namespace, TimestampMs, WorkerId,
+    WorkerInstanceId,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+// -- Setup helpers (mirrors wave9_operator.rs) --------------------
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    // SAFETY: test-only env mutation; `#[serial(ff_dev_mode)]` gates
+    // every reader + writer across this crate's test binaries.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:rfc-024-reclaim-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("construct backend")
+}
+
+fn new_exec_id() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id")
+}
+
+fn uuid_of(eid: &ExecutionId) -> Uuid {
+    Uuid::parse_str(eid.as_str().split_once("}:").unwrap().1).unwrap()
+}
+
+fn create_args(exec_id: &ExecutionId, lane_id: &LaneId) -> CreateExecutionArgs {
+    CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: lane_id.clone(),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(now_ms()),
+    }
+}
+
+async fn create_runnable(b: &Arc<SqliteBackend>) -> (ExecutionId, LaneId) {
+    let lane_id = LaneId::new(format!("lane-{}", Uuid::new_v4()));
+    let exec_id = new_exec_id();
+    let args = create_args(&exec_id, &lane_id);
+    let r = b.create_execution(args).await.expect("create");
+    assert!(matches!(r, CreateExecutionResult::Created { .. }));
+    let exec_uuid = uuid_of(&exec_id);
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', public_state='pending', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    (exec_id, lane_id)
+}
+
+async fn create_and_claim(
+    b: &Arc<SqliteBackend>,
+) -> (ExecutionId, LaneId, ff_core::backend::Handle) {
+    let (exec_id, lane_id) = create_runnable(b).await;
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i1"),
+        30_000,
+        None,
+    );
+    let handle = b
+        .claim(&lane_id, &CapabilitySet::default(), policy)
+        .await
+        .expect("claim")
+        .expect("handle");
+    (exec_id, lane_id, handle)
+}
+
+/// Force `ownership_state = 'lease_expired_reclaimable'` on an
+/// already-claimed execution — mirrors the `mark_expired` scanner
+/// arriving after TTL without actually waiting the TTL out.
+async fn force_lease_expired(b: &Arc<SqliteBackend>, exec_uuid: Uuid) {
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state='lease_expired_reclaimable' \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+}
+
+fn issue_args(exec_id: &ExecutionId, lane_id: &LaneId) -> IssueReclaimGrantArgs {
+    IssueReclaimGrantArgs::new(
+        exec_id.clone(),
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i2"),
+        lane_id.clone(),
+        None,
+        60_000,
+        None,
+        None,
+        Default::default(),
+        TimestampMs::from_millis(now_ms()),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn reclaim_args(
+    exec_id: &ExecutionId,
+    lane_id: &LaneId,
+    worker_id: &str,
+    worker_instance_id: &str,
+    current_attempt_index: u32,
+    max_reclaim_count: Option<u32>,
+) -> ReclaimExecutionArgs {
+    ReclaimExecutionArgs::new(
+        exec_id.clone(),
+        WorkerId::new(worker_id),
+        WorkerInstanceId::new(worker_instance_id),
+        lane_id.clone(),
+        None,
+        LeaseId::new(),
+        30_000,
+        AttemptId::new(),
+        String::new(),
+        max_reclaim_count,
+        WorkerInstanceId::new("w1-i1"),
+        AttemptIndex::new(current_attempt_index),
+    )
+}
+
+// -- issue_reclaim_grant ----------------------------------------------
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn issue_reclaim_grant_happy_path() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let r = b.issue_reclaim_grant(issue_args(&exec_id, &lane_id)).await.expect("issue");
+    let grant = match r {
+        IssueReclaimGrantOutcome::Granted(g) => g,
+        other => panic!("expected Granted, got {other:?}"),
+    };
+    assert_eq!(grant.execution_id, exec_id);
+    assert!(!grant.grant_key.is_empty(), "grant_key must be populated");
+    assert!(grant.expires_at_ms > 0);
+
+    let (count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_claim_grant WHERE partition_key=0 \
+         AND execution_id=?1 AND kind='reclaim'",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn issue_reclaim_grant_wrong_phase() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    // Execution is `active` + `leased` (not lease_expired_reclaimable).
+
+    let r = b.issue_reclaim_grant(issue_args(&exec_id, &lane_id)).await.expect("issue");
+    assert!(
+        matches!(r, IssueReclaimGrantOutcome::NotReclaimable { .. }),
+        "got {r:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn issue_reclaim_grant_lease_revoked_admits() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state='lease_revoked' \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let r = b.issue_reclaim_grant(issue_args(&exec_id, &lane_id)).await.expect("issue");
+    assert!(matches!(r, IssueReclaimGrantOutcome::Granted(_)), "got {r:?}");
+}
+
+// -- reclaim_execution ------------------------------------------------
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_happy_path() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, None))
+        .await
+        .expect("reclaim");
+    let handle = match r {
+        ReclaimExecutionOutcome::Claimed(h) => h,
+        other => panic!("expected Claimed, got {other:?}"),
+    };
+    assert_eq!(handle.kind, HandleKind::Reclaimed);
+
+    let (reclaim_count, attempt_index): (i64, i64) = sqlx::query_as(
+        "SELECT lease_reclaim_count, attempt_index FROM ff_exec_core \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(reclaim_count, 1);
+    assert_eq!(attempt_index, 1, "new attempt_index = prior (0) + 1");
+
+    let (grant_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_claim_grant WHERE partition_key=0 \
+         AND execution_id=?1 AND kind='reclaim'",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(grant_count, 0, "grant must be deleted after consumption");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_new_attempt_and_prior_marked_interrupted() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+    let _ = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, None))
+        .await
+        .expect("reclaim");
+
+    let (prior_outcome,): (Option<String>,) = sqlx::query_as(
+        "SELECT outcome FROM ff_attempt WHERE partition_key=0 \
+         AND execution_id=?1 AND attempt_index=0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(prior_outcome.as_deref(), Some("interrupted_reclaimed"));
+
+    let (new_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_attempt WHERE partition_key=0 \
+         AND execution_id=?1 AND attempt_index=1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(new_count, 1, "reclaim must insert a fresh attempt row");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_worker_id_mismatch() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    let err = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "other-worker", "other-i1", 0, None))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, ff_core::engine_error::EngineError::Validation { .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_grant_not_found() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, None))
+        .await
+        .expect("reclaim");
+    assert!(
+        matches!(r, ReclaimExecutionOutcome::GrantNotFound { .. }),
+        "got {r:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_grant_ttl_expired_returns_not_found() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    sqlx::query(
+        "UPDATE ff_claim_grant SET expires_at_ms = 1 \
+         WHERE partition_key=0 AND execution_id=?1 AND kind='reclaim'",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, None))
+        .await
+        .expect("reclaim");
+    assert!(
+        matches!(r, ReclaimExecutionOutcome::GrantNotFound { .. }),
+        "got {r:?}"
+    );
+    let (grant_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_claim_grant WHERE partition_key=0 \
+         AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(grant_count, 0);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_cap_exceeded() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    sqlx::query(
+        "UPDATE ff_exec_core SET lease_reclaim_count = 1 \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, Some(1)))
+        .await
+        .expect("reclaim");
+    match r {
+        ReclaimExecutionOutcome::ReclaimCapExceeded { reclaim_count, .. } => {
+            assert_eq!(reclaim_count, 1);
+        }
+        other => panic!("expected ReclaimCapExceeded, got {other:?}"),
+    }
+
+    let (phase, public_state): (String, String) = sqlx::query_as(
+        "SELECT lifecycle_phase, public_state FROM ff_exec_core \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(phase, "terminal");
+    assert_eq!(public_state, "failed");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_handle_kind_reclaimed() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, None))
+        .await
+        .expect("reclaim");
+    match r {
+        ReclaimExecutionOutcome::Claimed(h) => {
+            assert_eq!(h.kind, HandleKind::Reclaimed);
+        }
+        other => panic!("expected Claimed(Reclaimed), got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-sqlite/tests/rfc024_reclaim.rs
@@ -449,6 +449,275 @@ async fn reclaim_execution_cap_exceeded() {
     assert_eq!(public_state, "failed");
 }
 
+// -- Review-finding regression tests (F1, F2+F3, F4, F5, F7) ---------
+
+/// F1+F6: if the exec transitions to terminal between grant issuance
+/// and grant consumption, reclaim_execution returns NotReclaimable
+/// (no state mutation) instead of reviving the execution.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_exec_gone_terminal_returns_not_reclaimable() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    // Operator-cancel-style transition flips the exec to terminal
+    // after the grant is issued but before the worker consumes it.
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='terminal', ownership_state='unowned', \
+         public_state='cancelled' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, None))
+        .await
+        .expect("reclaim");
+    assert!(
+        matches!(r, ReclaimExecutionOutcome::NotReclaimable { .. }),
+        "got {r:?}"
+    );
+
+    // Critical: exec state must still be terminal (not revived).
+    let (phase,): (String,) = sqlx::query_as(
+        "SELECT lifecycle_phase FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(phase, "terminal", "exec must remain terminal, not revived");
+}
+
+/// F2+F3: cap-exceeded branch clears the prior attempt's lease
+/// fields, marks outcome = interrupted_reclaimed, and emits BOTH
+/// the completion_event (terminal_failed) and the lease_event
+/// (revoked) per RFC-019 §4.2.7 outbox matrix.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_cap_exceeded_clears_prior_attempt_and_emits_events() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    sqlx::query(
+        "UPDATE ff_exec_core SET lease_reclaim_count = 1 \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, Some(1)))
+        .await
+        .expect("reclaim");
+    assert!(matches!(r, ReclaimExecutionOutcome::ReclaimCapExceeded { .. }));
+
+    // Prior attempt lease-fencing fields cleared + outcome set.
+    let (outcome, worker_id, lease_expires): (Option<String>, Option<String>, Option<i64>) =
+        sqlx::query_as(
+            "SELECT outcome, worker_id, lease_expires_at_ms FROM ff_attempt \
+             WHERE partition_key=0 AND execution_id=?1 AND attempt_index=0",
+        )
+        .bind(exec_uuid)
+        .fetch_one(b.pool_for_test())
+        .await
+        .unwrap();
+    assert_eq!(outcome.as_deref(), Some("interrupted_reclaimed"));
+    assert!(worker_id.is_none(), "worker_id must be cleared");
+    assert!(lease_expires.is_none(), "lease_expires_at_ms must be cleared");
+
+    // completion_event emitted with outcome = 'failed'.
+    let (comp_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_completion_event WHERE partition_key=0 \
+         AND execution_id=?1 AND outcome='failed'",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(comp_count, 1, "terminal_failed must emit completion_event");
+
+    // lease_event emitted with event_type = 'revoked'. Column is
+    // TEXT, bind the hyphenated UUID string.
+    let (lease_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_lease_event WHERE partition_key=0 \
+         AND execution_id=?1 AND event_type='revoked'",
+    )
+    .bind(exec_uuid.to_string())
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(lease_count, 1, "terminal_failed must emit lease_event revoked");
+}
+
+/// F4: the minted handle embeds caller-supplied `attempt_id` +
+/// `lease_id` (not freshly minted internally). Also verifies
+/// LeaseEpoch is non-zero (F5 — monotonically bumped).
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_handle_carries_caller_ids_and_nonzero_epoch() {
+    use ff_core::handle_codec::decode as decode_handle;
+
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    let caller_attempt_id = AttemptId::new();
+    let caller_lease_id = LeaseId::new();
+    let args = ReclaimExecutionArgs::new(
+        exec_id.clone(),
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i2"),
+        lane_id.clone(),
+        None,
+        caller_lease_id.clone(),
+        30_000,
+        caller_attempt_id.clone(),
+        String::new(),
+        None,
+        WorkerInstanceId::new("w1-i1"),
+        AttemptIndex::new(0),
+    );
+    let r = b.reclaim_execution(args).await.expect("reclaim");
+    let handle = match r {
+        ReclaimExecutionOutcome::Claimed(h) => h,
+        other => panic!("expected Claimed, got {other:?}"),
+    };
+
+    let decoded = decode_handle(&handle.opaque).expect("decode handle");
+    assert_eq!(decoded.payload.attempt_id, caller_attempt_id, "attempt_id must round-trip");
+    assert_eq!(decoded.payload.lease_id, caller_lease_id, "lease_id must round-trip");
+    assert!(
+        decoded.payload.lease_epoch.0 >= 1,
+        "lease_epoch must be monotonically bumped (>=1), got {}",
+        decoded.payload.lease_epoch.0
+    );
+}
+
+/// F5: lease_epoch monotonically increases across successive
+/// reclaims. Each reclaim reads the prior attempt's epoch and writes
+/// prior + 1 to the new attempt row.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_lease_epoch_monotonic_across_reclaims() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+
+    // First reclaim (attempt_index 0 → 1).
+    force_lease_expired(&b, exec_uuid).await;
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue-1");
+    let _ = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, None))
+        .await
+        .expect("reclaim-1");
+
+    let (epoch_1,): (i64,) = sqlx::query_as(
+        "SELECT lease_epoch FROM ff_attempt WHERE partition_key=0 \
+         AND execution_id=?1 AND attempt_index=1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert!(epoch_1 >= 1, "first reclaim epoch must be >=1, got {epoch_1}");
+
+    // Second reclaim (1 → 2).
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state='lease_expired_reclaimable' \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue-2");
+    let _ = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i3", 1, None))
+        .await
+        .expect("reclaim-2");
+
+    let (epoch_2,): (i64,) = sqlx::query_as(
+        "SELECT lease_epoch FROM ff_attempt WHERE partition_key=0 \
+         AND execution_id=?1 AND attempt_index=2",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert!(
+        epoch_2 > epoch_1,
+        "second-reclaim epoch ({epoch_2}) must exceed first-reclaim epoch ({epoch_1})"
+    );
+}
+
+/// F7: caller-supplied `current_attempt_index` is ignored in favor of
+/// the server-authoritative `ff_exec_core.attempt_index`. A stale arg
+/// does not backward-pin state nor PK-collide.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_ignores_stale_current_attempt_index_arg() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    // Stale arg: caller thinks attempt_index is 999, but server
+    // authoritative is 0. Server must derive new_attempt_index = 0+1.
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 999, None))
+        .await
+        .expect("reclaim");
+    assert!(matches!(r, ReclaimExecutionOutcome::Claimed(_)), "got {r:?}");
+
+    let (attempt_index,): (i64,) = sqlx::query_as(
+        "SELECT attempt_index FROM ff_exec_core WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(b.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(
+        attempt_index, 1,
+        "server-derived attempt_index must be 1 (stored 0 + 1), NOT 1000 (stale arg + 1)"
+    );
+}
+
 #[tokio::test]
 #[serial(ff_dev_mode)]
 async fn reclaim_execution_handle_kind_reclaimed() {


### PR DESCRIPTION
## Summary

RFC-024 PR-E — SQLite backend impl of the lease-reclaim wiring pair
that advances closure of #371. Parallel to PR-D (Postgres); different
backend crate, disjoint scope.

- Migration 0017 — `ff_claim_grant` table + `ff_exec_core.lease_reclaim_count` column (SQLite dialect)
- `reclaim.rs` — `issue_reclaim_grant_impl` + `reclaim_execution_impl` under `BEGIN IMMEDIATE` txn
- `queries/claim_grant.rs` — dialect-forked SQL mirroring PG reference
- `backend.rs` — trait method overrides wrapped in `retry_serializable`
- 10 integration tests in `tests/rfc024_reclaim.rs`
- CHANGELOG entry

## Design

Follows RFC-024 §4.3 (SQLite wiring) + RFC-023 §4.1 (SQLite dialect
conventions: no partitioning per N=1 supervisor, BLOB for raw bytes,
TEXT JSON for capabilities, `BEGIN IMMEDIATE` replaces PG `FOR UPDATE`).

- `issue_reclaim_grant_impl` — validates `lifecycle_phase = 'active'` AND `ownership_state IN ('lease_expired_reclaimable', 'lease_revoked')`; inserts a fresh grant row with `kind='reclaim'`.
- `reclaim_execution_impl` — looks up the reclaim grant by `(partition_key, execution_id, kind='reclaim')`, validates worker_id (Lua contract at `flowfabric.lua:3088` — no `worker_instance_id` check; matches cairn per-request-spawn model), checks `lease_reclaim_count` against `args.max_reclaim_count.unwrap_or(1000)`, marks prior attempt `interrupted_reclaimed`, inserts fresh `ff_attempt` row at `prior_attempt_index + 1`, bumps `lease_reclaim_count`, consumes the grant row, emits an RFC-019 `reclaimed` lease event via the post-commit `PubSub::lease_history` broadcast, mints a `HandleKind::Reclaimed` handle.
- Cap-exceeded branch transitions the execution to `terminal_failed` matching the Valkey Lua at `flowfabric.lua:3049-3080`.
- Default max_reclaim_count: 1000 (RFC-024 §4.6 Rust-surface default). Per-call override via `ReclaimExecutionArgs.max_reclaim_count`.

## Migration number

RFC-024 reserved 0015 for SQLite claim-grant, but migration 0016 (RFC-020 Wave 9 follow-up #356) landed first. This PR lands on **0017** to avoid sequence collisions. The migration sequence is now 0001..=0014 + 0016 + 0017; gap at 0015 is explicit in `tests/migrations.rs` comments.

## Non-goals / deferrals

- No PG impl (PR-D — parallel).
- No Valkey impl (PR-F).
- No SDK admin endpoint (PR-G).
- No `Supports::issue_reclaim_grant` flag flip — the flag does not exist on the `Supports` struct yet.

## Test plan

- [x] `cargo build -p ff-backend-sqlite` clean
- [x] `cargo test -p ff-backend-sqlite --test migrations` — 4/4 pass
- [x] `cargo test -p ff-backend-sqlite --test rfc024_reclaim` — 10/10 pass
- [x] `cargo test -p ff-backend-sqlite` — full crate suite green
- [ ] CI matrix green (workspace-wide)
- [ ] Bot review findings addressed before admin-merge

## References

- RFC-024 §4.3 — SQLite wiring
- RFC-023 §4.1 — SQLite dialect conventions
- `crates/ff-script/src/flowfabric.lua:2985` — Lua `ff_reclaim_execution`
- `crates/ff-script/src/flowfabric.lua:3088` — Lua grant worker_id match contract
- `crates/ff-script/src/flowfabric.lua:3898` — Lua `ff_issue_reclaim_grant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new SQLite migration and transactional reclaim logic that mutates execution/attempt state and emits lease events; mistakes could affect lease recovery and terminalization behavior.
> 
> **Overview**
> Implements RFC-024 lease-reclaim on the SQLite backend by adding migration `0017_claim_grant_table` (new `ff_claim_grant` table plus `ff_exec_core.lease_reclaim_count`) and wiring new backend methods `issue_reclaim_grant` and `reclaim_execution`.
> 
> Adds SQLite-dialect reclaim queries and a new `reclaim.rs` module that performs grant issuance/consumption and reclaim execution in a single `BEGIN IMMEDIATE` transaction, including attempt roll-forward, reclaim-cap enforcement, and post-commit emission of a `reclaimed` lease event plus `HandleKind::Reclaimed`.
> 
> Updates migration tests for the new schema and adds a dedicated `rfc024_reclaim` integration test suite covering success and key rejection/error branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe1e683c4b9a46af59215c1fbf79eec46a1bfc2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->