### PR TITLE
fix: scope ff-core feature edges to core-only across scheduler/engine/sdk/backends (unblock agnostic-SDK compile anchor)

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -596,6 +596,42 @@ jobs:
             cargo check -p "$CRATE" --no-default-features --features "$feat"
           done <<< "$feats"
 
+  # RFC-023 Phase 4a — ff-core feature-leak guard. The agnostic-SDK
+  # compile anchor (`ff-sdk --no-default-features --features sqlite`)
+  # is only meaningful if ff-core stays at the minimal feature set
+  # (`core` only). Backends that over-activate their direct ff-core
+  # dep would silently leak `streaming` / `suspension` / `budget`
+  # through the sqlite cell and defeat the anchor. The valkey-default
+  # cell legitimately enables `streaming` via ff-backend-valkey's own
+  # `streaming` feature, so it is exempt.
+  feature-leak-guard:
+    name: feature-leak-guard (ff-sdk sqlite minimal)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+        with:
+          key: feature-leak-guard
+      - name: ff-sdk[sqlite] ff-core edge is core-only
+        run: |
+          set -euo pipefail
+          out=$(cargo tree -p ff-sdk --no-default-features --features sqlite --format '{p} {f}')
+          echo "$out" | grep -E "ff-core|ff-backend" || true
+          # Extract the feature list on every `ff-core vX` line in the
+          # tree. The first field after the trailing `) ` is the
+          # comma-joined active feature list.
+          ffcore_feats=$(echo "$out" | grep -oE "ff-core v[0-9.]+ \([^)]+\) [a-z,_-]*" | awk '{print $NF}' | sort -u)
+          echo "ff-core feature sets observed:"
+          echo "$ffcore_feats"
+          for forbidden in streaming suspension budget; do
+            if echo "$ffcore_feats" | grep -qw "$forbidden"; then
+              echo "FEATURE-LEAK: ff-core has '$forbidden' active in ff-sdk[sqlite] minimal anchor" >&2
+              exit 1
+            fi
+          done
+          echo "ff-sdk[sqlite] ff-core edge is minimal (core only) — ok"
+
   # RFC-023 §4.1 + issue #365 — parity-drift lint for the PG ↔ SQLite
   # migration pair. Blocks PRs that add a PG migration without a
   # matching SQLite port (or an `.sqlite-skip` entry with an issue
@@ -638,6 +674,7 @@ jobs:
       - publish-list-drift
       - non-exhaustive-lint
       - feature-propagation
+      - feature-leak-guard
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -651,6 +688,7 @@ jobs:
           PUBLISH_LIST_DRIFT_RESULT: ${{ needs.publish-list-drift.result }}
           NON_EXHAUSTIVE_LINT_RESULT: ${{ needs.non-exhaustive-lint.result }}
           FEATURE_PROPAGATION_RESULT: ${{ needs.feature-propagation.result }}
+          FEATURE_LEAK_GUARD_RESULT: ${{ needs.feature-leak-guard.result }}
         run: |
           fail=0
           case "$MATRIX_RESULT" in
@@ -684,5 +722,9 @@ jobs:
           case "$FEATURE_PROPAGATION_RESULT" in
             success|skipped) echo "feature-propagation: $FEATURE_PROPAGATION_RESULT — ok" ;;
             *) echo "feature-propagation: $FEATURE_PROPAGATION_RESULT — blocking merge" >&2; fail=1 ;;
+          esac
+          case "$FEATURE_LEAK_GUARD_RESULT" in
+            success|skipped) echo "feature-leak-guard: $FEATURE_LEAK_GUARD_RESULT — ok" ;;
+            *) echo "feature-leak-guard: $FEATURE_LEAK_GUARD_RESULT — blocking merge" >&2; fail=1 ;;
           esac
           exit $fail

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -28,7 +28,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -22,7 +22,7 @@ streaming = ["ff-core/streaming"]
 # impl honours the same `EngineBackend` method surface. Trait impl
 # bodies arrive in Phase 2+; Phase 1a returns `EngineError::Unavailable`
 # from every method except `capabilities()` + `prepare()`.
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
 
 # SQLite transport. Bundled SQLite is deliberately selected to decouple
 # the backend from the operating distro's libsqlite3 version — RFC-023

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core", "suspension", "budget"] }
+ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -23,7 +23,7 @@ observability = ["ff-observability/enabled"]
 postgres = ["dep:ff-backend-postgres", "dep:sqlx", "dep:uuid"]
 
 [dependencies]
-ff-core = { workspace = true }
+ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
 ff-observability = { workspace = true }
 ferriskey = { workspace = true }
 futures = { workspace = true }

--- a/crates/ff-scheduler/Cargo.toml
+++ b/crates/ff-scheduler/Cargo.toml
@@ -16,7 +16,7 @@ description = "FlowFabric claim-grant scheduler"
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { workspace = true }
+ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-scheduler's claim dispatcher uses FCALL helpers from
 # ff-script, so explicitly enable `valkey-client`.
 ff-script = { workspace = true, features = ["valkey-client"] }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -102,7 +102,7 @@ ferriskey = { workspace = true, optional = true }
 # RFC-023 Phase 1a: optional SQLite backend edge, activated by the
 # `sqlite` feature above. Off by default so Valkey consumers pay no
 # sqlx compile cost.
