### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-28
+
 ### Changed
 
 - **Agnostic-SDK PR-5.5 — `ClaimedTask` + `claim_from_grant` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "ff-observability",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "flowfabric"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ff-backend-postgres",
  "ff-backend-valkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -39,23 +39,23 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.11.0", path = "crates/ff-core" }
-ff-script = { version = "0.11.0", path = "crates/ff-script" }
-ff-engine = { version = "0.11.0", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.11.0", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.11.0", path = "crates/ff-sdk" }
-ff-server = { version = "0.11.0", path = "crates/ff-server" }
+ff-core = { version = "0.12.0", path = "crates/ff-core" }
+ff-script = { version = "0.12.0", path = "crates/ff-script" }
+ff-engine = { version = "0.12.0", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.12.0", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.12.0", path = "crates/ff-sdk" }
+ff-server = { version = "0.12.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.11.0", path = "crates/ff-backend-valkey" }
-ff-backend-postgres = { version = "0.11.0", path = "crates/ff-backend-postgres" }
-ff-backend-sqlite = { version = "0.11.0", path = "crates/ff-backend-sqlite" }
-ff-observability = { version = "0.11.0", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.11.0", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.11.0", path = "ferriskey" }
+ff-backend-valkey = { version = "0.12.0", path = "crates/ff-backend-valkey" }
+ff-backend-postgres = { version = "0.12.0", path = "crates/ff-backend-postgres" }
+ff-backend-sqlite = { version = "0.12.0", path = "crates/ff-backend-sqlite" }
+ff-observability = { version = "0.12.0", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.12.0", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.12.0", path = "ferriskey" }
 # Umbrella crate re-exporting the ff-* family (issue #279). Declared
 # at workspace scope so internal doc examples / dev-deps can name it
 # via `{ workspace = true }`.
