### PR TITLE
refactor(sdk): drop dead client field on ClaimedTask; ungate task.rs module (agnostic-SDK PR-2)

### DIFF
--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -88,7 +88,11 @@ pub mod engine_error;
 pub mod layer;
 #[cfg(feature = "valkey-default")]
 pub mod snapshot;
-#[cfg(feature = "valkey-default")]
+// v0.12 PR-2: `task` is always compiled. Items that depend on
+// ferriskey / ff-backend-valkey / ff-core streaming+suspension types
+// are gated at the item level inside `task.rs`; the module itself is
+// reachable under `default-features = false, features = ["sqlite"]`
+// so consumers can name `ClaimedTask` as a type.
 pub mod task;
 // RFC-023 Phase 1a (§4.4 item 10): `worker` is always compiled.
 // The ferriskey-dependent methods inside it are `valkey-default`-

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -1,12 +1,18 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
+#[cfg(feature = "valkey-default")]
 use std::time::Duration;
 
-use ferriskey::{Client, Value};
-use ff_core::backend::{Handle, HandleKind, PendingWaitpoint};
+#[cfg(feature = "valkey-default")]
+use ferriskey::Value;
+use ff_core::backend::Handle;
+#[cfg(feature = "valkey-default")]
+use ff_core::backend::{HandleKind, PendingWaitpoint};
+#[cfg(feature = "valkey-default")]
 use ff_core::contracts::ReportUsageResult;
 use ff_core::engine_backend::EngineBackend;
+#[cfg(feature = "valkey-default")]
 use ff_core::engine_error::StateKind;
 use ff_script::error::ScriptError;
 use ff_core::partition::PartitionConfig;
@@ -95,6 +101,7 @@ pub enum SignalOutcome {
     Duplicate { existing_signal_id: String },
 }
 
