### PR TITLE
feat(pg-backend): RFC-024 PR-D — issue_reclaim_grant + reclaim_execution + migration 0017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,55 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **RFC-024 PR-D — Postgres `issue_reclaim_grant` + `reclaim_execution`
+  real impls + migration 0017 (continues #371).** Replaces the
+  PR-B+C `EngineError::Unavailable` default with production SQL
+  bodies on the Postgres backend. Scope: `ff-backend-postgres`
+  only; SQLite (PR-E) + Valkey (PR-F) land separately.
+  - `crates/ff-backend-postgres/migrations/0017_claim_grant_table.sql`
+    — new 256-way HASH-partitioned `ff_claim_grant` table with
+    `kind IN ('claim','reclaim')` discriminator, JSONB
+    `worker_capabilities`, per-grant TTL columns + indexes on
+    `(partition_key, execution_id)` and `expires_at_ms`. Adds
+    `ff_exec_core.lease_reclaim_count INTEGER NOT NULL DEFAULT 0`
+    for the RFC-024 §4.6 1000-cap enforcement. Backfills existing
+    `raw_fields.claim_grant` JSON entries into `kind='claim'`
+    rows (grant_id = sha256(grant_key)). `backward_compatible = true`;
+    the legacy JSON column is left in place for one release per
+    RFC-024 §5 / §10 (a follow-up cleanup strips the residue
+    once rolling-deploy windows close).
+  - `crates/ff-backend-postgres/src/claim_grant.rs` — new module
+    housing the `ff_claim_grant` CRUD + the two RFC-024
+    impls. SERIALIZABLE + 3-attempt retry wrapper per the
+    Wave-9 `operator::cancel_execution_impl` pattern.
+  - `PostgresBackend::issue_reclaim_grant` — validates
+    `lifecycle_phase = 'active'` + (ownership_state in
+    `{'lease_expired_reclaimable','lease_revoked'}` OR the
+    attempt's lease has expired / is NULL) under `FOR NO KEY
+    UPDATE`; pre-checks the 1000-cap; signs a reclaim grant via
+    the existing `ff_waitpoint_hmac` keystore; inserts
+    `kind='reclaim'` row. Returns `Granted(ReclaimGrant)` /
+    `NotReclaimable` / `ReclaimCapExceeded`.
+  - `PostgresBackend::reclaim_execution` — locks the reclaim
+    grant row under `FOR UPDATE`, validates grant worker_id
+    match (RFC-024 §4.4 — `worker_instance_id` intentionally
+    informational only), validates TTL, inserts a NEW
+    `ff_attempt` row with `attempt_index = current + 1`
+    (`raw_fields.attempt_type = 'reclaim'`) matching Valkey
+    `ff_reclaim_execution` semantics, marks the prior attempt
+    `outcome = 'interrupted_reclaimed'`, bumps `exec_core.attempt_index`
+    + `lease_reclaim_count`, consumes the grant row, emits a
+    RFC-019 `reclaimed` lease event, and mints a
+    `Handle { kind: Reclaimed, lease_epoch: 1 }`. Enforces the
+    caller-supplied `max_reclaim_count` (default 1000); on
+    exceed: transitions to `terminal_failed` + consumes the
+    grant + returns `ReclaimCapExceeded`.
+  - `crates/ff-backend-postgres/tests/rfc024_reclaim.rs` — 7
+    integration scenarios (happy paths for both methods,
+    wrong-phase, cap-exceeded at issuance, worker-id mismatch,
+    TTL-expired grant, cap-exceeded at reclaim, scheduler
+    write-through verification).
+
 - **RFC-024 PR-B+C — trait method renames + new `ReclaimGrant` type +
   non_exhaustive constructors (closes partial of #371).** Folded PR-B
   and PR-C of the RFC-024 series because the new trait method
@@ -85,6 +134,16 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     backends keep compiling.
 
 ### Changed
+
+- **RFC-024 PR-D — Postgres scheduler claim-grant storage flips
+  from JSON stash to `ff_claim_grant` table.** Pre-PR-D the
+  scheduler wrote claim grants into
+  `ff_exec_core.raw_fields.claim_grant` as a JSON object (see
+  `scheduler.rs:252` pre-PR-D). Post-PR-D, the scheduler writes a
+  `kind='claim'` row to the new `ff_claim_grant` table; the
+  `verify_grant` read path reads worker identity from the same
+  table. `raw_fields.claim_grant` is left in place for one
+  release for backfill safety.
 
 - **RFC-024 PR-B+C — trait method rename + transitional aliases
   dropped.** Compile-break wave that lands in the same PR as the new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "futures-core",
  "hex",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -50,6 +50,11 @@ uuid = { workspace = true }
 # by `suspend_ops.rs` for opaque-handle / payload hex codec.
 hex = "0.4"
 
+# RFC-024 PR-D: SHA256 for the deterministic `ff_claim_grant.grant_id`
+# (sha256 of the HMAC-signed `grant_key` string — stable, collision-
+# resistant, same primitive already in transit via `ff-core::crypto::hmac`).
+sha2 = "0.10"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 futures = { workspace = true }

--- a/crates/ff-backend-postgres/migrations/0017_claim_grant_table.sql
+++ b/crates/ff-backend-postgres/migrations/0017_claim_grant_table.sql
@@ -1,0 +1,148 @@
+-- no-transaction
+-- RFC-024 PR-D — claim-grant table + lease_reclaim_count column.
+--
+-- Replaces the pre-RFC JSON stash at `ff_exec_core.raw_fields.claim_grant`
+-- with a properly-shaped table carrying a discriminator column
+-- (`kind IN ('claim','reclaim')`). Adds the `lease_reclaim_count`
+-- column needed by RFC-024 §9's reclaim-cap-exceeded enforcement
+-- (default ceiling 1000).
+--
+-- Migration numbering: RFC-024 drafts reserved 0015 for this work but
+-- 0015 was not pre-applied; 0016_started_at_ms landed first. This
+-- migration takes 0017. The JSON→table backfill is driven by an
+-- `INSERT ... SELECT` from the pre-existing `raw_fields.claim_grant`
+-- entries. The JSON field is LEFT in place for one release per
+-- RFC-024 §5 / §10 (a later migration strips the residue); readers
+-- post-migration consult the table only.
+--
+-- Additive (`backward_compatible = true`). The new table starts empty
+-- except for the backfilled JSON rows; existing schedulers / workers
+-- keep functioning because `raw_fields.claim_grant` remains readable.
+-- The scheduler.rs read + write paths flip to the new table in this
+-- PR, but a rolling-deploy window where the older process still reads
+-- JSON is safe: grants issued by the new process write BOTH to the
+-- table and — during a transition window — the legacy JSON blob
+-- remains a valid fallback (§6 Backend parity).
+
+-- ============================================================
+-- Section 0 — pgcrypto (digest()) for deterministic grant_id backfill
+-- ============================================================
+-- Idempotent; stock FF environments already carry pgcrypto via operator
+-- bootstrap. Declared up-front so the Section 3 backfill can call
+-- `digest(text, 'sha256')` unconditionally.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ============================================================
+-- Section 1 — ff_claim_grant table (256-way HASH-partitioned)
+-- ============================================================
+
+CREATE TABLE ff_claim_grant (
+    partition_key       smallint NOT NULL,
+    grant_id            bytea    NOT NULL,
+    execution_id        uuid     NOT NULL,
+    kind                text     NOT NULL CHECK (kind IN ('claim','reclaim')),
+    worker_id           text     NOT NULL,
+    worker_instance_id  text     NOT NULL,
+    lane_id             text,
+    capability_hash     text,
+    worker_capabilities jsonb    NOT NULL DEFAULT '[]'::jsonb,
+    route_snapshot_json text,
+    admission_summary   text,
+    grant_ttl_ms        bigint   NOT NULL,
+    issued_at_ms        bigint   NOT NULL,
+    expires_at_ms       bigint   NOT NULL,
+    PRIMARY KEY (partition_key, grant_id)
+) PARTITION BY HASH (partition_key);
+
+-- Execution lookup (used by reclaim_execution to locate a kind=reclaim
+-- grant by (partition_key, execution_id)).
+CREATE INDEX ff_claim_grant_execution_idx
+    ON ff_claim_grant (partition_key, execution_id);
+
+-- TTL sweep index (future reaper uses this; also used by reclaim_execution
+-- to reject expired grants via predicate push-down).
+CREATE INDEX ff_claim_grant_expiry_idx
+    ON ff_claim_grant (expires_at_ms);
+
+-- Section 1b — 256 HASH partitions. Matches the 0001_initial convention
+-- (one COMMIT per parent → avoids max_locks_per_transaction hits on
+-- stock pg installs). Single parent → single DO block.
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_claim_grant FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_claim_grant_p' || i, i); END LOOP; END $$;
+COMMIT;
+
+-- ============================================================
+-- Section 2 — lease_reclaim_count column on ff_exec_core
+-- ============================================================
+-- Set-once-per-reclaim counter. `reclaim_execution_impl` increments by
+-- one on each successful reclaim; at 1000 (default) the backend
+-- surfaces `ReclaimCapExceeded` and the execution transitions to
+-- terminal_failed (per §4.2 impl). Existing rows default to 0.
+
+ALTER TABLE ff_exec_core
+    ADD COLUMN IF NOT EXISTS lease_reclaim_count INTEGER NOT NULL DEFAULT 0;
+
+-- ============================================================
+-- Section 3 — Backfill JSON-stashed claim grants → table rows
+-- ============================================================
+-- The pre-RFC scheduler at `scheduler.rs:252` stashed grants into
+-- `ff_exec_core.raw_fields.claim_grant` as a JSON object:
+--   {
+--     "grant_key":          "pg:<hash-tag>:<uuid>:<expires_ms>:<kid>:<hex>",
+--     "worker_id":          "...",
+--     "worker_instance_id": "...",
+--     "expires_at_ms":      <bigint>,
+--     "issued_at_ms":       <bigint>,
+--     "kid":                "..."
+--   }
+--
+-- We backfill each such row as `kind='claim'`. The `grant_id` is the
+-- sha256 of the stored `grant_key` string (stable, deterministic, and
+-- decoupled from the HMAC encoding). `lane_id` is NULL for pre-RFC
+-- fresh-claim grants (RFC asymmetry — ClaimGrant does not carry
+-- lane_id; the post-rename ReclaimGrant does).
+
+INSERT INTO ff_claim_grant (
+    partition_key, grant_id, execution_id, kind,
+    worker_id, worker_instance_id, lane_id,
+    capability_hash, worker_capabilities,
+    route_snapshot_json, admission_summary,
+    grant_ttl_ms, issued_at_ms, expires_at_ms
+)
+SELECT
+    c.partition_key,
+    digest((c.raw_fields->'claim_grant'->>'grant_key')::text, 'sha256'),
+    c.execution_id,
+    'claim',
+    c.raw_fields->'claim_grant'->>'worker_id',
+    c.raw_fields->'claim_grant'->>'worker_instance_id',
+    NULL,
+    NULL,
+    '[]'::jsonb,
+    NULL,
+    NULL,
+    0,  -- grant_ttl_ms not persisted in legacy JSON shape
+    COALESCE((c.raw_fields->'claim_grant'->>'issued_at_ms')::bigint, 0),
+    COALESCE((c.raw_fields->'claim_grant'->>'expires_at_ms')::bigint, 0)
+  FROM ff_exec_core c
+ WHERE c.raw_fields ? 'claim_grant'
+   AND (c.raw_fields->'claim_grant'->>'grant_key') IS NOT NULL
+   AND (c.raw_fields->'claim_grant'->>'worker_id') IS NOT NULL
+   AND (c.raw_fields->'claim_grant'->>'worker_instance_id') IS NOT NULL
+ON CONFLICT (partition_key, grant_id) DO NOTHING;
+
+-- NOTE: `digest(text, 'sha256')` requires the `pgcrypto` extension,
+-- enabled in Section 0 above. Backfill is idempotent under
+-- ON CONFLICT — re-running the migration on an already-seeded
+-- install writes no duplicate rows.
+
+-- ============================================================
+-- Section 4 — Migration annotation
+-- ============================================================
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    17,
+    '0017_claim_grant_table',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/migrations/0017_claim_grant_table.sql
+++ b/crates/ff-backend-postgres/migrations/0017_claim_grant_table.sql
@@ -18,11 +18,16 @@
 -- Additive (`backward_compatible = true`). The new table starts empty
 -- except for the backfilled JSON rows; existing schedulers / workers
 -- keep functioning because `raw_fields.claim_grant` remains readable.
--- The scheduler.rs read + write paths flip to the new table in this
--- PR, but a rolling-deploy window where the older process still reads
--- JSON is safe: grants issued by the new process write BOTH to the
--- table and — during a transition window — the legacy JSON blob
--- remains a valid fallback (§6 Backend parity).
+-- The scheduler.rs read path flips to the new table in this PR.
+--
+-- DUAL-WRITE DURING ROLLOUT: `claim_grant::write_claim_grant` writes
+-- to BOTH the new `ff_claim_grant` table AND the legacy
+-- `ff_exec_core.raw_fields.claim_grant` JSON blob. The legacy write
+-- exists solely for mixed-version read compat during a rolling
+-- deploy — old-version processes verify grants by reading the JSON
+-- and must see fresh writes. A future v0.13+ migration (0018) drops
+-- the legacy JSON write once the deploy window closes.
+-- (§6 Backend parity.)
 
 -- ============================================================
 -- Section 0 — pgcrypto (digest()) for deterministic grant_id backfill

--- a/crates/ff-backend-postgres/src/claim_grant.rs
+++ b/crates/ff-backend-postgres/src/claim_grant.rs
@@ -28,7 +28,7 @@ use ff_core::contracts::{
 use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
 use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
 use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
-use ff_core::types::{AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseId};
+use ff_core::types::{AttemptIndex, ExecutionId, LeaseEpoch};
 use sha2::{Digest, Sha256};
 use sqlx::{PgPool, Postgres, Row};
 use uuid::Uuid;
@@ -105,6 +105,45 @@ pub async fn write_claim_grant<'c>(
     .execute(&mut **tx)
     .await
     .map_err(map_sqlx_error)?;
+
+    // RFC-024 PR-D rollout dual-write — mirror the grant into the
+    // legacy `ff_exec_core.raw_fields.claim_grant` JSON blob so an
+    // older-version reader still in the rolling-deploy window can
+    // verify grants issued by the new code. The new code reads from
+    // `ff_claim_grant` exclusively; this write exists only for
+    // mixed-version read compat and is dropped in a future
+    // v0.13+ migration (0018) once the deploy window closes.
+    //
+    // Shape matches the pre-PR-D payload at `scheduler.rs:252`:
+    //   { grant_key, worker_id, worker_instance_id,
+    //     expires_at_ms, issued_at_ms, kid }
+    // `kid` is not available here (sig lives inside `grant_key`);
+    // legacy verify code only needs the 5 fields it actually reads.
+    let grant_json = serde_json::json!({
+        "grant_key": grant_key,
+        "worker_id": worker_id,
+        "worker_instance_id": worker_instance_id,
+        "expires_at_ms": expires_at_ms,
+        "issued_at_ms": issued_at_ms,
+    });
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET raw_fields = jsonb_set(
+                   COALESCE(raw_fields, '{}'::jsonb),
+                   '{claim_grant}',
+                   $3::jsonb,
+                   true)
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(execution_id)
+    .bind(grant_json)
+    .execute(&mut **tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
     Ok(())
 }
 
@@ -164,10 +203,17 @@ fn split_exec_id(eid: &ExecutionId) -> Result<(i16, Uuid), EngineError> {
         kind: ValidationKind::InvalidInput,
         detail: format!("execution_id missing `}}:`: {s}"),
     })?;
-    let part: i16 = rest[..close].parse().map_err(|_| EngineError::Validation {
+    // Parse the wire-shape `u16` partition index and cast to the
+    // schema's `smallint` column type. Matches the
+    // `partition.index as i16` convention used in
+    // `budget.rs:221`/`exec_core.rs:318`. Parsing directly as `i16`
+    // would accept negatives and wrap under cast — wrong hash-tag
+    // routing on negative input.
+    let part_u: u16 = rest[..close].parse().map_err(|_| EngineError::Validation {
         kind: ValidationKind::InvalidInput,
         detail: format!("execution_id partition index not u16: {s}"),
     })?;
+    let part = part_u as i16;
     let uuid = Uuid::parse_str(&rest[close + 2..]).map_err(|_| EngineError::Validation {
         kind: ValidationKind::InvalidInput,
         detail: format!("execution_id UUID invalid: {s}"),
@@ -447,7 +493,10 @@ async fn reclaim_execution_once(
         });
     }
 
-    let next_reclaim_count = (cur_reclaim_count as u32).saturating_add(1);
+    // Column is `INTEGER NOT NULL DEFAULT 0` so the row value SHOULD
+    // always be ≥ 0. Clamp defensively anyway: a negative value would
+    // wrap under `as u32` and skip the cap check.
+    let next_reclaim_count = (cur_reclaim_count.max(0) as u32).saturating_add(1);
     if next_reclaim_count > max_reclaim_count {
         sqlx::query(
             r#"
@@ -576,11 +625,19 @@ async fn reclaim_execution_once(
 
     tx.commit().await.map_err(map_sqlx_error)?;
 
+    // RFC-024 §3.3 / §4.4: the HandlePayload carries the
+    // caller-supplied `attempt_id` + `lease_id`. Valkey PR-F round-
+    // trips these through `ff_reclaim_execution` ARGV[5] (lease_id) +
+    // ARGV[7] (attempt_id) — the Lua echoes them back in the success
+    // tuple, so the handle the Valkey surface mints embeds the
+    // caller's identifiers. Postgres has no Lua round-trip; we use
+    // the args values directly to preserve cross-backend parity +
+    // idempotency + lease fencing.
     let payload = HandlePayload::new(
         args.execution_id.clone(),
         AttemptIndex::new(u32::try_from(new_attempt_index.max(0)).unwrap_or(0)),
-        AttemptId::new(),
-        LeaseId::new(),
+        args.attempt_id.clone(),
+        args.lease_id.clone(),
         LeaseEpoch(1),
         u32::try_from(args.lease_ttl_ms.min(u32::MAX as u64)).unwrap_or(u32::MAX) as u64,
         args.lane_id.clone(),

--- a/crates/ff-backend-postgres/src/claim_grant.rs
+++ b/crates/ff-backend-postgres/src/claim_grant.rs
@@ -1,0 +1,621 @@
+//! RFC-024 PR-D — `ff_claim_grant` table accessors + the two new
+//! RFC-024 methods (`issue_reclaim_grant`, `reclaim_execution`).
+//!
+//! Replaces the pre-RFC JSON stash at
+//! `ff_exec_core.raw_fields.claim_grant` (see `scheduler.rs:252` pre-
+//! PR-D). The scheduler's write path now calls
+//! [`write_claim_grant`] below; the scheduler's verify/read path
+//! (`scheduler::verify_grant`) reads from the same table.
+//!
+//! # Isolation
+//!
+//! Both RFC-024 methods run under SERIALIZABLE + a 3-attempt retry
+//! loop (mirrors `operator::cancel_execution_impl`).
+//!
+//! # Grant identity
+//!
+//! `grant_id` (BYTEA PK) is the sha256 of the Valkey/HMAC-signed
+//! `grant_key` string. Deterministic, stable across retries, and
+//! decoupled from the HMAC encoding (no need to re-sign on backfill).
+
+use std::time::Duration;
+
+use ff_core::backend::{BackendTag, Handle, HandleKind};
+use ff_core::contracts::{
+    IssueReclaimGrantArgs, IssueReclaimGrantOutcome, ReclaimExecutionArgs,
+    ReclaimExecutionOutcome, ReclaimGrant,
+};
+use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
+use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
+use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
+use ff_core::types::{AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseId};
+use sha2::{Digest, Sha256};
+use sqlx::{PgPool, Postgres, Row};
+use uuid::Uuid;
+
+use crate::error::map_sqlx_error;
+use crate::lease_event;
+use crate::signal::{current_active_kid, hmac_sign};
+
+const MAX_ATTEMPTS: u32 = 3;
+
+/// Default per-Rust-surface ceiling per RFC-024 §4.6.
+pub const DEFAULT_MAX_RECLAIM_COUNT: u32 = 1000;
+
+/// sha256(grant_key) → 32-byte grant_id.
+pub fn grant_id_from_key(grant_key: &str) -> Vec<u8> {
+    let mut h = Sha256::new();
+    h.update(grant_key.as_bytes());
+    h.finalize().to_vec()
+}
+
+fn capabilities_jsonb(caps: &std::collections::BTreeSet<String>) -> serde_json::Value {
+    serde_json::Value::Array(
+        caps.iter()
+            .map(|c| serde_json::Value::String(c.clone()))
+            .collect(),
+    )
+}
+
+/// Insert a fresh claim grant row. Called by the scheduler's Stage 5.
+#[allow(clippy::too_many_arguments)]
+pub async fn write_claim_grant<'c>(
+    tx: &mut sqlx::Transaction<'c, Postgres>,
+    partition_key: i16,
+    grant_key: &str,
+    execution_id: Uuid,
+    worker_id: &str,
+    worker_instance_id: &str,
+    grant_ttl_ms: u64,
+    issued_at_ms: i64,
+    expires_at_ms: i64,
+) -> Result<(), EngineError> {
+    let grant_id = grant_id_from_key(grant_key);
+    sqlx::query(
+        r#"
+        INSERT INTO ff_claim_grant (
+            partition_key, grant_id, execution_id, kind,
+            worker_id, worker_instance_id, lane_id,
+            capability_hash, worker_capabilities,
+            route_snapshot_json, admission_summary,
+            grant_ttl_ms, issued_at_ms, expires_at_ms
+        ) VALUES (
+            $1, $2, $3, 'claim',
+            $4, $5, NULL,
+            NULL, '[]'::jsonb,
+            NULL, NULL,
+            $6, $7, $8
+        )
+        ON CONFLICT (partition_key, grant_id) DO UPDATE SET
+            worker_id = EXCLUDED.worker_id,
+            worker_instance_id = EXCLUDED.worker_instance_id,
+            grant_ttl_ms = EXCLUDED.grant_ttl_ms,
+            issued_at_ms = EXCLUDED.issued_at_ms,
+            expires_at_ms = EXCLUDED.expires_at_ms
+        "#,
+    )
+    .bind(partition_key)
+    .bind(&grant_id)
+    .bind(execution_id)
+    .bind(worker_id)
+    .bind(worker_instance_id)
+    .bind(i64::try_from(grant_ttl_ms).unwrap_or(i64::MAX))
+    .bind(issued_at_ms)
+    .bind(expires_at_ms)
+    .execute(&mut **tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+/// Read a claim-grant row (kind='claim') for verification /
+/// diagnostics. Returns `Ok(None)` when absent.
+pub async fn read_claim_grant_identity(
+    pool: &PgPool,
+    partition_key: i16,
+    execution_id: Uuid,
+) -> Result<Option<(String, String)>, EngineError> {
+    let row = sqlx::query(
+        r#"
+        SELECT worker_id, worker_instance_id
+          FROM ff_claim_grant
+         WHERE partition_key = $1
+           AND execution_id = $2
+           AND kind = 'claim'
+         ORDER BY issued_at_ms DESC
+         LIMIT 1
+        "#,
+    )
+    .bind(partition_key)
+    .bind(execution_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    Ok(row.map(|r| {
+        (
+            r.get::<String, _>("worker_id"),
+            r.get::<String, _>("worker_instance_id"),
+        )
+    }))
+}
+
+// ─── retry helpers ──────────────────────────────────────────────────
+
+fn is_retryable_serialization(err: &EngineError) -> bool {
+    matches!(err, EngineError::Contention(ContentionKind::LeaseConflict))
+}
+
+async fn begin_serializable(pool: &PgPool) -> Result<sqlx::Transaction<'_, Postgres>, EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(tx)
+}
+
+fn split_exec_id(eid: &ExecutionId) -> Result<(i16, Uuid), EngineError> {
+    let s = eid.as_str();
+    let rest = s.strip_prefix("{fp:").ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id missing `{{fp:` prefix: {s}"),
+    })?;
+    let close = rest.find("}:").ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id missing `}}:`: {s}"),
+    })?;
+    let part: i16 = rest[..close].parse().map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id partition index not u16: {s}"),
+    })?;
+    let uuid = Uuid::parse_str(&rest[close + 2..]).map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id UUID invalid: {s}"),
+    })?;
+    Ok((part, uuid))
+}
+
+fn now_ms() -> i64 {
+    let d = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO);
+    (d.as_millis() as i64).max(0)
+}
+
+// ─── issue_reclaim_grant ─────────────────────────────────────────────
+
+async fn issue_reclaim_grant_once(
+    pool: &PgPool,
+    args: &IssueReclaimGrantArgs,
+) -> Result<IssueReclaimGrantOutcome, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let (kid, secret) = current_active_kid(pool)
+        .await?
+        .ok_or(EngineError::Unavailable {
+            op: "issue_reclaim_grant: ff_waitpoint_hmac keystore empty",
+        })?;
+
+    let mut tx = begin_serializable(pool).await?;
+
+    // RFC §4.2 admission gate — lifecycle_phase='active' AND either
+    // a reclaimable ownership_state literal OR the pre-RFC implicit
+    // "lease expired / released" shape (lease_expires_at_ms <= now OR
+    // worker_instance_id NULL).
+    let row = sqlx::query(
+        r#"
+        SELECT ec.lifecycle_phase,
+               ec.ownership_state,
+               ec.lease_reclaim_count,
+               a.lease_expires_at_ms,
+               a.worker_instance_id
+          FROM ff_exec_core ec
+          LEFT JOIN ff_attempt a
+            ON a.partition_key = ec.partition_key
+           AND a.execution_id  = ec.execution_id
+           AND a.attempt_index = ec.attempt_index
+         WHERE ec.partition_key = $1 AND ec.execution_id = $2
+         FOR NO KEY UPDATE OF ec
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+
+    let lifecycle_phase: String = row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let ownership_state: String = row.try_get("ownership_state").map_err(map_sqlx_error)?;
+    let reclaim_count: i32 = row.try_get("lease_reclaim_count").map_err(map_sqlx_error)?;
+    let lease_expires_at: Option<i64> = row
+        .try_get::<Option<i64>, _>("lease_expires_at_ms")
+        .map_err(map_sqlx_error)?;
+    let worker_instance_id: Option<String> = row
+        .try_get::<Option<String>, _>("worker_instance_id")
+        .map_err(map_sqlx_error)?;
+
+    let reclaim_count_u = u32::try_from(reclaim_count.max(0)).unwrap_or(0);
+    if reclaim_count_u >= DEFAULT_MAX_RECLAIM_COUNT {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(IssueReclaimGrantOutcome::ReclaimCapExceeded {
+            execution_id: args.execution_id.clone(),
+            reclaim_count: reclaim_count_u,
+        });
+    }
+
+    let now = now_ms();
+    let lease_expired = match lease_expires_at {
+        Some(exp) => exp <= now,
+        None => worker_instance_id.is_none() || worker_instance_id.as_deref() == Some(""),
+    };
+    let reclaimable_state = matches!(
+        ownership_state.as_str(),
+        "lease_expired_reclaimable" | "lease_revoked"
+    );
+    let phase_active = lifecycle_phase == "active";
+    if !(phase_active && (reclaimable_state || lease_expired)) {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(IssueReclaimGrantOutcome::NotReclaimable {
+            execution_id: args.execution_id.clone(),
+            detail: format!(
+                "execution not reclaimable: lifecycle_phase={lifecycle_phase}, ownership_state={ownership_state}"
+            ),
+        });
+    }
+
+    let partition = Partition {
+        family: PartitionFamily::Execution,
+        index: part as u16,
+    };
+    let hash_tag = partition.hash_tag();
+    let expires_at_ms = now.saturating_add_unsigned(args.grant_ttl_ms.min(i64::MAX as u64));
+    let message = format!(
+        "{hash_tag}|{exec_uuid}|{wid}|{wiid}|{exp}|reclaim",
+        wid = args.worker_id.as_str(),
+        wiid = args.worker_instance_id.as_str(),
+        exp = expires_at_ms,
+    );
+    let sig = hmac_sign(&secret, &kid, message.as_bytes());
+    let grant_key = format!("pg:reclaim:{hash_tag}:{exec_uuid}:{expires_at_ms}:{sig}");
+    let grant_id = grant_id_from_key(&grant_key);
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_claim_grant (
+            partition_key, grant_id, execution_id, kind,
+            worker_id, worker_instance_id, lane_id,
+            capability_hash, worker_capabilities,
+            route_snapshot_json, admission_summary,
+            grant_ttl_ms, issued_at_ms, expires_at_ms
+        ) VALUES (
+            $1, $2, $3, 'reclaim',
+            $4, $5, $6,
+            $7, $8,
+            $9, $10,
+            $11, $12, $13
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(&grant_id)
+    .bind(exec_uuid)
+    .bind(args.worker_id.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .bind(args.lane_id.as_str())
+    .bind(args.capability_hash.as_deref())
+    .bind(capabilities_jsonb(&args.worker_capabilities))
+    .bind(args.route_snapshot_json.as_deref())
+    .bind(args.admission_summary.as_deref())
+    .bind(i64::try_from(args.grant_ttl_ms).unwrap_or(i64::MAX))
+    .bind(now)
+    .bind(expires_at_ms)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(IssueReclaimGrantOutcome::Granted(ReclaimGrant::new(
+        args.execution_id.clone(),
+        PartitionKey::from(&partition),
+        grant_key,
+        expires_at_ms as u64,
+        args.lane_id.clone(),
+    )))
+}
+
+pub async fn issue_reclaim_grant_impl(
+    pool: &PgPool,
+    args: IssueReclaimGrantArgs,
+) -> Result<IssueReclaimGrantOutcome, EngineError> {
+    let mut last: Option<EngineError> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match issue_reclaim_grant_once(pool, &args).await {
+            Ok(r) => return Ok(r),
+            Err(err) if is_retryable_serialization(&err) => {
+                if attempt + 1 < MAX_ATTEMPTS {
+                    let ms = 5u64 * (1u64 << attempt);
+                    tokio::time::sleep(Duration::from_millis(ms)).await;
+                }
+                last = Some(err);
+                continue;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    let _ = last;
+    Err(EngineError::Contention(ContentionKind::RetryExhausted))
+}
+
+// ─── reclaim_execution ─────────────────────────────────────────────
+
+async fn reclaim_execution_once(
+    pool: &PgPool,
+    args: &ReclaimExecutionArgs,
+) -> Result<ReclaimExecutionOutcome, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let max_reclaim_count = args.max_reclaim_count.unwrap_or(DEFAULT_MAX_RECLAIM_COUNT);
+
+    let mut tx = begin_serializable(pool).await?;
+
+    let grant_row = sqlx::query(
+        r#"
+        SELECT grant_id, worker_id, expires_at_ms, lane_id
+          FROM ff_claim_grant
+         WHERE partition_key = $1
+           AND execution_id = $2
+           AND kind = 'reclaim'
+         ORDER BY issued_at_ms DESC
+         FOR UPDATE
+         LIMIT 1
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(grant_row) = grant_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(ReclaimExecutionOutcome::GrantNotFound {
+            execution_id: args.execution_id.clone(),
+        });
+    };
+    let grant_id: Vec<u8> = grant_row.try_get("grant_id").map_err(map_sqlx_error)?;
+    let grant_worker_id: String = grant_row.try_get("worker_id").map_err(map_sqlx_error)?;
+    let grant_expires_at_ms: i64 = grant_row
+        .try_get("expires_at_ms")
+        .map_err(map_sqlx_error)?;
+
+    // RFC-024 §4.4 worker identity contract: worker_id must match;
+    // worker_instance_id is informational only.
+    if grant_worker_id != args.worker_id.as_str() {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!(
+                "reclaim_execution: grant.worker_id={grant_worker_id} != args.worker_id={}",
+                args.worker_id.as_str()
+            ),
+        });
+    }
+    let now = now_ms();
+    if grant_expires_at_ms <= now {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(ReclaimExecutionOutcome::GrantNotFound {
+            execution_id: args.execution_id.clone(),
+        });
+    }
+
+    let core_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, attempt_index, lease_reclaim_count
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR NO KEY UPDATE
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(core_row) = core_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Err(EngineError::NotFound {
+            entity: "execution",
+        });
+    };
+    let lifecycle_phase: String = core_row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let cur_attempt_index: i32 = core_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    let cur_reclaim_count: i32 = core_row
+        .try_get("lease_reclaim_count")
+        .map_err(map_sqlx_error)?;
+
+    if lifecycle_phase == "terminal" || lifecycle_phase == "cancelled" {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(ReclaimExecutionOutcome::NotReclaimable {
+            execution_id: args.execution_id.clone(),
+            detail: format!("execution terminal: lifecycle_phase={lifecycle_phase}"),
+        });
+    }
+
+    let next_reclaim_count = (cur_reclaim_count as u32).saturating_add(1);
+    if next_reclaim_count > max_reclaim_count {
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase    = 'terminal',
+                   ownership_state    = 'unowned',
+                   eligibility_state  = 'not_applicable',
+                   public_state       = 'failed',
+                   attempt_state      = 'terminal_failed',
+                   terminal_at_ms     = COALESCE(terminal_at_ms, $3),
+                   lease_reclaim_count = $4,
+                   cancellation_reason = COALESCE(cancellation_reason, 'reclaim_cap_exceeded')
+             WHERE partition_key = $1 AND execution_id = $2
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(now)
+        .bind(i32::try_from(next_reclaim_count).unwrap_or(i32::MAX))
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        sqlx::query("DELETE FROM ff_claim_grant WHERE partition_key = $1 AND grant_id = $2")
+            .bind(part)
+            .bind(&grant_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(ReclaimExecutionOutcome::ReclaimCapExceeded {
+            execution_id: args.execution_id.clone(),
+            reclaim_count: next_reclaim_count,
+        });
+    }
+
+    // Mark prior attempt `interrupted_reclaimed`.
+    sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET outcome = 'interrupted_reclaimed',
+               terminal_at_ms = COALESCE(terminal_at_ms, $4)
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(cur_attempt_index)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Insert NEW attempt row (attempt_index = cur+1, epoch = 1,
+    // attempt_type = 'reclaim' in raw_fields).
+    let new_attempt_index = cur_attempt_index + 1;
+    let lease_ttl_ms = i64::try_from(args.lease_ttl_ms).unwrap_or(i64::MAX);
+    let new_lease_expires = now.saturating_add(lease_ttl_ms);
+    sqlx::query(
+        r#"
+        INSERT INTO ff_attempt (
+            partition_key, execution_id, attempt_index,
+            worker_id, worker_instance_id,
+            lease_epoch, lease_expires_at_ms, started_at_ms,
+            raw_fields
+        ) VALUES (
+            $1, $2, $3,
+            $4, $5,
+            1, $6, $7,
+            jsonb_build_object('attempt_type', 'reclaim')
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(new_attempt_index)
+    .bind(args.worker_id.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .bind(new_lease_expires)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Flip exec_core to active on the new attempt; bump reclaim count.
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET lifecycle_phase   = 'active',
+               ownership_state   = 'leased',
+               eligibility_state = 'not_applicable',
+               public_state      = 'running',
+               attempt_state     = 'running_attempt',
+               attempt_index     = $3,
+               lease_reclaim_count = $4,
+               started_at_ms     = COALESCE(started_at_ms, $5)
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(new_attempt_index)
+    .bind(i32::try_from(next_reclaim_count).unwrap_or(i32::MAX))
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Consume the grant.
+    sqlx::query("DELETE FROM ff_claim_grant WHERE partition_key = $1 AND grant_id = $2")
+        .bind(part)
+        .bind(&grant_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // RFC-019 Stage B outbox: lease reclaimed.
+    lease_event::emit(
+        &mut tx,
+        part,
+        exec_uuid,
+        None,
+        lease_event::EVENT_RECLAIMED,
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    let payload = HandlePayload::new(
+        args.execution_id.clone(),
+        AttemptIndex::new(u32::try_from(new_attempt_index.max(0)).unwrap_or(0)),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(1),
+        u32::try_from(args.lease_ttl_ms.min(u32::MAX as u64)).unwrap_or(u32::MAX) as u64,
+        args.lane_id.clone(),
+        args.worker_instance_id.clone(),
+    );
+    Ok(ReclaimExecutionOutcome::Claimed(mint_handle(
+        payload,
+        HandleKind::Reclaimed,
+    )))
+}
+
+pub async fn reclaim_execution_impl(
+    pool: &PgPool,
+    args: ReclaimExecutionArgs,
+) -> Result<ReclaimExecutionOutcome, EngineError> {
+    let mut last: Option<EngineError> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match reclaim_execution_once(pool, &args).await {
+            Ok(r) => return Ok(r),
+            Err(err) if is_retryable_serialization(&err) => {
+                if attempt + 1 < MAX_ATTEMPTS {
+                    let ms = 5u64 * (1u64 << attempt);
+                    tokio::time::sleep(Duration::from_millis(ms)).await;
+                }
+                last = Some(err);
+                continue;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    let _ = last;
+    Err(EngineError::Contention(ContentionKind::RetryExhausted))
+}
+
+fn mint_handle(payload: HandlePayload, kind: HandleKind) -> Handle {
+    let op = encode_opaque(BackendTag::Postgres, &payload);
+    Handle::new(BackendTag::Postgres, kind, op)
+}

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -42,7 +42,8 @@ use ff_core::contracts::{
 #[cfg(feature = "core")]
 use ff_core::state::PublicState;
 use ff_core::contracts::{
-    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, ReportUsageResult,
+    CancelFlowResult, ExecutionSnapshot, FlowSnapshot, IssueReclaimGrantArgs,
+    IssueReclaimGrantOutcome, ReclaimExecutionArgs, ReclaimExecutionOutcome, ReportUsageResult,
     RotateWaitpointHmacSecretAllArgs, RotateWaitpointHmacSecretAllResult, SeedOutcome,
     SeedWaitpointHmacSecretArgs, SuspendArgs, SuspendOutcome,
 };
@@ -86,6 +87,7 @@ pub use sqlx::PgPool;
 mod admin;
 pub mod attempt;
 pub mod budget;
+pub mod claim_grant;
 pub mod completion;
 #[cfg(feature = "core")]
 pub mod dispatch;
@@ -538,6 +540,24 @@ impl EngineBackend for PostgresBackend {
         token: ResumeToken,
     ) -> Result<Option<Handle>, EngineError> {
         attempt::claim_from_resume_grant(&self.pool, token).await
+    }
+
+    // RFC-024 PR-D — lease-reclaim grant issuance + consumption.
+
+    #[tracing::instrument(name = "pg.issue_reclaim_grant", skip_all)]
+    async fn issue_reclaim_grant(
+        &self,
+        args: IssueReclaimGrantArgs,
+    ) -> Result<IssueReclaimGrantOutcome, EngineError> {
+        claim_grant::issue_reclaim_grant_impl(&self.pool, args).await
+    }
+
+    #[tracing::instrument(name = "pg.reclaim_execution", skip_all)]
+    async fn reclaim_execution(
+        &self,
+        args: ReclaimExecutionArgs,
+    ) -> Result<ReclaimExecutionOutcome, EngineError> {
+        claim_grant::reclaim_execution_impl(&self.pool, args).await
     }
 
     #[tracing::instrument(name = "pg.delay", skip_all)]

--- a/crates/ff-backend-postgres/src/scheduler.rs
+++ b/crates/ff-backend-postgres/src/scheduler.rs
@@ -249,28 +249,31 @@ impl PostgresScheduler {
         let sig = hmac_sign(secret, kid, message.as_bytes());
         let grant_key = format!("pg:{hash_tag}:{exec_uuid}:{expires_at_ms}:{sig}");
 
-        // Persist the grant inside raw_fields.claim_grant. No schema
-        // delta; raw_fields is the Wave-3 convention for untyped
-        // overflow.
-        let grant_patch = serde_json::json!({
-            "claim_grant": {
-                "grant_key": grant_key,
-                "worker_id": worker_id.as_str(),
-                "worker_instance_id": worker_instance_id.as_str(),
-                "expires_at_ms": expires_at_ms,
-                "issued_at_ms": now,
-                "kid": kid,
-            }
-        });
+        // RFC-024 PR-D: persist the grant into `ff_claim_grant` (the
+        // properly-shaped table with `kind` discriminator). Pre-PR-D
+        // this used the JSON stash at `ff_exec_core.raw_fields.claim_grant`
+        // — the JSON column is left in place for one release for
+        // backfill safety (RFC §5 / §10) but is no longer consulted
+        // by the read path.
+        crate::claim_grant::write_claim_grant(
+            &mut tx,
+            part,
+            &grant_key,
+            exec_uuid,
+            worker_id.as_str(),
+            worker_instance_id.as_str(),
+            grant_ttl_ms,
+            now,
+            expires_at_ms,
+        )
+        .await?;
         sqlx::query(
             r#"
             UPDATE ff_exec_core
-               SET raw_fields = raw_fields || $1::jsonb,
-                   eligibility_state = 'pending_claim'
-             WHERE partition_key = $2 AND execution_id = $3
+               SET eligibility_state = 'pending_claim'
+             WHERE partition_key = $1 AND execution_id = $2
             "#,
         )
-        .bind(grant_patch)
         .bind(part)
         .bind(exec_uuid)
         .execute(&mut *tx)
@@ -348,9 +351,10 @@ pub async fn verify_grant(pool: &PgPool, grant: &ClaimGrant) -> Result<(), Grant
     Ok(())
 }
 
-/// Read the worker identity embedded in `raw_fields.claim_grant`.
-/// Needed by [`verify_grant`] so the signed message can be
-/// reconstructed deterministically.
+/// Read the worker identity for a claim grant by (partition_key,
+/// execution_id). RFC-024 PR-D: reads from the new `ff_claim_grant`
+/// table (kind='claim'); pre-PR-D this read from
+/// `ff_exec_core.raw_fields.claim_grant`.
 async fn read_grant_identity(
     pool: &PgPool,
     grant: &ClaimGrant,
@@ -364,28 +368,11 @@ async fn read_grant_identity(
         .map(|(_, u)| u)
         .ok_or(GrantVerifyError::Malformed)?;
     let exec_uuid = Uuid::parse_str(uuid_str).map_err(|_| GrantVerifyError::Malformed)?;
-    let row = sqlx::query(
-        "SELECT raw_fields FROM ff_exec_core WHERE partition_key = $1 AND execution_id = $2",
-    )
-    .bind(part)
-    .bind(exec_uuid)
-    .fetch_optional(pool)
-    .await
-    .map_err(|_| GrantVerifyError::Transport)?
-    .ok_or(GrantVerifyError::UnknownGrant)?;
-    let raw: JsonValue = row.try_get("raw_fields").map_err(|_| GrantVerifyError::Transport)?;
-    let cg = raw.get("claim_grant").ok_or(GrantVerifyError::UnknownGrant)?;
-    let wid = cg
-        .get("worker_id")
-        .and_then(JsonValue::as_str)
-        .ok_or(GrantVerifyError::Malformed)?
-        .to_owned();
-    let wiid = cg
-        .get("worker_instance_id")
-        .and_then(JsonValue::as_str)
-        .ok_or(GrantVerifyError::Malformed)?
-        .to_owned();
-    Ok((wid, wiid))
+    let ident = crate::claim_grant::read_claim_grant_identity(pool, part, exec_uuid)
+        .await
+        .map_err(|_| GrantVerifyError::Transport)?
+        .ok_or(GrantVerifyError::UnknownGrant)?;
+    Ok(ident)
 }
 
 /// Errors from [`verify_grant`].

--- a/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
@@ -1,0 +1,438 @@
+//! RFC-024 PR-D — issue_reclaim_grant + reclaim_execution integration
+//! tests against a live Postgres with migration 0017 applied.
+//!
+//! Running:
+//!   FF_PG_TEST_URL=postgres://... cargo test -p ff-backend-postgres
+//!     --test rfc024_reclaim -- --ignored
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::backend::HandleKind;
+use ff_core::contracts::{
+    IssueReclaimGrantArgs, IssueReclaimGrantOutcome, ReclaimExecutionArgs,
+    ReclaimExecutionOutcome,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{
+    AttemptId, ExecutionId, LaneId, LeaseId, TimestampMs, WorkerId, WorkerInstanceId,
+};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    sqlx::query(
+        r#"
+        INSERT INTO ff_waitpoint_hmac (kid, secret, rotated_at_ms, active)
+        VALUES ('rfc024-test', decode('0102030405060708', 'hex'), $1, true)
+        ON CONFLICT (kid) DO NOTHING
+        "#,
+    )
+    .bind(now_ms())
+    .execute(&pool)
+    .await
+    .expect("seed hmac");
+    Some(pool)
+}
+
+async fn seed_exec(
+    pool: &PgPool,
+    lane: &str,
+    ownership_state: &str,
+    lifecycle_phase: &str,
+    lease_reclaim_count: i32,
+) -> (i16, Uuid, LaneId) {
+    let part: i16 = 0;
+    let exec_uuid = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            required_capabilities, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms, lease_reclaim_count
+        ) VALUES (
+            $1, $2, NULL, $3,
+            '{}', 0,
+            $5, $4, 'not_applicable',
+            'running', 'running_attempt',
+            0, $6, $7
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lane)
+    .bind(ownership_state)
+    .bind(lifecycle_phase)
+    .bind(now_ms())
+    .bind(lease_reclaim_count)
+    .execute(pool)
+    .await
+    .expect("seed exec");
+    sqlx::query(
+        r#"
+        INSERT INTO ff_attempt (
+            partition_key, execution_id, attempt_index,
+            worker_id, worker_instance_id,
+            lease_epoch, lease_expires_at_ms, started_at_ms
+        ) VALUES ($1, $2, 0, 'w-orig', 'w-orig-1', 1, 0, $3)
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("seed attempt");
+    (part, exec_uuid, LaneId::new(lane))
+}
+
+fn backend_from_pool(pool: PgPool) -> Arc<dyn EngineBackend> {
+    PostgresBackend::from_pool(pool, PartitionConfig::default())
+}
+
+fn issue_args(eid: ExecutionId, lane: LaneId, worker: &str) -> IssueReclaimGrantArgs {
+    IssueReclaimGrantArgs::new(
+        eid,
+        WorkerId::new(worker),
+        WorkerInstanceId::new(format!("{worker}-1")),
+        lane,
+        None,
+        60_000,
+        None,
+        None,
+        BTreeSet::new(),
+        TimestampMs::from_millis(now_ms()),
+    )
+}
+
+fn reclaim_args(
+    eid: ExecutionId,
+    lane: LaneId,
+    worker: &str,
+    max: Option<u32>,
+) -> ReclaimExecutionArgs {
+    ReclaimExecutionArgs::new(
+        eid,
+        WorkerId::new(worker),
+        WorkerInstanceId::new(format!("{worker}-1")),
+        lane,
+        None,
+        LeaseId::new(),
+        30_000,
+        AttemptId::new(),
+        "{}".into(),
+        max,
+        WorkerInstanceId::new("w-orig-1"),
+        ff_core::types::AttemptIndex::new(0),
+    )
+}
+
+fn exec_id(part: i16, uuid: Uuid) -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:{part}}}:{uuid}")).unwrap()
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn issue_reclaim_grant_happy_path() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-iss-happy-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let args = issue_args(exec_id(part, exec_uuid), lane_id, "w-rec");
+    let out = backend.issue_reclaim_grant(args).await.expect("ok");
+    match out {
+        IssueReclaimGrantOutcome::Granted(g) => {
+            assert_eq!(g.execution_id, exec_id(part, exec_uuid));
+            assert!(g.expires_at_ms as i64 > now_ms());
+        }
+        other => panic!("expected Granted, got {other:?}"),
+    }
+    let row = sqlx::query(
+        "SELECT kind, worker_id FROM ff_claim_grant WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("row");
+    assert_eq!(row.get::<String, _>("kind"), "reclaim");
+    assert_eq!(row.get::<String, _>("worker_id"), "w-rec");
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn issue_reclaim_grant_wrong_phase_not_reclaimable() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-iss-phase-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) = seed_exec(&pool, &lane, "leased", "runnable", 0).await;
+    sqlx::query("UPDATE ff_attempt SET lease_expires_at_ms = $1 WHERE partition_key = $2 AND execution_id = $3")
+        .bind(now_ms() + 60_000)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let backend = backend_from_pool(pool.clone());
+    let args = issue_args(exec_id(part, exec_uuid), lane_id, "w-rec");
+    let out = backend.issue_reclaim_grant(args).await.expect("ok");
+    assert!(
+        matches!(out, IssueReclaimGrantOutcome::NotReclaimable { .. }),
+        "got {out:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn issue_reclaim_grant_cap_exceeded() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-iss-cap-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 1000).await;
+    let backend = backend_from_pool(pool.clone());
+    let args = issue_args(exec_id(part, exec_uuid), lane_id, "w-rec");
+    let out = backend.issue_reclaim_grant(args).await.expect("ok");
+    assert!(
+        matches!(
+            out,
+            IssueReclaimGrantOutcome::ReclaimCapExceeded { reclaim_count: 1000, .. }
+        ),
+        "got {out:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_happy_path_new_attempt_minted() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-happy-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+    let _ = match backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap()
+    {
+        IssueReclaimGrantOutcome::Granted(g) => g,
+        other => panic!("expected Granted, got {other:?}"),
+    };
+    let outcome = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", None))
+        .await
+        .expect("reclaim ok");
+    let handle = match outcome {
+        ReclaimExecutionOutcome::Claimed(h) => h,
+        other => panic!("expected Claimed, got {other:?}"),
+    };
+    assert_eq!(handle.kind, HandleKind::Reclaimed);
+
+    let row = sqlx::query(
+        "SELECT attempt_index, lease_reclaim_count, lifecycle_phase FROM ff_exec_core WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.get::<i32, _>("attempt_index"), 1);
+    assert_eq!(row.get::<i32, _>("lease_reclaim_count"), 1);
+    assert_eq!(row.get::<String, _>("lifecycle_phase"), "active");
+
+    let prior: Option<String> = sqlx::query_scalar(
+        "SELECT outcome FROM ff_attempt WHERE partition_key=$1 AND execution_id=$2 AND attempt_index=0",
+    )
+    .bind(part).bind(exec_uuid).fetch_one(&pool).await.unwrap();
+    assert_eq!(prior.as_deref(), Some("interrupted_reclaimed"));
+
+    let new_epoch: i64 = sqlx::query_scalar(
+        "SELECT lease_epoch FROM ff_attempt WHERE partition_key=$1 AND execution_id=$2 AND attempt_index=1",
+    )
+    .bind(part).bind(exec_uuid).fetch_one(&pool).await.unwrap();
+    assert_eq!(new_epoch, 1);
+
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_claim_grant WHERE partition_key=$1 AND execution_id=$2 AND kind='reclaim'",
+    )
+    .bind(part).bind(exec_uuid).fetch_one(&pool).await.unwrap();
+    assert_eq!(remaining, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_worker_id_mismatch_errors() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-wid-{}", Uuid::new_v4());
+    let (_part, _exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(_part, _exec_uuid);
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    let err = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-other", None))
+        .await
+        .expect_err("must error");
+    assert!(
+        matches!(err, ff_core::engine_error::EngineError::Validation { .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_ttl_expired_grant_not_found() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-ttl-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE ff_claim_grant SET expires_at_ms = 1 WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let outcome = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", None))
+        .await
+        .expect("ok");
+    assert!(
+        matches!(outcome, ReclaimExecutionOutcome::GrantNotFound { .. }),
+        "got {outcome:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_cap_exceeded_transitions_terminal() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-cap-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lease_reclaim_count = 5 WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let outcome = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", Some(5)))
+        .await
+        .expect("ok");
+    assert!(
+        matches!(
+            outcome,
+            ReclaimExecutionOutcome::ReclaimCapExceeded { reclaim_count: 6, .. }
+        ),
+        "got {outcome:?}"
+    );
+    let phase: String = sqlx::query_scalar(
+        "SELECT lifecycle_phase FROM ff_exec_core WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(phase, "terminal");
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn scheduler_claim_grant_writes_new_table_kind_claim() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-sched-tbl-{}", Uuid::new_v4());
+    let part: i16 = 0;
+    let exec_uuid = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            required_capabilities, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms
+        ) VALUES (
+            $1, $2, NULL, $3,
+            '{}', 0,
+            'runnable', 'unowned', 'eligible_now',
+            'waiting', 'pending_first_attempt',
+            0, $4
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(&lane)
+    .bind(now_ms())
+    .execute(&pool)
+    .await
+    .unwrap();
+    let sched = ff_backend_postgres::scheduler::PostgresScheduler::new(pool.clone());
+    let grant = sched
+        .claim_for_worker(
+            &LaneId::new(&lane),
+            &WorkerId::new("w-sched"),
+            &WorkerInstanceId::new("w-sched-1"),
+            &BTreeSet::new(),
+            30_000,
+        )
+        .await
+        .unwrap();
+    assert!(grant.is_some(), "scheduler should issue a grant");
+    let row: Option<(String, String)> = sqlx::query_as(
+        "SELECT kind, worker_id FROM ff_claim_grant WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    let row = row.expect("grant row in ff_claim_grant");
+    assert_eq!(row.0, "claim");
+    assert_eq!(row.1, "w-sched");
+}

--- a/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
@@ -435,4 +435,144 @@ async fn scheduler_claim_grant_writes_new_table_kind_claim() {
     let row = row.expect("grant row in ff_claim_grant");
     assert_eq!(row.0, "claim");
     assert_eq!(row.1, "w-sched");
+
+    // RFC-024 PR-D rollout dual-write: the legacy JSON blob at
+    // `ff_exec_core.raw_fields.claim_grant` must ALSO be populated
+    // so an older-version reader in a rolling-deploy window can
+    // still verify grants issued by the new code.
+    let legacy_json: sqlx::types::JsonValue = sqlx::query_scalar(
+        "SELECT raw_fields->'claim_grant' FROM ff_exec_core WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        legacy_json.is_object(),
+        "legacy raw_fields.claim_grant must be populated by dual-write, got {legacy_json}"
+    );
+    assert_eq!(
+        legacy_json.get("worker_id").and_then(|v| v.as_str()),
+        Some("w-sched")
+    );
+    assert_eq!(
+        legacy_json.get("worker_instance_id").and_then(|v| v.as_str()),
+        Some("w-sched-1")
+    );
+    assert!(
+        legacy_json.get("grant_key").and_then(|v| v.as_str()).is_some(),
+        "legacy blob missing grant_key: {legacy_json}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_handle_carries_caller_supplied_ids() {
+    // F6 parity: HandlePayload inside the minted handle must embed
+    // the caller-supplied attempt_id + lease_id, not fresh IDs.
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-ids-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    let caller_attempt = AttemptId::new();
+    let caller_lease = LeaseId::new();
+    let args = ReclaimExecutionArgs::new(
+        eid.clone(),
+        WorkerId::new("w-rec"),
+        WorkerInstanceId::new("w-rec-1"),
+        lane_id.clone(),
+        None,
+        caller_lease.clone(),
+        30_000,
+        caller_attempt.clone(),
+        "{}".into(),
+        None,
+        WorkerInstanceId::new("w-orig-1"),
+        ff_core::types::AttemptIndex::new(0),
+    );
+    let outcome = backend.reclaim_execution(args).await.expect("ok");
+    let handle = match outcome {
+        ReclaimExecutionOutcome::Claimed(h) => h,
+        other => panic!("expected Claimed, got {other:?}"),
+    };
+    let decoded = ff_core::handle_codec::decode(&handle.opaque).expect("decode handle");
+    assert_eq!(
+        decoded.payload.attempt_id, caller_attempt,
+        "HandlePayload.attempt_id must echo caller-supplied value"
+    );
+    assert_eq!(
+        decoded.payload.lease_id, caller_lease,
+        "HandlePayload.lease_id must echo caller-supplied value"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_negative_reclaim_count_does_not_wrap() {
+    // F5 defensive clamp: a (hypothetical) negative
+    // `lease_reclaim_count` row must not wrap under `as u32`. The
+    // schema disallows negatives via `DEFAULT 0`, but the code
+    // clamps before cast anyway. Force a negative via direct UPDATE
+    // (bypassing the schema's intent) and confirm the clamped path
+    // still increments to 1 rather than saturating.
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-neg-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    // Bypass: overwrite the count to -1 post-seed.
+    sqlx::query(
+        "UPDATE ff_exec_core SET lease_reclaim_count = -1 WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    let outcome = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", None))
+        .await
+        .expect("ok");
+    assert!(
+        matches!(outcome, ReclaimExecutionOutcome::Claimed(_)),
+        "got {outcome:?}"
+    );
+    let new_count: i32 = sqlx::query_scalar(
+        "SELECT lease_reclaim_count FROM ff_exec_core WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(new_count, 1, "clamped (-1).max(0)+1 must be 1, got {new_count}");
+}
+
+#[test]
+fn execution_id_parse_rejects_negative_partition() {
+    // F4 upstream invariant: `ExecutionId::parse` already enforces
+    // a `u16` partition index, so a negative literal never reaches
+    // `split_exec_id` in practice. The i16→u16 parse fix in
+    // `split_exec_id` is defense-in-depth + matches the Wave-9
+    // `partition.index as i16` convention; verify the upstream
+    // invariant that makes that layering sound.
+    assert!(
+        ExecutionId::parse("{fp:-1}:00000000-0000-0000-0000-000000000000").is_err(),
+        "ExecutionId::parse must reject negative partition index"
+    );
+    assert!(
+        ExecutionId::parse("{fp:0}:00000000-0000-0000-0000-000000000000").is_ok()
+    );
 }

--- a/crates/ff-backend-sqlite/migrations/.sqlite-skip
+++ b/crates/ff-backend-sqlite/migrations/.sqlite-skip
@@ -13,3 +13,8 @@
 #
 # The parity-drift lint (`scripts/lint-migrations.sh`) parses this
 # format directly.
+
+# RFC-024 PR-D (Postgres) is landing ahead of PR-E (SQLite). The
+# SQLite sibling for `0017_claim_grant_table.sql` lands in PR-E
+# and this skip-entry is removed then.
+0017_claim_grant_table.sql # issue:371


### PR DESCRIPTION
## Summary

Postgres slice of RFC-024: replaces the PR-B+C `EngineError::Unavailable` default on `issue_reclaim_grant` + `reclaim_execution` with production SQL bodies. Closes the Postgres side of #371 (pull-mode deadlock).

Scope — `ff-backend-postgres` only. SQLite (PR-E) + Valkey (PR-F) land separately.

### RFC-024 §4.2 wiring

- **Migration `0017_claim_grant_table.sql`** — 256-way HASH-partitioned `ff_claim_grant` table with `kind IN ('claim','reclaim')` discriminator, JSONB `worker_capabilities`, TTL columns + indexes. Adds `ff_exec_core.lease_reclaim_count INTEGER` for the §4.6 1000-cap enforcement. Backfills existing `raw_fields.claim_grant` JSON → `kind='claim'` rows (grant_id = sha256(grant_key)). `backward_compatible = true`. The legacy JSON column is left in place for one release per RFC §5 / §10.
- **New `claim_grant` module** — `ff_claim_grant` CRUD + the two RFC-024 method impls. SERIALIZABLE + 3-attempt retry wrapper, mirroring Wave-9 `operator::cancel_execution_impl`.
- **`issue_reclaim_grant`** — validates `lifecycle_phase = 'active'` + (`ownership_state IN ('lease_expired_reclaimable','lease_revoked')` OR the attempt's lease has expired / is NULL) under `FOR NO KEY UPDATE`; pre-checks the 1000-cap; signs a reclaim grant via `ff_waitpoint_hmac`; inserts `kind='reclaim'` row. Returns `Granted(ReclaimGrant)` / `NotReclaimable` / `ReclaimCapExceeded`.
- **`reclaim_execution`** — locks reclaim grant under `FOR UPDATE`; validates `grant.worker_id == args.worker_id` (§4.4 — `worker_instance_id` informational only); validates TTL; inserts NEW `ff_attempt` row (`attempt_index = current+1`, `raw_fields.attempt_type = 'reclaim'`); marks prior attempt `interrupted_reclaimed`; bumps `exec_core.attempt_index` + `lease_reclaim_count`; consumes grant; emits RFC-019 `reclaimed` lease event; mints `Handle { kind: Reclaimed, lease_epoch: 1 }`. Enforces `max_reclaim_count` (default 1000); on exceed → `terminal_failed` + `ReclaimCapExceeded`.
- **scheduler.rs** — claim-grant writes flip from `raw_fields.claim_grant` JSON stash to the new table (`kind='claim'`). `verify_grant` identity read follows.

### Migration 0017 summary

- `ff_claim_grant` table (256 HASH partitions, 2 secondary indexes)
- `ff_exec_core.lease_reclaim_count INTEGER NOT NULL DEFAULT 0`
- Backfill via `INSERT ... SELECT ... ON CONFLICT DO NOTHING` (idempotent)
- `backward_compatible = true`

### Tests

7 integration scenarios in `rfc024_reclaim.rs` (all `#[ignore]`d behind `FF_PG_TEST_URL`):

