### PR TITLE
feat(sdk): backend-agnostic admin client facade (v0.13 ergonomics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Backend-agnostic `FlowFabricAdminClient` facade (SC-10 ergonomics
+  follow-up, v0.13).** `FlowFabricAdminClient` now supports both HTTP
+  (`new` / `with_token` — existing) and embedded
+  (`connect_with(Arc<dyn EngineBackend>)` — new) transports behind
+  one public method surface. `claim_for_worker`,
+  `issue_reclaim_grant`, and `rotate_waitpoint_secret` dispatch to
+  the matching `EngineBackend` trait method on the embedded path.
+  Consumers running under `FF_DEV_MODE=1` + SQLite no longer need to
+  drop down to trait-direct `backend.issue_reclaim_grant(...)` — the
+  full SDK admin surface is reachable without standing up an
+  `ff-server`. `EngineError::Unavailable` from the backend maps to
+  `SdkError::AdminApi { status: 503, kind: Some("unavailable"), ... }`
+  so callers see a uniform admin-error surface regardless of
+  transport. `examples/incident-remediation` updated to drive the
+  supervisor's reclaim path through the facade. See
+  [`docs/CONSUMER_MIGRATION_0.13.md`](docs/CONSUMER_MIGRATION_0.13.md).
+
 ## [0.12.0] - 2026-04-28
 
 ### Changed

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -14,9 +14,11 @@
 //! string-like token value (`&str` or `String`) via
 //! `impl AsRef<str>`).
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::contracts::RotateWaitpointHmacSecretOutcome;
+use ff_core::engine_backend::EngineBackend;
 // v0.12 PR-6: these imports only power the Valkey-typed
 // `rotate_waitpoint_hmac_secret_all_partitions` helper at the bottom
 // of the module; gated so the ungated module builds clean under
@@ -38,17 +40,54 @@ use crate::SdkError;
 /// than a client-side timeout error.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(130);
 
-/// Client for the `ff-server` admin REST surface.
+/// Client for FlowFabric admin primitives — backend-agnostic facade
+/// (v0.13 SC-10 ergonomics).
 ///
-/// Construct via [`FlowFabricAdminClient::new`] (no auth) or
-/// [`FlowFabricAdminClient::with_token`] (Bearer auth). Both
-/// return a ready-to-use client backed by a single pooled
-/// `reqwest::Client` — reuse the instance across calls instead of
-/// building one per request.
+/// Two construction shapes:
+///
+/// * [`FlowFabricAdminClient::new`] / [`FlowFabricAdminClient::with_token`]
+///   — HTTP transport targeting a running `ff-server`.
+/// * [`FlowFabricAdminClient::connect_with`] — embedded transport
+///   that dispatches directly through an `Arc<dyn EngineBackend>`.
+///   No `ff-server` required; works under `FF_DEV_MODE=1` + SQLite
+///   and in any in-process deployment.
+///
+/// The public method surface is identical across both transports;
+/// consumers choose at construction time. Admin methods that have
+/// no backend-trait equivalent return
+/// [`SdkError::AdminApi`] with status 503 on the embedded path —
+/// today every method on this client maps cleanly, so this fallback
+/// is only reached if a future admin primitive lands HTTP-first.
 #[derive(Debug, Clone)]
 pub struct FlowFabricAdminClient {
-    http: reqwest::Client,
-    base_url: String,
+    transport: AdminTransport,
+}
+
+/// Internal discriminator between the HTTP and embedded transports.
+/// Private by design — the public API is uniform across both shapes
+/// (see the [`FlowFabricAdminClient`] type-level docs).
+#[derive(Clone)]
+enum AdminTransport {
+    Http {
+        http: reqwest::Client,
+        base_url: String,
+    },
+    Embedded(Arc<dyn EngineBackend>),
+}
+
+impl std::fmt::Debug for AdminTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdminTransport::Http { base_url, .. } => f
+                .debug_struct("Http")
+                .field("base_url", base_url)
+                .finish_non_exhaustive(),
+            AdminTransport::Embedded(backend) => f
+                .debug_struct("Embedded")
+                .field("backend", &backend.backend_label())
+                .finish(),
+        }
+    }
 }
 
 impl FlowFabricAdminClient {
@@ -64,9 +103,41 @@ impl FlowFabricAdminClient {
                 context: "build reqwest::Client".into(),
             })?;
         Ok(Self {
-            http,
-            base_url: normalize_base_url(base_url.into()),
+            transport: AdminTransport::Http {
+                http,
+                base_url: normalize_base_url(base_url.into()),
+            },
         })
+    }
+
+    /// Build a client that dispatches admin primitives directly
+    /// through an `Arc<dyn EngineBackend>`, bypassing HTTP entirely.
+    ///
+    /// # When to use
+    ///
+    /// * `FF_DEV_MODE=1` SQLite scenarios where no `ff-server` is
+    ///   running.
+    /// * In-process / embedded deployments that hold a backend
+    ///   handle already (e.g. tests, examples, scheduler-hosting
+    ///   binaries).
+    ///
+    /// # Semantic parity
+    ///
+    /// Each method on [`FlowFabricAdminClient`] dispatches to the
+    /// equivalent `EngineBackend` trait method (see the RFC-024 /
+    /// RFC-017 admin surfaces). Validation + request-body translation
+    /// mirror the server-side handler in `ff-server` so consumers see
+    /// the same error shape regardless of transport.
+    ///
+    /// `EngineError::Unavailable` from the backend — emitted by
+    /// backends that have not implemented a given method — is mapped
+    /// to [`SdkError::AdminApi`] with `status = 503` and
+    /// `kind = Some("unavailable")` so callers see a uniform
+    /// admin-error surface across transports.
+    pub fn connect_with(backend: Arc<dyn EngineBackend>) -> Self {
+        Self {
+            transport: AdminTransport::Embedded(backend),
+        }
     }
 
     /// Build a client that sends `Authorization: Bearer <token>` on
@@ -125,8 +196,10 @@ impl FlowFabricAdminClient {
                 context: "build reqwest::Client".into(),
             })?;
         Ok(Self {
-            http,
-            base_url: normalize_base_url(base_url.into()),
+            transport: AdminTransport::Http {
+                http,
+                base_url: normalize_base_url(base_url.into()),
+            },
         })
     }
 
@@ -145,68 +218,14 @@ impl FlowFabricAdminClient {
         &self,
         req: ClaimForWorkerRequest,
     ) -> Result<Option<ClaimForWorkerResponse>, SdkError> {
-        // Percent-encode `worker_id` in the URL path — `WorkerId` is a
-        // free-form string (could contain `/`, spaces, `%`, etc.) and
-        // splicing it verbatim would produce malformed URLs or
-        // misrouted paths. `Url::path_segments_mut().push` handles the
-        // encoding natively.
-        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| SdkError::Config {
-            context: "admin_client: claim_for_worker".into(),
-            field: Some("base_url".into()),
-            message: format!("invalid base_url '{}': {e}", self.base_url),
-        })?;
-        {
-            let mut segs = url.path_segments_mut().map_err(|_| SdkError::Config {
-                context: "admin_client: claim_for_worker".into(),
-                field: Some("base_url".into()),
-                message: format!("base_url cannot be a base URL: '{}'", self.base_url),
-            })?;
-            segs.extend(&["v1", "workers", &req.worker_id, "claim"]);
+        match &self.transport {
+            AdminTransport::Http { http, base_url } => {
+                claim_for_worker_http(http, base_url, req).await
+            }
+            AdminTransport::Embedded(backend) => {
+                claim_for_worker_embedded(backend.as_ref(), req).await
+            }
         }
-        let url = url.to_string();
-        let resp = self
-            .http
-            .post(&url)
-            .json(&req)
-            .send()
-            .await
-            .map_err(|e| SdkError::Http {
-                source: e,
-                context: "POST /v1/workers/{worker_id}/claim".into(),
-            })?;
-
-        let status = resp.status();
-        if status == reqwest::StatusCode::NO_CONTENT {
-            return Ok(None);
-        }
-        if status.is_success() {
-            return resp
-                .json::<ClaimForWorkerResponse>()
-                .await
-                .map(Some)
-                .map_err(|e| SdkError::Http {
-                    source: e,
-                    context: "decode claim_for_worker response body".into(),
-                });
-        }
-
-        // Error path — mirror rotate_waitpoint_secret's ErrorBody decode.
-        let status_u16 = status.as_u16();
-        let raw = resp.text().await.map_err(|e| SdkError::Http {
-            source: e,
-            context: format!("read claim_for_worker error body (status {status_u16})"),
-        })?;
-        let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
-        Err(SdkError::AdminApi {
-            status: status_u16,
-            message: parsed
-                .as_ref()
-                .map(|b| b.error.clone())
-                .unwrap_or_else(|| raw.clone()),
-            kind: parsed.as_ref().and_then(|b| b.kind.clone()),
-            retryable: parsed.as_ref().and_then(|b| b.retryable),
-            raw_body: raw,
-        })
     }
 
     /// Rotate the waitpoint HMAC secret on the server.
