### PR TITLE
feat(core+backends): EngineBackend::read_waitpoint_token (cairn #434, v0.13)

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -526,6 +526,7 @@ impl EngineBackend for PostgresBackend {
         unavailable("pg.create_waitpoint")
     }
 
+    #[cfg(feature = "core")]
     #[tracing::instrument(name = "pg.read_waitpoint_token", skip_all)]
     async fn read_waitpoint_token(
         &self,

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -526,6 +526,15 @@ impl EngineBackend for PostgresBackend {
         unavailable("pg.create_waitpoint")
     }
 
+    #[tracing::instrument(name = "pg.read_waitpoint_token", skip_all)]
+    async fn read_waitpoint_token(
+        &self,
+        partition: PartitionKey,
+        waitpoint_id: &ff_core::types::WaitpointId,
+    ) -> Result<Option<String>, EngineError> {
+        suspend_ops::read_waitpoint_token_impl(&self.pool, &partition, waitpoint_id).await
+    }
+
     #[tracing::instrument(name = "pg.observe_signals", skip_all)]
     async fn observe_signals(
         &self,

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -1200,3 +1200,38 @@ pub(crate) async fn list_pending_waitpoints_impl(
     }
     Ok(result)
 }
+
+/// Point-read of a waitpoint's HMAC token from `ff_waitpoint_pending`
+/// keyed by `(partition_key, waitpoint_id)`. Used by cairn's
+/// signal-bridge to authenticate signal-resume requests on Postgres
+/// deployments.
+///
+/// Missing row → `Ok(None)` (signal may legitimately arrive after
+/// the waitpoint has been consumed or expired). Empty `token` →
+/// `Ok(None)` for parity with the Valkey HGET mapping, even though
+/// the column is `NOT NULL` and Postgres writers always populate it.
+pub(crate) async fn read_waitpoint_token_impl(
+    pool: &PgPool,
+    partition: &ff_core::partition::PartitionKey,
+    waitpoint_id: &WaitpointId,
+) -> Result<Option<String>, EngineError> {
+    let part: i16 = partition
+        .parse()
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("partition_key: {e}"),
+        })?
+        .index as i16;
+    let wp_uuid = wp_uuid(waitpoint_id)?;
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT token FROM ff_waitpoint_pending \
+         WHERE partition_key = $1 AND waitpoint_id = $2 \
+         LIMIT 1",
+    )
+    .bind(part)
+    .bind(wp_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    Ok(row.map(|(t,)| t).filter(|s| !s.is_empty()))
+}

--- a/crates/ff-backend-postgres/tests/suspend_signal.rs
+++ b/crates/ff-backend-postgres/tests/suspend_signal.rs
@@ -1071,3 +1071,55 @@ async fn suspend_by_triple_fresh_returns_suspended() {
     let _ = fx.lane;
     let _ = fx.pool;
 }
+
+/// Issue #434 — `EngineBackend::read_waitpoint_token` on Postgres.
+/// After suspend, the waitpoint row carries a kid-prefixed HMAC
+/// token; reading it through the trait returns `Ok(Some(token))`.
+/// An unknown `WaitpointId` on the same partition returns
+/// `Ok(None)`.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_waitpoint_token_returns_some_for_existing_and_none_for_missing() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+
+    let (args, wp_id) = make_suspend_args("wpk:read-token");
+    let _ = fx
+        .backend
+        .suspend(&fx.handle, args)
+        .await
+        .expect("suspend ok");
+
+    let partition = ff_core::partition::PartitionKey::from(
+        &ff_core::partition::Partition {
+            family: ff_core::partition::PartitionFamily::Flow,
+            index: fx.part as u16,
+        },
+    );
+
+    let token = fx
+        .backend
+        .read_waitpoint_token(partition.clone(), &wp_id)
+        .await
+        .expect("read_waitpoint_token ok");
+    let token = token.expect("waitpoint row exists → token populated");
+    assert!(
+        !token.is_empty() && token.contains(':'),
+        "stored token should be kid-prefixed hex, got {token:?}"
+    );
+
+    let missing = fx
+        .backend
+        .read_waitpoint_token(partition, &WaitpointId::new())
+        .await
+        .expect("read_waitpoint_token ok for missing");
+    assert!(missing.is_none(), "missing waitpoint should read back None");
+
+    let _ = fx.exec_id;
+    let _ = fx.exec_uuid;
+    let _ = fx.lease_epoch;
+    let _ = fx.attempt_index;
+    let _ = fx.lane;
+    let _ = fx.pool;
+}

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2679,6 +2679,14 @@ impl EngineBackend for SqliteBackend {
         .await
     }
 
