### PR TITLE
feat(ff-engine+backends): PR-7b/2 reconciler scanners trait-routed (cairn #436)

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -8154,6 +8154,53 @@ impl EngineBackend for ValkeyBackend {
             .map_err(transport_fk)?;
         Ok(())
     }
+
+    // PR-7b Cluster 2: wraps `ff_unblock_execution` (RFC-010 §6).
+    // KEYS[3]: exec_core, <source_blocked_zset>, eligible_zset
+    // ARGV[3]: execution_id, now_ms, expected_blocking_reason
+    //
+    // `expected_blocking_reason` selects which of the three blocked
+    // ZSETs (`blocked:budget`, `blocked:quota`, `blocked:route`) is
+    // drained. The Lua body re-validates `blocking_reason` on
+    // `exec_core` to fence a stale unblock when the execution has
+    // already transitioned.
+    async fn unblock_execution(
+        &self,
+        partition: Partition,
+        lane_id: &LaneId,
+        execution_id: &ExecutionId,
+        expected_blocking_reason: &str,
+        now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        let tag = partition.hash_tag();
+        let eid_str = execution_id.as_str();
+        let idx = IndexKeys::new(&partition);
+
+        let exec_core = format!("ff:exec:{}:{}:core", tag, eid_str);
+        let blocked_zset = match expected_blocking_reason {
+            "waiting_for_budget" => idx.lane_blocked_budget(lane_id),
+            "waiting_for_quota" => idx.lane_blocked_quota(lane_id),
+            "waiting_for_capable_worker" => idx.lane_blocked_route(lane_id),
+            other => {
+                return Err(EngineError::Validation {
+                    kind: ff_core::engine_error::ValidationKind::InvalidBlockingReason,
+                    detail: format!("unblock_execution: {other}"),
+                });
+            }
+        };
+        let eligible_zset = idx.lane_eligible(lane_id);
+
+        let keys: [&str; 3] = [&exec_core, &blocked_zset, &eligible_zset];
+        let now_s = now_ms.to_string();
+        let argv: [&str; 3] = [eid_str, &now_s, expected_blocking_reason];
+
+        let _: ferriskey::Value = self
+            .client
+            .fcall("ff_unblock_execution", &keys, &argv)
+            .await
+            .map_err(transport_fk)?;
+        Ok(())
+    }
 }
 
 /// Aggregate partition-level lease-history stream key. RFC-019 Stage A

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -2162,6 +2162,47 @@ pub trait EngineBackend: Send + Sync + 'static {
             op: "expire_suspension",
         })
     }
+
+    // ── PR-7b Cluster 2 — Reconciler scanner operations ─────────
+    //
+    // Per-execution write hooks invoked by the `unblock` scanner. The
+    // other two cluster-2 scanners (`budget_reset`, `dependency_reconciler`)
+    // route through `reset_budget` + `resolve_dependency`, which are
+    // already part of the RFC-017 service-layer surface and live above.
+
+    /// Unblock-scanner hook — move an execution from a blocked ZSET back
+    /// to `eligible_now` once its blocking condition has cleared (budget
+    /// under limit, quota window drained, or a capable worker has come
+    /// online). `expected_blocking_reason` discriminates which of the
+    /// `blocked:{budget,quota,route}` sets the execution is leaving and
+    /// also fences against a stale unblock (Lua rejects if the core's
+    /// `blocking_reason` no longer matches).
+    ///
+    /// # Backend status
+    ///
+    /// - **Valkey:** wraps `ff_unblock_execution` (RFC-010 §6). Atomic
+    ///   single-slot FCALL on `{p:N}`.
+    /// - **Postgres:** `Unavailable` (structural). PG does not persist a
+    ///   per-reason `blocked:{budget,quota,route}` index — scheduler
+    ///   eligibility is re-evaluated live via SQL predicates on
+    ///   `ff_exec_core` + budget / quota tables (see
+    ///   `ff_backend_postgres::scheduler`). Nothing to reconcile, so the
+    ///   engine's PG scanner loop does not run this path; callers on
+    ///   a PG deployment receive the typed `Unavailable` per PR-7b/final
+    ///   contract.
+    /// - **SQLite:** `Unavailable` for the same reason as Postgres.
+    async fn unblock_execution(
+        &self,
+        _partition: crate::partition::Partition,
+        _lane_id: &LaneId,
+        _execution_id: &ExecutionId,
+        _expected_blocking_reason: &str,
+        _now_ms: TimestampMs,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "unblock_execution",
+        })
+    }
 }
 
 /// Which scanner invoked [`EngineBackend::expire_execution`].

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -2711,6 +2711,45 @@ mod tests {
         }
     }
 