@@ -240,54 +259,14 @@ impl FlowFabricAdminClient {
         &self,
         req: RotateWaitpointSecretRequest,
     ) -> Result<RotateWaitpointSecretResponse, SdkError> {
-        let url = format!("{}/v1/admin/rotate-waitpoint-secret", self.base_url);
-        let resp = self
-            .http
-            .post(&url)
-            .json(&req)
-            .send()
-            .await
-            .map_err(|e| SdkError::Http {
-                source: e,
-                context: "POST /v1/admin/rotate-waitpoint-secret".into(),
-            })?;
-
-        let status = resp.status();
-        if status.is_success() {
-            return resp
-                .json::<RotateWaitpointSecretResponse>()
-                .await
-                .map_err(|e| SdkError::Http {
-                    source: e,
-                    context: "decode rotate-waitpoint-secret response body".into(),
-                });
+        match &self.transport {
+            AdminTransport::Http { http, base_url } => {
+                rotate_waitpoint_secret_http(http, base_url, req).await
+            }
+            AdminTransport::Embedded(backend) => {
+                rotate_waitpoint_secret_embedded(backend.as_ref(), req).await
+            }
         }
-
-        // Non-2xx: parse the server's ErrorBody if we can, fall
-        // back to a raw body otherwise. Propagate body-read
-        // transport errors as Http rather than silently flattening
-        // them into `AdminApi { raw_body: "" }` — a connection drop
-        // mid-body-read is a transport fault, not an API-layer
-        // reject, and misclassifying it strips `is_retryable`'s
-        // timeout/connect signal from the caller.
-        let status_u16 = status.as_u16();
-        let raw = resp.text().await.map_err(|e| SdkError::Http {
-            source: e,
-            context: format!(
-                "read rotate-waitpoint-secret error response body (status {status_u16})"
-            ),
-        })?;
-        let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
-        Err(SdkError::AdminApi {
-            status: status_u16,
-            message: parsed
-                .as_ref()
-                .map(|b| b.error.clone())
-                .unwrap_or_else(|| raw.clone()),
-            kind: parsed.as_ref().and_then(|b| b.kind.clone()),
-            retryable: parsed.as_ref().and_then(|b| b.retryable),
-            raw_body: raw,
-        })
     }
 
     /// Request a lease-reclaim grant for an execution in
@@ -353,64 +332,428 @@ impl FlowFabricAdminClient {
         execution_id: &str,
         req: IssueReclaimGrantRequest,
     ) -> Result<IssueReclaimGrantResponse, SdkError> {
-        // Percent-encode `execution_id` in the URL path — the id is a
-        // free-form string and splicing verbatim would produce
-        // malformed URLs. Mirrors `claim_for_worker`'s handling.
-        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| SdkError::Config {
-            context: "admin_client: issue_reclaim_grant".into(),
-            field: Some("base_url".into()),
-            message: format!("invalid base_url '{}': {e}", self.base_url),
-        })?;
-        {
-            let mut segs = url.path_segments_mut().map_err(|_| SdkError::Config {
-                context: "admin_client: issue_reclaim_grant".into(),
-                field: Some("base_url".into()),
-                message: format!("base_url cannot be a base URL: '{}'", self.base_url),
-            })?;
-            segs.extend(&["v1", "executions", execution_id, "reclaim"]);
+        match &self.transport {
+            AdminTransport::Http { http, base_url } => {
+                issue_reclaim_grant_http(http, base_url, execution_id, req).await
+            }
+            AdminTransport::Embedded(backend) => {
+                issue_reclaim_grant_embedded(backend.as_ref(), execution_id, req).await
+            }
         }
-        let url = url.to_string();
-        let resp = self
-            .http
-            .post(&url)
-            .json(&req)
-            .send()
+    }
+}
+
+// ── HTTP-transport helpers (private) ─────────────────────────────────
+
+async fn claim_for_worker_http(
+    http: &reqwest::Client,
+    base_url: &str,
+    req: ClaimForWorkerRequest,
+) -> Result<Option<ClaimForWorkerResponse>, SdkError> {
+    // Percent-encode `worker_id` in the URL path — `WorkerId` is a
+    // free-form string (could contain `/`, spaces, `%`, etc.) and
+    // splicing it verbatim would produce malformed URLs or
+    // misrouted paths. `Url::path_segments_mut().push` handles the
+    // encoding natively.
+    let mut url = reqwest::Url::parse(base_url).map_err(|e| SdkError::Config {
+        context: "admin_client: claim_for_worker".into(),
+        field: Some("base_url".into()),
+        message: format!("invalid base_url '{}': {e}", base_url),
+    })?;
+    {
+        let mut segs = url.path_segments_mut().map_err(|_| SdkError::Config {
+            context: "admin_client: claim_for_worker".into(),
+            field: Some("base_url".into()),
+            message: format!("base_url cannot be a base URL: '{}'", base_url),
+        })?;
+        segs.extend(&["v1", "workers", &req.worker_id, "claim"]);
+    }
+    let url = url.to_string();
+    let resp = http
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .map_err(|e| SdkError::Http {
+            source: e,
+            context: "POST /v1/workers/{worker_id}/claim".into(),
+        })?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::NO_CONTENT {
+        return Ok(None);
+    }
+    if status.is_success() {
+        return resp
+            .json::<ClaimForWorkerResponse>()
+            .await
+            .map(Some)
+            .map_err(|e| SdkError::Http {
+                source: e,
+                context: "decode claim_for_worker response body".into(),
+            });
+    }
+
+    // Error path — mirror rotate_waitpoint_secret's ErrorBody decode.
+    let status_u16 = status.as_u16();
+    let raw = resp.text().await.map_err(|e| SdkError::Http {
+        source: e,
+        context: format!("read claim_for_worker error body (status {status_u16})"),
+    })?;
+    let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
+    Err(SdkError::AdminApi {
+        status: status_u16,
+        message: parsed
+            .as_ref()
+            .map(|b| b.error.clone())
+            .unwrap_or_else(|| raw.clone()),
+        kind: parsed.as_ref().and_then(|b| b.kind.clone()),
+        retryable: parsed.as_ref().and_then(|b| b.retryable),
+        raw_body: raw,
+    })
+}
+
+async fn rotate_waitpoint_secret_http(
+    http: &reqwest::Client,
+    base_url: &str,
+    req: RotateWaitpointSecretRequest,
+) -> Result<RotateWaitpointSecretResponse, SdkError> {
+    let url = format!("{}/v1/admin/rotate-waitpoint-secret", base_url);
+    let resp = http
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .map_err(|e| SdkError::Http {
+            source: e,
+            context: "POST /v1/admin/rotate-waitpoint-secret".into(),
+        })?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return resp
+            .json::<RotateWaitpointSecretResponse>()
             .await
             .map_err(|e| SdkError::Http {
                 source: e,
-                context: "POST /v1/executions/{id}/reclaim".into(),
-            })?;
-
-        let status = resp.status();
-        if status.is_success() {
-            return resp
-                .json::<IssueReclaimGrantResponse>()
-                .await
-                .map_err(|e| SdkError::Http {
-                    source: e,
-                    context: "decode issue_reclaim_grant response body".into(),
-                });
-        }
-
-        let status_u16 = status.as_u16();
-        let raw = resp.text().await.map_err(|e| SdkError::Http {
-            source: e,
-            context: format!(
-                "read issue_reclaim_grant error body (status {status_u16})"
-            ),
-        })?;
-        let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
-        Err(SdkError::AdminApi {
-            status: status_u16,
-            message: parsed
-                .as_ref()
-                .map(|b| b.error.clone())
-                .unwrap_or_else(|| raw.clone()),
-            kind: parsed.as_ref().and_then(|b| b.kind.clone()),
-            retryable: parsed.as_ref().and_then(|b| b.retryable),
-            raw_body: raw,
-        })
+                context: "decode rotate-waitpoint-secret response body".into(),
+            });
     }
