### PR TITLE
docs(core): align read_current_attempt_index rustdoc with cross-backend behavior

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -926,10 +926,27 @@ async fn read_execution_context_impl(
 /// Point-read of the execution's current attempt-index from the
 /// `{exec}:core` hash. Single `HGET current_attempt_index` — the same
 /// pattern the SDK worker previously issued inline before it dispatched
-/// `ff_claim_resumed_execution`. Missing row surfaces as
-/// [`EngineError::Validation { kind: InvalidInput, .. }`] matching the
-/// PG + SQLite siblings; the SDK only calls this post-grant, so an
-/// absent core hash is an invariant violation rather than a silent 0.
+/// `ff_claim_resumed_execution`.
+///
+/// **Missing-data semantics (Valkey-specific — diverges from PG/SQLite).**
+/// Both the missing-field case (`exec_core` present but
+/// `current_attempt_index` absent / empty-string, i.e. pre-claim state)
+/// and the missing-row case (no `exec_core` hash at all) are mapped to
+/// `AttemptIndex(0)`. This preserves the pre-PR-3 inline-`HGET`
+/// semantic (`.and_then(parse).unwrap_or(0)`) so a resume-grant consumed
+/// against a not-yet-claimed execution reaches the downstream FCALL,
+/// which then surfaces the proper business-logic error
+/// (`NotAResumedExecution` / `ExecutionNotLeaseable`) instead of the
+/// pre-read blowing up with `Corruption`.
+///
+/// PG and SQLite siblings instead return
+/// [`EngineError::Validation { kind: InvalidInput, .. }`] on the
+/// missing-row case; the asymmetry is intentional — Valkey's happy
+/// path requires `exec_core` to exist (grant issuance is the only
+/// caller) so a missing row there is already prevented by the
+/// invariant. See the trait rustdoc on
+/// `EngineBackend::read_current_attempt_index` (see
+/// `ff_core::engine_backend`) for the cross-backend contract.
 #[tracing::instrument(
     name = "ff.read_current_attempt_index",
     skip_all,

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -367,19 +367,38 @@ pub trait EngineBackend: Send + Sync + 'static {
     /// Per-backend shape:
     ///
     /// * **Valkey** — `HGET {exec}:core current_attempt_index` on the
-    ///   execution's partition. Single command. A pre-claim execution
-    ///   (`exec_core` present but `current_attempt_index` absent or
-    ///   empty-string) reads back as `0` to match the pre-PR-3 inline
-    ///   SDK semantic — the downstream FCALL then surfaces the proper
-    ///   `NotAResumedExecution` / `ExecutionNotLeaseable` error.
+    ///   execution's partition. Single command. Both the
+    ///   **missing-field** case (`exec_core` present but
+    ///   `current_attempt_index` absent or empty-string, i.e. pre-claim
+    ///   state) **and** the **missing-row** case (no `exec_core` hash
+    ///   at all) read back as `AttemptIndex(0)`. This preserves the
+    ///   pre-PR-3 inline-`HGET` semantic and is safe because Valkey's
+    ///   happy path requires `exec_core` to exist before this method
+    ///   is reached — the SDK only calls `read_current_attempt_index`
+    ///   post-grant, and grant issuance is gated on `exec_core`
+    ///   presence. A genuinely absent row would surface as the proper
+    ///   business-logic error (`NotAResumedExecution` /
+    ///   `ExecutionNotLeaseable`) on the downstream FCALL.
     /// * **Postgres** — `SELECT attempt_index FROM ff_exec_core
-    ///   WHERE partition_key = $1 AND execution_id = $2`; the column
-    ///   is `NOT NULL DEFAULT 0` so a pre-claim row naturally reads
-    ///   back as `0`. Missing row surfaces as `InvalidInput`.
+    ///   WHERE partition_key = $1 AND execution_id = $2`. The column
+    ///   is `NOT NULL DEFAULT 0` so a pre-claim row reads back as `0`
+    ///   (matching Valkey's missing-field case). **Missing row**
+    ///   surfaces as [`EngineError::Validation { kind:
+    ///   ValidationKind::InvalidInput, .. }`](crate::engine_error::EngineError::Validation)
+    ///   — diverges from Valkey's missing-row `→ 0` mapping.
     /// * **SQLite** — `SELECT attempt_index FROM ff_exec_core
-    ///   WHERE partition_key = ? AND execution_id = ?`; same semantics
-    ///   as PG (column is `NOT NULL DEFAULT 0`; missing row surfaces
-    ///   as `InvalidInput`).
+    ///   WHERE partition_key = ? AND execution_id = ?`; identical
+    ///   semantics to Postgres (missing-row → `InvalidInput`).
+    ///
+    /// **Cross-backend asymmetry on missing row is intentional.** The
+    /// SDK happy path never observes it (grant issuance on Valkey
+    /// requires `exec_core`, and PG/SQLite currently return
+    /// `Unavailable` from `claim_from_grant` per
+    /// `project_claim_from_grant_pg_sqlite_gap.md`). Consumers writing
+    /// backend-agnostic tooling against this method directly must
+    /// treat the missing-row case as backend-dependent — match on
+    /// `InvalidInput` for PG/SQLite, and treat an unexpected `0` as
+    /// the Valkey equivalent signal.
     ///
     /// The default impl returns [`EngineError::Unavailable`] so the
     /// trait addition is non-breaking for out-of-tree backends (same


### PR DESCRIPTION
## Summary

PR-5.5 follow-up A. The Valkey `read_current_attempt_index_impl` returns `AttemptIndex(0)` on both missing-field AND missing-row, while PG + SQLite return `Validation{InvalidInput}` on missing-row. The trait rustdoc (`ff_core::engine_backend`) and the Valkey impl rustdoc (`ff_backend_valkey::lib`) previously mis-described this:

- Trait rustdoc said Valkey returns `0` only for missing-field and was silent on missing-row.
- Valkey impl rustdoc claimed parity with PG/SQLite (`Validation{InvalidInput}` on missing row) that the body (`.unwrap_or(0)`) does not enforce.

This PR updates both rustdocs to explicitly document the asymmetry (option (a) per prior adjudication: Valkey missing-row → 0 is acceptable because the SDK happy path requires `exec_core` to exist via grant issuance), and points backend-agnostic-tooling consumers at the divergence so they match correctly per backend.

Docs-only. No code or test changes.

## Test plan

- [x] `cargo doc --no-deps -p ff-core -p ff-backend-valkey` builds clean (only pre-existing warnings)
- [ ] CI: Matrix CI green (docs-only — no behaviour risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 86ce86d90b600edea1e158b9b04ba2ca69d88a57. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->