### PR TITLE
chore(ff-test): install tracing subscriber for integration tests (unblock arm-cluster READONLY diagnosis)

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -285,8 +285,18 @@ jobs:
           FF_HOST: 127.0.0.1
           FF_PORT: ${{ matrix.mode == 'cluster' && '7000' || '6379' }}
           FF_CLUSTER: ${{ matrix.mode == 'cluster' && '1' || '0' }}
+          # PR #429 follow-up: on cluster cells, route ferriskey +
+          # ff-script diagnostic traces to the test log surface via
+          # the `ff-test` fmt subscriber installed by
+          # `init_test_tracing()`. Standalone + mac cells leave
+          # `RUST_LOG` unset so the subscriber is a no-op (keeps
+          # passing-cell logs noise-free). `ferriskey=warn` is the
+          # level at which slot-refresh + READONLY retry observability
+          # shipped in #426/#427/#429; `ff_script=debug` picks up the
+          # loader retry loop.
+          RUST_LOG: ${{ matrix.mode == 'cluster' && 'ferriskey=warn,ff_script=debug' || '' }}
         run: |
-          cargo test -p ff-test -- --test-threads=1
+          cargo test -p ff-test -- --test-threads=1 --nocapture
 
       # ── Diagnostics on failure ────────────────────────────────────
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -295,8 +295,16 @@ jobs:
           # shipped in #426/#427/#429; `ff_script=debug` picks up the
           # loader retry loop.
           RUST_LOG: ${{ matrix.mode == 'cluster' && 'ferriskey=warn,ff_script=debug' || '' }}
+          FF_MODE: ${{ matrix.mode }}
         run: |
-          cargo test -p ff-test -- --test-threads=1 --nocapture
+          # `--nocapture` only on cluster cells so the fmt subscriber
+          # output actually reaches the CI log. Standalone + mac cells
+          # keep the default (captured) form to stay noise-free.
+          if [ "$FF_MODE" = "cluster" ]; then
+            cargo test -p ff-test -- --test-threads=1 --nocapture
+          else
+            cargo test -p ff-test -- --test-threads=1
+          fi
 
       # ── Diagnostics on failure ────────────────────────────────────
 

--- a/crates/ff-test/Cargo.toml
+++ b/crates/ff-test/Cargo.toml
@@ -38,6 +38,15 @@ uuid = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+# PR #429 follow-up: install a process-wide tracing subscriber at
+# integration-test startup so diagnostic `warn!` / `debug!` traces
+# from ferriskey + ff-script reach CI logs when `RUST_LOG` is set.
+# Observability shipped in #426/#427/#429 was silently dropped
+# because no test binary installed a subscriber.
+# `fmt` = stdout formatter; `env-filter` = `RUST_LOG`-driven filtering;
+# `registry` stays for the scoped-subscriber pattern in
+# `engine_backend_observability.rs`.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "registry"] }
 
 [dev-dependencies]
 # RFC-016 Stage E asserts metric emission end-to-end. The `observability`
@@ -51,9 +60,6 @@ serial_test = "3"
 axum = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 futures = { workspace = true }
-# Issue #154 — tracing span capture in the observability wiring test.
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
-
 [features]
 # RFC-017 Wave 8 Stage E1: gate the `http_postgres_smoke` integration
 # test behind a feature so workspace-default `cargo test` does not

