### PR TITLE
docs: add v0.12 trait-method parity rows + consumer-migration §limitations (pre-tag)

### DIFF
--- a/docs/CONSUMER_MIGRATION_0.12.md
+++ b/docs/CONSUMER_MIGRATION_0.12.md
@@ -416,6 +416,69 @@ methods are gated on ff-core's `streaming` feature, which the
 [`claim_via_server`]: https://docs.rs/ff-sdk/latest/ff_sdk/struct.FlowFabricWorker.html#method.claim_via_server
 [`Scheduler::claim_for_worker`]: https://docs.rs/ff-scheduler
 
+## Known limitations
+
+RFC-023 + RFC-024 + the agnostic-SDK work in v0.12 expand the
+backend-agnostic surface significantly, but a handful of paths remain
+Valkey-first. None block the headline v0.12 consumer flows; all are
+scoped for v0.13 RFC follow-up. Document these so consumers building
+against PG / SQLite aren't surprised at runtime. The
+`claim_from_grant` / `claim_via_server` runtime-`Unavailable` gap on
+PG/SQLite is covered in §8 above; the items below round out the
+surface.
+
+### Scanner-bypass primitives — Valkey only
+
+`EngineBackend::scan_eligible_executions`, `issue_claim_grant`, and
+`block_route` (the agnostic-SDK PR-5 scanner primitives) ship as
+Valkey-only in v0.12; PG and SQLite inherit the `Unavailable` trait
+default. These methods exist to let benches / specialized tooling
+bypass the scheduler; they are gated behind the bench-only
+`direct-valkey-claim` feature on the SDK caller side and are **not**
+a general consumer surface.
+
+PG / SQLite deployments use the scheduler-routed
+`FlowFabricWorker::claim()` path, which is fully supported and
+handles eligibility, capability match, and admission server-side.
+No consumer action needed.
+
+### `read_current_attempt_index` asymmetry
+
+All three backends implement `EngineBackend::read_current_attempt_index`
+in v0.12, but the missing-row behaviour differs by design:
+
+- **Valkey** — returns `AttemptIndex(0)` when `exec_core` is present
+  but the `current_attempt_index` HGET field is absent or empty
+  (matches pre-PR-3 inline SDK semantic). The downstream
+  `claim_resumed_execution` FCALL surfaces the proper
+  `NotAResumedExecution` / `ExecutionNotLeaseable` reject.
+- **Postgres / SQLite** — column is `NOT NULL DEFAULT 0` so a
+  pre-claim row naturally reads `0`, but a **missing** row surfaces
+  as `EngineError::Validation { kind: InvalidInput }`.
+
+The SDK only invokes this method on the resume-grant path after
+`claim_from_resume_grant` admission has already resolved the
+execution, so `exec_core` is guaranteed to exist and the asymmetry is
+not consumer-observable under normal operation. Documented here so
+downstream tooling that calls the trait method directly isn't
+surprised. See rustdoc on
+`EngineBackend::read_current_attempt_index` for the canonical
+per-backend shape.
+
+### v0.12 vs v0.11 bench baseline pending
+
+Published v0.11 → v0.12 bench deltas (Valkey claim/complete p50/p99,
+PG rev-7 cancel p99, SQLite baseline) are **not** captured in-repo at
+tag time. GitHub Actions runners produce noisy numbers (shared
+tenants, variable CPU steal, I/O contention) and are unsuitable for
+bench baselining per post-v0.12-PR-5.5 retrospective (memory:
+`feedback_valkey_cli_not_redis_cli` §"Separate but related").
+
+Fresh baselines run on dedicated hosts post-tag will land in a
+follow-up PR against the bench harness README. If you need pre-tag
+perf signal for a PG / Valkey deployment decision, reach out on the
+repo — we can point at the most recent dedicated-host run.
+
 ## Non-changes
 
 - No Rust API break on Valkey or Postgres hot paths **outside

--- a/docs/CONSUMER_MIGRATION_0.12.md
+++ b/docs/CONSUMER_MIGRATION_0.12.md
@@ -469,15 +469,15 @@ per-backend shape.
 
 Published v0.11 → v0.12 bench deltas (Valkey claim/complete p50/p99,
 PG rev-7 cancel p99, SQLite baseline) are **not** captured in-repo at
-tag time. GitHub Actions runners produce noisy numbers (shared
-tenants, variable CPU steal, I/O contention) and are unsuitable for
-bench baselining per post-v0.12-PR-5.5 retrospective (memory:
-`feedback_valkey_cli_not_redis_cli` §"Separate but related").
+tag time. GitHub Actions runners produce numbers too noisy to baseline
+against (shared tenants, variable CPU steal, I/O contention), so they
+are not used as the source of truth for release-to-release perf
+comparisons.
 
 Fresh baselines run on dedicated hosts post-tag will land in a
 follow-up PR against the bench harness README. If you need pre-tag
