### PR TITLE
fix(backend-sqlite): enable libsqlite3-sys bundled feature per RFC-023 §7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `ff-backend-sqlite`: `Cargo.toml` now correctly enables
+  `libsqlite3-sys/bundled` via an explicit dep so the backend actually
+  links a bundled SQLite, matching the long-standing "Bundled SQLite
+  is deliberately selected" comment. sqlx 0.8 has no `sqlite-bundled`
+  feature alias, so the previous config silently fell through to
+  system-linked `libsqlite3-sys` and the comment did not hold.
+  Deterministic CI builds + distro independence per RFC-023 §7.1
+  (JSON1 + RETURNING rely on SQLite >= 3.35). `examples/ff-dev` now
+  asserts the `SELECT sqlite_version()` floor at startup and
+  `scripts/smoke-sqlite.sh` logs the bundled version in CI output.
 - `ff-backend-postgres`: `ff_attempt.outcome` is now cleared on the
   exec-cancel paths that previously left it stale — `cancel_flow`
   member loop (`src/flow.rs`) and `exec_core::cancel` (the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "ff-core",
  "futures-core",
  "hex",
+ "libsqlite3-sys",
  "serde_json",
  "serial_test",
  "sqlx",

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -54,6 +54,13 @@ hex = "0.4"
 # `ff-backend-postgres` uses for its lease/completion subscribers.
 futures-core = { workspace = true }
 
+[package.metadata.cargo-machete]
+# `libsqlite3-sys` is not imported directly; it is declared so Cargo's
+# feature unification enables the `bundled` feature on sqlx's transitive
+# use of it (RFC-023 §7.1). cargo-machete can't see through feature
+# propagation, so whitelist the dep here.
+ignored = ["libsqlite3-sys"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 # Env-var isolation across the two test files (`guard.rs` +

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -28,6 +28,13 @@ ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, f
 # the backend from the operating distro's libsqlite3 version — RFC-023
 # §7.1 owner recommendation. JSON1 + RETURNING (>= 3.35) rely on this.
 sqlx = { workspace = true, features = ["sqlite", "runtime-tokio", "macros", "migrate", "json", "chrono", "uuid"] }
+# Explicit `libsqlite3-sys` dep with the `bundled` feature enabled. sqlx
+# 0.8 does not expose a `sqlite-bundled` feature alias, so bundled-mode
+# has to be turned on via a direct dep + Cargo's feature unification.
+# Without this, sqlx's `sqlite` feature pulls `libsqlite3-sys` in
+# system-link mode and the "bundled" claim in the comment above silently
+# does not hold. Version pin must match the one sqlx 0.8 resolves to.
+libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/examples/ff-dev/Cargo.lock
+++ b/examples/ff-dev/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
  "ff-core",
  "futures-core",
  "hex",
+ "libsqlite3-sys",
  "serde_json",
  "sqlx",
  "tokio",

--- a/examples/ff-dev/src/main.rs
+++ b/examples/ff-dev/src/main.rs
@@ -106,6 +106,28 @@ async fn main() -> Result<()> {
         "dialed SQLite dev backend"
     );
 
+    // RFC-023 §7.1: bundled libsqlite3-sys must ship SQLite >= 3.35
+    // (JSON1 + RETURNING). Log the runtime-reported version on the
+    // side-pool so smoke logs show which SQLite the bundled build
+    // pulled in; parse + assert the floor so an accidental
+    // libsqlite3-sys downgrade fails the smoke-gate loudly.
+    let sqlite_version: String =
+        sqlx::query_scalar("SELECT sqlite_version()")
+            .fetch_one(&side_pool)
+            .await
+            .context("SELECT sqlite_version()")?;
+    info!(version = %sqlite_version, "sqlite_version");
+    {
+        let mut parts = sqlite_version.split('.');
+        let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        anyhow::ensure!(
+            major > 3 || (major == 3 && minor >= 35),
+            "bundled SQLite {} is below RFC-023 §7.1 floor (3.35)",
+            sqlite_version
+        );
+    }
+
     // ── 3. Create a flow + three executions ────────────────────────────
     //
     // These are the RFC-012 ingress-row trait methods: every backend

--- a/scripts/smoke-sqlite.sh
+++ b/scripts/smoke-sqlite.sh
@@ -81,6 +81,7 @@ fi
 EXPECTED=(
     "FlowFabric SQLite backend active (FF_DEV_MODE=1)"
     "dialed SQLite dev backend"
+    "sqlite_version"
     "create_flow"
     "claim → minted handle"
     "complete"
@@ -99,6 +100,14 @@ for needle in "${EXPECTED[@]}"; do
         exit 1
     fi
 done
+
+# Surface the bundled SQLite version from the ff-dev log (RFC-023 §7.1
+# floor: >= 3.35, enforced by ff-dev itself). Grep the first
+# `sqlite_version` log line so CI logs show which SQLite the bundled
+# build pulled in.
+if SQLITE_VERSION_LINE="$(grep -F 'sqlite_version' "${OUT}" | head -n 1)"; then
+    echo "==> smoke-sqlite: bundled ${SQLITE_VERSION_LINE}"
+fi
 
 END_NS="$(date +%s%N)"
 ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))


### PR DESCRIPTION
## Summary

Closes a config gap flagged by the Phase 4b docs agent (PR #399 bot finding #7): `crates/ff-backend-sqlite/Cargo.toml` has long claimed "Bundled SQLite is deliberately selected" in its comment, but sqlx 0.8 does not expose a `sqlite-bundled` feature alias and no explicit `libsqlite3-sys` dep+feature was declared — so Cargo silently fell through to system-linked `libsqlite3-sys`. `Cargo.lock` showed bindgen/system linkage, not bundled.

Per RFC-023 §7.1 + owner decision (memory: `project_sqlite_bundled_config_gap.md`): **enable bundled** for deterministic CI + distro independence. JSON1 + RETURNING require SQLite >= 3.35, which not all distros ship.

- `ff-backend-sqlite/Cargo.toml`: explicit `libsqlite3-sys = { version = "0.30", features = ["bundled"] }`. Cargo feature unification propagates `bundled` into sqlx-sqlite; verified via verbose build showing `--cfg feature="bundled"` on both `libsqlite3-sys` + `sqlx-sqlite` and `-l static=sqlite3` on the link line.
- `examples/ff-dev/src/main.rs`: `SELECT sqlite_version()` at startup with the RFC-023 §7.1 floor (3.35) asserted in-process; logs the runtime version so smoke output shows which SQLite the bundled build pulled in.
- `scripts/smoke-sqlite.sh`: new `sqlite_version` expected-substring + surfaces the version line in the smoke summary.
- `CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification

- `cargo build -p ff-backend-sqlite` — clean
- `cargo test -p ff-backend-sqlite` — all green
- `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` — clean
- `cargo clippy` on `examples/ff-dev --all-targets -- -D warnings` — clean
- `bash scripts/smoke-sqlite.sh` — PASS; bundled SQLite version reported as **3.46.0**

## Binary size

- Bundled `libsqlite3.a` static archive: ~3.1 MB
- `ff-dev` release binary with bundled: 8.15 MB (well under the STOP-trigger 2x threshold)

## Semver

Internal build config change only — no public API impact.

## Test plan

- [ ] CI matrix green on all cells (Linux/macOS/Windows) — bundled mode requires a C toolchain; watch the Windows cell specifically
- [ ] `smoke-sqlite` job logs show bundled SQLite version line
- [ ] No regression in ff-backend-sqlite or ff-dev test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/linkage behavior changes by switching SQLite to a statically bundled `libsqlite3-sys`, which can affect CI/toolchain requirements and binary size across platforms. Added runtime version assertions may fail fast if the bundled SQLite version regresses.
> 
> **Overview**
> Ensures the SQLite backend actually links a bundled SQLite by adding an explicit `libsqlite3-sys` dependency with the `bundled` feature (fixing prior silent system-linking under `sqlx` 0.8).
> 
> Strengthens the SQLite dev smoke by logging `SELECT sqlite_version()` at `ff-dev` startup, asserting SQLite >= 3.35, and updating `scripts/smoke-sqlite.sh` to require and surface the version line in CI output. Updates the `CHANGELOG.md` entry to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587d8cef38134fe18be52925604428d3f2244996. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->