### PR TITLE
fix: propagate streaming feature gates in backend crates (unblock release-automation lint)

### DIFF
--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -343,9 +343,11 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn list_edges(
         &self,
-        flow_id: &FlowId,
-        direction: EdgeDirection,
-    ) -> Result<Vec<EdgeSnapshot>, EngineError>;
+        _flow_id: &FlowId,
+        _direction: EdgeDirection,
+    ) -> Result<Vec<EdgeSnapshot>, EngineError> {
+        Err(EngineError::Unavailable { op: "list_edges" })
+    }
 
     /// Snapshot a single dependency edge by its owning flow + edge id.
     ///
@@ -366,9 +368,13 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn describe_edge(
         &self,
-        flow_id: &FlowId,
-        edge_id: &EdgeId,
-    ) -> Result<Option<EdgeSnapshot>, EngineError>;
+        _flow_id: &FlowId,
+        _edge_id: &EdgeId,
+    ) -> Result<Option<EdgeSnapshot>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "describe_edge",
+        })
+    }
 
     /// Resolve an execution's owning flow id, if any.
     ///
@@ -388,8 +394,12 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn resolve_execution_flow_id(
         &self,
-        eid: &ExecutionId,
-    ) -> Result<Option<FlowId>, EngineError>;
+        _eid: &ExecutionId,
+    ) -> Result<Option<FlowId>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "resolve_execution_flow_id",
+        })
+    }
 
     /// List flows on a partition with cursor-based pagination (issue
     /// #185).
@@ -433,10 +443,12 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn list_flows(
         &self,
-        partition: PartitionKey,
-        cursor: Option<FlowId>,
-        limit: usize,
-    ) -> Result<ListFlowsPage, EngineError>;
+        _partition: PartitionKey,
+        _cursor: Option<FlowId>,
+        _limit: usize,
+    ) -> Result<ListFlowsPage, EngineError> {
+        Err(EngineError::Unavailable { op: "list_flows" })
+    }
 
     /// Enumerate registered lanes with cursor-based pagination.
     ///
@@ -464,9 +476,11 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn list_lanes(
         &self,
-        cursor: Option<LaneId>,
-        limit: usize,
-    ) -> Result<ListLanesPage, EngineError>;
+        _cursor: Option<LaneId>,
+        _limit: usize,
+    ) -> Result<ListLanesPage, EngineError> {
+        Err(EngineError::Unavailable { op: "list_lanes" })
+    }
 
     /// List suspended executions in one partition, cursor-paginated,
     /// with each entry's suspension `reason_code` populated (issue
@@ -497,10 +511,14 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn list_suspended(
         &self,
-        partition: PartitionKey,
-        cursor: Option<ExecutionId>,
-        limit: usize,
-    ) -> Result<ListSuspendedPage, EngineError>;
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListSuspendedPage, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "list_suspended",
+        })
+    }
 
     /// Forward-only paginated listing of the executions indexed under
     /// one partition.
@@ -530,10 +548,14 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn list_executions(
         &self,
-        partition: PartitionKey,
-        cursor: Option<ExecutionId>,
-        limit: usize,
-    ) -> Result<ListExecutionsPage, EngineError>;
+        _partition: PartitionKey,
+        _cursor: Option<ExecutionId>,
+        _limit: usize,
+    ) -> Result<ListExecutionsPage, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "list_executions",
+        })
+    }
 
     // ── Trigger ops (issue #150) ──
 
@@ -561,8 +583,12 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn deliver_signal(
         &self,
-        args: DeliverSignalArgs,
-    ) -> Result<DeliverSignalResult, EngineError>;
+        _args: DeliverSignalArgs,
+    ) -> Result<DeliverSignalResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "deliver_signal",
+        })
+    }
 
     /// Claim a resumed execution — a previously-suspended attempt that
     /// has cleared its resume condition (e.g. via
