### PR TITLE
feat(backend-postgres): implement create_waitpoint (cairn #435, v0.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   transport. `examples/incident-remediation` updated to drive the
   supervisor's reclaim path through the facade. See
   [`docs/CONSUMER_MIGRATION_0.13.md`](docs/CONSUMER_MIGRATION_0.13.md).
+- **`ff-backend-postgres`: `EngineBackend::create_waitpoint` implemented.**
+  Completes cairn #435 — the previously stubbed (`EngineError::Unavailable`)
+  caller-initiated waitpoint path now mints a fresh `WaitpointId`, signs
+  a token under the active HMAC kid, and INSERTs a `pending` row into
+  `ff_waitpoint_pending`. Behaviour mirrors `ff-backend-sqlite`'s
+  `create_waitpoint_impl` and Valkey's `ff_create_pending_waitpoint`:
+  state stays `pending` (only `suspend` activates); tokens bind to
+  `"{execution_id}:{waitpoint_id}"` so the existing `deliver_signal`
+  verify path accepts them unchanged; `waitpoint_key` is not an
+  idempotency key — every call mints a distinct `WaitpointId`. Unblocks
+  approval-flow control-plane paths on Postgres deployments.
 
 ## [0.12.0] - 2026-04-28
 

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -409,6 +409,7 @@ impl PostgresBackend {
 /// (rather than a macro) so rust-analyzer / IDE jumps show a single
 /// definition site for the Wave 0 stub pattern.
 #[inline]
+#[cfg_attr(feature = "streaming", allow(dead_code))]
 fn unavailable<T>(op: &'static str) -> Result<T, EngineError> {
     Err(EngineError::Unavailable { op })
 }
@@ -519,11 +520,11 @@ impl EngineBackend for PostgresBackend {
     #[tracing::instrument(name = "pg.create_waitpoint", skip_all)]
     async fn create_waitpoint(
         &self,
-        _handle: &Handle,
-        _waitpoint_key: &str,
-        _expires_in: Duration,
+        handle: &Handle,
+        waitpoint_key: &str,
+        expires_in: Duration,
     ) -> Result<PendingWaitpoint, EngineError> {
-        unavailable("pg.create_waitpoint")
+        suspend_ops::create_waitpoint_impl(&self.pool, handle, waitpoint_key, expires_in).await
     }
 
     #[cfg(feature = "core")]

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -719,8 +719,17 @@ pub(crate) async fn create_waitpoint_impl(
     let wp_id = WaitpointId::new();
     let wp_u = wp_uuid(&wp_id)?;
     let now = now_ms();
-    let expires_at =
-        now.saturating_add(i64::try_from(expires_in.as_millis()).unwrap_or(i64::MAX));
+    // Caller-supplied `expires_in` that doesn't fit in i64 ms is a
+    // nonsense value (>292M years). Reject as validation rather than
+    // silently clamping — `bigint expires_at_ms` can't represent it
+    // and saturating would mask the bad input.
+    let expires_ms = i64::try_from(expires_in.as_millis()).map_err(|_| {
+        EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "expires_in exceeds i64 milliseconds".into(),
+        }
+    })?;
+    let expires_at = now.saturating_add(expires_ms);
     let msg = format!("{}:{}", payload.execution_id, wp_id);
     let token = hmac_sign(&secret, &kid, msg.as_bytes());
 

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -719,20 +719,17 @@ pub(crate) async fn create_waitpoint_impl(
     let wp_id = WaitpointId::new();
     let wp_u = wp_uuid(&wp_id)?;
     let now = now_ms();
-    // Caller-supplied `expires_in` that doesn't fit in i64 ms is a
-    // nonsense value (>292M years). Reject as validation rather than
-    // silently clamping — `bigint expires_at_ms` can't represent it
-    // and saturating would mask the bad input.
-    let expires_ms = i64::try_from(expires_in.as_millis()).map_err(|_| {
-        EngineError::Validation {
-            kind: ValidationKind::InvalidInput,
-            detail: "expires_in exceeds i64 milliseconds".into(),
-        }
-    })?;
-    let expires_at = now.checked_add(expires_ms).ok_or(EngineError::Validation {
-        kind: ValidationKind::InvalidInput,
-        detail: "expires_in causes expires_at_ms overflow".into(),
-    })?;
+    // Clamp oversized `expires_in` to match the other backends:
+    //   * `ff-backend-sqlite::create_waitpoint_impl` uses
+    //     `i64::try_from(...).unwrap_or(i64::MAX)` + `saturating_add`.
+    //   * `ff-backend-valkey` / `ff_create_pending_waitpoint` Lua casts
+    //     with `as i64`.
+    //
+    // A stricter "overflow => Validation" contract would diverge from
+    // both — that tightening needs a one-shot trait-docs + all-three-
+    // backends change, not a PG-only fork. Keep parity until then.
+    let expires_ms = i64::try_from(expires_in.as_millis()).unwrap_or(i64::MAX);
+    let expires_at = now.saturating_add(expires_ms);
     let msg = format!("{}:{}", payload.execution_id, wp_id);
     let token = hmac_sign(&secret, &kid, msg.as_bytes());
 

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -729,7 +729,10 @@ pub(crate) async fn create_waitpoint_impl(
             detail: "expires_in exceeds i64 milliseconds".into(),
         }
     })?;
-    let expires_at = now.saturating_add(expires_ms);
+    let expires_at = now.checked_add(expires_ms).ok_or(EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: "expires_in causes expires_at_ms overflow".into(),
+    })?;
     let msg = format!("{}:{}", payload.execution_id, wp_id);
     let token = hmac_sign(&secret, &kid, msg.as_bytes());
 

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -21,7 +21,9 @@
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use ff_core::backend::{BackendTag, Handle, HandleKind, HandleOpaque, ResumeSignal, WaitpointHmac};
+use ff_core::backend::{
+    BackendTag, Handle, HandleKind, HandleOpaque, PendingWaitpoint, ResumeSignal, WaitpointHmac,
+};
 use ff_core::contracts::{
     AdditionalWaitpointBinding, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
     ClaimedResumedExecution, CompositeBody, DeliverSignalArgs, DeliverSignalResult,
@@ -673,6 +675,79 @@ async fn suspend_core(
         })
     })
     .await
