### PR TITLE
ci(release): add pre-publish smoke-sqlite leg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,9 +192,32 @@ jobs:
       - name: Run smoke gate
         run: bash scripts/smoke-v0.7.sh
 
+  smoke-sqlite:
+    # RFC-023 Phase 4 pre-publish smoke for the dev-only SQLite backend.
+    # Exercises the consumer-visible parity surface committed in
+    # RFC-023 §4.3 (see scripts/smoke-sqlite.sh header for the exact
+    # list) end-to-end against an in-memory SQLite pool. No external
+    # fixtures — everything is in-process.
+    #
+    # Per feedback_smoke_before_release.md + feedback_smoke_after_publish.md:
+    # workspace tests don't catch consumer-visible breakage on the
+    # SQLite headline; this leg runs the ff-dev example binary against
+    # the published trait shape (workspace-path deps in this context)
+    # BEFORE the tag-gated publish step. A failure here blocks publish
+    # just like the Valkey+PG smoke leg.
+    name: Pre-publish smoke-sqlite (v0.12+)
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+      - name: Run smoke-sqlite gate
+        run: bash scripts/smoke-sqlite.sh
+
   publish:
     name: Publish crates
-    needs: [verify, smoke]
+    needs: [verify, smoke, smoke-sqlite]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- Adds a new `smoke-sqlite` job to `.github/workflows/release.yml` that runs `scripts/smoke-sqlite.sh` before `publish`, gating the tag workflow on the SQLite headline parity surface (RFC-023 §4.3) alongside the existing Valkey+PG smoke leg.
- `publish` job now needs both `smoke` and `smoke-sqlite`.
- Self-contained: no external fixtures, in-process against `:memory:`. Verified green locally in ~4s (SQLite 3.46.0 bundled).

## Why now
Per `feedback_smoke_before_release.md` + `feedback_smoke_after_publish.md`: published-artifact smoke is a release gate, not a post-mortem. v0.12 adds the SQLite dev backend as a consumer-visible headline, so the gate needs a SQLite leg to match. Landing pre-tag so v0.12.0 benefits from it.

## Test plan
- [x] Local `bash scripts/smoke-sqlite.sh` → PASS (3986 ms wall-clock)
- [ ] Workflow YAML parses + job runs on a dry-run dispatch (validated by merging into main for real tag runs; workflow_dispatch with `dry_run: true` does NOT exercise the new job because `smoke` + `smoke-sqlite` are needed by `publish`, not by `verify`)
- [ ] Scoped minimally: only touches `release.yml`, no script changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the tag-triggered release gate: a new job can block publishes if the SQLite smoke script is flaky or misconfigured, but it doesn’t alter product code.
> 
> **Overview**
> Adds a new **pre-publish `smoke-sqlite`** job to the tag-triggered `release.yml` workflow to run `scripts/smoke-sqlite.sh` (in-memory SQLite, no external services) alongside the existing Valkey+Postgres smoke gate.
> 
> Updates `publish` to require `smoke-sqlite` as an additional dependency, so a failing SQLite parity smoke blocks crate publishing before the release proceeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d33b91dd531fecd3e55be65af0f1d4dd45d811. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->