### PR TITLE
feat(ff-sdk+ff-server+docs): RFC-024 PR-G — SDK admin surface + worker dispatch + CONSUMER_MIGRATION_0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **RFC-024 PR-G — SDK consumer surface for lease-reclaim (closes
+  #371 end-to-end).** Adds the three consumer-facing surfaces that
+  cairn-fabric (and any pull-mode consumer) calls to recover from
+  `lease_expired`. Backend impls landed earlier in PR-D/E/F; this
+  PR wires them through to the SDK + HTTP.
+  - `ff-sdk::FlowFabricAdminClient::issue_reclaim_grant(&self,
+    execution_id, IssueReclaimGrantRequest) ->
+    Result<IssueReclaimGrantResponse, SdkError>` — HTTP admin-surface
+    wrapper over `POST /v1/executions/{id}/reclaim`. `status`-
+    discriminated response enum with `Granted` /
+    `NotReclaimable` / `ReclaimCapExceeded` variants; consumers
+    lift `Granted` into `ff_core::contracts::ReclaimGrant` via
+    `IssueReclaimGrantResponse::into_grant`. `valkey-default`-gated
+    (lives alongside the existing reqwest-based admin surface).
+  - `ff-sdk::FlowFabricWorker::claim_from_reclaim_grant(&self,
+    ReclaimGrant, ReclaimExecutionArgs) ->
+    Result<ReclaimExecutionOutcome, SdkError>` — **backend-agnostic**
+    (no cfg gate). Dispatches through
+    `EngineBackend::reclaim_execution` on whichever backend the
+    worker was connected with. Compiles + runs under
+    `--no-default-features, features = ["sqlite"]`; companion
+    compile-anchor in `crates/ff-sdk/tests/rfc024_sdk.rs` pins the
+    signature so accidental cfg-gating regressions fail the build.
+  - `ff-server`: new `POST /v1/executions/{id}/reclaim` route.
+    Dispatches through the `EngineBackend` trait's
+    `issue_reclaim_grant`; all three in-tree backends
+    (Valkey / Postgres / SQLite) implement it at v0.12.0. 64 KiB
+    `BODY_LIMIT_CONTROL` cap; validates `worker_id` /
+    `worker_instance_id` / `lane_id` the same way the existing
+    `/v1/workers/{id}/claim` handler does, rejects zero-or-over-
+    60s `grant_ttl_ms`.
+- `docs/CONSUMER_MIGRATION_0.12.md` §7 — comprehensive RFC-024
+  consumer-migration section: breaking-change inventory from PR-B/C,
+  additive surfaces from PR-G, full cairn F64-bridge-retry →
+  reclaim migration snippet, handle-kind awareness note, and the
+  `ReclaimGrant` vs `ResumeGrant` rename clarification for
+  migrators.
+
 - `examples/ff-dev/` — RFC-023 Phase 4 headline example for the
   SQLite dev-only backend (v0.12.0 release target). ~200-line
   consumer-facing demo that drives the `EngineBackend` trait directly

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -295,13 +295,23 @@ impl FlowFabricAdminClient {
     ///
     /// The request body carries `worker_capabilities`. Consumers typically
     /// source these from their registered worker's configured
-    /// `WorkerConfig::capabilities` — the Lua
-    /// `ff_issue_reclaim_grant` validates the requested capability-hash
-    /// against the execution's route snapshot; a mismatch surfaces as
+    /// `WorkerConfig::capabilities`. Admission compares
+    /// `worker_capabilities` against the execution's
+    /// `required_capabilities` (persisted on `exec_core` at
+    /// `create_execution` time from
+    /// `ExecutionPolicy.routing_requirements.required_capabilities`);
+    /// any required capability missing from the worker set surfaces as
     /// `IssueReclaimGrantResponse::NotReclaimable { detail:
-    /// "capability_mismatch" }`. The SDK does not re-read worker state
-    /// automatically — admin clients are not bound to a worker — so
-    /// the consumer threads the capabilities through at call-time.
+    /// "capability_mismatch: <missing csv>" }` (Lua
+    /// `ff_issue_reclaim_grant`, `crates/ff-script/src/flowfabric.lua`
+    /// §3969-3982; sqlite/PG backends mirror the check). The SDK does
+    /// not re-read worker state automatically — admin clients are not
+    /// bound to a worker — so the consumer threads the capabilities
+    /// through at call-time.
+    ///
+    /// `capability_hash` is NOT consulted for admission; it is stored
+    /// verbatim on the grant hash for audit / downstream observability
+    /// only.
     ///
     /// # Consumer flow (RFC-024 §4.4)
     ///
@@ -413,8 +423,12 @@ pub struct IssueReclaimGrantRequest {
     /// Lane the execution belongs to. Needed by
     /// `ff_issue_reclaim_grant` for `KEYS[*]` construction.
     pub lane_id: String,
-    /// Capability hash for capability-match validation; `None` to
-    /// skip the match (the Lua's `ARGV[5]` defaults to empty).
+    /// Opaque capability-hash token stored verbatim on the issued
+    /// grant for audit / downstream observability. NOT used for
+    /// admission — admission compares `worker_capabilities` against
+    /// the execution's `required_capabilities` (see the
+    /// [`FlowFabricAdminClient::issue_reclaim_grant`] rustdoc).
+    /// `None` leaves the field empty on the grant.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capability_hash: Option<String>,
     /// Grant TTL in milliseconds. Bounded server-side.

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -281,6 +281,266 @@ impl FlowFabricAdminClient {
             raw_body: raw,
         })
     }
+
+    /// Request a lease-reclaim grant for an execution in
+    /// `lease_expired_reclaimable` or `lease_revoked` state (RFC-024
+    /// §3.5).
+    ///
+    /// Routes `POST /v1/executions/{execution_id}/reclaim`. The
+    /// ff-server handler dispatches through the `EngineBackend` trait
+    /// to whichever backend the server was started with (Valkey /
+    /// Postgres / SQLite).
+    ///
+    /// # worker_capabilities (RFC-024 §3.2 B-2)
+    ///
+    /// The request body carries `worker_capabilities`. Consumers typically
+    /// source these from their registered worker's configured
+    /// `WorkerConfig::capabilities` — the Lua
+    /// `ff_issue_reclaim_grant` validates the requested capability-hash
+    /// against the execution's route snapshot; a mismatch surfaces as
+    /// `IssueReclaimGrantResponse::NotReclaimable { detail:
+    /// "capability_mismatch" }`. The SDK does not re-read worker state
+    /// automatically — admin clients are not bound to a worker — so
+    /// the consumer threads the capabilities through at call-time.
+    ///
+    /// # Consumer flow (RFC-024 §4.4)
+    ///
+    /// 1. Consumer's `POST /v1/runs/:id/complete` returns
+    ///    `lease_expired`.
+    /// 2. Consumer calls this method; handles
+    ///    [`IssueReclaimGrantResponse::Granted`] → builds a
+    ///    [`ff_core::contracts::ReclaimGrant`] via
+    ///    [`IssueReclaimGrantResponse::into_grant`].
+    /// 3. Consumer passes the grant to
+    ///    [`crate::FlowFabricWorker::claim_from_reclaim_grant`] along
+    ///    with a fresh [`ff_core::contracts::ReclaimExecutionArgs`];
+    ///    the new attempt is minted with `HandleKind::Reclaimed`.
+    /// 4. Consumer drives terminal writes on the fresh lease.
+    ///
+    /// # Errors
+    ///
+    /// * [`SdkError::AdminApi`] — non-2xx response. 404 when the
+    ///   execution does not exist; 400 on malformed `execution_id` or
+    ///   body.
+    /// * [`SdkError::Http`] — transport error (connect, body
+    ///   decode, client-side timeout).
+    ///
+    /// # Retry semantics
+    ///
+    /// Idempotent on the Lua side: repeated calls against an execution
+    /// already re-leased (a concurrent reclaim beat this one) surface
+    /// as `NotReclaimable`. Safe to retry on transport faults.
+    pub async fn issue_reclaim_grant(
+        &self,
+        execution_id: &str,
+        req: IssueReclaimGrantRequest,
+    ) -> Result<IssueReclaimGrantResponse, SdkError> {
+        // Percent-encode `execution_id` in the URL path — the id is a
+        // free-form string and splicing verbatim would produce
+        // malformed URLs. Mirrors `claim_for_worker`'s handling.
+        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| SdkError::Config {
+            context: "admin_client: issue_reclaim_grant".into(),
+            field: Some("base_url".into()),
+            message: format!("invalid base_url '{}': {e}", self.base_url),
+        })?;
+        {
+            let mut segs = url.path_segments_mut().map_err(|_| SdkError::Config {
+                context: "admin_client: issue_reclaim_grant".into(),
+                field: Some("base_url".into()),
+                message: format!("base_url cannot be a base URL: '{}'", self.base_url),
+            })?;
+            segs.extend(&["v1", "executions", execution_id, "reclaim"]);
+        }
+        let url = url.to_string();
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .map_err(|e| SdkError::Http {
+                source: e,
+                context: "POST /v1/executions/{id}/reclaim".into(),
+            })?;
+
+        let status = resp.status();
+        if status.is_success() {
+            return resp
+                .json::<IssueReclaimGrantResponse>()
+                .await
+                .map_err(|e| SdkError::Http {
+                    source: e,
+                    context: "decode issue_reclaim_grant response body".into(),
+                });
+        }
+
+        let status_u16 = status.as_u16();
+        let raw = resp.text().await.map_err(|e| SdkError::Http {
+            source: e,
+            context: format!(
+                "read issue_reclaim_grant error body (status {status_u16})"
+            ),
+        })?;
+        let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
+        Err(SdkError::AdminApi {
+            status: status_u16,
+            message: parsed
+                .as_ref()
+                .map(|b| b.error.clone())
+                .unwrap_or_else(|| raw.clone()),
+            kind: parsed.as_ref().and_then(|b| b.kind.clone()),
+            retryable: parsed.as_ref().and_then(|b| b.retryable),
+            raw_body: raw,
+        })
+    }
+}
+
+/// Request body for `POST /v1/executions/{execution_id}/reclaim`
+/// (RFC-024 §3.5).
+///
+/// Mirrors `ff_server::api::IssueReclaimGrantBody` 1:1. The
+/// `execution_id` goes in the URL path, not the body.
+#[derive(Debug, Clone, Serialize)]
+pub struct IssueReclaimGrantRequest {
+    /// Worker identity requesting the grant. The Lua
+    /// `ff_reclaim_execution` validates grant consumption via
+    /// `grant.worker_id == args.worker_id` (RFC-024 §4.4) — the
+    /// worker consuming the grant must match this value.
+    pub worker_id: String,
+    /// Worker-instance identity. Informational at grant-issuance
+    /// time; stored on the grant so consumers can correlate events.
+    pub worker_instance_id: String,
+    /// Lane the execution belongs to. Needed by
+    /// `ff_issue_reclaim_grant` for `KEYS[*]` construction.
+    pub lane_id: String,
+    /// Capability hash for capability-match validation; `None` to
+    /// skip the match (the Lua's `ARGV[5]` defaults to empty).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_hash: Option<String>,
+    /// Grant TTL in milliseconds. Bounded server-side.
+    pub grant_ttl_ms: u64,
+    /// Route snapshot JSON carried onto the grant for audit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route_snapshot_json: Option<String>,
+    /// Admission summary string carried onto the grant for audit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_summary: Option<String>,
+    /// Worker capability tokens. Consumers typically source these
+    /// from their registered worker's `WorkerConfig::capabilities`
+    /// (see [`FlowFabricAdminClient::issue_reclaim_grant`] rustdoc
+    /// for the override contract).
+    #[serde(default)]
+    pub worker_capabilities: Vec<String>,
+}
+
+/// Response body for `POST /v1/executions/{execution_id}/reclaim`
+/// (RFC-024 §3.5).
+///
+/// The server serializes this struct with a `status` discriminator so
+/// consumers can match on structured outcomes without re-parsing a
+/// 200-vs-4xx split for business-logic outcomes (mirrors
+/// `RotateWaitpointSecretResponse`'s precedent).
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum IssueReclaimGrantResponse {
+    /// Grant issued. Build a
+    /// [`ff_core::contracts::ReclaimGrant`] via
+    /// [`Self::into_grant`] and feed it to
+    /// [`crate::FlowFabricWorker::claim_from_reclaim_grant`].
+    Granted {
+        execution_id: String,
+        partition_key: ff_core::partition::PartitionKey,
+        grant_key: String,
+        expires_at_ms: u64,
+        lane_id: String,
+    },
+    /// Execution is not in a reclaimable state (not
+    /// `lease_expired_reclaimable` / `lease_revoked`).
+    NotReclaimable {
+        execution_id: String,
+        detail: String,
+    },
+    /// `max_reclaim_count` exceeded; execution transitioned to
+    /// terminal_failed. Consumers stop retrying and surface a
+    /// structural failure.
+    ReclaimCapExceeded {
+        execution_id: String,
+        reclaim_count: u32,
+    },
+}
+
+impl IssueReclaimGrantResponse {
+    /// Convert a [`Self::Granted`] response into a typed
+    /// [`ff_core::contracts::ReclaimGrant`] for handoff to
+    /// [`crate::FlowFabricWorker::claim_from_reclaim_grant`].
+    ///
+    /// Returns [`SdkError::AdminApi`] when the wire variant is not
+    /// `Granted` (consumer asked for a grant but the server replied
+    /// with a terminal outcome) or when `execution_id` / `lane_id`
+    /// are malformed — the latter signals a drift between server and
+    /// SDK, so failing loud prevents silent misrouting.
+    pub fn into_grant(self) -> Result<ff_core::contracts::ReclaimGrant, SdkError> {
+        match self {
+            IssueReclaimGrantResponse::Granted {
+                execution_id,
+                partition_key,
+                grant_key,
+                expires_at_ms,
+                lane_id,
+            } => {
+                let eid = ff_core::types::ExecutionId::parse(&execution_id)
+                    .map_err(|e| SdkError::AdminApi {
+                        status: 200,
+                        message: format!(
+                            "issue_reclaim_grant: server returned malformed execution_id '{execution_id}': {e}"
+                        ),
+                        kind: Some("malformed_response".to_owned()),
+                        retryable: Some(false),
+                        raw_body: String::new(),
+                    })?;
+                let lane = ff_core::types::LaneId::try_new(lane_id.clone())
+                    .map_err(|e| SdkError::AdminApi {
+                        status: 200,
+                        message: format!(
+                            "issue_reclaim_grant: server returned malformed lane_id '{lane_id}': {e}"
+                        ),
+                        kind: Some("malformed_response".to_owned()),
+                        retryable: Some(false),
+                        raw_body: String::new(),
+                    })?;
+                Ok(ff_core::contracts::ReclaimGrant::new(
+                    eid,
+                    partition_key,
+                    grant_key,
+                    expires_at_ms,
+                    lane,
+                ))
+            }
+            IssueReclaimGrantResponse::NotReclaimable { execution_id, detail } => {
+                Err(SdkError::AdminApi {
+                    status: 200,
+                    message: format!(
+                        "issue_reclaim_grant: execution '{execution_id}' not reclaimable: {detail}"
+                    ),
+                    kind: Some("not_reclaimable".to_owned()),
+                    retryable: Some(false),
+                    raw_body: String::new(),
+                })
+            }
+            IssueReclaimGrantResponse::ReclaimCapExceeded {
+                execution_id,
+                reclaim_count,
+            } => Err(SdkError::AdminApi {
+                status: 200,
+                message: format!(
+                    "issue_reclaim_grant: execution '{execution_id}' hit reclaim cap ({reclaim_count})"
+                ),
+                kind: Some("reclaim_cap_exceeded".to_owned()),
+                retryable: Some(false),
+                raw_body: String::new(),
+            }),
+        }
+    }
 }
 
 /// Request body for `POST /v1/admin/rotate-waitpoint-secret`.

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -100,7 +100,8 @@ pub mod worker;
 // Re-exports for convenience
 #[cfg(feature = "valkey-default")]
 pub use admin::{
-    rotate_waitpoint_hmac_secret_all_partitions, FlowFabricAdminClient, PartitionRotationOutcome,
+    rotate_waitpoint_hmac_secret_all_partitions, FlowFabricAdminClient,
+    IssueReclaimGrantRequest, IssueReclaimGrantResponse, PartitionRotationOutcome,
     RotateWaitpointSecretRequest, RotateWaitpointSecretResponse,
 };
 // RFC-023 Phase 1a: re-export `SqliteBackend` so consumers using

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1516,6 +1516,91 @@ impl FlowFabricWorker {
         Ok(task)
     }
 
