### PR TITLE
feat(ff-engine+backends): PR-7b/3 cancel-family scanners trait-routed (cairn #436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **PR-7b Cluster 3: cancel-family scanners trait-routed (cairn #436).**
+  Two new `EngineBackend` trait methods plus the
+  `SiblingCancelReconcileAction` enum on
+  `ff_core::engine_backend`: `drain_sibling_cancel_group` (RFC-016
+  Stage C — atomic SREM + HDEL for a drained sibling-cancel tuple)
+  and `reconcile_sibling_cancel_group` (RFC-016 Stage D — the
+  three-way Invariant-Q6 disposition). Valkey wires both to the
+  existing `ff_drain_sibling_cancel_group` and
+  `ff_reconcile_sibling_cancel_group` FCALLs; Postgres + SQLite
+  default to `Unavailable` (PG's
+  `reconcilers::edge_cancel_{dispatcher,reconciler}::*_tick`
+  already owns the equivalent batched SQL path; the Valkey-shaped
+  per-tuple call is not a cairn-consumer surface). The three
+  cancel-family scanners — `cancel_reconciler`,
+  `edge_cancel_dispatcher`, `edge_cancel_reconciler` — now route
+  their FCALL bodies through `EngineBackend::cancel_execution` +
+  `ack_cancel_member` (verified semantic match: both existing trait
+  methods already FCALL the same Lua fns with byte-identical
+  KEYS/ARGV as the scanner internals) plus the two new
+  sibling-cancel methods. Legacy direct-FCALL paths remain as a
+  fallback for construction sites that do not supply a backend
+  (test harnesses + `EdgeCancelDispatcher::new` /
+  `EdgeCancelReconciler::new`).
 - **PR-7b Cluster 1: foundation scanner operations on `EngineBackend`
   (cairn #436).** Five new trait methods + `ExpirePhase` enum on
   `ff_core::engine_backend::EngineBackend` for the six simple-expiry

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -56,7 +56,7 @@ use ff_core::contracts::{
 use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::engine_error::{StateKind, ValidationKind};
 use ff_core::partition::PartitionKey;
-use ff_core::engine_backend::{EngineBackend, ExpirePhase};
+use ff_core::engine_backend::{EngineBackend, ExpirePhase, SiblingCancelReconcileAction};
 use ff_core::engine_error::EngineError;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
 use ff_core::partition::{PartitionConfig, execution_partition, flow_partition};
@@ -8200,6 +8200,96 @@ impl EngineBackend for ValkeyBackend {
             .await
             .map_err(transport_fk)?;
         Ok(())
+    }
+
+    /// PR-7b Cluster 3: route `edge_cancel_dispatcher::drain_group`
+    /// through the trait. Wraps `FCALL ff_drain_sibling_cancel_group`
+    /// with the same `(pending_cancel_groups, edgegroup)` KEYS and
+    /// `(flow_id, downstream_eid)` ARGV the Valkey scanner body used.
+    async fn drain_sibling_cancel_group(
+        &self,
+        flow_partition: Partition,
+        flow_id: &FlowId,
+        downstream_eid: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        let fctx = FlowKeyContext::new(&flow_partition, flow_id);
+        let fidx = FlowIndexKeys::new(&flow_partition);
+        let pending_key = fidx.pending_cancel_groups();
+        let edgegroup_key = fctx.edgegroup(downstream_eid);
+        let flow_id_str = flow_id.to_string();
+        let downstream_eid_str = downstream_eid.to_string();
+        let keys = [pending_key.as_str(), edgegroup_key.as_str()];
+        let argv = [flow_id_str.as_str(), downstream_eid_str.as_str()];
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_drain_sibling_cancel_group", &keys, &argv)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    "drain_sibling_cancel_group: FCALL ff_drain_sibling_cancel_group",
+                )
+            })?;
+        Ok(())
+    }
+
+    /// PR-7b Cluster 3: route `edge_cancel_reconciler::reconcile_one_group`
+    /// through the trait. Wraps `FCALL ff_reconcile_sibling_cancel_group`
+    /// and decodes the Lua `{1, "OK", <action>, ...}` reply shape into
+    /// the typed [`SiblingCancelReconcileAction`].
+    async fn reconcile_sibling_cancel_group(
+        &self,
+        flow_partition: Partition,
+        flow_id: &FlowId,
+        downstream_eid: &ExecutionId,
+    ) -> Result<SiblingCancelReconcileAction, EngineError> {
+        let fctx = FlowKeyContext::new(&flow_partition, flow_id);
+        let fidx = FlowIndexKeys::new(&flow_partition);
+        let pending_key = fidx.pending_cancel_groups();
+        let edgegroup_key = fctx.edgegroup(downstream_eid);
+        let flow_id_str = flow_id.to_string();
+        let downstream_eid_str = downstream_eid.to_string();
+        let keys = [pending_key.as_str(), edgegroup_key.as_str()];
+        let argv = [flow_id_str.as_str(), downstream_eid_str.as_str()];
+        let val: ferriskey::Value = self
+            .client
+            .fcall("ff_reconcile_sibling_cancel_group", &keys, &argv)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    transport_fk(e),
+                    "reconcile_sibling_cancel_group: \
+                     FCALL ff_reconcile_sibling_cancel_group",
+                )
+            })?;
+
+        // Lua shape: `{1, "OK", <action>, <detail?>}`. Extract index 2.
+        let action_str = match &val {
+            ferriskey::Value::Array(arr) => arr
+                .get(2)
+                .and_then(|r| r.as_ref().ok())
+                .and_then(|v| match v {
+                    ferriskey::Value::BulkString(b) => {
+                        Some(String::from_utf8_lossy(b).into_owned())
+                    }
+                    ferriskey::Value::SimpleString(s) => Some(s.clone()),
+                    _ => None,
+                }),
+            _ => None,
+        };
+
+        match action_str.as_deref() {
+            Some("sremmed_stale") => Ok(SiblingCancelReconcileAction::SremmedStale),
+            Some("completed_drain") => Ok(SiblingCancelReconcileAction::CompletedDrain),
+            Some("no_op") => Ok(SiblingCancelReconcileAction::NoOp),
+            _ => Err(EngineError::Transport {
+                backend: "valkey",
+                source: "reconcile_sibling_cancel_group: unparsable FCALL \
+                         reply (expected [..,..,action,..])"
+                    .to_owned()
+                    .into(),
+            }),
+        }
     }
 }
 