+
+    // Non-2xx: parse the server's ErrorBody if we can, fall
+    // back to a raw body otherwise. Propagate body-read
+    // transport errors as Http rather than silently flattening
+    // them into `AdminApi { raw_body: "" }` — a connection drop
+    // mid-body-read is a transport fault, not an API-layer
+    // reject, and misclassifying it strips `is_retryable`'s
+    // timeout/connect signal from the caller.
+    let status_u16 = status.as_u16();
+    let raw = resp.text().await.map_err(|e| SdkError::Http {
+        source: e,
+        context: format!(
+            "read rotate-waitpoint-secret error response body (status {status_u16})"
+        ),
+    })?;
+    let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
+    Err(SdkError::AdminApi {
+        status: status_u16,
+        message: parsed
+            .as_ref()
+            .map(|b| b.error.clone())
+            .unwrap_or_else(|| raw.clone()),
+        kind: parsed.as_ref().and_then(|b| b.kind.clone()),
+        retryable: parsed.as_ref().and_then(|b| b.retryable),
+        raw_body: raw,
+    })
+}
+
+async fn issue_reclaim_grant_http(
+    http: &reqwest::Client,
+    base_url: &str,
+    execution_id: &str,
+    req: IssueReclaimGrantRequest,
+) -> Result<IssueReclaimGrantResponse, SdkError> {
+    // Percent-encode `execution_id` in the URL path — the id is a
+    // free-form string and splicing verbatim would produce
+    // malformed URLs. Mirrors `claim_for_worker`'s handling.
+    let mut url = reqwest::Url::parse(base_url).map_err(|e| SdkError::Config {
+        context: "admin_client: issue_reclaim_grant".into(),
+        field: Some("base_url".into()),
+        message: format!("invalid base_url '{}': {e}", base_url),
+    })?;
+    {
+        let mut segs = url.path_segments_mut().map_err(|_| SdkError::Config {
+            context: "admin_client: issue_reclaim_grant".into(),
+            field: Some("base_url".into()),
+            message: format!("base_url cannot be a base URL: '{}'", base_url),
+        })?;
+        segs.extend(&["v1", "executions", execution_id, "reclaim"]);
+    }
+    let url = url.to_string();
+    let resp = http
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .map_err(|e| SdkError::Http {
+            source: e,
+            context: "POST /v1/executions/{id}/reclaim".into(),
+        })?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return resp
+            .json::<IssueReclaimGrantResponse>()
+            .await
+            .map_err(|e| SdkError::Http {
+                source: e,
+                context: "decode issue_reclaim_grant response body".into(),
+            });
+    }
+
+    let status_u16 = status.as_u16();
+    let raw = resp.text().await.map_err(|e| SdkError::Http {
+        source: e,
+        context: format!(
+            "read issue_reclaim_grant error body (status {status_u16})"
+        ),
+    })?;
+    let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
+    Err(SdkError::AdminApi {
+        status: status_u16,
+        message: parsed
+            .as_ref()
+            .map(|b| b.error.clone())
+            .unwrap_or_else(|| raw.clone()),
+        kind: parsed.as_ref().and_then(|b| b.kind.clone()),
+        retryable: parsed.as_ref().and_then(|b| b.retryable),
+        raw_body: raw,
+    })
+}
+
+// ── Embedded-transport helpers (private) ─────────────────────────────
+//
+// Dispatch directly through the `EngineBackend` trait. The request
+// body validation mirrors the server-side handler in
+// `ff-server::api`. Translation between the wire DTOs and the core
+// `contracts::*` types lives here so consumers get identical
+// surfaces across transports.
+
+/// Map an `EngineError` from a backend call into the `SdkError::AdminApi`
+/// surface so embedded and HTTP transports emit the same shape. `Unavailable`
+/// becomes 503 with kind `"unavailable"`; every other engine error bubbles
+/// up via `SdkError::Engine`.
+fn engine_err_to_admin(err: ff_core::engine_error::EngineError, op: &str) -> SdkError {
+    if let ff_core::engine_error::EngineError::Unavailable { op: backend_op } = &err {
+        return SdkError::AdminApi {
+            status: 503,
+            message: format!(
+                "{op}: backend does not implement '{backend_op}' on this transport"
+            ),
+            kind: Some("unavailable".to_owned()),
+            retryable: Some(false),
+            raw_body: String::new(),
+        };
+    }
+    SdkError::Engine(Box::new(err))
+}
+
+async fn claim_for_worker_embedded(
+    backend: &dyn EngineBackend,
+    req: ClaimForWorkerRequest,
+) -> Result<Option<ClaimForWorkerResponse>, SdkError> {
+    // Mirror ff-server's validation + translation. Errors surface as
+    // SdkError::Config so consumers see validation faults loud rather
+    // than as backend transport errors.
+    let lane_id = ff_core::types::LaneId::try_new(req.lane_id).map_err(|e| SdkError::Config {
+        context: "admin_client: claim_for_worker".into(),
+        field: Some("lane_id".into()),
+        message: e.to_string(),
+    })?;
+    if req.worker_id.trim().is_empty() {
+        return Err(SdkError::Config {
+            context: "admin_client: claim_for_worker".into(),
+            field: Some("worker_id".into()),
+            message: "must be non-empty".into(),
+        });
+    }
+    if req.worker_instance_id.trim().is_empty() {
+        return Err(SdkError::Config {
+            context: "admin_client: claim_for_worker".into(),
+            field: Some("worker_instance_id".into()),
+            message: "must be non-empty".into(),
+        });
+    }
+    if req.grant_ttl_ms == 0 {
+        return Err(SdkError::Config {
+            context: "admin_client: claim_for_worker".into(),
+            field: Some("grant_ttl_ms".into()),
+            message: "must be > 0".into(),
+        });
+    }
+    let caps: std::collections::BTreeSet<String> = req.capabilities.into_iter().collect();
+    let args = ff_core::contracts::ClaimForWorkerArgs::new(
+        lane_id,
+        ff_core::types::WorkerId::new(req.worker_id),
+        ff_core::types::WorkerInstanceId::new(req.worker_instance_id),
+        caps,
+        req.grant_ttl_ms,
+    );
+    match backend
+        .claim_for_worker(args)
+        .await
+        .map_err(|e| engine_err_to_admin(e, "claim_for_worker"))?
+    {
+        ff_core::contracts::ClaimForWorkerOutcome::NoWork => Ok(None),
+        ff_core::contracts::ClaimForWorkerOutcome::Granted(grant) => {
+            Ok(Some(ClaimForWorkerResponse {
+                execution_id: grant.execution_id.to_string(),
+                partition_key: grant.partition_key,
+                grant_key: grant.grant_key,
+                expires_at_ms: grant.expires_at_ms,
+            }))
+        }
+        // `ClaimForWorkerOutcome` is `#[non_exhaustive]`; mirror
+        // ff-server's 503 policy on unknown variants.
+        _ => Err(SdkError::AdminApi {
+            status: 503,
+            message: "claim_for_worker: backend returned a non-exhaustive outcome this SDK build does not understand".to_owned(),
+            kind: Some("unknown_outcome".to_owned()),
+            retryable: Some(false),
+            raw_body: String::new(),
+        }),
+    }
+}
+
+async fn issue_reclaim_grant_embedded(
+    backend: &dyn EngineBackend,
+    execution_id: &str,
+    req: IssueReclaimGrantRequest,
+) -> Result<IssueReclaimGrantResponse, SdkError> {
+    let exec_id = ff_core::types::ExecutionId::parse(execution_id).map_err(|e| SdkError::Config {
+        context: "admin_client: issue_reclaim_grant".into(),
+        field: Some("execution_id".into()),
+        message: e.to_string(),
+    })?;
+    let lane_id = ff_core::types::LaneId::try_new(req.lane_id).map_err(|e| SdkError::Config {
+        context: "admin_client: issue_reclaim_grant".into(),
+        field: Some("lane_id".into()),
+        message: e.to_string(),
+    })?;
+    if req.worker_id.trim().is_empty() {
+        return Err(SdkError::Config {
+            context: "admin_client: issue_reclaim_grant".into(),
+            field: Some("worker_id".into()),
+            message: "must be non-empty".into(),
+        });
+    }
+    if req.worker_instance_id.trim().is_empty() {
+        return Err(SdkError::Config {
+            context: "admin_client: issue_reclaim_grant".into(),
+            field: Some("worker_instance_id".into()),
+            message: "must be non-empty".into(),
+        });
+    }
+    if req.grant_ttl_ms == 0 {
+        return Err(SdkError::Config {
+            context: "admin_client: issue_reclaim_grant".into(),
+            field: Some("grant_ttl_ms".into()),
+            message: "must be > 0".into(),
+        });
+    }
+    let caps: std::collections::BTreeSet<String> = req.worker_capabilities.into_iter().collect();
+    let args = ff_core::contracts::IssueReclaimGrantArgs::new(
+        exec_id,
+        ff_core::types::WorkerId::new(req.worker_id),
+        ff_core::types::WorkerInstanceId::new(req.worker_instance_id),
+        lane_id,
+        req.capability_hash,
+        req.grant_ttl_ms,
+        req.route_snapshot_json,
+        req.admission_summary,
+        caps,
+        ff_core::types::TimestampMs::now(),
+    );
+    match backend
+        .issue_reclaim_grant(args)
+        .await
+        .map_err(|e| engine_err_to_admin(e, "issue_reclaim_grant"))?
+    {
+        ff_core::contracts::IssueReclaimGrantOutcome::Granted(grant) => {
+            Ok(IssueReclaimGrantResponse::Granted {
+                execution_id: grant.execution_id.to_string(),
+                partition_key: grant.partition_key,
+                grant_key: grant.grant_key,
+                expires_at_ms: grant.expires_at_ms,
+                lane_id: grant.lane_id.as_str().to_owned(),
+            })
+        }
+        ff_core::contracts::IssueReclaimGrantOutcome::NotReclaimable { execution_id, detail } => {
+            Ok(IssueReclaimGrantResponse::NotReclaimable {
+                execution_id: execution_id.to_string(),
+                detail,
+            })
+        }
+        ff_core::contracts::IssueReclaimGrantOutcome::ReclaimCapExceeded {
+            execution_id,
+            reclaim_count,
+        } => Ok(IssueReclaimGrantResponse::ReclaimCapExceeded {
+            execution_id: execution_id.to_string(),
+            reclaim_count,
+        }),
+        _ => Err(SdkError::AdminApi {
+            status: 503,
+            message: "issue_reclaim_grant: backend returned a non-exhaustive outcome this SDK build does not understand".to_owned(),
+            kind: Some("unknown_outcome".to_owned()),
+            retryable: Some(false),
+            raw_body: String::new(),
+        }),
+    }
+}
+
+async fn rotate_waitpoint_secret_embedded(
+    backend: &dyn EngineBackend,
+    req: RotateWaitpointSecretRequest,
+) -> Result<RotateWaitpointSecretResponse, SdkError> {
+    // Note: unlike the HTTP handler, this path does not enforce the
+    // 120s end-to-end timeout (there is no HTTP deadline to honour)
+    // and does not emit the `audit`-target `waitpoint_hmac_rotation_*`
+    // events (those are server-owned operator-audit signals). The
+    // rotation itself is idempotent on the same (new_kid,
+    // new_secret_hex) pair, so retries are safe.
+    //
+    // `grace_ms = 0` mirrors the server's `rotate_waitpoint_secret`
+    // which does not forward a grace window to the backend primitive —
+    // backends provision grace from their own configuration.
+    let args = ff_core::contracts::RotateWaitpointHmacSecretAllArgs::new(
+        req.new_kid.clone(),
+        req.new_secret_hex,
+        0,
+    );
+    let result = backend
+        .rotate_waitpoint_hmac_secret_all(args)
+        .await
+        .map_err(|e| engine_err_to_admin(e, "rotate_waitpoint_secret"))?;
+
+    // Collapse the per-partition entries into the HTTP response shape
+    // the server emits — rotated count + failed indices + echoed
+    // new_kid — so consumers see identical return values across
+    // transports.
+    let mut rotated: u16 = 0;
+    let mut failed: Vec<u16> = Vec::new();
+    for entry in &result.entries {
+        match &entry.result {
+            Ok(_) => {
+                rotated = rotated.saturating_add(1);
+            }
+            Err(_) => failed.push(entry.partition),
+        }
+    }
+    Ok(RotateWaitpointSecretResponse {
+        rotated,
+        failed,
+        new_kid: req.new_kid,
+    })
 }
 
 /// Request body for `POST /v1/executions/{execution_id}/reclaim`

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -40,6 +40,22 @@ use crate::SdkError;
 /// than a client-side timeout error.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(130);
 