-perf signal for a PG / Valkey deployment decision, reach out on the
-repo — we can point at the most recent dedicated-host run.
+perf signal for a PG / Valkey deployment decision, open an issue on
+the repo — we can point at the most recent dedicated-host run.
 
 ## Non-changes
 

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -451,12 +451,15 @@ gate.
 
 ### RFC-024 + agnostic-SDK trait surface at v0.12.0
 
-v0.12 adds ten trait methods to `EngineBackend` covering RFC-024
-lease-reclaim and the agnostic-SDK PR-1..PR-5.5 series (trait-routed
-read primitives + scanner primitives + grant-consumer dispatch). Row
-values reflect actual bodies on `main` at tag-prep time — per-backend
-`grep 'fn <method>' crates/ff-backend-*/src/**` against the trait
-defaults in `crates/ff-core/src/engine_backend.rs`.
+The ten `EngineBackend` trait methods below are the v0.12 trait
+surface relevant to this release — nine are new in v0.12 (RFC-024
+lease-reclaim + the agnostic-SDK PR-1..PR-5.5 trait-routed read
+primitives, scanner primitives, and grant-consumer dispatch);
+`deliver_signal` predates v0.12 on the trait and is included here
+because the SDK caller is no longer `valkey-default`-gated in v0.12.
+Row values reflect actual bodies on `main` at tag-prep time —
+per-backend `grep 'fn <method>' crates/ff-backend-*/src/**` against
+the trait defaults in `crates/ff-core/src/engine_backend.rs`.
 
 | Method | Valkey | Postgres | SQLite | Notes |
 |---|---|---|---|---|
