### PR TITLE
ci: reclaim disk on ubuntu-latest runners to prevent integration-test link OOM

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -126,6 +126,30 @@ jobs:
             mode: standalone
 
     steps:
+      # Free ~22 GB on ubuntu-latest before the cargo-test link stage.
+      # The ff-test integration binaries (serial_test + reqwest + axum +
+      # many static-linked deps) otherwise exhaust the runner's ~14 GB
+      # usable disk during sequential linking, producing deterministic
+      # `No space left on device` failures on the ubuntu-latest x
+      # valkey-8 x {standalone,cluster} cells. ARM + macOS runners have
+      # enough disk — the step is gated to x86_64 ubuntu-latest only to
+      # avoid paying the ~60-90s cost on hosts that don't need it.
+      # Removes: tool-cache (~6.5 GB), Android SDK (~14 GB), .NET (~2 GB),
+      # Haskell (~5.5 GB), swap file (~4 GB). Keeps docker-images (service
+      # containers: valkey, postgres) and large apt packages (preserves
+      # apt-get speed for the redis-tools install downstream).
+      - name: Free disk space (ubuntu-latest)
+        if: matrix.host.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       # Third-party actions pinned to commit SHAs (CodeQL
       # security-and-quality rule + supply-chain hardening). Tag
       # comments name the version each SHA points at; refresh by
@@ -327,6 +351,20 @@ jobs:
       # naming works without editing the test harness.
       FF_PG_TEST_URL: postgres://postgres:postgres@localhost:5432/ff_smoke
     steps:
+      # Free ~22 GB before cargo-test link stages. See the rationale on
+      # the `matrix` job's free-disk step. Unconditional here (job is
+      # pinned to ubuntu-latest).
+      - name: Free disk space (ubuntu-latest)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
@@ -655,6 +693,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Free ~22 GB — same rationale as the `matrix` job's free-disk
+      # step. The ff-dev smoke builds enough of the workspace to hit
+      # the same link-stage disk pressure.
+      - name: Free disk space (ubuntu-latest)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,20 @@ jobs:
       FF_HOST: localhost
       FF_PORT: "6379"
     steps:
+      # Free ~22 GB — the `e2e tests (serial)` step below runs
+      # `cargo test -p ff-test` which exhausts runner disk during the
+      # integration-binary link stage. Same fix pattern as matrix.yml.
+      - name: Free disk space (ubuntu-latest)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       # Third-party action pins — see matrix.yml for the resolve-and-
       # update procedure. Tag comments name the version each SHA
       # dereferences to.
@@ -181,6 +195,23 @@ jobs:
       # strict; CI override is environmental allowance only.
       FF_SMOKE_FANOUT_P99_MS: "1200"
     steps:
+      # Free ~22 GB on ubuntu-latest before the smoke build/link stage.
+      # Matches matrix.yml free-disk rationale — integration binaries
+      # exhaust the runner's ~14 GB usable disk during linking. Blocking
+      # the tag-gated publish on a disk-exhaustion flake is especially
+      # painful (see feedback_smoke_before_release.md), so this step is
+      # load-bearing for release reliability.
+      - name: Free disk space (ubuntu-latest)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
@@ -209,6 +240,20 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     steps:
+      # Free ~22 GB — same rationale as the smoke job above. This leg
+      # also links integration binaries; a disk-exhaustion failure here
+      # blocks the tag-gated publish just as hard.
+      - name: Free disk space (ubuntu-latest)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0


### PR DESCRIPTION
## Root cause

GH-Actions `ubuntu-latest` runners ship with ~14 GB usable disk. Our `Integration tests (serial)` step runs `cargo test -p ff-test -- --test-threads=1`, which links many integration binaries (`serial_test` + `reqwest` + `axum` + static-linked deps) sequentially. The accumulated `/tmp/cc*.ltrans*.o` intermediates exhaust disk mid-link, producing deterministic:

```
ld: ... /tmp/cc*.ltrans*.o: No space left on device
```