-flowfabric = { version = "0.11.0", path = "crates/flowfabric" }
+flowfabric = { version = "0.12.0", path = "crates/flowfabric" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -28,7 +28,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.12.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -22,7 +22,7 @@ streaming = ["ff-core/streaming"]
 # impl honours the same `EngineBackend` method surface. Trait impl
 # bodies arrive in Phase 2+; Phase 1a returns `EngineError::Unavailable`
 # from every method except `capabilities()` + `prepare()`.
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.12.0", path = "../ff-core", default-features = false, features = ["core"] }
 
 # SQLite transport. Bundled SQLite is deliberately selected to decouple
 # the backend from the operating distro's libsqlite3 version — RFC-023

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.12.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -23,7 +23,7 @@ observability = ["ff-observability/enabled"]
 postgres = ["dep:ff-backend-postgres", "dep:sqlx", "dep:uuid"]
 
 [dependencies]
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.12.0", path = "../ff-core", default-features = false, features = ["core"] }
 ff-observability = { workspace = true }
 # v0.12 PR-7a transitional: `Engine::start_*` accepts
 # `Arc<dyn EngineBackend>` on the boundary but scanners still speak
@@ -36,7 +36,7 @@ ff-observability = { workspace = true }
 # silently defeat the explicit `ff-core` anchor on line 26
 # (`default-features = false, features = ["core"]`) and re-expose
 # streaming-gated trait methods on `ff-engine`.
-ff-backend-valkey = { version = "0.11.0", path = "../ff-backend-valkey", default-features = false }
+ff-backend-valkey = { version = "0.12.0", path = "../ff-backend-valkey", default-features = false }
 ferriskey = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ff-scheduler/Cargo.toml
+++ b/crates/ff-scheduler/Cargo.toml
@@ -16,7 +16,7 @@ description = "FlowFabric claim-grant scheduler"
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.12.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-scheduler's claim dispatcher uses FCALL helpers from
 # ff-script, so explicitly enable `valkey-client`.
 ff-script = { workspace = true, features = ["valkey-client"] }

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -49,7 +49,7 @@ valkey-client = ["dep:ferriskey"]
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.12.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: optional so `--no-default-features` drops the transport edge.
 ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -84,7 +84,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.11.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.12.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-script's defaults are empty — the `valkey-client`
 # feature (which owns the `ferriskey` dep edge) is activated below by
 # the `valkey-default` feature, NOT here. This keeps
@@ -102,7 +102,7 @@ ferriskey = { workspace = true, optional = true }
 # RFC-023 Phase 1a: optional SQLite backend edge, activated by the
 # `sqlite` feature above. Off by default so Valkey consumers pay no
 # sqlx compile cost.
-ff-backend-sqlite = { version = "0.11.0", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
+ff-backend-sqlite = { version = "0.12.0", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/crates/flowfabric/Cargo.toml
+++ b/crates/flowfabric/Cargo.toml
@@ -53,7 +53,7 @@ ff-core = { workspace = true }
 # dep's default-features at the consumer site. Pinning version +
 # path here matches the workspace.dependencies entry; `cargo release`
 # keeps both in lockstep via `shared-version = true`.
-ff-sdk = { version = "0.11.0", path = "../ff-sdk", default-features = false }
+ff-sdk = { version = "0.12.0", path = "../ff-sdk", default-features = false }
 
 ff-backend-valkey = { workspace = true, optional = true }
 ff-backend-postgres = { workspace = true, optional = true }

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

Workspace version bump v0.11.0 → v0.12.0 + CHANGELOG cut.

- `cargo release minor --execute` bump across all 13 publishable crates (b640fed).
- CHANGELOG [Unreleased] → [0.12.0] - 2026-04-28 (11c2777).
- Tag `v0.12.0` created locally at 11c2777 (CHANGELOG commit); **NOT pushed** — held for owner go/no-go per §5 release gate.

## v0.12 headlines

- **RFC-023 SQLite dev-only backend** — third `EngineBackend` impl lands. Positioned permanently as dev-only/testing; bundled SQLite 3.46.0 (floor 3.35). New `examples/ff-dev` (~345 LoC) exercises create_flow → claim → complete → change_priority → cancel_execution → read_execution_info → subscribe_completion end-to-end with zero Docker.
- **RFC-024 lease-reclaim SDK surface (PR-G)** — `FlowFabricAdminClient::issue_reclaim_grant` + `FlowFabricWorker::claim_from_reclaim_grant` (backend-agnostic, SQLite-compilable) + `POST /v1/executions/{id}/reclaim`. All three in-tree backends implement.
- **Agnostic-SDK PR-5 / 5.5** — `ClaimedTask` + claim hot paths ungated, route through `EngineBackend`. `Handle` + friends gain Serde derives; PG/SQLite populate `claim_resumed_execution.handle` with real backend-tagged encoded handles.
- **PG parity fix** — first-claim now writes `public_state='running'` for parity with resume-claim + SQLite (was relying on read-boundary `normalise_public_state` shim).
- **SQLite bundled** — `libsqlite3-sys/bundled` now correctly enabled via explicit dep (sqlx 0.8 has no `sqlite-bundled` feature alias; prior config silently system-linked).
- **`ff_attempt.outcome` cleared on all cancel paths** (#355). **`ff_exec_core.started_at_ms` added as set-once column** (#356, migration 0016).

## §5 release-gate status (all PASS)

- [x] smoke-v0.7.sh PASS (7 scenarios × Valkey+Postgres, strict)
- [x] All 9 examples build clean (release)
- [x] Live-run ff-dev PASS (SQLite 3.46.0 bundled, end-to-end)
- [x] New release-headline example: examples/ff-dev (345 LoC)
- [x] README + CONSUMER_MIGRATION_0.12.md current (v0.11→v0.12 diff documented)
- [x] CHANGELOG complete (Changed/Added/Fixed/Documentation sections)
- [x] POSTGRES_PARITY_MATRIX.md v0.12.0 section present (SQLite column populated)
- [x] Pre-publish smoke wired in release.yml (`needs: [verify, smoke, smoke-sqlite]` via PR #422)

## CI expectations (per owner guidance)

Expected-red on this PR (same class as prior v0.12 PRs — #407, #411, #419, #420, #422):

- `cargo-semver-checks` — v0.12 breaking surface is intentional (RFC-024 renames, `#[non_exhaustive]` additions documented in CONSUMER_MIGRATION_0.12.md §3-4).
- `quality-gates-complete` aggregator — rolls up semver-checks red.
- `ubuntu-latest · valkey {7.2, 8} · {standalone, cluster}` — infra SIGBUS (ARM + macOS + Postgres legs + smoke-sqlite all pass).
- `matrix-tests-complete` aggregator — rolls up SIGBUS legs.

Any OTHER failure blocks.

## Next steps (Phase D — PAUSED for owner go/no-go)

1. Owner approves merge.
2. Admin-merge this PR to main.
3. `git push origin v0.12.0` (tag push fires release.yml → verify → smoke → smoke-sqlite → publish → GH release).
4. Post-publish: run scratch-project smoke against crates.io artifacts (`scripts/published-smoke.sh 0.12.0`).

## Test plan

- [x] `cargo release minor --dry-run` clean
- [x] `bash scripts/smoke-v0.7.sh` PASS (both backends, strict)
- [x] All examples compile in release mode
- [x] `FF_DEV_MODE=1 cargo run -p ff-dev-example --release` ran end-to-end
- [ ] CI on this PR: verify expected-red matches prior pattern; any other failure surfaces
- [ ] Owner go/no-go
- [ ] Post-tag: watch publish workflow, run post-publish scratch smoke

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is a mechanical release cut (version bumps + changelog entry) with no functional code changes.
> 
> **Overview**
> Cuts the `v0.12.0` release by **adding a dated `0.12.0` section** to `CHANGELOG.md` and **bumping the workspace + all published crate versions** from `0.11.0` to `0.12.0` (including updating `Cargo.lock` and workspace dependency pins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c277762a4f35db1c6d6ae3465c16a154691a6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->