### PR TITLE
chore: add release automation guardrails (publish-list, non_exhaustive, lua-version, feature-propagation)

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -438,6 +438,139 @@ jobs:
             exit 1
           fi
 
+      # Additive guard (2026-04 release-automation batch). If this PR
+      # touches any .lua source — either the sharded `lua/**/*.lua`
+      # sources or the generated `crates/ff-script/**/*.lua` bundle —
+      # the `flowfabric_lua_version` counter MUST also change. The
+      # ff-script loader only reloads the Lua library when the
+      # checked-in version number changes; Lua edits without a bump
+      # leave deployed consumers on the old cached FUNCTION LIBRARY
+      # (silent stale FCALLs). See project_ff_script_stale_lua_in_dev.md.
+      #
+      # Uses `github.base_ref` for PRs. On push-to-main this step is
+      # skipped via the `if` — the diff would resolve against the
+      # same commit and yield nothing meaningful.
+      - name: Require flowfabric_lua_version bump when Lua changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- \
+            'crates/ff-script/**/*.lua' 'lua/**/*.lua' || true)
+          if [ -z "$changed" ]; then
+            echo "No Lua source changes — version bump not required."
+            exit 0
+          fi
+          echo "Lua source changes in this PR:"
+          echo "$changed"
+          version_diff=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- \
+            crates/ff-script/src/flowfabric_lua_version || true)
+          if [ -z "$version_diff" ]; then
+            echo "::error::Lua sources changed but crates/ff-script/src/flowfabric_lua_version did NOT. ff-script gates FUNCTION LIBRARY reloads on this counter; edits without a bump leave deployed consumers on stale Lua (silent stale FCALLs). Bump the counter in the same commit. See project_ff_script_stale_lua_in_dev.md." >&2
+            exit 1
+          fi
+          echo "flowfabric_lua_version bumped — ok."
+
+  # ── Release-automation guardrails (chore/release-automation) ────────
+  #
+  # Three additive CI checks + one extension above. None modify
+  # existing gate behaviour. Each enforces an exact memory-file
+  # lesson the project has already paid for:
+  #
+  #   publish-list-drift     -> feedback_release_publish_list_drift.md
+  #   non-exhaustive-lint    -> feedback_non_exhaustive_needs_constructor.md
+  #   feature-propagation    -> feedback_feature_flag_propagation.md
+  #   (lua-version-bump step above) -> project_ff_script_stale_lua_in_dev.md
+
+  publish-list-drift:
+    name: publish-list drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+        with:
+          key: tools-publish-list-lint
+      - name: cargo run -p publish-list-lint
+        run: cargo run -p publish-list-lint
+
+  non-exhaustive-lint:
+    name: non_exhaustive constructor lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+        with:
+          key: tools-non-exhaustive-lint
+      - name: cargo run -p non-exhaustive-lint
+        run: cargo run -p non-exhaustive-lint
+
+  # feature-flag propagation audit. For each publishable crate,
+  # verify `--no-default-features` builds, then exercise each
+  # feature from that crate's `[features]` table in isolation.
+  # Catches internal feature leaks where a dependent crate forgot
+  # `default-features = false` and silently pulled in a flag via
+  # the default set (v0.3.2: feedback_feature_flag_propagation.md).
+  #
+  # One matrix cell per publishable crate; inside each cell a shell
+  # loop iterates features (N+1 checks; the Cartesian option is
+  # rejected). Crate list hardcoded to match publish-list-lint's
+  # source of truth — if the two disagree, publish-list-drift fails
+  # first so this list cannot silently drift.
+  feature-propagation:
+    name: feature-propagation (${{ matrix.crate }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - ferriskey
+          - ff-core
+          - ff-script
+          - ff-observability
+          - ff-observability-http
+          - ff-scheduler
+          - ff-backend-valkey
+          - ff-backend-postgres
+          - ff-backend-sqlite
+          - ff-engine
+          - ff-sdk
+          - ff-server
+          - flowfabric
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+        with:
+          key: feature-propagation-${{ matrix.crate }}
+      - name: cargo check --no-default-features
+        env:
+          CRATE: ${{ matrix.crate }}
+        run: cargo check -p "$CRATE" --no-default-features
+      - name: cargo check --no-default-features --features <each>
+        env:
+          CRATE: ${{ matrix.crate }}
+        # Extract feature keys from `cargo metadata` for $CRATE and
+        # exercise each one in isolation. `default` is skipped —
+        # that's the opt-in alias, already exercised above via
+        # `--no-default-features`.
+        run: |
+          feats=$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c "import sys,json,os; m=json.load(sys.stdin); \
+                p=[x for x in m['packages'] if x['name']==os.environ['CRATE']][0]; \
+                print('\n'.join(f for f in p['features'] if f!='default'))")
+          if [ -z "$feats" ]; then
+            echo "no non-default features for $CRATE — nothing to do"
+            exit 0
+          fi
+          while IFS= read -r feat; do
+            [ -z "$feat" ] && continue
+            echo "== cargo check -p $CRATE --no-default-features --features $feat =="
+            cargo check -p "$CRATE" --no-default-features --features "$feat"
+          done <<< "$feats"
+
   # RFC-023 §4.1 + issue #365 — parity-drift lint for the PG ↔ SQLite
   # migration pair. Blocks PRs that add a PG migration without a
   # matching SQLite port (or an `.sqlite-skip` entry with an issue
@@ -471,7 +604,15 @@ jobs:
 
   matrix-tests-complete:
     name: matrix-tests-complete
-    needs: [matrix, matrix-postgres, lua-drift, migration-parity, smoke-sqlite]
+    needs:
+      - matrix
+      - matrix-postgres
+      - lua-drift
+      - migration-parity
+      - smoke-sqlite
+      - publish-list-drift
+      - non-exhaustive-lint
+      - feature-propagation
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -482,6 +623,9 @@ jobs:
           DRIFT_RESULT: ${{ needs.lua-drift.result }}
           MIGRATION_PARITY_RESULT: ${{ needs.migration-parity.result }}
           SMOKE_SQLITE_RESULT: ${{ needs.smoke-sqlite.result }}
+          PUBLISH_LIST_DRIFT_RESULT: ${{ needs.publish-list-drift.result }}
+          NON_EXHAUSTIVE_LINT_RESULT: ${{ needs.non-exhaustive-lint.result }}
+          FEATURE_PROPAGATION_RESULT: ${{ needs.feature-propagation.result }}
         run: |
           fail=0
           case "$MATRIX_RESULT" in
@@ -503,5 +647,17 @@ jobs:
           case "$SMOKE_SQLITE_RESULT" in
             success|skipped) echo "smoke-sqlite: $SMOKE_SQLITE_RESULT — ok" ;;
             *) echo "smoke-sqlite: $SMOKE_SQLITE_RESULT — blocking merge" >&2; fail=1 ;;
+          esac
+          case "$PUBLISH_LIST_DRIFT_RESULT" in
+            success|skipped) echo "publish-list-drift: $PUBLISH_LIST_DRIFT_RESULT — ok" ;;
+            *) echo "publish-list-drift: $PUBLISH_LIST_DRIFT_RESULT — blocking merge" >&2; fail=1 ;;
+          esac
+          case "$NON_EXHAUSTIVE_LINT_RESULT" in
+            success|skipped) echo "non-exhaustive-lint: $NON_EXHAUSTIVE_LINT_RESULT — ok" ;;
+            *) echo "non-exhaustive-lint: $NON_EXHAUSTIVE_LINT_RESULT — blocking merge" >&2; fail=1 ;;
+          esac
+          case "$FEATURE_PROPAGATION_RESULT" in
+            success|skipped) echo "feature-propagation: $FEATURE_PROPAGATION_RESULT — ok" ;;
+            *) echo "feature-propagation: $FEATURE_PROPAGATION_RESULT — blocking merge" >&2; fail=1 ;;
           esac
           exit $fail

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -426,7 +426,14 @@ jobs:
     name: ff-script lua drift
     runs-on: ubuntu-latest
     steps:
+      # `fetch-depth: 0` — the lua-version-bump step below diffs
+      # against `origin/${base_ref}`, which needs a merge-base. The
+      # default shallow clone (depth=1) breaks merge-base and
+      # previously masked the failure via `|| true`, silently
+      # bypassing the guard.
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
       - name: regenerate flowfabric.lua
         run: scripts/gen-ff-script-lua.sh
       - name: verify no drift
@@ -455,9 +462,17 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
+          # `set -e` is on by default in GitHub Actions `run:` steps.
+          # We want `git diff` failures to fail the step loudly rather
+          # than masking via `|| true` — a shallow-clone merge-base
+          # error would previously collapse the changed-file set to
+          # empty and let Lua edits through without a version bump.
+          # `fetch-depth: 0` on the checkout step above keeps merge-base
+          # resolvable; if either git call below errors, the whole
+          # step fails and a human investigates.
           git fetch --no-tags --depth=1 origin "$BASE_REF"
           changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- \
-            'crates/ff-script/**/*.lua' 'lua/**/*.lua' || true)
+            'crates/ff-script/**/*.lua' 'lua/**/*.lua')
           if [ -z "$changed" ]; then
             echo "No Lua source changes — version bump not required."
             exit 0
@@ -465,7 +480,7 @@ jobs:
           echo "Lua source changes in this PR:"
           echo "$changed"
           version_diff=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- \