Evidence pattern — **not** infra flake:

| Cell | Result |
|---|---|
| `ubuntu-latest` · valkey 8 · standalone | red (disk exhaustion) |
| `ubuntu-latest` · valkey 8 · cluster    | red (disk exhaustion) |
| `ubuntu-24.04-arm` · valkey 8 · *       | green (larger VM disk) |
| `macos-latest` · valkey 8 · standalone  | green (different fs layout) |
| `ubuntu-latest` · valkey 7.2 · standalone | sometimes green (fewer version-gated binaries) |
| `ubuntu-latest` · postgres 16           | green (fewer integration binaries) |

Dumped Valkey logs on the failed runs confirm the Valkey service was healthy — the runner disk, not our service, is the failure. Architectural asymmetry rules out any issue with our code.

## Fix

Add `jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be` (v1.3.1, pinned to SHA per supply-chain hardening convention) as the **first** step in every ubuntu-latest-hosted job that compiles `ff-test`-class integration binaries. Reclaims ~22 GB by removing unused pre-installed tooling.

### Jobs touched

- `matrix.yml` › `matrix` — gated `if: matrix.host.os == 'ubuntu-latest'` (ARM + macOS cells skip)
- `matrix.yml` › `matrix-postgres` (always ubuntu-latest)
- `matrix.yml` › `smoke-sqlite` (always ubuntu-latest)
- `release.yml` › `verify` — runs `cargo test -p ff-test`
- `release.yml` › `smoke` — tag-gated publish reliability
- `release.yml` › `smoke-sqlite` — tag-gated publish reliability

### Surgical tool-removal config

```yaml
tool-cache: true         # ~6.5 GB, unused
android: true            # ~14 GB, unused
dotnet: true             # ~2 GB, unused
haskell: true            # ~5.5 GB, unused
large-packages: false    # preserves apt-get speed for redis-tools
docker-images: false     # keep valkey + postgres service container images
swap-storage: true       # ~4 GB swap file we don't use
```

Cross-check: grepped `.github/workflows/**` for `dotnet`, `android`, `ghcup`, `stack`, `haskell`, `codeql-swift`, `codeql-ruby` — no usages outside the CodeQL workflow itself (which ships its own binaries via `github/codeql-action`, independent of `/opt/hostedtoolcache/CodeQL`).

## Expected reclaim

~22-28 GB. Pre-fix: link stage hits 100% disk. Post-fix: well under 50%.

## Trade-off

`jlumbroso/free-disk-space` adds ~60-90s wall-time per affected job. Acceptable in exchange for deterministic CI on the valkey matrix cells and reliable tag-time smoke.

## Validation plan

- [ ] `matrix` · valkey 8 · standalone green on this branch's head SHA
- [ ] `matrix` · valkey 8 · cluster green on this branch's head SHA
- [ ] 2 consecutive green runs (one insufficient — ubuntu-latest has occasional real infra issues)
- [ ] Post-free disk peak usage visible in logs (spot-check one run)

## Memory-file correction

`project_stage_b_quorum_flake.md` previously attributed this failure class to runner tmpfs/disk exhaustion as infra. Post-merge note: this was our link-stage disk pressure; fix pointer is this PR's merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that add a pre-step to reclaim disk; main impact is slightly longer CI runtime and potential for the third-party action to misbehave.
> 
> **Overview**
> Prevents deterministic `No space left on device` CI failures on GitHub-hosted `ubuntu-latest` runners by adding a first-step disk cleanup (`jlumbroso/free-disk-space`, SHA-pinned) before Rust build/link-heavy test phases.
> 
> Applies the cleanup across the Valkey matrix job (gated to `ubuntu-latest` cells), the Postgres parity job, and the SQLite smoke job in `matrix.yml`, and similarly adds the step to `verify`, `smoke`, and `smoke-sqlite` in `release.yml` to reduce tag-gated release flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0538f6ac37d78a24471f95e7a84f7f0101eb5266. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->