+    // ── unblock_execution (PR-7b Cluster 2) ──
+
+    /// Default impl returns `Unavailable { op: "unblock_execution" }`
+    /// so non-Valkey deployments get a typed `Unavailable` rather than
+    /// a panic. The engine scanner loop on PG/SQLite skips this path
+    /// entirely (scheduler eligibility is re-evaluated live via SQL
+    /// predicates), but a stray direct call must still fail gracefully.
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_unblock_execution_is_unavailable() {
+        use crate::partition::{Partition, PartitionFamily};
+
+        let b = DefaultBackend;
+        let partition = Partition {
+            family: PartitionFamily::Execution,
+            index: 0,
+        };
+        let eid = ExecutionId::parse(
+            "{fp:0}:55555555-5555-5555-5555-555555555555",
+        )
+        .unwrap();
+        let lane = LaneId::new("default");
+        match b
+            .unblock_execution(
+                partition,
+                &lane,
+                &eid,
+                "waiting_for_budget",
+                TimestampMs::from_millis(0),
+            )
+            .await
+        {
+            Err(EngineError::Unavailable { op }) => {
+                assert_eq!(op, "unblock_execution");
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
     // ── validate_tag_key (issue #433) ──
 
     #[test]

--- a/crates/ff-engine/src/lib.rs
+++ b/crates/ff-engine/src/lib.rs
@@ -425,9 +425,10 @@ impl Engine {
         // Budget reset scanner (iterates budget partitions).
         // Filter is accepted but not applied (budget partitions don't
         // carry the per-execution namespace / instance_tag shape).
-        let budget_reset = Arc::new(BudgetResetScanner::with_filter(
+        let budget_reset = Arc::new(BudgetResetScanner::with_filter_and_backend(
             config.budget_reset_interval,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             budget_reset,

--- a/crates/ff-engine/src/scanner/budget_reset.rs
+++ b/crates/ff-engine/src/scanner/budget_reset.rs
@@ -7,11 +7,15 @@
 //!
 //! Reference: RFC-008 §Budget Reset, RFC-010 §6.11
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::contracts::ResetBudgetArgs;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::budget_resets_key;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::types::{BudgetId, TimestampMs};
 
 use super::{ScanResult, Scanner};
 
@@ -21,6 +25,11 @@ pub struct BudgetResetScanner {
     interval: Duration,
     /// Issue #122: accepted for uniform API; not applied.
     filter: ScannerFilter,
+    /// PR-7b Cluster 2: trait-dispatch target for the per-budget
+    /// `ff_reset_budget` FCALL. When `None` (legacy test construction)
+    /// the scanner falls back to the pre-trait direct-FCALL path on
+    /// the supplied `ferriskey::Client`.
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl BudgetResetScanner {
@@ -34,7 +43,26 @@ impl BudgetResetScanner {
     /// `namespace` / `instance_tag` filter dimensions do not map
     /// onto budget partitions.
     pub fn with_filter(interval: Duration, filter: ScannerFilter) -> Self {
-        Self { interval, filter }
+        Self {
+            interval,
+            filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 2: wire an `EngineBackend` so the per-budget
+    /// reset routes through the trait (`EngineBackend::reset_budget`)
+    /// rather than issuing a raw FCALL against the scanner client.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            filter,
+            backend: Some(backend),
+        }
     }
 }
 
@@ -98,27 +126,56 @@ impl Scanner for BudgetResetScanner {
         let mut errors: u32 = 0;
 
         for budget_id_str in &due {
-            // FCALL ff_reset_budget on {b:M}
-            // KEYS (3): budget_def, budget_usage, budget_resets_zset
-            // ARGV (1): budget_id
-            let budget_def = format!("ff:budget:{}:{}", tag, budget_id_str);
-            let budget_usage = format!("ff:budget:{}:{}:usage", tag, budget_id_str);
+            let res = if let Some(ref backend) = self.backend {
+                // PR-7b Cluster 2: trait-routed reset. Valkey wraps
+                // `ff_reset_budget` (same KEYS/ARGV as the legacy path);
+                // Postgres + SQLite run their per-row reset tx mirroring
+                // the Lua semantic (`budget::reset_budget_impl`).
+                let Ok(bid) = BudgetId::parse(budget_id_str) else {
+                    tracing::warn!(
+                        partition,
+                        budget_id = budget_id_str.as_str(),
+                        "budget_reset: malformed budget id; skipping"
+                    );
+                    errors += 1;
+                    continue;
+                };
+                backend
+                    .reset_budget(ResetBudgetArgs {
+                        budget_id: bid,
+                        now: TimestampMs::from_millis(now_ms as i64),
+                    })
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            } else {
+                // Test-only fallback: direct FCALL on the scanner client.
+                // Mirrors the cluster-1 lease_expiry pattern — preserves
+                // pre-trait-routing unit tests that construct the scanner
+                // without a backend.
+                //
+                // KEYS (3): budget_def, budget_usage, budget_resets_zset
+                // ARGV (2): budget_id, now_ms
+                let budget_def = format!("ff:budget:{}:{}", tag, budget_id_str);
+                let budget_usage = format!("ff:budget:{}:{}:usage", tag, budget_id_str);
+                let keys: [&str; 3] = [&budget_def, &budget_usage, &resets_key];
+                let now_s = now_ms.to_string();
+                let argv: [&str; 2] = [budget_id_str.as_str(), &now_s];
+                client
+                    .fcall::<ferriskey::Value>("ff_reset_budget", &keys, &argv)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            };
 
-            let keys: [&str; 3] = [&budget_def, &budget_usage, &resets_key];
-            let now_s = now_ms.to_string();
-            let argv: [&str; 2] = [budget_id_str.as_str(), &now_s];
-
-            match client
-                .fcall::<ferriskey::Value>("ff_reset_budget", &keys, &argv)
-                .await
-            {
-                Ok(_) => processed += 1,
+            match res {
+                Ok(()) => processed += 1,
                 Err(e) => {
                     tracing::warn!(
                         partition,
                         budget_id = budget_id_str.as_str(),
                         error = %e,
-                        "budget_reset: ff_reset_budget failed"
+                        "budget_reset: reset_budget failed"
                     );
                     errors += 1;
                 }

--- a/crates/ff-engine/src/scanner/dependency_reconciler.rs
+++ b/crates/ff-engine/src/scanner/dependency_reconciler.rs
@@ -17,10 +17,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::contracts::ResolveDependencyArgs;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, execution_partition};
-use ff_core::types::{ExecutionId, LaneId};
+use ff_core::types::{AttemptIndex, EdgeId, ExecutionId, FlowId, LaneId, TimestampMs};
 
 use super::{should_skip_candidate, ScanResult, Scanner};
 
@@ -138,7 +139,7 @@ impl Scanner for DependencyReconciler {
                     continue;
                 }
                 match reconcile_one_execution(
-                    client, &tag, &idx, lane, eid_str,
+                    client, self.backend.as_ref(), &p, &tag, &idx, lane, eid_str,
                     &mut upstream_cache, &self.partition_config,
                 ).await {
                     Ok(n) => total_processed += n,
@@ -160,8 +161,11 @@ impl Scanner for DependencyReconciler {
 }
 
 /// Reconcile one blocked execution. Returns count of edges resolved.
+#[allow(clippy::too_many_arguments)]
 async fn reconcile_one_execution(
     client: &ferriskey::Client,
+    backend: Option<&Arc<dyn EngineBackend>>,
+    partition: &Partition,
     tag: &str,
     idx: &IndexKeys,
     lane: &LaneId,
@@ -225,39 +229,17 @@ async fn reconcile_one_execution(
             Err(_) => continue,
         };
 
-        // Build KEYS for ff_resolve_dependency
+        // Read current_attempt_index + flow_id (needed for both the
+        // trait-routed and the fallback paths — Valkey's impl reads
+        // these itself from `ResolveDependencyArgs`).
         let exec_core = format!("ff:exec:{}:{}:core", tag, eid_str);
-        let deps_meta = format!("ff:exec:{}:{}:deps:meta", tag, eid_str);
-        let eligible_key = idx.lane_eligible(lane);
-        let blocked_deps_key = idx.lane_blocked_dependencies(lane);
-        let terminal_key = idx.lane_terminal(lane);
-
-        // For attempt_hash and stream_meta, read current_attempt_index
         let att_idx_str: Option<String> = client
             .cmd("HGET")
             .arg(&exec_core)
             .arg("current_attempt_index")
             .execute()
             .await?;
-        let att_idx = att_idx_str.as_deref().unwrap_or("0");
-        let attempt_hash = format!("ff:attempt:{}:{}:{}", tag, eid_str, att_idx);
-        let stream_meta = format!("ff:stream:{}:{}:{}:meta", tag, eid_str, att_idx);
-
-        // KEYS must match Lua positional order:
-        // [1] exec_core, [2] deps_meta, [3] unresolved_set, [4] dep_hash,
-        // [5] eligible_zset, [6] terminal_zset, [7] blocked_deps_zset,
-        // [8] attempt_hash, [9] stream_meta, [10] downstream_payload,
-        // [11] upstream_result, [12] edgegroup (RFC-016 Stage A)
-        // [10]/[11] added for Batch C item 3. [12] added for RFC-016
-        // Stage A: the per-downstream edgegroup hash lives under the
-        // flow partition, which is the same `{fp:N}` slot via RFC-011
-        // flow-affinity co-location.
-        let downstream_payload = format!("ff:exec:{}:{}:payload", tag, eid_str);
-        let upstream_result = format!("ff:exec:{}:{}:result", tag, upstream_id);
-        // Read the downstream's flow_id so we can construct the
-        // edgegroup key. Absent / empty flow_id (standalones) means
-        // there is no edge group; the key is harmless — Lua's
-        // `is_set`+`EXISTS` guards skip edgegroup writes.
+        let att_idx_n: u32 = att_idx_str.as_deref().and_then(|s| s.parse().ok()).unwrap_or(0);
         let flow_id_str: Option<String> = client
             .cmd("HGET")
             .arg(&exec_core)
@@ -265,19 +247,97 @@ async fn reconcile_one_execution(
             .execute()
             .await
             .unwrap_or_default();
+
+        if let Some(backend_arc) = backend {
+            // PR-7b Cluster 2: trait-routed resolve. The Valkey impl
+            // wraps `ff_resolve_dependency` with identical KEYS[14] /
+            // ARGV[5]; Postgres returns `Unavailable` (structural —
+            // PG's dispatch uses `dispatch_completion(event_id)` per
+            // `resolve_dependency` rustdoc).
+            let Ok(downstream_eid) = ExecutionId::parse(eid_str) else {
+                tracing::warn!(execution_id = eid_str, "malformed eid; skipping");
+                continue;
+            };
+            let Ok(upstream_eid) = ExecutionId::parse(&upstream_id) else {
+                tracing::warn!(upstream_id = %upstream_id, "malformed upstream eid; skipping");
+                continue;
+            };
+            let flow_id_parsed = flow_id_str
+                .as_deref()
+                .and_then(|s| if s.is_empty() { None } else { FlowId::parse(s).ok() });
+            // `resolve_dependency` requires a flow_id; standalone
+            // executions have no flow deps so skip — the Lua path's
+            // `_nil_` sentinel only works when the FCALL is issued
+            // anyway with a matching slot key. The trait surface uses
+            // a typed `FlowId` (no sentinel); defer standalones to the
+            // fallback path below.
+            let Some(flow_id) = flow_id_parsed else {
+                // No flow → no dep edges. Shouldn't happen here since
+                // we've just read `deps:unresolved` for this exec, but
+                // be defensive — skip silently rather than fabricate a
+                // nil flow id.
+                continue;
+            };
+            let Ok(edge_id_parsed) = EdgeId::parse(edge_id) else {
+                tracing::warn!(edge_id = edge_id.as_str(), "malformed edge_id; skipping");
+                continue;
+            };
+            let args = ResolveDependencyArgs::new(
+                *partition,
+                flow_id,
+                downstream_eid,
+                upstream_eid,
+                edge_id_parsed,
+                lane.clone(),
+                AttemptIndex::new(att_idx_n),
+                terminal_outcome.clone(),
+                TimestampMs::from_millis(now_ms as i64),
+            );
+            match backend_arc.resolve_dependency(args).await {
+                Ok(outcome) => {
+                    resolved += 1;
+                    tracing::debug!(
+                        execution_id = eid_str,
+                        edge_id = edge_id.as_str(),
+                        upstream_id = upstream_id.as_str(),
+                        resolution = resolution,
+                        ?outcome,
+                        "dependency_reconciler: resolved stale dependency"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        execution_id = eid_str,
+                        edge_id = edge_id.as_str(),
+                        error = %e,
+                        "dependency_reconciler: resolve_dependency failed"
+                    );
+                }
+            }
+            continue;
+        }
+
+        // ── Test-only fallback (no backend wired) ──
+        // Preserves the pre-trait-routing FCALL path for unit tests that
+        // construct the scanner without a backend. Mirrors cluster-1's
+        // lease_expiry pattern.
+        let deps_meta = format!("ff:exec:{}:{}:deps:meta", tag, eid_str);
+        let eligible_key = idx.lane_eligible(lane);
+        let blocked_deps_key = idx.lane_blocked_dependencies(lane);
+        let terminal_key = idx.lane_terminal(lane);
+
+        let att_idx = att_idx_str.as_deref().unwrap_or("0");
+        let attempt_hash = format!("ff:attempt:{}:{}:{}", tag, eid_str, att_idx);
+        let stream_meta = format!("ff:stream:{}:{}:{}:meta", tag, eid_str, att_idx);
+
+        let downstream_payload = format!("ff:exec:{}:{}:payload", tag, eid_str);
+        let upstream_result = format!("ff:exec:{}:{}:result", tag, upstream_id);
         let edgegroup_key = match flow_id_str.as_deref() {
             Some(fid) if !fid.is_empty() => {
                 format!("ff:flow:{}:{}:edgegroup:{}", tag, fid, eid_str)
             }
-            // Standalone execution — no dep edges possible, but we
-            // still need a cluster-slot-valid KEYS[12]. Use a
-            // well-formed sentinel key on the same {fp:N} tag; Lua's
-            // EXISTS guard skips the write.
             _ => format!("ff:flow:{}:_nil_:edgegroup:_nil_", tag),
         };
-        // RFC-016 Stage C: incoming_set + pending_cancel_groups SET
-        // for the sibling-enumeration + dispatcher-index path. Both
-        // live on the same {fp:N} slot as the edgegroup.
         let incoming_set_key = match flow_id_str.as_deref() {
             Some(fid) if !fid.is_empty() => {
                 format!("ff:flow:{}:{}:in:{}", tag, fid, eid_str)
@@ -288,28 +348,28 @@ async fn reconcile_one_execution(
             format!("ff:idx:{}:pending_cancel_groups", tag);
         let flow_id_owned = flow_id_str.clone().unwrap_or_default();
         let keys: [&str; 14] = [
-            &exec_core,                   // 1
-            &deps_meta,                   // 2
-            &deps_unresolved_key,         // 3
-            &dep_key,                     // 4
-            &eligible_key,                // 5
-            &terminal_key,                // 6
-            &blocked_deps_key,            // 7
-            &attempt_hash,                // 8
-            &stream_meta,                 // 9
-            &downstream_payload,          // 10
-            &upstream_result,             // 11
-            &edgegroup_key,               // 12
-            &incoming_set_key,            // 13 (RFC-016 Stage C)
-            &pending_cancel_groups_key,   // 14 (RFC-016 Stage C)
+            &exec_core,
+            &deps_meta,
+            &deps_unresolved_key,
+            &dep_key,
+            &eligible_key,
+            &terminal_key,
+            &blocked_deps_key,
+            &attempt_hash,
+            &stream_meta,
+            &downstream_payload,
+            &upstream_result,
+            &edgegroup_key,
+            &incoming_set_key,
+            &pending_cancel_groups_key,
         ];
         let now_s = now_ms.to_string();
         let argv: [&str; 5] = [
             edge_id.as_str(),
             resolution,
             &now_s,
-            flow_id_owned.as_str(),       // 4 (RFC-016 Stage C)
-            eid_str,                      // 5 (RFC-016 Stage C)
+            flow_id_owned.as_str(),
+            eid_str,
         ];
 
         match client
@@ -323,7 +383,7 @@ async fn reconcile_one_execution(
                     edge_id = edge_id.as_str(),
                     upstream_id = upstream_id.as_str(),
                     resolution,
-                    "dependency_reconciler: resolved stale dependency"
+                    "dependency_reconciler: resolved stale dependency (fallback)"
                 );
             }
             Err(e) => {
@@ -331,7 +391,7 @@ async fn reconcile_one_execution(
                     execution_id = eid_str,
                     edge_id = edge_id.as_str(),
                     error = %e,
-                    "dependency_reconciler: ff_resolve_dependency failed"
+                    "dependency_reconciler: ff_resolve_dependency failed (fallback)"
                 );
             }
         }

--- a/crates/ff-engine/src/scanner/dependency_reconciler.rs
+++ b/crates/ff-engine/src/scanner/dependency_reconciler.rs
@@ -262,21 +262,37 @@ async fn reconcile_one_execution(
                 tracing::warn!(upstream_id = %upstream_id, "malformed upstream eid; skipping");
                 continue;
             };
-            let flow_id_parsed = flow_id_str
-                .as_deref()
-                .and_then(|s| if s.is_empty() { None } else { FlowId::parse(s).ok() });
-            // `resolve_dependency` requires a flow_id; standalone
-            // executions have no flow deps so skip — the Lua path's
-            // `_nil_` sentinel only works when the FCALL is issued
-            // anyway with a matching slot key. The trait surface uses
-            // a typed `FlowId` (no sentinel); defer standalones to the
-            // fallback path below.
-            let Some(flow_id) = flow_id_parsed else {
-                // No flow → no dep edges. Shouldn't happen here since
-                // we've just read `deps:unresolved` for this exec, but
-                // be defensive — skip silently rather than fabricate a
-                // nil flow id.
-                continue;
+            // `resolve_dependency` requires a typed `FlowId`. Standalone
+            // executions (`flow_id` absent / empty) cannot have dep
+            // edges, so an entry in `deps:unresolved` for such an
+            // execution indicates data corruption or a partial write —
+            // skip with a warn rather than fabricating a sentinel flow
+            // id. The legacy FCALL path used a `_nil_` sentinel key,
+            // but that only worked because the Lua body's `EXISTS`
+            // guard silently no-ops on nil-shaped keys; the trait
+            // surface has no sentinel and forces us to diagnose the
+            // invariant violation instead.
+            let flow_id = match flow_id_str.as_deref() {
+                Some(s) if !s.is_empty() => match FlowId::parse(s) {
+                    Ok(fid) => fid,
+                    Err(_) => {
+                        tracing::warn!(
+                            execution_id = eid_str,
+                            flow_id = s,
+                            "dependency_reconciler: malformed flow_id; skipping"
+                        );
+                        continue;
+                    }
+                },
+                _ => {
+                    tracing::warn!(
+                        execution_id = eid_str,
+                        edge_id = edge_id.as_str(),
+                        "dependency_reconciler: unresolved dep edge on standalone execution \
+                         (missing flow_id) — likely data corruption; skipping"
+                    );
+                    continue;
+                }
             };
             let Ok(edge_id_parsed) = EdgeId::parse(edge_id) else {
                 tracing::warn!(edge_id = edge_id.as_str(), "malformed edge_id; skipping");

--- a/crates/ff-engine/src/scanner/unblock.rs
+++ b/crates/ff-engine/src/scanner/unblock.rs
@@ -32,7 +32,7 @@ use ff_core::backend::ScannerFilter;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, budget_partition};
-use ff_core::types::{BudgetId, LaneId};
+use ff_core::types::{BudgetId, ExecutionId, LaneId, TimestampMs};
 
 use super::{should_skip_candidate, ScanResult, Scanner};
 
@@ -316,12 +316,10 @@ async fn scan_blocked_set(
             continue;
         }
 
-        // Unblock: FCALL ff_unblock_execution on {p:N}
-        let eligible_key = idx.lane_eligible(lane);
-        let keys: [&str; 3] = [&core_key, blocked_key, &eligible_key];
-
+        // Unblock: trait-route → `EngineBackend::unblock_execution`
+        // (Valkey: wraps `ff_unblock_execution` FCALL on {p:N}).
         let now_ms = match crate::scanner::lease_expiry::server_time_ms(client).await {
-            Ok(t) => t.to_string(),
+            Ok(t) => t,
             Err(e) => {
                 tracing::warn!(
                     execution_id = eid_str.as_str(),
@@ -332,13 +330,39 @@ async fn scan_blocked_set(
                 continue;
             }
         };
-        let argv: [&str; 3] = [eid_str, &now_ms, expected_reason];
 
-        match client
-            .fcall::<ferriskey::Value>("ff_unblock_execution", &keys, &argv)
-            .await
-        {
-            Ok(_) => {
+        let res = if let Some(backend_arc) = backend {
+            let Ok(eid) = ExecutionId::parse(eid_str) else {
+                tracing::warn!(execution_id = eid_str.as_str(), "malformed eid; skipping");
+                continue;
+            };
+            backend_arc
+                .unblock_execution(
+                    *partition,
+                    lane,
+                    &eid,
+                    expected_reason,
+                    TimestampMs::from_millis(now_ms as i64),
+                )
+                .await
+                .map_err(|e| e.to_string())
+        } else {
+            // Test-only fallback: direct FCALL on the scanner client.
+            // Mirrors cluster-1 lease_expiry. KEYS(3)/ARGV(3) identical
+            // to the Valkey impl.
+            let eligible_key = idx.lane_eligible(lane);
+            let keys: [&str; 3] = [&core_key, blocked_key, &eligible_key];
+            let now_s = now_ms.to_string();
+            let argv: [&str; 3] = [eid_str, &now_s, expected_reason];
+            client
+                .fcall::<ferriskey::Value>("ff_unblock_execution", &keys, &argv)
+                .await
+                .map(|_: ferriskey::Value| ())
+                .map_err(|e| e.to_string())
+        };
+
+        match res {
+            Ok(()) => {
                 tracing::info!(
                     execution_id = eid_str.as_str(),
                     reason = expected_reason,
@@ -350,7 +374,7 @@ async fn scan_blocked_set(
                 tracing::warn!(
                     execution_id = eid_str.as_str(),
                     error = %e,
-                    "unblock_scanner: ff_unblock_execution failed"
+                    "unblock_scanner: unblock_execution failed"
                 );
                 errors += 1;
             }


### PR DESCRIPTION
## Summary

Cluster 2 of PR-7b: three reconciler scanners now dispatch through `EngineBackend` instead of issuing raw FCALLs against the scanner client. Adds **one** new trait method (`unblock_execution`); the other two scanners ride on service-layer methods already on the trait (`reset_budget` from RFC-017, `resolve_dependency` from PR-7b Step 0 / PR #441).

Per `/tmp/pr-7b-cluster-2.md` reduced scope. Unblocks cluster-3 (cancel-family) and cluster-4 (completion) to proceed in parallel.

## Scanners trait-routed (3)

| Scanner | Trait method | Source |
|---|---|---|
| `scanner/budget_reset` | `reset_budget(ResetBudgetArgs)` | pre-existing (RFC-017) |
| `scanner/dependency_reconciler` | `resolve_dependency(ResolveDependencyArgs)` | PR #441 (Step 0) |
| `scanner/unblock` | `unblock_execution(partition, lane, eid, reason, now)` | **new this PR** |

## Trait method added (1)

```rust
async fn unblock_execution(
    &self,
    partition: Partition,
    lane_id: &LaneId,
    execution_id: &ExecutionId,
    expected_blocking_reason: &str,   // "waiting_for_budget" | "waiting_for_quota" | "waiting_for_capable_worker"
    now_ms: TimestampMs,
) -> Result<(), EngineError>
```

Default impl returns `EngineError::Unavailable { op: "unblock_execution" }` per cluster-1 precedent.

## Backend impls

**Valkey** — real wrapper around `ff_unblock_execution` FCALL. KEYS[3] (`exec_core`, one of `blocked:{budget,quota,route}` selected by `expected_blocking_reason`, `eligible`) + ARGV[3] (`execution_id`, `now_ms`, `expected_blocking_reason`). Single-slot on `{p:N}`. Validation error on unknown blocking-reason.

**Postgres** — structurally `Unavailable`. PG does not persist a per-reason `blocked:{budget,quota,route}` index — scheduler eligibility is re-evaluated live via SQL predicates on `ff_exec_core` + budget / quota tables (see `ff_backend_postgres::scheduler`). Nothing to reconcile, so the engine's PG scanner loop does not run this path. Rustdoc on the trait method documents the rationale.

**SQLite** — same as Postgres.

Existing `reset_budget` + `resolve_dependency` coverage is unchanged:
- `reset_budget`: Valkey + Postgres + SQLite all implement real per-row reset transactions mirroring the Lua semantic (`budget::reset_budget_impl`).
- `resolve_dependency`: Valkey wraps `ff_resolve_dependency` (RFC-016 Stage C); Postgres + SQLite return `Unavailable` per the cascade rationale in the trait rustdoc (PG uses `dispatch_completion(event_id)` keyed on the outbox row).

## Valkey FCALL shapes (unchanged vs pre-routing)

- `ff_reset_budget` — KEYS[3] (budget_def, budget_usage, budget_resets), ARGV[2] (budget_id, now_ms).
- `ff_resolve_dependency` — KEYS[14] (exec_core, deps_meta, deps_unresolved, dep_hash, eligible, terminal, blocked_deps, attempt_hash, stream_meta, downstream_payload, upstream_result, edgegroup, incoming_set, pending_cancel_groups), ARGV[5] (edge_id, resolution, now_ms, flow_id, downstream_eid).
- `ff_unblock_execution` — KEYS[3] (exec_core, blocked_zset, eligible), ARGV[3] (execution_id, now_ms, expected_blocking_reason).

## Fallback path

Each scanner keeps a test-only fallback to the legacy direct-FCALL path when constructed without a backend (mirrors cluster-1's `lease_expiry` pattern) so existing unit tests that construct the scanner via `with_filter(...)` without an `Arc<dyn EngineBackend>` continue to work.

## Cumulative cairn #436 progress

- Cluster 1 (PR #443): 6 foundation scanners + 5 trait methods + `ExpirePhase` + `should_skip_candidate` trait dispatch. 3 of 5 new PG impls shipped real SQL (lease_expiry, attempt_timeout, suspension_timeout), the remaining 2 (promote_delayed, close_waitpoint, execution_deadline) landed as PG follow-on in same PR.
- **Cluster 2 (this PR)**: 3 reconciler scanners + 1 trait method. Valkey real, PG structurally-unavailable (documented).
- **Cumulative: 9 of 17 scanners trait-routed** (lease_expiry, delayed_promoter, pending_wp_expiry, attempt_timeout, execution_deadline, suspension_timeout, budget_reset, dependency_reconciler, unblock).

Remaining 8 scanners:
- Cluster 2b (5): index/budget/quota reconcilers, flow_projector, retention_trimmer — require new Lua fns + PG SQL procedures, deferred per brief.
- Cluster 3 (cancel-family, ~3): cancel_reconciler, edge_cancel_*.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite`
- [x] `cargo clippy -p ff-core -p ff-script -p ff-engine -p ff-scheduler -p ff-sdk -p ff-server -p ff-test -p ff-backend-sqlite --features ff-sdk/direct-valkey-claim -- -D warnings`
- [x] `cargo test -p ff-core -p ff-engine --lib --tests` (scanner_namespace_point_read + budget tests green)
- [ ] CI workspace tests green on new SHA
- [ ] CI Valkey matrix green (rerun once per project policy if same READONLY class)
- [ ] CI smoke-sqlite + feature-leak-guard + non-exhaustive lint + lua drift + publish-list + feature-propagation green

🤖 Generated with [Claude Code](https://claude.com/claude-code)