+}
+
+// ─── create_waitpoint ────────────────────────────────────────────────────
+
+/// Cairn #435 — caller-initiated waitpoint creation. Mints a fresh
+/// `WaitpointId`, signs a token under the active HMAC kid, and INSERTs
+/// a `pending` row into `ff_waitpoint_pending`. Mirrors
+/// `ff-backend-sqlite`'s `create_waitpoint_impl` + Valkey's
+/// `ff_create_pending_waitpoint` Lua: state stays `'pending'` (no
+/// activation — only `suspend` flips a waitpoint to `'active'`),
+/// `required_signal_names` is empty (wildcard wire marker), and the
+/// token is bound to `"{execution_id}:{waitpoint_id}"` so the
+/// pre-existing `deliver_signal` verify path accepts it unchanged.
+///
+/// Not idempotent by `waitpoint_key` — every call mints a fresh
+/// `WaitpointId`, matching both reference backends. Two calls with
+/// the same key produce two distinct waitpoints.
+pub(crate) async fn create_waitpoint_impl(
+    pool: &PgPool,
+    handle: &Handle,
+    waitpoint_key: &str,
+    expires_in: std::time::Duration,
+) -> Result<PendingWaitpoint, EngineError> {
+    let payload = decode_handle(handle)?;
+    let (part, exec_uuid) = split_exec_id(&payload.execution_id)?;
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let kid_row: Option<(String, Vec<u8>)> = sqlx::query_as(
+        "SELECT kid, secret FROM ff_waitpoint_hmac \
+         WHERE active = TRUE \
+         ORDER BY rotated_at_ms DESC LIMIT 1",
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let (kid, secret) = kid_row.ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: "ff_waitpoint_hmac empty — seed a kid before create_waitpoint".into(),
+    })?;
+
+    let wp_id = WaitpointId::new();
+    let wp_u = wp_uuid(&wp_id)?;
+    let now = now_ms();
+    let expires_at =
+        now.saturating_add(i64::try_from(expires_in.as_millis()).unwrap_or(i64::MAX));
+    let msg = format!("{}:{}", payload.execution_id, wp_id);
+    let token = hmac_sign(&secret, &kid, msg.as_bytes());
+
+    // State stays 'pending' — only the suspend path activates. Empty
+    // `required_signal_names` is the wildcard-wire marker per the
+    // `PendingWaitpointInfo` contract.
+    sqlx::query(
+        "INSERT INTO ff_waitpoint_pending \
+           (partition_key, waitpoint_id, execution_id, token_kid, token, \
+            created_at_ms, expires_at_ms, waitpoint_key, state, required_signal_names) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', '{}')",
+    )
+    .bind(part)
+    .bind(wp_u)
+    .bind(exec_uuid)
+    .bind(&kid)
+    .bind(&token)
+    .bind(now)
+    .bind(expires_at)
+    .bind(waitpoint_key)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(PendingWaitpoint::new(wp_id, WaitpointHmac::new(token)))
 }
 
 // ─── deliver_signal ──────────────────────────────────────────────────────