+    async fn read_waitpoint_token(
+        &self,
+        partition: PartitionKey,
+        waitpoint_id: &ff_core::types::WaitpointId,
+    ) -> Result<Option<String>, EngineError> {
+        crate::reads::read_waitpoint_token_impl(&self.inner.pool, &partition, waitpoint_id).await
+    }
+
     async fn observe_signals(&self, handle: &Handle) -> Result<Vec<ResumeSignal>, EngineError> {
         let pool = &self.inner.pool;
         retry_serializable(|| crate::suspend_ops::observe_signals_impl(pool, handle)).await

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2679,6 +2679,7 @@ impl EngineBackend for SqliteBackend {
         .await
     }
 
+    #[cfg(feature = "core")]
     async fn read_waitpoint_token(
         &self,
         partition: PartitionKey,

--- a/crates/ff-backend-sqlite/src/queries/waitpoint.rs
+++ b/crates/ff-backend-sqlite/src/queries/waitpoint.rs
@@ -59,6 +59,13 @@ pub const SELECT_WAITPOINT_KEY_BY_ID_SQL: &str =
     "SELECT waitpoint_key FROM ff_waitpoint_pending \
      WHERE partition_key = ?1 AND waitpoint_id = ?2";
 
+/// Point-read of a waitpoint's HMAC token, used by the signal-bridge
+/// to authenticate signal-resume requests on SQLite deployments.
+/// Binds: 1=partition_key (i64), 2=waitpoint_id (BLOB).
+pub const SELECT_WAITPOINT_TOKEN_BY_ID_SQL: &str =
+    "SELECT token FROM ff_waitpoint_pending \
+     WHERE partition_key = ?1 AND waitpoint_id = ?2 LIMIT 1";
+
 /// For deliver_signal: read kid + token + wp_key + bound execution.
 /// Returns (token_kid, token, waitpoint_key, execution_id).
 pub const SELECT_WAITPOINT_FOR_DELIVER_SQL: &str =

--- a/crates/ff-backend-sqlite/src/reads.rs
+++ b/crates/ff-backend-sqlite/src/reads.rs
@@ -485,3 +485,38 @@ pub(crate) async fn read_total_attempt_count_impl(
         .unwrap_or(0);
     Ok(ff_core::types::AttemptIndex::new(count))
 }
+
+/// Point-read of a waitpoint's HMAC token by `(partition, waitpoint_id)`
+/// for the signal-bridge resume path. Mirrors the Postgres impl at
+/// `ff-backend-postgres/src/suspend_ops.rs::read_waitpoint_token_impl`.
+///
+/// Missing row → `Ok(None)`. Empty `token` → `Ok(None)` (parity with
+/// the Valkey HGET mapping, even though the column is `NOT NULL`).
+pub(crate) async fn read_waitpoint_token_impl(
+    pool: &SqlitePool,
+    partition: &ff_core::partition::PartitionKey,
+    waitpoint_id: &ff_core::types::WaitpointId,
+) -> Result<Option<String>, EngineError> {
+    let part: i64 = partition
+        .parse()
+        .map_err(|e| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("partition_key: {e}"),
+        })?
+        .index as i64;
+    let wp_uuid_val = Uuid::parse_str(&waitpoint_id.to_string()).map_err(|e| {
+        EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!("waitpoint_id not a UUID: {e}"),
+        }
+    })?;
+    let row: Option<(String,)> = sqlx::query_as(
+        crate::queries::waitpoint::SELECT_WAITPOINT_TOKEN_BY_ID_SQL,
+    )
+    .bind(part)
+    .bind(wp_uuid_val)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    Ok(row.map(|(t,)| t).filter(|s| !s.is_empty()))
+}

--- a/crates/ff-backend-sqlite/tests/wave9_waitpoints.rs
+++ b/crates/ff-backend-sqlite/tests/wave9_waitpoints.rs
@@ -300,3 +300,40 @@ async fn list_pending_waitpoints_filters_closed_state() {
         "remaining entry is the non-closed one"
     );
 }