-ff-backend-sqlite = { workspace = true, optional = true }
+ff-backend-sqlite = { version = "0.11.0", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

The agnostic-SDK compile anchor `cargo check -p ff-sdk --no-default-features --features sqlite` was silently pulling ff-core's full feature surface (`streaming`, `suspension`, `budget`) — defeating its purpose of proving a minimal trait surface for the v0.12 backend-agnostic SDK (RFC-023 Phase 4a).

Root cause (two leaks stacked):
1. ff-backend-{sqlite,postgres,valkey} each carried `ff-core = { ..., features = ["core", "suspension", "budget"] }` on the direct dep line.
2. ff-sdk's `sqlite = ["dep:ff-backend-sqlite"]` pulled ff-backend-sqlite with its `default = ["core", "streaming"]` active.

## Before / after cargo tree

`cargo tree -p ff-sdk --no-default-features --features sqlite --format '{p} {f}'`

Before:
```
ff-sdk ... sqlite
├── ff-backend-sqlite ... core,default,streaming
│   ├── ff-core ... budget,core,streaming,suspension
├── ff-core ... budget,core,streaming,suspension
```

After:
```
ff-sdk ... sqlite
├── ff-backend-sqlite ... core
│   ├── ff-core ... core
├── ff-core ... core
```

## Edits

- **`crates/ff-scheduler/Cargo.toml`** — ff-core dep → `default-features = false, features = ["core"]` (defense-in-depth for future PR-7 anchors).
- **`crates/ff-engine/Cargo.toml`** — same shape.
- **`crates/ff-sdk/Cargo.toml`** — ff-backend-sqlite dep → `default-features = false, features = ["core"]`. ff-backend-valkey left as-is; it has no `core` feature and `valkey-default` legitimately activates `streaming`.
- **`crates/ff-backend-sqlite/Cargo.toml`** — direct ff-core dep `["core", "suspension", "budget"]` → `["core"]`.
- **`crates/ff-backend-valkey/Cargo.toml`** — same normalisation.
- **`crates/ff-backend-postgres/Cargo.toml`** — same normalisation.
- **`.github/workflows/matrix.yml`** — new `feature-leak-guard` job runs `cargo tree -p ff-sdk --no-default-features --features sqlite` and fails if ff-core has `streaming`, `suspension`, or `budget` active. Wired into `matrix-tests-complete` aggregator.

## What stayed

- `streaming` ff-core feature is preserved. Each backend's own `streaming = ["ff-core/streaming"]` feature still propagates when turned on (backend defaults stay `streaming`-on for ordinary use); the sqlite anchor disables the backend's default features, so ff-core/streaming is not activated in the minimal cell.
- `suspension` + `budget` ff-core features: confirmed unused for any `#[cfg]` gating (grep workspace: zero matches in `crates/**/*.rs`). They're declared-but-unused in ff-core's feature block — removing them from backend activations has no effect on compilation.

## Why ff-sdk's postgres cell isn't asserted

ff-sdk has no `postgres` feature today (only `sqlite` and `valkey-default`). The CI guard is scoped to the sqlite cell. When PR-1+ adds a `postgres` feature to ff-sdk, extend the guard.

## Verification

- `cargo check --workspace`: clean
- `cargo test --workspace --lib`: all green (ferriskey, ff-core, ff-script, ff-engine, ff-scheduler, ff-sdk, ff-server, ff-test, ff-backend-{sqlite,postgres,valkey}, flowfabric, ff-readiness-tests)
- `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-sqlite --features ff-sdk/direct-valkey-claim -- -D warnings`: clean (CI-equivalent)
- `cargo check -p ff-sdk --no-default-features --features sqlite`: clean — anchor now verifies a genuinely minimal trait surface
- `scripts/smoke-sqlite.sh`: PASS (17s)
- `feature-leak-guard` logic executed locally: passes

## Test plan

- [ ] CI matrix green including new `feature-leak-guard` job
- [ ] `matrix-tests-complete` aggregator reports `feature-leak-guard: success`
- [ ] smoke-sqlite PASS on CI runner
- [ ] No clippy regression in scoped clippy job

Unblocks PR-1+ for RFC-023 Phase 4a (v0.12 backend-agnostic SDK); the sqlite compile anchor can now flag accidental Valkey-specific surface area.

Research memo: ff-core feature unification leak investigation (local notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Cargo feature wiring across multiple crates; incorrect scoping could break builds or alter which `ff-core` APIs are compiled in. CI is extended to fail on unintended feature activation in the `ff-sdk` sqlite anchor.
> 
> **Overview**
> Tightens Cargo feature propagation so `ff-core` is pulled as **`core`-only** by default across `ff-backend-{postgres,sqlite,valkey}`, `ff-engine`, and `ff-scheduler`, preventing `streaming`/`suspension`/`budget` from being activated transitively.
> 
> Adjusts `ff-sdk`’s optional `sqlite` backend dependency to use `default-features = false` and `features = ["core"]`, ensuring `cargo check -p ff-sdk --no-default-features --features sqlite` remains a minimal “agnostic SDK” compile anchor.
> 
> Adds a new CI job `feature-leak-guard` in `matrix.yml` that runs `cargo tree` for the sqlite anchor and fails if forbidden `ff-core` features are present, and wires it into the `matrix-tests-complete` aggregator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f5b70c555c4bf5caef4715b98cb781a17bfb22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->