### PR TITLE
fix(backend-valkey): clamp create_waitpoint overflow to match PG/SQLite (parity)

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -2630,6 +2630,17 @@ async fn append_frame_impl(
     Ok(outcome)
 }
 
+/// Compute `expires_at_ms` for a pending waitpoint, clamping overflow to
+/// `i64::MAX` to match the PG + SQLite `create_waitpoint` behaviour
+/// (see `ff-backend-postgres::suspend_ops::create_waitpoint` ~L722-730 and
+/// `ff-backend-sqlite::suspend_ops::create_waitpoint_impl`). A stricter
+/// "overflow => Validation" contract would require a one-shot trait-docs +
+/// all-three-backends change; keep parity until then.
+fn waitpoint_expires_at_ms(now_ms: i64, expires_in: Duration) -> i64 {
+    let expires_in_ms = i64::try_from(expires_in.as_millis()).unwrap_or(i64::MAX);
+    now_ms.saturating_add(expires_in_ms)
+}
+
 /// Round-7 — `create_waitpoint` FCALL body. Migrated from
 /// `ff_sdk::task::ClaimedTask::create_pending_waitpoint`. 4 KEYS, 5
 /// ARGV. Mints a fresh `WaitpointId` client-side and returns the
@@ -2656,8 +2667,10 @@ async fn create_waitpoint_impl(
     let idx = IndexKeys::new(&partition);
 
     let waitpoint_id = WaitpointId::new();
-    let expires_at =
-        TimestampMs::from_millis(now_ms_timestamp().0 + expires_in.as_millis() as i64);
+    let expires_at = TimestampMs::from_millis(waitpoint_expires_at_ms(
+        now_ms_timestamp().0,
+        expires_in,
+    ));
 
     let keys: Vec<String> = vec![
         ctx.core(),
@@ -8465,6 +8478,21 @@ mod tests {
             cancel_policy_to_str(CancelFlowPolicy::CancelPending),
             "cancel_pending"
         );
+    }
+
+    /// `Duration::MAX.as_millis()` overflows `i64`. The pre-fix code used
+    /// `as i64` which silently truncates and can wrap NEGATIVE. Post-fix
+    /// should clamp to `i64::MAX` (via `saturating_add`) to match the PG +
+    /// SQLite `create_waitpoint` behaviour.
+    #[test]
+    fn create_waitpoint_expires_in_max_clamps_instead_of_wrapping() {
+        let now_ms: i64 = 1_700_000_000_000; // arbitrary positive "now"
+        let got = waitpoint_expires_at_ms(now_ms, Duration::MAX);
+        assert!(
+            got > 0,
+            "expires_at must not wrap negative on oversized expires_in (got {got})"
+        );
+        assert_eq!(got, i64::MAX, "expires_at must clamp to i64::MAX");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Harmonize `ff-backend-valkey::create_waitpoint_impl`'s `expires_at_ms` arithmetic with the saturating-clamp pattern already used by PG + SQLite. One call site, no trait-contract change.

## Why

PR #437 (Postgres `create_waitpoint`) retrospective surfaced that the Valkey backend was still using `expires_in.as_millis() as i64`, a silent-truncating cast that can wrap NEGATIVE for `expires_in > i64::MAX ms`. A negative `expires_at_ms` would make the waitpoint look permanently expired to the scanner.

PG (`crates/ff-backend-postgres/src/suspend_ops.rs:722-730`) and SQLite (`crates/ff-backend-sqlite/src/suspend_ops.rs:~640-689`) already clamp via `i64::try_from(...).unwrap_or(i64::MAX)` + `saturating_add`. This closes the Valkey half of the parity gap.

## What changed

- `crates/ff-backend-valkey/src/lib.rs`:
  - New private helper `waitpoint_expires_at_ms(now_ms, expires_in) -> i64` with a comment cross-referencing the PG + SQLite sites.
  - `create_waitpoint_impl` delegates its `expires_at` computation to the helper.
  - Added unit test `create_waitpoint_expires_in_max_clamps_instead_of_wrapping` — passes `Duration::MAX`, asserts result is positive and equals `i64::MAX`.

## What this does NOT change

- No trait-contract change (still clamps, does not raise `Validation`).
- No edits to PG or SQLite backends (already correct).
- No sweep of the other ~60 arithmetic sites across the three backends — a broader "overflow => Validation" harmonization is deferred to a v0.13/v0.14 RFC that touches all three backends + trait docs in one shot.

## Test plan

- [x] `cargo test -p ff-backend-valkey --lib` — 27 passed, 7 ignored (live-Valkey gated), 0 failed.
- [x] `cargo test --workspace --lib` — all suites green, 0 failures.
- [x] `cargo clippy -p ff-backend-valkey --all-targets -- -D warnings` — clean.
- [x] New unit test exercises the overflow boundary directly (pure-arithmetic helper, no FCALL infra required).