- `issue_reclaim_grant_happy_path` — Granted + row lands with `kind='reclaim'`
- `issue_reclaim_grant_wrong_phase_not_reclaimable`
- `issue_reclaim_grant_cap_exceeded` (seeded at 1000)
- `reclaim_execution_happy_path_new_attempt_minted` — attempt_index bumped, prior marked `interrupted_reclaimed`, `lease_reclaim_count = 1`, grant consumed, `HandleKind::Reclaimed`
- `reclaim_execution_worker_id_mismatch_errors` — Validation
- `reclaim_execution_ttl_expired_grant_not_found`
- `reclaim_execution_cap_exceeded_transitions_terminal`
- `scheduler_claim_grant_writes_new_table_kind_claim` — verifies scheduler write-through

### RFC vs reality notes

- RFC drafts reserved `0015` for this migration; `0016_started_at_ms` landed first, so this PR claims `0017`. The RFC-024 doc still references `0015`; no other-PR rename needed.
- `ownership_state = 'lease_expired_reclaimable'` is not a literal pg emits today; the impl also accepts the implicit "lease expired / released" shape (`lease_expires_at_ms <= now` OR `worker_instance_id IS NULL`) so consumers can reclaim without a scheduler scanner that emits the literal.

### Semver

No public API changes beyond what PR-B+C already landed (trait-default impls were `Unavailable`; now return real outcomes). No consumer-facing breakage.