--- a/crates/ff-backend-postgres/tests/suspend_signal.rs
+++ b/crates/ff-backend-postgres/tests/suspend_signal.rs
@@ -1141,13 +1141,14 @@ async fn create_waitpoint_mints_token_and_row() {
         .await
         .expect("create_waitpoint ok");
 
-    // Token shape: `<kid>:<hex>` (same format suspend produces).
+    // Token shape: `<kid>:<hex>` (same format suspend produces). Don't
+    // print the full token on failure — it's a live HMAC credential.
     let tok = pending.hmac_token.as_str();
-    assert!(
-        tok.starts_with("kid-suspend-1:"),
-        "token should embed active kid, got {tok}"
-    );
-    assert!(tok.len() > "kid-suspend-1:".len(), "token body missing");
+    let (kid, body) = tok
+        .split_once(':')
+        .expect("token has `<kid>:<body>` shape");
+    assert_eq!(kid, "kid-suspend-1", "token should embed active kid");
+    assert!(!body.is_empty(), "token body missing (len={})", body.len());
 
     // Row landed with state='pending' and the expected (exec, key).
     let wp_u = Uuid::parse_str(&pending.waitpoint_id.to_string()).unwrap();

--- a/crates/ff-backend-postgres/tests/suspend_signal.rs
+++ b/crates/ff-backend-postgres/tests/suspend_signal.rs
@@ -1123,3 +1123,186 @@ async fn read_waitpoint_token_returns_some_for_existing_and_none_for_missing() {
     let _ = fx.lane;
     let _ = fx.pool;
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Cairn #435 — create_waitpoint (explicit, caller-initiated).
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn create_waitpoint_mints_token_and_row() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let pending = fx
+        .backend
+        .create_waitpoint(&fx.handle, "wpk:cw-1", std::time::Duration::from_secs(60))
+        .await
+        .expect("create_waitpoint ok");
+
+    // Token shape: `<kid>:<hex>` (same format suspend produces).
+    let tok = pending.hmac_token.as_str();
+    assert!(
+        tok.starts_with("kid-suspend-1:"),
+        "token should embed active kid, got {tok}"
+    );
+    assert!(tok.len() > "kid-suspend-1:".len(), "token body missing");
+
+    // Row landed with state='pending' and the expected (exec, key).
+    let wp_u = Uuid::parse_str(&pending.waitpoint_id.to_string()).unwrap();
+    let row: (String, String, Uuid, Option<i64>) = sqlx::query_as(
+        "SELECT state, waitpoint_key, execution_id, expires_at_ms \
+           FROM ff_waitpoint_pending \
+          WHERE partition_key = $1 AND waitpoint_id = $2",
+    )
+    .bind(fx.part)
+    .bind(wp_u)
+    .fetch_one(&fx.pool)
+    .await
+    .expect("waitpoint row present");
+    assert_eq!(row.0, "pending");
+    assert_eq!(row.1, "wpk:cw-1");
+    assert_eq!(row.2, fx.exec_uuid);
+    assert!(row.3.is_some(), "expires_at_ms should be set");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn create_waitpoint_token_hmac_verifies() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let pending = fx
+        .backend
+        .create_waitpoint(&fx.handle, "wpk:cw-verify", std::time::Duration::from_secs(30))
+        .await
+        .expect("create_waitpoint ok");
+
+    // Parse `<kid>:<hex>` and verify against the active secret via
+    // the same primitive deliver_signal uses.
+    let tok = pending.hmac_token.as_str();
+    let (kid, _) = tok.split_once(':').expect("token has <kid>:<hex> shape");
+    let secret = ff_backend_postgres::signal::fetch_kid(&fx.pool, kid)
+        .await
+        .expect("fetch_kid ok")
+        .expect("kid present in keystore");
+    let msg = format!("{}:{}", fx.exec_id, pending.waitpoint_id);
+    match hmac_verify(&secret, kid, msg.as_bytes(), tok) {
+        Ok(()) => {}
+        Err(HmacVerifyError::WrongKid { .. }) => {
+            panic!("unexpected wrong-kid from create_waitpoint token")
+        }
+        Err(e) => panic!("hmac_verify failed: {e:?}"),
+    }
+    // Tamper: flipping a byte must reject.
+    let mut bad = tok.to_owned();
+    let last = bad.pop().unwrap();
+    bad.push(if last == '0' { '1' } else { '0' });
+    assert!(
+        hmac_verify(&secret, kid, msg.as_bytes(), &bad).is_err(),
+        "tampered token must fail verify"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn create_waitpoint_distinct_ids_per_call() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    // Parity with Valkey + SQLite: `waitpoint_key` is not an
+    // idempotency key — every call mints a fresh WaitpointId.
+    let a = fx
+        .backend
+        .create_waitpoint(&fx.handle, "wpk:cw-same", std::time::Duration::from_secs(60))
+        .await
+        .expect("first create");
+    let b = fx
+        .backend
+        .create_waitpoint(&fx.handle, "wpk:cw-same", std::time::Duration::from_secs(60))
+        .await
+        .expect("second create");
+    assert_ne!(
+        a.waitpoint_id, b.waitpoint_id,
+        "each call must mint a fresh WaitpointId"
+    );
+    assert_ne!(
+        a.hmac_token.as_str(),
+        b.hmac_token.as_str(),
+        "tokens are per-(exec, waitpoint_id) — distinct ids ⇒ distinct tokens"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn create_waitpoint_without_seeded_kid_errors() {
+    // Fresh schema, no rotate/seed — the keystore is empty.
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+
+    // Minimal exec + attempt, matching `setup_exec_or_skip` sans the
+    // hmac rotate.
+    let lane = LaneId::new("default");
+    let exec_id = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let part = exec_id.partition() as i16;
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    let now = TimestampMs::now().0;
+    sqlx::query(
+        "INSERT INTO ff_exec_core \
+           (partition_key, execution_id, lane_id, attempt_index, \
+            lifecycle_phase, ownership_state, eligibility_state, \
+            public_state, attempt_state, created_at_ms) \
+         VALUES ($1, $2, $3, 0, 'active', 'leased', 'not_applicable', \
+                 'running', 'running_attempt', $4)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lane.as_str())
+    .bind(now)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, worker_id, \
+            worker_instance_id, lease_epoch, lease_expires_at_ms, started_at_ms) \
+         VALUES ($1, $2, 0, 'w1', 'wi1', 1, $3, $4)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now + 30_000)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let payload = HandlePayload::new(
+        exec_id,
+        AttemptIndex::new(0),
+        AttemptId::new(),
+        LeaseId::new(),
+        LeaseEpoch(1),
+        30_000,
+        lane,
+        WorkerInstanceId::new("wi1"),
+    );
+    let handle = Handle::new(
+        BackendTag::Postgres,
+        HandleKind::Fresh,
+        encode_opaque(BackendTag::Postgres, &payload),
+    );
+    let backend = PostgresBackend::from_pool(pool, PartitionConfig::default())
+        as std::sync::Arc<dyn EngineBackend>;
+
+    let err = backend
+        .create_waitpoint(&handle, "wpk:no-kid", std::time::Duration::from_secs(10))
+        .await
+        .expect_err("keystore empty must fail");
+    assert!(
+        matches!(err, EngineError::Validation { .. }),
+        "expected Validation (no active kid), got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Replaces the `EngineError::Unavailable` stub on `ff-backend-postgres`'s `EngineBackend::create_waitpoint` with a live SQL implementation — unblocks cairn v0.13 approval-flow control-plane paths on Postgres deployments.
- Behaviour mirrors `ff-backend-sqlite::create_waitpoint_impl` (the closest-analogue relational backend — **not** stubbed, this is PG-only scope) and Valkey's `ff_create_pending_waitpoint` Lua: same token message binding (`"{execution_id}:{waitpoint_id}"`), same `<kid>:<hex>` shape, same `state='pending'` row, same "not idempotent by `waitpoint_key`" parity.
- No new HMAC primitives, no schema change. Reuses `hmac_sign` (re-exported from `signal.rs`, the one `suspend_core` already uses — tokens round-trip through the existing `deliver_signal` verify path). `ff_waitpoint_pending` schema already carried every column needed.

Closes #435.

## Helper reuse pattern

| Surface | Source | Reused where |
|---|---|---|
| HMAC signing | `ff-backend-postgres::signal::hmac_sign` (re-export of `ff_core::crypto::hmac::hmac_sign`) | `suspend_core` at `suspend_ops.rs:503`; now also `create_waitpoint_impl`. |
| Active-kid lookup | `SELECT kid, secret FROM ff_waitpoint_hmac WHERE active = TRUE ORDER BY rotated_at_ms DESC LIMIT 1` | Same query shape used inside `suspend_core`. |
| `ff_waitpoint_pending` row shape | `INSERT INTO ff_waitpoint_pending (partition_key, waitpoint_id, execution_id, token_kid, token, created_at_ms, expires_at_ms, waitpoint_key, state, required_signal_names)` | Columns match `suspend_core`'s active-state INSERT and SQLite's pending-state INSERT; this path writes `state='pending'` + empty `required_signal_names` per SQLite's reference. |
| Token message | `format!("{}:{}", execution_id, waitpoint_id)` | Identical to `suspend_core` so `deliver_signal` verifies these tokens unchanged. |

Single non-SERIALIZABLE transaction (fresh-UUID INSERT, no cross-row invariants) — matches SQLite's `begin_immediate` single-tx shape.

## Parity with Valkey + SQLite

- Token: `<kid>:<hex>` prefix — confirmed by test.
- `PendingWaitpoint::new(waitpoint_id, WaitpointHmac::new(token))` — same return shape all three backends hand out.
- Two calls with the same `waitpoint_key` produce two distinct `WaitpointId`s — confirmed by test; matches both reference implementations.
- Empty keystore → `EngineError::Validation` — confirmed by test.

## SQLite parity status

**SQLite is NOT stubbed** — `ff-backend-sqlite::suspend_ops::create_waitpoint_impl` at `crates/ff-backend-sqlite/src/suspend_ops.rs:640` is live and exercised by `tests/producer_suspend.rs::create_waitpoint_hmac_token_verifies`. This PR's PG implementation was modelled directly on SQLite's. No cross-backend bundle work needed.

## Test plan

- [x] `cargo check -p ff-backend-postgres --lib` + `--all-features` — green
- [x] `cargo test -p ff-backend-postgres --lib` — 20 passed
- [x] `cargo test -p ff-backend-postgres --test suspend_signal -- --include-ignored create_waitpoint` with live PG — 4/4 new tests pass
- [x] Full `suspend_signal` suite under live PG — 19 pre-existing + 4 new all green when serialized; the 2 `allof_two_waitpoints_requires_both` / `composite_count_distinct_sources_requires_distinct` flakes under `--test-threads` are pre-existing serializable-retry contention, unchanged by this PR (confirmed: pass clean on `--test-threads=1`)
- [x] `cargo test --workspace --lib` — green
- [x] `cargo clippy -p ff-backend-postgres --all-targets --all-features -- -D warnings` — clean
- [x] `scripts/smoke-sqlite.sh` — PASS (17.6s)
- [ ] CI full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)