+
+/// Issue #434 — `EngineBackend::read_waitpoint_token` happy path on
+/// SQLite. Suspend creates a waitpoint row with a HMAC token;
+/// reading it back through the trait returns `Ok(Some(token))`.
+/// A fresh `WaitpointId` that was never written returns `Ok(None)`.
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn read_waitpoint_token_returns_some_for_existing_and_none_for_missing() {
+    let b = fresh_backend().await;
+    let (_exec_id, handle) = create_and_claim(&b).await;
+    let seeded = suspend_n(&b, &handle, 1).await;
+    let wp_id = seeded[0].0.clone();
+
+    let partition = ff_core::partition::PartitionKey::from(
+        &ff_core::partition::Partition {
+            family: ff_core::partition::PartitionFamily::Flow,
+            index: 0,
+        },
+    );
+
+    let token = b
+        .read_waitpoint_token(partition.clone(), &wp_id)
+        .await
+        .expect("read_waitpoint_token ok");
+    let token = token.expect("waitpoint row exists → token populated");
+    assert!(
+        !token.is_empty() && token.contains(':'),
+        "stored token should be kid-prefixed hex, got {token:?}"
+    );
+
+    // Missing waitpoint → Ok(None).
+    let missing = b
+        .read_waitpoint_token(partition, &WaitpointId::new())
+        .await
+        .expect("read_waitpoint_token ok for missing");
+    assert!(missing.is_none(), "missing waitpoint should read back None");
+}

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -2608,6 +2608,38 @@ async fn create_waitpoint_impl(
     ))
 }
 
+/// Point-read of a waitpoint's stored HMAC token. Targets the
+/// `ff:wp:<tag>:<wp_id>` hash's `waitpoint_token` field (written by
+/// the Lua suspension path, see `lua/suspension.lua:289`).
+///
+/// Empty string / missing field / missing hash all map to
+/// `Ok(None)` — signal delivery can legitimately race waitpoint
+/// consumption or expiry, and the signal-bridge authenticates on the
+/// token presence rather than on waitpoint liveness. The raw
+/// partition hash-tag is extracted from the opaque
+/// [`PartitionKey`] so this helper does not require a
+/// [`PartitionConfig`] round-trip.
+#[tracing::instrument(
+    name = "ff.read_waitpoint_token",
+    skip_all,
+    fields(backend = "valkey", waitpoint_id = %waitpoint_id)
+)]
+async fn read_waitpoint_token_impl(
+    client: &ferriskey::Client,
+    partition: &PartitionKey,
+    waitpoint_id: &WaitpointId,
+) -> Result<Option<String>, EngineError> {
+    let key = format!("ff:wp:{}:{}", partition.as_str(), waitpoint_id);
+    let raw: Option<String> = client
+        .cmd("HGET")
+        .arg(&key)
+        .arg("waitpoint_token")
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    Ok(raw.filter(|s| !s.is_empty()))
+}
+
 /// Round-7 — `report_usage` FCALL body. Migrated from
 /// `ff_sdk::task::ClaimedTask::report_usage`. 3 KEYS, N ARGV (variable
 /// by dimension count).
@@ -5054,6 +5086,21 @@ impl EngineBackend for ValkeyBackend {
                 "create_waitpoint: FCALL ff_create_pending_waitpoint",
             )
         })
+    }
+
+    async fn read_waitpoint_token(
+        &self,
+        partition: PartitionKey,
+        waitpoint_id: &WaitpointId,
+    ) -> Result<Option<String>, EngineError> {
+        read_waitpoint_token_impl(&self.client, &partition, waitpoint_id)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "read_waitpoint_token: HGET ff:wp:<tag>:<wp_id> waitpoint_token",
+                )
+            })
     }
 
     async fn observe_signals(

--- a/crates/ff-backend-valkey/tests/read_waitpoint_token_missing.rs
+++ b/crates/ff-backend-valkey/tests/read_waitpoint_token_missing.rs
@@ -1,0 +1,38 @@
+//! Issue #434 — `EngineBackend::read_waitpoint_token` on Valkey.
+//!
+//! `Ok(None)` for a waitpoint that was never written: HGET on a
+//! missing hash key returns `nil`, which the impl maps to `None`.
+//! This is the signal-bridge's graceful-degradation path — a signal
+//! may arrive after its waitpoint has been consumed or expired, and
+//! a missing waitpoint is not an error on that path.
+//!
+//! Ignore-gated (live Valkey at 127.0.0.1:6379 required), matching
+//! the sibling live tests in `capabilities.rs` +
+//! `read_execution_context_missing.rs`.
+
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::BackendConfig;
+use ff_core::partition::{Partition, PartitionFamily, PartitionKey};
+use ff_core::types::WaitpointId;
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore]
+async fn read_waitpoint_token_missing_returns_none() {
+    let backend = ValkeyBackend::connect(BackendConfig::valkey("127.0.0.1", 6379))
+        .await
+        .expect("connect ValkeyBackend");
+
+    // Mint a fresh waitpoint id that was never written to the
+    // backend, and an arbitrary partition. HGET nil → Ok(None).
+    let partition = PartitionKey::from(&Partition {
+        family: PartitionFamily::Flow,
+        index: 0,
+    });
+    let wp_id = WaitpointId::new();
+
+    let out = backend
+        .read_waitpoint_token(partition, &wp_id)
+        .await
+        .expect("missing waitpoint must be Ok(None), not an error");
+    assert!(out.is_none(), "expected None for missing waitpoint, got {out:?}");
+}

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -90,7 +90,9 @@ use crate::contracts::{StreamCursor, StreamFrames};
 use crate::engine_error::EngineError;
 #[cfg(feature = "core")]
 use crate::types::EdgeId;
