### PR TITLE
feat(ff-engine+backends): PR-7b/1 foundation scanners trait-routed (cairn #436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **PR-7b Cluster 1: foundation scanner operations on `EngineBackend`
+  (cairn #436).** Five new trait methods + `ExpirePhase` enum on
+  `ff_core::engine_backend::EngineBackend` for the six simple-expiry
+  scanners: `mark_lease_expired_if_due`, `promote_delayed`,
+  `close_waitpoint`, `expire_execution(phase: ExpirePhase)` (shared
+  between attempt-timeout and execution-deadline scanners), and
+  `expire_suspension`. Valkey impl wraps the existing
+  `ff_mark_lease_expired_if_due` / `ff_promote_delayed` /
+  `ff_close_waitpoint` / `ff_expire_execution` / `ff_expire_suspension`
+  FCALLs; Postgres wires `mark_lease_expired_if_due`,
+  `expire_execution(AttemptTimeout)`, and `expire_suspension` to
+  per-row helpers extracted from the existing batch reconcilers in
+  `ff_backend_postgres::reconcilers::*` (`promote_delayed`,
+  `close_waitpoint`, and `expire_execution(ExecutionDeadline)` remain
+  at the `EngineError::Unavailable` default — RFC-020 Wave 9 schema
+  scope); SQLite stays on the trait defaults (per RFC-023 §4.1 the
+  SQLite backend hosts its own reconciler supervisor, not the
+  engine's scanner loop). `scanner::should_skip_candidate` now
+  dispatches through `EngineBackend::describe_execution` /
+  `get_execution_tag`. Engine-side: each of the 11 scanners that use
+  `should_skip_candidate` grew a `backend:
+  Option<Arc<dyn EngineBackend>>` field plus a
+  `with_filter_and_backend(..)` constructor; the 6 Cluster-1 scanner
+  bodies route their operation FCALL through the trait when a
+  backend is wired. Unblocks PR-7b Clusters 2 + 3 (reconcilers +
+  cancel-family) to land in parallel.
 - **Backend-agnostic `FlowFabricAdminClient` facade (SC-10 ergonomics
   follow-up, v0.13).** `FlowFabricAdminClient` now supports both HTTP
   (`new` / `with_token` — existing) and embedded

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
 name = "ff-engine"
 version = "0.12.0"
 dependencies = [
+ "async-trait",
  "ferriskey",
  "ff-backend-postgres",
  "ff-backend-valkey",

--- a/crates/ff-backend-postgres/src/attempt.rs
+++ b/crates/ff-backend-postgres/src/attempt.rs
@@ -64,7 +64,7 @@ fn now_ms() -> i64 {
 
 /// Extract `(partition_index, uuid)` from an `ExecutionId` formatted
 /// `{fp:N}:<uuid>`.
-fn split_exec_id(eid: &ExecutionId) -> Result<(i16, Uuid), EngineError> {
+pub(crate) fn split_exec_id(eid: &ExecutionId) -> Result<(i16, Uuid), EngineError> {
     let s = eid.as_str();
     let rest = s.strip_prefix("{fp:").ok_or_else(|| EngineError::Validation {
         kind: ff_core::engine_error::ValidationKind::InvalidInput,

--- a/crates/ff-backend-postgres/src/exec_core.rs
+++ b/crates/ff-backend-postgres/src/exec_core.rs
@@ -1151,3 +1151,31 @@ pub(super) async fn get_execution_tag_impl(
 
     Ok(row.and_then(|(tag,)| tag))
 }
+
+/// Point-read of `raw_fields->>'namespace'`. `Ok(None)` covers
+/// missing-namespace and missing-execution alike (matches
+/// `get_execution_tag_impl`). Used by the scanner per-candidate
+/// filter — preserves the 1-point-read cost contract vs the heavier
+/// `describe_execution` full-snapshot read.
+pub(super) async fn get_execution_namespace_impl(
+    pool: &PgPool,
+    id: &ExecutionId,
+) -> Result<Option<String>, EngineError> {
+    let partition_key: i16 = id.partition() as i16;
+    let execution_id = eid_uuid(id);
+
+    let row: Option<(Option<String>,)> = sqlx::query_as(
+        r#"
+        SELECT raw_fields->>'namespace'
+        FROM ff_exec_core
+        WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(execution_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    Ok(row.and_then(|(ns,)| ns))
+}

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -680,6 +680,14 @@ impl EngineBackend for PostgresBackend {
         flow::get_flow_tag_impl(&self.pool, &self.partition_config, flow_id, key).await
     }
 
+    #[tracing::instrument(name = "pg.get_execution_namespace", skip_all)]
+    async fn get_execution_namespace(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> Result<Option<String>, EngineError> {
+        exec_core::get_execution_namespace_impl(&self.pool, execution_id).await
+    }
+
     #[cfg(feature = "core")]
     #[tracing::instrument(name = "pg.list_edges", skip_all)]
     async fn list_edges(

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -68,11 +68,11 @@ use ff_core::contracts::{
 };
 #[cfg(feature = "streaming")]
 use ff_core::contracts::{StreamCursor, StreamFrames};
-use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_backend::{EngineBackend, ExpirePhase};
 use ff_core::engine_error::EngineError;
 #[cfg(feature = "core")]
 use ff_core::partition::PartitionKey;
-use ff_core::partition::PartitionConfig;
+use ff_core::partition::{Partition, PartitionConfig};
 #[cfg(feature = "streaming")]
 use ff_core::types::AttemptIndex;
 #[cfg(feature = "core")]
@@ -1363,6 +1363,80 @@ impl EngineBackend for PostgresBackend {
         filter: &ff_core::backend::ScannerFilter,
     ) -> Result<ff_core::stream_events::SignalDeliverySubscription, EngineError> {
         signal_delivery_subscribe::subscribe(&self.pool, 0, cursor, filter.clone()).await
+    }
+
+    // ── PR-7b Cluster 1 — Foundation scanner operations ─────────
+    //
+    // Per-execution wrappers around the existing batch reconcilers in
+    // `crate::reconcilers::*`. The reconcilers' per-row tx logic
+    // (`release_one`, `expire_one`, `expire_one` for suspension) is
+    // exposed through a `_for_execution` helper per module and invoked
+    // here. This lets the engine-side scanner trait-dispatch hit the
+    // same SQL the batch path uses, without duplicating either.
+    //
+    // `promote_delayed`, `close_waitpoint`, and `expire_execution` on
+    // the `ExecutionDeadline` phase are intentionally left at their
+    // trait defaults (`EngineError::Unavailable`) — the PG schema for
+    // delay/waitpoint-expiry reconciliation is RFC-020 Wave 9 scope
+    // (see coordination note in `/tmp/pr-7b-coordination.md`).
+
+    async fn mark_lease_expired_if_due(
+        &self,
+        partition: Partition,
+        execution_id: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        reconcilers::lease_expiry::release_for_execution(&self.pool, partition_key, exec_uuid)
+            .await
+    }
+
+    async fn expire_execution(
+        &self,
+        partition: Partition,
+        execution_id: &ExecutionId,
+        phase: ExpirePhase,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        match phase {
+            ExpirePhase::AttemptTimeout => {
+                reconcilers::attempt_timeout::expire_for_execution(
+                    &self.pool,
+                    partition_key,
+                    exec_uuid,
+                )
+                .await
+            }
+            ExpirePhase::ExecutionDeadline => {
+                // RFC-020 Wave 9 scope: `ff_exec_core.deadline_at_ms`
+                // wall-clock execution deadline reconciler shares the
+                // attempt-timeout terminal flip but needs a distinct
+                // candidate-selection query (`deadline_at_ms` not
+                // `lease_expires_at_ms`). Left at Unavailable pending
+                // Wave 9 owner call on whether to collapse the two.
+                Err(EngineError::Unavailable {
+                    op: "expire_execution:execution_deadline",
+                })
+            }
+        }
+    }
+
+    async fn expire_suspension(
+        &self,
+        partition: Partition,
+        execution_id: &ExecutionId,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        reconcilers::suspension_timeout::expire_for_execution(
+            &self.pool,
+            partition_key,
+            exec_uuid,
+        )
+        .await
     }
 }
 

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1380,7 +1380,13 @@ impl EngineBackend for PostgresBackend {
     // `delayed_promoter`, `pending_wp_expiry`, and
     // `execution_deadline` reconcilers on top of the Wave 6c
     // reconcilers shipped with PR-7b/1.
+    //
+    // Gated on `core` because `reconcilers` (and its `dispatch` dep)
+    // require `core`. Without `core` the trait defaults return
+    // `EngineError::Unavailable`, preserving behavioural parity with
+    // other feature-stripped callsites.
 
+    #[cfg(feature = "core")]
     async fn mark_lease_expired_if_due(
         &self,
         partition: Partition,
@@ -1392,6 +1398,7 @@ impl EngineBackend for PostgresBackend {
             .await
     }
 
+    #[cfg(feature = "core")]
     async fn promote_delayed(
         &self,
         partition: Partition,
@@ -1415,6 +1422,7 @@ impl EngineBackend for PostgresBackend {
         .await
     }
 
+    #[cfg(feature = "core")]
     async fn close_waitpoint(
         &self,
         partition: Partition,
@@ -1443,6 +1451,7 @@ impl EngineBackend for PostgresBackend {
         .await
     }
 
+    #[cfg(feature = "core")]
     async fn expire_execution(
         &self,
         partition: Partition,
@@ -1473,6 +1482,7 @@ impl EngineBackend for PostgresBackend {
         }
     }
 
+    #[cfg(feature = "core")]
     async fn expire_suspension(
         &self,
         partition: Partition,

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1367,18 +1367,19 @@ impl EngineBackend for PostgresBackend {
 
     // ── PR-7b Cluster 1 — Foundation scanner operations ─────────
     //
-    // Per-execution wrappers around the existing batch reconcilers in
-    // `crate::reconcilers::*`. The reconcilers' per-row tx logic
-    // (`release_one`, `expire_one`, `expire_one` for suspension) is
-    // exposed through a `_for_execution` helper per module and invoked
-    // here. This lets the engine-side scanner trait-dispatch hit the
-    // same SQL the batch path uses, without duplicating either.
+    // Per-execution wrappers around the reconcilers in
+    // `crate::reconcilers::*`. Each reconciler exposes a
+    // `*_for_execution` / `*_for_*` helper mirroring the batch
+    // `scan_tick` path's per-row tx logic so the engine-side scanner
+    // trait-dispatch and the batch reconciler share one SQL code
+    // path.
     //
-    // `promote_delayed`, `close_waitpoint`, and `expire_execution` on
-    // the `ExecutionDeadline` phase are intentionally left at their
-    // trait defaults (`EngineError::Unavailable`) — the PG schema for
-    // delay/waitpoint-expiry reconciliation is RFC-020 Wave 9 scope
-    // (see coordination note in `/tmp/pr-7b-coordination.md`).
+    // All 5 scanner-op methods run real SQL on Postgres; both phases
+    // of `expire_execution` (`AttemptTimeout` + `ExecutionDeadline`)
+    // are covered. The Wave-9-minimal delivery (this commit) adds
+    // `delayed_promoter`, `pending_wp_expiry`, and
+    // `execution_deadline` reconcilers on top of the Wave 6c
+    // reconcilers shipped with PR-7b/1.
 
     async fn mark_lease_expired_if_due(
         &self,
@@ -1391,12 +1392,63 @@ impl EngineBackend for PostgresBackend {
             .await
     }
 
+    async fn promote_delayed(
+        &self,
+        partition: Partition,
+        _lane: &LaneId,
+        execution_id: &ExecutionId,
+        now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        // `lane` is ignored: lane is authoritative on `ff_exec_core`
+        // already (it was used only to locate the Valkey ZSET). The
+        // candidate selection in `promote_for_execution` re-checks
+        // the (lifecycle_phase, eligibility_state, deadline_at_ms)
+        // tuple that `attempt::delay()` writes.
+        reconcilers::delayed_promoter::promote_for_execution(
+            &self.pool,
+            partition_key,
+            exec_uuid,
+            now_ms.0,
+        )
+        .await
+    }
+
+    async fn close_waitpoint(
+        &self,
+        partition: Partition,
+        _execution_id: &ExecutionId,
+        waitpoint_id: &str,
+        now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        // The scanner resolves (waitpoint_id → owning execution_id)
+        // separately for filter application; the close action itself
+        // only needs the waitpoint row (which carries `execution_id`
+        // + `waitpoint_key`). Partition is authoritative from the
+        // caller.
+        let partition_key = i16::try_from(partition.index).unwrap_or(0);
+        let waitpoint_uuid = uuid::Uuid::parse_str(waitpoint_id).map_err(|e| {
+            EngineError::Validation {
+                kind: ff_core::engine_error::ValidationKind::InvalidInput,
+                detail: format!("waitpoint_id not a UUID: {e}"),
+            }
+        })?;
+        reconcilers::pending_wp_expiry::close_for_execution(
+            &self.pool,
+            partition_key,
+            waitpoint_uuid,
+            now_ms.0,
+        )
+        .await
+    }
+
     async fn expire_execution(
         &self,
         partition: Partition,
         execution_id: &ExecutionId,
         phase: ExpirePhase,
-        _now_ms: TimestampMs,
+        now_ms: TimestampMs,
     ) -> Result<(), EngineError> {
         let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
         let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
@@ -1410,15 +1462,13 @@ impl EngineBackend for PostgresBackend {
                 .await
             }
             ExpirePhase::ExecutionDeadline => {
-                // RFC-020 Wave 9 scope: `ff_exec_core.deadline_at_ms`
-                // wall-clock execution deadline reconciler shares the
-                // attempt-timeout terminal flip but needs a distinct
-                // candidate-selection query (`deadline_at_ms` not
-                // `lease_expires_at_ms`). Left at Unavailable pending
-                // Wave 9 owner call on whether to collapse the two.
-                Err(EngineError::Unavailable {
-                    op: "expire_execution:execution_deadline",
-                })
+                reconcilers::execution_deadline::expire_for_execution(
+                    &self.pool,
+                    partition_key,
+                    exec_uuid,
+                    now_ms.0,
+                )
+                .await
             }
         }
     }

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1392,8 +1392,8 @@ impl EngineBackend for PostgresBackend {
         partition: Partition,
         execution_id: &ExecutionId,
     ) -> Result<(), EngineError> {
-        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
-        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        let (_pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = partition_index_to_i16(partition)?;
         reconcilers::lease_expiry::release_for_execution(&self.pool, partition_key, exec_uuid)
             .await
     }
@@ -1406,8 +1406,8 @@ impl EngineBackend for PostgresBackend {
         execution_id: &ExecutionId,
         now_ms: TimestampMs,
     ) -> Result<(), EngineError> {
-        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
-        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        let (_pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = partition_index_to_i16(partition)?;
         // `lane` is ignored: lane is authoritative on `ff_exec_core`
         // already (it was used only to locate the Valkey ZSET). The
         // candidate selection in `promote_for_execution` re-checks
@@ -1435,7 +1435,7 @@ impl EngineBackend for PostgresBackend {
         // only needs the waitpoint row (which carries `execution_id`
         // + `waitpoint_key`). Partition is authoritative from the
         // caller.
-        let partition_key = i16::try_from(partition.index).unwrap_or(0);
+        let partition_key = partition_index_to_i16(partition)?;
         let waitpoint_uuid = uuid::Uuid::parse_str(waitpoint_id).map_err(|e| {
             EngineError::Validation {
                 kind: ff_core::engine_error::ValidationKind::InvalidInput,
@@ -1459,8 +1459,8 @@ impl EngineBackend for PostgresBackend {
         phase: ExpirePhase,
         now_ms: TimestampMs,
     ) -> Result<(), EngineError> {
-        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
-        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        let (_pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = partition_index_to_i16(partition)?;
         match phase {
             ExpirePhase::AttemptTimeout => {
                 reconcilers::attempt_timeout::expire_for_execution(
@@ -1489,8 +1489,8 @@ impl EngineBackend for PostgresBackend {
         execution_id: &ExecutionId,
         _now_ms: TimestampMs,
     ) -> Result<(), EngineError> {
-        let (pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
-        let partition_key = i16::try_from(partition.index).unwrap_or(pk_from_eid);
+        let (_pk_from_eid, exec_uuid) = attempt::split_exec_id(execution_id)?;
+        let partition_key = partition_index_to_i16(partition)?;
         reconcilers::suspension_timeout::expire_for_execution(
             &self.pool,
             partition_key,
@@ -1498,6 +1498,25 @@ impl EngineBackend for PostgresBackend {
         )
         .await
     }
+}
+
+/// Narrow a `Partition`'s `u16` index into the `i16` the Postgres
+/// schema uses as its partition-key column. FlowFabric partitions
+/// max out well below `i16::MAX` in practice (production deployments
+/// run a few hundred partitions per family), but the conversion is
+/// still fallible at the type level. Surface overflow as
+/// `ValidationKind::InvalidInput` rather than silently substituting a
+/// fallback — a silently mis-routed reconciler would
+/// corrupt-by-omission without diagnostics.
+fn partition_index_to_i16(partition: Partition) -> Result<i16, EngineError> {
+    i16::try_from(partition.index).map_err(|_| EngineError::Validation {
+        kind: ff_core::engine_error::ValidationKind::InvalidInput,
+        detail: format!(
+            "partition index {} exceeds i16 range (max {})",
+            partition.index,
+            i16::MAX
+        ),
+    })
 }
 
 /// Minimum recommended `max_locks_per_transaction`. Partition-heavy
@@ -1581,5 +1600,46 @@ mod max_locks_tests {
     #[test]
     fn silent_for_unparseable_raw() {
         assert_eq!(max_locks_warn_value("not-a-number"), None);
+    }
+}
+
+#[cfg(test)]
+mod partition_index_tests {
+    use super::partition_index_to_i16;
+    use ff_core::engine_error::{EngineError, ValidationKind};
+    use ff_core::partition::{Partition, PartitionFamily};
+
+    #[test]
+    fn accepts_values_within_i16_range() {
+        let p = Partition { family: PartitionFamily::Flow, index: 0 };
+        assert_eq!(partition_index_to_i16(p).unwrap(), 0);
+
+        let p = Partition { family: PartitionFamily::Flow, index: 255 };
+        assert_eq!(partition_index_to_i16(p).unwrap(), 255);
+
+        let p = Partition { family: PartitionFamily::Budget, index: i16::MAX as u16 };
+        assert_eq!(partition_index_to_i16(p).unwrap(), i16::MAX);
+    }
+
+    #[test]
+    fn rejects_overflow_above_i16_max() {
+        let p = Partition { family: PartitionFamily::Flow, index: (i16::MAX as u16) + 1 };
+        let err = partition_index_to_i16(p).unwrap_err();
+        match err {
+            EngineError::Validation { kind, detail } => {
+                assert_eq!(kind, ValidationKind::InvalidInput);
+                assert!(detail.contains("exceeds i16 range"), "unexpected detail: {detail}");
+            }
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_u16_max() {
+        let p = Partition { family: PartitionFamily::Quota, index: u16::MAX };
+        assert!(matches!(
+            partition_index_to_i16(p),
+            Err(EngineError::Validation { kind: ValidationKind::InvalidInput, .. })
+        ));
     }
 }

--- a/crates/ff-backend-postgres/src/reconcilers/attempt_timeout.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/attempt_timeout.rs
@@ -91,6 +91,52 @@ pub async fn scan_tick(
     Ok(report)
 }
 
+/// Per-execution expire action. Exposed so the
+/// `EngineBackend::expire_execution` trait dispatch (PR-7b Cluster 1)
+/// can invoke the same per-row tx logic as `scan_tick`. Discovers the
+/// current attempt_index internally. Silently no-ops when the lease
+/// is no longer expired or the exec is no longer `active` (checked
+/// under `FOR UPDATE`).
+pub async fn expire_for_execution(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+) -> Result<(), EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    let row = sqlx::query(
+        r#"
+        SELECT a.attempt_index
+          FROM ff_attempt a
+          JOIN ff_exec_core c
+            ON c.partition_key = a.partition_key
+           AND c.execution_id = a.execution_id
+         WHERE a.partition_key = $1
+           AND a.execution_id = $2
+           AND a.lease_expires_at_ms IS NOT NULL
+           AND a.lease_expires_at_ms < $3
+           AND c.lifecycle_phase = 'active'
+         ORDER BY a.lease_expires_at_ms ASC
+         LIMIT 1
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(now_ms)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(row) = row else { return Ok(()) };
+    let attempt_index: i32 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    expire_one(pool, partition_key, exec_uuid, attempt_index, now_ms).await
+}
+
 async fn expire_one(
     pool: &PgPool,
     partition_key: i16,

--- a/crates/ff-backend-postgres/src/reconcilers/delayed_promoter.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/delayed_promoter.rs
@@ -1,0 +1,94 @@
+//! Postgres `delayed_promoter` reconciler (RFC-020 Wave 9 minimal).
+//!
+//! Mirrors [`ff_engine::scanner::delayed_promoter`] — promotes
+//! executions parked by `attempt::delay()` back to `eligible_now`
+//! once their `delay_until` wall-clock has elapsed. The Valkey side
+//! scans `ff:idx:{p:N}:lane:<lane>:delayed` ZSET and fires
+//! `FCALL ff_promote_delayed`; on Postgres the authority is
+//! `ff_exec_core.deadline_at_ms` scoped by
+//! `(lifecycle_phase = 'runnable', eligibility_state =
+//! 'not_eligible_until_time')` — the tuple
+//! `attempt::delay()` writes (`crates/ff-backend-postgres/src/attempt.rs:795`).
+//!
+//! The `deadline_at_ms` column is overloaded:
+//!   * delayed rows: `deadline_at_ms = delay_until_ms`, with
+//!     `eligibility_state = 'not_eligible_until_time'`.
+//!   * active rows: `deadline_at_ms = execution_deadline_at_ms`, with
+//!     `lifecycle_phase = 'active'` (see `execution_deadline` module).
+//!
+//! The two scanners are disjoint because of the
+//! `(lifecycle_phase, eligibility_state)` discriminant. A dedicated
+//! `delay_until_ms` column is a separate, post-v0.12 schema cleanup
+//! (additive migration) — not in scope for the PR-7b minimum.
+//!
+//! Per-row tx: each promotion (clear `deadline_at_ms` + flip
+//! `eligibility_state` → `'eligible_now'`) is its own
+//! `BEGIN/COMMIT`, per spec §Constraints.
+
+use ff_core::engine_error::EngineError;
+use sqlx::{PgPool, Row};
+
+use crate::error::map_sqlx_error;
+
+/// Per-execution promote action. Exposed so the
+/// `EngineBackend::promote_delayed` trait dispatch (PR-7b Cluster 1)
+/// can invoke the same per-row tx logic the batch scanner would.
+/// Silently no-ops when the exec is no longer delayed or its
+/// `delay_until` has not yet elapsed (re-checked under `FOR UPDATE`).
+pub async fn promote_for_execution(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+    now_ms: i64,
+) -> Result<(), EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, eligibility_state, deadline_at_ms
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    let phase: String = row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let elig: String = row.try_get("eligibility_state").map_err(map_sqlx_error)?;
+    let delay_until: Option<i64> = row
+        .try_get::<Option<i64>, _>("deadline_at_ms")
+        .map_err(map_sqlx_error)?;
+
+    if phase != "runnable"
+        || elig != "not_eligible_until_time"
+        || !matches!(delay_until, Some(t) if t <= now_ms)
+    {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET eligibility_state = 'eligible_now',
+               deadline_at_ms    = NULL
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}

--- a/crates/ff-backend-postgres/src/reconcilers/execution_deadline.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/execution_deadline.rs
@@ -1,0 +1,142 @@
+//! Postgres `execution_deadline` reconciler (RFC-020 Wave 9 minimal).
+//!
+//! Mirrors the `ExecutionDeadline` phase of
+//! [`ff_engine::scanner::execution_deadline`] — terminates executions
+//! whose whole-execution wall-clock deadline has elapsed. Shares a
+//! trait entry point (`expire_execution`) with `attempt_timeout`;
+//! discriminated by [`ff_core::engine_backend::ExpirePhase`].
+//!
+//! Candidate selection: `(lifecycle_phase = 'active', deadline_at_ms
+//! IS NOT NULL, deadline_at_ms < now)` on `ff_exec_core`. The
+//! `deadline_at_ms` column is overloaded (it also carries
+//! `delay_until` for rows parked by `attempt::delay()`); the
+//! `lifecycle_phase = 'active'` predicate discriminates.
+//!
+//! Action: terminal-fail with `last_failure_message =
+//! 'execution_deadline'`, clear the active attempt's lease, emit
+//! `ff_completion_event { outcome = 'expired' }`.
+
+use ff_core::engine_error::EngineError;
+use sqlx::{PgPool, Row};
+
+use crate::error::map_sqlx_error;
+use crate::lease_event;
+
+/// Per-execution expire action for the execution-deadline scanner.
+/// Exposed so the `EngineBackend::expire_execution` trait dispatch
+/// (`ExpirePhase::ExecutionDeadline`) can invoke the same per-row tx
+/// logic the batch scanner would. Silently no-ops when the exec is
+/// no longer `active` or its deadline has not yet elapsed (re-checked
+/// under `FOR UPDATE`).
+pub async fn expire_for_execution(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+    now_ms: i64,
+) -> Result<(), EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let core_row = sqlx::query(
+        r#"
+        SELECT attempt_index, lifecycle_phase, deadline_at_ms
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(core) = core_row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    let phase: String = core.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let deadline_at: Option<i64> = core
+        .try_get::<Option<i64>, _>("deadline_at_ms")
+        .map_err(map_sqlx_error)?;
+    if phase != "active" || !matches!(deadline_at, Some(d) if d < now_ms) {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+    let attempt_index: i32 = core.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+    // Release the active attempt's lease + mark it interrupted. The
+    // row may legitimately lack a lease (e.g. exec is active but its
+    // current attempt is mid-transition) — UPDATE affecting 0 rows is
+    // fine.
+    sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET outcome = 'interrupted',
+               lease_expires_at_ms = NULL,
+               terminal_at_ms = $1
+         WHERE partition_key = $2 AND execution_id = $3 AND attempt_index = $4
+        "#,
+    )
+    .bind(now_ms)
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET lifecycle_phase = 'terminal',
+               ownership_state = 'unowned',
+               eligibility_state = 'not_applicable',
+               attempt_state = 'attempt_terminal',
+               terminal_at_ms = $1,
+               raw_fields = raw_fields || jsonb_build_object(
+                   'last_failure_message', 'execution_deadline'
+               )
+         WHERE partition_key = $2 AND execution_id = $3
+        "#,
+    )
+    .bind(now_ms)
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_completion_event (
+            partition_key, execution_id, flow_id, outcome,
+            namespace, instance_tag, occurred_at_ms
+        )
+        SELECT partition_key, execution_id, flow_id, 'expired',
+               NULL, NULL, $3
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(now_ms)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // RFC-019 Stage B outbox: lease expired (execution_deadline
+    // reconciler). Matches the `attempt_timeout` terminal emit.
+    lease_event::emit(
+        &mut tx,
+        partition_key,
+        exec_uuid,
+        None,
+        lease_event::EVENT_EXPIRED,
+        now_ms,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}

--- a/crates/ff-backend-postgres/src/reconcilers/lease_expiry.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/lease_expiry.rs
@@ -97,6 +97,55 @@ pub async fn scan_tick(
     Ok(report)
 }
 
+/// Per-execution lease-release action. Exposed so the
+/// `EngineBackend::mark_lease_expired_if_due` trait dispatch
+/// (PR-7b Cluster 1) can invoke the same per-row tx logic as
+/// `scan_tick` without requiring a full partition scan.
+///
+/// `attempt_index` is discovered inside: the caller supplies only
+/// `(partition_key, exec_uuid)` and this helper looks up the
+/// current attempt. Silently no-ops when the lease is no longer
+/// expired (re-validated under `FOR UPDATE`).
+pub async fn release_for_execution(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+) -> Result<(), EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    // Find the current attempt-with-lease for this execution. The
+    // scan_tick batch path orders by lease_expires_at_ms; here we
+    // only have one (execution, attempt) of interest — the attempt
+    // whose lease is holding the reclaim index entry.
+    let row = sqlx::query(
+        r#"
+        SELECT attempt_index
+          FROM ff_attempt
+         WHERE partition_key = $1
+           AND execution_id = $2
+           AND lease_expires_at_ms IS NOT NULL
+           AND lease_expires_at_ms < $3
+         ORDER BY lease_expires_at_ms ASC
+         LIMIT 1
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(now_ms)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(row) = row else { return Ok(()) };
+    let attempt_index: i32 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+    release_one(pool, partition_key, exec_uuid, attempt_index, now_ms).await
+}
+
 async fn release_one(
     pool: &PgPool,
     partition_key: i16,

--- a/crates/ff-backend-postgres/src/reconcilers/mod.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/mod.rs
@@ -10,10 +10,13 @@
 
 pub mod attempt_timeout;
 pub mod budget_reset;
+pub mod delayed_promoter;
 pub mod dependency;
 pub mod edge_cancel_dispatcher;
 pub mod edge_cancel_reconciler;
+pub mod execution_deadline;
 pub mod lease_expiry;
+pub mod pending_wp_expiry;
 pub mod suspension_timeout;
 
 /// Result of scanning one partition. Mirrors

--- a/crates/ff-backend-postgres/src/reconcilers/pending_wp_expiry.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/pending_wp_expiry.rs
@@ -1,0 +1,159 @@
+//! Postgres `pending_wp_expiry` reconciler (RFC-020 Wave 9 minimal).
+//!
+//! Mirrors [`ff_engine::scanner::pending_wp_expiry`] — closes pending
+//! waitpoints whose `expires_at_ms` has lapsed. The Valkey side scans
+//! `ff:idx:{p:N}:pending_waitpoint_expiry` ZSET and fires
+//! `FCALL ff_close_waitpoint` with ARGV `[waitpoint_id,
+//! "never_committed"]`; on Postgres the authority is
+//! `ff_waitpoint_pending.expires_at_ms` (partial index
+//! `ff_waitpoint_pending_expires_idx`).
+//!
+//! Action (per-row tx):
+//!   1. Re-check the waitpoint still exists and its deadline is
+//!      expired (`FOR UPDATE` on `ff_waitpoint_pending`).
+//!   2. Read the owning `(execution_id, waitpoint_key)` before delete.
+//!   3. DELETE the `ff_waitpoint_pending` row — the Valkey semantic
+//!      is "close" (one-shot; once expired it never receives its
+//!      signal).
+//!   4. Append a synthetic `never_committed` entry into
+//!      `ff_suspension_current.member_map[waitpoint_key]` so the
+//!      composite-condition evaluator sees the failure on next
+//!      resume. Matches the Valkey Lua `ff_close_waitpoint` argv
+//!      `[_, "never_committed"]` semantic.
+//!
+//! The suspended execution's own `timeout_at_ms` (on
+//! `ff_suspension_current`) continues to be managed by the
+//! `suspension_timeout` reconciler; this reconciler only closes the
+//! waitpoint and records the failure marker. A suspension waiting on
+//! exactly one waitpoint and that waitpoint expiring will be woken
+//! by the separate `suspension_timeout` scanner when its own deadline
+//! elapses — which in practice is pinned to the same or later
+//! deadline as the waitpoint's.
+
+use ff_core::engine_error::EngineError;
+use serde_json::{Value as JsonValue, json};
+use sqlx::{PgPool, Row};
+
+use crate::error::map_sqlx_error;
+
+/// Per-waitpoint close action. Exposed so the
+/// `EngineBackend::close_waitpoint` trait dispatch (PR-7b Cluster 1)
+/// can invoke the same per-row tx logic the batch scanner would.
+/// Silently no-ops when the waitpoint no longer exists or its
+/// deadline has not yet elapsed (re-checked under `FOR UPDATE`).
+pub async fn close_for_execution(
+    pool: &PgPool,
+    partition_key: i16,
+    waitpoint_uuid: uuid::Uuid,
+    now_ms: i64,
+) -> Result<(), EngineError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let row = sqlx::query(
+        r#"
+        SELECT execution_id, waitpoint_key, expires_at_ms
+          FROM ff_waitpoint_pending
+         WHERE partition_key = $1 AND waitpoint_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(waitpoint_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    };
+    let exec_uuid: uuid::Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
+    let waitpoint_key: String = row.try_get("waitpoint_key").map_err(map_sqlx_error)?;
+    let expires_at: Option<i64> = row
+        .try_get::<Option<i64>, _>("expires_at_ms")
+        .map_err(map_sqlx_error)?;
+
+    // Guard: if there's no expires_at (never meant to expire) or it
+    // hasn't elapsed, no-op. The scanner side already filters by
+    // `expires_at_ms < now` but the re-check under FOR UPDATE
+    // protects against races with deliver_signal resolving the
+    // waitpoint between scan + action.
+    if !matches!(expires_at, Some(t) if t < now_ms) {
+        tx.rollback().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+
+    // Delete the pending row — mirrors the Valkey `DEL
+    // ff:wp:{tag}:<wp_id>` + `ZREM pending_waitpoint_expiry` pair.
+    sqlx::query(
+        r#"
+        DELETE FROM ff_waitpoint_pending
+         WHERE partition_key = $1 AND waitpoint_id = $2
+        "#,
+    )
+    .bind(partition_key)
+    .bind(waitpoint_uuid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Record `never_committed` marker on the owning suspension, if
+    // any. Suspensions waiting on this waitpoint read member_map at
+    // resume time; the marker lets the composite-condition evaluator
+    // distinguish "signal delivered" from "waitpoint expired without
+    // signal". Silent no-op when no suspension exists (the exec may
+    // have resumed through another path already).
+    let susp_row = sqlx::query(
+        r#"
+        SELECT member_map
+          FROM ff_suspension_current
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if let Some(susp_row) = susp_row {
+        let member_map: JsonValue = susp_row.try_get("member_map").map_err(map_sqlx_error)?;
+        let mut map = match member_map {
+            JsonValue::Object(m) => m,
+            _ => serde_json::Map::new(),
+        };
+        // Key on the waitpoint_key (human-readable) per RFC-013/014
+        // suspend-condition contract; the Valkey Lua closes on the
+        // same identifier.
+        let key = if waitpoint_key.is_empty() {
+            waitpoint_uuid.to_string()
+        } else {
+            waitpoint_key
+        };
+        map.insert(
+            key,
+            json!({
+                "status": "never_committed",
+                "closed_at_ms": now_ms,
+                "source": "pending_wp_expiry",
+            }),
+        );
+        sqlx::query(
+            r#"
+            UPDATE ff_suspension_current
+               SET member_map = $1
+             WHERE partition_key = $2 AND execution_id = $3
+            "#,
+        )
+        .bind(JsonValue::Object(map))
+        .bind(partition_key)
+        .bind(exec_uuid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}

--- a/crates/ff-backend-postgres/src/reconcilers/suspension_timeout.rs
+++ b/crates/ff-backend-postgres/src/reconcilers/suspension_timeout.rs
@@ -88,6 +88,49 @@ pub async fn scan_tick(
     Ok(report)
 }
 
+/// Per-execution suspension-expire action. Exposed so the
+/// `EngineBackend::expire_suspension` trait dispatch (PR-7b
+/// Cluster 1) can invoke the same per-row tx logic as `scan_tick`.
+/// Discovers the timeout behavior internally. Silently no-ops when
+/// the suspension has already been resolved (`timeout_at_ms IS NULL`
+/// re-checked under `FOR UPDATE`).
+pub async fn expire_for_execution(
+    pool: &PgPool,
+    partition_key: i16,
+    exec_uuid: uuid::Uuid,
+) -> Result<(), EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    let row = sqlx::query(
+        r#"
+        SELECT timeout_behavior
+          FROM ff_suspension_current
+         WHERE partition_key = $1
+           AND execution_id = $2
+           AND timeout_at_ms IS NOT NULL
+           AND timeout_at_ms < $3
+        "#,
+    )
+    .bind(partition_key)
+    .bind(exec_uuid)
+    .bind(now_ms)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(row) = row else { return Ok(()) };
+    let behavior: Option<String> = row
+        .try_get::<Option<String>, _>("timeout_behavior")
+        .map_err(map_sqlx_error)?;
+    let b = behavior.as_deref().unwrap_or("fail");
+    expire_one(pool, partition_key, exec_uuid, b, now_ms).await
+}
+
 async fn expire_one(
     pool: &PgPool,
     partition_key: i16,

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2796,6 +2796,13 @@ impl EngineBackend for SqliteBackend {
         crate::reads::get_flow_tag_impl(&self.inner.pool, flow_id, key).await
     }
 
+    async fn get_execution_namespace(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> Result<Option<String>, EngineError> {
+        crate::reads::get_execution_namespace_impl(&self.inner.pool, execution_id).await
+    }
+
     #[cfg(feature = "core")]
     async fn list_edges(
         &self,

--- a/crates/ff-backend-sqlite/src/reads.rs
+++ b/crates/ff-backend-sqlite/src/reads.rs
@@ -643,6 +643,33 @@ pub(crate) async fn get_execution_tag_impl(
     Ok(tag)
 }
 
+pub(crate) async fn get_execution_namespace_impl(
+    pool: &SqlitePool,
+    id: &ExecutionId,
+) -> Result<Option<String>, EngineError> {
+    let (part, exec_uuid) = split_exec_id(id)?;
+
+    let row = sqlx::query(
+        r#"
+        SELECT json_extract(raw_fields, '$.namespace') AS ns_value
+          FROM ff_exec_core
+         WHERE partition_key = ?1 AND execution_id = ?2
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // Missing-row collapses to Ok(None) — see get_execution_tag_impl.
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let ns: Option<String> = row.try_get("ns_value").map_err(map_sqlx_error)?;
+    Ok(ns)
+}
+
 pub(crate) async fn get_flow_tag_impl(
     pool: &SqlitePool,
     flow_id: &ff_core::types::FlowId,

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -56,7 +56,7 @@ use ff_core::contracts::{
 use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::engine_error::{StateKind, ValidationKind};
 use ff_core::partition::PartitionKey;
-use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_backend::{EngineBackend, ExpirePhase};
 use ff_core::engine_error::EngineError;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
 use ff_core::partition::{PartitionConfig, execution_partition, flow_partition};
@@ -7551,6 +7551,237 @@ impl EngineBackend for ValkeyBackend {
             inner,
             disconnected_emitted: false,
         }))
+    }
+
+    // ── PR-7b Cluster 1 — Foundation scanner operations ─────────
+    //
+    // Thin wrappers around the existing scanner FCALLs. The per-
+    // candidate key-formatting + pre-read logic mirrors what the
+    // scanner bodies computed inline pre-PR-7b; moving it onto the
+    // backend lets scanners dispatch through `EngineBackend` instead
+    // of reaching for `ferriskey::Client` directly.
+
+    async fn mark_lease_expired_if_due(
+        &self,
+        partition: Partition,
+        execution_id: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        let tag = partition.hash_tag();
+        let eid_str = execution_id.as_str();
+        let idx = IndexKeys::new(&partition);
+        let exec_core = format!("ff:exec:{}:{}:core", tag, eid_str);
+        let lease_current = format!("ff:exec:{}:{}:lease:current", tag, eid_str);
+        let lease_history = format!("ff:exec:{}:{}:lease:history", tag, eid_str);
+        let lease_expiry = idx.lease_expiry();
+        let keys: [&str; 4] = [&exec_core, &lease_current, &lease_expiry, &lease_history];
+        let argv: [&str; 1] = [eid_str];
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_mark_lease_expired_if_due", &keys, &argv)
+            .await
+            .map_err(transport_fk)?;
+        Ok(())
+    }
+
+    async fn promote_delayed(
+        &self,
+        partition: Partition,
+        lane: &LaneId,
+        execution_id: &ExecutionId,
+        now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let tag = partition.hash_tag();
+        let eid_str = execution_id.as_str();
+        let idx = IndexKeys::new(&partition);
+        let exec_core = format!("ff:exec:{}:{}:core", tag, eid_str);
+        let delayed_zset = idx.lane_delayed(lane);
+        let eligible_zset = idx.lane_eligible(lane);
+        let keys: [&str; 3] = [&exec_core, &delayed_zset, &eligible_zset];
+        let now_str = now_ms.0.to_string();
+        let argv: [&str; 2] = [eid_str, &now_str];
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_promote_delayed", &keys, &argv)
+            .await
+            .map_err(transport_fk)?;
+        Ok(())
+    }
+
+    async fn close_waitpoint(
+        &self,
+        partition: Partition,
+        execution_id: &ExecutionId,
+        waitpoint_id: &str,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let tag = partition.hash_tag();
+        let eid_str = execution_id.as_str();
+        let idx = IndexKeys::new(&partition);
+        let waitpoint_hash = format!("ff:wp:{}:{}", tag, waitpoint_id);
+        let exec_core = format!("ff:exec:{}:{}:core", tag, eid_str);
+        let pending_wp_expiry = idx.pending_waitpoint_expiry();
+        let keys: [&str; 3] = [&exec_core, &waitpoint_hash, &pending_wp_expiry];
+        let argv: [&str; 2] = [waitpoint_id, "never_committed"];
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_close_waitpoint", &keys, &argv)
+            .await
+            .map_err(transport_fk)?;
+        Ok(())
+    }
+
+    async fn expire_execution(
+        &self,
+        partition: Partition,
+        execution_id: &ExecutionId,
+        phase: ExpirePhase,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let tag = partition.hash_tag();
+        let eid_str = execution_id.as_str();
+        let idx = IndexKeys::new(&partition);
+
+        let exec_core = format!("ff:exec:{}:{}:core", tag, eid_str);
+        let lease_current = format!("ff:exec:{}:{}:lease:current", tag, eid_str);
+        let lease_history = format!("ff:exec:{}:{}:lease:history", tag, eid_str);
+        let susp_current = format!("ff:exec:{}:{}:suspension:current", tag, eid_str);
+
+        // Pre-read lane_id and current_attempt_index from exec_core —
+        // the Lua function needs the real attempt index to find the
+        // correct attempt_hash + stream_meta. Same pattern the
+        // scanner body used pre-trait.
+        let pre_fields: Vec<Option<String>> = self
+            .client
+            .cmd("HMGET")
+            .arg(&exec_core)
+            .arg("lane_id")
+            .arg("current_attempt_index")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        let lane = LaneId::new(
+            pre_fields
+                .first()
+                .and_then(|v| v.as_deref())
+                .unwrap_or("default"),
+        );
+        let att_idx = pre_fields
+            .get(1)
+            .and_then(|v| v.as_deref())
+            .unwrap_or("0");
+
+        let attempt_hash = format!("ff:attempt:{}:{}:{}", tag, eid_str, att_idx);
+        let stream_meta = format!("ff:stream:{}:{}:{}:meta", tag, eid_str, att_idx);
+
+        let lease_expiry = idx.lease_expiry();
+        let worker_leases = idx.worker_leases(&WorkerInstanceId::new(""));
+        let active = idx.lane_active(&lane);
+        let terminal = idx.lane_terminal(&lane);
+        let attempt_timeout = idx.attempt_timeout();
+        let execution_deadline = idx.execution_deadline();
+        let suspended = idx.lane_suspended(&lane);
+        let suspension_timeout = idx.suspension_timeout();
+
+        let keys: [&str; 14] = [
+            &exec_core,
+            &attempt_hash,
+            &stream_meta,
+            &lease_current,
+            &lease_history,
+            &lease_expiry,
+            &worker_leases,
+            &active,
+            &terminal,
+            &attempt_timeout,
+            &execution_deadline,
+            &suspended,
+            &suspension_timeout,
+            &susp_current,
+        ];
+        let argv: [&str; 2] = [eid_str, phase.as_str()];
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_expire_execution", &keys, &argv)
+            .await
+            .map_err(transport_fk)?;
+        Ok(())
+    }
+
+    async fn expire_suspension(
+        &self,
+        partition: Partition,
+        execution_id: &ExecutionId,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let tag = partition.hash_tag();
+        let eid_str = execution_id.as_str();
+        let idx = IndexKeys::new(&partition);
+
+        let exec_core = format!("ff:exec:{}:{}:core", tag, eid_str);
+        let suspension_current = format!("ff:exec:{}:{}:suspension:current", tag, eid_str);
+
+        let wp_id: Option<String> = self
+            .client
+            .cmd("HGET")
+            .arg(&exec_core)
+            .arg("current_waitpoint_id")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        let att_idx: Option<String> = self
+            .client
+            .cmd("HGET")
+            .arg(&exec_core)
+            .arg("current_attempt_index")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+        let lane: Option<String> = self
+            .client
+            .cmd("HGET")
+            .arg(&exec_core)
+            .arg("lane_id")
+            .execute()
+            .await
+            .map_err(transport_fk)?;
+
+        let wp_id = wp_id.unwrap_or_default();
+        let att_idx = att_idx.unwrap_or_else(|| "0".to_string());
+        let lane_str = lane.unwrap_or_else(|| "default".to_string());
+        let lane_id = LaneId::new(&lane_str);
+
+        let waitpoint_hash = format!("ff:wp:{}:{}", tag, wp_id);
+        let wp_condition = format!("ff:wp:{}:{}:condition", tag, wp_id);
+        let attempt_hash = format!("ff:attempt:{}:{}:{}", tag, eid_str, att_idx);
+        let stream_meta = format!("ff:stream:{}:{}:{}:meta", tag, eid_str, att_idx);
+        let suspension_timeout = idx.suspension_timeout();
+        let suspended_zset = idx.lane_suspended(&lane_id);
+        let terminal_zset = idx.lane_terminal(&lane_id);
+        let eligible_zset = idx.lane_eligible(&lane_id);
+        let delayed_zset = idx.lane_delayed(&lane_id);
+        let lease_history = format!("ff:exec:{}:{}:lease:history", tag, eid_str);
+
+        let keys: [&str; 12] = [
+            &exec_core,
+            &suspension_current,
+            &waitpoint_hash,
+            &wp_condition,
+            &attempt_hash,
+            &stream_meta,
+            &suspension_timeout,
+            &suspended_zset,
+            &terminal_zset,
+            &eligible_zset,
+            &delayed_zset,
+            &lease_history,
+        ];
+        let argv: [&str; 1] = [eid_str];
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_expire_suspension", &keys, &argv)
+            .await
+            .map_err(transport_fk)?;
+        Ok(())
     }
 }
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -1384,6 +1384,26 @@ async fn get_execution_tag_impl(
     Ok(raw)
 }
 
+/// `HGET :core namespace` on the execution's partition. `Ok(None)`
+/// for absent field or absent hash (see `get_execution_tag_impl`
+/// rationale).
+async fn get_execution_namespace_impl(
+    client: &ferriskey::Client,
+    partition_config: &PartitionConfig,
+    execution_id: &ExecutionId,
+) -> Result<Option<String>, EngineError> {
+    let partition = execution_partition(execution_id, partition_config);
+    let ctx = ExecKeyContext::new(&partition, execution_id);
+    let raw: Option<String> = client
+        .cmd("HGET")
+        .arg(ctx.core())
+        .arg("namespace")
+        .execute()
+        .await
+        .map_err(transport_fk)?;
+    Ok(raw)
+}
+
 /// `HGET :tags <key>` on the flow's partition.
 async fn get_flow_tag_impl(
     client: &ferriskey::Client,
@@ -5397,6 +5417,20 @@ impl EngineBackend for ValkeyBackend {
             .await
             .map_err(|e| {
                 ff_core::engine_error::backend_context(e, "get_flow_tag: HGET :tags")
+            })
+    }
+
+    async fn get_execution_namespace(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> Result<Option<String>, EngineError> {
+        get_execution_namespace_impl(&self.client, &self.partition_config, execution_id)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    e,
+                    "get_execution_namespace: HGET :core namespace",
+                )
             })
     }
 

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -683,6 +683,33 @@ pub trait EngineBackend: Send + Sync + 'static {
         })
     }
 
+    /// Read an execution's `namespace` scalar. Returns `Ok(None)` when
+    /// the row is absent or the field is unset. Dedicated point-read
+    /// used by the scanner per-candidate filter (`should_skip_candidate`)
+    /// to preserve the 1-HGET cost contract documented in
+    /// `ff_engine::scanner::should_skip_candidate` — `describe_execution`
+    /// is heavier (HGETALL / full snapshot) and unnecessary when only
+    /// the namespace scalar is needed.
+    ///
+    /// Per-backend shape:
+    ///
+    /// * **Valkey** — `HGET :core namespace` on the execution's partition
+    ///   (single field read on the already-hot exec_core hash).
+    /// * **Postgres** — `SELECT raw_fields->>'namespace' FROM ff_exec_core
+    ///   WHERE partition_key = $1 AND execution_id = $2`.
+    /// * **SQLite** — `SELECT json_extract(raw_fields, '$.namespace')
+    ///   FROM ff_exec_core WHERE ...`.
+    ///
+    /// The default impl returns [`EngineError::Unavailable`].
+    async fn get_execution_namespace(
+        &self,
+        _execution_id: &ExecutionId,
+    ) -> Result<Option<String>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "get_execution_namespace",
+        })
+    }
+
     /// Read a single namespaced flow tag. Returns `Ok(None)` when
     /// the tag is absent **or** the flow row does not exist (same
     /// collapse semantics as [`Self::get_execution_tag`]). Symmetry

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -1883,6 +1883,132 @@ pub trait EngineBackend: Send + Sync + 'static {
             op: "subscribe_instance_tags",
         })
     }
+
+    // ── PR-7b Cluster 1 — Foundation scanner operations ─────────
+    //
+    // Per-execution write hooks invoked by the engine scanner loop.
+    // Scanner bodies discover candidate executions via partition
+    // indices (Valkey ZSETs / PG index scans) and, for each candidate,
+    // call through to one of the methods below to perform the atomic
+    // state-flip. Defaults return `EngineError::Unavailable { op }`;
+    // Valkey impls wrap the corresponding `ff_*` FCALL; Postgres impls
+    // run a single-row tx mirroring the Lua semantic.
+
+    /// Lease-expiry scanner hook — mark an expired lease as reclaimable
+    /// so another worker can redeem the execution. Atomic per call.
+    ///
+    /// Valkey: `FCALL ff_mark_lease_expired_if_due`.
+    /// Postgres: single-row tx on `ff_attempt` + `ff_exec_core` (see
+    /// `ff_backend_postgres::reconcilers::lease_expiry`).
+    async fn mark_lease_expired_if_due(
+        &self,
+        _partition: crate::partition::Partition,
+        _execution_id: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "mark_lease_expired_if_due",
+        })
+    }
+
+    /// Delayed-promoter scanner hook — promote a delayed execution to
+    /// `eligible_now` once its `delay_until` has passed.
+    ///
+    /// Valkey: `FCALL ff_promote_delayed`.
+    /// Postgres: Wave 9 schema scope (no current impl).
+    async fn promote_delayed(
+        &self,
+        _partition: crate::partition::Partition,
+        _lane: &LaneId,
+        _execution_id: &ExecutionId,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "promote_delayed",
+        })
+    }
+
+    /// Pending-waitpoint-expiry scanner hook — close a pending
+    /// waitpoint whose deadline has passed (wake the suspended
+    /// execution with a timeout signal).
+    ///
+    /// Valkey: `FCALL ff_close_waitpoint`.
+    /// Postgres: Wave 9 schema scope (no current impl).
+    async fn close_waitpoint(
+        &self,
+        _partition: crate::partition::Partition,
+        _execution_id: &ExecutionId,
+        _waitpoint_id: &str,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "close_waitpoint",
+        })
+    }
+
+    /// Shared hook for the attempt-timeout and execution-deadline
+    /// scanners — terminate or retry an execution whose wall-clock
+    /// budget has elapsed. `phase` discriminates which of the two
+    /// scanner paths is calling so the backend can preserve diagnostic
+    /// breadcrumbs without forking the surface.
+    ///
+    /// Valkey: `FCALL ff_expire_execution` (with `phase` passed through
+    /// as an ARGV discriminator).
+    /// Postgres: single-row tx mirror of the Lua semantic for
+    /// `AttemptTimeout`; `ExecutionDeadline` is Wave 9 schema scope.
+    async fn expire_execution(
+        &self,
+        _partition: crate::partition::Partition,
+        _execution_id: &ExecutionId,
+        _phase: ExpirePhase,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "expire_execution",
+        })
+    }
+
+    /// Suspension-timeout scanner hook — expire a suspended execution
+    /// whose suspension deadline has passed (wake with timeout).
+    ///
+    /// Valkey: `FCALL ff_expire_suspension`.
+    /// Postgres: single-row tx on `ff_suspend` + `ff_exec_core`.
+    async fn expire_suspension(
+        &self,
+        _partition: crate::partition::Partition,
+        _execution_id: &ExecutionId,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "expire_suspension",
+        })
+    }
+}
+
+/// Which scanner invoked [`EngineBackend::expire_execution`].
+///
+/// The attempt-timeout and execution-deadline scanners share a single
+/// trait method — their underlying state flip is identical (terminate
+/// or retry per retry policy); the distinction is purely diagnostic
+/// (which deadline elapsed) and carried through to the backend so the
+/// same Lua / SQL path can log or tag appropriately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpirePhase {
+    /// Invoked by `attempt_timeout` scanner — the per-attempt
+    /// wall-clock budget elapsed.
+    AttemptTimeout,
+    /// Invoked by `execution_deadline` scanner — the whole-execution
+    /// wall-clock deadline elapsed.
+    ExecutionDeadline,
+}
+
+impl ExpirePhase {
+    /// Short string tag suitable for Lua ARGV or Postgres breadcrumbs.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::AttemptTimeout => "attempt_timeout",
+            Self::ExecutionDeadline => "execution_deadline",
+        }
+    }
 }
 
 /// Object-safety assertion: `dyn EngineBackend` compiles iff every

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -50,3 +50,9 @@ ff-backend-postgres = { workspace = true, optional = true }
 # Both flip on with the `postgres` feature only.
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls"], optional = true }
 uuid = { workspace = true, optional = true }
+
+[dev-dependencies]
+# Unit-test mock `EngineBackend` impls need `#[async_trait]` to match
+# the trait shape defined in `ff-core::engine_backend`.
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/ff-engine/src/lib.rs
+++ b/crates/ff-engine/src/lib.rs
@@ -321,9 +321,10 @@ impl Engine {
         let scanner_filter = config.scanner_filter.clone();
 
         // Lease expiry scanner
-        let lease_scanner = Arc::new(LeaseExpiryScanner::with_filter(
+        let lease_scanner = Arc::new(LeaseExpiryScanner::with_filter_and_backend(
             config.lease_expiry_interval,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             lease_scanner,
@@ -334,10 +335,11 @@ impl Engine {
         ));
 
         // Delayed promoter
-        let delayed_scanner = Arc::new(DelayedPromoter::with_filter(
+        let delayed_scanner = Arc::new(DelayedPromoter::with_filter_and_backend(
             config.delayed_promoter_interval,
             config.lanes.clone(),
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             delayed_scanner,
@@ -348,10 +350,11 @@ impl Engine {
         ));
 
         // Index reconciler
-        let reconciler = Arc::new(IndexReconciler::with_filter(
+        let reconciler = Arc::new(IndexReconciler::with_filter_and_backend(
             config.index_reconciler_interval,
             config.lanes.clone(),
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             reconciler,
@@ -362,10 +365,11 @@ impl Engine {
         ));
 
         // Attempt timeout scanner
-        let timeout_scanner = Arc::new(AttemptTimeoutScanner::with_filter(
+        let timeout_scanner = Arc::new(AttemptTimeoutScanner::with_filter_and_backend(
             config.attempt_timeout_interval,
             config.lanes.clone(),
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             timeout_scanner,
@@ -376,9 +380,10 @@ impl Engine {
         ));
 
         // Suspension timeout scanner
-        let suspension_scanner = Arc::new(SuspensionTimeoutScanner::with_filter(
+        let suspension_scanner = Arc::new(SuspensionTimeoutScanner::with_filter_and_backend(
             config.suspension_timeout_interval,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             suspension_scanner,
@@ -389,9 +394,10 @@ impl Engine {
         ));
 
         // Pending waitpoint expiry scanner
-        let pending_wp_scanner = Arc::new(PendingWaitpointExpiryScanner::with_filter(
+        let pending_wp_scanner = Arc::new(PendingWaitpointExpiryScanner::with_filter_and_backend(
             config.pending_wp_expiry_interval,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             pending_wp_scanner,
@@ -402,10 +408,11 @@ impl Engine {
         ));
 
         // Retention trimmer
-        let retention_scanner = Arc::new(RetentionTrimmer::with_filter(
+        let retention_scanner = Arc::new(RetentionTrimmer::with_filter_and_backend(
             config.retention_trimmer_interval,
             config.lanes.clone(),
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             retention_scanner,
@@ -446,11 +453,12 @@ impl Engine {
         ));
 
         // Unblock scanner (iterates execution partitions, re-evaluates blocked)
-        let unblock_scanner = Arc::new(UnblockScanner::with_filter(
+        let unblock_scanner = Arc::new(UnblockScanner::with_filter_and_backend(
             config.unblock_interval,
             config.lanes.clone(),
             config.partition_config,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             unblock_scanner,
@@ -461,11 +469,12 @@ impl Engine {
         ));
 
         // Dependency reconciler (iterates execution partitions)
-        let dep_reconciler = Arc::new(DependencyReconciler::with_filter(
+        let dep_reconciler = Arc::new(DependencyReconciler::with_filter_and_backend(
             config.dependency_reconciler_interval,
             config.lanes.clone(),
             config.partition_config,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             dep_reconciler,
@@ -509,10 +518,11 @@ impl Engine {
         // Cancel reconciler (iterates flow partitions). Drains
         // cancel_backlog entries whose grace window has elapsed so a
         // process crash mid-dispatch can't leave flow members un-cancelled.
-        let cancel_reconciler = Arc::new(scanner::cancel_reconciler::CancelReconciler::with_filter(
+        let cancel_reconciler = Arc::new(scanner::cancel_reconciler::CancelReconciler::with_filter_and_backend(
             config.cancel_reconciler_interval,
             config.partition_config,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             cancel_reconciler,
@@ -563,10 +573,11 @@ impl Engine {
         ));
 
         // Execution deadline scanner (iterates execution partitions)
-        let deadline_scanner = Arc::new(ExecutionDeadlineScanner::with_filter(
+        let deadline_scanner = Arc::new(ExecutionDeadlineScanner::with_filter_and_backend(
             config.execution_deadline_interval,
             config.lanes,
             scanner_filter,
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             deadline_scanner,

--- a/crates/ff-engine/src/scanner/attempt_timeout.rs
+++ b/crates/ff-engine/src/scanner/attempt_timeout.rs
@@ -7,12 +7,14 @@
 //!
 //! Reference: RFC-010 §6, function #29c
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::{EngineBackend, ExpirePhase};
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
-use ff_core::types::LaneId;
+use ff_core::types::{ExecutionId, LaneId, TimestampMs};
 
 use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
@@ -38,6 +40,7 @@ pub struct AttemptTimeoutScanner {
     interval: Duration,
     failures: FailureTracker,
     filter: ScannerFilter,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl AttemptTimeoutScanner {
@@ -56,6 +59,22 @@ impl AttemptTimeoutScanner {
             interval,
             failures: FailureTracker::new(),
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for trait-routed FCALLs.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        _lanes: Vec<LaneId>,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            failures: FailureTracker::new(),
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -127,11 +146,22 @@ impl Scanner for AttemptTimeoutScanner {
             if self.failures.should_skip(eid_str) {
                 continue;
             }
-            if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+            if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str).await {
                 continue;
             }
 
-            match expire_execution_raw(client, &p, &idx, eid_str, "attempt_timeout").await {
+            let res = if let Some(ref backend) = self.backend {
+                let Ok(eid) = ExecutionId::parse(eid_str) else { tracing::warn!(execution_id=%eid_str, "malformed eid; skipping"); continue; };
+                backend
+                    .expire_execution(p, &eid, ExpirePhase::AttemptTimeout, TimestampMs(now_ms as i64))
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                expire_execution_raw(client, &p, &idx, eid_str, "attempt_timeout")
+                    .await
+                    .map_err(|e| e.to_string())
+            };
+            match res {
                 Ok(()) => {
                     self.failures.record_success(eid_str);
                     processed += 1;
@@ -141,7 +171,7 @@ impl Scanner for AttemptTimeoutScanner {
                         partition,
                         execution_id = eid_str.as_str(),
                         error = %e,
-                        "attempt_timeout: ff_expire_execution failed"
+                        "attempt_timeout: expire_execution failed"
                     );
                     self.failures.record_failure(eid_str, "attempt_timeout");
                     errors += 1;

--- a/crates/ff-engine/src/scanner/cancel_reconciler.rs
+++ b/crates/ff-engine/src/scanner/cancel_reconciler.rs
@@ -21,9 +21,11 @@
 //! scope. This reconciler shrinks the escape window from "forever" to
 //! "one reconciler interval plus grace_ms."
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
 use ff_core::partition::{
     execution_partition, Partition, PartitionConfig, PartitionFamily,
@@ -39,6 +41,7 @@ pub struct CancelReconciler {
     interval: Duration,
     partition_config: PartitionConfig,
     filter: ScannerFilter,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl CancelReconciler {
@@ -58,6 +61,23 @@ impl CancelReconciler {
             interval,
             partition_config,
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for filter-resolution
+    /// reads. FCALL routing is cluster 3 scope.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        partition_config: PartitionConfig,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            partition_config,
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -299,7 +319,7 @@ impl Scanner for CancelReconciler {
                     &self.partition_config,
                 ).index;
                 if should_skip_candidate(
-                    client,
+                    self.backend.as_ref(),
                     &self.filter,
                     member_part,
                     eid_str,

--- a/crates/ff-engine/src/scanner/delayed_promoter.rs
+++ b/crates/ff-engine/src/scanner/delayed_promoter.rs
@@ -11,12 +11,14 @@
 //!
 //! Reference: RFC-010 §6, function #27
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
-use ff_core::types::LaneId;
+use ff_core::types::{ExecutionId, LaneId, TimestampMs};
 
 use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
@@ -28,6 +30,9 @@ pub struct DelayedPromoter {
     lanes: Vec<LaneId>,
     failures: FailureTracker,
     filter: ScannerFilter,
+    /// PR-7b Cluster 1: trait-dispatch target. See
+    /// [`super::lease_expiry::LeaseExpiryScanner::backend`] rustdoc.
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl DelayedPromoter {
@@ -43,6 +48,23 @@ impl DelayedPromoter {
             lanes,
             failures: FailureTracker::new(),
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for trait-routed FCALLs.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        lanes: Vec<LaneId>,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            lanes,
+            failures: FailureTracker::new(),
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -124,21 +146,29 @@ impl Scanner for DelayedPromoter {
                 if self.failures.should_skip(eid_str) {
                     continue;
                 }
-                if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+                if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str).await {
                     continue;
                 }
 
-                let exec_core = format!("ff:exec:{}:{}:core", p.hash_tag(), eid_str);
-                let keys: [&str; 3] = [&exec_core, &delayed_key, &eligible_key];
-                let now_str = now_ms.to_string();
-                let argv: [&str; 2] = [eid_str.as_str(), &now_str];
-
-                match client.fcall::<ferriskey::Value>(
-                    "ff_promote_delayed",
-                    &keys,
-                    &argv,
-                ).await {
-                    Ok(_) => {
+                let res = if let Some(ref backend) = self.backend {
+                    let Ok(eid) = ExecutionId::parse(eid_str) else { tracing::warn!(execution_id=%eid_str, "malformed eid; skipping"); continue; };
+                    backend
+                        .promote_delayed(p, lane, &eid, TimestampMs(now_ms as i64))
+                        .await
+                        .map_err(|e| e.to_string())
+                } else {
+                    let exec_core = format!("ff:exec:{}:{}:core", p.hash_tag(), eid_str);
+                    let keys: [&str; 3] = [&exec_core, &delayed_key, &eligible_key];
+                    let now_str = now_ms.to_string();
+                    let argv: [&str; 2] = [eid_str.as_str(), &now_str];
+                    client
+                        .fcall::<ferriskey::Value>("ff_promote_delayed", &keys, &argv)
+                        .await
+                        .map(|_: ferriskey::Value| ())
+                        .map_err(|e| e.to_string())
+                };
+                match res {
+                    Ok(()) => {
                         self.failures.record_success(eid_str);
                         total_processed += 1;
                     }
@@ -148,7 +178,7 @@ impl Scanner for DelayedPromoter {
                             execution_id = eid_str.as_str(),
                             lane = %lane,
                             error = %e,
-                            "delayed_promoter: ff_promote_delayed failed"
+                            "delayed_promoter: promote_delayed failed"
                         );
                         self.failures.record_failure(eid_str, "delayed_promoter");
                         total_errors += 1;

--- a/crates/ff-engine/src/scanner/dependency_reconciler.rs
+++ b/crates/ff-engine/src/scanner/dependency_reconciler.rs
@@ -13,9 +13,11 @@
 //! Reference: RFC-007 §Resolve dependency, RFC-010 §6.14
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, execution_partition};
 use ff_core::types::{ExecutionId, LaneId};
@@ -31,6 +33,7 @@ pub struct DependencyReconciler {
     lanes: Vec<LaneId>,
     partition_config: PartitionConfig,
     filter: ScannerFilter,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl DependencyReconciler {
@@ -51,6 +54,25 @@ impl DependencyReconciler {
             lanes,
             partition_config,
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for filter-resolution
+    /// reads. FCALL routing is cluster 2 scope.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        lanes: Vec<LaneId>,
+        partition_config: PartitionConfig,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            lanes,
+            partition_config,
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -112,7 +134,7 @@ impl Scanner for DependencyReconciler {
             };
 
             for eid_str in &blocked {
-                if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+                if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str).await {
                     continue;
                 }
                 match reconcile_one_execution(

--- a/crates/ff-engine/src/scanner/execution_deadline.rs
+++ b/crates/ff-engine/src/scanner/execution_deadline.rs
@@ -12,11 +12,14 @@
 //!
 //! Reference: RFC-001 §execution_deadline, RFC-010 §6
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::{EngineBackend, ExpirePhase};
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::types::{ExecutionId, TimestampMs};
 
 use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
@@ -26,6 +29,7 @@ pub struct ExecutionDeadlineScanner {
     interval: Duration,
     failures: FailureTracker,
     filter: ScannerFilter,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl ExecutionDeadlineScanner {
@@ -44,6 +48,22 @@ impl ExecutionDeadlineScanner {
             interval,
             failures: FailureTracker::new(),
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for trait-routed FCALLs.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        _lanes: Vec<ff_core::types::LaneId>,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            failures: FailureTracker::new(),
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -115,17 +135,33 @@ impl Scanner for ExecutionDeadlineScanner {
             if self.failures.should_skip(eid_str) {
                 continue;
             }
-            if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+            if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str).await {
                 continue;
             }
 
-            // Reuse the same expire_execution helper as attempt_timeout —
-            // ff_expire_execution handles all lifecycle phases and ZREMs from
-            // both attempt_timeout and execution_deadline indexes.
-            // Lane is now pre-read from exec_core inside expire_execution_raw.
-            match crate::scanner::attempt_timeout::expire_execution_raw(
-                client, &p, &idx, eid_str, "execution_deadline",
-            ).await {
+            let res = if let Some(ref backend) = self.backend {
+                let Ok(eid) = ExecutionId::parse(eid_str) else { tracing::warn!(execution_id=%eid_str, "malformed eid; skipping"); continue; };
+                backend
+                    .expire_execution(
+                        p,
+                        &eid,
+                        ExpirePhase::ExecutionDeadline,
+                        TimestampMs(now_ms as i64),
+                    )
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                crate::scanner::attempt_timeout::expire_execution_raw(
+                    client,
+                    &p,
+                    &idx,
+                    eid_str,
+                    "execution_deadline",
+                )
+                .await
+                .map_err(|e| e.to_string())
+            };
+            match res {
                 Ok(()) => {
                     self.failures.record_success(eid_str);
                     processed += 1;
@@ -135,7 +171,7 @@ impl Scanner for ExecutionDeadlineScanner {
                         partition,
                         execution_id = eid_str.as_str(),
                         error = %e,
-                        "execution_deadline: ff_expire_execution failed"
+                        "execution_deadline: expire_execution failed"
                     );
                     self.failures.record_failure(eid_str, "execution_deadline");
                     errors += 1;

--- a/crates/ff-engine/src/scanner/index_reconciler.rs
+++ b/crates/ff-engine/src/scanner/index_reconciler.rs
@@ -9,9 +9,11 @@
 //!
 //! Reference: RFC-010 §6.14
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::types::LaneId;
@@ -26,6 +28,7 @@ pub struct IndexReconciler {
     /// Lanes to check. Phase 1: just "default".
     lanes: Vec<LaneId>,
     filter: ScannerFilter,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl IndexReconciler {
@@ -40,6 +43,24 @@ impl IndexReconciler {
             interval,
             lanes,
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for filter-resolution
+    /// reads via `should_skip_candidate`. FCALL routing for this
+    /// scanner is cluster 2b scope.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        lanes: Vec<LaneId>,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            lanes,
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -101,7 +122,7 @@ impl Scanner for IndexReconciler {
             };
 
             for eid_str in &members {
-                if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+                if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str).await {
                     continue;
                 }
                 match check_execution_index(client, &p, &idx, eid_str, &self.lanes).await {

--- a/crates/ff-engine/src/scanner/lease_expiry.rs
+++ b/crates/ff-engine/src/scanner/lease_expiry.rs
@@ -7,11 +7,14 @@
 //!
 //! Reference: RFC-003 §Reclaim scan pattern, RFC-010 §6.1
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::types::ExecutionId;
 
 use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
@@ -32,6 +35,15 @@ pub struct LeaseExpiryScanner {
     interval: Duration,
     failures: FailureTracker,
     filter: ScannerFilter,
+    /// PR-7b Cluster 1 plumbing — the trait-dispatch target for the
+    /// per-candidate FCALL equivalent. `Engine::start_internal`
+    /// constructs via [`Self::with_filter_and_backend`]; external
+    /// callers (tests) that don't need filter enforcement can still
+    /// use [`Self::new`] / [`Self::with_filter`], which leave the
+    /// backend at `None`. When `None` + a non-noop filter is set,
+    /// [`should_skip_candidate`] returns conservative-skip (same
+    /// posture as a transport error).
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl LeaseExpiryScanner {
@@ -46,6 +58,23 @@ impl LeaseExpiryScanner {
             interval,
             failures: FailureTracker::new(),
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: like [`Self::with_filter`] but wires the
+    /// `EngineBackend` through for trait-routed FCALLs +
+    /// filter-resolution reads.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            failures: FailureTracker::new(),
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -121,27 +150,50 @@ impl Scanner for LeaseExpiryScanner {
             if self.failures.should_skip(eid_str) {
                 continue;
             }
-            if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+            if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str)
+                .await
+            {
                 continue;
             }
 
-            let exec_core = format!("ff:exec:{}:{}:core", p.hash_tag(), eid_str);
-            let lease_current = format!("ff:exec:{}:{}:lease:current", p.hash_tag(), eid_str);
-            let lease_history = format!("ff:exec:{}:{}:lease:history", p.hash_tag(), eid_str);
-
-            let keys: [&str; 4] = [
-                &exec_core,
-                &lease_current,
-                &lease_expiry_key,
-                &lease_history,
-            ];
-
-            match client.fcall::<ferriskey::Value>(
-                "ff_mark_lease_expired_if_due",
-                &keys,
-                &[eid_str.as_str()],
-            ).await {
-                Ok(_) => {
+            let res = if let Some(ref backend) = self.backend {
+                // PR-7b Cluster 1: trait-routed FCALL. The Valkey
+                // impl wraps `ff_mark_lease_expired_if_due` with
+                // identical KEYS + ARGV; Postgres runs a single-row
+                // tx via `reconcilers::lease_expiry::release_for_execution`.
+                let Ok(eid) = ExecutionId::parse(eid_str) else { tracing::warn!(execution_id=%eid_str, "malformed eid; skipping"); continue; };
+                backend
+                    .mark_lease_expired_if_due(p, &eid)
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                // Test-only fallback: direct FCALL on the supplied
+                // client. Preserves the pre-trait-routing path for
+                // unit tests that construct the scanner without a
+                // backend.
+                let exec_core = format!("ff:exec:{}:{}:core", p.hash_tag(), eid_str);
+                let lease_current =
+                    format!("ff:exec:{}:{}:lease:current", p.hash_tag(), eid_str);
+                let lease_history =
+                    format!("ff:exec:{}:{}:lease:history", p.hash_tag(), eid_str);
+                let keys: [&str; 4] = [
+                    &exec_core,
+                    &lease_current,
+                    &lease_expiry_key,
+                    &lease_history,
+                ];
+                client
+                    .fcall::<ferriskey::Value>(
+                        "ff_mark_lease_expired_if_due",
+                        &keys,
+                        &[eid_str.as_str()],
+                    )
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            };
+            match res {
+                Ok(()) => {
                     self.failures.record_success(eid_str);
                     processed += 1;
                 }
@@ -150,7 +202,7 @@ impl Scanner for LeaseExpiryScanner {
                         partition,
                         execution_id = eid_str.as_str(),
                         error = %e,
-                        "lease_expiry: ff_mark_lease_expired_if_due failed"
+                        "lease_expiry: mark_lease_expired_if_due failed"
                     );
                     self.failures.record_failure(eid_str, "lease_expiry");
                     errors += 1;

--- a/crates/ff-engine/src/scanner/mod.rs
+++ b/crates/ff-engine/src/scanner/mod.rs
@@ -244,12 +244,12 @@ pub async fn should_skip_candidate(
     };
 
     if let Some(ref want_ns) = filter.namespace {
-        match backend.describe_execution(&exec_id).await {
-            // describe_execution is heavier than a single HGET (reads
-            // the full ExecutionSnapshot) but the cost is acceptable
-            // at scanner cadence — a few-hundred candidates/cycle,
-            // short-circuits on first miss.
-            Ok(Some(snap)) if &snap.namespace == want_ns => {}
+        // Dedicated point-read — preserves the 1-HGET cost contract
+        // documented above. `describe_execution` would be an N-field
+        // HGETALL / full-snapshot read and is the wrong tool when only
+        // the namespace scalar is needed.
+        match backend.get_execution_namespace(&exec_id).await {
+            Ok(Some(ref got)) if got == want_ns.as_str() => {}
             _ => return true,
         }
     }
@@ -391,3 +391,4 @@ impl ScannerRunner {
         })
     }
 }
+

--- a/crates/ff-engine/src/scanner/mod.rs
+++ b/crates/ff-engine/src/scanner/mod.rs
@@ -30,8 +30,8 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
-use ff_core::partition::{Partition, PartitionFamily};
-use ff_core::types::Namespace;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::types::ExecutionId;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
@@ -220,48 +220,42 @@ pub trait Scanner: Send + Sync + 'static {
 /// worse than the scanner temporarily underclaiming — the next cycle
 /// picks it back up once the backend recovers.
 pub async fn should_skip_candidate(
-    client: &ferriskey::Client,
+    backend: Option<&Arc<dyn EngineBackend>>,
     filter: &ScannerFilter,
-    partition: u16,
+    _partition: u16,
     eid: &str,
 ) -> bool {
     if filter.is_noop() {
         return false;
     }
-    let p = Partition {
-        family: PartitionFamily::Execution,
-        index: partition,
+    // With a non-noop filter but no backend plumbed, skip
+    // conservatively — same posture as a transport error. The
+    // in-tree engine path (`Engine::start_internal`) always plumbs a
+    // backend; `None` only reaches here from test-only scanner
+    // constructors that use `ScannerFilter::default()` (noop), so
+    // the first branch above already short-circuits.
+    let Some(backend) = backend else {
+        return true;
     };
-    let tag = p.hash_tag();
+    let Ok(exec_id) = ExecutionId::parse(eid) else {
+        // Malformed eid → skip conservatively (matches pre-PR-7b
+        // posture: anything we can't validate gets filtered out).
+        return true;
+    };
 
     if let Some(ref want_ns) = filter.namespace {
-        let core_key = format!("ff:exec:{}:{}:core", tag, eid);
-        match client
-            .cmd("HGET")
-            .arg(&core_key)
-            .arg("namespace")
-            .execute::<Option<String>>()
-            .await
-        {
-            Ok(Some(s)) => {
-                if &Namespace::new(s) != want_ns {
-                    return true;
-                }
-            }
-            // nil or transport error — skip conservatively.
+        match backend.describe_execution(&exec_id).await {
+            // describe_execution is heavier than a single HGET (reads
+            // the full ExecutionSnapshot) but the cost is acceptable
+            // at scanner cadence — a few-hundred candidates/cycle,
+            // short-circuits on first miss.
+            Ok(Some(snap)) if &snap.namespace == want_ns => {}
             _ => return true,
         }
     }
 
     if let Some((ref tag_key, ref want_value)) = filter.instance_tag {
-        let tags_key = format!("ff:exec:{}:{}:tags", tag, eid);
-        match client
-            .cmd("HGET")
-            .arg(&tags_key)
-            .arg(tag_key.as_str())
-            .execute::<Option<String>>()
-            .await
-        {
+        match backend.get_execution_tag(&exec_id, tag_key.as_str()).await {
             Ok(Some(v)) if &v == want_value => {}
             _ => return true,
         }

--- a/crates/ff-engine/src/scanner/pending_wp_expiry.rs
+++ b/crates/ff-engine/src/scanner/pending_wp_expiry.rs
@@ -6,11 +6,14 @@
 //!
 //! Reference: RFC-004 §Pending waitpoint expiry scanner, RFC-010 §6.3
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::types::{ExecutionId, TimestampMs};
 
 use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
@@ -20,6 +23,8 @@ pub struct PendingWaitpointExpiryScanner {
     interval: Duration,
     failures: FailureTracker,
     filter: ScannerFilter,
+    /// PR-7b Cluster 1: trait-dispatch target.
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl PendingWaitpointExpiryScanner {
@@ -36,6 +41,21 @@ impl PendingWaitpointExpiryScanner {
             interval,
             failures: FailureTracker::new(),
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for trait-routed FCALLs.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            failures: FailureTracker::new(),
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -129,12 +149,38 @@ impl Scanner for PendingWaitpointExpiryScanner {
                     }
                 };
                 let Some(eid) = eid else { continue };
-                if should_skip_candidate(client, &self.filter, partition, &eid).await {
+                if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, &eid).await {
                     continue;
                 }
             }
 
-            match close_expired_waitpoint(client, &tag, &idx, wp_id_str).await {
+            let res = if let Some(ref backend) = self.backend {
+                // Resolve owning execution_id from the waitpoint hash
+                // — the trait takes both (exec_id, wp_id) so the
+                // Valkey impl doesn't re-read it. If the hash is
+                // missing/resolve fails we still attempt the call
+                // with an empty exec_id (the Lua cleanup path no-ops
+                // on missing exec_core).
+                let eid_str: String = client
+                    .cmd("HGET")
+                    .arg(format!("ff:wp:{}:{}", tag, wp_id_str).as_str())
+                    .arg("execution_id")
+                    .execute::<Option<String>>()
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default();
+                let Ok(eid) = ExecutionId::parse(&eid_str) else { tracing::warn!(execution_id=%eid_str, "malformed eid; skipping"); continue; };
+                backend
+                    .close_waitpoint(p, &eid, wp_id_str, TimestampMs(now_ms as i64))
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                close_expired_waitpoint(client, &tag, &idx, wp_id_str)
+                    .await
+                    .map_err(|e| e.to_string())
+            };
+            match res {
                 Ok(()) => {
                     self.failures.record_success(wp_id_str);
                     processed += 1;
@@ -144,7 +190,7 @@ impl Scanner for PendingWaitpointExpiryScanner {
                         partition,
                         waitpoint_id = wp_id_str.as_str(),
                         error = %e,
-                        "pending_wp_expiry: ff_close_waitpoint failed"
+                        "pending_wp_expiry: close_waitpoint failed"
                     );
                     self.failures.record_failure(wp_id_str, "pending_wp_expiry");
                     errors += 1;

--- a/crates/ff-engine/src/scanner/retention_trimmer.rs
+++ b/crates/ff-engine/src/scanner/retention_trimmer.rs
@@ -11,9 +11,11 @@
 //!
 //! Reference: RFC-010 §6.12
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::types::LaneId;
@@ -31,6 +33,7 @@ pub struct RetentionTrimmer {
     /// Default retention period in ms (used when execution has no policy).
     default_retention_ms: u64,
     filter: ScannerFilter,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl RetentionTrimmer {
@@ -46,6 +49,24 @@ impl RetentionTrimmer {
             lanes,
             default_retention_ms: DEFAULT_RETENTION_MS,
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for filter-resolution
+    /// reads via `should_skip_candidate`.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        lanes: Vec<LaneId>,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            lanes,
+            default_retention_ms: DEFAULT_RETENTION_MS,
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -120,7 +141,7 @@ impl Scanner for RetentionTrimmer {
             }
 
             for eid_str in &expired {
-                if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+                if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str).await {
                     continue;
                 }
                 match purge_execution(

--- a/crates/ff-engine/src/scanner/suspension_timeout.rs
+++ b/crates/ff-engine/src/scanner/suspension_timeout.rs
@@ -7,11 +7,14 @@
 //!
 //! Reference: RFC-004 §Timeout scanner, RFC-010 §6.2
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::types::{ExecutionId, TimestampMs};
 
 use super::{should_skip_candidate, FailureTracker, ScanResult, Scanner};
 
@@ -32,6 +35,7 @@ pub struct SuspensionTimeoutScanner {
     interval: Duration,
     failures: FailureTracker,
     filter: ScannerFilter,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl SuspensionTimeoutScanner {
@@ -46,6 +50,21 @@ impl SuspensionTimeoutScanner {
             interval,
             failures: FailureTracker::new(),
             filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for trait-routed FCALLs.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            failures: FailureTracker::new(),
+            filter,
+            backend: Some(backend),
         }
     }
 }
@@ -118,11 +137,22 @@ impl Scanner for SuspensionTimeoutScanner {
             if self.failures.should_skip(eid_str) {
                 continue;
             }
-            if should_skip_candidate(client, &self.filter, partition, eid_str).await {
+            if should_skip_candidate(self.backend.as_ref(), &self.filter, partition, eid_str).await {
                 continue;
             }
 
-            match expire_suspension(client, &tag, &idx, eid_str).await {
+            let res = if let Some(ref backend) = self.backend {
+                let Ok(eid) = ExecutionId::parse(eid_str) else { tracing::warn!(execution_id=%eid_str, "malformed eid; skipping"); continue; };
+                backend
+                    .expire_suspension(p, &eid, TimestampMs(now_ms as i64))
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                expire_suspension(client, &tag, &idx, eid_str)
+                    .await
+                    .map_err(|e| e.to_string())
+            };
+            match res {
                 Ok(()) => {
                     self.failures.record_success(eid_str);
                     processed += 1;
@@ -132,7 +162,7 @@ impl Scanner for SuspensionTimeoutScanner {
                         partition,
                         execution_id = eid_str.as_str(),
                         error = %e,
-                        "suspension_timeout: ff_expire_suspension failed"
+                        "suspension_timeout: expire_suspension failed"
                     );
                     self.failures.record_failure(eid_str, "suspension_timeout");
                     errors += 1;

--- a/crates/ff-engine/src/scanner/unblock.rs
+++ b/crates/ff-engine/src/scanner/unblock.rs
@@ -29,6 +29,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::Mutex as AsyncMutex;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, budget_partition};
 use ff_core::types::{BudgetId, LaneId};
@@ -69,6 +70,7 @@ pub struct UnblockScanner {
     /// cadence (one partition at a time per scanner task), so the mutex
     /// is effectively uncontended in steady state.
     caps_cache: Arc<AsyncMutex<CapsUnionCache>>,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 /// Worker-caps union snapshot with a monotonic freshness timestamp.
@@ -103,6 +105,30 @@ impl UnblockScanner {
                 fetched_at: None,
                 ttl: interval,
             })),
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 1: wire an `EngineBackend` for filter-resolution
+    /// reads. FCALL routing is cluster 2 scope.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        lanes: Vec<LaneId>,
+        partition_config: PartitionConfig,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            lanes,
+            partition_config,
+            filter,
+            caps_cache: Arc::new(AsyncMutex::new(CapsUnionCache {
+                snapshot: None,
+                fetched_at: None,
+                ttl: interval,
+            })),
+            backend: Some(backend),
         }
     }
 }
@@ -151,7 +177,7 @@ impl Scanner for UnblockScanner {
             // Scan blocked:budget
             let budget_key = idx.lane_blocked_budget(lane);
             let r = scan_blocked_set(
-                client, &p, &idx, lane, &budget_key,
+                client, self.backend.as_ref(), &p, &idx, lane, &budget_key,
                 "waiting_for_budget", &mut budget_cache,
                 &caps_cache,
                 &self.partition_config,
@@ -163,7 +189,7 @@ impl Scanner for UnblockScanner {
             // Scan blocked:quota
             let quota_key = idx.lane_blocked_quota(lane);
             let r = scan_blocked_set(
-                client, &p, &idx, lane, &quota_key,
+                client, self.backend.as_ref(), &p, &idx, lane, &quota_key,
                 "waiting_for_quota", &mut budget_cache,
                 &caps_cache,
                 &self.partition_config,
@@ -177,7 +203,7 @@ impl Scanner for UnblockScanner {
             // checks subset coverage. See check_route_cleared below.
             let route_key = idx.lane_blocked_route(lane);
             let r = scan_blocked_set(
-                client, &p, &idx, lane, &route_key,
+                client, self.backend.as_ref(), &p, &idx, lane, &route_key,
                 "waiting_for_capable_worker", &mut budget_cache,
                 &caps_cache,
                 &self.partition_config,
@@ -198,6 +224,7 @@ impl Scanner for UnblockScanner {
 #[allow(clippy::too_many_arguments)]
 async fn scan_blocked_set(
     client: &ferriskey::Client,
+    backend: Option<&Arc<dyn EngineBackend>>,
     partition: &Partition,
     idx: &IndexKeys,
     lane: &LaneId,
@@ -240,7 +267,7 @@ async fn scan_blocked_set(
     let tag = partition.hash_tag();
 
     for eid_str in &blocked {
-        if should_skip_candidate(client, filter, partition.index, eid_str).await {
+        if should_skip_candidate(backend, filter, partition.index, eid_str).await {
             continue;
         }
         // Read blocking_reason from exec_core to confirm still blocked

--- a/crates/ff-engine/tests/scanner_namespace_point_read.rs
+++ b/crates/ff-engine/tests/scanner_namespace_point_read.rs
@@ -1,0 +1,294 @@
+//! Regression guard for the scanner per-candidate filter cost
+//! contract (issue #122 / PR #443 Issue-2 fix).
+//!
+//! `scanner::should_skip_candidate` must route the namespace check
+//! through `EngineBackend::get_execution_namespace` — a single-field
+//! point read — **not** `describe_execution`, which issues an
+//! N-field HGETALL / full-snapshot read on every backend.
+//!
+//! This test exercises the helper against a mock `EngineBackend`
+//! that:
+//!
+//! * Implements `get_execution_namespace` (returns a scripted value).
+//! * Implements every **other** required trait method as a `todo!()`
+//!   or `EngineError::Unavailable { ... }` stub (the trait has
+//!   required-without-default methods that any `impl` must provide).
+//! * Inherits the **default** `Err(Unavailable)` body for every
+//!   default-provided method — including `describe_execution`. If
+//!   `should_skip_candidate` ever regresses to calling
+//!   `describe_execution` for the namespace check, that default body
+//!   fires, the filter rejects conservatively, and the
+//!   "matching-namespace passes" assertion below fails.
+//!
+//! The trait-surface stub is bulky but mechanical; it's the price of
+//! having a pure-Rust regression guard that doesn't need a live
+//! Valkey. The `ff-test/scanner_filter_isolation` integration test
+//! remains the end-to-end cover.
+
+#![allow(clippy::too_many_arguments)]
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ff_core::backend::{
+    AppendFrameOutcome, CancelFlowPolicy, CancelFlowWait, CapabilitySet, ClaimPolicy, FailOutcome,
+    FailureClass, FailureReason, Frame, Handle, LeaseRenewal, PendingWaitpoint, ResumeSignal,
+    ResumeToken, ScannerFilter, SummaryDocument, SuspendArgs, SuspendOutcome, TailVisibility,
+    UsageDimensions,
+};
+use ff_core::contracts::{
+    CancelFlowResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult, DeliverSignalArgs,
+    DeliverSignalResult, EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot, ExecutionContext,
+    ExecutionSnapshot, FlowSnapshot, ListExecutionsPage, ListFlowsPage, ListLanesPage,
+    ListSuspendedPage, ReportUsageResult, RotateWaitpointHmacSecretAllArgs,
+    RotateWaitpointHmacSecretAllResult, SetEdgeGroupPolicyResult, StreamCursor, StreamFrames,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::EngineError;
+use ff_core::partition::PartitionKey;
+use ff_core::types::{
+    AttemptIndex, BudgetId, EdgeId, ExecutionId, FlowId, LaneId, Namespace, SignalId, TimestampMs,
+    WaitpointId,
+};
+use ff_engine::scanner::should_skip_candidate;
+
+fn unavailable(op: &'static str) -> EngineError {
+    EngineError::Unavailable { op }
+}
+
+/// Mock that only implements `get_execution_namespace`. Everything
+/// else returns `Unavailable`; the default trait body for
+/// `describe_execution` also returns `Unavailable`.
+#[derive(Default)]
+struct NamespaceOnlyBackend {
+    stored_namespace: Option<String>,
+    get_ns_calls: AtomicU32,
+}
+
+#[async_trait]
+impl EngineBackend for NamespaceOnlyBackend {
+    async fn get_execution_namespace(
+        &self,
+        _execution_id: &ExecutionId,
+    ) -> Result<Option<String>, EngineError> {
+        self.get_ns_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(self.stored_namespace.clone())
+    }
+
+    // ─── Required (no default) methods — all stub Unavailable ───
+
+    async fn claim(
+        &self,
+        _lane: &LaneId,
+        _capabilities: &CapabilitySet,
+        _policy: ClaimPolicy,
+    ) -> Result<Option<Handle>, EngineError> {
+        Err(unavailable("mock::claim"))
+    }
+    async fn renew(&self, _handle: &Handle) -> Result<LeaseRenewal, EngineError> {
+        Err(unavailable("mock::renew"))
+    }
+    async fn progress(
+        &self,
+        _handle: &Handle,
+        _percent: Option<u8>,
+        _message: Option<String>,
+    ) -> Result<(), EngineError> {
+        Err(unavailable("mock::progress"))
+    }
+    async fn append_frame(
+        &self,
+        _handle: &Handle,
+        _frame: Frame,
+    ) -> Result<AppendFrameOutcome, EngineError> {
+        Err(unavailable("mock::append_frame"))
+    }
+    async fn complete(
+        &self,
+        _handle: &Handle,
+        _payload: Option<Vec<u8>>,
+    ) -> Result<(), EngineError> {
+        Err(unavailable("mock::complete"))
+    }
+    async fn fail(
+        &self,
+        _handle: &Handle,
+        _reason: FailureReason,
+        _classification: FailureClass,
+    ) -> Result<FailOutcome, EngineError> {
+        Err(unavailable("mock::fail"))
+    }
+    async fn cancel(&self, _handle: &Handle, _reason: &str) -> Result<(), EngineError> {
+        Err(unavailable("mock::cancel"))
+    }
+    async fn suspend(
+        &self,
+        _handle: &Handle,
+        _args: SuspendArgs,
+    ) -> Result<SuspendOutcome, EngineError> {
+        Err(unavailable("mock::suspend"))
+    }
+    async fn create_waitpoint(
+        &self,
+        _handle: &Handle,
+        _waitpoint_key: &str,
+        _expires_in: Duration,
+    ) -> Result<PendingWaitpoint, EngineError> {
+        Err(unavailable("mock::create_waitpoint"))
+    }
+    async fn observe_signals(
+        &self,
+        _handle: &Handle,
+    ) -> Result<Vec<ResumeSignal>, EngineError> {
+        Err(unavailable("mock::observe_signals"))
+    }
+    async fn claim_from_resume_grant(
+        &self,
+        _token: ResumeToken,
+    ) -> Result<Option<Handle>, EngineError> {
+        Err(unavailable("mock::claim_from_resume_grant"))
+    }
+    async fn delay(
+        &self,
+        _handle: &Handle,
+        _delay_until: TimestampMs,
+    ) -> Result<(), EngineError> {
+        Err(unavailable("mock::delay"))
+    }
+    async fn wait_children(&self, _handle: &Handle) -> Result<(), EngineError> {
+        Err(unavailable("mock::wait_children"))
+    }
+    async fn describe_execution(
+        &self,
+        _id: &ExecutionId,
+    ) -> Result<Option<ExecutionSnapshot>, EngineError> {
+        // Intentionally Unavailable — the point of this test is to
+        // prove should_skip_candidate does not take this path for
+        // the namespace check.
+        Err(unavailable("mock::describe_execution"))
+    }
+    async fn read_execution_context(
+        &self,
+        _execution_id: &ExecutionId,
+    ) -> Result<ExecutionContext, EngineError> {
+        Err(unavailable("mock::read_execution_context"))
+    }
+    async fn describe_flow(&self, _id: &FlowId) -> Result<Option<FlowSnapshot>, EngineError> {
+        Err(unavailable("mock::describe_flow"))
+    }
+    async fn cancel_flow(
+        &self,
+        _id: &FlowId,
+        _policy: CancelFlowPolicy,
+        _wait: CancelFlowWait,
+    ) -> Result<CancelFlowResult, EngineError> {
+        Err(unavailable("mock::cancel_flow"))
+    }
+    async fn report_usage(
+        &self,
+        _handle: &Handle,
+        _budget: &BudgetId,
+        _dimensions: UsageDimensions,
+    ) -> Result<ReportUsageResult, EngineError> {
+        Err(unavailable("mock::report_usage"))
+    }
+}
+
+fn test_eid_string() -> String {
+    // Any valid `{fp:N}:<uuid>` string; the mock ignores it.
+    "{fp:0}:00000000-0000-0000-0000-000000000001".to_owned()
+}
+
+#[tokio::test]
+async fn namespace_filter_passes_on_match_via_point_read() {
+    let mock = Arc::new(NamespaceOnlyBackend {
+        stored_namespace: Some("alpha".to_owned()),
+        ..Default::default()
+    });
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let filter = ScannerFilter::new().with_namespace(Namespace::new("alpha"));
+
+    let skip = should_skip_candidate(Some(&backend), &filter, 0, &test_eid_string()).await;
+    assert!(!skip, "matching-namespace candidate must pass the filter");
+    assert_eq!(
+        mock.get_ns_calls.load(Ordering::Relaxed),
+        1,
+        "exactly one get_execution_namespace call (1-point-read contract)",
+    );
+}
+
+#[tokio::test]
+async fn namespace_filter_rejects_on_mismatch() {
+    let mock = Arc::new(NamespaceOnlyBackend {
+        stored_namespace: Some("beta".to_owned()),
+        ..Default::default()
+    });
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let filter = ScannerFilter::new().with_namespace(Namespace::new("alpha"));
+
+    let skip = should_skip_candidate(Some(&backend), &filter, 0, &test_eid_string()).await;
+    assert!(skip, "mismatched-namespace candidate must be skipped");
+}
+
+#[tokio::test]
+async fn namespace_filter_rejects_on_missing_row() {
+    let mock = Arc::new(NamespaceOnlyBackend {
+        stored_namespace: None,
+        ..Default::default()
+    });
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let filter = ScannerFilter::new().with_namespace(Namespace::new("alpha"));
+
+    let skip = should_skip_candidate(Some(&backend), &filter, 0, &test_eid_string()).await;
+    assert!(skip, "absent-row candidate must be skipped conservatively");
+}
+
+#[tokio::test]
+async fn noop_filter_skips_backend_entirely() {
+    let mock = Arc::new(NamespaceOnlyBackend::default());
+    let backend: Arc<dyn EngineBackend> = mock.clone();
+    let filter = ScannerFilter::new();
+
+    let skip = should_skip_candidate(Some(&backend), &filter, 0, &test_eid_string()).await;
+    assert!(!skip, "noop filter must pass without touching the backend");
+    assert_eq!(
+        mock.get_ns_calls.load(Ordering::Relaxed),
+        0,
+        "noop filter must not invoke get_execution_namespace",
+    );
+}
+
+// Silence unused-import lints on the big surface list — the stub
+// impls above reference every import, but the compiler counts them
+// per-attribute.
+#[allow(dead_code)]
+fn _unused_refs(
+    _: ListExecutionsPage,
+    _: ListFlowsPage,
+    _: ListLanesPage,
+    _: ListSuspendedPage,
+    _: DeliverSignalArgs,
+    _: DeliverSignalResult,
+    _: ClaimResumedExecutionArgs,
+    _: ClaimResumedExecutionResult,
+    _: EdgeDependencyPolicy,
+    _: EdgeDirection,
+    _: EdgeSnapshot,
+    _: SetEdgeGroupPolicyResult,
+    _: RotateWaitpointHmacSecretAllArgs,
+    _: RotateWaitpointHmacSecretAllResult,
+    _: StreamCursor,
+    _: StreamFrames,
+    _: SummaryDocument,
+    _: TailVisibility,
+    _: AttemptIndex,
+    _: EdgeId,
+    _: SignalId,
+    _: WaitpointId,
+    _: PartitionKey,
+) {
+}

--- a/crates/ff-test/tests/scanner_filter_isolation.rs
+++ b/crates/ff-test/tests/scanner_filter_isolation.rs
@@ -98,6 +98,11 @@ fn full_eid(bare_uuid: &str) -> String {
 #[tokio::test]
 async fn scanner_namespace_filter_isolates_candidates() {
     let client = build_client().await;
+    // PR-7b Cluster 1: `should_skip_candidate` now dispatches through
+    // `EngineBackend` (via `describe_execution` / `get_execution_tag`),
+    // not raw `ferriskey::Client` HGETs.
+    let be: std::sync::Arc<dyn ff_core::engine_backend::EngineBackend> =
+        backend().await;
 
     // Full execution-id strings matching production shape.
     let alpha_eid = full_eid("11111111-1111-1111-1111-111111111111");
@@ -130,26 +135,26 @@ async fn scanner_namespace_filter_isolates_candidates() {
 
     // Each filter must admit its own candidate and reject the other.
     assert!(
-        !should_skip_candidate(&client, &alpha_filter, PARTITION, &alpha_eid).await,
+        !should_skip_candidate(Some(&be), &alpha_filter, PARTITION, &alpha_eid).await,
         "alpha filter must admit alpha candidate"
     );
     assert!(
-        should_skip_candidate(&client, &alpha_filter, PARTITION, &beta_eid).await,
+        should_skip_candidate(Some(&be), &alpha_filter, PARTITION, &beta_eid).await,
         "alpha filter must reject beta candidate"
     );
     assert!(
-        !should_skip_candidate(&client, &beta_filter, PARTITION, &beta_eid).await,
+        !should_skip_candidate(Some(&be), &beta_filter, PARTITION, &beta_eid).await,
         "beta filter must admit beta candidate"
     );
     assert!(
-        should_skip_candidate(&client, &beta_filter, PARTITION, &alpha_eid).await,
+        should_skip_candidate(Some(&be), &beta_filter, PARTITION, &alpha_eid).await,
         "beta filter must reject alpha candidate"
     );
 
     // A no-op filter admits both — confirms the short-circuit path.
     let noop = ScannerFilter::default();
-    assert!(!should_skip_candidate(&client, &noop, PARTITION, &alpha_eid).await);
-    assert!(!should_skip_candidate(&client, &noop, PARTITION, &beta_eid).await);
+    assert!(!should_skip_candidate(Some(&be), &noop, PARTITION, &alpha_eid).await);
+    assert!(!should_skip_candidate(Some(&be), &noop, PARTITION, &beta_eid).await);
 
     // Cleanup.
     let _: i64 = client

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -478,3 +478,25 @@ the trait defaults in `crates/ff-core/src/engine_backend.rs`.
 Consumer-facing limitations for this surface live in
 [`CONSUMER_MIGRATION_0.12.md`](CONSUMER_MIGRATION_0.12.md) §Known
 limitations.
+
+### PR-7b Cluster 1 — Foundation scanner operations (cairn #436)
+
+Per-execution write hooks invoked by the engine scanner loop. Each
+method is per-row tx on Postgres, mirroring the Valkey `FCALL`
+semantic. SQLite hosts its own reconciler supervisor (RFC-023
+Phase 3.5 §4.1) and inherits the trait default — these hooks are
+never invoked under SQLite's N=1 topology.
+
+| Method | Valkey | Postgres | SQLite | Notes |
+|---|---|---|---|---|
+| `mark_lease_expired_if_due` | `impl` | `impl` | `Unavailable` (default, intentional) | Valkey: `FCALL ff_mark_lease_expired_if_due`. Postgres: `reconcilers::lease_expiry::release_for_execution` (per-row tx on `ff_attempt` + `ff_exec_core`). |
+| `promote_delayed` | `impl` | `impl` | `Unavailable` (default, intentional) | Valkey: `FCALL ff_promote_delayed`. Postgres: `reconcilers::delayed_promoter::promote_for_execution` — re-checks `(lifecycle_phase='runnable', eligibility_state='not_eligible_until_time', deadline_at_ms <= now)` and flips `eligibility_state → 'eligible_now'` + clears `deadline_at_ms` under `FOR UPDATE`. `deadline_at_ms` is overloaded with the `execution_deadline` scanner on Postgres; the `(lifecycle_phase, eligibility_state)` tuple disambiguates. A dedicated `delay_until_ms` column is a post-v0.12 additive cleanup. |
+| `close_waitpoint` | `impl` | `impl` | `Unavailable` (default, intentional) | Valkey: `FCALL ff_close_waitpoint` (ARGV `[waitpoint_id, "never_committed"]`). Postgres: `reconcilers::pending_wp_expiry::close_for_execution` — DELETE on `ff_waitpoint_pending` + append `{"status":"never_committed",...}` marker into `ff_suspension_current.member_map[waitpoint_key]` so the composite-condition evaluator sees the failure at resume time. |
+| `expire_execution` (`AttemptTimeout`) | `impl` | `impl` | `Unavailable` (default, intentional) | Valkey: `FCALL ff_expire_execution` (ARGV `[eid, "attempt_timeout"]`). Postgres: `reconcilers::attempt_timeout::expire_for_execution` — per-row tx terminates or retries per `policy.retry_policy.max_retries` + emits `ff_completion_event` on terminal + `ff_lease_event` outbox. |
+| `expire_execution` (`ExecutionDeadline`) | `impl` | `impl` | `Unavailable` (default, intentional) | Valkey: `FCALL ff_expire_execution` (ARGV `[eid, "execution_deadline"]`). Postgres: `reconcilers::execution_deadline::expire_for_execution` — per-row tx flips `ff_exec_core.lifecycle_phase='terminal'` with `last_failure_message='execution_deadline'` + clears active attempt lease + emits `ff_completion_event{outcome='expired'}` + `ff_lease_event` outbox. Candidate selection scopes by `lifecycle_phase='active'` to disambiguate from `promote_delayed`'s `deadline_at_ms` overload. |
+| `expire_suspension` | `impl` | `impl` | `Unavailable` (default, intentional) | Valkey: `FCALL ff_expire_suspension`. Postgres: `reconcilers::suspension_timeout::expire_for_execution` — per-row tx honors `TimeoutBehavior` (Fail/Cancel/Expire/Escalate → terminal; AutoResumeWithTimeoutSignal → synthetic signal in `member_map[__timeout__]`). |
+
+All five foundation-scanner ops land real SQL on Postgres as of
+PR-7b Cluster 1 + Wave-9-minimal (this row). Consumer deployments
+switching from Valkey to Postgres no longer see `Unavailable` for
+scanner-op writes.


### PR DESCRIPTION
## Summary

PR-7b Cluster 1 of the 5-PR tranche delivering cairn #436 (engine-side removal of the Valkey-only `downcast::<ValkeyBackend>` panic). Lands the foundation: 5 new `EngineBackend` trait methods + `ExpirePhase` enum, wires Valkey thin-wrapper impls, real Postgres per-row SQL where the reconciler schema is already landed, and migrates `scanner::should_skip_candidate` to `EngineBackend` dispatch. **Unblocks Clusters 2 + 3 to land in parallel.**

Per briefs [`/tmp/pr-7b-cluster-1.md`](/tmp/pr-7b-cluster-1.md) + [`/tmp/pr-7b-coordination.md`](/tmp/pr-7b-coordination.md).

## What changed

### `ff-core::engine_backend` — 5 new trait methods + `ExpirePhase` enum

Per-execution scanner-op write hooks, all with a default body of `EngineError::Unavailable { op }` so out-of-tree backends keep compiling:

| Method | Scanner |
|---|---|
| `mark_lease_expired_if_due(partition, execution_id)` | lease_expiry |
| `promote_delayed(partition, lane, execution_id, now_ms)` | delayed_promoter |
| `close_waitpoint(partition, execution_id, waitpoint_id, now_ms)` | pending_wp_expiry |
| `expire_execution(partition, execution_id, phase: ExpirePhase, now_ms)` | attempt_timeout + execution_deadline (shared) |
| `expire_suspension(partition, execution_id, now_ms)` | suspension_timeout |

`ExpirePhase { AttemptTimeout, ExecutionDeadline }` discriminates the two callers of `expire_execution` so Lua/SQL can preserve diagnostic breadcrumbs.

### Valkey impl — 5 thin FCALL wrappers

The per-candidate key-formatting + pre-read logic previously inlined in scanner bodies moves onto `ValkeyBackend`. Same KEYS/ARGV as before; no semantic change.

### Postgres impl — real SQL for 3 of 5, defaulted for 2

Owner override (`No Unavailable PG/SQLite stubs for scanner operations`) honored where the Wave 6c reconciler schema + per-row logic already exists:

- `mark_lease_expired_if_due` → `reconcilers::lease_expiry::release_for_execution` (new `pub` per-row helper extracted from existing `scan_tick` path).
- `expire_execution(AttemptTimeout)` → `reconcilers::attempt_timeout::expire_for_execution` (ditto).
- `expire_suspension` → `reconcilers::suspension_timeout::expire_for_execution` (ditto).

`promote_delayed`, `close_waitpoint`, and `expire_execution(ExecutionDeadline)` remain at the trait-default `EngineError::Unavailable` — RFC-020 Wave 9 schema scope (see coordination doc §"RFC-scale finding"). They're explicitly marked Unavailable with the Wave-9 follow-up reference in-line.

### SQLite impl — defaulted

Per [RFC-023 Phase 3.5 §4.1](https://github.com/avifenesh/flowfabric-archive) SQLite hosts its own reconciler supervisor (`scanner_supervisor.rs`), not the engine's scanner loop. Per-execution scanner-op trait methods stay at the `EngineError::Unavailable` default for SQLite — they'd never be invoked under SQLite's N=1 single-writer topology.

### Engine — backend plumbing + trait routing

- `scanner::should_skip_candidate(backend, filter, partition, eid)` — signature changed to take `Option<&Arc<dyn EngineBackend>>`. Routes through `backend.describe_execution(&eid).namespace` + `backend.get_execution_tag(&eid, key)` (both landed pre-PR-7b).
- All 11 scanners that call `should_skip_candidate` grew a `backend: Option<Arc<dyn EngineBackend>>` field + a `with_filter_and_backend(..)` constructor. Pre-existing `new(..)` / `with_filter(..)` constructors keep compiling (set `backend: None`) so existing tests don't break; with a non-noop filter + `backend: None` the helper conservatively skips (same posture as a transport error).
- The 6 Cluster-1 scanner bodies route their operation FCALL through the trait when a backend is wired (`if let Some(ref backend) = self.backend { backend.mark_lease_expired_if_due(...).await } else { client.fcall(...).await }`). The direct-client fallback preserves the pre-PR-7b code path for test-only scanner constructors.
- `Engine::start_internal` uses `with_filter_and_backend` for all 11 scanners, plumbing `backend: Arc<dyn EngineBackend>` through. The Scanner trait signature change (drop `client: &ferriskey::Client`) is deferred to PR-7b/final per the 4-cluster coordination plan.

### Zero `Unavailable` stubs for PG scanner ops we can do; explicit defers for the 3 we can't

Per owner directive — 3 of 5 Postgres scanner-op methods run real SQL; the 2 that can't (plus the `ExecutionDeadline` variant of the shared `expire_execution`) are documented inline with Wave 9 schema-scope pointers. No silent `Unavailable`s anywhere.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace --lib` — 297 + 223 + 10 + … all lib tests pass
- [x] `cargo clippy -p ff-core -p ff-engine -p ff-backend-valkey -p ff-backend-postgres -p ff-backend-sqlite --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` — clean
- [x] `scanner_filter_isolation` integration test updated to construct a `ValkeyBackend` and drive `should_skip_candidate` through the trait — matches the owner constraint that scanner-op trait dispatch is exercised, not stubbed.

## What's next (per coordination doc)

- **Cluster 2 (reconcilers)** — `budget_reset`, `dependency_reconciler`, `unblock` — now unblocked to ship in parallel.
- **Cluster 3 (cancel-family)** — `cancel_reconciler`, `edge_cancel_{dispatcher,reconciler}` — now unblocked to ship in parallel.
- **Cluster 4 (completion-listener)** — already independent; shipping in parallel.
- **PR-7b/final** — after 1-4 merge, swaps the `Scanner` trait signature (drops `client: &ferriskey::Client`), removes `Engine::start_internal`'s `downcast_ref::<ValkeyBackend>` + panic, ships PG-backed engine integration test. Then v0.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)