### PR TITLE
refactor(sdk+core): add EngineBackend::claim_execution; route claim_from_grant through trait (agnostic-SDK PR-4)

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -39,7 +39,7 @@ use ff_core::contracts::decode::{
 };
 use ff_core::contracts::{
     AdditionalWaitpointBinding, CancelFlowArgs, CancelFlowResult, ClaimExecutionArgs,
-    ClaimResumedExecutionArgs, ClaimResumedExecutionResult, CompositeBody,
+    ClaimExecutionResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult, CompositeBody,
     CountKind, DeliverSignalArgs, DeliverSignalResult, EdgeDirection, EdgeSnapshot,
     ExecutionContext, ExecutionSnapshot, FlowSnapshot, FlowStatus, FlowSummary, IssueReclaimGrantArgs,
     IssueReclaimGrantOutcome, ListExecutionsPage, ListFlowsPage, ListLanesPage,
@@ -3980,20 +3980,20 @@ async fn claim_impl(
         let lease_id = LeaseId::new();
         let attempt_id = AttemptId::new();
 
-        let args = ClaimExecutionArgs {
-            execution_id: execution_id.clone(),
-            worker_id: policy.worker_id.clone(),
-            worker_instance_id: policy.worker_instance_id.clone(),
-            lane_id: lane.clone(),
-            lease_id: lease_id.clone(),
-            lease_ttl_ms: u64::from(policy.lease_ttl_ms),
-            attempt_id: attempt_id.clone(),
-            expected_attempt_index: att_idx,
-            attempt_policy_json: "{}".to_owned(),
-            attempt_timeout_ms: None,
-            execution_deadline_at: None,
-            now: TimestampMs::now(),
-        };
+        let args = ClaimExecutionArgs::new(
+            execution_id.clone(),
+            policy.worker_id.clone(),
+            policy.worker_instance_id.clone(),
+            lane.clone(),
+            lease_id.clone(),
+            u64::from(policy.lease_ttl_ms),
+            attempt_id.clone(),
+            att_idx,
+            "{}".to_owned(),
+            None,
+            None,
+            TimestampMs::now(),
+        );
 
         let exec_keys = ExecOpKeys {
             ctx: &ctx,
@@ -4393,6 +4393,36 @@ async fn reclaim_execution_impl(
         lease_id = %args.lease_id,
     )
 )]
+/// Grant-consumer path for [`EngineBackend::claim_execution`].
+///
+/// Fires exactly one `ff_claim_execution` FCALL against the
+/// execution's partition, consuming the scheduler-issued claim grant
+/// and minting the attempt row. Key/ARGV shape is identical to what
+/// `claim_impl` (the scheduler-bypass scanner) fires post-grant and
+/// to the pre-PR-4 direct-FCALL helper on the SDK worker — this
+/// extraction preserves every observable Valkey write byte-for-byte.
+async fn claim_execution_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    args: ClaimExecutionArgs,
+) -> Result<ClaimExecutionResult, EngineError> {
+    let partition = execution_partition(&args.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &args.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let keys = ExecOpKeys {
+        ctx: &ctx,
+        idx: &idx,
+        lane_id: &args.lane_id,
+        worker_instance_id: &args.worker_instance_id,
+    };
+    let execution_id = args.execution_id.clone();
+    let partial = ff_claim_execution(client, &keys, &args)
+        .await
+        .map_err(EngineError::from)?;
+    Ok(partial.complete(execution_id))
+}
+
 async fn claim_resumed_execution_impl(
     client: &ferriskey::Client,
     partition_config: &PartitionConfig,
@@ -5005,6 +5035,20 @@ impl EngineBackend for ValkeyBackend {
                 ff_core::engine_error::backend_context(
                     e,
                     "claim_resumed_execution: FCALL ff_claim_resumed_execution",
+                )
+            })
+    }
+
+    async fn claim_execution(
+        &self,
+        args: ClaimExecutionArgs,
+    ) -> Result<ClaimExecutionResult, EngineError> {
+        claim_execution_impl(&self.client, &self.partition_config, args)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "claim_execution: FCALL ff_claim_execution",
                 )
             })
     }

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -4393,36 +4393,6 @@ async fn reclaim_execution_impl(
         lease_id = %args.lease_id,
     )
 )]