-use crate::types::{AttemptIndex, BudgetId, ExecutionId, FlowId, LaneId, LeaseFence, TimestampMs};
+use crate::types::{
+    AttemptIndex, BudgetId, ExecutionId, FlowId, LaneId, LeaseFence, TimestampMs, WaitpointId,
+};
 
 /// The engine write surface — a single trait a backend implementation
 /// honours to serve a `FlowFabricWorker`.
@@ -251,6 +253,58 @@ pub trait EngineBackend: Send + Sync + 'static {
         waitpoint_key: &str,
         expires_in: Duration,
     ) -> Result<PendingWaitpoint, EngineError>;
+
+    /// Read the HMAC token stored on a waitpoint record, keyed by
+    /// `(partition, waitpoint_id)`.
+    ///
+    /// Returns `Ok(Some(token))` when the waitpoint exists and carries
+    /// a token, `Ok(None)` when the waitpoint does not exist or no
+    /// token field is present. A missing waitpoint is not an error —
+    /// signals can legitimately arrive after a waitpoint has been
+    /// consumed or expired, and the signal-bridge authenticates on the
+    /// presence of a matching token, not on the waitpoint's liveness.
+    ///
+    /// # Use case
+    ///
+    /// Control-plane signal delivery (cairn signal-bridge): at
+    /// signal-resume time the bridge reads the token off the
+    /// waitpoint hash / row to authenticate the resume request it
+    /// subsequently issues. Previously implemented as direct
+    /// `ferriskey::Client::hget(waitpoint_key, "waitpoint_token")` —
+    /// Valkey-only. This method routes the read through the trait so
+    /// the pattern works on Postgres + SQLite as well.
+    ///
+    /// # Per-backend shape
+    ///
+    /// * **Valkey** — `HGET ff:wp:<tag>:<waitpoint_id> waitpoint_token`
+    ///   on the waitpoint's partition. Empty string / missing field
+    ///   maps to `None`.
+    /// * **Postgres** — `SELECT token FROM ff_waitpoint_pending
+    ///   WHERE partition_key = $1 AND waitpoint_id = $2 LIMIT 1`.
+    ///   Row-absent → `None`; empty `token` → `None`.
+    /// * **SQLite** — same shape as Postgres.
+    ///
+    /// The `partition` argument is the opaque [`PartitionKey`]
+    /// produced by FlowFabric (typically extracted from the
+    /// `Handle` / `ResumeToken` the waitpoint was minted against).
+    ///
+    /// # Default impl
+    ///
+    /// Returns [`EngineError::Unavailable`] with
+    /// `op = "read_waitpoint_token"` so out-of-tree backends and
+    /// in-tree backends not yet overriding this method continue to
+    /// compile. Mirrors the precedent used by
+    /// [`Self::issue_reclaim_grant`] / [`Self::reclaim_execution`].
+    #[cfg(feature = "core")]
+    async fn read_waitpoint_token(
+        &self,
+        _partition: PartitionKey,
+        _waitpoint_id: &WaitpointId,
+    ) -> Result<Option<String>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "read_waitpoint_token",
+        })
+    }
 
     /// Non-mutating observation of signals that satisfied the handle's
     /// resume condition.

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -90,9 +90,9 @@ use crate::contracts::{StreamCursor, StreamFrames};
 use crate::engine_error::EngineError;
 #[cfg(feature = "core")]
 use crate::types::EdgeId;
