### PR TITLE
chore: doc nits sweep + reclaim cap-exceeded cross-backend verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `ff-backend-sqlite`: `backend.rs` `:memory:` URI rewrite comment
+  corrected to match the code (`file::memory:?cache=shared` — no
+  `uri=true` query param; sqlx infers URI mode from the `file:`
+  prefix). Doc-only.
+- `ff-backend-sqlite`: `tests/hot_path.rs` comment on
+  `claim_happy_path_mints_handle_and_transitions_state` clarified —
+  removed the inaccurate "column remained at `'waiting'`" literal
+  (the seed row uses `'pending'`); now describes the general bug
+  (claim path did not update `public_state` at all) without naming
+  a specific pre-claim literal. Doc-only.
+- `scripts/smoke-sqlite.sh`: guard leg now distinguishes a clean
+  refusal from a crash/link-error / empty-output case by asserting
+  (1) non-zero exit, (2) non-empty output, (3) refusal message
+  present — each as an independent check with its own failure
+  message. Previously a `cargo run` that produced no output could
+  in principle false-pass the inverted-grep assertion.
+
 - `ff-backend-postgres`: `ff_attempt.outcome` is now cleared on the
   exec-cancel paths that previously left it stale — `cancel_flow`
   member loop (`src/flow.rs`) and `exec_core::cancel` (the

--- a/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-postgres/tests/rfc024_reclaim.rs
@@ -383,6 +383,40 @@ async fn reclaim_execution_cap_exceeded_transitions_terminal() {
 
 #[tokio::test]
 #[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
+async fn reclaim_execution_cap_exceeded_at_argv9_exact_boundary() {
+    // Investigation: per memory project_reclaim_cap_exceeded_investigation.md,
+    // the PR-F (#402) agent observed `lease_reclaim_count=4, max=Some(4)`
+    // returning `Claimed` instead of `ReclaimCapExceeded` on Valkey. This
+    // PG parallel asserts the same exact-boundary scenario enforces the
+    // cap on the SQL backend too. PG reports the post-increment count
+    // (see sibling cap_exceeded_transitions_terminal test at
+    // `lease_reclaim_count=5, max=5 -> reclaim_count=6`), so boundary
+    // `count=4, max=4` -> `reclaim_count=5`.
+    let Some(pool) = setup_or_skip().await else { return; };
+    let lane = format!("lane-rec-cap-exact-{}", Uuid::new_v4());
+    let (part, exec_uuid, lane_id) =
+        seed_exec(&pool, &lane, "lease_expired_reclaimable", "active", 4).await;
+    let backend = backend_from_pool(pool.clone());
+    let eid = exec_id(part, exec_uuid);
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone(), lane_id.clone(), "w-rec"))
+        .await
+        .unwrap();
+    let outcome = backend
+        .reclaim_execution(reclaim_args(eid.clone(), lane_id.clone(), "w-rec", Some(4)))
+        .await
+        .expect("ok");
+    assert!(
+        matches!(
+            outcome,
+            ReclaimExecutionOutcome::ReclaimCapExceeded { reclaim_count: 5, .. }
+        ),
+        "expected ReclaimCapExceeded at lease_reclaim_count=max=4 boundary, got {outcome:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires live Postgres (FF_PG_TEST_URL)"]
 async fn scheduler_claim_grant_writes_new_table_kind_claim() {
     let Some(pool) = setup_or_skip().await else { return; };
     let lane = format!("lane-sched-tbl-{}", Uuid::new_v4());

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2376,10 +2376,11 @@ impl SqliteBackend {
         // file creation still dedup.
         //
         // F1: bare `:memory:` is rewritten to
-        // `file::memory:?cache=shared&uri=true` so a multi-connection
-        // pool shares ONE in-memory database. Without this rewrite,
-        // each pool connection opens its own private DB and tests see
-        // schema mismatches silently.
+        // `file::memory:?cache=shared` so a multi-connection pool shares
+        // ONE in-memory database. Without this rewrite, each pool
+        // connection opens its own private DB and tests see schema
+        // mismatches silently. (sqlx infers URI mode from the `file:`
+        // prefix, so no explicit `uri=true` query parameter is needed.)
         let is_memory = is_memory_uri(path);
         let effective_path: std::borrow::Cow<'_, str> = if path == ":memory:" {
             std::borrow::Cow::Borrowed("file::memory:?cache=shared")

--- a/crates/ff-backend-sqlite/tests/hot_path.rs
+++ b/crates/ff-backend-sqlite/tests/hot_path.rs
@@ -186,11 +186,10 @@ async fn claim_happy_path_mints_handle_and_transitions_state() {
     // `public_state = 'running'` parity write with Postgres
     // (`ff-backend-postgres/src/suspend_ops.rs:958-960`). The
     // Spine-B normaliser maps the raw literal back to
-    // `PublicState::Active`; before the fix the `public_state`
-    // column remained at its create-time `'waiting'` literal
-    // (`'pending'` is the sibling `attempt_state` literal, not
-    // `public_state`) and direct SQL readers observed the wrong
-    // public state even though the inferred enum was correct.
+    // `PublicState::Active`; before the fix the claim path did not
+    // update `public_state` at all, so direct SQL readers saw
+    // whatever pre-claim literal the row was seeded with even
+    // though the inferred enum was correct.
     assert_eq!(
         read_exec_public_state(&backend, exec_uuid).await,
         "running"

--- a/crates/ff-backend-sqlite/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-sqlite/tests/rfc024_reclaim.rs
@@ -449,6 +449,46 @@ async fn reclaim_execution_cap_exceeded() {
     assert_eq!(public_state, "failed");
 }
 
+/// Investigation: per memory project_reclaim_cap_exceeded_investigation.md,
+/// the PR-F (#402) agent observed `lease_reclaim_count=4, max=Some(4)`
+/// returning `Claimed` instead of `ReclaimCapExceeded` on Valkey. This
+/// SQLite parallel asserts the same exact-boundary scenario enforces
+/// the cap here too — the SQLite backend shares none of the Lua code
+/// path, but the contract (reclaim_count >= max_reclaim_count → cap
+/// exceeded) must be uniform across backends.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn reclaim_execution_cap_exceeded_at_exact_boundary() {
+    let b = fresh_backend().await;
+    let (exec_id, lane_id, _handle) = create_and_claim(&b).await;
+    let exec_uuid = uuid_of(&exec_id);
+    force_lease_expired(&b, exec_uuid).await;
+
+    sqlx::query(
+        "UPDATE ff_exec_core SET lease_reclaim_count = 4 \
+         WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+
+    let _ = b
+        .issue_reclaim_grant(issue_args(&exec_id, &lane_id))
+        .await
+        .expect("issue");
+
+    let r = b
+        .reclaim_execution(reclaim_args(&exec_id, &lane_id, "w1", "w1-i2", 0, Some(4)))
+        .await
+        .expect("reclaim");
+
+    assert!(
+        matches!(r, ReclaimExecutionOutcome::ReclaimCapExceeded { .. }),
+        "expected ReclaimCapExceeded at lease_reclaim_count=max=4 boundary, got {r:?}"
+    );
+}
+
 // -- Review-finding regression tests (F1, F2+F3, F4, F5, F7) ---------
 
 /// F1+F6: if the exec transitions to terminal between grant issuance

--- a/crates/ff-backend-valkey/tests/rfc024_reclaim.rs
+++ b/crates/ff-backend-valkey/tests/rfc024_reclaim.rs
@@ -477,6 +477,61 @@ async fn issue_reclaim_grant_surfaces_server_authoritative_expires_at() {
 
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "requires live Valkey at 127.0.0.1:6379"]
+async fn reclaim_execution_cap_exceeded_at_argv9_exact_boundary() {
+    // Investigation: per memory project_reclaim_cap_exceeded_investigation.md,
+    // the PR-F (#402) agent observed `lease_reclaim_count=4, max=Some(4)`
+    // returning `Claimed(Handle)` instead of `ReclaimCapExceeded`. This
+    // test exercises the exact boundary with no policy override so the
+    // code path is purely ARGV[9] + Lua `>=` comparison at
+    // `flowfabric.lua:3065`.
+    let eid = new_eid();
+    let raw = setup_lease_expired_reclaimable(&eid).await;
+
+    let partition = partition_for(&eid);
+    let ctx = ExecKeyContext::new(&partition, &eid);
+    let core_key = ctx.core();
+
+    let _: Value = raw
+        .cmd("HSET")
+        .arg(&core_key)
+        .arg("lease_reclaim_count")
+        .arg("4")
+        .execute()
+        .await
+        .expect("HSET lease_reclaim_count");
+
+    let backend = connect_backend().await;
+    let _ = backend
+        .issue_reclaim_grant(issue_args(eid.clone()))
+        .await
+        .expect("issue_reclaim_grant");
+
+    let out = backend
+        .reclaim_execution(reclaim_args(eid.clone(), Some(4)))
+        .await
+        .expect("reclaim_execution");
+
+    match out {
+        ReclaimExecutionOutcome::ReclaimCapExceeded {
+            execution_id,
+            reclaim_count,
+        } => {
+            assert_eq!(execution_id, eid);
+            assert_eq!(
+                reclaim_count, 4,
+                "authoritative cap should surface ARGV[9] max=4"
+            );
+        }
+        other => panic!(
+            "expected ReclaimCapExceeded at lease_reclaim_count=max=4 boundary, got {other:?}"
+        ),
+    }
+
+    cleanup_execution(&raw, &eid).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "requires live Valkey at 127.0.0.1:6379"]
 async fn reclaim_execution_cap_exceeded_reports_policy_override_not_argv_default() {
     // RFC-024 §4.6 regression: when a per-execution policy override at
     // <core>:policy sets `max_reclaim_count`, the Lua enforces that cap

--- a/scripts/smoke-sqlite.sh
+++ b/scripts/smoke-sqlite.sh
@@ -52,17 +52,32 @@ trap 'rm -f "${OUT}" "${GUARD_OUT}"' EXIT
 
 echo "==> smoke-sqlite: verify production guard refuses without FF_DEV_MODE"
 # Invoke the pre-built binary directly. Scrub `FF_DEV_MODE` from the
-# child env even if the caller set it so the leg is deterministic. The
-# assertion is stricter than "non-zero exit": we grep for the specific
-# refusal message, so a crash / panic / link error cannot false-pass
-# the leg.
-if env -u FF_DEV_MODE "${FF_DEV_BIN}" > "${GUARD_OUT}" 2>&1 ; then
+# child env even if the caller set it so the leg is deterministic.
+#
+# The guard leg asserts three independent conditions so a compile-fail
+# / panic / link error cannot false-pass by producing empty output:
+#   (1) binary exists + is executable (checked above)
+#   (2) binary exits non-zero without FF_DEV_MODE=1
+#   (3) stderr/stdout contains the exact refusal message
+#
+# Condition (3) is checked against a captured exit code (not chained
+# inside an `if` with `set -e` semantics) so the "no output" case
+# produces a DISTINCT failure mode from the "exit-zero" case.
+set +e
+env -u FF_DEV_MODE "${FF_DEV_BIN}" > "${GUARD_OUT}" 2>&1
+GUARD_EXIT=$?
+set -e
+if [[ "${GUARD_EXIT}" -eq 0 ]]; then
     echo "FAIL: ff-dev exited 0 without FF_DEV_MODE=1 — production guard regressed" >&2
     tail -n 40 "${GUARD_OUT}" >&2 || true
     exit 2
 fi
+if [[ ! -s "${GUARD_OUT}" ]]; then
+    echo "FAIL: ff-dev exited ${GUARD_EXIT} but produced no output — likely crash/link-error, not a clean refusal" >&2
+    exit 2
+fi
 if ! grep -Fq "FF_DEV_MODE=1 is required" "${GUARD_OUT}"; then
-    echo "FAIL: guard-leg exited non-zero but refusal message not present — assumed regression" >&2
+    echo "FAIL: ff-dev exited ${GUARD_EXIT} with output but refusal message missing — guard regressed or refusal text changed" >&2
     tail -n 40 "${GUARD_OUT}" >&2 || true
     exit 2
 fi


### PR DESCRIPTION
## Summary

Two small independent follow-ups bundled into one PR per manager direction.

### Task A — Doc nits sweep

Per memory notes `project_post_pr392_doc_nits.md` + `project_v012_phase4a_smoke_guard_nit.md`:

- **`ff-backend-sqlite/src/backend.rs`** — `:memory:` rewrite comment corrected. The code rewrites bare `:memory:` to `file::memory:?cache=shared` (not `...&uri=true` as the comment previously claimed). Added a note that sqlx infers URI mode from the `file:` prefix.
- **`ff-backend-sqlite/tests/hot_path.rs`** — `claim_happy_path_mints_handle_and_transitions_state` comment reworded. The seed row writes `public_state = 'pending'` directly (not `'waiting'`), so the pre-fix claim bug manifested as "column stayed at `'pending'`", not "column stayed at `'waiting'`". New text describes the general bug (claim path did not update `public_state` at all) without naming a specific pre-claim literal.
- **`scripts/smoke-sqlite.sh`** — guard leg split into three independent assertions: (1) non-zero exit, (2) non-empty output, (3) refusal message present. Each has its own failure message. Previously a `cargo run` that produced no output could in principle false-pass the inverted-grep assertion.

### Task B — `reclaim_cap_exceeded` cross-backend verification

Per memory note `project_reclaim_cap_exceeded_investigation.md`: PR-F (#402) agent observed `lease_reclaim_count=4, max=Some(4)` returning `Claimed(Handle)` instead of `ReclaimCapExceeded` on Valkey.

Added exact-boundary end-to-end tests on all three backends:

- `ff-backend-sqlite::reclaim_execution_cap_exceeded_at_exact_boundary` — PASS
- `ff-backend-postgres::reclaim_execution_cap_exceeded_at_argv9_exact_boundary` — PASS (returns `reclaim_count=5` post-increment, consistent with sibling test at `count=5,max=5 → reclaim_count=6`)
- `ff-backend-valkey::reclaim_execution_cap_exceeded_at_argv9_exact_boundary` — PASS (returns `reclaim_count=4` authoritative cap)

**Root cause of PR-F observation**: stale Lua `FUNCTION LIBRARY` on the test Valkey. Reproduced empirically — running the Valkey cap-exceeded tests against a pre-existing `flowfabric` library returned `Claimed` instead of `ReclaimCapExceeded`, and the sibling `reclaim_execution_cap_exceeded_reports_policy_override_not_argv_default` test also failed (returning ARGV[9] default 1000 instead of policy cap 3). After `FUNCTION DELETE flowfabric` + reload from `crates/ff-script/src/flowfabric.lua`, both tests passed.

Takeaway: `ensure_library` only reloads when `FCALL ff_version` reports a version mismatch. If a dev Valkey has an older library loaded and `flowfabric_lua_version` wasn't bumped alongside the Lua changes, dev/test runs silently use stale FCALLs. Lua `flowfabric.lua:3065` `>=` boundary and ARGV[9] threading in `ff-backend-valkey/src/lib.rs:4154-4180` are correct.

### CHANGELOG

```
### Fixed
- ff-backend-sqlite: backend.rs :memory: rewrite comment corrected to match code
- ff-backend-sqlite: hot_path.rs test comment clarified (removed specific literal claim)
- scripts/smoke-sqlite.sh: guard leg now distinguishes compile-fail from refusal-message-check
```

## Test plan

- [x] `cargo test -p ff-backend-sqlite --test rfc024_reclaim` — 16/16 pass (FF_DEV_MODE=1)
- [x] `cargo test -p ff-backend-sqlite --test hot_path` — 22/22 pass (FF_DEV_MODE=1)
- [x] `cargo test -p ff-backend-postgres --test rfc024_reclaim -- --ignored` — 11/11 pass (live PG)
- [x] `cargo test -p ff-backend-valkey --test rfc024_reclaim -- --ignored` — 7/7 pass (live Valkey, fresh FUNCTION LOAD)
- [x] `scripts/smoke-sqlite.sh` — PASS (18s wall-clock)
- [ ] Full CI green on the matrix
- [ ] Admin-merge after matrix-green

## Memory updates

All three memory notes marked RESOLVED with pointers to this PR:
- `project_post_pr392_doc_nits.md`
- `project_v012_phase4a_smoke_guard_nit.md`
- `project_reclaim_cap_exceeded_investigation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to comments, test coverage, and a shell smoke-check script; no runtime backend logic is modified. Main impact is CI/release-gate behavior becoming stricter, which could surface previously hidden failures.
> 
> **Overview**
> Adds cross-backend integration tests to verify `reclaim_execution` returns `ReclaimCapExceeded` at the exact `lease_reclaim_count == max_reclaim_count` boundary (Postgres, SQLite, and Valkey; live-backend tests remain `#[ignore]`).
> 
> Tightens `scripts/smoke-sqlite.sh` production-guard validation by separately asserting non-zero exit, non-empty output, and presence of the refusal string to prevent false-passes on crashes/empty output.
> 
> Doc-only nits: corrects the SQLite `:memory:` rewrite comment in `ff-backend-sqlite/src/backend.rs` and clarifies a historical `public_state` test comment in `ff-backend-sqlite/tests/hot_path.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9eb06fbc24fd619aae759a9646bbab58bbaeab4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->