--- a/crates/ff-backend-valkey/tests/pr7b_sibling_cancel_group.rs
+++ b/crates/ff-backend-valkey/tests/pr7b_sibling_cancel_group.rs
@@ -1,0 +1,264 @@
+//! PR-7b Cluster 3 — direct trait integration for
+//! `EngineBackend::drain_sibling_cancel_group` +
+//! `EngineBackend::reconcile_sibling_cancel_group` on Valkey.
+//!
+//! These tests complement the full-server RFC-016 Stage D scenarios in
+//! `ff-test::flow_edge_policies_stage_d` by exercising the new trait
+//! methods (PR-7b/3) against a live Valkey without a running engine.
+//! Keeps the trait shim honest against the underlying
+//! `ff_drain_sibling_cancel_group` / `ff_reconcile_sibling_cancel_group`
+//! Lua functions.
+//!
+//! Gated `#[ignore]` because they require a live Valkey at
+//! `127.0.0.1:6379` (same convention as the sibling `rfc024_reclaim`
+//! suite). Run with:
+//!
+//! ```
+//! valkey-cli -h 127.0.0.1 -p 6379 ping
+//! cargo test -p ff-backend-valkey --test pr7b_sibling_cancel_group -- --ignored
+//! ```
+
+use std::sync::Arc;
+
+use ff_backend_valkey::ValkeyBackend;
+use ff_core::backend::BackendConfig;
+use ff_core::engine_backend::{EngineBackend, SiblingCancelReconcileAction};
+use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext};
+use ff_core::partition::{execution_partition, flow_partition, PartitionConfig};
+use ff_core::types::{ExecutionId, FlowId};
+
+const HOST: &str = "127.0.0.1";
+const PORT: u16 = 6379;
+
+fn cfg() -> PartitionConfig {
+    PartitionConfig::default()
+}
+
+async fn raw_client() -> ferriskey::Client {
+    ferriskey::ClientBuilder::new()
+        .host(HOST, PORT)
+        .build()
+        .await
+        .expect("build raw ferriskey client")
+}
+
+async fn connect_backend() -> Arc<dyn EngineBackend> {
+    ValkeyBackend::connect(BackendConfig::valkey(HOST, PORT))
+        .await
+        .expect("connect ValkeyBackend")
+}
+
+/// SADD the pending-cancel-groups tuple the way the dispatcher Lua would
+/// have before crashing.
+async fn sadd_pending(client: &ferriskey::Client, fid: &FlowId, downstream: &ExecutionId) {
+    let fp = flow_partition(fid, &cfg());
+    let pending_key = FlowIndexKeys::new(&fp).pending_cancel_groups();
+    let member = format!("{}|{}", fid, downstream);
+    let _: i64 = client
+        .cmd("SADD")
+        .arg(pending_key.as_str())
+        .arg(member.as_str())
+        .execute()
+        .await
+        .expect("SADD pending_cancel_groups");
+}
+
+async fn sismember_pending(
+    client: &ferriskey::Client,
+    fid: &FlowId,
+    downstream: &ExecutionId,
+) -> bool {
+    let fp = flow_partition(fid, &cfg());
+    let pending_key = FlowIndexKeys::new(&fp).pending_cancel_groups();
+    let member = format!("{}|{}", fid, downstream);
+    client
+        .cmd("SISMEMBER")
+        .arg(pending_key.as_str())
+        .arg(member.as_str())
+        .execute()
+        .await
+        .expect("SISMEMBER pending_cancel_groups")
+}
+
+/// Seed a satisfied edgegroup hash. `flag=true` → dispatcher still owes
+/// drain; `flag=false` → dispatcher already HDEL'd flag but crashed
+/// before the SREM.
+async fn seed_edgegroup(
+    client: &ferriskey::Client,
+    fid: &FlowId,
+    downstream: &ExecutionId,
+    siblings: &[ExecutionId],
+    flag: bool,
+) {
+    let fp = flow_partition(fid, &cfg());
+    let fctx = FlowKeyContext::new(&fp, fid);
+    let edgegroup_key = fctx.edgegroup(downstream);
+    let members_str: String = siblings
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("|");
+
+    let cmd = client
+        .cmd("HSET")
+        .arg(edgegroup_key.as_str())
+        .arg("policy_variant")
+        .arg("any_of")
+        .arg("on_satisfied")
+        .arg("cancel_remaining")
+        .arg("group_state")
+        .arg("satisfied")
+        .arg("cancel_siblings_reason")
+        .arg("sibling_quorum_satisfied")
+        .arg("cancel_siblings_pending_members")
+        .arg(members_str.as_str());
+    let cmd = if flag {
+        cmd.arg("cancel_siblings_pending_flag").arg("true")
+    } else {
+        cmd
+    };
+    let _: i64 = cmd.execute().await.expect("HSET edgegroup");
+}
+
+/// Force an exec_core into terminal/cancelled so the reconciler's
+/// terminal-check sees it as already drained.
+async fn force_terminal(client: &ferriskey::Client, eid: &ExecutionId) {
+    let partition = execution_partition(eid, &cfg());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let _: i64 = client
+        .cmd("HSET")
+        .arg(ctx.core().as_str())
+        .arg("lifecycle_phase")
+        .arg("terminal")
+        .arg("terminal_outcome")
+        .arg("cancelled")
+        .arg("cancellation_reason")
+        .arg("sibling_quorum_satisfied")
+        .execute()
+        .await
+        .expect("HSET exec_core terminal");
+}
+
+/// Cleanup keys between test runs so repeated `--ignored` invocations
+/// don't interfere.
+async fn cleanup(client: &ferriskey::Client, fid: &FlowId, downstream: &ExecutionId, siblings: &[ExecutionId]) {
+    let fp = flow_partition(fid, &cfg());
+    let fctx = FlowKeyContext::new(&fp, fid);
+    let fidx = FlowIndexKeys::new(&fp);
+    let _: i64 = client
+        .cmd("DEL")
+        .arg(fctx.edgegroup(downstream).as_str())
+        .arg(fidx.pending_cancel_groups().as_str())
+        .execute()
+        .await
+        .unwrap_or(0);
+    for eid in siblings {
+        let partition = execution_partition(eid, &cfg());
+        let ctx = ExecKeyContext::new(&partition, eid);
+        let _: i64 = client
+            .cmd("DEL")
+            .arg(ctx.core().as_str())
+            .execute()
+            .await
+            .unwrap_or(0);
+    }
+}
+
+fn mint_sibling_ids(n: usize) -> Vec<ExecutionId> {
+    (0..n).map(|_| ExecutionId::for_flow(&FlowId::new(), &cfg())).collect()
+}
+
+/// `drain_sibling_cancel_group` on a satisfied group with flag set +
+/// members already terminal drains the flag and removes the tuple.
+/// Mirrors the dispatcher's own drain step but exercised through the
+/// trait.
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "requires live Valkey at 127.0.0.1:6379"]
+async fn drain_sibling_cancel_group_removes_tuple() {
+    let backend = connect_backend().await;
+    let raw = raw_client().await;
+    let fid = FlowId::new();
+    let downstream = ExecutionId::for_flow(&FlowId::new(), &cfg());
+    let siblings = mint_sibling_ids(2);
+    cleanup(&raw, &fid, &downstream, &siblings).await;
+
+    // Seed: flag=true, members terminal, pending tuple present.
+    seed_edgegroup(&raw, &fid, &downstream, &siblings, true).await;
+    for s in &siblings {
+        force_terminal(&raw, s).await;
+    }
+    sadd_pending(&raw, &fid, &downstream).await;
+    assert!(sismember_pending(&raw, &fid, &downstream).await);
+
+    // Exercise trait method.
+    let fp = flow_partition(&fid, &cfg());
+    backend
+        .drain_sibling_cancel_group(fp, &fid, &downstream)
+        .await
+        .expect("drain_sibling_cancel_group");
+
+    // Post-condition: pending tuple gone.
+    assert!(!sismember_pending(&raw, &fid, &downstream).await);
+
+    cleanup(&raw, &fid, &downstream, &siblings).await;
+}
+
+/// `reconcile_sibling_cancel_group` on a stale tuple (flag absent, no
+/// edgegroup hash) SREMs the tuple and reports `SremmedStale`.
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "requires live Valkey at 127.0.0.1:6379"]
+async fn reconcile_sibling_cancel_group_sremms_stale() {
+    let backend = connect_backend().await;
+    let raw = raw_client().await;
+    let fid = FlowId::new();
+    let downstream = ExecutionId::for_flow(&FlowId::new(), &cfg());
+    let siblings: Vec<ExecutionId> = Vec::new();
+    cleanup(&raw, &fid, &downstream, &siblings).await;
+
+    // Seed: pending tuple with no edgegroup hash at all — the canonical
+    // stale shape.
+    sadd_pending(&raw, &fid, &downstream).await;
+    assert!(sismember_pending(&raw, &fid, &downstream).await);
+
+    let fp = flow_partition(&fid, &cfg());
+    let action = backend
+        .reconcile_sibling_cancel_group(fp, &fid, &downstream)
+        .await
+        .expect("reconcile_sibling_cancel_group");
+
+    assert_eq!(action, SiblingCancelReconcileAction::SremmedStale);
+    assert!(!sismember_pending(&raw, &fid, &downstream).await);
+
+    cleanup(&raw, &fid, &downstream, &siblings).await;
+}
+
+/// `reconcile_sibling_cancel_group` on an interrupted drain (flag=true,
+/// every listed sibling already terminal) returns `CompletedDrain` and
+/// clears the pending tuple.
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "requires live Valkey at 127.0.0.1:6379"]
+async fn reconcile_sibling_cancel_group_completes_drain() {
+    let backend = connect_backend().await;
+    let raw = raw_client().await;
+    let fid = FlowId::new();
+    let downstream = ExecutionId::for_flow(&FlowId::new(), &cfg());
+    let siblings = mint_sibling_ids(2);
+    cleanup(&raw, &fid, &downstream, &siblings).await;
+
+    seed_edgegroup(&raw, &fid, &downstream, &siblings, true).await;
+    for s in &siblings {
+        force_terminal(&raw, s).await;
+    }
+    sadd_pending(&raw, &fid, &downstream).await;
+
+    let fp = flow_partition(&fid, &cfg());
+    let action = backend
+        .reconcile_sibling_cancel_group(fp, &fid, &downstream)
+        .await
+        .expect("reconcile_sibling_cancel_group");
+
+    assert_eq!(action, SiblingCancelReconcileAction::CompletedDrain);
+    assert!(!sismember_pending(&raw, &fid, &downstream).await);
+
+    cleanup(&raw, &fid, &downstream, &siblings).await;
+}

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -2203,6 +2203,93 @@ pub trait EngineBackend: Send + Sync + 'static {
             op: "unblock_execution",
         })
     }