-use crate::types::{
-    AttemptIndex, BudgetId, ExecutionId, FlowId, LaneId, LeaseFence, TimestampMs, WaitpointId,
-};
+#[cfg(feature = "core")]
+use crate::types::WaitpointId;
+use crate::types::{AttemptIndex, BudgetId, ExecutionId, FlowId, LaneId, LeaseFence, TimestampMs};
 
 /// The engine write surface — a single trait a backend implementation
 /// honours to serve a `FlowFabricWorker`.

--- a/examples/ff-dev/Cargo.lock
+++ b/examples/ff-dev/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",


### PR DESCRIPTION
## Summary

Closes #434. Adds `EngineBackend::read_waitpoint_token(partition, waitpoint_id) -> Result<Option<String>, EngineError>` so cairn's signal-bridge can read the HMAC token off a waitpoint record through the trait, on any backend.

Today the bridge does `ferriskey::Client::hget(waitpoint_key, \"waitpoint_token\")` — Valkey-only. Postgres/SQLite deployments have no route. This PR lands the portable read surface.

## Backend impls

- **Valkey**: `HGET ff:wp:<tag>:<wp_id> waitpoint_token` on the waitpoint's partition. Empty / nil maps to `Ok(None)`.
- **Postgres**: `SELECT token FROM ff_waitpoint_pending WHERE partition_key = \$1 AND waitpoint_id = \$2 LIMIT 1`. Row-absent / empty → `Ok(None)`.
- **SQLite**: identical shape to PG.

Per PR-1 / RFC-024 PR-D precedent, the default body returns `EngineError::Unavailable { op: \"read_waitpoint_token\" }` so out-of-tree backends continue to compile.

## Return type

`Option<String>`. Valkey stores the token as a kid-prefixed hex string (`<kid>:<hex>`) via `HSET ... waitpoint_token <str>` in `lua/suspension.lua:289`. PG/SQLite store the same wire shape in `ff_waitpoint_pending.token TEXT NOT NULL`. No `Vec<u8>` / bytes escape hatch required — the token is always a printable ASCII string on the wire.

## Semantics

Missing waitpoint → `Ok(None)`, not an error. Signals may legitimately arrive after a waitpoint has been consumed or expired; the signal-bridge authenticates on token presence, not waitpoint liveness. Empty-string `token` (Valkey HGET quirk if operator poked at the hash) also maps to `None` for parity across backends.

## Independence from #435

Issue #434's body notes that `pg.create_waitpoint` is stubbed (#435). These are different methods. `read_waitpoint_token` is a read surface that works whenever **something** has populated the row — on PG/SQLite the suspend path already writes `ff_waitpoint_pending` with a minted token via `suspend_core`, so this read works today on that path. #435 remains open for the explicit `create_waitpoint` write path.

## Tests

- `crates/ff-backend-sqlite/tests/wave9_waitpoints.rs::read_waitpoint_token_returns_some_for_existing_and_none_for_missing` — runs in-process against in-memory SQLite. **Passes locally**. Asserts the stored token is kid-prefixed (`<kid>:<hex>`) and that an unwritten waitpoint reads back `None`.
- `crates/ff-backend-postgres/tests/suspend_signal.rs::read_waitpoint_token_returns_some_for_existing_and_none_for_missing` — ignore-gated on `FF_PG_TEST_URL`.
- `crates/ff-backend-valkey/tests/read_waitpoint_token_missing.rs::read_waitpoint_token_missing_returns_none` — ignore-gated on a live Valkey at `127.0.0.1:6379`, mirroring `read_execution_context_missing.rs`.

## Validation

- [x] `cargo check --workspace` clean.
- [x] `cargo clippy -p ff-core -p ff-backend-{valkey,postgres,sqlite} --all-targets --all-features` clean.
- [x] `cargo test --workspace --lib` — all tests pass.
- [x] SQLite test exercises the full suspend → read-back flow in-process and passes.
- [x] `scripts/smoke-sqlite.sh` PASS (18.1s).
- [x] `cargo run --bin non-exhaustive-lint` clean.
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` clean.
- [ ] Valkey-gated + Postgres-gated integration tests — CI on merge.

## Breaking change

Additive trait method with a default `Unavailable` body. No out-of-tree `EngineBackend` impl has to change. Same breaking-change class as PR #411 / PR #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)