-            crates/ff-script/src/flowfabric_lua_version || true)
+            crates/ff-script/src/flowfabric_lua_version)
           if [ -z "$version_diff" ]; then
             echo "::error::Lua sources changed but crates/ff-script/src/flowfabric_lua_version did NOT. ff-script gates FUNCTION LIBRARY reloads on this counter; edits without a bump leave deployed consumers on stale Lua (silent stale FCALLs). Bump the counter in the same commit. See project_ff_script_stale_lua_in_dev.md." >&2
             exit 1
@@ -517,8 +532,12 @@ jobs:
   # One matrix cell per publishable crate; inside each cell a shell
   # loop iterates features (N+1 checks; the Cartesian option is
   # rejected). Crate list hardcoded to match publish-list-lint's
-  # source of truth — if the two disagree, publish-list-drift fails
-  # first so this list cannot silently drift.
+  # source of truth; `publish-list-lint` parses THIS block as its
+  # 5th source and fails if the list drifts from the canonical four
+  # (workspace Cargo.toml / release.toml / release.yml / RELEASING.md).
+  # v0.13 target: generate this list at runtime from the
+  # `# LINT-PUBLISH-LIST-CRATE:` markers so there is a single source
+  # of truth instead of a lint-asserted mirror.
   feature-propagation:
     name: feature-propagation (${{ matrix.crate }})
     runs-on: ubuntu-latest

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -470,7 +470,13 @@ jobs:
           # `fetch-depth: 0` on the checkout step above keeps merge-base
           # resolvable; if either git call below errors, the whole
           # step fails and a human investigates.
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          #
+          # Omit `--depth` on the fetch below: a shallow `--depth=1`
+          # fetch of BASE_REF gives only the base tip with no parents,
+          # and `diff A...B` needs a merge-base which may be several
+          # commits back on a non-rebased PR. Full fetch is cheap here
+          # (workflow runs once per PR-update, not per commit).
+          git fetch --no-tags origin "$BASE_REF"
           changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- \
             'crates/ff-script/**/*.lua' 'lua/**/*.lua')
           if [ -z "$changed" ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "non-exhaustive-lint"
+version = "0.0.0"
+dependencies = [
+ "syn",
+ "walkdir",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,7 +2514,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2551,6 +2559,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "publish-list-lint"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -3232,6 +3248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,6 +3878,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,14 +3909,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3879,8 +3939,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4642,6 +4708,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ members = [
     "crates/ff-observability",
     "crates/ff-observability-http",
     "crates/flowfabric",
+    "tools/publish-list-lint",
+    "tools/non-exhaustive-lint",
 ]
 
 [workspace.package]

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,28 @@
+# LINT-PUBLISH-LIST:BEGIN
+# Structured, machine-readable source of truth for the publishable
+# crate set. Parsed by `tools/publish-list-lint` and cross-checked
+# against `.github/workflows/release.yml` + `docs/RELEASING.md`.
+#
+# Format: one `# LINT-PUBLISH-LIST-CRATE: <name>` line per publishable
+# crate, in publish (topological) order. Do NOT reorder without also
+# updating release.yml and RELEASING.md in the same PR.
+# See feedback_release_publish_list_drift.md — v0.3.0/v0.3.1 failed
+# twice from this drift; the lint guards against a third occurrence.
+# LINT-PUBLISH-LIST-CRATE: ferriskey
+# LINT-PUBLISH-LIST-CRATE: ff-core
+# LINT-PUBLISH-LIST-CRATE: ff-script
+# LINT-PUBLISH-LIST-CRATE: ff-observability
+# LINT-PUBLISH-LIST-CRATE: ff-observability-http
+# LINT-PUBLISH-LIST-CRATE: ff-scheduler
+# LINT-PUBLISH-LIST-CRATE: ff-backend-valkey
+# LINT-PUBLISH-LIST-CRATE: ff-backend-postgres
+# LINT-PUBLISH-LIST-CRATE: ff-backend-sqlite
+# LINT-PUBLISH-LIST-CRATE: ff-engine
+# LINT-PUBLISH-LIST-CRATE: ff-sdk
+# LINT-PUBLISH-LIST-CRATE: ff-server
+# LINT-PUBLISH-LIST-CRATE: flowfabric
+# LINT-PUBLISH-LIST:END
+
 # cargo-release config for FlowFabric workspace.
 #
 # This config drives `cargo release <level>` to perform a consolidated,

--- a/tools/non-exhaustive-lint/Cargo.toml
+++ b/tools/non-exhaustive-lint/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "non-exhaustive-lint"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[package.metadata.release]
+release = false
+
+[dependencies]
+syn = { version = "2", features = ["full", "parsing", "visit"] }
+walkdir = "2"

--- a/tools/non-exhaustive-lint/Cargo.toml
+++ b/tools/non-exhaustive-lint/Cargo.toml
@@ -2,6 +2,7 @@
 name = "non-exhaustive-lint"
 version = "0.0.0"
 edition = "2024"
+license = "Apache-2.0"
 publish = false
 
 [package.metadata.release]

--- a/tools/non-exhaustive-lint/README.md
+++ b/tools/non-exhaustive-lint/README.md
@@ -8,8 +8,14 @@ Accepted constructor shapes:
 - An inherent `impl Ty { pub fn <name>(...) -> Self }` or
   `impl Ty { pub fn <name>(...) -> Ty }` — any associated function
   that is `pub`, takes no `self` receiver, and returns the type by
-  value. Captures `new`, `builder`, `none`, `normal`, `with_ttl`,
-  `empty`, `from_parts`, etc.
+  value. Captures `new`, `none`, `normal`, `with_ttl`, `empty`,
+  `from_parts`, etc.
+- A `pub fn builder() -> BuilderTy` whose return type is a **separate
+  builder struct** is NOT counted here — the builder must itself have
+  a reachable `.build()`/`.finish()` path to `Ty`. In practice, pair
+  the `#[non_exhaustive]` target with either a direct-field
+  constructor (`pub fn new(...) -> Self`) or an `impl From<Builder>
+  for Ty`; the latter satisfies the lint via the `From` rule.
 - `impl From<...> for Ty`
 - `impl TryFrom<...> for Ty`
 - `impl Default for Ty`, or `#[derive(Default)]` on the struct.
@@ -68,7 +74,7 @@ Then:
 
 ```sh
 cargo run -p non-exhaustive-lint
-# Expected: exit 1 + "crates/ff-core/src/lib.rs:0 — DeadApi"
+# Expected: exit 1 + "crates/ff-core/src/lib.rs — DeadApi"
 ```
 
 Remove the marker (add `impl DeadApi { pub fn new() -> Self { ... } }`

--- a/tools/non-exhaustive-lint/README.md
+++ b/tools/non-exhaustive-lint/README.md
@@ -1,8 +1,18 @@
 # non-exhaustive-lint
 
-Flags `pub` **structs** marked `#[non_exhaustive]` that have no
-constructor (`fn new`, `fn builder`, `impl From<...>`, or `impl TryFrom<...>`)
-in the same file.
+Flags `pub` **structs** marked `#[non_exhaustive]` that have no public
+constructor in the same file.
+
+Accepted constructor shapes:
+
+- An inherent `impl Ty { pub fn <name>(...) -> Self }` or
+  `impl Ty { pub fn <name>(...) -> Ty }` — any associated function
+  that is `pub`, takes no `self` receiver, and returns the type by
+  value. Captures `new`, `builder`, `none`, `normal`, `with_ttl`,
+  `empty`, `from_parts`, etc.
+- `impl From<...> for Ty`
+- `impl TryFrom<...> for Ty`
+- `impl Default for Ty`, or `#[derive(Default)]` on the struct.
 
 Enums are intentionally skipped: `#[non_exhaustive]` on an enum only
 restricts `match` exhaustiveness, it does not block variant
@@ -19,13 +29,22 @@ merge.
 
 - Scan root: `crates/`. Excludes `tools/`, `examples/`, `benches/`,
   in-crate `tests/` + `benches/` subdirs, and `build.rs`.
-- Only top-level `pub` items (not `pub(crate)` etc.).
+- Any `pub` struct, anywhere in the file including nested modules.
+  `syn::visit` recurses into `mod` blocks; that matches the intent
+  (a `src/` tree routinely nests public types inside modules).
+- Only `pub` items (not `pub(crate)` / `pub(super)`).
 - Variant-level `#[non_exhaustive]` is out of scope.
 - Constructors are only detected in the SAME file as the type
   definition; re-exports are not followed. This is the deliberate
   "sufficient" bar per the plan decision: a type with its constructor
   far away is rare in this codebase and still catches a human reviewer's
   eye.
+
+## Parse failures are fatal
+
+If a `.rs` file under `crates/` cannot be read or parsed, the lint
+exits non-zero. Silently skipping on parse errors would let a genuine
+violation hide behind a syntax glitch.
 
 ## Run locally
 
@@ -53,4 +72,5 @@ cargo run -p non-exhaustive-lint
 ```
 
 Remove the marker (add `impl DeadApi { pub fn new() -> Self { ... } }`
-or `impl From<String> for DeadApi`) and the lint passes.
+or `impl From<String> for DeadApi`, or `#[derive(Default)]`) and the
+lint passes.

--- a/tools/non-exhaustive-lint/README.md
+++ b/tools/non-exhaustive-lint/README.md
@@ -1,0 +1,56 @@
+# non-exhaustive-lint
+
+Flags `pub` **structs** marked `#[non_exhaustive]` that have no
+constructor (`fn new`, `fn builder`, `impl From<...>`, or `impl TryFrom<...>`)
+in the same file.
+
+Enums are intentionally skipped: `#[non_exhaustive]` on an enum only
+restricts `match` exhaustiveness, it does not block variant
+construction (`Enum::Variant` still works downstream). Only structs
+become unbuildable when `#[non_exhaustive]` lands without a
+constructor.
+
+Motivation: `feedback_non_exhaustive_needs_constructor.md`. Such a type is
+unbuildable by downstream consumers and is effectively dead API. v0.3.2's
+smoke caught one example after the fact; this lint catches them before
+merge.
+
+## Scope
+
+- Scan root: `crates/`. Excludes `tools/`, `examples/`, `benches/`,
+  in-crate `tests/` + `benches/` subdirs, and `build.rs`.
+- Only top-level `pub` items (not `pub(crate)` etc.).
+- Variant-level `#[non_exhaustive]` is out of scope.
+- Constructors are only detected in the SAME file as the type
+  definition; re-exports are not followed. This is the deliberate
+  "sufficient" bar per the plan decision: a type with its constructor
+  far away is rare in this codebase and still catches a human reviewer's
+  eye.
+
+## Run locally
+
+```sh
+cargo run -p non-exhaustive-lint
+```
+
+## Reproduce a failure
+
+Add a throwaway violation:
+
+```rust
+// crates/ff-core/src/lib.rs (TEMP — do not commit)
+#[non_exhaustive]
+pub struct DeadApi {
+    pub name: String,
+}
+```
+
+Then:
+
+```sh
+cargo run -p non-exhaustive-lint
+# Expected: exit 1 + "crates/ff-core/src/lib.rs:0 — DeadApi"
+```
+
+Remove the marker (add `impl DeadApi { pub fn new() -> Self { ... } }`
+or `impl From<String> for DeadApi`) and the lint passes.

--- a/tools/non-exhaustive-lint/src/main.rs
+++ b/tools/non-exhaustive-lint/src/main.rs
@@ -1,0 +1,191 @@
+//! non-exhaustive-lint — flag `pub` items marked `#[non_exhaustive]`
+//! that have no constructor in the same file.
+//!
+//! Motivation: `feedback_non_exhaustive_needs_constructor.md`. A public
+//! #[non_exhaustive] type without a constructor is unbuildable outside
+//! the defining crate (downstream users cannot use struct literal
+//! syntax, and without a `fn new`/`fn builder`/`impl (Try)From` they
+//! have no way to obtain a value). v0.3.2 shipped such a dead API.
+//!
+//! Scope (per plan decision):
+//!   - A constructor in the SAME FILE as the type definition is
+//!     sufficient — re-exports are not followed, cross-file
+//!     constructors are not tolerated.
+//!   - Only `pub struct`s. Enums are intentionally skipped —
+//!     `#[non_exhaustive]` on an enum restricts `match` exhaustiveness
+//!     but does not block variant construction (`Enum::Variant` still
+//!     works downstream). Variant-level `#[non_exhaustive]` is also
+//!     out of scope.
+//!   - `pub(crate)` / `pub(super)` are ignored — only `pub` items.
+//!   - Accepted constructor shapes within the same file:
+//!       * an `impl Ty { fn new(...) -> ... }` (any visibility)
+//!       * an `impl Ty { fn builder(...) -> ... }` (any visibility)
+//!       * `impl From<_> for Ty`
+//!       * `impl TryFrom<_> for Ty`
+//!
+//! Scan root: `crates/` — the published surface. `tools/`, `examples/`,
+//! and `benches/` are excluded.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use syn::{Attribute, Item, ItemImpl, ItemStruct, Visibility, visit::Visit};
+use walkdir::WalkDir;
+
+fn main() -> ExitCode {
+    let repo = std::env::current_dir().expect("cwd");
+    let scan_root = repo.join("crates");
+    let mut findings: Vec<Finding> = Vec::new();
+    for entry in WalkDir::new(&scan_root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+    {
+        let path = entry.path();
+        // Skip tests/benches/examples/build.rs — consumer surface only.
+        if path_contains_component(path, "tests")
+            || path_contains_component(path, "benches")
+            || path_contains_component(path, "examples")
+            || path.file_name().and_then(|n| n.to_str()) == Some("build.rs")
+        {
+            continue;
+        }
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(file) = syn::parse_file(&src) else {
+            continue;
+        };
+        let mut v = FileVisitor::default();
+        v.visit_file(&file);
+        for (ty_name, span_line) in v.non_exhaustive_pub_types {
+            if !v.constructors.get(&ty_name).copied().unwrap_or(false) {
+                findings.push(Finding {
+                    path: path.strip_prefix(&repo).unwrap_or(path).to_path_buf(),
+                    ty: ty_name,
+                    line: span_line,
+                });
+            }
+        }
+    }
+
+    if findings.is_empty() {
+        println!("non-exhaustive-lint: OK — no violations found in crates/");
+        return ExitCode::SUCCESS;
+    }
+
+    eprintln!("non-exhaustive-lint: {} violation(s)", findings.len());
+    eprintln!();
+    eprintln!("Each of the following `pub` items is marked `#[non_exhaustive]`");
+    eprintln!("but has no sibling constructor (fn new / fn builder / impl From /");
+    eprintln!("impl TryFrom) in the same file. Downstream consumers cannot build");
+    eprintln!("a value — the type is effectively dead API.");
+    eprintln!();
+    eprintln!("See feedback_non_exhaustive_needs_constructor.md.");
+    eprintln!();
+    for f in &findings {
+        eprintln!("  {}:{} — {}", f.path.display(), f.line, f.ty);
+    }
+    ExitCode::FAILURE
+}
+
+#[derive(Debug)]
+struct Finding {
+    path: PathBuf,
+    ty: String,
+    line: usize,
+}
+
+fn path_contains_component(path: &Path, comp: &str) -> bool {
+    path.components()
+        .any(|c| c.as_os_str().to_str() == Some(comp))
+}
+
+#[derive(Default)]
+struct FileVisitor {
+    /// (type name, approximate line number) for each `pub` struct/enum
+    /// carrying `#[non_exhaustive]`.
+    non_exhaustive_pub_types: Vec<(String, usize)>,
+    /// Type name -> true if any constructor found in-file.
+    constructors: BTreeMap<String, bool>,
+}
+
+impl<'ast> Visit<'ast> for FileVisitor {
+    fn visit_item(&mut self, item: &'ast Item) {
+        match item {
+            Item::Struct(s) => self.check_struct(s),
+            Item::Impl(i) => self.check_impl(i),
+            _ => {}
+        }
+        syn::visit::visit_item(self, item);
+    }
+}
+
+impl FileVisitor {
+    fn check_struct(&mut self, s: &ItemStruct) {
+        if !is_pub(&s.vis) {
+            return;
+        }
+        if !has_non_exhaustive(&s.attrs) {
+            return;
+        }
+        // Unit / tuple / named-field structs all require an
+        // explicit constructor once #[non_exhaustive] is on — struct
+        // literal syntax is blocked downstream regardless of shape.
+        self.non_exhaustive_pub_types.push((s.ident.to_string(), 0));
+    }
+
+    fn check_impl(&mut self, i: &ItemImpl) {
+        // Target type name (only if it's a plain path like `Foo` or `Foo<T>`).
+        let Some(target) = impl_target_name(i) else {
+            return;
+        };
+
+        // `impl From<...> for Target` and `impl TryFrom<...> for Target`.
+        if let Some((_not, trait_, _for)) = &i.trait_ {
+            if let Some(last) = trait_.segments.last() {
+                let name = last.ident.to_string();
+                if name == "From" || name == "TryFrom" {
+                    self.constructors.insert(target, true);
+                    return;
+                }
+            }
+            // Other trait impls don't count as constructors.
+            return;
+        }
+
+        // Inherent impl — look for `fn new` / `fn builder` on the type.
+        for item in &i.items {
+            if let syn::ImplItem::Fn(m) = item {
+                let name = m.sig.ident.to_string();
+                if name == "new" || name == "builder" {
+                    self.constructors.insert(target.clone(), true);
+                }
+            }
+        }
+    }
+}
+
+fn is_pub(v: &Visibility) -> bool {
+    matches!(v, Visibility::Public(_))
+}
+
+fn has_non_exhaustive(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|a| a.path().is_ident("non_exhaustive"))
+}
+
+fn impl_target_name(i: &ItemImpl) -> Option<String> {
+    let ty = &*i.self_ty;
+    if let syn::Type::Path(tp) = ty {
+        return tp.path.segments.last().map(|s| s.ident.to_string());
+    }
+    None
+}
+
+// Line numbers are printed as 0 today — `syn` spans round-trip through
+// `proc_macro2` and surfacing `LineColumn` from non-proc-macro context
+// isn't stable. The type name is grep-able; that's sufficient for the
+// CI error to point at the right file.

--- a/tools/non-exhaustive-lint/src/main.rs
+++ b/tools/non-exhaustive-lint/src/main.rs
@@ -24,8 +24,11 @@
 //!       * an `impl Ty { pub fn <name>(...) -> Self }` — any public
 //!         associated function that returns `Self` (by value, not a
 //!         reference) and takes no `self` receiver. This captures
-//!         `new`, `builder`, `none`, `normal`, `with_ttl`, `empty`,
-//!         etc.
+//!         `new`, `none`, `normal`, `with_ttl`, `empty`, etc. A
+//!         `pub fn builder() -> BuilderTy` returning a *separate*
+//!         builder type does NOT count on its own — pair with an
+//!         `impl From<Builder> for Ty` so there is a reachable value
+//!         path to the target type.
 //!       * an `impl Ty { pub fn <name>(...) -> Ty }` — same but with
 //!         the type named explicitly.
 //!       * `impl From<_> for Ty`
@@ -88,12 +91,11 @@ fn main() -> ExitCode {
         };
         let mut v = FileVisitor::default();
         v.visit_file(&file);
-        for (ty_name, span_line) in v.non_exhaustive_pub_types {
+        for ty_name in v.non_exhaustive_pub_types {
             if !v.constructors.get(&ty_name).copied().unwrap_or(false) {
                 findings.push(Finding {
                     path: rel.clone(),
                     ty: ty_name,
-                    line: span_line,
                 });
             }
         }
@@ -132,7 +134,7 @@ fn main() -> ExitCode {
     eprintln!("See feedback_non_exhaustive_needs_constructor.md.");
     eprintln!();
     for f in &findings {
-        eprintln!("  {}:{} — {}", f.path.display(), f.line, f.ty);
+        eprintln!("  {} — {}", f.path.display(), f.ty);
     }
     ExitCode::FAILURE
 }
@@ -141,7 +143,6 @@ fn main() -> ExitCode {
 struct Finding {
     path: PathBuf,
     ty: String,
-    line: usize,
 }
 
 fn path_contains_component(path: &Path, comp: &str) -> bool {
@@ -151,9 +152,8 @@ fn path_contains_component(path: &Path, comp: &str) -> bool {
 
 #[derive(Default)]
 struct FileVisitor {
-    /// (type name, approximate line number) for each `pub` struct
-    /// carrying `#[non_exhaustive]`.
-    non_exhaustive_pub_types: Vec<(String, usize)>,
+    /// Type names of every `pub` struct carrying `#[non_exhaustive]`.
+    non_exhaustive_pub_types: Vec<String>,
     /// Type name -> true if any accepted constructor shape found in-file.
     constructors: BTreeMap<String, bool>,
 }
@@ -186,7 +186,7 @@ impl FileVisitor {
         if has_derive_default(&s.attrs) {
             self.constructors.insert(name.clone(), true);
         }
-        self.non_exhaustive_pub_types.push((name, 0));
+        self.non_exhaustive_pub_types.push(name);
     }
 
     fn check_impl(&mut self, i: &ItemImpl) {

--- a/tools/non-exhaustive-lint/src/main.rs
+++ b/tools/non-exhaustive-lint/src/main.rs
@@ -1,43 +1,61 @@
 //! non-exhaustive-lint — flag `pub` items marked `#[non_exhaustive]`
-//! that have no constructor in the same file.
+//! that have no public constructor in the same file.
 //!
 //! Motivation: `feedback_non_exhaustive_needs_constructor.md`. A public
 //! #[non_exhaustive] type without a constructor is unbuildable outside
 //! the defining crate (downstream users cannot use struct literal
-//! syntax, and without a `fn new`/`fn builder`/`impl (Try)From` they
-//! have no way to obtain a value). v0.3.2 shipped such a dead API.
+//! syntax, and without a `pub fn` returning `Self` / `Type` or a
+//! `From`/`TryFrom` impl they have no way to obtain a value). v0.3.2
+//! shipped such a dead API.
 //!
 //! Scope (per plan decision):
 //!   - A constructor in the SAME FILE as the type definition is
 //!     sufficient — re-exports are not followed, cross-file
 //!     constructors are not tolerated.
-//!   - Only `pub struct`s. Enums are intentionally skipped —
-//!     `#[non_exhaustive]` on an enum restricts `match` exhaustiveness
-//!     but does not block variant construction (`Enum::Variant` still
-//!     works downstream). Variant-level `#[non_exhaustive]` is also
-//!     out of scope.
+//!   - Only `pub` structs (anywhere in the file, including nested
+//!     modules — `syn::visit` recurses, which matches the intent:
+//!     `src/` trees routinely nest public types inside `mod`s).
+//!     Enums are intentionally skipped — `#[non_exhaustive]` on an
+//!     enum restricts `match` exhaustiveness but does not block
+//!     variant construction (`Enum::Variant` still works downstream).
+//!     Variant-level `#[non_exhaustive]` is also out of scope.
 //!   - `pub(crate)` / `pub(super)` are ignored — only `pub` items.
 //!   - Accepted constructor shapes within the same file:
-//!       * an `impl Ty { fn new(...) -> ... }` (any visibility)
-//!       * an `impl Ty { fn builder(...) -> ... }` (any visibility)
+//!       * an `impl Ty { pub fn <name>(...) -> Self }` — any public
+//!         associated function that returns `Self` (by value, not a
+//!         reference) and takes no `self` receiver. This captures
+//!         `new`, `builder`, `none`, `normal`, `with_ttl`, `empty`,
+//!         etc.
+//!       * an `impl Ty { pub fn <name>(...) -> Ty }` — same but with
+//!         the type named explicitly.
 //!       * `impl From<_> for Ty`
 //!       * `impl TryFrom<_> for Ty`
+//!       * `impl Default for Ty` (derive counted via the struct's own
+//!         `#[derive(Default)]` attr, handled below).
 //!
 //! Scan root: `crates/` — the published surface. `tools/`, `examples/`,
 //! and `benches/` are excluded.
+//!
+//! Parse failures are fatal: a `.rs` file under `crates/` that cannot
+//! be read or parsed is treated as a lint error, not silently skipped.
+//! Skipping on parse error would let a genuine violation hide behind a
+//! syntax glitch in the same file.
 
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use syn::{Attribute, Item, ItemImpl, ItemStruct, Visibility, visit::Visit};
+use syn::{
+    Attribute, Item, ItemImpl, ItemStruct, ReturnType, Type, Visibility, visit::Visit,
+};
 use walkdir::WalkDir;
 
 fn main() -> ExitCode {
     let repo = std::env::current_dir().expect("cwd");
     let scan_root = repo.join("crates");
     let mut findings: Vec<Finding> = Vec::new();
+    let mut parse_errors: Vec<String> = Vec::new();
     for entry in WalkDir::new(&scan_root)
         .into_iter()
         .filter_map(Result::ok)
@@ -53,23 +71,49 @@ fn main() -> ExitCode {
         {
             continue;
         }
-        let Ok(src) = fs::read_to_string(path) else {
-            continue;
+        let rel = path.strip_prefix(&repo).unwrap_or(path).to_path_buf();
+        let src = match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                parse_errors.push(format!("read {}: {e}", rel.display()));
+                continue;
+            }
         };
-        let Ok(file) = syn::parse_file(&src) else {
-            continue;
+        let file = match syn::parse_file(&src) {
+            Ok(f) => f,
+            Err(e) => {
+                parse_errors.push(format!("parse {}: {e}", rel.display()));
+                continue;
+            }
         };
         let mut v = FileVisitor::default();
         v.visit_file(&file);
         for (ty_name, span_line) in v.non_exhaustive_pub_types {
             if !v.constructors.get(&ty_name).copied().unwrap_or(false) {
                 findings.push(Finding {
-                    path: path.strip_prefix(&repo).unwrap_or(path).to_path_buf(),
+                    path: rel.clone(),
                     ty: ty_name,
                     line: span_line,
                 });
             }
         }
+    }
+
+    if !parse_errors.is_empty() {
+        eprintln!(
+            "non-exhaustive-lint: {} file(s) under crates/ failed to read/parse",
+            parse_errors.len()
+        );
+        eprintln!();
+        eprintln!(
+            "Skipping on parse errors would let genuine violations hide behind syntax glitches."
+        );
+        eprintln!("Fix the file or exclude it explicitly if intentional.");
+        eprintln!();
+        for e in &parse_errors {
+            eprintln!("  {e}");
+        }
+        return ExitCode::FAILURE;
     }
 
     if findings.is_empty() {
@@ -80,9 +124,10 @@ fn main() -> ExitCode {
     eprintln!("non-exhaustive-lint: {} violation(s)", findings.len());
     eprintln!();
     eprintln!("Each of the following `pub` items is marked `#[non_exhaustive]`");
-    eprintln!("but has no sibling constructor (fn new / fn builder / impl From /");
-    eprintln!("impl TryFrom) in the same file. Downstream consumers cannot build");
-    eprintln!("a value — the type is effectively dead API.");
+    eprintln!("but has no sibling public constructor (pub fn returning Self / Ty,");
+    eprintln!("#[derive(Default)], impl Default, impl From, impl TryFrom) in the");
+    eprintln!("same file. Downstream consumers cannot build a value — the type is");
+    eprintln!("effectively dead API.");
     eprintln!();
     eprintln!("See feedback_non_exhaustive_needs_constructor.md.");
     eprintln!();
@@ -106,10 +151,10 @@ fn path_contains_component(path: &Path, comp: &str) -> bool {
 
 #[derive(Default)]
 struct FileVisitor {
-    /// (type name, approximate line number) for each `pub` struct/enum
+    /// (type name, approximate line number) for each `pub` struct
     /// carrying `#[non_exhaustive]`.
     non_exhaustive_pub_types: Vec<(String, usize)>,
-    /// Type name -> true if any constructor found in-file.
+    /// Type name -> true if any accepted constructor shape found in-file.
     constructors: BTreeMap<String, bool>,
 }
 
@@ -135,7 +180,13 @@ impl FileVisitor {
         // Unit / tuple / named-field structs all require an
         // explicit constructor once #[non_exhaustive] is on — struct
         // literal syntax is blocked downstream regardless of shape.
-        self.non_exhaustive_pub_types.push((s.ident.to_string(), 0));
+        let name = s.ident.to_string();
+        // `#[derive(Default)]` on the struct itself is an acceptable
+        // constructor: downstream can call `Ty::default()`.
+        if has_derive_default(&s.attrs) {
+            self.constructors.insert(name.clone(), true);
+        }
+        self.non_exhaustive_pub_types.push((name, 0));
     }
 
     fn check_impl(&mut self, i: &ItemImpl) {
@@ -144,11 +195,12 @@ impl FileVisitor {
             return;
         };
 
-        // `impl From<...> for Target` and `impl TryFrom<...> for Target`.
+        // `impl From<...> for Target`, `impl TryFrom<...> for Target`,
+        // `impl Default for Target`.
         if let Some((_not, trait_, _for)) = &i.trait_ {
             if let Some(last) = trait_.segments.last() {
                 let name = last.ident.to_string();
-                if name == "From" || name == "TryFrom" {
+                if name == "From" || name == "TryFrom" || name == "Default" {
                     self.constructors.insert(target, true);
                     return;
                 }
@@ -157,11 +209,21 @@ impl FileVisitor {
             return;
         }
 
-        // Inherent impl — look for `fn new` / `fn builder` on the type.
+        // Inherent impl — look for any `pub fn` that takes no `self`
+        // receiver and returns `Self` or the target type by value.
+        // This captures `new`, `builder`, `none`, `normal`, `empty`,
+        // `with_ttl`, `from_parts`, etc.
         for item in &i.items {
             if let syn::ImplItem::Fn(m) = item {
-                let name = m.sig.ident.to_string();
-                if name == "new" || name == "builder" {
+                if !matches!(m.vis, Visibility::Public(_)) {
+                    continue;
+                }
+                // Skip methods — a method (has a `self` receiver) is
+                // not a consumer-side constructor.
+                if m.sig.inputs.iter().any(|arg| matches!(arg, syn::FnArg::Receiver(_))) {
+                    continue;
+                }
+                if fn_returns_target_by_value(&m.sig.output, &target) {
                     self.constructors.insert(target.clone(), true);
                 }
             }
@@ -177,15 +239,53 @@ fn has_non_exhaustive(attrs: &[Attribute]) -> bool {
     attrs.iter().any(|a| a.path().is_ident("non_exhaustive"))
 }
 
+fn has_derive_default(attrs: &[Attribute]) -> bool {
+    for a in attrs {
+        if !a.path().is_ident("derive") {
+            continue;
+        }
+        let mut found = false;
+        let _ = a.parse_nested_meta(|meta| {
+            if meta.path.is_ident("Default") {
+                found = true;
+            }
+            Ok(())
+        });
+        if found {
+            return true;
+        }
+    }
+    false
+}
+
 fn impl_target_name(i: &ItemImpl) -> Option<String> {
     let ty = &*i.self_ty;
-    if let syn::Type::Path(tp) = ty {
+    if let Type::Path(tp) = ty {
         return tp.path.segments.last().map(|s| s.ident.to_string());
     }
     None
 }
 
-// Line numbers are printed as 0 today — `syn` spans round-trip through
-// `proc_macro2` and surfacing `LineColumn` from non-proc-macro context
-// isn't stable. The type name is grep-able; that's sufficient for the
-// CI error to point at the right file.
+/// `true` iff the function signature returns `Self` or `<target>`
+/// by value — not a reference, not `Option<Self>`, not
+/// `Result<Self, _>`. We deliberately stay strict: a consumer-side
+/// constructor must yield a value the caller can bind directly.
+///
+/// Bare-value `Self`/`Ty` is the common shape (`fn none() -> Self`,
+/// `fn new() -> Ty`); `Result<Self, E>` fallible constructors are
+/// handled via `impl TryFrom` or by pairing with an infallible
+/// constructor. If that proves too strict in practice we'll widen;
+/// today every live constructor in crates/ fits this shape.
+fn fn_returns_target_by_value(ret: &ReturnType, target: &str) -> bool {
+    let ReturnType::Type(_, ty) = ret else {
+        return false;
+    };
+    let Type::Path(tp) = &**ty else {
+        return false;
+    };
+    let Some(last) = tp.path.segments.last() else {
+        return false;
+    };
+    let name = last.ident.to_string();
+    name == "Self" || name == target
+}

--- a/tools/publish-list-lint/Cargo.toml
+++ b/tools/publish-list-lint/Cargo.toml
@@ -2,6 +2,7 @@
 name = "publish-list-lint"
 version = "0.0.0"
 edition = "2024"
+license = "Apache-2.0"
 publish = false
 
 [package.metadata.release]

--- a/tools/publish-list-lint/Cargo.toml
+++ b/tools/publish-list-lint/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "publish-list-lint"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[package.metadata.release]
+release = false
+
+[dependencies]
+toml = "0.8"
+serde = { workspace = true }

--- a/tools/publish-list-lint/README.md
+++ b/tools/publish-list-lint/README.md
@@ -1,0 +1,45 @@
+# publish-list-lint
+
+Cross-checks the publishable crate set across four sources of truth:
+
+1. Workspace `Cargo.toml` members (filtered by `publish != false` AND
+   `package.metadata.release.release != false`).
+2. `release.toml` — structured `# LINT-PUBLISH-LIST-CRATE:` marker block.
+3. `.github/workflows/release.yml` — `cargo publish -p <name>` steps.
+4. `docs/RELEASING.md` — "What gets published" numbered list.
+
+Fails CI if any of the four disagree.
+
+Motivation: `feedback_release_publish_list_drift.md`. Adding a new publishable
+workspace crate requires updating all four locations in the same PR; v0.3.0
+and v0.3.1 each partial-published because one of them was missed.
+
+## Run locally
+
+```sh
+cargo run -p publish-list-lint
+```
+
+## Reproduce a failure
+
+Run from the repo root:
+
+```sh
+# 1) Rename one entry in release.toml's LINT-PUBLISH-LIST block:
+sed -i 's/LINT-PUBLISH-LIST-CRATE: flowfabric/LINT-PUBLISH-LIST-CRATE: flowfabrik/' release.toml
+
+cargo run -p publish-list-lint
+# Expected: exit 1 + diff message identifying `flowfabric` as missing
+# from release.toml and `flowfabrik` as present in release.toml only.
+
+git checkout release.toml
+```
+
+## Decisions
+
+- **Structured markers over free-text parsing** — fragile-comment regex is
+  explicitly rejected. The `# LINT-PUBLISH-LIST-CRATE:` prefix is part of the
+  contract; removing or renaming it breaks this lint.
+- **Plain-text scan of release.yml** — keeps the tool a single dep. A full
+  YAML parse would need `serde_yaml` with its security caveats; the
+  `cargo publish -p <name>` pattern is stable across all 13 steps.

--- a/tools/publish-list-lint/README.md
+++ b/tools/publish-list-lint/README.md
@@ -1,14 +1,30 @@
 # publish-list-lint
 
-Cross-checks the publishable crate set across four sources of truth:
+Cross-checks the publishable crate set across five sources of truth:
 
-1. Workspace `Cargo.toml` members (filtered by `publish != false` AND
-   `package.metadata.release.release != false`).
+1. Workspace `Cargo.toml` members (filtered by `publish != false` — both
+   boolean `false` and the empty-array form `publish = []` count as
+   unpublishable — AND `package.metadata.release.release != false`).
 2. `release.toml` — structured `# LINT-PUBLISH-LIST-CRATE:` marker block.
 3. `.github/workflows/release.yml` — `cargo publish -p <name>` steps.
 4. `docs/RELEASING.md` — "What gets published" numbered list.
+5. `.github/workflows/matrix.yml` — `feature-propagation` matrix
+   `crate:` list.
 
-Fails CI if any of the four disagree.
+Fails CI if any of the five disagree as a set. Additionally asserts
+that `release.toml` and `release.yml` agree on *publish order* — the
+two author the same topological sequence, so order drift between them
+means the doc lies about what the workflow actually does. `docs/RELEASING.md`
+and the feature-propagation matrix are order-free (narrative + parallel
+sharding respectively).
+
+### Follow-up (v0.13 target)
+
+Replace the hardcoded `crate:` list in the feature-propagation matrix
+with a setup step that generates it from the `# LINT-PUBLISH-LIST-CRATE:`
+markers at runtime, so there is a single source of truth instead of a
+lint-asserted mirror. The current design trades a lint extension for
+faster v0.12 ship; a dynamic matrix is the correct endgame.
 
 Motivation: `feedback_release_publish_list_drift.md`. Adding a new publishable
 workspace crate requires updating all four locations in the same PR; v0.3.0

--- a/tools/publish-list-lint/src/main.rs
+++ b/tools/publish-list-lint/src/main.rs
@@ -3,17 +3,36 @@
 //!
 //! Sources:
 //!   - Workspace `Cargo.toml` members, filtered by `package.publish != false`
+//!     (also treats the empty-array form `publish = []` as unpublishable)
 //!     AND `package.metadata.release.release != false`. This is the ground
 //!     truth derived from the source tree.
 //!   - `release.toml` `# LINT-PUBLISH-LIST-CRATE:` marker block
-//!     (structured, in publish order).
-//!   - `.github/workflows/release.yml` — `cargo publish -p <name>` steps.
+//!     (structured, in publish/topological order).
+//!   - `.github/workflows/release.yml` — `cargo publish -p <name>` steps
+//!     (in publish/topological order).
 //!   - `docs/RELEASING.md` — numbered publish list.
+//!   - `.github/workflows/matrix.yml` — `feature-propagation` matrix
+//!     `crate:` list (order not asserted; this is a parallel check).
 //!
-//! Fails with exit 1 if any of the four sources disagree.
+//! Equality is asserted as a set across all five sources. In addition,
+//! the two publish-ordered sources (`release.toml` + `release.yml`) must
+//! agree on *sequence*, because the release workflow publishes in the
+//! `release.yml` order and `release.toml` documents that order for
+//! humans — drift between them means the doc lies about what the
+//! workflow does. `docs/RELEASING.md` is human-authored narrative and
+//! the feature-propagation matrix is parallel-sharded, so their order
+//! is not asserted.
+//!
+//! Fails with exit 1 if any source disagrees.
 //!
 //! See `feedback_release_publish_list_drift.md` — v0.3.0/v0.3.1 failed
 //! twice from publish-list drift.
+//!
+//! Follow-up (v0.13 target): replace the hardcoded feature-propagation
+//! matrix `crate:` list in `.github/workflows/matrix.yml` with a setup
+//! step that generates it from the `# LINT-PUBLISH-LIST-CRATE:` markers
+//! at runtime, eliminating the fifth copy entirely. The v0.12 lint
+//! extension below is the faster-to-ship interim guardrail.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -60,8 +79,9 @@ fn main() -> ExitCode {
                 "Sources of truth must agree: workspace Cargo.toml (publish=true + metadata.release.release!=false),"
             );
             eprintln!(
-                "  release.toml LINT-PUBLISH-LIST-CRATE block, .github/workflows/release.yml, docs/RELEASING.md."
+                "  release.toml LINT-PUBLISH-LIST block, .github/workflows/release.yml, docs/RELEASING.md,"
             );
+            eprintln!("  .github/workflows/matrix.yml feature-propagation matrix.");
             eprintln!("See feedback_release_publish_list_drift.md");
             ExitCode::FAILURE
         }
@@ -77,9 +97,13 @@ fn repo_root() -> PathBuf {
 
 fn run(repo: &Path) -> Result<(), Vec<String>> {
     let publishable_from_workspace = discover_publishable(repo).map_err(|e| vec![e])?;
-    let from_release_toml = parse_release_toml(repo).map_err(|e| vec![e])?;
-    let from_release_yml = parse_release_yml(repo).map_err(|e| vec![e])?;
+    let (from_release_toml_set, from_release_toml_vec) =
+        parse_release_toml(repo).map_err(|e| vec![e])?;
+    let (from_release_yml_set, from_release_yml_vec) =
+        parse_release_yml(repo).map_err(|e| vec![e])?;
     let from_releasing_md = parse_releasing_md(repo).map_err(|e| vec![e])?;
+    let from_feature_propagation =
+        parse_feature_propagation_matrix(repo).map_err(|e| vec![e])?;
 
     let mut errs = Vec::new();
 
@@ -87,14 +111,14 @@ fn run(repo: &Path) -> Result<(), Vec<String>> {
         "workspace Cargo.toml",
         "release.toml LINT-PUBLISH-LIST",
         &publishable_from_workspace,
-        &from_release_toml,
+        &from_release_toml_set,
         &mut errs,
     );
     diff(
         "workspace Cargo.toml",
         ".github/workflows/release.yml",
         &publishable_from_workspace,
-        &from_release_yml,
+        &from_release_yml_set,
         &mut errs,
     );
     diff(
@@ -104,6 +128,23 @@ fn run(repo: &Path) -> Result<(), Vec<String>> {
         &from_releasing_md,
         &mut errs,
     );
+    diff(
+        "workspace Cargo.toml",
+        ".github/workflows/matrix.yml feature-propagation",
+        &publishable_from_workspace,
+        &from_feature_propagation,
+        &mut errs,
+    );
+
+    // Order check: release.toml and release.yml publish order must agree.
+    // (docs/RELEASING.md + feature-propagation are parallel/narrative and
+    // intentionally order-free.)
+    if from_release_toml_vec != from_release_yml_vec {
+        errs.push(format!(
+            "release.toml LINT-PUBLISH-LIST order disagrees with release.yml publish step order:\n     release.toml: {:?}\n     release.yml : {:?}",
+            from_release_toml_vec, from_release_yml_vec
+        ));
+    }
 
     if errs.is_empty() {
         let mut names: Vec<_> = publishable_from_workspace.iter().cloned().collect();
@@ -162,11 +203,17 @@ fn discover_publishable(repo: &Path) -> Result<BTreeSet<String>, String> {
             continue;
         };
 
-        // `publish = false` => not publishable.
-        if let Some(p) = &pkg.publish
-            && p.as_bool() == Some(false)
-        {
-            continue;
+        // Cargo treats both `publish = false` AND `publish = []` (an
+        // empty array of registries) as "do not publish". Handle both.
+        if let Some(p) = &pkg.publish {
+            if p.as_bool() == Some(false) {
+                continue;
+            }
+            if let Some(arr) = p.as_array()
+                && arr.is_empty()
+            {
+                continue;
+            }
         }
 
         // [package.metadata.release] release = false => excluded.
@@ -182,11 +229,12 @@ fn discover_publishable(repo: &Path) -> Result<BTreeSet<String>, String> {
     Ok(publishable)
 }
 
-fn parse_release_toml(repo: &Path) -> Result<BTreeSet<String>, String> {
+fn parse_release_toml(repo: &Path) -> Result<(BTreeSet<String>, Vec<String>), String> {
     let raw = fs::read_to_string(repo.join("release.toml"))
         .map_err(|e| format!("reading release.toml: {e}"))?;
     let mut in_block = false;
     let mut set = BTreeSet::new();
+    let mut order = Vec::new();
     for line in raw.lines() {
         let t = line.trim();
         if t == "# LINT-PUBLISH-LIST:BEGIN" {
@@ -203,23 +251,25 @@ fn parse_release_toml(repo: &Path) -> Result<BTreeSet<String>, String> {
         if let Some(rest) = t.strip_prefix("# LINT-PUBLISH-LIST-CRATE:") {
             let name = rest.trim().to_string();
             if !name.is_empty() {
-                set.insert(name);
+                set.insert(name.clone());
+                order.push(name);
             }
         }
     }
     if set.is_empty() {
         return Err("release.toml missing LINT-PUBLISH-LIST block or it's empty".into());
     }
-    Ok(set)
+    Ok((set, order))
 }
 
-fn parse_release_yml(repo: &Path) -> Result<BTreeSet<String>, String> {
+fn parse_release_yml(repo: &Path) -> Result<(BTreeSet<String>, Vec<String>), String> {
     // Plain-text scan: each publish step has a run line containing
     // `cargo publish -p <name>`. Avoids a full YAML dep for a single
     // grep-style extraction.
     let raw = fs::read_to_string(repo.join(".github/workflows/release.yml"))
         .map_err(|e| format!("reading release.yml: {e}"))?;
     let mut set = BTreeSet::new();
+    let mut order = Vec::new();
     for line in raw.lines() {
         let t = line.trim();
         if let Some(idx) = t.find("cargo publish -p ") {
@@ -227,14 +277,15 @@ fn parse_release_yml(repo: &Path) -> Result<BTreeSet<String>, String> {
             // take until first whitespace
             let name: String = rest.chars().take_while(|c| !c.is_whitespace()).collect();
             if !name.is_empty() {
-                set.insert(name);
+                set.insert(name.clone());
+                order.push(name);
             }
         }
     }
     if set.is_empty() {
         return Err("release.yml contains no `cargo publish -p` steps".into());
     }
-    Ok(set)
+    Ok((set, order))
 }
 
 fn parse_releasing_md(repo: &Path) -> Result<BTreeSet<String>, String> {
@@ -254,25 +305,97 @@ fn parse_releasing_md(repo: &Path) -> Result<BTreeSet<String>, String> {
             continue;
         }
         // Numbered-list entry: "1. `ferriskey`", allowing indentation.
+        // We peel off any ASCII-digit prefix, then require ". `name`".
         let t = line.trim_start();
-        if let Some(after_num) = t.strip_prefix(|c: char| c.is_ascii_digit()) {
-            // strip further digits in case of "10."
-            let after_num = after_num.trim_start_matches(|c: char| c.is_ascii_digit());
-            if let Some(after_dot) = after_num.strip_prefix(". ")
-                && let Some(rest) = after_dot.strip_prefix('`')
-                && let Some(end) = rest.find('`')
-            {
-                set.insert(rest[..end].to_string());
+        let first = t.chars().next();
+        if !matches!(first, Some(c) if c.is_ascii_digit()) {
+            // Stop once we hit the "Excluded" subheader.
+            if line.starts_with("Excluded from publish") {
+                break;
             }
+            continue;
         }
-        // Stop once we hit the "Excluded" subheader.
-        if line.starts_with("Excluded from publish") {
-            break;
+        let after_num = t.trim_start_matches(|c: char| c.is_ascii_digit());
+        if let Some(after_dot) = after_num.strip_prefix(". ")
+            && let Some(rest) = after_dot.strip_prefix('`')
+            && let Some(end) = rest.find('`')
+        {
+            set.insert(rest[..end].to_string());
         }
     }
     if set.is_empty() {
         return Err(
             "docs/RELEASING.md 'What gets published' section yielded no crate names".into(),
+        );
+    }
+    Ok(set)
+}
+
+fn parse_feature_propagation_matrix(repo: &Path) -> Result<BTreeSet<String>, String> {
+    // Plain-text scan of `.github/workflows/matrix.yml` for the
+    // `feature-propagation:` job's `matrix.crate:` list. We locate the
+    // `feature-propagation:` job header, then find the `crate:` key
+    // and collect the subsequent `- <name>` entries until indentation
+    // drops out of the list. A full YAML parse is avoided for the same
+    // reason as parse_release_yml — single-key extraction, no security
+    // caveats, stable input shape.
+    let path = repo.join(".github/workflows/matrix.yml");
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let mut set = BTreeSet::new();
+    let mut in_job = false;
+    let mut in_crate_list = false;
+    let mut list_indent: Option<usize> = None;
+    for line in raw.lines() {
+        if line.starts_with("  feature-propagation:") {
+            in_job = true;
+            continue;
+        }
+        if !in_job {
+            continue;
+        }
+        // Next top-level (2-space indent) job header ends our scan.
+        if line.starts_with("  ")
+            && !line.starts_with("   ")
+            && line.trim_end().ends_with(':')
+            && !line.trim_start().starts_with('-')
+            && !line.starts_with("  feature-propagation:")
+        {
+            break;
+        }
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("crate:") {
+            in_crate_list = true;
+            list_indent = None;
+            continue;
+        }
+        if in_crate_list {
+            if !trimmed.starts_with("- ") {
+                // Either a sibling key or end-of-list.
+                if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                    in_crate_list = false;
+                }
+                continue;
+            }
+            let indent = line.len() - trimmed.len();
+            match list_indent {
+                None => list_indent = Some(indent),
+                Some(expected) if expected != indent => {
+                    in_crate_list = false;
+                    continue;
+                }
+                _ => {}
+            }
+            let name = trimmed.trim_start_matches("- ").trim().to_string();
+            if !name.is_empty() {
+                set.insert(name);
+            }
+        }
+    }
+    if set.is_empty() {
+        return Err(
+            ".github/workflows/matrix.yml feature-propagation matrix yielded no crate names"
+                .into(),
         );
     }
     Ok(set)

--- a/tools/publish-list-lint/src/main.rs
+++ b/tools/publish-list-lint/src/main.rs
@@ -1,0 +1,279 @@
+//! publish-list-lint — cross-check the publishable crate set against
+//! every place it's enumerated.
+//!
+//! Sources:
+//!   - Workspace `Cargo.toml` members, filtered by `package.publish != false`
+//!     AND `package.metadata.release.release != false`. This is the ground
+//!     truth derived from the source tree.
+//!   - `release.toml` `# LINT-PUBLISH-LIST-CRATE:` marker block
+//!     (structured, in publish order).
+//!   - `.github/workflows/release.yml` — `cargo publish -p <name>` steps.
+//!   - `docs/RELEASING.md` — numbered publish list.
+//!
+//! Fails with exit 1 if any of the four sources disagree.
+//!
+//! See `feedback_release_publish_list_drift.md` — v0.3.0/v0.3.1 failed
+//! twice from publish-list drift.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceRoot {
+    workspace: WorkspaceSection,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceSection {
+    members: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CrateManifest {
+    package: Option<CratePackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CratePackage {
+    name: String,
+    #[serde(default)]
+    publish: Option<toml::Value>,
+    #[serde(default)]
+    metadata: Option<toml::Value>,
+}
+
+fn main() -> ExitCode {
+    let repo = repo_root();
+    match run(&repo) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(errs) => {
+            eprintln!("publish-list-lint: FAIL");
+            for e in &errs {
+                eprintln!("  - {e}");
+            }
+            eprintln!();
+            eprintln!(
+                "Sources of truth must agree: workspace Cargo.toml (publish=true + metadata.release.release!=false),"
+            );
+            eprintln!(
+                "  release.toml LINT-PUBLISH-LIST-CRATE block, .github/workflows/release.yml, docs/RELEASING.md."
+            );
+            eprintln!("See feedback_release_publish_list_drift.md");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn repo_root() -> PathBuf {
+    // The binary is run as `cargo run -p publish-list-lint` from the
+    // workspace root, so CWD is the repo root. CI and the
+    // pre-publish rehearsal both invoke it that way.
+    std::env::current_dir().expect("cwd")
+}
+
+fn run(repo: &Path) -> Result<(), Vec<String>> {
+    let publishable_from_workspace = discover_publishable(repo).map_err(|e| vec![e])?;
+    let from_release_toml = parse_release_toml(repo).map_err(|e| vec![e])?;
+    let from_release_yml = parse_release_yml(repo).map_err(|e| vec![e])?;
+    let from_releasing_md = parse_releasing_md(repo).map_err(|e| vec![e])?;
+
+    let mut errs = Vec::new();
+
+    diff(
+        "workspace Cargo.toml",
+        "release.toml LINT-PUBLISH-LIST",
+        &publishable_from_workspace,
+        &from_release_toml,
+        &mut errs,
+    );
+    diff(
+        "workspace Cargo.toml",
+        ".github/workflows/release.yml",
+        &publishable_from_workspace,
+        &from_release_yml,
+        &mut errs,
+    );
+    diff(
+        "workspace Cargo.toml",
+        "docs/RELEASING.md",
+        &publishable_from_workspace,
+        &from_releasing_md,
+        &mut errs,
+    );
+
+    if errs.is_empty() {
+        let mut names: Vec<_> = publishable_from_workspace.iter().cloned().collect();
+        names.sort();
+        println!(
+            "publish-list-lint: OK — {} publishable crates agree across all sources:",
+            names.len()
+        );
+        for n in names {
+            println!("  {n}");
+        }
+        Ok(())
+    } else {
+        Err(errs)
+    }
+}
+
+fn diff(
+    a_name: &str,
+    b_name: &str,
+    a: &BTreeSet<String>,
+    b: &BTreeSet<String>,
+    errs: &mut Vec<String>,
+) {
+    let only_a: Vec<_> = a.difference(b).cloned().collect();
+    let only_b: Vec<_> = b.difference(a).cloned().collect();
+    if !only_a.is_empty() {
+        errs.push(format!(
+            "{a_name} lists crates missing from {b_name}: {only_a:?}"
+        ));
+    }
+    if !only_b.is_empty() {
+        errs.push(format!(
+            "{b_name} lists crates missing from {a_name}: {only_b:?}"
+        ));
+    }
+}
+
+fn discover_publishable(repo: &Path) -> Result<BTreeSet<String>, String> {
+    let root: WorkspaceRoot = toml::from_str(
+        &fs::read_to_string(repo.join("Cargo.toml"))
+            .map_err(|e| format!("reading Cargo.toml: {e}"))?,
+    )
+    .map_err(|e| format!("parsing Cargo.toml: {e}"))?;
+
+    let mut publishable = BTreeSet::new();
+    for member in &root.workspace.members {
+        // Skip `tools/*` — those are self-declared publish = false.
+        // We still parse them below, but they won't make the cut.
+        let manifest_path = repo.join(member).join("Cargo.toml");
+        let raw = fs::read_to_string(&manifest_path)
+            .map_err(|e| format!("reading {}: {e}", manifest_path.display()))?;
+        let manifest: CrateManifest = toml::from_str(&raw)
+            .map_err(|e| format!("parsing {}: {e}", manifest_path.display()))?;
+        let Some(pkg) = manifest.package else {
+            continue;
+        };
+
+        // `publish = false` => not publishable.
+        if let Some(p) = &pkg.publish
+            && p.as_bool() == Some(false)
+        {
+            continue;
+        }
+
+        // [package.metadata.release] release = false => excluded.
+        if let Some(meta) = &pkg.metadata
+            && let Some(release) = meta.get("release")
+            && release.get("release").and_then(|v| v.as_bool()) == Some(false)
+        {
+            continue;
+        }
+
+        publishable.insert(pkg.name);
+    }
+    Ok(publishable)
+}
+
+fn parse_release_toml(repo: &Path) -> Result<BTreeSet<String>, String> {
+    let raw = fs::read_to_string(repo.join("release.toml"))
+        .map_err(|e| format!("reading release.toml: {e}"))?;
+    let mut in_block = false;
+    let mut set = BTreeSet::new();
+    for line in raw.lines() {
+        let t = line.trim();
+        if t == "# LINT-PUBLISH-LIST:BEGIN" {
+            in_block = true;
+            continue;
+        }
+        if t == "# LINT-PUBLISH-LIST:END" {
+            in_block = false;
+            continue;
+        }
+        if !in_block {
+            continue;
+        }
+        if let Some(rest) = t.strip_prefix("# LINT-PUBLISH-LIST-CRATE:") {
+            let name = rest.trim().to_string();
+            if !name.is_empty() {
+                set.insert(name);
+            }
+        }
+    }
+    if set.is_empty() {
+        return Err("release.toml missing LINT-PUBLISH-LIST block or it's empty".into());
+    }
+    Ok(set)
+}
+
+fn parse_release_yml(repo: &Path) -> Result<BTreeSet<String>, String> {
+    // Plain-text scan: each publish step has a run line containing
+    // `cargo publish -p <name>`. Avoids a full YAML dep for a single
+    // grep-style extraction.
+    let raw = fs::read_to_string(repo.join(".github/workflows/release.yml"))
+        .map_err(|e| format!("reading release.yml: {e}"))?;
+    let mut set = BTreeSet::new();
+    for line in raw.lines() {
+        let t = line.trim();
+        if let Some(idx) = t.find("cargo publish -p ") {
+            let rest = &t[idx + "cargo publish -p ".len()..];
+            // take until first whitespace
+            let name: String = rest.chars().take_while(|c| !c.is_whitespace()).collect();
+            if !name.is_empty() {
+                set.insert(name);
+            }
+        }
+    }
+    if set.is_empty() {
+        return Err("release.yml contains no `cargo publish -p` steps".into());
+    }
+    Ok(set)
+}
+
+fn parse_releasing_md(repo: &Path) -> Result<BTreeSet<String>, String> {
+    let raw = fs::read_to_string(repo.join("docs/RELEASING.md"))
+        .map_err(|e| format!("reading docs/RELEASING.md: {e}"))?;
+    // The "What gets published" section enumerates crates as a
+    // numbered list `<N>. \`<crate>\`` lines. Anchor on the section
+    // header to avoid false positives elsewhere in the doc.
+    let mut set = BTreeSet::new();
+    let mut in_section = false;
+    for line in raw.lines() {
+        if line.starts_with("## ") {
+            in_section = line.contains("What gets published");
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        // Numbered-list entry: "1. `ferriskey`", allowing indentation.
+        let t = line.trim_start();
+        if let Some(after_num) = t.strip_prefix(|c: char| c.is_ascii_digit()) {
+            // strip further digits in case of "10."
+            let after_num = after_num.trim_start_matches(|c: char| c.is_ascii_digit());
+            if let Some(after_dot) = after_num.strip_prefix(". ")
+                && let Some(rest) = after_dot.strip_prefix('`')
+                && let Some(end) = rest.find('`')
+            {
+                set.insert(rest[..end].to_string());
+            }
+        }
+        // Stop once we hit the "Excluded" subheader.
+        if line.starts_with("Excluded from publish") {
+            break;
+        }
+    }
+    if set.is_empty() {
+        return Err(
+            "docs/RELEASING.md 'What gets published' section yielded no crate names".into(),
+        );
+    }
+    Ok(set)
+}

--- a/tools/publish-list-lint/src/main.rs
+++ b/tools/publish-list-lint/src/main.rs
@@ -192,8 +192,10 @@ fn discover_publishable(repo: &Path) -> Result<BTreeSet<String>, String> {
 
     let mut publishable = BTreeSet::new();
     for member in &root.workspace.members {
-        // Skip `tools/*` — those are self-declared publish = false.
-        // We still parse them below, but they won't make the cut.
+        // All workspace members are parsed; `tools/*` crates declare
+        // `publish = false` in their own manifest, so they're filtered
+        // out below by the publish / metadata.release.release gates
+        // rather than by a path-prefix skip.
         let manifest_path = repo.join(member).join("Cargo.toml");
         let raw = fs::read_to_string(&manifest_path)
             .map_err(|e| format!("reading {}: {e}", manifest_path.display()))?;


### PR DESCRIPTION
## Summary

Four additive CI guards that enforce memory-file lessons the project has already paid for in partial-published releases / dead consumer APIs. None modify existing gate behaviour; all wire into the existing `matrix-tests-complete` sentinel so branch protection picks them up automatically. This is a fast-follow to v0.12 — do NOT merge before v0.12 tags.

### 1. publish-list-drift — enforces `feedback_release_publish_list_drift.md`

New Rust bin `tools/publish-list-lint` cross-checks the publishable crate set across four sources of truth: workspace `Cargo.toml` members (filtered by `publish != false` AND `package.metadata.release.release != false`), a new structured `# LINT-PUBLISH-LIST-CRATE:` marker block at the top of `release.toml`, `cargo publish -p <name>` steps in `.github/workflows/release.yml`, and the "What gets published" list in `docs/RELEASING.md`. v0.3.0 and v0.3.1 each partial-published when one of those four drifted; the lint blocks the third occurrence.

### 2. non-exhaustive-lint — enforces `feedback_non_exhaustive_needs_constructor.md`

New Rust bin `tools/non-exhaustive-lint` (`syn` + `walkdir`) scans `crates/` for `pub struct`s marked `#[non_exhaustive]` that have no sibling constructor (`fn new` / `fn builder` / `impl From` / `impl TryFrom`) in the same file. Enums are intentionally skipped — `#[non_exhaustive]` on an enum only restricts `match` exhaustiveness, it does not block variant construction (`Enum::Variant` still works downstream). Only structs become unbuildable dead API, which is what v0.3.2's smoke caught.

### 3. lua-version-bump — enforces `project_ff_script_stale_lua_in_dev.md`

New step in the existing `lua-drift` job fails PRs that edit any `.lua` source (`lua/**/*.lua` or `crates/ff-script/**/*.lua`) without bumping `crates/ff-script/src/flowfabric_lua_version`. The `ff-script` loader gates FUNCTION LIBRARY reloads on this counter; edits without a bump leave deployed consumers on the stale cached library (silent stale FCALLs).

### 4. feature-propagation — enforces `feedback_feature_flag_propagation.md`

New matrix job `feature-propagation`, one cell per publishable crate (13 cells, hardcoded to match the publish-list-lint source of truth). Each cell runs `cargo check --no-default-features` then loops over the crate's own `[features]` keys and runs `cargo check --no-default-features --features <feat>` per feature. N+1 checks per cell; the Cartesian-explosion shape was rejected. Internal-feature leaks (where a dependent crate forgot `default-features = false` and silently pulled in a flag via the default set) fail here rather than post-publish.

## Pre-existing violations surfaced

Per plan: documented, NOT fixed in this PR (plan calls them out as "known preexisting"; the four guards land first, fixes follow separately).

### non-exhaustive-lint (8 structs)

| Crate | File | Struct |
| --- | --- | --- |
| ff-server | `crates/ff-server/src/config.rs` | `PostgresServerConfig` |
| ff-server | `crates/ff-server/src/config.rs` | `ServerConfig` |
| ff-core   | `crates/ff-core/src/backend.rs`  | `BestEffortLiveConfig` |
| ff-core   | `crates/ff-core/src/backend.rs`  | `BackendTimeouts` |
| ff-core   | `crates/ff-core/src/backend.rs`  | `BackendRetry` |
| ff-core   | `crates/ff-core/src/backend.rs`  | `BackendConfig` |
| ff-core   | `crates/ff-core/src/contracts/mod.rs` | `ResumePolicy` |
| ff-core   | `crates/ff-core/src/capability.rs` | `Supports` |

Each of these is a `#[non_exhaustive]` public struct with no `fn new`, `fn builder`, `impl From`, or `impl TryFrom` in the defining file. Several are constructed via `serde` deserialize in practice, but downstream consumers wanting a programmatic build path have no surface. Follow-up issue recommended.

### feature-propagation (backend crates, single-feature cells)

| Crate | Failing cells |
| --- | --- |
| ff-backend-valkey  | `--no-default-features`, `--features observability` |
| ff-backend-postgres | `--no-default-features`, `--features observability`, `--features streaming` |
| ff-backend-sqlite  | `--no-default-features`, `--features streaming` |

Each fails with `E0046: not all trait items implemented` — the backend cfg-gates the `streaming` trait methods on the `streaming` feature, but `ff-core`'s trait requires them unconditionally (or the backend's `core` feature is an implicit "you must enable this" that isn't in the default set). Pre-existing RFC-012 feature-matrix gap; follow-up issue recommended.

### publish-list-drift + lua-version-bump

Green on current `main` — no pre-existing drift.

## Decisions inline

- `release.toml` uses a structured `# LINT-PUBLISH-LIST-CRATE:` marker block (fragile-comment regex rejected).
- `non-exhaustive-lint` accepts same-file constructors only; re-exports not followed; enums excluded.
- `feature-propagation` uses one cell per crate with an N+1 inner loop (Cartesian rejected).
- Deferred: consumer-artifact pre-publish smoke gate. Design notes parked at `project_pre_publish_smoke_gate_todo.md` (private memory) with MEMORY.md pointer. Blockers: touches release critical path, owner review separately required.

## Test plan

- [ ] CI green on this PR (matrix-tests-complete sentinel picks up the three new jobs + the extended `lua-drift` step).
- [ ] Local `cargo run -p publish-list-lint` PASS against `main`.
- [ ] Local `cargo run -p non-exhaustive-lint` reports the 8 pre-existing structs above and nothing else.
- [ ] Each tool's README documents a reproduction recipe (verified locally: renaming a release.toml entry flips publish-list-lint to FAIL; adding a throwaway `#[non_exhaustive] pub struct` flips non-exhaustive-lint to FAIL).
- [ ] `cargo clippy -p publish-list-lint -p non-exhaustive-lint --all-targets -- -D warnings` clean.
- [ ] Workspace-wide `cargo clippy --workspace --all-targets -- -D warnings` is **not** clean — the 13 failures are all pre-existing in `ff-test` tests (redundant field names, needless range loops, PartitionConfig clones on Copy). Not touched; that debt is outside this PR's scope and CI's actual clippy invocation is narrower.

## Scope boundaries

- NO pre-publish smoke gate (deferred — see memory pointer above).
- NO CHANGELOG merge-driver.
- NO threshold changes to existing checks.
- Pre-existing violations NOT fixed — surfaced only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new required CI gates (including a 13-crate feature matrix) that can block merges and increase CI time if misconfigured, but it does not change runtime product code paths.
> 
> **Overview**
> Adds **three new required CI jobs** and extends an existing one in `.github/workflows/matrix.yml`: a PR-only guard requiring a `flowfabric_lua_version` bump whenever any `.lua` source changes, a `publish-list-drift` job that runs a new `publish-list-lint` tool, a `non-exhaustive-lint` job that runs a new `non-exhaustive-lint` tool, and a `feature-propagation` matrix that `cargo check`s each publishable crate with `--no-default-features` and each feature in isolation.
> 
> Introduces two new internal Rust binaries under `tools/` (added to the workspace and lockfile): `publish-list-lint` cross-checks the publishable crate list across `Cargo.toml`, `release.toml`, `.github/workflows/release.yml`, and `docs/RELEASING.md`, and `non-exhaustive-lint` scans `crates/` for `pub struct` `#[non_exhaustive]` types lacking an in-file constructor. `release.toml` gains a structured `# LINT-PUBLISH-LIST-CRATE:` marker block used by the publish-list lint, and `matrix-tests-complete` is updated to aggregate these new job results so branch protection picks them up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a5bc5b381a464c6df512ba9978314e175080303. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->