+
+    /// RFC-016 Stage C — sibling-cancel group drain.
+    ///
+    /// After `edge_cancel_dispatcher` has issued
+    /// [`EngineBackend::cancel_execution`] against every listed
+    /// sibling of a `(flow_id, downstream_eid)` group, this trait
+    /// method atomically removes the tuple from the partition-local
+    /// pending-cancel-groups index and clears the per-group flag +
+    /// members state.
+    ///
+    /// Valkey: `FCALL ff_drain_sibling_cancel_group` (SREM +
+    /// HDEL in one Lua unit).
+    /// Postgres: `Unavailable` — PG's Wave-6b
+    /// `reconcilers::edge_cancel_dispatcher::dispatcher_tick`
+    /// owns the equivalent row drain inside its own per-group
+    /// transaction; the Valkey-shaped per-tuple call is not used on
+    /// the PG scanner path.
+    /// SQLite: `Unavailable` (mirrors PG; RFC-023 scope).
+    #[cfg(feature = "core")]
+    async fn drain_sibling_cancel_group(
+        &self,
+        _flow_partition: crate::partition::Partition,
+        _flow_id: &FlowId,
+        _downstream_eid: &ExecutionId,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "drain_sibling_cancel_group",
+        })
+    }
+
+    /// RFC-016 Stage D — sibling-cancel group reconcile (Invariant
+    /// Q6 safety net).
+    ///
+    /// Re-examines a `(flow_id, downstream_eid)` tuple in the
+    /// partition-local pending-cancel-groups index and returns one
+    /// of three atomic dispositions — see
+    /// [`SiblingCancelReconcileAction`] — so the crash-recovery
+    /// reconciler can drain stale or completed tuples without
+    /// fighting the Stage-C dispatcher.
+    ///
+    /// Valkey: `FCALL ff_reconcile_sibling_cancel_group`.
+    /// Postgres: `Unavailable` — PG's
+    /// `reconcilers::edge_cancel_reconciler::reconciler_tick`
+    /// owns the row-level reconcile inside its own batched tx.
+    /// SQLite: `Unavailable` (mirrors PG).
+    #[cfg(feature = "core")]
+    async fn reconcile_sibling_cancel_group(
+        &self,
+        _flow_partition: crate::partition::Partition,
+        _flow_id: &FlowId,
+        _downstream_eid: &ExecutionId,
+    ) -> Result<SiblingCancelReconcileAction, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "reconcile_sibling_cancel_group",
+        })
+    }
+}
+
+/// RFC-016 Stage D outcome of a single
+/// [`EngineBackend::reconcile_sibling_cancel_group`] call.
+///
+/// Cardinality is intentionally bounded to three so the
+/// `ff_sibling_cancel_reconcile_total{action}` metric label stays
+/// closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiblingCancelReconcileAction {
+    /// Pending tuple was stale (flag cleared or edgegroup absent);
+    /// SREM'd / DELETE'd without touching the group.
+    SremmedStale,
+    /// Flag still set but every listed sibling is already terminal —
+    /// an interrupted drain. Flag cleared + tuple drained.
+    CompletedDrain,
+    /// Flag set and at least one sibling non-terminal — dispatcher
+    /// owns this tuple; left untouched.
+    NoOp,
+}
+
+impl SiblingCancelReconcileAction {
+    /// Short label for observability (matches the Lua + PG action
+    /// strings exactly).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SremmedStale => "sremmed_stale",
+            Self::CompletedDrain => "completed_drain",
+            Self::NoOp => "no_op",
+        }
+    }
 }
 
 /// Which scanner invoked [`EngineBackend::expire_execution`].