@@ -465,7 +468,7 @@ defaults in `crates/ff-core/src/engine_backend.rs`.
 | `read_execution_context` | `impl` | `impl` | `impl` | **Agnostic-SDK PR-1** (#411). Point-read of `ExecutionContext` for the SDK worker's resume path. Missing row surfaces as `Validation { kind: InvalidInput }` on all three — SDK only invokes post-claim so a missing row is a loud invariant violation. |
 | `read_current_attempt_index` | `impl` | `impl` | `impl` | **Agnostic-SDK PR-3.** Documented asymmetry (rustdoc on `EngineBackend::read_current_attempt_index`): Valkey returns `AttemptIndex(0)` when `exec_core` is present but `current_attempt_index` is absent/empty (pre-PR-3 inline parity); PG/SQLite use `NOT NULL DEFAULT 0` so a pre-claim row reads `0` naturally, but a missing row surfaces as `Validation { kind: InvalidInput }`. The downstream `claim_resumed_execution` FCALL / SQL surfaces the proper `NotAResumedExecution` / `ExecutionNotLeaseable` reject. |
 | `read_total_attempt_count` | `impl` | `impl` | `impl` | **Agnostic-SDK PR-5.5** (#419). Valkey HGET on `{exec}:core` (monotonic total-claims counter, distinct from `current_attempt_index`); PG reads `raw_fields` JSONB extract via `exec_core::read_total_attempt_count_impl`; SQLite reads via `json_extract` in `crates/ff-backend-sqlite/src/reads.rs`. |
-| `claim_execution` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-4** (#417). Trait-routed grant-consumer for the SDK `claim_from_grant` path. Valkey fires one `ff_claim_execution` FCALL; PG/SQLite inherit the `Err(Unavailable { op: "claim_execution" })` default. PG grants flow today through `PostgresScheduler::claim_for_worker` (sibling struct, not a trait method); SQLite has no grant-consumer path. Full trait-level grant-consumer parity is v0.13 RFC-scope — see [`project_claim_from_grant_pg_sqlite_gap`](../claude-memory/project_claim_from_grant_pg_sqlite_gap.md) for motivation. |
+| `claim_execution` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-4** (#417). Trait-routed grant-consumer for the SDK `claim_from_grant` path. Valkey fires one `ff_claim_execution` FCALL; PG/SQLite inherit the `Err(Unavailable { op: "claim_execution" })` default. PG's grant-consumer flow today routes through `PostgresScheduler::claim_for_worker` — a separate scheduler-side entry point distinct from this trait method; SQLite has no grant-consumer path. Full trait-level grant-consumer parity for PG + SQLite is v0.13 RFC-scope; see [`CONSUMER_MIGRATION_0.12.md`](CONSUMER_MIGRATION_0.12.md) §Known limitations. |
 | `scan_eligible_executions` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-5** (#418). Scanner-bypass primitive — lane-eligible ZSET peek. Valkey-only by design; PG/SQLite consumers use the scheduler-routed `claim_for_worker` path which handles eligibility server-side. Exposed behind the `direct-valkey-claim` bench-only feature; not a general consumer surface. |
 | `issue_claim_grant` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-5.** Scheduler-bypass claim-grant write. Pairs with `scan_eligible_executions`; same Valkey-only scope and `direct-valkey-claim` feature gating. PG/SQLite consumers use `claim_for_worker`. |
 | `block_route` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-5.** Moves an execution from lane-eligible ZSET to `blocked_route` ZSET after a capability-mismatch reject. Valkey-only; PG/SQLite admission rejects are handled server-side inside the scheduler-routed `claim_for_worker` path. |

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -448,3 +448,29 @@ flags above from `Supports::none()` at release time; the `impl`
 entries here are the post-flip state. See
 `crates/ff-backend-sqlite/tests/capabilities.rs` for the snapshot
 gate.
+
+### RFC-024 + agnostic-SDK trait surface at v0.12.0
+
+v0.12 adds ten trait methods to `EngineBackend` covering RFC-024
+lease-reclaim and the agnostic-SDK PR-1..PR-5.5 series (trait-routed
+read primitives + scanner primitives + grant-consumer dispatch). Row
+values reflect actual bodies on `main` at tag-prep time — per-backend
+`grep 'fn <method>' crates/ff-backend-*/src/**` against the trait
+defaults in `crates/ff-core/src/engine_backend.rs`.
+
+| Method | Valkey | Postgres | SQLite | Notes |
+|---|---|---|---|---|
+| `issue_reclaim_grant` | `impl` | `impl` | `impl` | **RFC-024.** PR-F (Valkey), PR-D (PG), PR-E (SQLite). Admission write for the lease-reclaim path; rejects `NotReclaimable` on non-`active` lifecycle or capability-mismatch. |
+| `reclaim_execution` | `impl` | `impl` | `impl` | **RFC-024.** Grant-consumer for reclaim; mints a fresh attempt on `lease_expired_reclaimable` / `lease_revoked`. All three backends enforce `max_reclaim_count` (default 1000) + emit `HandleKind::Reclaimed`. |
+| `read_execution_context` | `impl` | `impl` | `impl` | **Agnostic-SDK PR-1** (#411). Point-read of `ExecutionContext` for the SDK worker's resume path. Missing row surfaces as `Validation { kind: InvalidInput }` on all three — SDK only invokes post-claim so a missing row is a loud invariant violation. |
+| `read_current_attempt_index` | `impl` | `impl` | `impl` | **Agnostic-SDK PR-3.** Documented asymmetry (rustdoc on `EngineBackend::read_current_attempt_index`): Valkey returns `AttemptIndex(0)` when `exec_core` is present but `current_attempt_index` is absent/empty (pre-PR-3 inline parity); PG/SQLite use `NOT NULL DEFAULT 0` so a pre-claim row reads `0` naturally, but a missing row surfaces as `Validation { kind: InvalidInput }`. The downstream `claim_resumed_execution` FCALL / SQL surfaces the proper `NotAResumedExecution` / `ExecutionNotLeaseable` reject. |
+| `read_total_attempt_count` | `impl` | `impl` | `impl` | **Agnostic-SDK PR-5.5** (#419). Valkey HGET on `{exec}:core` (monotonic total-claims counter, distinct from `current_attempt_index`); PG reads `raw_fields` JSONB extract via `exec_core::read_total_attempt_count_impl`; SQLite reads via `json_extract` in `crates/ff-backend-sqlite/src/reads.rs`. |
+| `claim_execution` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-4** (#417). Trait-routed grant-consumer for the SDK `claim_from_grant` path. Valkey fires one `ff_claim_execution` FCALL; PG/SQLite inherit the `Err(Unavailable { op: "claim_execution" })` default. PG grants flow today through `PostgresScheduler::claim_for_worker` (sibling struct, not a trait method); SQLite has no grant-consumer path. Full trait-level grant-consumer parity is v0.13 RFC-scope — see [`project_claim_from_grant_pg_sqlite_gap`](../claude-memory/project_claim_from_grant_pg_sqlite_gap.md) for motivation. |
+| `scan_eligible_executions` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-5** (#418). Scanner-bypass primitive — lane-eligible ZSET peek. Valkey-only by design; PG/SQLite consumers use the scheduler-routed `claim_for_worker` path which handles eligibility server-side. Exposed behind the `direct-valkey-claim` bench-only feature; not a general consumer surface. |
+| `issue_claim_grant` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-5.** Scheduler-bypass claim-grant write. Pairs with `scan_eligible_executions`; same Valkey-only scope and `direct-valkey-claim` feature gating. PG/SQLite consumers use `claim_for_worker`. |
+| `block_route` | `impl` | `Unavailable` (default) | `Unavailable` (default) | **Agnostic-SDK PR-5.** Moves an execution from lane-eligible ZSET to `blocked_route` ZSET after a capability-mismatch reject. Valkey-only; PG/SQLite admission rejects are handled server-side inside the scheduler-routed `claim_for_worker` path. |
+| `deliver_signal` | `impl` | `impl` | `impl` | **Agnostic-SDK PR-3** (#416). Method was already trait-routed pre-v0.12 across all three backends; the v0.12 change is removing the `valkey-default`-feature module gate on the SDK caller so consumers compiling `--no-default-features --features sqlite` (or `postgres`) can reach it. |
+
+Consumer-facing limitations for this surface live in
+[`CONSUMER_MIGRATION_0.12.md`](CONSUMER_MIGRATION_0.12.md) §Known
+limitations.


### PR DESCRIPTION
## Summary

Two doc-only blockers surfaced by the Phase 4d v0.12 readiness audit. Both are required before tagging v0.12.0.

- **POSTGRES_PARITY_MATRIX.md** — added a dedicated sub-table under the v0.12.0 section covering the ten trait methods shipped this release (RFC-024 reclaim + agnostic-SDK PR-1..PR-5.5):
  - `issue_reclaim_grant`, `reclaim_execution` — all three backends `impl` (PR-D/E/F).
  - `read_execution_context` (#411), `read_current_attempt_index` (PR-3), `read_total_attempt_count` (#419), `deliver_signal` (#416) — all three `impl`.
  - `claim_execution` (#417), `scan_eligible_executions` / `issue_claim_grant` / `block_route` (#418) — Valkey `impl`; PG + SQLite inherit `Unavailable` default. Cross-links `project_claim_from_grant_pg_sqlite_gap`.
  - Status verified per-backend via grep against `engine_backend.rs` + each backend's impl file; not guessed.
- **CONSUMER_MIGRATION_0.12.md** — added §Known limitations covering:
  - Scanner-bypass primitives (Valkey-only by design; bench-only `direct-valkey-claim` feature; PG/SQLite use scheduler-routed `claim()`).
  - `read_current_attempt_index` missing-row asymmetry (Valkey `AttemptIndex(0)` vs PG/SQLite `Validation{InvalidInput}`); documented for consumer awareness even though the SDK happy path guarantees `exec_core` presence.
  - v0.12-vs-v0.11 bench baseline pending (GH runners unsuitable; dedicated-host run post-tag).
  - Cross-references the pre-existing §8 PR-5.5 section for the `claim_from_grant` / `claim_via_server` runtime-`Unavailable` gap rather than duplicating.

## Context

- Phase 4d readiness audit flagged both gaps as pre-tag blockers, independent of the in-flight PR #419 (now merged).
- PR #419 merged during this work; `read_total_attempt_count` status accordingly documented as `impl` across all three backends (verified against `exec_core::read_total_attempt_count_impl` on PG, `crate::reads::read_total_attempt_count_impl` on SQLite, `read_total_attempt_count_impl` Lua-backed on Valkey).
- Follow-up A (read_current_attempt_index rustdoc asymmetry note) has already landed on main (`engine_backend.rs` §read_current_attempt_index docstring); the §limitations entry references that canonical source.

## Test plan

- [x] `cargo check --workspace` clean.
- [x] No merge-conflict markers in either doc.
- [x] §limitations tone is consumer-focused; cairn-audience oriented.
- [x] Parity-matrix rows match reality per backend (per-method grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only update that clarifies v0.12 backend/trait parity and calls out Valkey-only or backend-asymmetric paths; no runtime code changes.
> 
> **Overview**
> Adds a new **§Known limitations** to `CONSUMER_MIGRATION_0.12.md`, documenting v0.12 backend-agnostic gaps that are still *Valkey-first* (bench-only scanner-bypass primitives), the per-backend missing-row behavior difference for `read_current_attempt_index`, and that v0.11→v0.12 benchmark baselines are not yet published.
> 
> Extends `POSTGRES_PARITY_MATRIX.md` with a dedicated v0.12 table covering the ten newly added `EngineBackend` trait methods (RFC-024 reclaim + agnostic-SDK PR-1..PR-5.5), explicitly marking which are `impl` vs `Unavailable` on Postgres/SQLite and cross-linking to the consumer migration limitations section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3979a443ae88475491d9e4a97e83deb253489542. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->