## Test plan

- [ ] `cargo build --workspace --all-targets` — clean
- [ ] `cargo clippy -p ff-backend-postgres --all-targets -- -D warnings` — clean
- [ ] CI matrix-green (migration-parity + workspace build)
- [ ] Integration tests with `FF_PG_TEST_URL` pointing at migrated pg — 7/7 pass
- [ ] Address all bot findings per feedback_pr_comment_sweep_before_merge.md before admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Postgres schema (partitioned `ff_claim_grant`, new counter column) and SERIALIZABLE transactional reclaim logic that changes lease/attempt state transitions; mistakes could affect reclaimability, data consistency, or rollout migrations.
> 
> **Overview**
> Implements RFC-024 reclaim support on the Postgres backend by replacing the prior `EngineError::Unavailable` stubs with real SQL for `issue_reclaim_grant` and `reclaim_execution`, including grant signing, TTL validation, and minting a new `HandleKind::Reclaimed` after creating a new attempt and marking the prior one `interrupted_reclaimed`.
> 
> Introduces migration `0017_claim_grant_table.sql` adding a 256-way HASH-partitioned `ff_claim_grant` table (with TTL indexes) plus `ff_exec_core.lease_reclaim_count` for reclaim-cap enforcement, and backfills legacy `raw_fields.claim_grant` JSON into `kind='claim'` rows.
> 
> Updates the Postgres scheduler to persist and verify claim grants via `ff_claim_grant` instead of `ff_exec_core.raw_fields`, and adds live-Postgres integration tests covering happy paths and key error/cap/TTL scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0583bf860b30d65a2c5cf7d851070f7409d09443. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->