--- a/crates/ff-test/src/fixtures.rs
+++ b/crates/ff-test/src/fixtures.rs
@@ -62,6 +62,12 @@ impl TestCluster {
     /// Each test gets a fresh connection to avoid shared-state issues.
     /// Library loading happens once (first test loads, others verify).
     pub async fn connect() -> Self {
+        // PR #429 follow-up: install the process-wide `RUST_LOG`-gated
+        // tracing subscriber before the first Valkey round trip so any
+        // ferriskey / ff-script `warn!` emitted during connect or
+        // library load reaches the test log surface.
+        crate::init_test_tracing();
+
         let client = build_client_from_env()
             .await
             .unwrap_or_else(|e| panic!("Failed to connect to Valkey: {e}"));

--- a/crates/ff-test/src/lib.rs
+++ b/crates/ff-test/src/lib.rs
@@ -36,3 +36,75 @@ pub mod helpers;
 // Re-export key types for convenience in tests
 pub use ff_core::state::*;
 pub use ff_core::types::*;
+
+use std::sync::OnceLock;
+
+/// Guard so the global subscriber is installed at most once per
+/// integration-test binary.
+static TRACING_INIT: OnceLock<()> = OnceLock::new();
+
+/// Install a process-wide `tracing_subscriber::fmt` subscriber,
+/// gated on the `RUST_LOG` env var.
+///
+/// Rationale (PR #429 follow-up): PRs #426/#427/#429 shipped three
+/// layers of `tracing::warn!` observability meant to diagnose the
+/// arm-cluster `FUNCTION LOAD -> READONLY` flake. Those traces never
+/// reached CI logs because no `ff-test` integration-test binary
+/// installed a subscriber. This helper wires a fmt subscriber with
+/// `EnvFilter::from_default_env()` so setting `RUST_LOG` at CI (or
+/// locally) produces visible output. If `RUST_LOG` is unset the
+/// helper is a no-op — zero allocation, zero cost.
+///
+/// Idempotent: the first caller installs the global default; later
+/// calls are ignored via `OnceLock`. This does not interfere with
+/// the thread-local scoped subscriber used in
+/// `engine_backend_observability.rs` (`tracing::subscriber::set_default`
+/// wins within its scope; the global serves everything else).
+///
+/// Called automatically from [`fixtures::TestCluster::connect`] so
+/// every integration test picks it up without per-test boilerplate.
+pub fn init_test_tracing() {
+    TRACING_INIT.get_or_init(|| {
+        // Treat unset OR empty as "no subscriber". GitHub Actions
+        // matrix-gated env expressions (`${{ cond && 'x' || '' }}`)
+        // set the var to an empty string on the false branch rather
+        // than leaving it unset, and we don't want a passing cell to
+        // pay the subscriber-init cost for an empty filter.
+        match std::env::var_os("RUST_LOG") {
+            Some(v) if !v.is_empty() => {}
+            _ => return,
+        }
+        // `try_init` is the non-panicking form — if some other
+        // subscriber was already installed (e.g. a test opted to
+        // set one up itself before calling a ff-test helper), we
+        // leave it alone.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .try_init();
+    });
+}
+
+#[cfg(test)]
+mod init_test_tracing_tests {
+    use super::init_test_tracing;
+
+    // Unit-level sanity check: when `RUST_LOG` is unset, the helper
+    // returns without panicking and does not install a subscriber.
+    // When it IS set, `try_init()` succeeds on the first call and
+    // subsequent calls are ignored via the `OnceLock`.
+    //
+    // Full end-to-end verification (a `warn!` line actually appears
+    // on the captured test writer) is exercised via
+    // `RUST_LOG=... cargo test -- --nocapture` in CI; see the
+    // cluster cell's `RUST_LOG` env on the integration-tests step.
+    #[test]
+    fn init_is_noop_without_rust_log() {
+        // We cannot reliably manipulate the process env in a
+        // parallel test binary, so just confirm the call is safe
+        // and idempotent. The real branch coverage comes from the
+        // CI run with `RUST_LOG` set.
+        init_test_tracing();
+        init_test_tracing();
+    }
+}

--- a/crates/ff-test/src/lib.rs
+++ b/crates/ff-test/src/lib.rs
@@ -64,16 +64,21 @@ static TRACING_INIT: OnceLock<()> = OnceLock::new();
 /// Called automatically from [`fixtures::TestCluster::connect`] so
 /// every integration test picks it up without per-test boilerplate.
 pub fn init_test_tracing() {
+    // Treat unset OR empty as "no subscriber". GitHub Actions
+    // matrix-gated env expressions (`${{ cond && 'x' || '' }}`) set
+    // the var to an empty string on the false branch rather than
+    // leaving it unset, and we don't want a passing cell to pay the
+    // subscriber-init cost for an empty filter.
+    //
+    // Check `RUST_LOG` BEFORE touching `TRACING_INIT` so a no-op call
+    // does not lock the `OnceLock` into the "not installed" state.
+    // Otherwise a test that reads `RUST_LOG=unset`, calls this helper,
+    // and later sets `RUST_LOG=...` would never get a subscriber.
+    match std::env::var_os("RUST_LOG") {
+        Some(v) if !v.is_empty() => {}
+        _ => return,
+    }
     TRACING_INIT.get_or_init(|| {
-        // Treat unset OR empty as "no subscriber". GitHub Actions
-        // matrix-gated env expressions (`${{ cond && 'x' || '' }}`)
-        // set the var to an empty string on the false branch rather
-        // than leaving it unset, and we don't want a passing cell to
-        // pay the subscriber-init cost for an empty filter.
-        match std::env::var_os("RUST_LOG") {
-            Some(v) if !v.is_empty() => {}
-            _ => return,
-        }
         // `try_init` is the non-panicking form — if some other
         // subscriber was already installed (e.g. a test opted to
         // set one up itself before calling a ff-test helper), we


### PR DESCRIPTION
## Summary

- Install a process-wide `tracing_subscriber::fmt` subscriber in `ff-test::lib`, gated on `RUST_LOG`, via `OnceLock` + `try_init()`. Called automatically from `TestCluster::connect()` so every integration-test binary picks it up.
- Cluster cells (x86 + arm) in `matrix.yml` now set `RUST_LOG=ferriskey=warn,ff_script=debug` on the integration-tests step and pass `--nocapture` so the fmt writer reaches CI log output. Standalone + mac cells leave `RUST_LOG` unset (no-op, zero cost).
- Existing scoped subscriber in `engine_backend_observability.rs` (`set_default`) keeps working — thread-local scoped subscribers shadow the global default within their scope.

## Motivation

PRs #426, #427, and #429 each shipped `tracing::warn!` observability intended to diagnose the arm-cluster `FUNCTION LOAD -> READONLY` flake. Per the diagnosis agent's verdict on the 4th investigation, every one of those traces has been silently dropped — `ff-test` integration-test binaries have never installed a subscriber. Four rounds of fix-and-rerun have been flying blind.

This PR makes those traces visible. Next step (separate PR) is re-running #429's CI with the subscriber flowing so we can discriminate between hypotheses H1 (stale `CLUSTER SLOTS`), H1b (refresh-dispatch routing bug), H3 (loader budget composition), and H3b (bootstrap-settle timing).

This PR is observability infrastructure only. No flake fix.

## Verification

- `cargo test -p ff-test --lib` green (10 tests including the new `init_is_noop_without_rust_log` sanity check).
- `cargo clippy -p ff-test --lib -- -D warnings` clean.
- Temporary smoke test (removed before commit) confirmed `RUST_LOG=ff_script=debug,ferriskey=warn cargo test ... -- --nocapture` produces lines like:
  `2026-04-29T12:45:10Z WARN ff_script: RUST_LOG subscriber works`
  `2026-04-29T12:45:10Z WARN ferriskey: ferriskey target admitted`

## Test plan

- [ ] Matrix CI green on all cells.
- [ ] Cluster cells show `RUST_LOG` env set in the "Integration tests (serial)" step log.
- [ ] If the cluster cell hits the READONLY flake on this PR, the CI log shows the `warn!` lines from #426/#427/#429 (proving the subscriber is wired). If it stays green, the subscriber is still wired — just no retries happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)