### PR TITLE
fix: add constructors for 8 public #[non_exhaustive] structs (unblock release-automation lint)

### DIFF
--- a/crates/ff-core/src/backend.rs
+++ b/crates/ff-core/src/backend.rs
@@ -339,6 +339,14 @@ pub struct BestEffortLiveConfig {
 
 impl BestEffortLiveConfig {
     /// Construct with the given `ttl_ms` and defaults for the other
+    /// knobs. Alias for [`Self::with_ttl`] — provided so external
+    /// consumers have a conventional `new` constructor against this
+    /// `#[non_exhaustive]` struct.
+    pub fn new(ttl_ms: u32) -> Self {
+        Self::with_ttl(ttl_ms)
+    }
+
+    /// Construct with the given `ttl_ms` and defaults for the other
     /// knobs. Matches the shorthand used by
     /// [`StreamMode::best_effort_live`].
     pub fn with_ttl(ttl_ms: u32) -> Self {
@@ -1164,6 +1172,16 @@ pub struct BackendTimeouts {
     pub request: Option<Duration>,
 }
 
+impl BackendTimeouts {
+    /// Construct a [`BackendTimeouts`] with all fields set to their
+    /// backend-default sentinel (`None`). Equivalent to
+    /// [`Self::default`] — provided so external consumers have an
+    /// explicit constructor against this `#[non_exhaustive]` struct.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// Retry policy shared across backend connections.
 ///
 /// Matches ferriskey's `ConnectionRetryStrategy` shape (see
@@ -1189,6 +1207,16 @@ pub struct BackendRetry {
     /// Jitter as a percentage of the computed backoff. `None` ⇒ backend
     /// default.
     pub jitter_percent: Option<u32>,
+}
+
+impl BackendRetry {
+    /// Construct a [`BackendRetry`] with all fields set to their
+    /// backend-default sentinel (`None`). Equivalent to
+    /// [`Self::default`] — provided so external consumers have an
+    /// explicit constructor against this `#[non_exhaustive]` struct.
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 /// Valkey-specific connection parameters.
@@ -1279,6 +1307,19 @@ pub struct BackendConfig {
 }
 
 impl BackendConfig {
+    /// Construct a [`BackendConfig`] directly from a
+    /// [`BackendConnection`] variant, with default timeouts + retry.
+    /// Provided so external consumers have an explicit constructor
+    /// against this `#[non_exhaustive]` struct; for the common paths
+    /// prefer [`Self::valkey`] / [`Self::postgres`].
+    pub fn new(connection: BackendConnection) -> Self {
+        Self {
+            connection,
+            timeouts: BackendTimeouts::default(),
+            retry: BackendRetry::default(),
+        }
+    }
+
     /// Build a Valkey BackendConfig from host+port. Other fields take
     /// backend defaults.
     pub fn valkey(host: impl Into<String>, port: u16) -> Self {

--- a/crates/ff-core/src/capability.rs
+++ b/crates/ff-core/src/capability.rs
@@ -147,6 +147,14 @@ pub struct Supports {
 }
 
 impl Supports {
+    /// Construct a [`Supports`] with every field `false`. Alias for
+    /// [`Self::none`] — provided so external consumers have a
+    /// conventional `new` constructor against this `#[non_exhaustive]`
+    /// struct. Equivalent to [`Self::default`].
+    pub const fn new() -> Self {
+        Self::none()
+    }
+
     /// Construct a `Supports` with every field `false`. Useful as a
     /// starting point when assembling a backend-specific capability
     /// snapshot. Consumers should never see this directly —

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -3783,7 +3783,21 @@ pub struct ResumePolicy {
     pub close_waitpoint_on_resume: bool,
 }
 
+impl Default for ResumePolicy {
+    fn default() -> Self {
+        Self::normal()
+    }
+}
+
 impl ResumePolicy {
+    /// Construct a [`ResumePolicy`] with the canonical v1 defaults
+    /// (see [`Self::normal`]). Alias for [`Self::normal`] — provided
+    /// so external consumers have a conventional `new` constructor
+    /// against this `#[non_exhaustive]` struct.
+    pub fn new() -> Self {
+        Self::normal()
+    }
+
     /// Canonical v1 defaults (RFC-013 §2.2.1):
     /// * `resume_target = Runnable`
     /// * `consume_matched_signals = true`

--- a/crates/ff-server/src/config.rs
+++ b/crates/ff-server/src/config.rs
@@ -55,6 +55,18 @@ pub struct PostgresServerConfig {
     pub pool_size: u32,
 }
 
+impl PostgresServerConfig {
+    /// Construct a new config with the given URL and the default
+    /// `pool_size = 10` (matches sqlx's out-of-box default +
+    /// [`ff_core::backend::PostgresConnection`] default).
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            pool_size: 10,
+        }
+    }
+}
+
 impl Default for PostgresServerConfig {
     fn default() -> Self {
         Self {
@@ -223,6 +235,18 @@ pub struct ServerConfig {
     /// Meaningful only when `backend == BackendKind::Sqlite`; the
     /// Valkey/Postgres paths ignore these fields.
     pub sqlite: SqliteServerConfig,
+}
+
+impl ServerConfig {
+    /// Construct a [`ServerConfig`] with the same defaults as
+    /// [`Self::default`]. Provided so external consumers have an
+    /// explicit constructor against this `#[non_exhaustive]` struct
+    /// (struct-literal + `..Default::default()` spread are both
+    /// forbidden cross-crate). Override fields field-by-field after
+    /// calling; for env-driven boot use [`Self::from_env`].
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 impl ServerConfig {


### PR DESCRIPTION
## Summary

Adds explicit constructors on 8 public `#[non_exhaustive]` structs so external consumers can construct them without relying on struct-literal syntax or `..Default::default()` spread (both forbidden cross-crate on `#[non_exhaustive]` types).

Flagged by the `non-exhaustive-lint` check in PR #408 (`chore: add release automation guardrails`). Per project memory (`feedback_no_preexisting_excuse` + `feedback_non_exhaustive_needs_constructor`), validation-discovered bugs get fixed in place rather than deferred. Landing this ahead of #408 so its CI comes up green.

## Constructors added

All additive; no existing call sites changed.

| # | Struct | File:line | Constructor |
|---|--------|-----------|-------------|
| 1 | `PostgresServerConfig` | `crates/ff-server/src/config.rs:48` | `pub fn new(url: impl Into<String>) -> Self` — URL + default `pool_size=10` |
| 2 | `ServerConfig` | `crates/ff-server/src/config.rs:171` | `pub fn new() -> Self` — delegates to `Default` (env-driven boot remains via `from_env`) |
| 3 | `BestEffortLiveConfig` | `crates/ff-core/src/backend.rs:333` | `pub fn new(ttl_ms: u32) -> Self` — alias for existing `with_ttl` |
| 4 | `BackendTimeouts` | `crates/ff-core/src/backend.rs:1162` | `pub fn new() -> Self` — delegates to `Default` |
| 5 | `BackendRetry` | `crates/ff-core/src/backend.rs:1180` | `pub fn new() -> Self` — delegates to `Default` |
| 6 | `BackendConfig` | `crates/ff-core/src/backend.rs:1275` | `pub fn new(connection: BackendConnection) -> Self` — direct from a `BackendConnection` variant with default timeouts + retry (prefer `valkey()`/`postgres()` for common paths) |
| 7 | `ResumePolicy` | `crates/ff-core/src/contracts/mod.rs:3777` | `pub fn new() -> Self` + `impl Default` — both delegate to `normal()`. `Default` added because clippy's `new_without_default` fires on bare `new()` when no `Default` exists, and `normal()` already encodes the canonical v1 defaults. |
| 8 | `Supports` | `crates/ff-core/src/capability.rs:61` | `pub const fn new() -> Self` — `const` alias for existing `none()` |

## Scope boundaries (per ticket)

- Did **not** touch the 13 pre-existing `ff-test` clippy errors.
- Did **not** touch the 7 feature-propagation failures (other agent).
- Did **not** fix other `#[non_exhaustive]` enums/structs outside the 8-item list.
- Did **not** remove any `#[non_exhaustive]` marker. None of the 8 structs revealed a compelling reason to drop the marker — all of them sit on backend-config / capability-snapshot surfaces where additive field growth is the explicit contract.
- Did **not** modify call sites. Constructors are additive.

## Test plan

- [x] `cargo check --workspace --all-features` clean.
- [x] `cargo clippy -p ff-core -p ff-server --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test -p ff-core -p ff-server --lib --all-features` → 222 + 28 pass.
- [x] Workspace clippy: only pre-existing `ferriskey` (vendored) + `ff-sdk` `result_large_err` errors remain; verified present on `main` before this change.
- [ ] CI green on push.
- [ ] Re-run `non-exhaustive-lint` tool from PR #408 against this branch after merge and confirm all 8 violations disappear.

## Links

- Flagged by: #408
- Refs: `feedback_no_preexisting_excuse`, `feedback_non_exhaustive_needs_constructor`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive constructors/default impls on public `#[non_exhaustive]` structs; no behavioral changes beyond exposing new, safe construction paths for downstream crates.
> 
> **Overview**
> Adds explicit `new()` constructors (and in one case a `Default` impl) for several public `#[non_exhaustive]` structs so external crates can instantiate them without forbidden struct literals or `..Default::default()` spread.
> 
> This covers backend/config surfaces like `BestEffortLiveConfig`, `BackendTimeouts`, `BackendRetry`, `BackendConfig`, capability snapshot `Supports`, server configs (`ServerConfig`, `PostgresServerConfig`), and resume behavior via `ResumePolicy` (now `Default` = `normal()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc62673c9cd2e1d93b65ca3d4ac0dc9df0e56b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->