### PR TITLE
fix(ferriskey): close remaining FUNCTION LOAD cluster READONLY path (v0.12 tag-blocker residual)

### DIFF
--- a/ferriskey/src/cluster/mod.rs
+++ b/ferriskey/src/cluster/mod.rs
@@ -1531,6 +1531,45 @@ impl<C> Future for Request<C> {
                         .into()
                     }
                     RetryMethod::RefreshSlotsAndRetry => {
+                        // FanOut sub-request short-circuit.
+                        //
+                        // A sub-request dispatched by `execute_on_multiple_nodes`
+                        // carries `CmdArg::MultiCmd` with routing
+                        // `InternalSingleNodeRouting::Connection { address, .. }`
+                        // — pinned to the originally-selected node. On READONLY
+                        // (replica rejected a write), `reset_routing` rewrites
+                        // that to `ByAddress(address)` — still the same
+                        // (now-replica) node. Slot refresh therefore cannot
+                        // redirect this sub-request, and local retries burn
+                        // the full `number_of_retries` budget against a
+                        // replica (~30s with default params) before the
+                        // error bubbles up to the aggregator.
+                        //
+                        // That delay exhausts bounded application-level
+                        // wall-clock budgets (e.g. ff-script's 14.5s
+                        // library-load loop) long before the aggregate-level
+                        // READONLY → RefreshSlots + redrive fires
+                        // (`OperationTarget::FanOut` arm above, introduced
+                        // by the #426 fix). Short-circuit here: respond with
+                        // the READONLY error immediately so the aggregator
+                        // observes it on the next `try_join_all` poll and
+                        // can redrive the whole fan-out against the
+                        // refreshed slot map.
+                        if err.kind() == ErrorKind::ReadOnly
+                            && matches!(
+                                this.request.as_ref().unwrap().info.cmd,
+                                CmdArg::MultiCmd { .. }
+                            )
+                        {
+                            warn!(
+                                "FanOut sub-request on {:?} returned READONLY; bubbling up to \
+                                 aggregator for topology-refreshing redrive (no local retry)",
+                                address
+                            );
+                            self.respond(Err(err));
+                            return Next::Done.into();
+                        }
+
                         let mut request = this.request.take().unwrap();
                         request.info.reset_routing();
                         Next::RefreshSlots {


### PR DESCRIPTION
## Summary

Closes the residual `Server::start` → `FUNCTION LOAD (flowfabric lib)` → `ReadOnly` failure on Valkey cluster that surfaced on PR #423 (release/v0.12.0) after PR #426 (FanOut aggregator READONLY fix) and PR #424 (disk reclaim) both landed on main.

## Hypothesis verification

**#426 patched the aggregator.** The `OperationTarget::FanOut` arm at `ferriskey/src/cluster/mod.rs:1449-1489` triggers `Next::RefreshSlots` + redrive when the aggregate receives a READONLY. That closed the loop on #426's own cluster CI runs.

**What #426 did not close.** Each FanOut sub-request is dispatched as:

```rust
// ferriskey/src/cluster/mod.rs:2897-2911
PendingRequest {
    info: RequestInfo {
        cmd: CmdArg::MultiCmd {
            cmd,
            routing: InternalSingleNodeRouting::Connection { address, conn }.into(),
        },
    },
    ..
}
```

— pinned by connection to the originally-selected node. When that node has become a replica between slot-map refresh and sub-request dispatch, it rejects the write with READONLY. The sub-request's retry path at `ferriskey/src/cluster/mod.rs:1533` hits `RetryMethod::RefreshSlotsAndRetry` and calls `reset_routing`, which rewrites `Connection { address }` → `ByAddress(address)` (`ferriskey/src/cluster/mod.rs:1124-1126`) — still the same (now-replica) node. Slot refresh cannot redirect a `ByAddress` route, so local retries burn the full `number_of_retries` budget against the replica (~30 s with default params; `RetryParams::default` is 16 retries at `ferriskey/src/cluster/client.rs:57-72`).

Additionally `poll_recover` explicitly returns `Poll::Ready(Ok(()))` even while the slot-refresh task is still running (`ferriskey/src/cluster/mod.rs:3706-3713`), so retries against the stale slot map can fire before the refresh lands.

That ~30 s sub-request burn exhausts the ff-script loader's 14.5 s library-load loop (`crates/ff-script/src/loader.rs:76-77`) long before the aggregate-level #426 arm ever sees a READONLY error. Failing run `25100636210` panicked at exactly ~18 s — consistent with one sub-request retry cycle burning the budget before the aggregator can redrive.

Hypotheses ruled out:
- **#1 (different code path)**: `function_load_replace` → `self.execute` → generic cluster dispatch → `try_request` → `try_cmd_request` (mod.rs:3176, 3057) → `execute_on_multiple_nodes` — same FanOut path #426 patched. Confirmed.
- **#4 (Cargo.lock staleness)**: ferriskey is path-vendored (`Cargo.toml:54`). No lock issue.

## Fix shape

Surgical short-circuit in the sub-request retry arm. When `err.kind() == ErrorKind::ReadOnly` AND the command is `CmdArg::MultiCmd` (i.e. the request is a FanOut sub-request), respond with the error immediately — no local retry, no `reset_routing`. The aggregator observes the error on the next `try_join_all` poll (mod.rs:2268-2274) and invokes the existing `OperationTarget::FanOut` READONLY arm from #426 to refresh the slot map and redrive the whole fan-out against the new topology.

Scope:
- Only `ErrorKind::ReadOnly` maps to `RetryMethod::RefreshSlotsAndRetry` (`ferriskey/src/value.rs:1002`) so no other retry class is affected.
- Gated on `CmdArg::MultiCmd` so single-node commands retain the existing retry semantics.
- All 262 ferriskey unit tests pass locally.

## Relationship to #426

#426 was the correct half of the fix (aggregate-level retry + topology refresh). This PR closes the other half (stop sub-requests from burning retry budget on a pinned-to-replica route before the aggregator can see the error). Together they form the complete FUNCTION LOAD cluster READONLY story; separately, #426 alone leaves a ~30 s sub-request burn that defeats bounded outer budgets.

## Test plan

- [ ] Cluster CI cells (ubuntu-latest + arm) GREEN on 2 consecutive runs on this PR
- [ ] After merge: PR #423 (release/v0.12.0) rebased onto new main; cluster CI cells GREEN on 2 consecutive runs
- [ ] ferriskey `cargo test -p ferriskey --lib` — 262 tests pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)