### PR TITLE
refactor(engine): trait-object backend param for start_with_completions (agnostic-SDK PR-7a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ version = "0.11.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
+ "ff-backend-valkey",
  "ff-core",
  "ff-observability",
  "futures",

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "futures-core",
  "hex",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -713,6 +714,7 @@ dependencies = [
  "ff-core",
  "futures-core",
  "hex",
+ "libsqlite3-sys",
  "serde_json",
  "sqlx",
  "tokio",
@@ -788,6 +790,7 @@ version = "0.11.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
+ "ff-backend-valkey",
  "ff-core",
  "ff-observability",
  "futures",

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -4407,6 +4407,10 @@ fn acquire_stream_permit(
 
 #[async_trait]
 impl EngineBackend for ValkeyBackend {
+    fn as_any(&self) -> &(dyn std::any::Any + 'static) {
+        self
+    }
+
     async fn claim(
         &self,
         lane: &LaneId,

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -1079,6 +1079,26 @@ pub trait EngineBackend: Send + Sync + 'static {
         "unknown"
     }
 
+    /// Backend downcast escape hatch (v0.12 PR-7a transitional).
+    ///
+    /// Scanner supervisors in `ff-engine` still dispatch through a
+    /// concrete `ferriskey::Client`; to keep the engine's public
+    /// boundary backend-agnostic (`Arc<dyn EngineBackend>`) while the
+    /// scanner internals remain Valkey-shaped, the engine downcasts
+    /// via this method and reaches in for the embedded client. Every
+    /// backend that wants to be consumed by `Engine::start_with_completions`
+    /// overrides this to return `self` as `&dyn Any`; the default
+    /// returns a placeholder so a stray `downcast_ref` fails cleanly
+    /// rather than risking unsound behaviour.
+    ///
+    /// v0.13 (PR-7b) will trait-ify individual scanners onto
+    /// `EngineBackend` and retire this method.
+    fn as_any(&self) -> &(dyn std::any::Any + 'static) {
+        // Placeholder so the default does not expose `Self` for
+        // downcast. Backends override to return `self`.
+        &()
+    }
+
     /// RFC-018 Stage A: snapshot of this backend's identity + the
     /// flat `Supports` surface it can actually service. Consumers use
     /// this at startup to gate UI features / choose between alternative

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -1092,7 +1092,11 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// rather than risking unsound behaviour.
     ///
     /// v0.13 (PR-7b) will trait-ify individual scanners onto
-    /// `EngineBackend` and retire this method.
+    /// `EngineBackend` and retire `ff-engine`'s dependence on this
+    /// downcast path. The method itself will remain on the trait
+    /// (likely deprecated) rather than be removed — removing a
+    /// public trait method is a breaking change for external
+    /// `impl EngineBackend` blocks.
     fn as_any(&self) -> &(dyn std::any::Any + 'static) {
         // Placeholder so the default does not expose `Self` for
         // downcast. Backends override to return `self`.

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -25,6 +25,12 @@ postgres = ["dep:ff-backend-postgres", "dep:sqlx", "dep:uuid"]
 [dependencies]
 ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
 ff-observability = { workspace = true }
+# v0.12 PR-7a transitional: `Engine::start_*` accepts
+# `Arc<dyn EngineBackend>` on the boundary but scanners still speak
+# ferriskey, so `start_internal` downcasts the backend to
+# `ValkeyBackend` and reaches for the embedded client. v0.13 (PR-7b)
+# trait-ifies the scanner surface and drops this dep.
+ff-backend-valkey = { workspace = true }
 ferriskey = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -30,7 +30,13 @@ ff-observability = { workspace = true }
 # ferriskey, so `start_internal` downcasts the backend to
 # `ValkeyBackend` and reaches for the embedded client. v0.13 (PR-7b)
 # trait-ifies the scanner surface and drops this dep.
-ff-backend-valkey = { workspace = true }
+#
+# `default-features = false` is load-bearing: `ff-backend-valkey`'s
+# default feature set enables `ff-core/streaming`, which would
+# silently defeat the explicit `ff-core` anchor on line 26
+# (`default-features = false, features = ["core"]`) and re-expose
+# streaming-gated trait methods on `ff-engine`.
+ff-backend-valkey = { version = "0.11.0", path = "../ff-backend-valkey", default-features = false }
 ferriskey = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ff-engine/src/lib.rs
+++ b/crates/ff-engine/src/lib.rs
@@ -198,9 +198,10 @@ impl Engine {
     /// is [`ff_backend_valkey::ValkeyBackend`] only; v0.13 (PR-7b)
     /// will trait-ify the scanner surface and accept any
     /// `EngineBackend` implementation. Passing a non-Valkey backend
-    /// today panics at scanner-spawn time (by design — the cairn
-    /// embedding path that motivated this signature goes through
-    /// Valkey until the trait-ification lands).
+    /// today panics immediately inside this constructor (before any
+    /// scanner tasks are spawned) — by design; the cairn embedding
+    /// path that motivated this signature goes through Valkey until
+    /// the trait-ification lands.
     pub fn start(config: EngineConfig, backend: Arc<dyn EngineBackend>) -> Self {
         // Construct a fresh metrics handle here so direct callers
         // (examples, tests) don't need to. Under the default build
@@ -242,15 +243,18 @@ impl Engine {
     ///
     /// # Backend parameter (v0.12 PR-7a)
     ///
-    /// `backend` is an `Arc<dyn EngineBackend>` so cairn and other
-    /// consumers can construct an engine around a non-Valkey backend
-    /// without touching scanner internals. The scanner supervisors
-    /// today still speak ferriskey, so this constructor downcasts
-    /// `backend.as_any()` to
-    /// [`ff_backend_valkey::ValkeyBackend`] and reaches for the
-    /// embedded `ferriskey::Client`. v0.13 (PR-7b) will trait-ify
-    /// each scanner onto `EngineBackend` and retire the downcast —
-    /// the public signature stays stable through that transition.
+    /// `backend` is an `Arc<dyn EngineBackend>` so the public
+    /// constructor signature is backend-agnostic — cairn and other
+    /// consumers can sequence their engine construction around this
+    /// shape without waiting for the scanner trait-ification. Runtime
+    /// support in v0.12 is still Valkey-only: the scanner supervisors
+    /// today speak ferriskey, so this constructor downcasts
+    /// `backend.as_any()` to [`ff_backend_valkey::ValkeyBackend`] and
+    /// reaches for the embedded `ferriskey::Client`. v0.13 (PR-7b)
+    /// will trait-ify each scanner onto `EngineBackend` and retire
+    /// the downcast — the public signature stays stable through that
+    /// transition, so consumers wiring up the v0.12 shape today
+    /// don't change their call site.
     ///
     /// # Panics
     ///
@@ -296,15 +300,18 @@ impl Engine {
         // speak ferriskey directly; until PR-7b trait-ifies them,
         // reach in for the embedded client. Only in-tree consumer is
         // ff-server which always constructs a `ValkeyBackend`.
-        let client = backend
+        let client = match backend
             .as_any()
             .downcast_ref::<ff_backend_valkey::ValkeyBackend>()
-            .expect(
-                "Engine::start_* in v0.12 requires ValkeyBackend; \
-                 non-Valkey support lands in v0.13 (PR-7b).",
-            )
-            .client()
-            .clone();
+        {
+            Some(vb) => vb.client().clone(),
+            None => panic!(
+                "Engine::start_* in v0.12 requires ValkeyBackend \
+                 (got backend_label={:?}); non-Valkey support lands \
+                 in v0.13 (PR-7b).",
+                backend.backend_label(),
+            ),
+        };
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let num_partitions = config.partition_config.num_flow_partitions;
         let router = Arc::new(PartitionRouter::new(config.partition_config));

--- a/crates/ff-engine/src/lib.rs
+++ b/crates/ff-engine/src/lib.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
 use ff_core::completion_backend::CompletionStream;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::partition::PartitionConfig;
 use ff_core::types::LaneId;
 use tokio::sync::watch;
@@ -188,10 +189,19 @@ pub struct Engine {
 }
 
 impl Engine {
-    /// Start the engine with the given config and Valkey client.
+    /// Start the engine with the given config and backend.
     ///
     /// Spawns background scanner tasks. Returns immediately.
-    pub fn start(config: EngineConfig, client: ferriskey::Client) -> Self {
+    ///
+    /// `backend` must be a backend whose [`EngineBackend::as_any`]
+    /// downcasts to a supported concrete type. In v0.12 (PR-7a) that
+    /// is [`ff_backend_valkey::ValkeyBackend`] only; v0.13 (PR-7b)
+    /// will trait-ify the scanner surface and accept any
+    /// `EngineBackend` implementation. Passing a non-Valkey backend
+    /// today panics at scanner-spawn time (by design — the cairn
+    /// embedding path that motivated this signature goes through
+    /// Valkey until the trait-ification lands).
+    pub fn start(config: EngineConfig, backend: Arc<dyn EngineBackend>) -> Self {
         // Construct a fresh metrics handle here so direct callers
         // (examples, tests) don't need to. Under the default build
         // (`observability` feature off) this is the no-op shim. With
@@ -201,7 +211,7 @@ impl Engine {
         // isolation. Production code uses
         // [`Self::start_with_metrics`] to plumb the same handle
         // through the HTTP /metrics route.
-        Self::start_with_metrics(config, client, Arc::new(ff_observability::Metrics::new()))
+        Self::start_with_metrics(config, backend, Arc::new(ff_observability::Metrics::new()))
     }
 
     /// PR-94: start the engine with a shared observability registry.
@@ -213,10 +223,10 @@ impl Engine {
     /// `MeterProvider`; otherwise the shim no-ops.
     pub fn start_with_metrics(
         config: EngineConfig,
-        client: ferriskey::Client,
+        backend: Arc<dyn EngineBackend>,
         metrics: Arc<ff_observability::Metrics>,
     ) -> Self {
-        Self::start_internal(config, client, metrics, None)
+        Self::start_internal(config, backend, metrics, None)
     }
 
     /// Start the engine with a shared observability registry and a
@@ -229,21 +239,72 @@ impl Engine {
     /// latency from `interval × levels` to `~RTT × levels`. The
     /// `dependency_reconciler` scanner remains as a safety net for
     /// completions missed during subscriber reconnect windows.
+    ///
+    /// # Backend parameter (v0.12 PR-7a)
+    ///
+    /// `backend` is an `Arc<dyn EngineBackend>` so cairn and other
+    /// consumers can construct an engine around a non-Valkey backend
+    /// without touching scanner internals. The scanner supervisors
+    /// today still speak ferriskey, so this constructor downcasts
+    /// `backend.as_any()` to
+    /// [`ff_backend_valkey::ValkeyBackend`] and reaches for the
+    /// embedded `ferriskey::Client`. v0.13 (PR-7b) will trait-ify
+    /// each scanner onto `EngineBackend` and retire the downcast —
+    /// the public signature stays stable through that transition.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `backend.as_any().downcast_ref::<ValkeyBackend>()`
+    /// is `None`. The only in-tree caller (`ff-server`) constructs a
+    /// `ValkeyBackend` before calling; external consumers that want
+    /// non-Valkey support must wait for PR-7b.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use ff_core::engine_backend::EngineBackend;
+    /// # async fn ex(
+    /// #     cfg: ff_engine::EngineConfig,
+    /// #     metrics: Arc<ff_observability::Metrics>,
+    /// #     stream: ff_core::completion_backend::CompletionStream,
+    /// #     backend: Arc<dyn EngineBackend>, // e.g. from ValkeyBackend::connect
+    /// # ) {
+    /// // Valkey backend: works today (v0.12 PR-7a).
+    /// let engine = ff_engine::Engine::start_with_completions(
+    ///     cfg, backend, metrics, stream,
+    /// );
+    /// # let _ = engine;
+    /// # }
+    /// ```
     pub fn start_with_completions(
         config: EngineConfig,
-        client: ferriskey::Client,
+        backend: Arc<dyn EngineBackend>,
         metrics: Arc<ff_observability::Metrics>,
         completions: CompletionStream,
     ) -> Self {
-        Self::start_internal(config, client, metrics, Some(completions))
+        Self::start_internal(config, backend, metrics, Some(completions))
     }
 
     fn start_internal(
         config: EngineConfig,
-        client: ferriskey::Client,
+        backend: Arc<dyn EngineBackend>,
         metrics: Arc<ff_observability::Metrics>,
         completions: Option<CompletionStream>,
     ) -> Self {
+        // v0.12 PR-7a transitional downcast. Scanners today still
+        // speak ferriskey directly; until PR-7b trait-ifies them,
+        // reach in for the embedded client. Only in-tree consumer is
+        // ff-server which always constructs a `ValkeyBackend`.
+        let client = backend
+            .as_any()
+            .downcast_ref::<ff_backend_valkey::ValkeyBackend>()
+            .expect(
+                "Engine::start_* in v0.12 requires ValkeyBackend; \
+                 non-Valkey support lands in v0.13 (PR-7b).",
+            )
+            .client()
+            .clone();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let num_partitions = config.partition_config.num_flow_partitions;
         let router = Arc::new(PartitionRouter::new(config.partition_config));

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -454,9 +454,19 @@ impl Server {
                 "subscribe_completions: {e}"
             )))?;
 
+        // PR-7a: `Engine::start_with_completions` takes
+        // `Arc<dyn EngineBackend>` on the boundary (scanners still
+        // downcast to `ValkeyBackend` internally — v0.13 PR-7b
+        // retires that). Reuse `completion_backend`: it already
+        // wraps the same `client` via
+        // `from_client_partitions_and_connection`, so this is a
+        // plain `Arc<ValkeyBackend>` → `Arc<dyn EngineBackend>`
+        // coercion, no second dial.
+        let engine_backend: Arc<dyn EngineBackend> =
+            completion_backend.clone() as Arc<dyn EngineBackend>;
         let engine = Engine::start_with_completions(
             engine_cfg,
-            client.clone(),
+            engine_backend,
             metrics.clone(),
             completion_stream,
         );


### PR DESCRIPTION
## Summary

- Replace `client: ferriskey::Client` with `backend: Arc<dyn EngineBackend>` on `Engine::start`, `start_with_metrics`, and `start_with_completions`. Public boundary is now backend-agnostic.
- Add `EngineBackend::as_any` escape hatch (placeholder default; `ValkeyBackend` overrides) so scanner supervisors can downcast and reach for the embedded `ferriskey::Client`. Ugly and explicitly transitional — PR-7b (v0.13) trait-ifies each scanner and retires the downcast while keeping this signature stable.
- Single in-tree caller (`ff-server::Server::start_with_metrics`) updated: reuses the existing `completion_backend: Arc<ValkeyBackend>` via coercion (no second dial).

## Motivation

Unblocks cairn (and other consumers) embedding a FlowFabric engine around a non-Valkey backend without touching scanner internals. The scope report splits PR-7 into boundary-fix (v0.12, this PR) + scanner trait-ification (v0.13, followup). This PR is the boundary-fix only.

## Scope (PR-7a only)

- Boundary signature change on `Engine::start*`.
- `EngineBackend::as_any` default + `ValkeyBackend` override.
- `ff-engine` gains a transitional path-dep on `ff-backend-valkey` for the downcast target (documented + scheduled for PR-7b retirement).
- 17 `supervised_spawn` call sites: scanner signatures + bodies unchanged — they continue to receive a cloned `ferriskey::Client` extracted at the top of `start_internal`.
- `completion_listener::spawn_dispatch_loop`: unchanged, receives the same ferriskey client.
- Doctest in `start_with_completions` rustdoc showing the Valkey construction shape.

## Followup (v0.13, PR-7b)

Trait-ify the scanner surface on `EngineBackend` so `start_internal` can drop the downcast and ff-engine can drop the `ff-backend-valkey` path-dep. Public `Engine::start*` signatures stay stable through that transition.

## Breaking change

`Engine::start`, `Engine::start_with_metrics`, `Engine::start_with_completions` now take `Arc<dyn EngineBackend>` instead of `ferriskey::Client`. Only in-tree caller is `ff-server`, updated in this PR.

## Test plan

- [x] `cargo check --workspace --all-features` green
- [x] `cargo clippy -p ff-engine -p ff-backend-valkey -p ff-core -p ff-server --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib --workspace` — all our crates pass (ferriskey `shared_client_tests` require a live Valkey and are unrelated pre-existing)
- [x] `cargo test --doc -p ff-engine` — new doctest passes
- [x] `cargo tree -p ff-sdk --no-default-features --features sqlite` — no ff-engine / ff-backend-valkey edges; ff-sdk stays minimal
- [x] `scripts/smoke-sqlite.sh` PASS
- [x] `scripts/smoke-v0.7.sh` PASS (Valkey + Postgres scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change to `ff-engine` startup constructors and introduces a runtime downcast/panic path if a non-`ValkeyBackend` is passed. The logic is straightforward but touches engine initialization and backend wiring used in production startup.
> 
> **Overview**
> `Engine::start`, `start_with_metrics`, and `start_with_completions` now take `Arc<dyn EngineBackend>` instead of a raw `ferriskey::Client`, making the public engine boundary backend-agnostic.
> 
> Adds a transitional `EngineBackend::as_any` downcast hook (with `ValkeyBackend` overriding it) so `ff-engine` can extract the embedded `ferriskey::Client` for existing scanner supervisors; `ff-server` is updated to pass an `Arc<ValkeyBackend>` coerced to `Arc<dyn EngineBackend>`.
> 
> `ff-engine` gains a direct dependency on `ff-backend-valkey` to support the downcast target, and lockfiles are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50f6c881e8d45e3f3e09825ee9871948d1337e75. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->