--- a/crates/ff-engine/src/lib.rs
+++ b/crates/ff-engine/src/lib.rs
@@ -538,11 +538,12 @@ impl Engine {
         // `ff_drain_sibling_cancel_group`, issues per-sibling
         // `ff_cancel_execution` with sibling_quorum reasons.
         let edge_cancel_dispatcher = Arc::new(
-            scanner::edge_cancel_dispatcher::EdgeCancelDispatcher::with_filter_and_metrics(
+            scanner::edge_cancel_dispatcher::EdgeCancelDispatcher::with_filter_metrics_and_backend(
                 config.edge_cancel_dispatcher_interval,
                 config.partition_config,
                 scanner_filter.clone(),
                 metrics.clone(),
+                backend.clone(),
             ),
         );
         handles.push(supervised_spawn(
@@ -559,10 +560,11 @@ impl Engine {
         // by an engine crash. Runs at a slower cadence than the
         // dispatcher so it never fights the happy path.
         let edge_cancel_reconciler = Arc::new(
-            scanner::edge_cancel_reconciler::EdgeCancelReconciler::with_filter_and_metrics(
+            scanner::edge_cancel_reconciler::EdgeCancelReconciler::with_filter_metrics_and_backend(
                 config.edge_cancel_reconciler_interval,
                 scanner_filter.clone(),
                 metrics.clone(),
+                backend.clone(),
             ),
         );
         handles.push(supervised_spawn(

--- a/crates/ff-engine/src/scanner/cancel_reconciler.rs
+++ b/crates/ff-engine/src/scanner/cancel_reconciler.rs
@@ -400,8 +400,14 @@ impl CancelReconciler {
     ///
     /// "Ack-worthy" semantics preserved:
     /// - success: true
-    /// - already-terminal / not-found: true (no point retrying)
-    /// - transient transport: false (retry next cycle)
+    /// - already-terminal (`Contention(ExecutionNotActive)`) /
+    ///   `NotFound`: true (the member is gone; retrying is pointless)
+    /// - `Validation` / `Bug`: true — these are non-convergent under
+    ///   retry. Acking prevents a poison cancel-group member from
+    ///   triggering retry storms on every reconcile tick. Emitted at
+    ///   `warn` level so operators notice the malformed entry.
+    /// - transient transport / other `Contention` / `ResourceExhausted` /
+    ///   `State` / `Unavailable`: false (retry next cycle)
     async fn cancel_member(
         &self,
         client: &ferriskey::Client,

--- a/crates/ff-engine/src/scanner/cancel_reconciler.rs
+++ b/crates/ff-engine/src/scanner/cancel_reconciler.rs
@@ -25,12 +25,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::contracts::CancelExecutionArgs;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
 use ff_core::partition::{
     execution_partition, Partition, PartitionConfig, PartitionFamily,
 };
-use ff_core::types::{AttemptIndex, ExecutionId, FlowId, LaneId, WaitpointId, WorkerInstanceId};
+use ff_core::types::{
+    AttemptIndex, CancelSource, ExecutionId, FlowId, LaneId, TimestampMs, WaitpointId,
+    WorkerInstanceId,
+};
 
 use super::{should_skip_candidate, ScanResult, Scanner};
 
@@ -329,37 +333,55 @@ impl Scanner for CancelReconciler {
                     continue;
                 }
 
-                if cancel_member(
-                    client,
-                    &self.partition_config,
-                    &execution_id,
-                    &reason,
-                )
-                .await
+                if self
+                    .cancel_member(client, &execution_id, &reason)
+                    .await
                 {
-                    // ACK via FCALL so SREM + conditional backlog ZREM
-                    // are one atomic unit on the flow partition. If the
-                    // ack itself fails transiently the member stays in
-                    // pending_cancels and the next cycle retries; count
-                    // it as an error so scanner stats reflect real
+                    // ACK: SREM + conditional backlog ZREM as one
+                    // atomic unit on the flow partition. Prefer the
+                    // trait's `ack_cancel_member` when a backend is
+                    // wired; fall back to the direct FCALL otherwise.
+                    // A transient ack failure leaves the member in
+                    // pending_cancels for next-cycle retry; count it
+                    // as an error so scanner stats reflect real
                     // progress (Copilot feedback).
-                    let flow_id_str = flow_id.to_string();
-                    let ack_keys = [pending_key.as_str(), backlog_key.as_str()];
-                    let ack_args = [eid_str.as_str(), flow_id_str.as_str()];
-                    match client
-                        .fcall::<ferriskey::Value>("ff_ack_cancel_member", &ack_keys, &ack_args)
-                        .await
-                    {
-                        Ok(_) => processed += 1,
-                        Err(e) => {
-                            tracing::debug!(
-                                flow_id = %flow_id,
-                                execution_id = %eid_str,
-                                error = %e,
-                                "cancel_reconciler: ack failed; retry next cycle"
-                            );
-                            errors += 1;
+                    let ack_ok = if let Some(backend) = self.backend.as_ref() {
+                        match backend.ack_cancel_member(&flow_id, &execution_id).await {
+                            Ok(()) => true,
+                            Err(e) => {
+                                tracing::debug!(
+                                    flow_id = %flow_id,
+                                    execution_id = %eid_str,
+                                    error = %e,
+                                    "cancel_reconciler: ack (trait) failed; retry next cycle"
+                                );
+                                false
+                            }
                         }
+                    } else {
+                        let flow_id_str = flow_id.to_string();
+                        let ack_keys = [pending_key.as_str(), backlog_key.as_str()];
+                        let ack_args = [eid_str.as_str(), flow_id_str.as_str()];
+                        match client
+                            .fcall::<ferriskey::Value>("ff_ack_cancel_member", &ack_keys, &ack_args)
+                            .await
+                        {
+                            Ok(_) => true,
+                            Err(e) => {
+                                tracing::debug!(
+                                    flow_id = %flow_id,
+                                    execution_id = %eid_str,
+                                    error = %e,
+                                    "cancel_reconciler: ack failed; retry next cycle"
+                                );
+                                false
+                            }
+                        }
+                    };
+                    if ack_ok {
+                        processed += 1;
+                    } else {
+                        errors += 1;
                     }
                 } else {
                     errors += 1;
@@ -371,20 +393,83 @@ impl Scanner for CancelReconciler {
     }
 }
 
-/// Issue a single operator-override cancel on the member's partition.
-/// Returns true on "ack-worthy" (success OR already-terminal OR
-/// non-retryable transport error we don't want to poison the queue
-/// with). Returns false on transient transport errors; the next
-/// reconciler cycle will retry.
+impl CancelReconciler {
+    /// PR-7b Cluster 3: prefer the backend trait's
+    /// [`EngineBackend::cancel_execution`] when a backend is wired;
+    /// fall back to the legacy direct-FCALL path otherwise.
+    ///
+    /// "Ack-worthy" semantics preserved:
+    /// - success: true
+    /// - already-terminal / not-found: true (no point retrying)
+    /// - transient transport: false (retry next cycle)
+    async fn cancel_member(
+        &self,
+        client: &ferriskey::Client,
+        execution_id: &ExecutionId,
+        reason: &str,
+    ) -> bool {
+        if let Some(backend) = self.backend.as_ref() {
+            let args = CancelExecutionArgs {
+                execution_id: execution_id.clone(),
+                reason: reason.to_owned(),
+                source: CancelSource::OperatorOverride,
+                lease_id: None,
+                lease_epoch: None,
+                attempt_id: None,
+                now: TimestampMs::now(),
+            };
+            return match backend.cancel_execution(args).await {
+                Ok(_) => true,
+                // Lua `execution_not_active` maps to
+                // `Contention(ExecutionNotActive)` — the member is
+                // already terminal; ack to avoid re-issue. All other
+                // `Contention` variants are genuinely transient so
+                // match only the exact `ExecutionNotActive` kind.
+                Err(ff_core::engine_error::EngineError::Contention(
+                    ff_core::engine_error::ContentionKind::ExecutionNotActive { .. },
+                )) => true,
+                // Lua `execution_not_found` → already gone; ack.
+                Err(ff_core::engine_error::EngineError::NotFound { .. }) => true,
+                // Validation / bug: re-issuing won't converge; ack to
+                // avoid poison. Log at warn so operators notice.
+                Err(ref e @ ff_core::engine_error::EngineError::Validation { .. })
+                | Err(ref e @ ff_core::engine_error::EngineError::Bug(_)) => {
+                    tracing::warn!(
+                        execution_id = %execution_id,
+                        error = %e,
+                        "cancel_reconciler: non-transient trait error; ack to avoid poison"
+                    );
+                    true
+                }
+                // Transport / other contention / resource-exhausted
+                // / state / unavailable are transient: leave member
+                // for next cycle.
+                Err(e) => {
+                    tracing::debug!(
+                        execution_id = %execution_id,
+                        error = %e,
+                        "cancel_reconciler: transient trait error; retry next cycle"
+                    );
+                    false
+                }
+            };
+        }
+
+        cancel_member_fcall(client, &self.partition_config, execution_id, reason).await
+    }
+}
+
+/// Legacy direct-FCALL path — kept as a fallback for construction
+/// paths that do not supply an `EngineBackend` (test harnesses +
+/// legacy `new` / `with_filter` call sites). Returns true on
+/// "ack-worthy" (success OR already-terminal OR non-retryable
+/// transport error we don't want to poison the queue with).
 ///
 /// Mirrors ff-server's `build_cancel_execution_fcall` exactly:
 /// pre-reads `lane_id`, `current_attempt_index`, `current_waitpoint_id`,
 /// `current_worker_instance_id` from exec_core so the 21-KEY list
-/// touches the REAL lane/worker indexes. Hardcoding those (first
-/// draft) would leave stale entries in lane_eligible / worker_leases /
-/// etc for any non-default-lane member — flagged by Copilot + Cursor
-/// Bugbot on PR #56.
-async fn cancel_member(
+/// touches the REAL lane/worker indexes.
+async fn cancel_member_fcall(
     client: &ferriskey::Client,
     partition_config: &PartitionConfig,
     execution_id: &ExecutionId,

--- a/crates/ff-engine/src/scanner/edge_cancel_dispatcher.rs
+++ b/crates/ff-engine/src/scanner/edge_cancel_dispatcher.rs
@@ -31,9 +31,12 @@
 //! `LetRun` late-terminal metric; Stage E adds the full reconciler +
 //! observability polish. Crash-mid-cancel recovery is Stage D.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::contracts::CancelExecutionArgs;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::{
     ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys,
 };
@@ -41,8 +44,8 @@ use ff_core::partition::{
     execution_partition, Partition, PartitionConfig, PartitionFamily,
 };
 use ff_core::types::{
-    AttemptIndex, ExecutionId, FlowId, LaneId, WaitpointId,
-    WorkerInstanceId,
+    AttemptIndex, CancelSource, ExecutionId, FlowId, LaneId, TimestampMs,
+    WaitpointId, WorkerInstanceId,
 };
 
 use super::{ScanResult, Scanner};
@@ -63,7 +66,8 @@ pub struct EdgeCancelDispatcher {
     interval: Duration,
     partition_config: PartitionConfig,
     filter: ScannerFilter,
-    metrics: std::sync::Arc<ff_observability::Metrics>,
+    metrics: Arc<ff_observability::Metrics>,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl EdgeCancelDispatcher {
@@ -80,7 +84,7 @@ impl EdgeCancelDispatcher {
             interval,
             partition_config,
             filter,
-            std::sync::Arc::new(ff_observability::Metrics::new()),
+            Arc::new(ff_observability::Metrics::new()),
         )
     }
 
@@ -88,13 +92,33 @@ impl EdgeCancelDispatcher {
         interval: Duration,
         partition_config: PartitionConfig,
         filter: ScannerFilter,
-        metrics: std::sync::Arc<ff_observability::Metrics>,
+        metrics: Arc<ff_observability::Metrics>,
     ) -> Self {
         Self {
             interval,
             partition_config,
             filter,
             metrics,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 3: wire an `EngineBackend` so per-sibling cancel
+    /// and per-group drain route through the trait instead of a
+    /// direct `FCALL` on the raw `ferriskey::Client`.
+    pub fn with_filter_metrics_and_backend(
+        interval: Duration,
+        partition_config: PartitionConfig,
+        filter: ScannerFilter,
+        metrics: Arc<ff_observability::Metrics>,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            partition_config,
+            filter,
+            metrics,
+            backend: Some(backend),
         }
     }
 }
@@ -291,7 +315,7 @@ impl EdgeCancelDispatcher {
                  draining tuple (likely already drained or racing retention)"
             );
             return self
-                .drain_group(client, pending_key, &edgegroup_key, &flow_id, &downstream_eid)
+                .drain_group(client, flow_p, &flow_id, &downstream_eid)
                 .await;
         }
 
@@ -338,13 +362,9 @@ impl EdgeCancelDispatcher {
             };
 
             self.metrics.inc_sibling_cancel_dispatched(static_reason);
-            match cancel_sibling(
-                client,
-                &self.partition_config,
-                &sib_eid,
-                reason_str,
-            )
-            .await
+            match self
+                .cancel_sibling(client, &sib_eid, reason_str)
+                .await
             {
                 SiblingDisposition::Cancelled => {
                     cancel_dispositions[0] += 1;
@@ -386,22 +406,49 @@ impl EdgeCancelDispatcher {
             }
         }
 
-        // Drain: atomic SREM + HDEL.
-        self.drain_group(client, pending_key, &edgegroup_key, &flow_id, &downstream_eid)
+        // Drain: atomic SREM + HDEL via trait.
+        self.drain_group(client, flow_p, &flow_id, &downstream_eid)
             .await
     }
 
     async fn drain_group(
         &self,
         client: &ferriskey::Client,
-        pending_key: &str,
-        edgegroup_key: &str,
+        flow_p: &Partition,
         flow_id: &FlowId,
         downstream_eid: &ExecutionId,
     ) -> GroupOutcome {
+        // PR-7b Cluster 3: prefer the trait method when a backend is
+        // wired; fall back to a direct FCALL on the raw client for
+        // construction paths that did not supply a backend (test
+        // harnesses + legacy `new`/`with_filter` call sites) so this
+        // refactor stays source-compatible with the existing scanner
+        // runner contract.
+        if let Some(backend) = self.backend.as_ref() {
+            return match backend
+                .drain_sibling_cancel_group(*flow_p, flow_id, downstream_eid)
+                .await
+            {
+                Ok(()) => GroupOutcome::Drained,
+                Err(e) => {
+                    tracing::warn!(
+                        flow_id = %flow_id,
+                        downstream = %downstream_eid,
+                        error = %e,
+                        "edge_cancel_dispatcher: drain (trait) failed; retry next cycle"
+                    );
+                    GroupOutcome::SkippedRetry
+                }
+            };
+        }
+
+        let fctx = FlowKeyContext::new(flow_p, flow_id);
+        let fidx = FlowIndexKeys::new(flow_p);
+        let pending_key = fidx.pending_cancel_groups();
+        let edgegroup_key = fctx.edgegroup(downstream_eid);
         let flow_id_str = flow_id.to_string();
         let downstream_eid_str = downstream_eid.to_string();
-        let keys = [pending_key, edgegroup_key];
+        let keys = [pending_key.as_str(), edgegroup_key.as_str()];
         let argv = [flow_id_str.as_str(), downstream_eid_str.as_str()];
         match client
             .fcall::<ferriskey::Value>(
@@ -423,6 +470,45 @@ impl EdgeCancelDispatcher {
             }
         }
     }
+
+    /// PR-7b Cluster 3: route per-sibling cancel through the trait
+    /// when a backend is wired. Falls back to the legacy direct-FCALL
+    /// path when the dispatcher was constructed without a backend
+    /// (test harnesses / `new`), preserving byte-identical KEYS/ARGV.
+    async fn cancel_sibling(
+        &self,
+        client: &ferriskey::Client,
+        sib_eid: &ExecutionId,
+        reason: &str,
+    ) -> SiblingDisposition {
+        if let Some(backend) = self.backend.as_ref() {
+            let args = CancelExecutionArgs {
+                execution_id: sib_eid.clone(),
+                reason: reason.to_owned(),
+                source: CancelSource::OperatorOverride,
+                lease_id: None,
+                lease_epoch: None,
+                attempt_id: None,
+                now: TimestampMs::now(),
+            };
+            return match backend.cancel_execution(args).await {
+                Ok(_) => SiblingDisposition::Cancelled,
+                // Lua `execution_not_active` maps to
+                // `Contention(ExecutionNotActive)` — the sibling is
+                // already terminal. Other `Contention` variants are
+                // genuinely transient so match only the exact kind.
+                Err(ff_core::engine_error::EngineError::Contention(
+                    ff_core::engine_error::ContentionKind::ExecutionNotActive { .. },
+                )) => SiblingDisposition::AlreadyTerminal,
+                Err(ff_core::engine_error::EngineError::NotFound { .. }) => {
+                    SiblingDisposition::NotFound
+                }
+                Err(_) => SiblingDisposition::TransientError,
+            };
+        }
+
+        cancel_sibling_fcall(client, &self.partition_config, sib_eid, reason).await
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -433,13 +519,19 @@ enum SiblingDisposition {
     TransientError,
 }
 
-/// Issue `ff_cancel_execution` against a sibling. Mirrors
-/// `cancel_reconciler::cancel_member` KEYS layout but with
+/// Legacy direct-FCALL sibling cancel — kept as a fallback for
+/// construction paths that do not supply an `EngineBackend` (test
+/// harnesses + `EdgeCancelDispatcher::new` / `with_filter`). Mirrors
+/// `cancel_reconciler::cancel_member` KEYS layout with
 /// `source = "operator_override"` — sibling-quorum cancels bypass
 /// lease-fence checks (no worker holds a lease stake here; the engine
 /// itself is pulling the plug). The `reason` is carried through as
 /// ARGV[2] and lands verbatim in exec_core's `cancellation_reason`.
-async fn cancel_sibling(
+///
+/// The backend-wired path in [`EdgeCancelDispatcher::cancel_sibling`]
+/// replaces this call at runtime once `ff-engine::lib` constructs the
+/// dispatcher with a backend.
+async fn cancel_sibling_fcall(
     client: &ferriskey::Client,
     partition_config: &PartitionConfig,
     sib_eid: &ExecutionId,

--- a/crates/ff-engine/src/scanner/edge_cancel_reconciler.rs
+++ b/crates/ff-engine/src/scanner/edge_cancel_reconciler.rs
@@ -22,9 +22,11 @@
 //! untouched so the 1s dispatcher cadence retains ownership of the
 //! happy path.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::{FlowIndexKeys, FlowKeyContext};
 use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::types::{ExecutionId, FlowId};
@@ -39,7 +41,8 @@ const BATCH_SIZE: usize = 50;
 pub struct EdgeCancelReconciler {
     interval: Duration,
     filter: ScannerFilter,
-    metrics: std::sync::Arc<ff_observability::Metrics>,
+    metrics: Arc<ff_observability::Metrics>,
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl EdgeCancelReconciler {
@@ -51,19 +54,37 @@ impl EdgeCancelReconciler {
         Self::with_filter_and_metrics(
             interval,
             filter,
-            std::sync::Arc::new(ff_observability::Metrics::new()),
+            Arc::new(ff_observability::Metrics::new()),
         )
     }
 
     pub fn with_filter_and_metrics(
         interval: Duration,
         filter: ScannerFilter,
-        metrics: std::sync::Arc<ff_observability::Metrics>,
+        metrics: Arc<ff_observability::Metrics>,
     ) -> Self {
         Self {
             interval,
             filter,
             metrics,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 3: wire an `EngineBackend` so per-tuple reconcile
+    /// routes through the trait instead of a direct `FCALL` on the
+    /// raw `ferriskey::Client`.
+    pub fn with_filter_metrics_and_backend(
+        interval: Duration,
+        filter: ScannerFilter,
+        metrics: Arc<ff_observability::Metrics>,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            filter,
+            metrics,
+            backend: Some(backend),
         }
     }
 }
@@ -216,57 +237,79 @@ impl EdgeCancelReconciler {
             }
         };
 
-        let fctx = FlowKeyContext::new(flow_p, &flow_id);
-        let edgegroup_key = fctx.edgegroup(&downstream_eid);
-        let flow_id_s = flow_id.to_string();
-        let downstream_s = downstream_eid.to_string();
-        let keys = [pending_key, edgegroup_key.as_str()];
-        let argv = [flow_id_s.as_str(), downstream_s.as_str()];
-
-        let reply: Result<ferriskey::Value, _> = client
-            .fcall(
-                "ff_reconcile_sibling_cancel_group",
-                &keys,
-                &argv,
-            )
-            .await;
-
-        match reply {
-            Ok(val) => match extract_action(&val) {
-                Some(action) => {
-                    self.metrics.inc_sibling_cancel_reconcile(action);
-                    match action {
-                        "sremmed_stale" | "completed_drain" => {
-                            tracing::debug!(
-                                flow_id = %flow_id,
-                                downstream = %downstream_eid,
-                                action,
-                                "edge_cancel_reconciler: action applied"
-                            );
-                            ReconcileOutcome::Acted
-                        }
-                        // "no_op"
-                        _ => ReconcileOutcome::NoOp,
-                    }
-                }
-                None => {
+        // PR-7b Cluster 3: prefer the trait method when a backend is
+        // wired; fall back to a direct FCALL on the raw client for
+        // construction paths that did not supply a backend (test
+        // harnesses + legacy `new`/`with_filter`).
+        let action = match self.backend.as_ref() {
+            Some(backend) => match backend
+                .reconcile_sibling_cancel_group(*flow_p, &flow_id, &downstream_eid)
+                .await
+            {
+                Ok(a) => a.as_str(),
+                Err(e) => {
                     tracing::warn!(
                         flow_id = %flow_id,
                         downstream = %downstream_eid,
-                        "edge_cancel_reconciler: unparsable FCALL reply"
+                        error = %e,
+                        "edge_cancel_reconciler: trait call failed; retry next cycle"
                     );
-                    ReconcileOutcome::Error
+                    return ReconcileOutcome::Error;
                 }
             },
-            Err(e) => {
-                tracing::warn!(
+            None => {
+                let fctx = FlowKeyContext::new(flow_p, &flow_id);
+                let edgegroup_key = fctx.edgegroup(&downstream_eid);
+                let flow_id_s = flow_id.to_string();
+                let downstream_s = downstream_eid.to_string();
+                let keys = [pending_key, edgegroup_key.as_str()];
+                let argv = [flow_id_s.as_str(), downstream_s.as_str()];
+
+                let reply: Result<ferriskey::Value, _> = client
+                    .fcall(
+                        "ff_reconcile_sibling_cancel_group",
+                        &keys,
+                        &argv,
+                    )
+                    .await;
+
+                match reply {
+                    Ok(val) => match extract_action(&val) {
+                        Some(a) => a,
+                        None => {
+                            tracing::warn!(
+                                flow_id = %flow_id,
+                                downstream = %downstream_eid,
+                                "edge_cancel_reconciler: unparsable FCALL reply"
+                            );
+                            return ReconcileOutcome::Error;
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            flow_id = %flow_id,
+                            downstream = %downstream_eid,
+                            error = %e,
+                            "edge_cancel_reconciler: FCALL failed; retry next cycle"
+                        );
+                        return ReconcileOutcome::Error;
+                    }
+                }
+            }
+        };
+
+        self.metrics.inc_sibling_cancel_reconcile(action);
+        match action {
+            "sremmed_stale" | "completed_drain" => {
+                tracing::debug!(
                     flow_id = %flow_id,
                     downstream = %downstream_eid,
-                    error = %e,
-                    "edge_cancel_reconciler: FCALL failed; retry next cycle"
+                    action,
+                    "edge_cancel_reconciler: action applied"
                 );
-                ReconcileOutcome::Error
+                ReconcileOutcome::Acted
             }
+            _ => ReconcileOutcome::NoOp,
         }
     }
 }


### PR DESCRIPTION
## Summary

PR-7b Cluster 3 of the `cairn #436` scanner-trait migration. Routes the three RFC-016 cancel-family scanners through `EngineBackend` instead of direct `FCALL`s on the raw `ferriskey::Client`.

**Stacked on** #443 (Cluster 1). Rebase onto `main` once #443 merges.

## Scanners migrated (3)

- `scanner/cancel_reconciler.rs` — per-member cancel + ack
- `scanner/edge_cancel_dispatcher.rs` — per-sibling cancel + per-group drain
- `scanner/edge_cancel_reconciler.rs` — Invariant-Q6 reconcile disposition

## Semantic-match verification (existing trait reuse)

Per the brief, verified the two existing trait methods match scanner-internal usage before adding new ones:

**`EngineBackend::cancel_execution`** — scanner call sites in `cancel_reconciler::cancel_member` and `edge_cancel_dispatcher::cancel_sibling` build byte-identical KEYS[21]+ARGV[5] to the trait's `CancelExecutionArgs`-driven FCALL:
- both hardcode `source = "operator_override"` (matches `CancelSource::OperatorOverride`)
- both pass empty `lease_id` / `lease_epoch` (matches `None` / `None`)
- both use the same 21-KEY lane/worker index layout
- both parse identical reply shape (`Array[Int(1)]` = cancelled, `Array[Int(0), "execution_not_active"]` = already terminal, `Array[Int(0), "execution_not_found"]` = not found)

Lua error codes map through `ff_script::engine_error_ext` to:
- `execution_not_active` → `EngineError::Contention(ContentionKind::ExecutionNotActive { .. })` → treated as already-terminal
- `execution_not_found` → `EngineError::NotFound` → treated as not-found
- everything else → transient; retry next cycle

**Result: reuse, no new `cancel_execution_from_scanner` variant needed.**

**`EngineBackend::ack_cancel_member`** — trait signature `(&FlowId, &ExecutionId)` exactly matches the scanner's 2-KEY + 2-ARGV FCALL shape. Direct reuse.

## New trait methods (2) — RFC-016 Stage C + D

```rust
async fn drain_sibling_cancel_group(
    &self, flow_partition: Partition, flow_id: &FlowId,
    downstream_eid: &ExecutionId,
) -> Result<(), EngineError>;

async fn reconcile_sibling_cancel_group(
    &self, flow_partition: Partition, flow_id: &FlowId,
    downstream_eid: &ExecutionId,
) -> Result<SiblingCancelReconcileAction, EngineError>;

pub enum SiblingCancelReconcileAction {
    SremmedStale, CompletedDrain, NoOp,
}
```

## Backend coverage

- **Valkey**: real FCALL wrappers for both new methods (same KEYS/ARGV as scanner internals).
- **Postgres**: `Unavailable` default. PG's Wave-6b `reconcilers::edge_cancel_{dispatcher,reconciler}::*_tick` already own the equivalent batched SQL path. The Valkey-shaped per-tuple call is **not** on a cairn-consumer surface — these sibling-cancel group ops are scanner-internal primitives, not operator/worker APIs cairn calls. Per owner constraint #1, `Unavailable` is correct here.
- **SQLite**: `Unavailable` default (mirrors PG; RFC-023 scope).

`cancel_execution` + `ack_cancel_member` are already implemented on both PG (`operator::cancel_execution_impl` + `operator::ack_cancel_member_impl`) and Valkey (pre-PR-7b). No new backend SQL needed.

## Fallback paths

Legacy direct-FCALL paths preserved for construction sites without a wired backend (test harnesses + `EdgeCancelDispatcher::new` / `EdgeCancelReconciler::new` / `with_filter*` variants without `_and_backend`). Runtime construction in `ff-engine/src/lib.rs` passes the backend through the new `with_filter_metrics_and_backend` constructors so the primary code path is trait-routed.

## Test plan

- [x] `cargo build --workspace` (clean)
- [x] `cargo clippy -p ff-core -p ff-backend-valkey -p ff-backend-postgres -p ff-backend-sqlite -p ff-engine --all-targets -- -D warnings` (clean)
- [x] `cargo test --workspace --lib` (all passing)
- [x] `cargo test --no-run --workspace` (all test targets compile)
- [x] `cargo build -p ff-backend-sqlite --no-default-features` (clean)
- [ ] CI gates (matrix tests + smoke-sqlite + feature-leak-guard + lua drift + publish-list drift + non_exhaustive + semver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)