### PR TITLE
fix(ff-script): extend FUNCTION LOAD retry window to 39.5s for cold-cluster gossip (v0.12 tag-blocker)

### DIFF
--- a/crates/ff-script/src/loader.rs
+++ b/crates/ff-script/src/loader.rs
@@ -68,13 +68,25 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
     //
     // This loader-side loop is kept for v0.12 as defense-in-depth:
     // the aggregate ferriskey retry bound is finite, and legitimate
-    // cold-start topology churn can outlive it. It is scheduled to
+    // cold-start topology churn can outlive it.
+    //
+    // Per the v0.12 tag-blocker diagnosis (#423, Verdict B): post-#426
+    // + #427, cluster cells still flaked ~25% of the time on the
+    // `Server::start` → `FUNCTION LOAD` → `READONLY` path, non-
+    // deterministically across tests, architectures, and primitives.
+    // The same fix path works once the cluster is warm; it simply
+    // wasn't given enough time on a cold cluster where gossip
+    // propagation can exceed ~15s. The retry window is extended
+    // here so the loader absorbs that cold-cluster gossip window
+    // without requiring a ferriskey-level change.
+    //
+    // Each retry remains productive (fresh topology refresh between
+    // attempts), so the total window is ~39.5s (500ms + 1s + 2s +
+    // 4s + 7s + 10s + 15s between 8 attempts). It is scheduled to
     // be simplified/removed in v0.13 once the ferriskey fix has
-    // proven sufficient across more CI runs. Each retry is still
-    // productive (fresh topology), so the total window is ~14.5s
-    // (500ms + 1s + 2s + 4s + 7s between 6 attempts).
-    const MAX_ATTEMPTS: u32 = 6;
-    let backoff_ms: [u64; 5] = [500, 1_000, 2_000, 4_000, 7_000];
+    // proven sufficient across more CI runs.
+    const MAX_ATTEMPTS: u32 = 8;
+    let backoff_ms: [u64; 7] = [500, 1_000, 2_000, 4_000, 7_000, 10_000, 15_000];
     let mut last_err = None;
     for attempt in 1..=MAX_ATTEMPTS {
         match client.function_load_replace(LIBRARY_SOURCE).await {


### PR DESCRIPTION
## Summary

v0.12 tag-blocker fix. Per the diagnosis on #423 (Verdict B, agent `a1fbce649a5358199`): post-#426 + #427, cluster cells still flake ~25% of the time on `Server::start` -> `FUNCTION LOAD` -> `READONLY`, non-deterministically across tests, architectures, and primitives.

Root cause: **cold-cluster gossip propagation window exceeds the 14.5s bounded retry budget**. The fix path itself is correct (same ferriskey `FanOut` aggregate arm that #427 hardened); it just isn't given enough time on a cold cluster.

This extends the loader-side retry from 6 attempts / ~14.5s to 8 attempts / ~39.5s:

```
[500ms, 1s, 2s, 4s, 7s]            -- old (5 sleeps, 6 attempts, 14.5s)
[500ms, 1s, 2s, 4s, 7s, 10s, 15s]  -- new (7 sleeps, 8 attempts, 39.5s)
```

Each retry remains productive: the existing per-iteration `force_cluster_slot_refresh()` ensures the next attempt routes against fresh topology.

## Evidence (per diagnosis)

- Post-#427 cluster-cell failure rate: **~25%**, non-deterministic
- Different tests fail across runs (no third-layer deterministic bug)
- x86 fails more than arm post-#427 (not arch-specific; timing-skew)
- Same code path succeeds on a warm cluster; just runs out of budget cold
- Rules out deterministic third-layer bug and arch-specific issue

## Why 39.5s / 8 attempts

- Observed cold-cluster gossip windows can exceed 15s before the primary/replica swap fully propagates into ferriskey's cached slot map.
- Exponential backoff to 15s preserves useful spacing: every sleep is long enough for a meaningful topology tick, nothing is a tight spin.
- Defense-in-depth only: ferriskey's #426 + #427 fix is still the correct structural fix; loader retry is the belt-and-braces that absorbs the long tail.

## Scope

- **Only file changed:** `crates/ff-script/src/loader.rs` (constants + rustdoc).
- **Not touched:** ferriskey (correct per #426/#427), `bootstrap.sh` (orthogonal, out of scope for v0.12), any other file.

## Test plan

- [x] `cargo test --workspace --lib` green (all tests pass)
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` clean
- [x] `scripts/smoke-sqlite.sh` PASS (17.1s wall-clock)
- [ ] Cluster cells on both arm + ubuntu-latest green
- [ ] **3 consecutive green cluster runs** required (per 25% post-#427 failure rate: 1 - 0.25^3 = 98% confidence that the extension actually absorbs the cold-cluster window, vs 94% with just 2 runs)

## STOP conditions

- 3rd cluster run still fails with READONLY -> 40s still insufficient -> surface for owner; real fix likely needs to be at cluster bootstrap or a different shape entirely.
- Non-cluster cell regresses -> STOP.

Cross-links the 3-part resolution: **#426 + #427 + this PR**.

Closes the third-reproducer tracked in `project_v012_release_cluster_flake_third_reproducer.md`.