@@ -588,8 +614,12 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn claim_resumed_execution(
         &self,
-        args: ClaimResumedExecutionArgs,
-    ) -> Result<ClaimResumedExecutionResult, EngineError>;
+        _args: ClaimResumedExecutionArgs,
+    ) -> Result<ClaimResumedExecutionResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "claim_resumed_execution",
+        })
+    }
 
     /// Operator-initiated cancellation of a flow and (optionally) its
     /// member executions. See RFC-012 §3.1.1 for the policy /wait
@@ -616,10 +646,14 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "core")]
     async fn set_edge_group_policy(
         &self,
-        flow_id: &FlowId,
-        downstream_execution_id: &ExecutionId,
-        policy: crate::contracts::EdgeDependencyPolicy,
-    ) -> Result<crate::contracts::SetEdgeGroupPolicyResult, EngineError>;
+        _flow_id: &FlowId,
+        _downstream_execution_id: &ExecutionId,
+        _policy: crate::contracts::EdgeDependencyPolicy,
+    ) -> Result<crate::contracts::SetEdgeGroupPolicyResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "set_edge_group_policy",
+        })
+    }
 
     // ── HMAC secret rotation (v0.7 migration-master Q4) ──
 
@@ -717,12 +751,14 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "streaming")]
     async fn read_stream(
         &self,
-        execution_id: &ExecutionId,
-        attempt_index: AttemptIndex,
-        from: StreamCursor,
-        to: StreamCursor,
-        count_limit: u64,
-    ) -> Result<StreamFrames, EngineError>;
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _from: StreamCursor,
+        _to: StreamCursor,
+        _count_limit: u64,
+    ) -> Result<StreamFrames, EngineError> {
+        Err(EngineError::Unavailable { op: "read_stream" })
+    }
 
     /// Tail a live attempt's stream.
     ///
@@ -745,13 +781,15 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "streaming")]
     async fn tail_stream(
         &self,
-        execution_id: &ExecutionId,
-        attempt_index: AttemptIndex,
-        after: StreamCursor,
-        block_ms: u64,
-        count_limit: u64,
-        visibility: TailVisibility,
-    ) -> Result<StreamFrames, EngineError>;
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+        _after: StreamCursor,
+        _block_ms: u64,
+        _count_limit: u64,
+        _visibility: TailVisibility,
+    ) -> Result<StreamFrames, EngineError> {
+        Err(EngineError::Unavailable { op: "tail_stream" })
+    }
 
     /// Read the rolling summary document for an attempt (RFC-015 §6.3).
     ///
@@ -764,9 +802,13 @@ pub trait EngineBackend: Send + Sync + 'static {
     #[cfg(feature = "streaming")]
     async fn read_summary(
         &self,
-        execution_id: &ExecutionId,
-        attempt_index: AttemptIndex,
-    ) -> Result<Option<SummaryDocument>, EngineError>;
+        _execution_id: &ExecutionId,
+        _attempt_index: AttemptIndex,
+    ) -> Result<Option<SummaryDocument>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "read_summary",
+        })
+    }
 
     // ── RFC-017 Stage A — Ingress (5) ──────────────────────────
     //


### PR DESCRIPTION
## Summary

