### PR TITLE
fix(pg-backend): reclaim cap-exceeded outbox + lease_epoch monotonicity (cross-backend parity)

### DIFF
--- a/crates/ff-backend-postgres/src/claim_grant.rs
+++ b/crates/ff-backend-postgres/src/claim_grant.rs
@@ -602,7 +602,11 @@ async fn reclaim_execution_once(
     // fencing remains monotonic across successive reclaims (matches
     // Valkey Lua `flowfabric.lua:3106` + SQLite `reclaim.rs`).
     let new_attempt_index = cur_attempt_index + 1;
-    let new_lease_epoch: i64 = prior_lease_epoch.saturating_add(1);
+    // Defensive clamp: `ff_attempt.lease_epoch` is `bigint` with no
+    // CHECK constraint, so a malformed row could surface a negative
+    // value. Clamp before bump so the DB-persisted epoch matches the
+    // handle's non-negative u64 value (no DB/handle divergence).
+    let new_lease_epoch: i64 = prior_lease_epoch.max(0).saturating_add(1);
     let lease_ttl_ms = i64::try_from(args.lease_ttl_ms).unwrap_or(i64::MAX);
     let new_lease_expires = now.saturating_add(lease_ttl_ms);
     sqlx::query(

--- a/crates/ff-backend-postgres/src/claim_grant.rs
+++ b/crates/ff-backend-postgres/src/claim_grant.rs
@@ -462,10 +462,15 @@ async fn reclaim_execution_once(
 
     let core_row = sqlx::query(
         r#"
-        SELECT lifecycle_phase, attempt_index, lease_reclaim_count
-          FROM ff_exec_core
-         WHERE partition_key = $1 AND execution_id = $2
-         FOR NO KEY UPDATE
+        SELECT ec.lifecycle_phase, ec.attempt_index, ec.lease_reclaim_count,
+               COALESCE(a.lease_epoch, 0) AS prior_lease_epoch
+          FROM ff_exec_core ec
+          LEFT JOIN ff_attempt a
+            ON a.partition_key = ec.partition_key
+           AND a.execution_id  = ec.execution_id
+           AND a.attempt_index = ec.attempt_index
+         WHERE ec.partition_key = $1 AND ec.execution_id = $2
+         FOR NO KEY UPDATE OF ec
         "#,
     )
     .bind(part)
@@ -483,6 +488,14 @@ async fn reclaim_execution_once(
     let cur_attempt_index: i32 = core_row.try_get("attempt_index").map_err(map_sqlx_error)?;
     let cur_reclaim_count: i32 = core_row
         .try_get("lease_reclaim_count")
+        .map_err(map_sqlx_error)?;
+    // Prior-attempt lease epoch drives the monotonic bump for the new
+    // attempt's `lease_epoch` (Bug B parity — Valkey Lua
+    // `flowfabric.lua:3106` + SQLite `reclaim.rs::reclaim_execution_inner`
+    // both use `prior + 1`). LEFT JOIN tolerates a missing
+    // prior-attempt row (COALESCE → 0, bump → 1).
+    let prior_lease_epoch: i64 = core_row
+        .try_get("prior_lease_epoch")
         .map_err(map_sqlx_error)?;
 
     if lifecycle_phase == "terminal" || lifecycle_phase == "cancelled" {
@@ -525,6 +538,40 @@ async fn reclaim_execution_once(
             .execute(&mut *tx)
             .await
             .map_err(map_sqlx_error)?;
+
+        // Bug A parity fix — RFC-024 §4.2.7 / RFC-019 outbox matrix:
+        // every terminal transition emits BOTH a completion_event and a
+        // lease_event. Cap-exceeded is `terminal_failed`, so both fire.
+        // Mirrors SQLite `reclaim.rs::reclaim_execution_inner` cap-
+        // exceeded branch (lines 376-384, post-PR-E `d16ad68`).
+        sqlx::query(
+            r#"
+            INSERT INTO ff_completion_event (
+                partition_key, execution_id, flow_id, outcome,
+                namespace, instance_tag, occurred_at_ms
+            )
+            SELECT partition_key, execution_id, flow_id, 'failed',
+                   NULL, NULL, $3
+              FROM ff_exec_core
+             WHERE partition_key = $1 AND execution_id = $2
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        lease_event::emit(
+            &mut tx,
+            part,
+            exec_uuid,
+            None,
+            lease_event::EVENT_REVOKED,
+            now,
+        )
+        .await?;
+
         tx.commit().await.map_err(map_sqlx_error)?;
         return Ok(ReclaimExecutionOutcome::ReclaimCapExceeded {
             execution_id: args.execution_id.clone(),
@@ -549,9 +596,13 @@ async fn reclaim_execution_once(
     .await
     .map_err(map_sqlx_error)?;
 
-    // Insert NEW attempt row (attempt_index = cur+1, epoch = 1,
-    // attempt_type = 'reclaim' in raw_fields).
+    // Insert NEW attempt row (attempt_index = cur+1, epoch = prior+1,
+    // attempt_type = 'reclaim' in raw_fields). Bug B parity fix: the
+    // new lease_epoch is derived from the prior attempt's epoch so
+    // fencing remains monotonic across successive reclaims (matches
+    // Valkey Lua `flowfabric.lua:3106` + SQLite `reclaim.rs`).
     let new_attempt_index = cur_attempt_index + 1;
+    let new_lease_epoch: i64 = prior_lease_epoch.saturating_add(1);
     let lease_ttl_ms = i64::try_from(args.lease_ttl_ms).unwrap_or(i64::MAX);
     let new_lease_expires = now.saturating_add(lease_ttl_ms);
     sqlx::query(
@@ -564,7 +615,7 @@ async fn reclaim_execution_once(
         ) VALUES (
             $1, $2, $3,
             $4, $5,
-            1, $6, $7,
+            $8, $6, $7,
             jsonb_build_object('attempt_type', 'reclaim')
         )
         "#,
@@ -576,6 +627,7 @@ async fn reclaim_execution_once(
     .bind(args.worker_instance_id.as_str())
     .bind(new_lease_expires)
     .bind(now)
+    .bind(new_lease_epoch)
     .execute(&mut *tx)
     .await
     .map_err(map_sqlx_error)?;
@@ -638,7 +690,7 @@ async fn reclaim_execution_once(
         AttemptIndex::new(u32::try_from(new_attempt_index.max(0)).unwrap_or(0)),
         args.attempt_id.clone(),
         args.lease_id.clone(),
-        LeaseEpoch(1),
+        LeaseEpoch(u64::try_from(new_lease_epoch.max(0)).unwrap_or(0)),
         u32::try_from(args.lease_ttl_ms.min(u32::MAX as u64)).unwrap_or(u32::MAX) as u64,
         args.lane_id.clone(),
         args.worker_instance_id.clone(),

--- a/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
@@ -271,11 +271,13 @@ async fn reclaim_execution_happy_path_new_attempt_minted() {
     .bind(part).bind(exec_uuid).fetch_one(&pool).await.unwrap();
     assert_eq!(prior.as_deref(), Some("interrupted_reclaimed"));
 
+    // Bug B parity: new attempt's lease_epoch = prior + 1. `seed_exec`
+    // writes the prior attempt with lease_epoch=1, so reclaim mints 2.
     let new_epoch: i64 = sqlx::query_scalar(
         "SELECT lease_epoch FROM ff_attempt WHERE partition_key=$1 AND execution_id=$2 AND attempt_index=1",
     )
     .bind(part).bind(exec_uuid).fetch_one(&pool).await.unwrap();
-    assert_eq!(new_epoch, 1);
+    assert_eq!(new_epoch, 2);
 
     let remaining: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)::bigint FROM ff_claim_grant WHERE partition_key=$1 AND execution_id=$2 AND kind='reclaim'",
@@ -558,6 +560,135 @@ async fn reclaim_execution_negative_reclaim_count_does_not_wrap() {
     .await
     .unwrap();
     assert_eq!(new_count, 1, "clamped (-1).max(0)+1 must be 1, got {new_count}");
+}
+
+/// Bug A parity: cap-exceeded emits BOTH a completion_event
+/// (outcome='failed') and a lease_event (event_type='revoked'). Per
+/// RFC-024 §4.2.7 / RFC-019 outbox matrix, every terminal transition
+/// fires both. Mirrors SQLite
+/// `reclaim_cap_exceeded_clears_prior_attempt_and_emits_events`.
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_cap_exceeded_emits_completion_and_lease_revoked() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-cap-outbox-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lease_reclaim_count = 5 WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let outcome = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", Some(5)))
+        .await
+        .expect("ok");
+    assert!(
+        matches!(outcome, ReclaimExecutionOutcome::ReclaimCapExceeded { .. }),
+        "expected cap-exceeded, got {outcome:?}"
+    );
+
+    let comp_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_completion_event \
+         WHERE partition_key=$1 AND execution_id=$2 AND outcome='failed'",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        comp_count, 1,
+        "terminal_failed must emit completion_event(outcome='failed')"
+    );
+
+    let lease_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM ff_lease_event \
+         WHERE partition_key=$1 AND execution_id=$2 AND event_type='revoked'",
+    )
+    .bind(i32::from(part))
+    .bind(exec_uuid.to_string())
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        lease_count, 1,
+        "terminal_failed must emit lease_event(event_type='revoked')"
+    );
+}
+
+/// Bug B parity: lease_epoch is derived from prior attempt's epoch
+/// (prior+1) and monotonically increases across successive reclaims.
+/// Mirrors SQLite `reclaim_execution_lease_epoch_monotonic_across_reclaims`
+/// + Valkey Lua `flowfabric.lua:3106`.
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_lease_epoch_monotonic_across_reclaims() {
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-epoch-mono-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 0).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    let _ = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", None))
+        .await
+        .expect("reclaim-1");
+
+    let epoch_1: i64 = sqlx::query_scalar(
+        "SELECT lease_epoch FROM ff_attempt WHERE partition_key=$1 AND execution_id=$2 AND attempt_index=1",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(epoch_1 >= 1, "first reclaim epoch must be >=1, got {epoch_1}");
+
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state='lease_expired_reclaimable' \
+         WHERE partition_key=$1 AND execution_id=$2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    let _ = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", None))
+        .await
+        .expect("reclaim-2");
+
+    let epoch_2: i64 = sqlx::query_scalar(
+        "SELECT lease_epoch FROM ff_attempt WHERE partition_key=$1 AND execution_id=$2 AND attempt_index=2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        epoch_2 > epoch_1,
+        "second-reclaim epoch ({epoch_2}) must exceed first ({epoch_1})"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two parity bugs in `ff-backend-postgres::reclaim_execution_once`, caught during PR-E (SQLite impl, merged `d16ad68` / #401) review of PR-D (PG impl, merged `92f2c03` / #403). Both must land before v0.12 tag.

### Bug A — PG cap-exceeded path missing outbox emits
RFC-024 §4.2.7 / RFC-019 outbox matrix requires every terminal transition to emit BOTH:
- `ff_completion_event` with `outcome='failed'`
- `ff_lease_event` with `event_type='revoked'`

PG's cap-exceeded branch flipped exec_core to `terminal_failed` + consumed the grant but emitted neither. Fix: emit both before commit, mirroring SQLite `reclaim.rs:376-384`.

### Bug B — PG hardcoded `LeaseEpoch(1)` on handle mint
Valkey Lua (`flowfabric.lua:3106`) and SQLite (`reclaim.rs:409`) both compute `new_lease_epoch = prior_lease_epoch + 1` so fencing remains monotonic across successive reclaims. PG now LEFT JOINs `ff_attempt` in the core SELECT to read the prior attempt's `lease_epoch`, writing `prior+1` into the new `ff_attempt.lease_epoch` column AND the minted `HandlePayload`.

## Changes

- `crates/ff-backend-postgres/src/claim_grant.rs::reclaim_execution_once`: LEFT JOIN prior attempt's `lease_epoch`; cap-exceeded branch emits completion_event + lease_event; handle mint uses `prior+1` instead of `1`.
- `crates/ff-backend-postgres/tests/rfc024_reclaim.rs`: 2 new regression tests + 1 assertion update.

## Test plan

- [x] `cargo clippy -p ff-backend-postgres --all-targets -- -D warnings` clean
- [x] `cargo test -p ff-backend-postgres --test rfc024_reclaim -- --ignored` — all 12 tests pass against live PG
  - New: `reclaim_cap_exceeded_emits_completion_and_lease_revoked` (mirrors SQLite)
  - New: `reclaim_execution_lease_epoch_monotonic_across_reclaims` (mirrors SQLite)
  - Updated: `reclaim_execution_happy_path_new_attempt_minted` — `new_epoch` now 2 (prior=1 + 1) instead of 1
- [ ] Full CI matrix green

## Semver

Internal fix; no public API change. No semver break.

## References
- RFC-024 §4.2.7 outbox matrix
- SQLite parity: `crates/ff-backend-sqlite/src/reclaim.rs:376-384` + `:409` (PR-E, merge `d16ad68`)
- Valkey Lua: `flowfabric.lua:3106` (PR-F)
- PR-D bug source: `92f2c03` (#403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Postgres reclaim execution path, changing terminal-transition outbox emissions and lease fencing (`lease_epoch`) behavior; mistakes could cause missing events or incorrect lease fencing across reclaims.
> 
> **Overview**
> Fixes two Postgres reclaim parity bugs.
> 
> On reclaim cap-exceeded, the Postgres backend now emits both required outbox records: a `ff_completion_event` with outcome `failed` and a `ff_lease_event` with event type `revoked`.
> 
> For successful reclaims, the new attempt’s `lease_epoch` is now derived as `prior_lease_epoch + 1` (read via a `LEFT JOIN` on the prior attempt) and the minted handle carries this bumped epoch, ensuring monotonic fencing across successive reclaims; tests are updated/added to cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc9d0e0ad0f4e5dd43f10e5245a62b965b21e21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->