+    /// Consume a [`ReclaimGrant`] to mint a fresh attempt for a
+    /// lease-expired / lease-revoked execution (RFC-024 §3.4).
+    ///
+    /// Backend-agnostic. Routes through
+    /// [`EngineBackend::reclaim_execution`] on whatever backend the
+    /// worker was connected with (Valkey via `connect` / `connect_with`,
+    /// Postgres / SQLite via `connect_with`). Distinct from
+    /// [`claim_from_resume_grant`]: reclaim creates a NEW attempt row
+    /// and bumps `lease_reclaim_count` (`HandleKind::Reclaimed`), while
+    /// resume re-uses the existing attempt under
+    /// `ff_claim_resumed_execution` (`HandleKind::Resumed`).
+    ///
+    /// # Return shape
+    ///
+    /// Returns the raw [`ReclaimExecutionOutcome`] so consumers match
+    /// on the four outcomes (`Claimed(Handle)`, `NotReclaimable`,
+    /// `ReclaimCapExceeded`, `GrantNotFound`) and decide their
+    /// dispatch. The `Claimed` variant carries a [`Handle`] whose
+    /// `kind` is [`HandleKind::Reclaimed`]; downstream ops (complete,
+    /// fail, renew, append_frame, …) take the handle directly via the
+    /// `EngineBackend` trait.
+    ///
+    /// This contrasts with [`claim_from_resume_grant`], which wraps
+    /// the handle in a [`ClaimedTask`] with a concurrency-permit and
+    /// auto-lease-renewal loop. Those affordances are
+    /// `valkey-default`-gated today (they depend on the bundled
+    /// `ferriskey::Client` + `lease_ttl_ms` renewal timer). The
+    /// reclaim surface is intentionally narrower so it compiles under
+    /// `--no-default-features, features = ["sqlite"]` and consumers
+    /// can drive the reclaim flow on any backend.
+    ///
+    /// # Feature compatibility
+    ///
+    /// No cfg-gate. Compiles + runs under every feature set ff-sdk
+    /// supports (including sqlite-only). Verified by the compile-time
+    /// type assertion in `sqlite_only_compile_surface_tests`.
+    ///
+    /// # worker_capabilities
+    ///
+    /// `ReclaimExecutionArgs::worker_capabilities` is NOT part of the
+    /// Lua FCALL (the reclaim Lua validates grant consumption via
+    /// `grant.worker_id == args.worker_id` only — see
+    /// `crates/ff-script/src/flowfabric.lua:3088` and RFC-024 §4.4).
+    /// Capability matching happens at grant-issuance time (see
+    /// [`FlowFabricAdminClient::issue_reclaim_grant`]
+    /// — in the `ff-sdk::admin` module, `valkey-default`-gated).
+    ///
+    /// # Errors
+    ///
+    /// * [`SdkError::Engine`] — the backend's `reclaim_execution`
+    ///   returned an [`EngineError`] (transport fault, validation
+    ///   failure, `Unavailable` from a backend that does not
+    ///   implement RFC-024 — currently only pre-RFC out-of-tree
+    ///   backends).
+    ///
+    /// [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
+    /// [`ReclaimExecutionOutcome`]: ff_core::contracts::ReclaimExecutionOutcome
+    /// [`Handle`]: ff_core::backend::Handle
+    /// [`HandleKind::Reclaimed`]: ff_core::backend::HandleKind::Reclaimed
+    /// [`EngineBackend::reclaim_execution`]: ff_core::engine_backend::EngineBackend::reclaim_execution
+    /// [`EngineError`]: ff_core::engine_error::EngineError
+    /// [`claim_from_resume_grant`]: FlowFabricWorker::claim_from_resume_grant
+    /// [`FlowFabricAdminClient::issue_reclaim_grant`]: crate::admin::FlowFabricAdminClient::issue_reclaim_grant
+    pub async fn claim_from_reclaim_grant(
+        &self,
+        _grant: ff_core::contracts::ReclaimGrant,
+        args: ff_core::contracts::ReclaimExecutionArgs,
+    ) -> Result<ff_core::contracts::ReclaimExecutionOutcome, SdkError> {
+        // `ReclaimGrant` is accepted as a parameter so the call-site
+        // shape matches RFC-024 §3.4 (consumer receives a grant from
+        // `issue_reclaim_grant` and feeds it + args into
+        // `claim_from_reclaim_grant`). The grant metadata is
+        // already embedded in the backend's server-side store
+        // (Valkey `claim_grant` hash, PG/SQLite `ff_claim_grant`
+        // table) keyed by (execution_id, grant_key) — the trait
+        // method looks it up from `args.execution_id`. Binding the
+        // grant to the signature preserves the two-step flow on
+        // the consumer API without a runtime assertion that the
+        // grant matches the args.
+        self.backend
+            .reclaim_execution(args)
+            .await
+            .map_err(|e| SdkError::Engine(Box::new(e)))
+    }
+
     /// Low-level resume claim. Forwards through
     /// [`EngineBackend::claim_resumed_execution`](ff_core::engine_backend::EngineBackend::claim_resumed_execution)
     /// — the trait-level trigger surface landed in issue #150 — and

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1581,7 +1581,7 @@ impl FlowFabricWorker {
     /// [`FlowFabricAdminClient::issue_reclaim_grant`]: crate::admin::FlowFabricAdminClient::issue_reclaim_grant
     pub async fn claim_from_reclaim_grant(
         &self,
-        _grant: ff_core::contracts::ReclaimGrant,
+        grant: ff_core::contracts::ReclaimGrant,
         args: ff_core::contracts::ReclaimExecutionArgs,
     ) -> Result<ff_core::contracts::ReclaimExecutionOutcome, SdkError> {
         // `ReclaimGrant` is accepted as a parameter so the call-site
@@ -1591,10 +1591,26 @@ impl FlowFabricWorker {
         // already embedded in the backend's server-side store
         // (Valkey `claim_grant` hash, PG/SQLite `ff_claim_grant`
         // table) keyed by (execution_id, grant_key) — the trait
-        // method looks it up from `args.execution_id`. Binding the
-        // grant to the signature preserves the two-step flow on
-        // the consumer API without a runtime assertion that the
-        // grant matches the args.
+        // method looks it up from `args.execution_id`.
+        //
+        // The overlap between `ReclaimGrant` and
+        // `ReclaimExecutionArgs` is (execution_id, lane_id);
+        // mismatched grant/args is a consumer-side bug (grant-for-A
+        // + args-for-B), and silently forwarding lets the SDK act
+        // on the args execution. Reject the mismatch up front so
+        // the misuse surfaces at the SDK boundary instead of
+        // succeeding against the wrong execution. The grant's
+        // `expires_at_ms` is validated against wall-clock now so
+        // an already-expired grant is rejected without a backend
+        // round-trip (the backend also enforces expiry, but the
+        // SDK-side check gives a crisper error and preserves the
+        // reclaim-budget / lease slot).
+        // `TimestampMs` is an `i64` (Unix-epoch ms); cast to `u64` for
+        // comparison against `ReclaimGrant::expires_at_ms`. Clamp
+        // negatives to 0 so a pre-epoch system clock (vanishingly
+        // unlikely, but representable) doesn't wrap to a future u64.
+        let now_ms: u64 = TimestampMs::now().0.max(0) as u64;
+        validate_reclaim_grant_against_args(&grant, &args, now_ms)?;
         self.backend
             .reclaim_execution(args)
             .await
@@ -1833,6 +1849,161 @@ async fn read_partition_config(client: &Client) -> Result<PartitionConfig, SdkEr
         num_budget_partitions: parse("num_budget_partitions", 32),
         num_quota_partitions: parse("num_quota_partitions", 32),
     })
+}
+
+/// Cross-check the [`ReclaimGrant`] handed back by
+/// `issue_reclaim_grant` against the [`ReclaimExecutionArgs`] the
+/// consumer is about to dispatch. Catches the grant-for-A + args-for-B
+/// misuse at the SDK boundary before a backend round-trip (PR #407
+/// review F1).
+///
+/// The overlap between the two types is `(execution_id, lane_id)`;
+/// `partition_key` / `grant_key` live only on the grant and are
+/// verified server-side. The grant's `expires_at_ms` is also
+/// validated against `now_ms` so an expired grant fails fast without
+/// burning a backend call (the backend enforces expiry too, but the
+/// SDK-side check gives a crisper, typed error).
+///
+/// [`ReclaimGrant`]: ff_core::contracts::ReclaimGrant
+/// [`ReclaimExecutionArgs`]: ff_core::contracts::ReclaimExecutionArgs
+fn validate_reclaim_grant_against_args(
+    grant: &ff_core::contracts::ReclaimGrant,
+    args: &ff_core::contracts::ReclaimExecutionArgs,
+    now_ms: u64,
+) -> Result<(), SdkError> {
+    if grant.execution_id != args.execution_id {
+        return Err(SdkError::Config {
+            context: "claim_from_reclaim_grant".to_owned(),
+            field: Some("execution_id".to_owned()),
+            message: format!(
+                "grant.execution_id ({}) does not match args.execution_id ({})",
+                grant.execution_id, args.execution_id
+            ),
+        });
+    }
+    if grant.lane_id != args.lane_id {
+        return Err(SdkError::Config {
+            context: "claim_from_reclaim_grant".to_owned(),
+            field: Some("lane_id".to_owned()),
+            message: format!(
+                "grant.lane_id ({}) does not match args.lane_id ({})",
+                grant.lane_id.as_str(),
+                args.lane_id.as_str()
+            ),
+        });
+    }
+    if grant.expires_at_ms <= now_ms {
+        return Err(SdkError::Config {
+            context: "claim_from_reclaim_grant".to_owned(),
+            field: Some("expires_at_ms".to_owned()),
+            message: format!(
+                "grant expired: expires_at_ms={} now_ms={}",
+                grant.expires_at_ms, now_ms
+            ),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod reclaim_grant_validation_tests {
+    //! Unit tests for `validate_reclaim_grant_against_args` — the
+    //! SDK-side cross-check that catches grant/args mismatch (PR #407
+    //! review F1). No Valkey / backend required: the helper is pure.
+    use super::validate_reclaim_grant_against_args;
+    use crate::SdkError;
+    use ff_core::contracts::{ReclaimExecutionArgs, ReclaimGrant};
+    use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
+    use ff_core::types::{
+        AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseId, WorkerId, WorkerInstanceId,
+    };
+
+    const EXEC_A: &str = "{fp:7}:00000000-0000-4000-8000-000000000001";
+    const EXEC_B: &str = "{fp:7}:00000000-0000-4000-8000-000000000002";
+
+    fn exec(s: &str) -> ExecutionId {
+        ExecutionId::parse(s).expect("valid execution id")
+    }
+
+    fn grant_for(execution_id: ExecutionId, lane: &str, expires_at_ms: u64) -> ReclaimGrant {
+        ReclaimGrant::new(
+            execution_id,
+            PartitionKey::from(&Partition { family: PartitionFamily::Flow, index: 7 }),
+            "reclaim:grant:abc".to_owned(),
+            expires_at_ms,
+            LaneId::new(lane),
+        )
+    }
+
+    fn args_for(execution_id: ExecutionId, lane: &str) -> ReclaimExecutionArgs {
+        ReclaimExecutionArgs::new(
+            execution_id,
+            WorkerId::new("w1"),
+            WorkerInstanceId::new("w1-i1"),
+            LaneId::new(lane),
+            None,
+            LeaseId::new(),
+            30_000,
+            AttemptId::new(),
+            "{}".to_owned(),
+            None,
+            WorkerInstanceId::new("w1-i0"),
+            AttemptIndex::new(0),
+        )
+    }
+
+    #[test]
+    fn accepts_matching_grant_and_args() {
+        let g = grant_for(exec(EXEC_A), "main", 2_000);
+        let a = args_for(exec(EXEC_A), "main");
+        assert!(validate_reclaim_grant_against_args(&g, &a, 1_000).is_ok());
+    }
+
+    #[test]
+    fn rejects_mismatched_execution_id() {
+        let g = grant_for(exec(EXEC_A), "main", 2_000);
+        let a = args_for(exec(EXEC_B), "main");
+        let err = validate_reclaim_grant_against_args(&g, &a, 1_000)
+            .expect_err("expected mismatched execution_id to fail");
+        match err {
+            SdkError::Config { field, .. } => assert_eq!(field.as_deref(), Some("execution_id")),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_mismatched_lane_id() {
+        let g = grant_for(exec(EXEC_A), "main", 2_000);
+        let a = args_for(exec(EXEC_A), "other");
+        let err = validate_reclaim_grant_against_args(&g, &a, 1_000)
+            .expect_err("expected mismatched lane_id to fail");
+        match err {
+            SdkError::Config { field, .. } => assert_eq!(field.as_deref(), Some("lane_id")),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_expired_grant() {
+        // expires_at_ms == now_ms is rejected (strict `<=`) so the
+        // server's TTL enforcement window can't race us.
+        let g = grant_for(exec(EXEC_A), "main", 1_000);
+        let a = args_for(exec(EXEC_A), "main");
+        let err = validate_reclaim_grant_against_args(&g, &a, 1_000)
+            .expect_err("expected expired grant to fail");
+        match err {
+            SdkError::Config { field, .. } => assert_eq!(field.as_deref(), Some("expires_at_ms")),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+
+        // Also rejected when already past expiry.
+        let err2 = validate_reclaim_grant_against_args(&g, &a, 5_000)
+            .expect_err("expected past-expiry grant to fail");
+        match err2 {
+            SdkError::Config { field, .. } => assert_eq!(field.as_deref(), Some("expires_at_ms")),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1609,7 +1609,7 @@ impl FlowFabricWorker {
         // comparison against `ReclaimGrant::expires_at_ms`. Clamp
         // negatives to 0 so a pre-epoch system clock (vanishingly
         // unlikely, but representable) doesn't wrap to a future u64.
-        let now_ms: u64 = TimestampMs::now().0.max(0) as u64;
+        let now_ms: u64 = ff_core::types::TimestampMs::now().0.max(0) as u64;
         validate_reclaim_grant_against_args(&grant, &args, now_ms)?;
         self.backend
             .reclaim_execution(args)

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1551,7 +1551,13 @@ impl FlowFabricWorker {
     ///
     /// No cfg-gate. Compiles + runs under every feature set ff-sdk
     /// supports (including sqlite-only). Verified by the compile-time
-    /// type assertion in `sqlite_only_compile_surface_tests`.
+    /// type assertion
+    /// `worker_claim_from_reclaim_grant_is_backend_agnostic_at_type_level`
+    /// in `crates/ff-sdk/tests/rfc024_sdk.rs`, which pins the method's
+    /// full signature under the default feature set and is paralleled
+    /// by `sqlite_only_compile_surface_tests` in this file for the
+    /// `--no-default-features, features = ["sqlite"]` compile anchor on
+    /// the rest of the backend-agnostic surface.
     ///
     /// # worker_capabilities
     ///

--- a/crates/ff-sdk/tests/rfc024_sdk.rs
+++ b/crates/ff-sdk/tests/rfc024_sdk.rs
@@ -63,7 +63,7 @@ fn issue_reclaim_grant_request_skips_none_optional_fields() {
 fn issue_reclaim_grant_response_granted_deserializes() {
     let wire = serde_json::json!({
         "status": "granted",
-        "execution_id": "0x0100000000000000000000000000000000000000000000000000000000000001",
+        "execution_id": "{fp:7}:11111111-1111-4111-8111-111111111111",
         "partition_key": "{fp:7}",
         "grant_key": "reclaim:grant:abc",
         "expires_at_ms": 1_700_000_000_000u64,
@@ -86,7 +86,7 @@ fn issue_reclaim_grant_response_granted_deserializes() {
 fn issue_reclaim_grant_response_not_reclaimable_deserializes() {
     let wire = serde_json::json!({
         "status": "not_reclaimable",
-        "execution_id": "0x0100000000000000000000000000000000000000000000000000000000000001",
+        "execution_id": "{fp:7}:11111111-1111-4111-8111-111111111111",
         "detail": "capability_mismatch",
     });
     let resp: IssueReclaimGrantResponse = serde_json::from_value(wire).expect("deserialize");
@@ -102,7 +102,7 @@ fn issue_reclaim_grant_response_not_reclaimable_deserializes() {
 fn issue_reclaim_grant_response_reclaim_cap_exceeded_deserializes() {
     let wire = serde_json::json!({
         "status": "reclaim_cap_exceeded",
-        "execution_id": "0x0100000000000000000000000000000000000000000000000000000000000001",
+        "execution_id": "{fp:7}:11111111-1111-4111-8111-111111111111",
         "reclaim_count": 1000,
     });
     let resp: IssueReclaimGrantResponse = serde_json::from_value(wire).expect("deserialize");
@@ -117,14 +117,14 @@ fn issue_reclaim_grant_response_reclaim_cap_exceeded_deserializes() {
 #[test]
 fn issue_reclaim_grant_response_into_grant_rejects_non_granted_variants() {
     let not_reclaimable = IssueReclaimGrantResponse::NotReclaimable {
-        execution_id: "0x0100000000000000000000000000000000000000000000000000000000000001"
+        execution_id: "{fp:7}:11111111-1111-4111-8111-111111111111"
             .into(),
         detail: "capability_mismatch".into(),
     };
     assert!(not_reclaimable.into_grant().is_err());
 
     let cap_exceeded = IssueReclaimGrantResponse::ReclaimCapExceeded {
-        execution_id: "0x0100000000000000000000000000000000000000000000000000000000000001"
+        execution_id: "{fp:7}:11111111-1111-4111-8111-111111111111"
             .into(),
         reclaim_count: 1000,
     };

--- a/crates/ff-sdk/tests/rfc024_sdk.rs
+++ b/crates/ff-sdk/tests/rfc024_sdk.rs
@@ -1,0 +1,157 @@
+//! RFC-024 PR-G — SDK consumer surface tests.
+//!
+//! Covers:
+//! * `FlowFabricAdminClient::issue_reclaim_grant` request / response
+//!   wire-shape round-trip.
+//! * `FlowFabricWorker::claim_from_reclaim_grant` backend-agnostic
+//!   dispatch compiles under the default feature set.
+//! * The same method is addressable under
+//!   `default-features = false, features = ["sqlite"]` — see
+//!   `sqlite_only_compile_surface_tests` inside `worker.rs` for the
+//!   sqlite-only compile anchor that the PR-C surface landed.
+//!
+//! Integration tests exercising a full claim → lease-expire →
+//! issue_reclaim_grant → claim_from_reclaim_grant → complete loop
+//! are `#[ignore]`d; they require a live backend and are driven
+//! from the smoke scripts (`scripts/smoke-sqlite.sh`,
+//! `scripts/smoke-v0.7.sh`) per RFC-024 §9.
+
+#![cfg(feature = "valkey-default")]
+
+use ff_sdk::admin::{IssueReclaimGrantRequest, IssueReclaimGrantResponse};
+
+#[test]
+fn issue_reclaim_grant_request_serializes_all_fields() {
+    let req = IssueReclaimGrantRequest {
+        worker_id: "w1".into(),
+        worker_instance_id: "w1-i1".into(),
+        lane_id: "main".into(),
+        capability_hash: Some("cap-hash-abc".into()),
+        grant_ttl_ms: 30_000,
+        route_snapshot_json: Some(r#"{"route":"x"}"#.into()),
+        admission_summary: Some("admitted".into()),
+        worker_capabilities: vec!["cpu".into(), "gpu".into()],
+    };
+    let json = serde_json::to_value(&req).expect("serialize");
+    assert_eq!(json["worker_id"], "w1");
+    assert_eq!(json["worker_instance_id"], "w1-i1");
+    assert_eq!(json["lane_id"], "main");
+    assert_eq!(json["capability_hash"], "cap-hash-abc");
+    assert_eq!(json["grant_ttl_ms"], 30_000);
+    assert_eq!(json["worker_capabilities"][0], "cpu");
+}
+
+#[test]
+fn issue_reclaim_grant_request_skips_none_optional_fields() {
+    let req = IssueReclaimGrantRequest {
+        worker_id: "w1".into(),
+        worker_instance_id: "w1-i1".into(),
+        lane_id: "main".into(),
+        capability_hash: None,
+        grant_ttl_ms: 30_000,
+        route_snapshot_json: None,
+        admission_summary: None,
+        worker_capabilities: vec![],
+    };
+    let json = serde_json::to_value(&req).expect("serialize");
+    assert!(json.get("capability_hash").is_none());
+    assert!(json.get("route_snapshot_json").is_none());
+    assert!(json.get("admission_summary").is_none());
+}
+
+#[test]
+fn issue_reclaim_grant_response_granted_deserializes() {
+    let wire = serde_json::json!({
+        "status": "granted",
+        "execution_id": "0x0100000000000000000000000000000000000000000000000000000000000001",
+        "partition_key": "{fp:7}",
+        "grant_key": "reclaim:grant:abc",
+        "expires_at_ms": 1_700_000_000_000u64,
+        "lane_id": "main",
+    });
+    let resp: IssueReclaimGrantResponse =
+        serde_json::from_value(wire).expect("deserialize granted");
+    match resp {
+        IssueReclaimGrantResponse::Granted {
+            grant_key, lane_id, ..
+        } => {
+            assert_eq!(grant_key, "reclaim:grant:abc");
+            assert_eq!(lane_id, "main");
+        }
+        other => panic!("expected Granted, got {other:?}"),
+    }
+}
+
+#[test]
+fn issue_reclaim_grant_response_not_reclaimable_deserializes() {
+    let wire = serde_json::json!({
+        "status": "not_reclaimable",
+        "execution_id": "0x0100000000000000000000000000000000000000000000000000000000000001",
+        "detail": "capability_mismatch",
+    });
+    let resp: IssueReclaimGrantResponse = serde_json::from_value(wire).expect("deserialize");
+    match resp {
+        IssueReclaimGrantResponse::NotReclaimable { detail, .. } => {
+            assert_eq!(detail, "capability_mismatch");
+        }
+        other => panic!("expected NotReclaimable, got {other:?}"),
+    }
+}
+
+#[test]
+fn issue_reclaim_grant_response_reclaim_cap_exceeded_deserializes() {
+    let wire = serde_json::json!({
+        "status": "reclaim_cap_exceeded",
+        "execution_id": "0x0100000000000000000000000000000000000000000000000000000000000001",
+        "reclaim_count": 1000,
+    });
+    let resp: IssueReclaimGrantResponse = serde_json::from_value(wire).expect("deserialize");
+    match resp {
+        IssueReclaimGrantResponse::ReclaimCapExceeded { reclaim_count, .. } => {
+            assert_eq!(reclaim_count, 1000);
+        }
+        other => panic!("expected ReclaimCapExceeded, got {other:?}"),
+    }
+}
+
+#[test]
+fn issue_reclaim_grant_response_into_grant_rejects_non_granted_variants() {
+    let not_reclaimable = IssueReclaimGrantResponse::NotReclaimable {
+        execution_id: "0x0100000000000000000000000000000000000000000000000000000000000001"
+            .into(),
+        detail: "capability_mismatch".into(),
+    };
+    assert!(not_reclaimable.into_grant().is_err());
+
+    let cap_exceeded = IssueReclaimGrantResponse::ReclaimCapExceeded {
+        execution_id: "0x0100000000000000000000000000000000000000000000000000000000000001"
+            .into(),
+        reclaim_count: 1000,
+    };
+    assert!(cap_exceeded.into_grant().is_err());
+}
+
+#[test]
+fn worker_claim_from_reclaim_grant_is_backend_agnostic_at_type_level() {
+    // Compile-time assertion that `claim_from_reclaim_grant` is
+    // addressable on `FlowFabricWorker` under the default feature
+    // set AND returns the advertised `ReclaimExecutionOutcome` type.
+    // Parallels the sqlite-only compile anchor inside worker.rs —
+    // the type-pin here ensures the public signature matches
+    // RFC-024 §3.4 and catches accidental cfg-gating regressions.
+    use ff_core::contracts::{ReclaimExecutionArgs, ReclaimExecutionOutcome, ReclaimGrant};
+    use ff_sdk::{FlowFabricWorker, SdkError};
+
+    // Type-erase the return via `Box<dyn Future>` so the assignment
+    // names only the Output type (no `impl Future` to spell). Any
+    // cfg-gate regression on the method fails compilation of this
+    // line; any signature drift fails the `Future::Output` match.
+    async fn _call(
+        w: &FlowFabricWorker,
+        g: ReclaimGrant,
+        a: ReclaimExecutionArgs,
+    ) -> Result<ReclaimExecutionOutcome, SdkError> {
+        w.claim_from_reclaim_grant(g, a).await
+    }
+    let _ = _call;
+}

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -608,6 +608,15 @@ pub fn router_with_metrics(
             "/v1/executions/{id}/revoke-lease",
             with_body_limit(post(revoke_lease), BODY_LIMIT_CONTROL),
         )
+        // RFC-024 PR-G: consumer-requested lease-reclaim grant for
+        // executions in lease_expired_reclaimable / lease_revoked
+        // state. Dispatches through the backend trait's
+        // `issue_reclaim_grant`; all three in-tree backends
+        // (Valkey/PG/SQLite) implement it at v0.12.0.
+        .route(
+            "/v1/executions/{id}/reclaim",
+            with_body_limit(post(issue_reclaim_grant), BODY_LIMIT_CONTROL),
+        )
         // Scheduler-routed claim (Batch C item 2). Worker POSTs lane +
         // identity + capabilities; server runs budget/quota/capability
         // admission via ff-scheduler and returns a ClaimGrant on
@@ -1137,6 +1146,136 @@ async fn revoke_lease(
         reason: "operator_revoke".to_owned(),
     };
     Ok(Json(server.backend().revoke_lease(args).await?))
+}
+
+// ── RFC-024 PR-G: issue reclaim grant ──
+//
+// `POST /v1/executions/{id}/reclaim` admits executions in
+// `lease_expired_reclaimable` or `lease_revoked` state into the
+// reclaim path. The handler dispatches through
+// `EngineBackend::issue_reclaim_grant`; all three in-tree backends
+// implement it at v0.12.0. Default-impl returns `Unavailable` for
+// out-of-tree backends so the handler surfaces 503 rather than a
+// mis-parsed error.
+
+#[derive(Deserialize)]
+struct IssueReclaimGrantBody {
+    worker_id: String,
+    worker_instance_id: String,
+    lane_id: String,
+    #[serde(default)]
+    capability_hash: Option<String>,
+    grant_ttl_ms: u64,
+    #[serde(default)]
+    route_snapshot_json: Option<String>,
+    #[serde(default)]
+    admission_summary: Option<String>,
+    #[serde(default)]
+    worker_capabilities: Vec<String>,
+}
+
+/// Wire shape for `ff_core::contracts::ReclaimGrant`. Opaque
+/// `partition_key` follows the `ClaimGrantDto` precedent (issue
+/// #91); consumers carry it verbatim back to
+/// `claim_from_reclaim_grant` without peeking at `PartitionFamily`.
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum IssueReclaimGrantResponseDto {
+    Granted {
+        execution_id: String,
+        partition_key: ff_core::partition::PartitionKey,
+        grant_key: String,
+        expires_at_ms: u64,
+        lane_id: String,
+    },
+    NotReclaimable {
+        execution_id: String,
+        detail: String,
+    },
+    ReclaimCapExceeded {
+        execution_id: String,
+        reclaim_count: u32,
+    },
+}
+
+/// Maximum grant TTL accepted — mirrors `CLAIM_GRANT_TTL_MS_MAX` so
+/// a misconfigured client can't squat an execution on a multi-hour
+/// reclaim grant.
+const RECLAIM_GRANT_TTL_MS_MAX: u64 = 60_000;
+
+async fn issue_reclaim_grant(
+    State(server): State<Arc<Server>>,
+    Path(id): Path<String>,
+    AppJson(body): AppJson<IssueReclaimGrantBody>,
+) -> Result<Response, ApiError> {
+    let execution_id = parse_execution_id(&id)?;
+    validate_identifier("worker_id", &body.worker_id)?;
+    validate_identifier("worker_instance_id", &body.worker_instance_id)?;
+    let worker_id = WorkerId::new(body.worker_id);
+    let worker_instance_id = WorkerInstanceId::new(body.worker_instance_id);
+    let lane_id = LaneId::try_new(body.lane_id).map_err(|e| {
+        ApiError(ServerError::InvalidInput(format!("lane_id: {e}")))
+    })?;
+    if body.grant_ttl_ms == 0 || body.grant_ttl_ms > RECLAIM_GRANT_TTL_MS_MAX {
+        return Err(ApiError(ServerError::InvalidInput(format!(
+            "grant_ttl_ms must be in 1..={RECLAIM_GRANT_TTL_MS_MAX}"
+        ))));
+    }
+    let caps: std::collections::BTreeSet<String> =
+        body.worker_capabilities.into_iter().collect();
+
+    let args = ff_core::contracts::IssueReclaimGrantArgs::new(
+        execution_id.clone(),
+        worker_id,
+        worker_instance_id,
+        lane_id.clone(),
+        body.capability_hash,
+        body.grant_ttl_ms,
+        body.route_snapshot_json,
+        body.admission_summary,
+        caps,
+        ff_core::types::TimestampMs::now(),
+    );
+
+    match server.backend().issue_reclaim_grant(args).await? {
+        IssueReclaimGrantOutcome::Granted(grant) => {
+            let dto = IssueReclaimGrantResponseDto::Granted {
+                execution_id: grant.execution_id.to_string(),
+                partition_key: grant.partition_key,
+                grant_key: grant.grant_key,
+                expires_at_ms: grant.expires_at_ms,
+                lane_id: grant.lane_id.as_str().to_owned(),
+            };
+            Ok((StatusCode::OK, Json(dto)).into_response())
+        }
+        IssueReclaimGrantOutcome::NotReclaimable { execution_id, detail } => {
+            let dto = IssueReclaimGrantResponseDto::NotReclaimable {
+                execution_id: execution_id.to_string(),
+                detail,
+            };
+            Ok((StatusCode::OK, Json(dto)).into_response())
+        }
+        IssueReclaimGrantOutcome::ReclaimCapExceeded {
+            execution_id,
+            reclaim_count,
+        } => {
+            let dto = IssueReclaimGrantResponseDto::ReclaimCapExceeded {
+                execution_id: execution_id.to_string(),
+                reclaim_count,
+            };
+            Ok((StatusCode::OK, Json(dto)).into_response())
+        }
+        // `IssueReclaimGrantOutcome` is `#[non_exhaustive]`; surface
+        // any future variant as 503 pointing at a client/server
+        // version mismatch.
+        _ => Ok((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorBody::plain(
+                "issue_reclaim_grant: backend returned a non-exhaustive outcome this server build does not understand".to_owned(),
+            )),
+        )
+            .into_response()),
+    }
 }
 
 // ── Scheduler-routed claim (Batch C item 2 PR-B) ──

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -1957,3 +1957,128 @@ mod claim_grant_dto_tests {
         assert_eq!(jf["partition_key"], je["partition_key"]);
     }
 }
+
+#[cfg(test)]
+mod reclaim_grant_dto_tests {
+    //! Wire-shape tests for `POST /v1/executions/{id}/reclaim`
+    //! (RFC-024 §3.5).
+    //!
+    //! Pins the exact request + response JSON shapes the server
+    //! accepts and emits, so any drift between the server DTOs and the
+    //! `ff-sdk::admin::IssueReclaimGrant{Request,Response}` types
+    //! surfaces at compile-adjacent test time rather than on a live
+    //! SDK round-trip. Parallels `claim_grant_dto_tests`.
+    use super::*;
+    use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
+    use serde_json::json;
+    use serde_json::Value;
+    use std::collections::BTreeSet;
+
+    fn sample_partition_key() -> PartitionKey {
+        let p = Partition {
+            family: PartitionFamily::Flow,
+            index: 7,
+        };
+        PartitionKey::from(&p)
+    }
+
+    #[test]
+    fn issue_reclaim_grant_body_deserializes_required_and_optional_fields() {
+        // Full-field wire shape the SDK emits. Exercises
+        // `#[serde(default)]` optional fields + `worker_capabilities`
+        // defaulting.
+        let wire = json!({
+            "worker_id": "w1",
+            "worker_instance_id": "w1-i1",
+            "lane_id": "main",
+            "capability_hash": "cap-hash-abc",
+            "grant_ttl_ms": 30_000u64,
+            "route_snapshot_json": "{\"route\":\"x\"}",
+            "admission_summary": "admitted",
+            "worker_capabilities": ["cpu", "gpu"],
+        });
+        let body: IssueReclaimGrantBody =
+            serde_json::from_value(wire).expect("deserialize full body");
+        assert_eq!(body.worker_id, "w1");
+        assert_eq!(body.worker_instance_id, "w1-i1");
+        assert_eq!(body.lane_id, "main");
+        assert_eq!(body.capability_hash.as_deref(), Some("cap-hash-abc"));
+        assert_eq!(body.grant_ttl_ms, 30_000);
+        assert_eq!(
+            body.route_snapshot_json.as_deref(),
+            Some("{\"route\":\"x\"}")
+        );
+        assert_eq!(body.admission_summary.as_deref(), Some("admitted"));
+        let caps: BTreeSet<&str> =
+            body.worker_capabilities.iter().map(String::as_str).collect();
+        assert!(caps.contains("cpu"));
+        assert!(caps.contains("gpu"));
+    }
+
+    #[test]
+    fn issue_reclaim_grant_body_defaults_when_optionals_absent() {
+        // Minimum wire shape; `capability_hash`, `route_snapshot_json`,
+        // `admission_summary` all `#[serde(default)]` to `None`, and
+        // `worker_capabilities` defaults to empty `Vec`.
+        let wire = json!({
+            "worker_id": "w1",
+            "worker_instance_id": "w1-i1",
+            "lane_id": "main",
+            "grant_ttl_ms": 30_000u64,
+        });
+        let body: IssueReclaimGrantBody =
+            serde_json::from_value(wire).expect("deserialize minimal body");
+        assert!(body.capability_hash.is_none());
+        assert!(body.route_snapshot_json.is_none());
+        assert!(body.admission_summary.is_none());
+        assert!(body.worker_capabilities.is_empty());
+    }
+
+    #[test]
+    fn issue_reclaim_grant_response_dto_granted_serializes_with_status_tag() {
+        let dto = IssueReclaimGrantResponseDto::Granted {
+            execution_id: "{fp:7}:11111111-1111-4111-8111-111111111111".to_owned(),
+            partition_key: sample_partition_key(),
+            grant_key: "reclaim:grant:abc".to_owned(),
+            expires_at_ms: 1_700_000_000_000,
+            lane_id: "main".to_owned(),
+        };
+        let json: Value = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["status"], "granted");
+        assert_eq!(
+            json["execution_id"],
+            "{fp:7}:11111111-1111-4111-8111-111111111111"
+        );
+        // `partition_key` serialises transparent: a bare string, not
+        // an object. Same precedent as `claim_grant_dto`.
+        assert_eq!(json["partition_key"], json!("{fp:7}"));
+        assert_eq!(json["grant_key"], "reclaim:grant:abc");
+        assert_eq!(json["expires_at_ms"], json!(1_700_000_000_000u64));
+        assert_eq!(json["lane_id"], "main");
+    }
+
+    #[test]
+    fn issue_reclaim_grant_response_dto_not_reclaimable_serializes_with_status_tag() {
+        let dto = IssueReclaimGrantResponseDto::NotReclaimable {
+            execution_id: "{fp:7}:11111111-1111-4111-8111-111111111111".to_owned(),
+            detail: "capability_mismatch: gpu".to_owned(),
+        };
+        let json: Value = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["status"], "not_reclaimable");
+        assert_eq!(json["detail"], "capability_mismatch: gpu");
+        assert!(json.get("grant_key").is_none());
+        assert!(json.get("partition_key").is_none());
+    }
+
+    #[test]
+    fn issue_reclaim_grant_response_dto_reclaim_cap_exceeded_serializes_with_status_tag() {
+        let dto = IssueReclaimGrantResponseDto::ReclaimCapExceeded {
+            execution_id: "{fp:7}:11111111-1111-4111-8111-111111111111".to_owned(),
+            reclaim_count: 1000,
+        };
+        let json: Value = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["status"], "reclaim_cap_exceeded");
+        assert_eq!(json["reclaim_count"], 1000);
+        assert!(json.get("grant_key").is_none());
+    }
+}

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -1198,10 +1198,11 @@ enum IssueReclaimGrantResponseDto {
     },
 }
 
-/// Maximum grant TTL accepted — mirrors `CLAIM_GRANT_TTL_MS_MAX` so
-/// a misconfigured client can't squat an execution on a multi-hour
-/// reclaim grant.
-const RECLAIM_GRANT_TTL_MS_MAX: u64 = 60_000;
+/// Maximum grant TTL accepted — aliased to `CLAIM_GRANT_TTL_MS_MAX`
+/// so a misconfigured client can't squat an execution on a
+/// multi-hour reclaim grant and so the two ceilings cannot drift
+/// (PR #407 review F2).
+const RECLAIM_GRANT_TTL_MS_MAX: u64 = CLAIM_GRANT_TTL_MS_MAX;
 
 async fn issue_reclaim_grant(
     State(server): State<Arc<Server>>,

--- a/docs/CONSUMER_MIGRATION_0.12.md
+++ b/docs/CONSUMER_MIGRATION_0.12.md
@@ -221,6 +221,26 @@ The three new consumer surfaces in v0.12.0:
   Request body carries worker identity + lane + capabilities;
   response is a `status`-discriminated JSON outcome.
 
+#### Admission model
+
+Grant issuance rejects with
+`IssueReclaimGrantResponse::NotReclaimable { detail }` when any of:
+
+- The execution's `lifecycle_phase` is not `active`, or its
+  `ownership_state` is neither `lease_expired_reclaimable` nor
+  `lease_revoked` (detail carries the observed state).
+- A capability is missing: the backend computes the set difference
+  of `exec_core.required_capabilities` (populated from
+  `ExecutionPolicy.routing_requirements.required_capabilities` at
+  `create_execution` time) minus the request's
+  `worker_capabilities`. A non-empty difference surfaces as
+  `detail: "capability_mismatch: <missing csv>"`.
+
+`capability_hash` on the request body is **not** consulted for
+admission — it is an opaque audit token stored verbatim on the
+grant hash. Set it to `None` unless you have a downstream
+correlation use-case.
+
 #### Cairn migration pattern — F64 bridge retry loop → reclaim
 
 Pre-RFC cairn-fabric pattern at `cairn-rs/.../f64_bridge.rs`
@@ -340,13 +360,15 @@ flow.
 - **Land the RFC-024 consumer migration** — replace the
   `F64 bridge retry loop` with the snippet above, drop the
   `remove once FF#371 ships` comment, close tracking issue #371.
-- **Optional: capability-hash correlation** — the
-  `IssueReclaimGrantRequest::capability_hash` field maps to the
-  execution's route-snapshot capability hash. Cairn's existing
-  capability plumbing at admission time can surface the same
-  hash on reclaim for stricter capability-match validation;
-  passing `None` (the ergonomic default) reuses the admission-
-  time stored hash.
+- **Optional: capability-hash audit correlation** — the
+  `IssueReclaimGrantRequest::capability_hash` field is an opaque
+  token stored verbatim on the issued grant for audit /
+  observability. It is **not** used for admission — admission
+  compares `worker_capabilities` against the execution's
+  `required_capabilities` (persisted on `exec_core` at
+  `create_execution` time). Cairn can thread its existing
+  admission-time capability-hash through for downstream
+  correlation, or pass `None` to leave the field empty.
 
 ## Non-changes
 

--- a/docs/CONSUMER_MIGRATION_0.12.md
+++ b/docs/CONSUMER_MIGRATION_0.12.md
@@ -165,24 +165,197 @@ test bodies (unsafe under parallel test harness on Rust 2024).
 | `FF_SQLITE_PATH` | `:memory:` | File path (`/tmp/ff-dev.db`) or URI (`file:name?mode=memory&cache=shared`). |
 | `FF_SQLITE_POOL_SIZE` | `4` | Pool size (1 writer + N–1 readers). |
 
+### 7. RFC-024 — lease-reclaim consumer surface
+
+RFC-024 (accepted 2026-04-26) lands in v0.12.0 alongside RFC-023.
+Closes the pull-mode deadlock at issue #371: consumers that drive
+FlowFabric one HTTP request at a time (cairn-fabric's model) could
+previously hit `lease_expired` on `POST /v1/runs/:id/complete` and
+have NO recovery path — `ff_issue_claim_grant` rejected with
+`execution_not_eligible` because the execution was in
+`lifecycle_phase = active`, not `runnable`. RFC-024 adds a dedicated
+admission path for the `lease_expired_reclaimable` / `lease_revoked`
+states.
+
+#### Breaking changes (pre-existing surfaces)
+
+These landed in PR-B/PR-C and are already documented in
+`CHANGELOG.md`:
+
+- **`ReclaimGrant` renamed to `ResumeGrant`** (the pre-RFC type
+  always represented the resume-after-suspend semantic). `cargo fix`
+  handles most call-sites.
+- **Trait method rename** `EngineBackend::claim_from_reclaim` →
+  `EngineBackend::claim_from_resume_grant`. Matching SDK method
+  rename on `FlowFabricWorker`.
+- **`ReclaimExecutionArgs::max_reclaim_count`** type change:
+  `u32` → `Option<u32>`. `None` ⇒ Rust-surface default of 1000
+  (RFC-024 §4.6). Existing callers passing a value wrap in
+  `Some(...)`; the Lua fallback of 100 still applies to pre-RFC
+  call sites (wire-compatible under `#[serde(default)]`).
+- **`#[non_exhaustive]`** added to `ClaimGrant`, `ResumeGrant`,
+  new `ReclaimGrant`, `IssueReclaimGrantArgs`,
+  `ReclaimExecutionArgs`. Each type gains an explicit `::new`
+  constructor (per
+  `feedback_non_exhaustive_needs_constructor`).
+- **`HandleKind::Reclaimed`** variant added. `HandleKind` is already
+  `#[non_exhaustive]`; consumers matching exhaustively add an arm
+  (or rely on `_ =>` fallthrough).
+
+#### Additive (PR-G — this release)
+
+The three new consumer surfaces in v0.12.0:
+
+- `FlowFabricAdminClient::issue_reclaim_grant(&self, execution_id,
+  IssueReclaimGrantRequest) -> Result<IssueReclaimGrantResponse,
+  SdkError>` — HTTP `POST /v1/executions/{id}/reclaim`. Admits the
+  execution into the reclaim path; returns a `Granted` /
+  `NotReclaimable` / `ReclaimCapExceeded` outcome.
+- `FlowFabricWorker::claim_from_reclaim_grant(&self, ReclaimGrant,
+  ReclaimExecutionArgs) -> Result<ReclaimExecutionOutcome,
+  SdkError>` — backend-agnostic. Dispatches through
+  `EngineBackend::reclaim_execution` on whichever backend the
+  worker was connected with. NOT `valkey-default`-gated; compiles
+  and runs under `--no-default-features, features = ["sqlite"]`.
+- `POST /v1/executions/{id}/reclaim` HTTP endpoint on `ff-server`.
+  Request body carries worker identity + lane + capabilities;
+  response is a `status`-discriminated JSON outcome.
+
+#### Cairn migration pattern — F64 bridge retry loop → reclaim
+
+Pre-RFC cairn-fabric pattern at `cairn-rs/.../f64_bridge.rs`
+(marked `remove once FF#371 ships`):
+
+```rust
+// BEFORE (v0.11): retry-with-backoff on lease_expired. Eventually
+// fails because `ff_issue_claim_grant` gates on runnable phase.
+loop {
+    match worker.complete(handle, output).await {
+        Err(SdkError::Engine(e)) if is_lease_expired(&e) => {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;  // retries until grant_ttl drifts out
+        }
+        other => return other,
+    }
+}
+```
+
+```rust
+// AFTER (v0.12): one-shot reclaim on lease_expired.
+use ff_sdk::admin::{FlowFabricAdminClient, IssueReclaimGrantRequest};
+use ff_core::contracts::ReclaimExecutionArgs;
+
+match worker.complete(handle, output).await {
+    Err(SdkError::Engine(e)) if is_lease_expired(&e) => {
+        // 1. Issue a reclaim grant via the admin HTTP surface.
+        let req = IssueReclaimGrantRequest {
+            worker_id: worker.config().worker_id.to_string(),
+            worker_instance_id:
+                worker.config().worker_instance_id.to_string(),
+            lane_id: lane.to_string(),
+            capability_hash: None,
+            grant_ttl_ms: 30_000,
+            route_snapshot_json: None,
+            admission_summary: None,
+            worker_capabilities: worker
+                .config()
+                .capabilities
+                .clone(),
+        };
+        let resp = admin
+            .issue_reclaim_grant(&execution_id.to_string(), req)
+            .await?;
+        let grant = resp.into_grant()?; // → SdkError on non-Granted
+
+        // 2. Consume the grant to mint a fresh attempt.
+        let args = ReclaimExecutionArgs::new(
+            execution_id.clone(),
+            worker.config().worker_id.clone(),
+            worker.config().worker_instance_id.clone(),
+            lane.clone(),
+            None,                               // capability_hash
+            new_lease_id,
+            worker.config().lease_ttl_ms,
+            new_attempt_id,
+            String::new(),                      // attempt_policy_json
+            None,                               // max_reclaim_count → 1000
+            old_worker_instance_id,
+            current_attempt_index,
+        );
+        match worker.claim_from_reclaim_grant(grant, args).await? {
+            ReclaimExecutionOutcome::Claimed(handle) => {
+                // 3. Retry the terminal write on the fresh lease.
+                worker.complete(&handle, output).await
+            }
+            ReclaimExecutionOutcome::NotReclaimable { detail, .. } => {
+                Err(structural_error(&format!(
+                    "reclaim rejected: {detail}"
+                )))
+            }
+            ReclaimExecutionOutcome::ReclaimCapExceeded {
+                reclaim_count, ..
+            } => {
+                Err(structural_error(&format!(
+                    "reclaim cap exceeded at {reclaim_count}"
+                )))
+            }
+            ReclaimExecutionOutcome::GrantNotFound { .. } => {
+                Err(structural_error("reclaim grant not found"))
+            }
+            _ => Err(structural_error("unknown reclaim outcome")),
+        }
+    }
+    other => other,
+}
+```
+
+The operator gap between `issue_reclaim_grant` and
+`claim_from_reclaim_grant` is sub-100ms in-process; the
+two-FCALL timing window is orders of magnitude tighter than #371's
+original `complete`-vs-operator-pause gap (RFC-024 §7.3).
+
+#### Handle-kind awareness
+
+After `claim_from_reclaim_grant` returns `Claimed(handle)`, the
+handle's `kind` is `HandleKind::Reclaimed` (distinct from
+`HandleKind::Fresh` / `HandleKind::Resumed`). Downstream
+metrics/tracing paths that already match on
+`HandleKind::Fresh` vs `HandleKind::Resumed` should add a
+`Reclaimed` arm to distinguish first-attempt vs resume-after-suspend
+vs reclaim-after-lease-expiry observability. The enum is
+`#[non_exhaustive]`; consumers can `_ =>` fallthrough instead.
+
+#### `ReclaimGrant` vs `ResumeGrant` — do not confuse
+
+Cairn migrators holding a pre-v0.12 `ReclaimGrant` variable: the
+v0.12 `ReclaimGrant` is a **new, distinct** type for the
+lease-reclaim path. The rename you need to apply to your existing
+code is `ReclaimGrant → ResumeGrant` (the pre-RFC type was
+always a resume grant — the name was the bug; RFC-024 §3.1). Only
+reach for the new `ReclaimGrant` when wiring the #371 recovery
+flow.
+
 ## What's next for cairn
 
-- **RFC-024 reclaim wiring** — accepted 2026-04-26, landing v0.13.
-  Adds a dedicated claim-grant/reclaim-grant table on Postgres +
-  SQLite to unblock pull-mode deadlock scenarios. Consumer migration
-  for RFC-024 will be **additive** — no breaking changes to the
-  existing claim/reclaim surface — but cairn should review
-  `rfcs/RFC-024-reclaim-wiring.md` to understand the new admission
-  path. Tracking issue #371.
+- **Land the RFC-024 consumer migration** — replace the
+  `F64 bridge retry loop` with the snippet above, drop the
+  `remove once FF#371 ships` comment, close tracking issue #371.
+- **Optional: capability-hash correlation** — the
+  `IssueReclaimGrantRequest::capability_hash` field maps to the
+  execution's route-snapshot capability hash. Cairn's existing
+  capability plumbing at admission time can surface the same
+  hash on reclaim for stricter capability-match validation;
+  passing `None` (the ergonomic default) reuses the admission-
+  time stored hash.
 
 ## Non-changes
 
-- No Rust API break on Valkey or Postgres hot paths.
-- No wire-format change on the HTTP / JSON surface.
-- Valkey backend behaviour unchanged.
-- No new trait methods on `EngineBackend`.
-- `HandleKind` unchanged (three variants: `Fresh`, `Resumed`,
-  `Suspended`).
+- No Rust API break on Valkey or Postgres hot paths **outside
+  the RFC-024 rename-set above**.
+- No wire-format change on the HTTP / JSON surface **other than
+  the additive `POST /v1/executions/{id}/reclaim` endpoint**.
+- Valkey backend claim/resume hot-path behaviour unchanged —
+  reclaim is a new, additive path.
 
 ## Upgrade checklist
 


### PR DESCRIPTION
## Summary

Closes #371 end-to-end. Backend impls landed in PR-D (#403, PG), PR-E (#401, SQLite), PR-F (#402, Valkey); this PR wires them through to the consumer surface cairn-fabric (and any pull-mode consumer) will call.

Implements RFC-024 §3.4 (worker dispatch), §3.5 (SDK admin surface), §4.4 (consumer flow), §8 (migration impact), §9 (release readiness).

## Consumer surface

**ff-sdk — 3 public additions:**

- `FlowFabricAdminClient::issue_reclaim_grant(&self, execution_id, IssueReclaimGrantRequest) -> Result<IssueReclaimGrantResponse, SdkError>` — HTTP wrapper over `POST /v1/executions/{id}/reclaim`. `status`-discriminated response enum (`Granted` / `NotReclaimable` / `ReclaimCapExceeded`); `Granted` lifts to a typed `ff_core::contracts::ReclaimGrant` via `IssueReclaimGrantResponse::into_grant`. `valkey-default`-gated (alongside existing reqwest-based admin surface).
- `FlowFabricWorker::claim_from_reclaim_grant(&self, ReclaimGrant, ReclaimExecutionArgs) -> Result<ReclaimExecutionOutcome, SdkError>` — **backend-agnostic** (no cfg gate). Dispatches through `EngineBackend::reclaim_execution`. Compiles + runs under `--no-default-features, features = ["sqlite"]`.
- `IssueReclaimGrantRequest` + `IssueReclaimGrantResponse` re-exported from `ff-sdk::admin`.

**ff-server — 1 HTTP addition:**

- `POST /v1/executions/{id}/reclaim` route. Dispatches through `EngineBackend::issue_reclaim_grant`; all three in-tree backends implement it. 64 KiB `BODY_LIMIT_CONTROL`; validates identifiers + lane_id + caps `grant_ttl_ms` to 1..=60s (matching the scheduler's ceiling).

**Docs — 1 migration-doc update:**

- `docs/CONSUMER_MIGRATION_0.12.md` §7 — full RFC-024 consumer section with breaking-change inventory, additive-surface enumeration, cairn F64-bridge-retry → reclaim migration snippet, handle-kind awareness note, and `ReclaimGrant` vs `ResumeGrant` clarification for migrators.

## Tests

`crates/ff-sdk/tests/rfc024_sdk.rs` (new, 7 tests, all pass):

- Request / response wire-shape round-trip (4 tests on request + response serialization).
- `into_grant` rejects non-Granted variants.
- `claim_from_reclaim_grant` backend-agnostic compile-anchor (complements the sqlite-only compile-anchor already in worker.rs's `sqlite_only_compile_surface_tests`).

Integration tests (full claim → lease-expire → reclaim-grant → reclaim-exec → complete round-trip against a live backend) are driven from the smoke scripts per RFC-024 §9, not this PR.

## Verification

- `cargo check --workspace` — clean
- `cargo check -p ff-sdk --no-default-features --features sqlite` — clean (RFC-024 §R8 sqlite-only feature set)
- `cargo clippy -p ff-sdk -p ff-server --all-targets -- -D warnings` — clean on edited crates
- `cargo test -p ff-sdk -p ff-server` — 147 passing, 0 failing, 7 ignored (all `#[ignore]`d integration tests that require a live backend)

## Cross-references

- Accepted RFC: `rfcs/RFC-024-reclaim-wiring.md` (Rev-2)
- PR-D (Postgres): #403
- PR-E (SQLite): #401
- PR-F (Valkey + Lua ARGV[9]): #402

## NOT in this PR

- Backend impls (landed in PR-D/E/F)
- RFC content changes (accepted)
- Type renames / trait method renames (landed in PR-B/C)
- Cairn-side code (peer-team; we produce the migration artifact in §7 of the consumer-migration doc).

## Test plan

- [ ] CI matrix green across valkey / postgres / sqlite cells
- [ ] `cargo check -p ff-sdk --no-default-features --features sqlite` stays clean in CI (RFC-024 §R8 acceptance)
- [ ] `cargo test -p ff-sdk --test rfc024_sdk` — 7 pass
- [ ] `cargo clippy -p ff-sdk -p ff-server --all-targets -- -D warnings` — clean
- [ ] CONSUMER_MIGRATION_0.12.md renders cleanly (no broken relative links)
- [ ] (post-merge, pre-v0.12 tag) smoke scripts exercise the full reclaim round-trip per RFC-024 §9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new reclaim flow across `ff-server` and `ff-sdk` (new endpoint + new public APIs) that impacts execution lease recovery; while mostly additive, it touches request validation/wire formats and backend dispatch paths that are easy to misconfigure or mismatch across versions.
> 
> **Overview**
> Implements the consumer-facing RFC-024 lease-reclaim wiring end-to-end: `ff-server` adds `POST /v1/executions/{id}/reclaim` (body validation, TTL cap, `status`-tagged JSON outcomes) dispatching to `EngineBackend::issue_reclaim_grant`.
> 
> `ff-sdk` adds `FlowFabricAdminClient::issue_reclaim_grant` (with new `IssueReclaimGrantRequest`/`IssueReclaimGrantResponse` + `into_grant`) and a backend-agnostic `FlowFabricWorker::claim_from_reclaim_grant` that forwards to `EngineBackend::reclaim_execution` without feature-gating; new unit/compile-surface tests pin the wire shape and signature.
> 
> Docs/changelog are updated with a new RFC-024 migration section describing the new reclaim flow and how consumers should migrate from `lease_expired` retry loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11017f2ac566cfab2ef6fb3a4a73d1c6de690fea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->