+/// Grace window in ms that the embedded `rotate_waitpoint_secret`
+/// path forwards to the backend primitive. Matches `ff-server`'s
+/// default `FF_WAITPOINT_HMAC_GRACE_MS` (24 h) so tokens signed by
+/// the outgoing kid remain valid for a full day after rotation
+/// without the embedded-path hard-killing in-flight flows. HTTP
+/// callers get whatever the server was configured with; embedded
+/// callers get this pinned default.
+pub const EMBEDDED_WAITPOINT_HMAC_GRACE_MS: u64 = 86_400_000;
+
+/// Maximum grant TTL (ms) the embedded admin path accepts on
+/// `claim_for_worker` / `issue_reclaim_grant`. Matches
+/// `ff-server`'s `CLAIM_GRANT_TTL_MS_MAX` / `RECLAIM_GRANT_TTL_MS_MAX`
+/// so the embedded transport rejects the same range the HTTP
+/// transport does.
+const EMBEDDED_GRANT_TTL_MS_MAX: u64 = 60_000;
+
 /// Client for FlowFabric admin primitives — backend-agnostic facade
 /// (v0.13 SC-10 ergonomics).
 ///
@@ -125,15 +141,34 @@ impl FlowFabricAdminClient {
     ///
     /// Each method on [`FlowFabricAdminClient`] dispatches to the
     /// equivalent `EngineBackend` trait method (see the RFC-024 /
-    /// RFC-017 admin surfaces). Validation + request-body translation
-    /// mirror the server-side handler in `ff-server` so consumers see
-    /// the same error shape regardless of transport.
+    /// RFC-017 admin surfaces). Validation **rules** + request-body
+    /// translation mirror the server-side handler in `ff-server` so
+    /// callers get the same accept / reject behaviour across
+    /// transports. Note: the exact [`SdkError`] variant differs —
+    /// embedded-path validation rejects surface as [`SdkError::Config`]
+    /// (no HTTP round-trip) while HTTP returns [`SdkError::AdminApi`]
+    /// with status `400`. Callers that need to distinguish a 4xx from
+    /// a transport fault should use [`SdkError::is_retryable`] or
+    /// match on `Config` + `AdminApi` together rather than relying on
+    /// a single variant.
     ///
     /// `EngineError::Unavailable` from the backend — emitted by
     /// backends that have not implemented a given method — is mapped
     /// to [`SdkError::AdminApi`] with `status = 503` and
     /// `kind = Some("unavailable")` so callers see a uniform
     /// admin-error surface across transports.
+    ///
+    /// # Divergence from the HTTP transport
+    ///
+    /// * `rotate_waitpoint_secret` forwards
+    ///   [`EMBEDDED_WAITPOINT_HMAC_GRACE_MS`] (24 h, matching
+    ///   `ff-server`'s default `FF_WAITPOINT_HMAC_GRACE_MS`) as the
+    ///   per-partition grace window. The HTTP transport reads the
+    ///   server's env-configured value; the embedded client has no
+    ///   config surface so it pins the documented default.
+    /// * No single-writer admin semaphore, no audit-log emission.
+    ///   These are `ff-server` responsibilities; embedded consumers
+    ///   wanting them bring their own gate.
     pub fn connect_with(backend: Arc<dyn EngineBackend>) -> Self {
         Self {
             transport: AdminTransport::Embedded(backend),
@@ -539,6 +574,54 @@ async fn issue_reclaim_grant_http(
 // `contracts::*` types lives here so consumers get identical
 // surfaces across transports.
 
+/// Validate a free-form identifier the same way `ff-server`'s
+/// `validate_identifier` does: non-empty, ≤256 bytes, no whitespace
+/// or control chars. Embedded-transport callers hit this before the
+/// request reaches the backend so invalid identifiers cannot leak
+/// past the SDK's parity guarantee.
+fn validate_admin_identifier(
+    op: &'static str,
+    field: &'static str,
+    value: &str,
+) -> Result<(), SdkError> {
+    if value.is_empty() {
+        return Err(SdkError::Config {
+            context: format!("admin_client: {op}"),
+            field: Some(field.into()),
+            message: "must not be empty".into(),
+        });
+    }
+    if value.len() > 256 {
+        return Err(SdkError::Config {
+            context: format!("admin_client: {op}"),
+            field: Some(field.into()),
+            message: format!("exceeds 256 bytes (got {})", value.len()),
+        });
+    }
+    if value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return Err(SdkError::Config {
+            context: format!("admin_client: {op}"),
+            field: Some(field.into()),
+            message: "must not contain whitespace or control characters".into(),
+        });
+    }
+    Ok(())
+}
+
+/// Bounded grant-TTL check mirroring `ff-server`'s
+/// `1..=CLAIM_GRANT_TTL_MS_MAX`. Shared between `claim_for_worker`
+/// and `issue_reclaim_grant` embedded paths.
+fn validate_admin_grant_ttl(op: &'static str, grant_ttl_ms: u64) -> Result<(), SdkError> {
+    if grant_ttl_ms == 0 || grant_ttl_ms > EMBEDDED_GRANT_TTL_MS_MAX {
+        return Err(SdkError::Config {
+            context: format!("admin_client: {op}"),
+            field: Some("grant_ttl_ms".into()),
+            message: format!("must be in 1..={EMBEDDED_GRANT_TTL_MS_MAX}"),
+        });
+    }
+    Ok(())
+}
+
 /// Map an `EngineError` from a backend call into the `SdkError::AdminApi`
 /// surface so embedded and HTTP transports emit the same shape. `Unavailable`
 /// becomes 503 with kind `"unavailable"`; every other engine error bubbles
@@ -570,27 +653,13 @@ async fn claim_for_worker_embedded(
         field: Some("lane_id".into()),
         message: e.to_string(),
     })?;
-    if req.worker_id.trim().is_empty() {
-        return Err(SdkError::Config {
-            context: "admin_client: claim_for_worker".into(),
-            field: Some("worker_id".into()),
-            message: "must be non-empty".into(),
-        });
-    }
-    if req.worker_instance_id.trim().is_empty() {
-        return Err(SdkError::Config {
-            context: "admin_client: claim_for_worker".into(),
-            field: Some("worker_instance_id".into()),
-            message: "must be non-empty".into(),
-        });
-    }
-    if req.grant_ttl_ms == 0 {
-        return Err(SdkError::Config {
-            context: "admin_client: claim_for_worker".into(),
-            field: Some("grant_ttl_ms".into()),
-            message: "must be > 0".into(),
-        });
-    }
+    validate_admin_identifier("claim_for_worker", "worker_id", &req.worker_id)?;
+    validate_admin_identifier(
+        "claim_for_worker",
+        "worker_instance_id",
+        &req.worker_instance_id,
+    )?;
+    validate_admin_grant_ttl("claim_for_worker", req.grant_ttl_ms)?;
     let caps: std::collections::BTreeSet<String> = req.capabilities.into_iter().collect();
     let args = ff_core::contracts::ClaimForWorkerArgs::new(
         lane_id,
@@ -640,27 +709,13 @@ async fn issue_reclaim_grant_embedded(
         field: Some("lane_id".into()),
         message: e.to_string(),
     })?;
-    if req.worker_id.trim().is_empty() {
-        return Err(SdkError::Config {
-            context: "admin_client: issue_reclaim_grant".into(),
-            field: Some("worker_id".into()),
-            message: "must be non-empty".into(),
-        });
-    }
-    if req.worker_instance_id.trim().is_empty() {
-        return Err(SdkError::Config {
-            context: "admin_client: issue_reclaim_grant".into(),
-            field: Some("worker_instance_id".into()),
-            message: "must be non-empty".into(),
-        });
-    }
-    if req.grant_ttl_ms == 0 {
-        return Err(SdkError::Config {
-            context: "admin_client: issue_reclaim_grant".into(),
-            field: Some("grant_ttl_ms".into()),
-            message: "must be > 0".into(),
-        });
-    }
+    validate_admin_identifier("issue_reclaim_grant", "worker_id", &req.worker_id)?;
+    validate_admin_identifier(
+        "issue_reclaim_grant",
+        "worker_instance_id",
+        &req.worker_instance_id,
+    )?;
+    validate_admin_grant_ttl("issue_reclaim_grant", req.grant_ttl_ms)?;
     let caps: std::collections::BTreeSet<String> = req.worker_capabilities.into_iter().collect();
     let args = ff_core::contracts::IssueReclaimGrantArgs::new(
         exec_id,
@@ -715,20 +770,40 @@ async fn rotate_waitpoint_secret_embedded(
     backend: &dyn EngineBackend,
     req: RotateWaitpointSecretRequest,
 ) -> Result<RotateWaitpointSecretResponse, SdkError> {
-    // Note: unlike the HTTP handler, this path does not enforce the
-    // 120s end-to-end timeout (there is no HTTP deadline to honour)
-    // and does not emit the `audit`-target `waitpoint_hmac_rotation_*`
-    // events (those are server-owned operator-audit signals). The
-    // rotation itself is idempotent on the same (new_kid,
-    // new_secret_hex) pair, so retries are safe.
-    //
-    // `grace_ms = 0` mirrors the server's `rotate_waitpoint_secret`
-    // which does not forward a grace window to the backend primitive —
-    // backends provision grace from their own configuration.
+    // Validation mirrors `ff-server::Server::rotate_waitpoint_secret`
+    // so the embedded and HTTP transports reject the same invalid
+    // inputs.
+    if req.new_kid.is_empty() || req.new_kid.contains(':') {
+        return Err(SdkError::Config {
+            context: "admin_client: rotate_waitpoint_secret".into(),
+            field: Some("new_kid".into()),
+            message: "must be non-empty and must not contain ':'".into(),
+        });
+    }
+    if req.new_secret_hex.is_empty()
+        || !req.new_secret_hex.len().is_multiple_of(2)
+        || !req.new_secret_hex.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err(SdkError::Config {
+            context: "admin_client: rotate_waitpoint_secret".into(),
+            field: Some("new_secret_hex".into()),
+            message: "must be a non-empty even-length hex string".into(),
+        });
+    }
+    // Embedded consumers have no config surface from which to read
+    // the per-deployment grace window, so pin the documented default
+    // matching `ff-server`'s `FF_WAITPOINT_HMAC_GRACE_MS` (24 h). See
+    // `EMBEDDED_WAITPOINT_HMAC_GRACE_MS` + the `connect_with` rustdoc
+    // for the rationale and divergence-from-HTTP notes. Unlike the
+    // HTTP handler, this path does not enforce the 120 s end-to-end
+    // timeout (no HTTP deadline to honour) and does not emit the
+    // `audit`-target `waitpoint_hmac_rotation_*` events (those are
+    // server-owned operator signals). Rotation is idempotent on the
+    // same (new_kid, new_secret_hex) pair, so retries remain safe.
     let args = ff_core::contracts::RotateWaitpointHmacSecretAllArgs::new(
         req.new_kid.clone(),
         req.new_secret_hex,
-        0,
+        EMBEDDED_WAITPOINT_HMAC_GRACE_MS,
     );
     let result = backend
         .rotate_waitpoint_hmac_secret_all(args)

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1676,6 +1676,54 @@ mod sqlite_only_compile_surface_tests {
         }
     }
 
+    /// v0.13 SC-10 compile anchor — the backend-agnostic admin facade
+    /// (`FlowFabricAdminClient::connect_with` + embedded-transport
+    /// methods) MUST be addressable under
+    /// `--no-default-features --features sqlite`. Without this anchor,
+    /// a regression that re-introduces a ferriskey symbol on the
+    /// embedded admin path would only surface on downstream
+    /// sqlite-only consumers.
+    #[test]
+    fn admin_facade_addressable_under_sqlite_only() {
+        use crate::admin::{
+            ClaimForWorkerRequest, ClaimForWorkerResponse, FlowFabricAdminClient,
+            IssueReclaimGrantRequest, IssueReclaimGrantResponse, RotateWaitpointSecretRequest,
+            RotateWaitpointSecretResponse,
+        };
+        use crate::SdkError;
+        use std::sync::Arc;
+
+        // `connect_with` is infallible; fn-pointer coerce pins the
+        // signature under the sqlite-only feature set.
+        let _ctor: fn(Arc<dyn EngineBackend>) -> FlowFabricAdminClient =
+            FlowFabricAdminClient::connect_with;
+
+        // Each async method is generic over `&self` lifetimes under
+        // `#[async_trait]`-style expansion, so pin via a wrapper fn.
+        #[allow(dead_code)]
+        async fn _pin_claim(
+            c: &FlowFabricAdminClient,
+            req: ClaimForWorkerRequest,
+        ) -> Result<Option<ClaimForWorkerResponse>, SdkError> {
+            c.claim_for_worker(req).await
+        }
+        #[allow(dead_code)]
+        async fn _pin_reclaim(
+            c: &FlowFabricAdminClient,
+            id: &str,
+            req: IssueReclaimGrantRequest,
+        ) -> Result<IssueReclaimGrantResponse, SdkError> {
+            c.issue_reclaim_grant(id, req).await
+        }
+        #[allow(dead_code)]
+        async fn _pin_rotate(
+            c: &FlowFabricAdminClient,
+            req: RotateWaitpointSecretRequest,
+        ) -> Result<RotateWaitpointSecretResponse, SdkError> {
+            c.rotate_waitpoint_secret(req).await
+        }
+    }
+
     /// v0.12 PR-3 compile anchor — the new
     /// [`EngineBackend::read_current_attempt_index`] trait method MUST
     /// be addressable under `--no-default-features --features sqlite`.

--- a/docs/CONSUMER_MIGRATION_0.13.md
+++ b/docs/CONSUMER_MIGRATION_0.13.md
@@ -136,9 +136,28 @@ let admin = FlowFabricAdminClient::connect_with(trait_obj.clone());
   transport.
 - Other `EngineError` variants surface as `SdkError::Engine(..)`
   unchanged.
-- Request-body validation mirrors `ff-server`'s handler so consumers
-  see the same `SdkError::Config` field-level rejections on the
-  embedded path.
+- Request-body validation **rules** mirror `ff-server`'s handler so
+  the embedded transport rejects the same inputs the HTTP transport
+  does. The exact `SdkError` variant differs — embedded-path
+  rejections surface as `SdkError::Config` (no HTTP round-trip) while
+  HTTP surfaces `SdkError::AdminApi` with status `400`. Match on
+  `SdkError::is_retryable` or on `Config | AdminApi` together if you
+  need transport-independence.
+
+## Divergence from the HTTP transport
+
+The embedded transport has no ff-server config surface to read from,
+so two behaviours are pinned to documented defaults rather than
+per-deployment values:
+
+- `rotate_waitpoint_secret` forwards `EMBEDDED_WAITPOINT_HMAC_GRACE_MS`
+  (24 h, matching `ff-server`'s default `FF_WAITPOINT_HMAC_GRACE_MS`)
+  as the per-partition grace window. Operators who need a non-default
+  grace should use the HTTP transport against an `ff-server` with
+  `FF_WAITPOINT_HMAC_GRACE_MS` set.
+- No single-writer admin semaphore, no audit-log emission. These are
+  `ff-server` responsibilities; embedded consumers wanting them bring
+  their own gate.
 
 ## Not in scope
 

--- a/docs/CONSUMER_MIGRATION_0.13.md
+++ b/docs/CONSUMER_MIGRATION_0.13.md
@@ -1,0 +1,152 @@
+# Consumer migration — v0.12 → v0.13
+
+**Scope.** v0.13 is an ergonomics release on top of v0.12. This doc
+covers the one consumer-visible SDK change in the release:
+`FlowFabricAdminClient` is now a **backend-agnostic facade**,
+constructible either over HTTP (existing behaviour) or directly over
+a backend trait object (new). No breaking changes — existing
+`connect` / `with_token` call-sites compile and behave identically.
+
+A per-change CHANGELOG listing is the source of truth; this doc
+focuses on the ergonomic upgrade path.
+
+## What changed
+
+### `FlowFabricAdminClient` is now backend-agnostic (SC-10 follow-up)
+
+**Motivation.** In v0.12 the SC-10 `incident-remediation` example
+exposed a rough edge: `FlowFabricAdminClient` was HTTP-only and
+required a running `ff-server`. Consumers running under
+`FF_DEV_MODE=1` + SQLite — the zero-infra dev story RFC-023 sells —
+could not use the SDK admin surface and had to drop down to
+trait-direct `EngineBackend::issue_reclaim_grant`. The RFC-024
+**worker** surface (`FlowFabricWorker::claim_from_reclaim_grant`)
+was already backend-agnostic; the **admin** surface was not. v0.13
+closes the parity gap.
+
+**Shape.** `FlowFabricAdminClient` now internally holds a private
+transport enum: `Http { reqwest::Client, base_url }` or
+`Embedded(Arc<dyn EngineBackend>)`. The public method surface is
+unchanged. Construction picks the transport:
+
+```rust
+// HTTP (existing — unchanged):
+let admin = FlowFabricAdminClient::new("http://ff-server.dev")?;
+let admin = FlowFabricAdminClient::with_token("https://ff-server", token)?;
+
+// Embedded trait-dispatch (v0.13, new):
+let backend: Arc<dyn EngineBackend> = SqliteBackend::new(uri).await?;
+let admin = FlowFabricAdminClient::connect_with(backend);
+```
+
+The three admin methods —
+`issue_reclaim_grant`, `claim_for_worker`, `rotate_waitpoint_secret` —
+behave identically across transports.
+
+## Migration
+
+### If you currently use `FlowFabricAdminClient::new` or `with_token`
+
+No action required. HTTP semantics, error shapes, and return values
+are unchanged.
+
+### If you currently trait-dispatch through `EngineBackend` to reach admin primitives
+
+Switch to the facade for a cleaner consumer shape. Before/after from
+`examples/incident-remediation`:
+
+```rust
+// Before (v0.12): supervisor calls the trait method directly.
+async fn issue_grant(
+    backend: &dyn EngineBackend,
+    exec_id: &ExecutionId,
+    lane: &LaneId,
+    worker_id: &str,
+    worker_instance_id: &str,
+) -> Result<ReclaimGrant> {
+    let outcome = backend
+        .issue_reclaim_grant(IssueReclaimGrantArgs::new(
+            exec_id.clone(),
+            WorkerId::new(worker_id),
+            WorkerInstanceId::new(worker_instance_id),
+            lane.clone(),
+            None,
+            60_000,
+            None,
+            None,
+            Default::default(),
+            TimestampMs::from_millis(now_ms()),
+        ))
+        .await?;
+    match outcome {
+        IssueReclaimGrantOutcome::Granted(g) => Ok(g),
+        other => anyhow::bail!("expected Granted, got {other:?}"),
+    }
+}
+
+// After (v0.13): supervisor drives the agnostic admin client.
+async fn issue_grant(
+    admin: &FlowFabricAdminClient,
+    exec_id: &ExecutionId,
+    lane: &LaneId,
+    worker_id: &str,
+    worker_instance_id: &str,
+) -> Result<ReclaimGrant> {
+    let resp = admin
+        .issue_reclaim_grant(
+            exec_id.as_str(),
+            IssueReclaimGrantRequest {
+                worker_id: worker_id.into(),
+                worker_instance_id: worker_instance_id.into(),
+                lane_id: lane.as_str().to_owned(),
+                capability_hash: None,
+                grant_ttl_ms: 60_000,
+                route_snapshot_json: None,
+                admission_summary: None,
+                worker_capabilities: Vec::new(),
+            },
+        )
+        .await?;
+    match resp {
+        IssueReclaimGrantResponse::Granted { .. } => resp.into_grant(),
+        IssueReclaimGrantResponse::NotReclaimable { detail, .. } => {
+            anyhow::bail!("expected Granted, got NotReclaimable: {detail}")
+        }
+        IssueReclaimGrantResponse::ReclaimCapExceeded { reclaim_count, .. } => {
+            anyhow::bail!("cap hit: {reclaim_count}")
+        }
+    }
+}
+```
+
+Construction site:
+
+```rust
+// v0.13: one line replaces the pattern of "hold trait_obj, rebuild
+// IssueReclaimGrantArgs at every call-site".
+let admin = FlowFabricAdminClient::connect_with(trait_obj.clone());
+```
+
+## Error-surface notes
+
+- The embedded transport translates `EngineError::Unavailable`
+  (emitted by backends that have not implemented a given method) into
+  `SdkError::AdminApi { status: 503, kind: Some("unavailable"), ... }`
+  so callers see a uniform admin-error surface regardless of
+  transport.
+- Other `EngineError` variants surface as `SdkError::Engine(..)`
+  unchanged.
+- Request-body validation mirrors `ff-server`'s handler so consumers
+  see the same `SdkError::Config` field-level rejections on the
+  embedded path.
+
+## Not in scope
+
+- HTTP admin semantics (`ff-server` unchanged).
+- New admin methods.
+- `rotate_waitpoint_hmac_secret_all_partitions` free fn stays
+  Valkey-gated (Valkey-specific FCALL fan-out; use the facade's
+  `rotate_waitpoint_secret` for the agnostic path).
+- `WorkerConfig.backend: BackendConfig` dead-field under
+  `connect_with` — unresolved from v0.12 `feedback_sdk_reclaim_ergonomics.md`
+  Finding 2; separate follow-up.

--- a/examples/incident-remediation/Cargo.lock
+++ b/examples/incident-remediation/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -620,11 +620,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ferriskey",
  "ff-backend-sqlite",

--- a/examples/incident-remediation/src/main.rs
+++ b/examples/incident-remediation/src/main.rs
@@ -42,13 +42,16 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use ff_core::backend::{BackendConfig, CapabilitySet, ClaimPolicy};
 use ff_core::contracts::{
-    AddExecutionToFlowArgs, CreateExecutionArgs, CreateFlowArgs, IssueReclaimGrantArgs,
-    IssueReclaimGrantOutcome, ReclaimExecutionArgs, ReclaimExecutionOutcome,
+    AddExecutionToFlowArgs, CreateExecutionArgs, CreateFlowArgs, ReclaimExecutionArgs,
+    ReclaimExecutionOutcome,
 };
 use ff_core::engine_backend::EngineBackend;
 use ff_core::types::{
     AttemptId, AttemptIndex, ExecutionId, FlowId, LaneId, LeaseId, Namespace, TimestampMs,
     WorkerId, WorkerInstanceId,
+};
+use ff_sdk::admin::{
+    FlowFabricAdminClient, IssueReclaimGrantRequest, IssueReclaimGrantResponse,
 };
 use ff_sdk::{FlowFabricWorker, WorkerConfig};
 use tracing::info;
@@ -151,6 +154,13 @@ async fn run_sqlite() -> Result<()> {
         .await
         .context("construct SqliteBackend")?;
     let trait_obj: Arc<dyn EngineBackend> = backend.clone();
+    // v0.13 SC-10 ergonomics: `FlowFabricAdminClient::connect_with`
+    // gives the supervisor the same admin surface it would have under
+    // an HTTP `ff-server`, with no server process required. The
+    // RFC-024 `issue_reclaim_grant` call below used to trait-dispatch
+    // through `backend.issue_reclaim_grant(...)`; with the facade the
+    // supervisor drives the agnostic SDK admin client instead.
+    let admin = FlowFabricAdminClient::connect_with(trait_obj.clone());
     info!(target: "engine", "[engine] SQLite dev backend ready");
 
     // Side-pool mirrors examples/ff-dev — dev-only column surgery the
@@ -248,19 +258,14 @@ async fn run_sqlite() -> Result<()> {
 
     // ── 5. Supervisor issues a reclaim grant (RFC-024 §3.2) ─────────────
     //
-    // NB: in a deployment with `ff-server` reachable, this is
-    // `FlowFabricAdminClient::issue_reclaim_grant` over HTTP. Under
-    // FF_DEV_MODE=1 + SQLite there is no ff-server, so we invoke the
-    // trait method directly — same primitive, no transport round-trip.
-    // See `docs/CONSUMER_MIGRATION_0.12.md` §7 for the HTTP shape.
-    let grant = issue_grant(
-        trait_obj.as_ref(),
-        &exec_id,
-        &lane,
-        "responder-b",
-        "responder-b-instance-1",
-    )
-    .await?;
+    // v0.13 SC-10 ergonomics: `FlowFabricAdminClient::issue_reclaim_grant`
+    // is backend-agnostic — the same method call works whether the
+    // client was built via `connect` (HTTP → `ff-server`) or
+    // `connect_with` (embedded trait-dispatch, as here). Under
+    // `FF_DEV_MODE=1` + SQLite no `ff-server` is running; the facade
+    // handles that. See `docs/CONSUMER_MIGRATION_0.13.md`.
+    let grant = issue_grant(&admin, &exec_id, &lane, "responder-b", "responder-b-instance-1")
+        .await?;
     info!(target: "supervisor", execution = %exec_id, grant = %grant.grant_key, "[supervisor] issued reclaim grant for Responder B");
 
     // ── 6. Responder B consumes the grant via the SDK ───────────────────
@@ -334,7 +339,7 @@ async fn run_sqlite() -> Result<()> {
         info!(target: "engine", round, "[engine] simulating lease expiry + reclaim round");
         force_lease_expired(&side_pool, &escalated).await?;
         let grant = issue_grant(
-            trait_obj.as_ref(),
+            &admin,
             &escalated,
             &lane,
             "responder-b",
@@ -403,30 +408,40 @@ async fn build_worker(
 }
 
 async fn issue_grant(
-    backend: &dyn EngineBackend,
+    admin: &FlowFabricAdminClient,
     exec_id: &ExecutionId,
     lane: &LaneId,
     worker_id: &str,
     worker_instance_id: &str,
 ) -> Result<ff_core::contracts::ReclaimGrant> {
-    let outcome = backend
-        .issue_reclaim_grant(IssueReclaimGrantArgs::new(
-            exec_id.clone(),
-            WorkerId::new(worker_id),
-            WorkerInstanceId::new(worker_instance_id),
-            lane.clone(),
-            None,
-            60_000,
-            None,
-            None,
-            Default::default(),
-            TimestampMs::from_millis(now_ms()),
-        ))
+    let resp = admin
+        .issue_reclaim_grant(
+            exec_id.as_str(),
+            IssueReclaimGrantRequest {
+                worker_id: worker_id.into(),
+                worker_instance_id: worker_instance_id.into(),
+                lane_id: lane.as_str().to_owned(),
+                capability_hash: None,
+                grant_ttl_ms: 60_000,
+                route_snapshot_json: None,
+                admission_summary: None,
+                worker_capabilities: Vec::new(),
+            },
+        )
         .await
-        .context("issue_reclaim_grant")?;
-    match outcome {
-        IssueReclaimGrantOutcome::Granted(g) => Ok(g),
-        other => anyhow::bail!("expected Granted, got {other:?}"),
+        .context("FlowFabricAdminClient::issue_reclaim_grant")?;
+    match resp {
+        IssueReclaimGrantResponse::Granted { .. } => resp
+            .into_grant()
+            .context("into_grant from Granted response"),
+        IssueReclaimGrantResponse::NotReclaimable { detail, .. } => {
+            anyhow::bail!("expected Granted, got NotReclaimable: {detail}")
+        }
+        IssueReclaimGrantResponse::ReclaimCapExceeded { reclaim_count, .. } => {
+            anyhow::bail!(
+                "expected Granted, got ReclaimCapExceeded (reclaim_count={reclaim_count})"
+            )
+        }
     }
 }
 
@@ -454,17 +469,6 @@ fn reclaim_args(
         WorkerInstanceId::new(old_worker_instance_id),
         AttemptIndex::new(current_attempt_index),
     )
-}
-
-fn now_ms() -> i64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    i64::try_from(
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis())
-            .unwrap_or(0),
-    )
-    .unwrap_or(0)
 }
 
 fn uuid_of(eid: &ExecutionId) -> Uuid {


### PR DESCRIPTION
## Summary

Closes the SC-10 ergonomics follow-up from v0.12 `feedback_sdk_reclaim_ergonomics` Finding 1. `FlowFabricAdminClient` is now a **backend-agnostic facade** — consumers running under `FF_DEV_MODE=1` + SQLite can drive the full SDK admin surface without standing up an `ff-server`, matching the RFC-024 worker surface (`claim_from_reclaim_grant`) which has been agnostic since v0.12 PR-5.5.

## Design — Option C (facade enum)

Investigation confirmed Option C is clean: all three admin methods (`issue_reclaim_grant`, `claim_for_worker`, `rotate_waitpoint_secret`) have direct `EngineBackend` trait equivalents, so the Embedded transport has no `Unavailable` fallthroughs. Public API unchanged; callers choose transport at construction.

Alternatives considered:
- **Option A (two constructors, methods return `Unavailable` for HTTP-only)** — same surface as C; rejected because Option C preserves the exact public shape.
- **Option B (extract `AdminClient` trait, two impls)** — forces consumers to import a trait; more ceremony for zero gain since all methods map cleanly.

## Changes

- `crates/ff-sdk/src/admin.rs` — introduce private `AdminTransport` enum `{ Http, Embedded }`; rewrite 3 methods to dispatch through it; add `FlowFabricAdminClient::connect_with(Arc<dyn EngineBackend>)`. HTTP path unchanged.
- Embedded path mirrors ff-server validation + DTO↔contracts translation; `EngineError::Unavailable` → `SdkError::AdminApi { status: 503, kind: "unavailable" }`.
- `examples/incident-remediation/src/main.rs` — supervisor reclaim path now drives the facade (`FlowFabricAdminClient::connect_with(trait_obj.clone())`), eliminating the trait-direct `EngineBackend::issue_reclaim_grant` workaround.
- `crates/ff-sdk/src/worker.rs` — new `admin_facade_addressable_under_sqlite_only` compile anchor in `sqlite_only_compile_surface_tests`.
- `docs/CONSUMER_MIGRATION_0.13.md` — new migration doc with before/after.
- `CHANGELOG.md` — `[Unreleased] Added` entry.

## Example LoC delta

Roughly neutral net LoC (+4), positive on clarity: the old `IssueReclaimGrantArgs::new(...)` 10-positional-arg call is replaced by a named-field request struct; HandleKind/outcome-matching moves to the well-known `IssueReclaimGrantResponse` enum. No more `EngineBackend` import bleeding into the reclaim grant path.

## Scope

**Out of scope per task directive:**
- HTTP admin semantics (`ff-server` untouched).
- New admin methods.
- `rotate_waitpoint_hmac_secret_all_partitions` free fn — stays `valkey-default`-gated (Valkey-specific FCALL fan-out; agnostic consumers use the facade's `rotate_waitpoint_secret`).
- `WorkerConfig.backend` dead-field from Finding 2 — separate follow-up.

## Test plan

- [x] `cargo test -p ff-sdk --lib` — green (44 passed).
- [x] `cargo test -p ff-sdk --lib --no-default-features --features sqlite` — green (35 passed; new `admin_facade_addressable_under_sqlite_only` anchor among them).
- [x] `cargo test --workspace --lib` — green.
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` — clean.
- [x] `cargo tree -p ff-sdk --no-default-features --features sqlite -e features | grep ff-core` — still just `core` (PR #412 anchor preserved).
- [x] `cargo build` on `examples/incident-remediation` — clean.
- [x] `FF_DEV_MODE=1 cargo run -p incident-remediation -- --backend sqlite` — full scenario green (happy-path reclaim + cap-exceeded branch, all expected log lines present).
- [x] Clippy on ff-sdk code: no new lints. (Workspace clippy has pre-existing errors in ferriskey vendored, ff-sdk layer test_support, and ff-backend-sqlite stream queries — not touched by this PR.)

Resolves `feedback_sdk_reclaim_ergonomics.md` Finding 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)