RFC-012 feature-matrix CI check (PR #408 `chore/release-automation`) caught 7 failing cells across the backend crates where `--no-default-features` builds failed with E0046 "not all trait items implemented". Per `feedback_no_preexisting_excuse.md` + `feedback_feature_flag_propagation.md` — real feature-propagation leak, fix in place.

## Root cause

`EngineBackend` trait methods gated on `#[cfg(feature = "streaming")]` / `#[cfg(feature = "core")]` of **ff-core**, but backend crates gate their `impl` methods on their **own** feature. Cargo's monotonic feature unification forces `ff-core/streaming` + `ff-core/core` on via `ff-scheduler` + `ff-script` (workspace default features), so the trait carries the methods when the backend's own feature is off — impl then missing trait item.

```
cargo tree -p ff-backend-valkey --no-default-features -e features -i ff-core
├── ff-core feature "default"
│   └── ff-scheduler v0.11.0
│       └── ff-scheduler feature "default"
│           └── ff-backend-valkey
```

## Fix shape — Option B (owner-prescribed)

Add `EngineError::Unavailable { op }` default bodies to 13 trait methods that previously lacked them. Mirrors the RFC-017 Stage A pattern already used across `create_execution`, `create_flow`, `cancel_execution`, etc. No trait API change for in-tree backends (real impls still override).

**Option A (trait-shape reshape)** rejected — cascades beyond 3-4 files, semver-break.
**Option C (cfg-gate the `impl` blocks)** rejected — would break consumers depending on backend existing under `--no-default-features`.

## Per-cell resolution

| Crate | Cell | Missing methods | Status |
|---|---|---|---|
| `ff-backend-valkey` | `--no-default-features` | `read_stream`, `tail_stream`, `read_summary` | FIXED |
| `ff-backend-valkey` | `--features observability` (no-default) | same 3 streaming | FIXED |
| `ff-backend-postgres` | `--no-default-features` | 10 core methods (list_edges, describe_edge, resolve_execution_flow_id, list_flows, list_lanes, list_suspended, list_executions, deliver_signal, claim_resumed_execution, set_edge_group_policy) | FIXED |
| `ff-backend-postgres` | `--features observability` (no-default) | same 10 core | FIXED |
| `ff-backend-postgres` | `--features streaming` (no-default) | same 10 core | FIXED |
| `ff-backend-sqlite` | `--no-default-features` | same 10 core | FIXED |
| `ff-backend-sqlite` | `--features streaming` (no-default) | same 10 core | FIXED |

13 trait methods gained defaults (10 core-gated + 3 streaming-gated).

## Trait-shape note for v0.12 agnostic-SDK work

The leak path (`ff-scheduler` → `ff-core/default`) means you can't actually achieve a trait slice via `ff-backend-* --no-default-features` today — feature unification overrides it in any realistic workspace build. For RFC-012's ultimate goal ("core-only minimal backend"), the fix is either (a) make `ff-scheduler` / `ff-script` consume ff-core with `default-features = false` + explicit feature list, or (b) reshape the trait so streaming is an extension trait. Out of scope here; flagged for v0.12 planning.

## Related

- Unblocks PR #408 `chore/release-automation` feature-propagation check.
- Consistent with RFC-017 §5.3 trait-growth convention.

## Test plan

- [x] All 7 previously-failing cells: `cargo check` clean
- [x] `cargo check --workspace --all-features` clean
- [x] `cargo test --workspace --lib --bins` all green
- [x] `cargo clippy -p ff-core -p ff-backend-valkey -p ff-backend-postgres -p ff-backend-sqlite --all-targets --all-features -- -D warnings` clean
- [x] `scripts/smoke-sqlite.sh` PASS
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` clean (SDK backend-agnostic STOP-trigger target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds default trait method bodies that return `EngineError::Unavailable`, affecting behavior only when a backend does not implement a feature-gated method (previously it would fail to compile). Main risk is callers now reaching runtime `Unavailable` errors if a backend unintentionally relies on the default instead of providing a real implementation.
> 
> **Overview**
> Fixes feature-flag propagation issues by giving previously-required, feature-gated `EngineBackend` methods default bodies that return `EngineError::Unavailable` (notably edge/flow/execution listing + trigger ops under `core`, and `read_stream`/`tail_stream`/`read_summary` under `streaming`).
> 
> This prevents backend crates from failing to compile in `--no-default-features` configurations when `ff-core` features are pulled in via dependency feature unification, while still surfacing missing backend support as a loud, typed runtime error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fbefd1e8cac59c6bfe838067d3616df81a1231f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->