+#[cfg(feature = "valkey-default")]
 impl SignalOutcome {
     /// Parse a raw `ff_deliver_signal` FCALL result into a `SignalOutcome`.
     ///
@@ -141,10 +148,8 @@ pub use ff_core::backend::FailOutcome;
 ///
 /// `complete`, `fail`, and `cancel` consume `self` — this prevents
 /// double-complete bugs at the type level.
+#[cfg_attr(not(feature = "valkey-default"), allow(dead_code))]
 pub struct ClaimedTask {
-    /// Shared Valkey client.
-    #[allow(dead_code)]
-    client: Client,
     /// `EngineBackend` the trait-migrated ops forward through.
     ///
     /// **RFC-012 Stage 1b + Round-7.** Today this is always a
@@ -214,15 +219,13 @@ pub struct ClaimedTask {
     _concurrency_permit: Option<OwnedSemaphorePermit>,
 }
 
+#[cfg(feature = "valkey-default")]
 impl ClaimedTask {
     /// Construct a `ClaimedTask` from the results of a successful
     /// `ff_claim_execution` or `ff_claim_resumed_execution` FCALL.
     ///
     /// # Arguments
     ///
-    /// * `client` — shared Valkey client used for subsequent lease
-    ///   renewals, signal delivery, and the final
-    ///   complete/fail/cancel FCALL.
     /// * `partition_config` — partition topology snapshot read at
     ///   `FlowFabricWorker::connect`. Used for key construction on
     ///   the lifetime of this task.
@@ -269,7 +272,6 @@ impl ClaimedTask {
     /// permit — not promoting this constructor.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        client: Client,
         backend: Arc<dyn EngineBackend>,
         partition_config: PartitionConfig,
         execution_id: ExecutionId,
@@ -311,7 +313,6 @@ impl ClaimedTask {
         );
 
         Self {
-            client,
             backend,
             partition_config,
             execution_id,
@@ -1042,6 +1043,7 @@ impl ClaimedTask {
 /// whether to call `stop_renewal()`: yes for landed responses, no
 /// for transport errors so the caller's retry path still sees a
 /// running renewal task.
+#[cfg(feature = "valkey-default")]
 fn fcall_landed<T>(r: &Result<T, crate::EngineError>) -> bool {
     match r {
         Ok(_) => true,
@@ -1057,6 +1059,7 @@ fn fcall_landed<T>(r: &Result<T, crate::EngineError>) -> bool {
 /// Stage 1b forwarder is reclassify a novel category as transient.
 /// Stage 1d (or issue #117) widens `FailureClass` with a
 /// `Custom(String)` arm for exact round-trip.
+#[cfg(feature = "valkey-default")]
 fn error_category_to_class(s: &str) -> ff_core::backend::FailureClass {
     use ff_core::backend::FailureClass;
     match s {
@@ -1106,6 +1109,7 @@ impl Drop for ClaimedTask {
 ///
 /// See `benches/harness/src/bin/long_running.rs` for the bench
 /// consumer that depends on this span naming.
+#[cfg(feature = "valkey-default")]
 #[tracing::instrument(
     name = "renew_lease",
     skip_all,
@@ -1133,6 +1137,7 @@ async fn renew_once(
 /// - `stop_signal` is notified (complete/fail/cancel called)
 /// - Renewal fails with a terminal error (stale_lease, lease_expired, etc.)
 /// - The task handle is aborted (ClaimedTask dropped)
+#[cfg(feature = "valkey-default")]
 fn spawn_renewal_task(
     backend: Arc<dyn EngineBackend>,
     handle: Handle,
@@ -1199,6 +1204,7 @@ fn spawn_renewal_task(
 }
 
 /// Check if an engine error means renewal should stop permanently.
+#[cfg(feature = "valkey-default")]
 #[allow(dead_code)]
 fn is_terminal_renewal_error(err: &crate::EngineError) -> bool {
     use crate::{ContentionKind, EngineError, StateKind};
@@ -1227,6 +1233,7 @@ fn is_terminal_renewal_error(err: &crate::EngineError) -> bool {
 /// parser paired with the producer (the Lua function registered at
 /// `lua/budget.lua:99`, `ff_report_usage_and_check`) is the defence
 /// against silent format drift between producer and consumer.
+#[cfg(feature = "valkey-default")]
 pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,
@@ -1291,6 +1298,7 @@ pub fn parse_report_usage_result(raw: &Value) -> Result<ReportUsageResult, SdkEr
     }
 }
 
+#[cfg(feature = "valkey-default")]
 fn usage_field_str(arr: &[Result<Value, ferriskey::Error>], index: usize) -> String {
     match arr.get(index) {
         Some(Ok(Value::BulkString(b))) => String::from_utf8_lossy(b).into_owned(),
@@ -1313,6 +1321,7 @@ fn usage_field_str(arr: &[Result<Value, ferriskey::Error>], index: usize) -> Str
 /// silently coercing to `0` would surface drift as "zero-usage breach"
 /// — arithmetically correct but semantically nonsense. Fail loudly
 /// instead so drift shows up as a parse error at the first call site.
+#[cfg(feature = "valkey-default")]
 fn parse_usage_u64(
     arr: &[Result<Value, ferriskey::Error>],
     index: usize,
@@ -1426,6 +1435,7 @@ fn resume_waitpoint_id_from_suspension(
     Ok(Some(waitpoint_id))
 }
 
+#[cfg(feature = "valkey-default")]
 #[cfg_attr(not(feature = "direct-valkey-claim"), allow(dead_code))]
 pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(), SdkError> {
     let arr = match raw {
@@ -1511,6 +1521,7 @@ pub(crate) fn parse_success_result(raw: &Value, function_name: &str) -> Result<(
 /// Parse ff_deliver_signal result:
 ///   ok(signal_id, effect)
 ///   ok_duplicate(existing_signal_id)
+#[cfg(feature = "valkey-default")]
 pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError> {
     let arr = match raw {
         Value::Array(arr) => arr,
@@ -1622,6 +1633,7 @@ pub(crate) fn parse_signal_result(raw: &Value) -> Result<SignalOutcome, SdkError
 /// Parse ff_fail_execution result:
 ///   ok("retry_scheduled", delay_until)
 ///   ok("terminal_failed")
+#[cfg(feature = "valkey-default")]
 #[allow(dead_code)]
 fn parse_fail_result(raw: &Value) -> Result<FailOutcome, SdkError> {
     let arr = match raw {
@@ -1722,24 +1734,28 @@ pub const MAX_TAIL_BLOCK_MS: u64 = 30_000;
 /// Maximum frames per read/tail call. Mirrors
 /// `ff_core::contracts::STREAM_READ_HARD_CAP` — re-exported here so SDK
 /// callers don't need to import ff-core just to read the bound.
+#[cfg(feature = "valkey-default")]
 pub use ff_core::contracts::STREAM_READ_HARD_CAP;
 
 /// Result of [`read_stream`] / [`tail_stream`] — frames plus the terminal
 /// signal so polling consumers can exit cleanly.
 ///
 /// Re-export of `ff_core::contracts::StreamFrames` for SDK ergonomics.
+#[cfg(feature = "valkey-default")]
 pub use ff_core::contracts::StreamFrames;
 
 /// Opaque cursor for [`read_stream`] / [`tail_stream`] — re-export of
 /// `ff_core::contracts::StreamCursor`. Wire tokens: `"start"`, `"end"`,
 /// `"<ms>"`, `"<ms>-<seq>"`. Bare `-` / `+` are rejected — use
 /// `StreamCursor::Start` / `StreamCursor::End` instead.
+#[cfg(feature = "valkey-default")]
 pub use ff_core::contracts::StreamCursor;
 
 /// Reject `Start` / `End` cursors at the XREAD (`tail_stream`) boundary
 /// — XREAD does not accept the open markers. Pulled out as a bare
 /// function so unit tests can exercise the guard without constructing a
 /// live `ferriskey::Client`.
+#[cfg(feature = "valkey-default")]
 fn validate_tail_cursor(after: &StreamCursor) -> Result<(), SdkError> {
     if !after.is_concrete() {
         return Err(SdkError::Config {
@@ -1754,6 +1770,7 @@ fn validate_tail_cursor(after: &StreamCursor) -> Result<(), SdkError> {
     Ok(())
 }
 
+#[cfg(feature = "valkey-default")]
 fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
     if count_limit == 0 {
         return Err(SdkError::Config {
@@ -1799,6 +1816,7 @@ fn validate_stream_read_count(count_limit: u64) -> Result<(), SdkError> {
 /// FCALLs behind the reply. The REST server isolates reads on its
 /// `tail_client`; direct SDK callers should either use a dedicated
 /// client OR paginate through smaller `count_limit` slices.
+#[cfg(feature = "valkey-default")]
 pub async fn read_stream(
     backend: &dyn EngineBackend,
     execution_id: &ExecutionId,
@@ -1882,6 +1900,7 @@ pub async fn read_stream(
 /// the client was built with a shorter `request_timeout`. No custom client
 /// configuration is required for timeout reasons — only for head-of-line
 /// isolation above.
+#[cfg(feature = "valkey-default")]
 pub async fn tail_stream(
     backend: &dyn EngineBackend,
     execution_id: &ExecutionId,
@@ -1904,6 +1923,7 @@ pub async fn tail_stream(
 
 /// Tail helper with an explicit RFC-015
 /// [`TailVisibility`](ff_core::backend::TailVisibility) filter.
+#[cfg(feature = "valkey-default")]
 pub async fn tail_stream_with_visibility(
     backend: &dyn EngineBackend,
     execution_id: &ExecutionId,
@@ -1939,7 +1959,7 @@ pub async fn tail_stream_with_visibility(
         .await?)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "valkey-default"))]
 mod tail_stream_boundary_tests {
     use super::*;
 
@@ -1980,7 +2000,7 @@ mod tail_stream_boundary_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "valkey-default"))]
 mod parse_report_usage_result_tests {
     use super::*;
 
@@ -2129,6 +2149,7 @@ mod parse_report_usage_result_tests {
 /// user-supplied key. Single-waitpoint scoping: all
 /// Single.waitpoint_key / Count.waitpoints[i] in the tree must be
 /// equal; this function returns the first one it encounters.
+#[cfg(feature = "valkey-default")]
 fn composite_first_waitpoint_key(body: &CompositeBody) -> Option<String> {
     match body {
         CompositeBody::AllOf { members } => members.iter().find_map(|m| match m {
@@ -2230,7 +2251,7 @@ mod resume_signals_tests {
     // is exercised by the integration tests in `ff-test`.
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "valkey-default"))]
 mod terminal_replay_parsing_tests {
     //! Unit tests for the SDK's parse path of the enriched
     //! `execution_not_active` error returned on a terminal-op replay.

--- a/crates/ff-sdk/src/task.rs
+++ b/crates/ff-sdk/src/task.rs
@@ -153,13 +153,14 @@ pub struct ClaimedTask {
     /// `EngineBackend` the trait-migrated ops forward through.
     ///
     /// **RFC-012 Stage 1b + Round-7.** Today this is always a
-    /// `ValkeyBackend` wrapping `client`. Most per-task ops
+    /// `ValkeyBackend` wrapping an internal `ferriskey::Client`. Most
+    /// per-task ops
     /// (`complete`/`fail`/`cancel`/`delay_execution`/
     /// `move_to_waiting_children`/`update_progress`/`resume_signals`/
     /// `create_pending_waitpoint`/`append_frame`/`report_usage`) route
-    /// through `backend.*()`. `suspend` still uses
-    /// `client.fcall("ff_suspend_execution", ...)` directly — this is
-    /// the deferred suspend per RFC-012 §R7.6.1, pending Stage 1d
+    /// through `backend.*()`. `suspend` still uses the backend's
+    /// internal `fcall("ff_suspend_execution", ...)` directly — this
+    /// is the deferred suspend per RFC-012 §R7.6.1, pending Stage 1d
     /// input-shape work. Lease renewal goes through
     /// `backend.renew(&handle)`. Round-7 (#135/#145) closed the four
     /// trait-shape gaps tracked by #117.
@@ -226,6 +227,11 @@ impl ClaimedTask {
     ///
     /// # Arguments
     ///
+    /// * `backend` — `Arc<dyn EngineBackend>` the per-task ops
+    ///   (`complete`/`fail`/`cancel`/`renew`/`append_frame`/…) forward
+    ///   through, plus the background lease-renewal task. Today this
+    ///   is always a `ValkeyBackend` (see the struct doc on `backend`
+    ///   above); RFC-023 widens the admissible backends.
     /// * `partition_config` — partition topology snapshot read at
     ///   `FlowFabricWorker::connect`. Used for key construction on
     ///   the lifetime of this task.

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1275,7 +1275,6 @@ impl FlowFabricWorker {
             .await?;
 
         Ok(ClaimedTask::new(
-            self.valkey_client().clone(),
             self.backend.clone(),
             self.partition_config,
             execution_id.clone(),
@@ -1676,7 +1675,6 @@ impl FlowFabricWorker {
             .await?;
 
         Ok(ClaimedTask::new(
-            self.valkey_client().clone(),
             self.backend.clone(),
             self.partition_config,
             execution_id.clone(),
@@ -2072,6 +2070,25 @@ mod sqlite_only_compile_surface_tests {
             id: &ExecutionId,
         ) -> Result<ExecutionContext, EngineError> {
             b.read_execution_context(id).await
+        }
+    }
+
+    /// v0.12 PR-2 compile anchor — `ClaimedTask` as a type MUST be
+    /// addressable under `--no-default-features --features sqlite`
+    /// (the `task` module is no longer `valkey-default`-gated at the
+    /// module level). The `impl ClaimedTask { ... }` block is still
+    /// valkey-gated because `synth_handle` / `new` depend on
+    /// `ff_backend_valkey::ValkeyBackend::encode_handle`; this anchor
+    /// pins the struct path + its field types through a generic-over-T
+    /// wrapper so a compile-time lookup of `ClaimedTask` is exercised
+    /// mechanically under the sqlite-only feature set.
+    #[test]
+    fn claimed_task_type_addressable_under_sqlite_only() {
+        use crate::task::ClaimedTask;
+
+        #[allow(dead_code)]
+        fn _pin<T>(_: std::marker::PhantomData<T>) -> std::marker::PhantomData<ClaimedTask> {
+            std::marker::PhantomData
         }
     }
 }


### PR DESCRIPTION
## Motivation

v0.12 backend-agnostic SDK PR-2 — mechanical dead-code purge + module-gate relocation. Independent of PR-1 / PR-0 (both already merged on main).

## Scope (5 edits)

1. **`crates/ff-sdk/src/task.rs`** — remove the dead `client: Client` field on `ClaimedTask` (was `#[allow(dead_code)]`; no in-crate reads).
2. **`crates/ff-sdk/src/task.rs`** — drop the matching `client: Client` parameter + assignment from `ClaimedTask::new`, and drop the `Client` import. `Value` stays (used by `SignalOutcome::from_fcall_value` + parsers) behind the `valkey-default` gate.
3. **`crates/ff-sdk/src/task.rs`** — remove the module-level `#[cfg(feature = "valkey-default")]` gate on items that stay pure after the field removal (struct `ClaimedTask`, `Drop`, `Signal*`, `SuspendedHandle` / `TrySuspendOutcome`). Item-level gates relocated to the ferriskey/ValkeyBackend-dependent items (`impl ClaimedTask`, `impl SignalOutcome`, parse_* helpers, `spawn_renewal_task` / `renew_once` / helpers, free `read_stream` / `tail_stream` / `tail_stream_with_visibility`, `validate_*`, and three test modules that use `Value` / `StreamCursor`).
4. **`crates/ff-sdk/src/lib.rs`** — relocate `pub mod task;` out from under `#[cfg(feature = "valkey-default")]`. `snapshot` / `admin` / re-exports stay gated (PR-3/PR-6 scope).
5. **`crates/ff-sdk/src/worker.rs`** — drop `self.valkey_client().clone()` from the two `ClaimedTask::new` call sites at ~1277 and ~1679, and add `claimed_task_type_addressable_under_sqlite_only` to `sqlite_only_compile_surface_tests` (compile-only PhantomData anchor, mirrors the PR-1 generic-wrapper trick that works around `#[async_trait]` fn-pointer-cast limitations).

## Non-goals

- PR-3 ungates `deliver_signal` + `admin.rs` (separate PR).
- PR-6 ungates `snapshot.rs` (separate PR).
- No `ff-core` feature-edge churn. The PR-0 `feature-leak-guard` CI job stays green.

## Feature-tree diff

Identical to PR-0 baseline — `cargo tree -p ff-sdk --no-default-features --features sqlite -e features | grep 'ff-core feature'` returns the same 4 occurrences of `ff-core feature "core"` as main. No `streaming` / `suspension` / `budget` activation.

## Compile-anchor shape

The existing `read_execution_context_addressable_under_sqlite_only` test (PR-1) uses a generic `_pin<B: EngineBackend + ?Sized>` wrapper to name a trait method through a trait bound. `ClaimedTask::new` is `pub(crate)` + depends on `ValkeyBackend::encode_handle`, so it can't be addressed from the sqlite-only anchor. Instead, the new anchor uses a `PhantomData<ClaimedTask>` wrapper — a pure type-level reference proving the path `crate::task::ClaimedTask` resolves under `--no-default-features --features sqlite`. The accessors + methods stay on the gated `impl ClaimedTask` block and are proven by the default-feature tests.

## Test plan

- [x] `cargo test --workspace --lib` green
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` clean
- [x] `cargo check --workspace --all-features` clean
- [x] `scripts/smoke-sqlite.sh` PASS (17 s wall-clock)
- [x] Feature-tree unchanged vs PR-0 baseline (`ff-core = [core]` only under sqlite-only)
- [x] New compile anchor `claimed_task_type_addressable_under_sqlite_only` passes under `--no-default-features --features sqlite`
- [ ] CI `feature-leak-guard` stays green (expected — no feature edges touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes dead state and reshuffles `cfg(feature = "valkey-default")` gates; main risk is unintended compile/feature-flag regressions across `sqlite` vs `valkey-default` builds.
> 
> **Overview**
> Makes `ff-sdk`’s `task` module always available (even without `valkey-default`) so consumers can reference `crate::task::ClaimedTask` under `--no-default-features --features sqlite`, while moving Valkey/ferriskey-dependent pieces to **item-level** `cfg` gates.
> 
> Drops the unused Valkey `client` field from `ClaimedTask` and removes the corresponding constructor argument, updating worker claim paths accordingly. Adds a sqlite-only compile-anchor test to ensure the `ClaimedTask` type remains nameable under the sqlite-only feature set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de4b9f06497d02c171421a342f4c058e6fc6b5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->