-/// Grant-consumer path for [`EngineBackend::claim_execution`].
-///
-/// Fires exactly one `ff_claim_execution` FCALL against the
-/// execution's partition, consuming the scheduler-issued claim grant
-/// and minting the attempt row. Key/ARGV shape is identical to what
-/// `claim_impl` (the scheduler-bypass scanner) fires post-grant and
-/// to the pre-PR-4 direct-FCALL helper on the SDK worker — this
-/// extraction preserves every observable Valkey write byte-for-byte.
-async fn claim_execution_impl(
-    client: &ferriskey::Client,
-    partition_config: &PartitionConfig,
-    args: ClaimExecutionArgs,
-) -> Result<ClaimExecutionResult, EngineError> {
-    let partition = execution_partition(&args.execution_id, partition_config);
-    let ctx = ExecKeyContext::new(&partition, &args.execution_id);
-    let idx = IndexKeys::new(&partition);
-
-    let keys = ExecOpKeys {
-        ctx: &ctx,
-        idx: &idx,
-        lane_id: &args.lane_id,
-        worker_instance_id: &args.worker_instance_id,
-    };
-    let execution_id = args.execution_id.clone();
-    let partial = ff_claim_execution(client, &keys, &args)
-        .await
-        .map_err(EngineError::from)?;
-    Ok(partial.complete(execution_id))
-}
-
 async fn claim_resumed_execution_impl(
     client: &ferriskey::Client,
     partition_config: &PartitionConfig,
@@ -4440,6 +4410,46 @@ async fn claim_resumed_execution_impl(
     };
     let execution_id = args.execution_id.clone();
     let partial = ff_claim_resumed_execution(client, &keys, &args)
+        .await
+        .map_err(EngineError::from)?;
+    Ok(partial.complete(execution_id))
+}
+
+/// Grant-consumer path for [`EngineBackend::claim_execution`].
+///
+/// Fires exactly one `ff_claim_execution` FCALL against the
+/// execution's partition, consuming the scheduler-issued claim grant
+/// and minting the attempt row. Key/ARGV shape is identical to what
+/// `claim_impl` (the scheduler-bypass scanner) fires post-grant and
+/// to the pre-PR-4 direct-FCALL helper on the SDK worker — this
+/// extraction preserves every observable Valkey write byte-for-byte.
+#[tracing::instrument(
+    name = "ff.claim_execution",
+    skip_all,
+    fields(
+        backend = "valkey",
+        execution_id = %args.execution_id,
+        worker_instance_id = %args.worker_instance_id,
+        lease_id = %args.lease_id,
+    )
+)]
+async fn claim_execution_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    args: ClaimExecutionArgs,
+) -> Result<ClaimExecutionResult, EngineError> {
+    let partition = execution_partition(&args.execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, &args.execution_id);
+    let idx = IndexKeys::new(&partition);
+
+    let keys = ExecOpKeys {
+        ctx: &ctx,
+        idx: &idx,
+        lane_id: &args.lane_id,
+        worker_instance_id: &args.worker_instance_id,
+    };
+    let execution_id = args.execution_id.clone();
+    let partial = ff_claim_execution(client, &keys, &args)
         .await
         .map_err(EngineError::from)?;
     Ok(partial.complete(execution_id))

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -328,6 +328,7 @@ impl ReclaimGrant {
 // ─── claim_execution ───
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ClaimExecutionArgs {
     pub execution_id: ExecutionId,
     pub worker_id: WorkerId,
@@ -351,6 +352,43 @@ pub struct ClaimExecutionArgs {
     pub now: TimestampMs,
 }
 
+impl ClaimExecutionArgs {
+    /// Construct a `ClaimExecutionArgs`. Added alongside
+    /// `#[non_exhaustive]` per `feedback_non_exhaustive_needs_constructor`
+    /// so consumers (SDK worker, backend impls) can still build the
+    /// args after the struct was sealed for forward-compat.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        execution_id: ExecutionId,
+        worker_id: WorkerId,
+        worker_instance_id: WorkerInstanceId,
+        lane_id: LaneId,
+        lease_id: LeaseId,
+        lease_ttl_ms: u64,
+        attempt_id: AttemptId,
+        expected_attempt_index: AttemptIndex,
+        attempt_policy_json: String,
+        attempt_timeout_ms: Option<u64>,
+        execution_deadline_at: Option<i64>,
+        now: TimestampMs,
+    ) -> Self {
+        Self {
+            execution_id,
+            worker_id,
+            worker_instance_id,
+            lane_id,
+            lease_id,
+            lease_ttl_ms,
+            attempt_id,
+            expected_attempt_index,
+            attempt_policy_json,
+            attempt_timeout_ms,
+            execution_deadline_at,
+            now,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClaimedExecution {
     pub execution_id: ExecutionId,
@@ -362,7 +400,14 @@ pub struct ClaimedExecution {
     pub lease_expires_at: TimestampMs,
 }
 
+/// Typed outcome of [`crate::engine_backend::EngineBackend::claim_execution`].
+///
+/// Single-variant today; `#[non_exhaustive]` reserves room for future
+/// outcomes (e.g. an explicit `NoGrant` variant if RFC-024 splits it
+/// out of `InvalidClaimGrant`) without a breaking match-arm churn on
+/// consumers.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ClaimExecutionResult {
     /// Successfully claimed.
     Claimed(ClaimedExecution),

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -693,13 +693,12 @@ pub trait EngineBackend: Send + Sync + 'static {
 
     /// Consume a scheduler-issued claim grant to mint a fresh attempt.
     ///
-    /// The SDK's grant-consumer path — paired with
-    /// [`FlowFabricWorker::claim_from_grant`](../../ff_sdk/struct.FlowFabricWorker.html#method.claim_from_grant)
-    /// — routes through this method. The scheduler has already
-    /// validated budget / quota / capabilities and written a grant
-    /// (Valkey `claim_grant` hash / PG+SQLite `ff_claim_grant` row);
-    /// this call atomically consumes that grant and creates the
-    /// attempt row, mints `lease_id` + `lease_epoch`, and returns a
+    /// The SDK's grant-consumer path — paired with `FlowFabricWorker::claim_from_grant`
+    /// in `ff-sdk` — routes through this method. The scheduler has
+    /// already validated budget / quota / capabilities and written a
+    /// grant (Valkey `claim_grant` hash); this call atomically
+    /// consumes that grant and creates the attempt row, mints
+    /// `lease_id` + `lease_epoch`, and returns a
     /// [`ClaimExecutionResult::Claimed`] carrying the minted lease
     /// triple.
     ///
@@ -707,7 +706,7 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// used by the `direct-valkey-claim` feature) — this method
     /// assumes the grant already exists and skips capability / ZSET
     /// scanning. The Valkey impl fires exactly one `ff_claim_execution`
-    /// FCALL; the PG / SQLite impls fire one CAS transaction.
+    /// FCALL.
     ///
     /// Typed failures surface via `ScriptError` → `EngineError`:
     /// `UseClaimResumedExecution` when the attempt is actually
@@ -718,11 +717,21 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// when the execution's `required_capabilities` drifted after
     /// grant issuance.
     ///
+    /// # Backend coverage
+    ///
+    /// * **Valkey** — implemented in `ff-backend-valkey` (one
+    ///   `ff_claim_execution` FCALL).
+    /// * **Postgres / SQLite** — use the `Err(Unavailable)` default in
+    ///   this PR. Grants on PG / SQLite today flow through
+    ///   `PostgresScheduler::claim_for_worker` (a sibling struct, not
+    ///   an `EngineBackend` method); wiring the default-over-trait
+    ///   behaviour into a PG / SQLite `claim_execution` impl lands
+    ///   with a future RFC-024 grant-consumer extension.
+    ///
     /// The default impl returns [`EngineError::Unavailable`] so the
-    /// trait addition is non-breaking for backends that have no
-    /// grant-consumer path (PG / SQLite today — grants are a Valkey
-    /// concept pending RFC-024 extensions). Same precedent as
-    /// [`Self::read_current_attempt_index`] landing in v0.12 PR-3.
+    /// trait addition is non-breaking for out-of-tree backends. Same
+    /// precedent as [`Self::read_current_attempt_index`] landing in
+    /// v0.12 PR-3.
     #[cfg(feature = "core")]
     async fn claim_execution(
         &self,

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -62,8 +62,9 @@ use crate::contracts::{
 use crate::contracts::{
     AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
     ApplyDependencyToChildResult, BudgetStatus, CancelExecutionArgs, CancelExecutionResult,
-    CancelFlowArgs, ChangePriorityArgs, ChangePriorityResult, ClaimForWorkerArgs,
-    ClaimForWorkerOutcome, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
+    CancelFlowArgs, ChangePriorityArgs, ChangePriorityResult, ClaimExecutionArgs,
+    ClaimExecutionResult, ClaimForWorkerArgs, ClaimForWorkerOutcome, ClaimResumedExecutionArgs,
+    ClaimResumedExecutionResult,
     CreateBudgetArgs, CreateBudgetResult, CreateExecutionArgs, CreateExecutionResult,
     CreateFlowArgs, CreateFlowResult, CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
     DeliverSignalArgs, DeliverSignalResult, EdgeDirection, EdgeSnapshot, ExecutionInfo,
@@ -687,6 +688,48 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<ClaimResumedExecutionResult, EngineError> {
         Err(EngineError::Unavailable {
             op: "claim_resumed_execution",
+        })
+    }
+
+    /// Consume a scheduler-issued claim grant to mint a fresh attempt.
+    ///
+    /// The SDK's grant-consumer path — paired with
+    /// [`FlowFabricWorker::claim_from_grant`](../../ff_sdk/struct.FlowFabricWorker.html#method.claim_from_grant)
+    /// — routes through this method. The scheduler has already
+    /// validated budget / quota / capabilities and written a grant
+    /// (Valkey `claim_grant` hash / PG+SQLite `ff_claim_grant` row);
+    /// this call atomically consumes that grant and creates the
+    /// attempt row, mints `lease_id` + `lease_epoch`, and returns a
+    /// [`ClaimExecutionResult::Claimed`] carrying the minted lease
+    /// triple.
+    ///
+    /// Distinct from [`Self::claim`] (the scheduler-bypass scanner
+    /// used by the `direct-valkey-claim` feature) — this method
+    /// assumes the grant already exists and skips capability / ZSET
+    /// scanning. The Valkey impl fires exactly one `ff_claim_execution`
+    /// FCALL; the PG / SQLite impls fire one CAS transaction.
+    ///
+    /// Typed failures surface via `ScriptError` → `EngineError`:
+    /// `UseClaimResumedExecution` when the attempt is actually
+    /// `attempt_interrupted` (caller should retry via
+    /// [`Self::claim_resumed_execution`] — see `ContentionKind` at
+    /// `ff_core::engine_error`), `InvalidClaimGrant` when the grant is
+    /// missing / consumed / worker-mismatched, `CapabilityMismatch`
+    /// when the execution's `required_capabilities` drifted after
+    /// grant issuance.
+    ///
+    /// The default impl returns [`EngineError::Unavailable`] so the
+    /// trait addition is non-breaking for backends that have no
+    /// grant-consumer path (PG / SQLite today — grants are a Valkey
+    /// concept pending RFC-024 extensions). Same precedent as
+    /// [`Self::read_current_attempt_index`] landing in v0.12 PR-3.
+    #[cfg(feature = "core")]
+    async fn claim_execution(
+        &self,
+        _args: ClaimExecutionArgs,
+    ) -> Result<ClaimExecutionResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "claim_execution",
         })
     }
 

--- a/crates/ff-script/src/functions/execution.rs
+++ b/crates/ff-script/src/functions/execution.rs
@@ -822,6 +822,9 @@ mod partial_tests {
         let full = partial.complete(eid.clone());
         match full {
             ClaimExecutionResult::Claimed(c) => assert_eq!(c.execution_id, eid),
+            // `#[non_exhaustive]` — v0.12 PR-4 sealed the enum for
+            // forward-compat. Single-variant today.
+            _ => unreachable!("ClaimExecutionResult has only `Claimed`"),
         }
     }
 

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -8,9 +8,18 @@ use std::sync::Arc;
 // `valkey-default` so the module compiles under
 // `--no-default-features, features = ["sqlite"]`.
 #[cfg(feature = "valkey-default")]
-use ferriskey::{Client, Value};
+use ferriskey::Client;
+// `Value` + `IndexKeys` are only referenced by the direct-claim
+// scanner (`claim_next`) and its helpers. v0.12 PR-4 routed the
+// `claim_from_grant` hot path through the trait so the last
+// always-on use of `Value` disappeared. Keep both imports scoped to
+// `direct-valkey-claim` so the default-feature build is warning-free.
+#[cfg(feature = "direct-valkey-claim")]
+use ferriskey::Value;
 #[cfg(feature = "valkey-default")]
-use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::keys::ExecKeyContext;
+#[cfg(feature = "direct-valkey-claim")]
+use ff_core::keys::IndexKeys;
 use ff_core::partition::PartitionConfig;
 #[cfg(feature = "valkey-default")]
 use ff_core::types::*;
@@ -856,14 +865,25 @@ impl FlowFabricWorker {
         }
     }
 
-    /// Low-level claim of a granted execution. Invokes
-    /// `ff_claim_execution` and returns a `ClaimedTask` with auto
-    /// lease renewal.
+    /// Low-level claim of a granted execution. Routes through
+    /// [`EngineBackend::claim_execution`](ff_core::engine_backend::EngineBackend::claim_execution)
+    /// — the trait-level grant-consumer method landed in v0.12 PR-4 —
+    /// and returns a `ClaimedTask` with auto lease renewal.
     ///
-    /// Previously gated behind `direct-valkey-claim`; ungated so
-    /// the public [`claim_from_grant`] entry point can reuse the
-    /// same FCALL plumbing. The method stays private — external
-    /// callers use `claim_from_grant`.
+    /// Pre-PR-4 the SDK fired the `ff_claim_execution` FCALL directly
+    /// against `valkey_client()` and hand-parsed the Lua response shape.
+    /// The body now collapses to `backend.claim_execution(args)` +
+    /// `backend.read_execution_context(...)` + `ClaimedTask::new(...)`;
+    /// the Valkey-specific FCALL plumbing lives behind the trait in
+    /// `ff_backend_valkey::claim_execution_impl`.
+    ///
+    /// The method stays `valkey-default`-gated because
+    /// [`ClaimedTask::new`](crate::task::ClaimedTask) still depends on
+    /// `ValkeyBackend::encode_handle` for handle synthesis (lease-
+    /// renewal loop cookie). The public [`claim_from_grant`] entry
+    /// point that calls this helper stays gated for the same reason.
+    /// A full cross-backend ungate awaits an agnostic `ClaimedTask::new`
+    /// (v0.12 PR-5 / `claim_next` scope).
     ///
     /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
     #[cfg(feature = "valkey-default")]
@@ -874,14 +894,16 @@ impl FlowFabricWorker {
         partition: &ff_core::partition::Partition,
         _now: TimestampMs,
     ) -> Result<ClaimedTask, SdkError> {
+        // Pre-read total_attempt_count from exec_core to derive the
+        // expected attempt index. The Lua uses total_attempt_count as
+        // the new index and builds the attempt key from the hash tag,
+        // so the Rust-side index is mainly documentation/debugging; we
+        // still plumb it through `ClaimExecutionArgs::expected_attempt_index`
+        // so the backend's KEYS construction lines up with what the
+        // Lua computes (byte-for-byte identical to pre-PR-4).
         let ctx = ExecKeyContext::new(partition, execution_id);
-        let idx = IndexKeys::new(partition);
-
-        // Pre-read total_attempt_count from exec_core to derive next attempt index.
-        // The Lua uses total_attempt_count as the new index and dynamically builds
-        // the attempt key from the hash tag, so KEYS[6-8] are placeholders, but
-        // we pass the correct index for documentation/debugging.
-        let total_str: Option<String> = self.valkey_client()
+        let total_str: Option<String> = self
+            .valkey_client()
             .cmd("HGET")
             .arg(ctx.core())
             .arg("total_attempt_count")
@@ -894,123 +916,39 @@ impl FlowFabricWorker {
             .unwrap_or(0);
         let att_idx = AttemptIndex::new(next_idx);
 
-        let lease_id = LeaseId::new().to_string();
-        let attempt_id = AttemptId::new().to_string();
-        let renew_before_ms = self.config.lease_ttl_ms * 2 / 3;
+        let args = ff_core::contracts::ClaimExecutionArgs::new(
+            execution_id.clone(),
+            self.config.worker_id.clone(),
+            self.config.worker_instance_id.clone(),
+            lane_id.clone(),
+            LeaseId::new(),
+            self.config.lease_ttl_ms,
+            AttemptId::new(),
+            att_idx,
+            "{}".to_owned(),
+            None,
+            None,
+            TimestampMs::now(),
+        );
 
-        // KEYS (14): must match lua/execution.lua ff_claim_execution positional order
-        let keys: Vec<String> = vec![
-            ctx.core(),                                    // 1  exec_core
-            ctx.claim_grant(),                             // 2  claim_grant
-            idx.lane_eligible(lane_id),                    // 3  eligible_zset
-            idx.lease_expiry(),                            // 4  lease_expiry_zset
-            idx.worker_leases(&self.config.worker_instance_id), // 5  worker_leases
-            ctx.attempt_hash(att_idx),                     // 6  attempt_hash (placeholder)
-            ctx.attempt_usage(att_idx),                    // 7  attempt_usage (placeholder)
-            ctx.attempt_policy(att_idx),                   // 8  attempt_policy (placeholder)
-            ctx.attempts(),                                // 9  attempts_zset
-            ctx.lease_current(),                           // 10 lease_current
-            ctx.lease_history(),                           // 11 lease_history
-            idx.lane_active(lane_id),                      // 12 active_index
-            idx.attempt_timeout(),                         // 13 attempt_timeout_zset
-            idx.execution_deadline(),                      // 14 execution_deadline_zset
-        ];
-
-        // ARGV (12): must match lua/execution.lua ff_claim_execution positional order
-        let args: Vec<String> = vec![
-            execution_id.to_string(),                      // 1  execution_id
-            self.config.worker_id.to_string(),             // 2  worker_id
-            self.config.worker_instance_id.to_string(),    // 3  worker_instance_id
-            lane_id.to_string(),                           // 4  lane
-            String::new(),                                 // 5  capability_hash
-            lease_id.clone(),                              // 6  lease_id
-            self.config.lease_ttl_ms.to_string(),          // 7  lease_ttl_ms
-            renew_before_ms.to_string(),                   // 8  renew_before_ms
-            attempt_id.clone(),                            // 9  attempt_id
-            "{}".to_owned(),                               // 10 attempt_policy_json
-            String::new(),                                 // 11 attempt_timeout_ms
-            String::new(),                                 // 12 execution_deadline_at
-        ];
-
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        let raw: Value = self.valkey_client()            
-            .fcall("ff_claim_execution", &key_refs, &arg_refs)
-            .await
-            .map_err(SdkError::from)?;
-
-        // Parse claim result: {1, "OK", lease_id, lease_epoch, attempt_index,
-        //                      attempt_id, attempt_type, lease_expires_at}
-        let arr = match &raw {
-            Value::Array(arr) => arr,
-            _ => {
+        // `ClaimExecutionResult` is `#[non_exhaustive]` (v0.12 PR-4)
+        // so let-binding requires an explicit wildcard arm even though
+        // `Claimed` is the only variant today. Future additive variants
+        // surface as a loud `unreachable` rather than a silent miss.
+        let claimed = match self.backend.claim_execution(args).await? {
+            ff_core::contracts::ClaimExecutionResult::Claimed(c) => c,
+            // `#[non_exhaustive]` — future additive variants surface
+            // as an explicit SDK-side rewrite rather than a silent miss.
+            other => {
                 return Err(SdkError::from(ff_script::error::ScriptError::Parse {
                     fcall: "ff_claim_execution".into(),
                     execution_id: Some(execution_id.to_string()),
-                    message: "expected Array".into(),
+                    message: format!(
+                        "unexpected ClaimExecutionResult variant: {other:?}"
+                    ),
                 }));
             }
         };
-
-        let status_code = match arr.first() {
-            Some(Ok(Value::Int(n))) => *n,
-            _ => {
-                return Err(SdkError::from(ff_script::error::ScriptError::Parse {
-                    fcall: "ff_claim_execution".into(),
-                    execution_id: Some(execution_id.to_string()),
-                    message: "bad status code".into(),
-                }));
-            }
-        };
-
-        if status_code != 1 {
-            let err_field_str = |idx: usize| -> String {
-                arr.get(idx)
-                    .and_then(|v| match v {
-                        Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                        Ok(Value::SimpleString(s)) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or_default()
-            };
-            let error_code = {
-                let s = err_field_str(1);
-                if s.is_empty() { "unknown".to_owned() } else { s }
-            };
-            let detail = err_field_str(2);
-
-            return Err(SdkError::from(
-                ff_script::error::ScriptError::from_code_with_detail(&error_code, &detail)
-                    .unwrap_or_else(|| ff_script::error::ScriptError::Parse {
-                        fcall: "ff_claim_execution".into(),
-                        execution_id: Some(execution_id.to_string()),
-                        message: format!("unknown error: {error_code}"),
-                    }),
-            ));
-        }
-
-        // Extract fields from success response
-        let field_str = |idx: usize| -> String {
-            arr.get(idx + 2) // skip status_code and "OK"
-                .and_then(|v| match v {
-                    Ok(Value::BulkString(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                    Ok(Value::SimpleString(s)) => Some(s.clone()),
-                    Ok(Value::Int(n)) => Some(n.to_string()),
-                    _ => None,
-                })
-                .unwrap_or_default()
-        };
-
-        // Lua returns: ok(lease_id, epoch, expires_at, attempt_id, attempt_index, attempt_type)
-        // Positions:       0         1       2           3            4              5
-        let lease_id = LeaseId::parse(&field_str(0))
-            .unwrap_or_else(|_| LeaseId::new());
-        let lease_epoch = LeaseEpoch::new(field_str(1).parse().unwrap_or(1));
-        // field_str(2) is expires_at — skip it (lease timing managed by renewal)
-        let attempt_id = AttemptId::parse(&field_str(3))
-            .unwrap_or_else(|_| AttemptId::new());
-        let attempt_index = AttemptIndex::new(field_str(4).parse().unwrap_or(0));
 
         // Read execution payload and metadata
         let (input_payload, execution_kind, tags) = self
@@ -1021,10 +959,10 @@ impl FlowFabricWorker {
             self.backend.clone(),
             self.partition_config,
             execution_id.clone(),
-            attempt_index,
-            attempt_id,
-            lease_id,
-            lease_epoch,
+            claimed.attempt_index,
+            claimed.attempt_id,
+            claimed.lease_id,
+            claimed.lease_epoch,
             self.config.lease_ttl_ms,
             lane_id.clone(),
             self.config.worker_instance_id.clone(),
@@ -1852,6 +1790,32 @@ mod sqlite_only_compile_surface_tests {
             id: &ExecutionId,
         ) -> Result<AttemptIndex, EngineError> {
             b.read_current_attempt_index(id).await
+        }
+    }
+
+    /// v0.12 PR-4 compile anchor — the new
+    /// [`EngineBackend::claim_execution`] trait method MUST be
+    /// addressable under `--no-default-features --features sqlite`.
+    /// Mirrors the PR-3 `read_current_attempt_index` anchor: takes a
+    /// generic over the trait bound so `#[async_trait]` lifetime
+    /// elision doesn't block a plain fn-pointer coercion.
+    ///
+    /// The method has an `Err(Unavailable)` default impl; PG + SQLite
+    /// backends don't override it today (grants are Valkey-only until
+    /// the PG/SQLite grant-consumer RFC lands). The anchor pins the
+    /// trait-surface signature — not a runtime call — so the compile
+    /// check passes cleanly on every feature set.
+    #[test]
+    fn claim_execution_addressable_under_sqlite_only() {
+        use ff_core::contracts::{ClaimExecutionArgs, ClaimExecutionResult};
+        use ff_core::engine_error::EngineError;
+
+        #[allow(dead_code)]
+        async fn _pin<B: EngineBackend + ?Sized>(
+            b: &B,
+            args: ClaimExecutionArgs,
+        ) -> Result<ClaimExecutionResult, EngineError> {
+            b.claim_execution(args).await
         }
     }
 

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -892,7 +892,7 @@ impl FlowFabricWorker {
         execution_id: &ExecutionId,
         lane_id: &LaneId,
         partition: &ff_core::partition::Partition,
-        _now: TimestampMs,
+        now: TimestampMs,
     ) -> Result<ClaimedTask, SdkError> {
         // Pre-read total_attempt_count from exec_core to derive the
         // expected attempt index. The Lua uses total_attempt_count as
@@ -928,17 +928,17 @@ impl FlowFabricWorker {
             "{}".to_owned(),
             None,
             None,
-            TimestampMs::now(),
+            now,
         );
 
         // `ClaimExecutionResult` is `#[non_exhaustive]` (v0.12 PR-4)
         // so let-binding requires an explicit wildcard arm even though
-        // `Claimed` is the only variant today. Future additive variants
-        // surface as a loud `unreachable` rather than a silent miss.
+        // `Claimed` is the only variant today. A future additive variant
+        // surfaces here as a typed `ScriptError::Parse` — loud, routed
+        // through the existing SDK error path, and never silently
+        // dropped.
         let claimed = match self.backend.claim_execution(args).await? {
             ff_core::contracts::ClaimExecutionResult::Claimed(c) => c,
-            // `#[non_exhaustive]` — future additive variants surface
-            // as an explicit SDK-side rewrite rather than a silent miss.
             other => {
                 return Err(SdkError::from(ff_script::error::ScriptError::Parse {
                     fcall: "ff_claim_execution".into(),


### PR DESCRIPTION
## Summary

v0.12 agnostic-SDK PR-4. Adds `EngineBackend::claim_execution` as the grant-consumer trait method and routes `FlowFabricWorker::claim_execution` (private helper behind `claim_from_grant` / `claim_via_server`) through it, retiring the last direct `ff_claim_execution` FCALL + Lua-response hand-parse in ff-sdk.

- 1 new trait method (`Unavailable` default, `core`-feature-gated) + ValkeyBackend override + SDK helper rewrite.
- Valkey impl extracts the post-grant `ff_claim_execution` FCALL into a dedicated `claim_execution_impl` shared with `claim_impl`'s scheduler-bypass scanner path. Keys + ARGV byte-for-byte identical to pre-PR-4 (verified live via `smoke-v0.7.sh` after `FUNCTION DELETE flowfabric`).
- `ClaimExecutionArgs` + `ClaimExecutionResult` sealed with `#[non_exhaustive]` + `ClaimExecutionArgs::new()` per `feedback_non_exhaustive_needs_constructor`.
- SDK `claim_execution` helper collapses from ~160 LOC of direct FCALL + Lua-response parsing + 30 LOC follow-up read to one `backend.claim_execution(args).await?` + `read_execution_context` call. `ClaimContentionKind::UseClaimResumedExecution` fallback inside `claim_from_grant` unchanged — the trait surfaces `EngineError::Contention` via the existing `ScriptError → EngineError` conversion.
- New compile anchor `claim_execution_addressable_under_sqlite_only` in `sqlite_only_compile_surface_tests`.

## Scope note

`claim_from_grant` + `claim_via_server` stay `#[cfg(feature = "valkey-default")]`-gated. `ClaimedTask::new` still synthesises its renewal-handle cookie via `ValkeyBackend::encode_handle`, so the public grant-consumer surface can't ungate cleanly until an agnostic `ClaimedTask::new` lands. That is PR-5 / `claim_next` scope per the v0.12 agnostic-SDK plan.

## Non-goals

- `claim_next` / direct-valkey-claim decoupling (PR-5).
- PG / SQLite `claim_execution` impls (requires an RFC-024 grant-consumer extension — PG scheduler has `claim_for_worker` on a separate struct today, not on `EngineBackend`). Both backends inherit the `Unavailable` default.
- Agnostic `ClaimedTask::new` (PR-5).

## Breaking-change note

- Additive trait method with `Unavailable` default — non-breaking for external `EngineBackend` impls (same pattern as PR-1 / PR-3).
- `#[non_exhaustive]` on `ClaimExecutionArgs` + `ClaimExecutionResult` is a breaking change only for consumers that constructed / exhaustively matched these types outside the workspace; no such consumers exist today (sole construction site was `ff-backend-valkey` internal, which now uses `::new()`).

## Test plan

- [x] `cargo test --workspace --lib` green.
- [x] `cargo clippy -p ff-core -p ff-backend-valkey -p ff-sdk -p ff-script --all-targets --all-features -- -D warnings` clean (workspace-wide clippy has pre-existing failures on `ff-test`, unchanged by this PR).
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` clean.
- [x] `cargo tree -p ff-sdk --no-default-features --features sqlite -e features` shows only `ff-core feature "core"` — no ferriskey / valkey leak.
- [x] `scripts/smoke-sqlite.sh` PASS (17.4s).
- [x] `scripts/smoke-v0.7.sh` PASS on Valkey + Postgres after `FUNCTION DELETE flowfabric` — every scenario green, behavior-preservation gate cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the execution-claiming path by introducing a new `EngineBackend` method and moving the SDK off direct Valkey FCALL/Lua parsing, which could affect grant consumption/attempt minting behavior if wiring or result handling is wrong.
> 
> **Overview**
> Adds a new `EngineBackend::claim_execution` (core-gated, defaulting to `Unavailable`) as the *grant-consumer* API for minting a fresh attempt from an existing scheduler-issued claim grant.
> 
> Updates the Valkey backend to implement this method by extracting a shared `claim_execution_impl` that performs the single `ff_claim_execution` FCALL, and updates the SDK’s `claim_from_grant` helper to call `backend.claim_execution(...)` instead of issuing/parsing the FCALL response directly.
> 
> Seals `ClaimExecutionArgs` and `ClaimExecutionResult` with `#[non_exhaustive]`, adds `ClaimExecutionArgs::new()` for construction, and adjusts tests/import gating to keep `sqlite`/no-default-features builds compiling cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544ad1bf777b4f83aef66a5c9b5e74e37ef032d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->