### PR TITLE
feat(ff-engine+backends): PR-7b/2b-A tally-recompute reconciler scanners (cairn #436)

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -56,7 +56,7 @@ use ff_core::contracts::{
 use ff_core::partition::{Partition, PartitionFamily};
 use ff_core::engine_error::{StateKind, ValidationKind};
 use ff_core::partition::PartitionKey;
-use ff_core::engine_backend::{EngineBackend, ExpirePhase, SiblingCancelReconcileAction};
+use ff_core::engine_backend::{EngineBackend, ExpirePhase, ReconcileCounts, SiblingCancelReconcileAction};
 use ff_core::engine_error::EngineError;
 use ff_core::keys::{ExecKeyContext, FlowIndexKeys, FlowKeyContext, IndexKeys};
 use ff_core::partition::{PartitionConfig, execution_partition, flow_partition};
@@ -638,6 +638,38 @@ impl ValkeyBackend {
             worker_instance_id,
         );
         handle_codec::encode_handle(&fields, kind)
+    }
+
+    /// Apply a `ScannerFilter` to one candidate eid inside the Valkey
+    /// reconciler path. Mirrors `ff_engine::scanner::should_skip_candidate`
+    /// exactly (noop → keep; parse error → skip; namespace mismatch → skip;
+    /// tag mismatch → skip) so cluster 2b-A tally-recompute scanners observe
+    /// the same filter semantics they did before PR-7b trait routing.
+    /// See that helper's rustdoc for fail-closed rationale (§Failure mode).
+    async fn scanner_skip_candidate(
+        &self,
+        filter: &ff_core::backend::ScannerFilter,
+        eid: &str,
+    ) -> bool {
+        if filter.is_noop() {
+            return false;
+        }
+        let Ok(exec_id) = ExecutionId::parse(eid) else {
+            return true;
+        };
+        if let Some(ref want_ns) = filter.namespace {
+            match self.get_execution_namespace(&exec_id).await {
+                Ok(Some(ref got)) if got == want_ns.as_str() => {}
+                _ => return true,
+            }
+        }
+        if let Some((ref tag_key, ref want_value)) = filter.instance_tag {
+            match self.get_execution_tag(&exec_id, tag_key.as_str()).await {
+                Ok(Some(v)) if &v == want_value => {}
+                _ => return true,
+            }
+        }
+        false
     }
 }
 
@@ -8303,6 +8335,532 @@ impl EngineBackend for ValkeyBackend {
             }),
         }
     }
+    // ── PR-7b Cluster 2b-A — Tally-recompute reconciler scanners ─────
+    //
+    // Each method runs a full scan-and-fix pass on one partition using
+    // the same Redis commands (SSCAN / HMGET / HGETALL / ZSCORE /
+    // ZREMRANGEBYSCORE / SREM / GET / SET / HSET / HDEL) the pre-routing
+    // scanner bodies used. The command shapes are preserved verbatim so
+    // this migration is behavioural-parity with the previous direct-client
+    // scanner path. No new Lua functions introduced.
+
+    async fn reconcile_execution_index(
+        &self,
+        partition: Partition,
+        lanes: &[LaneId],
+        filter: &ff_core::backend::ScannerFilter,
+    ) -> Result<ReconcileCounts, EngineError> {
+        const SCAN_COUNT: u32 = 100;
+        let idx = IndexKeys::new(&partition);
+        let all_exec_key = idx.all_executions();
+        let tag = partition.hash_tag();
+
+        let mut cursor = "0".to_string();
+        let mut processed: u32 = 0;
+        let mut errors: u32 = 0;
+
+        loop {
+            let result: ferriskey::Value = match self
+                .client
+                .cmd("SSCAN")
+                .arg(&all_exec_key)
+                .arg(cursor.as_str())
+                .arg("COUNT")
+                .arg(SCAN_COUNT.to_string().as_str())
+                .execute()
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(partition = partition.index, error = %e,
+                        "reconcile_execution_index: SSCAN failed");
+                    return Ok(ReconcileCounts { processed, errors: errors + 1 });
+                }
+            };
+
+            let (next_cursor, members) = parse_sscan_response(&result)
+                .unwrap_or_else(|| ("0".to_string(), vec![]));
+
+            for eid_str in &members {
+                if self.scanner_skip_candidate(filter, eid_str).await {
+                    continue;
+                }
+                match check_execution_index(&self.client, &tag, &idx, eid_str, lanes).await {
+                    Ok(true) => {}
+                    Ok(false) => processed += 1,
+                    Err(e) => {
+                        tracing::warn!(partition = partition.index,
+                            execution_id = eid_str.as_str(), error = %e,
+                            "reconcile_execution_index: check failed");
+                        errors += 1;
+                    }
+                }
+            }
+
+            cursor = next_cursor;
+            if cursor == "0" {
+                break;
+            }
+        }
+
+        Ok(ReconcileCounts { processed, errors })
+    }
+
+    async fn reconcile_budget_counters(
+        &self,
+        partition: Partition,
+        now_ms: TimestampMs,
+    ) -> Result<ReconcileCounts, EngineError> {
+        let tag = partition.hash_tag();
+        let policies_key = ff_core::keys::budget_policies_index(&tag);
+        let now_ms_u: u64 = now_ms.0.max(0) as u64;
+
+        let mut processed: u32 = 0;
+        let mut errors: u32 = 0;
+        let mut cursor = "0".to_string();
+
+        loop {
+            let result: ferriskey::Value = match self
+                .client
+                .cmd("SSCAN")
+                .arg(&policies_key)
+                .arg(cursor.as_str())
+                .arg("COUNT")
+                .arg("100")
+                .execute()
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(partition = partition.index, error = %e,
+                        "reconcile_budget_counters: SSCAN failed");
+                    return Ok(ReconcileCounts { processed, errors: errors + 1 });
+                }
+            };
+
+            let (next_cursor, budget_ids) = parse_sscan_tuple(&result);
+
+            for bid in &budget_ids {
+                match reconcile_one_budget(&self.client, &tag, &policies_key, bid, now_ms_u).await {
+                    Ok(true) => processed += 1,
+                    Ok(false) => {}
+                    Err(e) => {
+                        tracing::warn!(partition = partition.index,
+                            budget_id = bid.as_str(), error = %e,
+                            "reconcile_budget_counters: reconcile failed");
+                        errors += 1;
+                    }
+                }
+            }
+
+            cursor = next_cursor;
+            if cursor == "0" {
+                break;
+            }
+        }
+
+        Ok(ReconcileCounts { processed, errors })
+    }
+
+    async fn reconcile_quota_counters(
+        &self,
+        partition: Partition,
+        now_ms: TimestampMs,
+    ) -> Result<ReconcileCounts, EngineError> {
+        let tag = partition.hash_tag();
+        let policies_key = ff_core::keys::quota_policies_index(&tag);
+        let now_ms_u: u64 = now_ms.0.max(0) as u64;
+
+        let quota_ids: Vec<String> = match self
+            .client
+            .cmd("SMEMBERS")
+            .arg(&policies_key)
+            .execute()
+            .await
+        {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::warn!(partition = partition.index, error = %e,
+                    "reconcile_quota_counters: SMEMBERS failed");
+                return Ok(ReconcileCounts { processed: 0, errors: 1 });
+            }
+        };
+
+        if quota_ids.is_empty() {
+            return Ok(ReconcileCounts::default());
+        }
+
+        let mut processed: u32 = 0;
+        let mut errors: u32 = 0;
+
+        for qid in &quota_ids {
+            match reconcile_one_quota(&self.client, &tag, qid, now_ms_u).await {
+                Ok(true) => processed += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(partition = partition.index,
+                        quota_id = qid.as_str(), error = %e,
+                        "reconcile_quota_counters: reconcile failed");
+                    errors += 1;
+                }
+            }
+        }
+
+        Ok(ReconcileCounts { processed, errors })
+    }
+}
+
+// ── Helpers for Cluster 2b-A reconcilers ─────────────────────────
+
+/// Verify an execution's index membership against its core-hash state.
+/// Returns Ok(true) if consistent, Ok(false) if an inconsistency was
+/// logged. Mirrors the pre-routing `index_reconciler::check_execution_index`.
+async fn check_execution_index(
+    client: &ferriskey::Client,
+    tag: &str,
+    idx: &IndexKeys,
+    eid_str: &str,
+    _lanes: &[LaneId],
+) -> Result<bool, ferriskey::Error> {
+    let core_key = format!("ff:exec:{}:{}:core", tag, eid_str);
+
+    let fields: Vec<Option<String>> = client
+        .cmd("HMGET")
+        .arg(&core_key)
+        .arg("lifecycle_phase")
+        .arg("eligibility_state")
+        .arg("ownership_state")
+        .arg("lane_id")
+        .execute()
+        .await?;
+
+    if fields.is_empty() || fields[0].is_none() {
+        tracing::warn!(
+            execution_id = eid_str,
+            "reconcile_execution_index: execution in all_executions but core hash missing"
+        );
+        return Ok(false);
+    }
+
+    let lifecycle = fields[0].as_deref().unwrap_or("");
+    let eligibility = fields[1].as_deref().unwrap_or("");
+    let ownership = fields[2].as_deref().unwrap_or("");
+    let lane_str = fields[3].as_deref().unwrap_or("default");
+
+    let expected_index = match (lifecycle, eligibility, ownership) {
+        ("active", _, "leased") => "active",
+        ("runnable", "eligible_now", _) => "eligible",
+        ("runnable", "not_eligible_until_time", _) => "delayed",
+        ("runnable", "blocked_by_dependencies", _) => "blocked:dependencies",
+        ("runnable", "blocked_by_budget", _) => "blocked:budget",
+        ("runnable", "blocked_by_quota", _) => "blocked:quota",
+        ("runnable", "blocked_by_route", _) => "blocked:route",
+        ("runnable", "blocked_by_operator", _) => "blocked:operator",
+        ("suspended", _, _) => "suspended",
+        ("terminal", _, _) => "terminal",
+        _ => "unknown",
+    };
+
+    if expected_index == "unknown" {
+        return Ok(true);
+    }
+
+    let lane = LaneId::new(lane_str);
+    let expected_key = match expected_index {
+        "active" => idx.lane_active(&lane),
+        "eligible" => idx.lane_eligible(&lane),
+        "delayed" => idx.lane_delayed(&lane),
+        "blocked:dependencies" => idx.lane_blocked_dependencies(&lane),
+        "blocked:budget" => idx.lane_blocked_budget(&lane),
+        "blocked:quota" => idx.lane_blocked_quota(&lane),
+        "blocked:route" => idx.lane_blocked_route(&lane),
+        "blocked:operator" => idx.lane_blocked_operator(&lane),
+        "suspended" => idx.lane_suspended(&lane),
+        "terminal" => idx.lane_terminal(&lane),
+        _ => return Ok(true),
+    };
+
+    let score: Option<String> = client
+        .cmd("ZSCORE")
+        .arg(&expected_key)
+        .arg(eid_str)
+        .execute()
+        .await?;
+
+    if score.is_none() {
+        tracing::warn!(
+            execution_id = eid_str,
+            expected_index,
+            expected_key = expected_key.as_str(),
+            lifecycle,
+            eligibility,
+            ownership,
+            "reconcile_execution_index: execution missing from expected index"
+        );
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+/// Reconcile one budget (non-resetting only). Returns Ok(true) if the
+/// breach marker flipped.
+async fn reconcile_one_budget(
+    client: &ferriskey::Client,
+    tag: &str,
+    policies_key: &str,
+    budget_id: &str,
+    now_ms: u64,
+) -> Result<bool, ferriskey::Error> {
+    let def_key = format!("ff:budget:{}:{}", tag, budget_id);
+    let usage_key = format!("ff:budget:{}:{}:usage", tag, budget_id);
+    let limits_key = format!("ff:budget:{}:{}:limits", tag, budget_id);
+
+    // Fail-closed on transport errors (see pre-routing scanner rustdoc).
+    let def_raw: Vec<String> = client.cmd("HGETALL").arg(&def_key).execute().await?;
+    if def_raw.is_empty() {
+        let _: Option<i64> = client
+            .cmd("SREM")
+            .arg(policies_key)
+            .arg(budget_id)
+            .execute()
+            .await
+            .unwrap_or(None);
+        return Ok(false);
+    }
+
+    let def_map = pairs_to_map(&def_raw);
+    let reset_interval = def_map.get("reset_interval_ms").copied();
+    if let Some(ri) = reset_interval
+        && !ri.is_empty()
+        && ri != "0"
+    {
+        return Ok(false);
+    }
+
+    let usage_raw: Vec<String> = client.cmd("HGETALL").arg(&usage_key).execute().await?;
+    let limits_raw: Vec<String> = client.cmd("HGETALL").arg(&limits_key).execute().await?;
+    if limits_raw.is_empty() {
+        return Ok(false);
+    }
+
+    let usage = pairs_to_map(&usage_raw);
+    let limits = pairs_to_map(&limits_raw);
+
+    let mut any_breached = false;
+    for (field, limit_str) in &limits {
+        let dim = match field.strip_prefix("hard:") {
+            Some(d) => d,
+            None => continue,
+        };
+        let limit: i64 = limit_str.parse().unwrap_or(i64::MAX);
+        if limit <= 0 {
+            continue;
+        }
+        let current: i64 = usage.get(dim).and_then(|v| v.parse().ok()).unwrap_or(0);
+        if current > limit {
+            any_breached = true;
+            break;
+        }
+    }
+
+    let currently_breached = usage.contains_key("breached_at");
+
+    if any_breached && !currently_breached {
+        let _: () = client
+            .cmd("HSET")
+            .arg(&usage_key)
+            .arg("breached_at")
+            .arg(now_ms.to_string().as_str())
+            .execute()
+            .await?;
+        tracing::info!(budget_id, "reconcile_budget_counters: marked budget as breached");
+    } else if !any_breached && currently_breached {
+        let _: u32 = client
+            .cmd("HDEL")
+            .arg(&usage_key)
+            .arg("breached_at")
+            .execute()
+            .await?;
+        tracing::info!(budget_id, "reconcile_budget_counters: cleared budget breach");
+    }
+
+    Ok(any_breached != currently_breached)
+}
+
+/// Reconcile one quota policy. Returns Ok(true) if anything was
+/// trimmed / counter-corrected.
+async fn reconcile_one_quota(
+    client: &ferriskey::Client,
+    tag: &str,
+    quota_id: &str,
+    now_ms: u64,
+) -> Result<bool, ferriskey::Error> {
+    let mut did_work = false;
+    let def_key = format!("ff:quota:{}:{}", tag, quota_id);
+
+    let window_secs: Option<String> = client
+        .cmd("HGET")
+        .arg(&def_key)
+        .arg("requests_per_window_seconds")
+        .execute()
+        .await?;
+
+    if let Some(ref ws) = window_secs
+        && let Ok(secs) = ws.parse::<u64>()
+        && secs > 0
+    {
+        let window_ms = secs * 1000;
+        let window_key = format!("ff:quota:{}:{}:window:requests_per_window", tag, quota_id);
+        let cutoff = now_ms.saturating_sub(window_ms);
+
+        let removed: u32 = client
+            .cmd("ZREMRANGEBYSCORE")
+            .arg(&window_key)
+            .arg("-inf")
+            .arg(cutoff.to_string().as_str())
+            .execute()
+            .await
+            .unwrap_or(0);
+
+        if removed > 0 {
+            did_work = true;
+            tracing::debug!(quota_id, removed,
+                "reconcile_quota_counters: trimmed expired window entries");
+        }
+    }
+
+    let concurrency_cap: Option<String> = client
+        .cmd("HGET")
+        .arg(&def_key)
+        .arg("active_concurrency_cap")
+        .execute()
+        .await?;
+
+    if let Some(ref cap_str) = concurrency_cap
+        && let Ok(cap) = cap_str.parse::<u64>()
+        && cap > 0
+    {
+        let counter_key = format!("ff:quota:{}:{}:concurrency", tag, quota_id);
+        let admitted_set_key = format!("ff:quota:{}:{}:admitted_set", tag, quota_id);
+
+        let mut live_count: u64 = 0;
+        let mut cursor = "0".to_string();
+        loop {
+            let result: ferriskey::Value = client
+                .cmd("SSCAN")
+                .arg(&admitted_set_key)
+                .arg(cursor.as_str())
+                .arg("COUNT")
+                .arg("100")
+                .execute()
+                .await?;
+
+            let (next_cursor, members) = parse_sscan_tuple(&result);
+
+            for eid in &members {
+                let guard_key = format!("ff:quota:{}:{}:admitted:{}", tag, quota_id, eid);
+                let exists: bool = client.exists(&guard_key).await.unwrap_or(false);
+                if exists {
+                    live_count += 1;
+                } else {
+                    let _: () = client
+                        .cmd("SREM")
+                        .arg(&admitted_set_key)
+                        .arg(eid.as_str())
+                        .execute()
+                        .await
+                        .unwrap_or_default();
+                }
+            }
+
+            cursor = next_cursor;
+            if cursor == "0" {
+                break;
+            }
+        }
+
+        let stored: Option<String> = client.cmd("GET").arg(&counter_key).execute().await?;
+        let stored_count: i64 = stored.as_deref().and_then(|s| s.parse().ok()).unwrap_or(0);
+
+        if stored_count != live_count as i64 {
+            let _: () = client
+                .cmd("SET")
+                .arg(&counter_key)
+                .arg(live_count.to_string().as_str())
+                .execute()
+                .await?;
+            tracing::info!(
+                quota_id,
+                stored = stored_count,
+                actual = live_count,
+                "reconcile_quota_counters: corrected concurrency counter drift"
+            );
+            did_work = true;
+        }
+    }
+
+    Ok(did_work)
+}
+
+fn pairs_to_map(flat: &[String]) -> std::collections::HashMap<&str, &str> {
+    let mut map = std::collections::HashMap::new();
+    let mut i = 0;
+    while i + 1 < flat.len() {
+        map.insert(flat[i].as_str(), flat[i + 1].as_str());
+        i += 2;
+    }
+    map
+}
+
+/// Parse an `SSCAN` reply `[cursor, [member, ...]]`. Returns
+/// `("0", vec![])` on any unexpected shape (matches pre-routing
+/// scanner helper behaviour).
+fn parse_sscan_tuple(val: &ferriskey::Value) -> (String, Vec<String>) {
+    let arr = match val {
+        ferriskey::Value::Array(a) if a.len() >= 2 => a,
+        _ => return ("0".to_string(), vec![]),
+    };
+
+    let cursor = match &arr[0] {
+        Ok(ferriskey::Value::BulkString(b)) => String::from_utf8_lossy(b).into_owned(),
+        Ok(ferriskey::Value::SimpleString(s)) => s.clone(),
+        _ => return ("0".to_string(), vec![]),
+    };
+
+    let mut members = Vec::new();
+    match &arr[1] {
+        Ok(ferriskey::Value::Array(inner)) => {
+            for item in inner {
+                if let Ok(ferriskey::Value::BulkString(b)) = item {
+                    members.push(String::from_utf8_lossy(b).into_owned());
+                }
+            }
+        }
+        Ok(ferriskey::Value::Set(inner)) => {
+            for item in inner {
+                if let ferriskey::Value::BulkString(b) = item {
+                    members.push(String::from_utf8_lossy(b).into_owned());
+                }
+            }
+        }
+        _ => {}
+    }
+
+    (cursor, members)
+}
+
+/// Parse `SSCAN` into `Option<(cursor, members)>` — variant used by
+/// the index reconciler which treats an unparsable reply as an error
+/// rather than an empty page.
+fn parse_sscan_response(val: &ferriskey::Value) -> Option<(String, Vec<String>)> {
+    let (cursor, members) = parse_sscan_tuple(val);
+    // `parse_sscan_tuple` returns `("0", vec![])` on malformed input.
+    // Distinguish by re-checking the outer Array shape.
+    if !matches!(val, ferriskey::Value::Array(a) if a.len() >= 2) {
+        return None;
+    }
+    Some((cursor, members))
 }
 
 /// Aggregate partition-level lease-history stream key. RFC-019 Stage A

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -8378,14 +8378,38 @@ impl EngineBackend for ValkeyBackend {
                 }
             };
 
-            let (next_cursor, members) = parse_sscan_response(&result)
-                .unwrap_or_else(|| ("0".to_string(), vec![]));
+            let (next_cursor, members) = match parse_sscan_response(&result) {
+                Ok(v) => v,
+                Err(e) => {
+                    // Malformed SSCAN reply is a hard transport error —
+                    // surfacing it lets the next reconciler cycle retry
+                    // with a real error signal rather than silently
+                    // ending the scan and hiding index drift.
+                    tracing::warn!(
+                        partition = partition.index,
+                        hash_tag = %tag,
+                        error = %e,
+                        "reconcile_execution_index: malformed SSCAN reply; \
+                         aborting cycle to surface error"
+                    );
+                    return Err(e);
+                }
+            };
 
             for eid_str in &members {
                 if self.scanner_skip_candidate(filter, eid_str).await {
                     continue;
                 }
-                match check_execution_index(&self.client, &tag, &idx, eid_str, lanes).await {
+                match check_execution_index(
+                    &self.client,
+                    &partition,
+                    &tag,
+                    &idx,
+                    eid_str,
+                    lanes,
+                )
+                .await
+                {
                     Ok(true) => {}
                     Ok(false) => processed += 1,
                     Err(e) => {
@@ -8517,6 +8541,7 @@ impl EngineBackend for ValkeyBackend {
 /// logged. Mirrors the pre-routing `index_reconciler::check_execution_index`.
 async fn check_execution_index(
     client: &ferriskey::Client,
+    partition: &Partition,
     tag: &str,
     idx: &IndexKeys,
     eid_str: &str,
@@ -8536,6 +8561,8 @@ async fn check_execution_index(
 
     if fields.is_empty() || fields[0].is_none() {
         tracing::warn!(
+            partition = partition.index,
+            hash_tag = %tag,
             execution_id = eid_str,
             "reconcile_execution_index: execution in all_executions but core hash missing"
         );
@@ -8589,6 +8616,8 @@ async fn check_execution_index(
 
     if score.is_none() {
         tracing::warn!(
+            partition = partition.index,
+            hash_tag = %tag,
             execution_id = eid_str,
             expected_index,
             expected_key = expected_key.as_str(),
@@ -8850,17 +8879,70 @@ fn parse_sscan_tuple(val: &ferriskey::Value) -> (String, Vec<String>) {
     (cursor, members)
 }
 
-/// Parse `SSCAN` into `Option<(cursor, members)>` — variant used by
-/// the index reconciler which treats an unparsable reply as an error
-/// rather than an empty page.
-fn parse_sscan_response(val: &ferriskey::Value) -> Option<(String, Vec<String>)> {
-    let (cursor, members) = parse_sscan_tuple(val);
-    // `parse_sscan_tuple` returns `("0", vec![])` on malformed input.
-    // Distinguish by re-checking the outer Array shape.
-    if !matches!(val, ferriskey::Value::Array(a) if a.len() >= 2) {
-        return None;
+/// Parse `SSCAN` into a strict `(cursor, members)` tuple — variant
+/// used by the index reconciler which treats an unparsable reply as a
+/// hard transport error rather than silently ending the scan (which
+/// would hide index drift). Any unexpected outer shape, cursor
+/// variant, or member variant maps to `EngineError::Transport`.
+fn parse_sscan_response(
+    val: &ferriskey::Value,
+) -> Result<(String, Vec<String>), EngineError> {
+    fn transport(detail: &'static str) -> EngineError {
+        EngineError::Transport {
+            backend: "valkey",
+            source: format!("parse_sscan_response: {detail}").into(),
+        }
     }
-    Some((cursor, members))
+
+    let arr = match val {
+        ferriskey::Value::Array(a) if a.len() >= 2 => a,
+        _ => return Err(transport("expected Array(len >= 2) reply")),
+    };
+
+    let cursor = match &arr[0] {
+        Ok(ferriskey::Value::BulkString(b)) => String::from_utf8_lossy(b).into_owned(),
+        Ok(ferriskey::Value::SimpleString(s)) => s.clone(),
+        _ => return Err(transport("cursor element has unexpected variant")),
+    };
+
+    let mut members = Vec::new();
+    match &arr[1] {
+        Ok(ferriskey::Value::Array(inner)) => {
+            for item in inner {
+                match item {
+                    Ok(ferriskey::Value::BulkString(b)) => {
+                        members.push(String::from_utf8_lossy(b).into_owned());
+                    }
+                    _ => {
+                        return Err(transport(
+                            "member element has unexpected variant",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(ferriskey::Value::Set(inner)) => {
+            for item in inner {
+                match item {
+                    ferriskey::Value::BulkString(b) => {
+                        members.push(String::from_utf8_lossy(b).into_owned());
+                    }
+                    _ => {
+                        return Err(transport(
+                            "member element has unexpected variant",
+                        ));
+                    }
+                }
+            }
+        }
+        _ => {
+            return Err(transport(
+                "members element has unexpected variant (expected Array/Set)",
+            ));
+        }
+    }
+
+    Ok((cursor, members))
 }
 
 /// Aggregate partition-level lease-history stream key. RFC-019 Stage A

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -2307,6 +2307,79 @@ pub trait EngineBackend: Send + Sync + 'static {
             op: "reconcile_sibling_cancel_group",
         })
     }
+
+    // ── PR-7b Cluster 2b-A — Tally-recompute reconciler scanners ─────
+    //
+    // Coarse trait methods: each runs a full scan-and-fix pass over
+    // one partition. Unlike cluster-2's per-candidate write hooks,
+    // these scanners do multi-round-trip discovery (SSCAN / HMGET /
+    // HGETALL / ZSCORE / ZREMRANGEBYSCORE) interleaved with conditional
+    // writes. Moving the whole pass into the trait impl achieves the
+    // PR-7b/final contract ("scanner trait leaks no `ferriskey::Client`")
+    // without atomising operations that are inherently not atomic.
+    //
+    // Backend status (all three methods):
+    //
+    // - **Valkey:** real scan-loop in the trait impl; identical command
+    //   shape to the pre-routing scanner path.
+    // - **Postgres:** default `Unavailable`. PG mutates budget / quota
+    //   counters and scheduling state inside SERIALIZABLE transactions,
+    //   and the scheduler evaluates eligibility via live SQL predicates
+    //   on `ff_exec_core` + budget / quota tables — no persistent index
+    //   or counter hash that can drift, hence nothing to reconcile. The
+    //   engine's PG scanner supervisor does not run these paths.
+    // - **SQLite:** same as Postgres (RFC-023: SQLite runs its own
+    //   scanner supervisor; these FF-owned tally-recompute scanners
+    //   are not registered).
+
+    /// Index-reconciler pass — walks `ff:idx:{p:N}:all_executions`
+    /// and verifies each execution appears in the correct scheduling
+    /// sorted set (`eligible` / `delayed` / `blocked:*` / `active` /
+    /// `suspended` / `terminal`) for its current `(lifecycle_phase,
+    /// eligibility_state, ownership_state)` triple. Phase 1 is
+    /// log-only; auto-fix is deferred to a later phase (RFC-010 §6.14).
+    async fn reconcile_execution_index(
+        &self,
+        _partition: crate::partition::Partition,
+        _lanes: &[LaneId],
+        _filter: &crate::backend::ScannerFilter,
+    ) -> Result<ReconcileCounts, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "reconcile_execution_index",
+        })
+    }
+
+    /// Budget-reconciler pass — walks `ff:budget:{b:M}:policies_idx`,
+    /// reads each budget's definition / usage / limits, and reconciles
+    /// the `breached_at` marker against hard limits. Resetting budgets
+    /// (non-zero `reset_interval_ms`) are skipped — they are handled
+    /// by the `budget_reset` scanner (cluster 2). Drops index entries
+    /// for budgets whose definition hash has been deleted (retention
+    /// purge / manual). RFC-008 §Budget Reconciliation, RFC-010 §6.5.
+    async fn reconcile_budget_counters(
+        &self,
+        _partition: crate::partition::Partition,
+        _now_ms: TimestampMs,
+    ) -> Result<ReconcileCounts, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "reconcile_budget_counters",
+        })
+    }
+
+    /// Quota-reconciler pass — walks `ff:quota:{q:M}:policies_idx`,
+    /// trims expired entries from rate-limit sliding windows, and
+    /// recomputes each policy's concurrency counter by walking its
+    /// `admitted_set` and pruning entries whose admission guard key
+    /// has TTLed out. RFC-008 §Quota Reconciliation, RFC-010 §6.6.
+    async fn reconcile_quota_counters(
+        &self,
+        _partition: crate::partition::Partition,
+        _now_ms: TimestampMs,
+    ) -> Result<ReconcileCounts, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "reconcile_quota_counters",
+        })
+    }
 }
 
 /// RFC-016 Stage D outcome of a single
@@ -2338,6 +2411,23 @@ impl SiblingCancelReconcileAction {
             Self::NoOp => "no_op",
         }
     }
+}
+
+/// Result of one reconciler scan pass over a single partition.
+///
+/// `processed` counts candidates where the reconciler detected a
+/// correctable condition (drift, breach flip, stale guard). `errors`
+/// counts transport / parse failures. Scanners sum these into the
+/// engine's per-pass metrics exactly as they did before PR-7b/2b-A.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReconcileCounts {
+    /// Items the scanner corrected (drift fix, breach flip, guard
+    /// eviction). Zero when the partition is healthy.
+    pub processed: u32,
+    /// Items the scanner could not process due to transport or parse
+    /// errors. Non-zero values surface through scanner metrics and
+    /// should be investigated.
+    pub errors: u32,
 }
 
 /// Which scanner invoked [`EngineBackend::expire_execution`].
@@ -3097,6 +3187,59 @@ mod tests {
         let args = EvaluateFlowEligibilityArgs { execution_id: eid };
         match b.evaluate_flow_eligibility(args).await.unwrap_err() {
             EngineError::Unavailable { op } => assert_eq!(op, "evaluate_flow_eligibility"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    // ── Cluster 2b-A tally-recompute reconcilers ──
+
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_reconcile_execution_index_is_unavailable() {
+        use crate::backend::ScannerFilter;
+        use crate::partition::{Partition, PartitionFamily};
+        let b = DefaultBackend;
+        let partition = Partition { family: PartitionFamily::Execution, index: 0 };
+        let lanes = [LaneId::new("default")];
+        let filter = ScannerFilter::default();
+        match b
+            .reconcile_execution_index(partition, &lanes, &filter)
+            .await
+            .unwrap_err()
+        {
+            EngineError::Unavailable { op } => assert_eq!(op, "reconcile_execution_index"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_reconcile_budget_counters_is_unavailable() {
+        use crate::partition::{Partition, PartitionFamily};
+        let b = DefaultBackend;
+        let partition = Partition { family: PartitionFamily::Budget, index: 0 };
+        match b
+            .reconcile_budget_counters(partition, TimestampMs::from_millis(0))
+            .await
+            .unwrap_err()
+        {
+            EngineError::Unavailable { op } => assert_eq!(op, "reconcile_budget_counters"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_reconcile_quota_counters_is_unavailable() {
+        use crate::partition::{Partition, PartitionFamily};
+        let b = DefaultBackend;
+        let partition = Partition { family: PartitionFamily::Quota, index: 0 };
+        match b
+            .reconcile_quota_counters(partition, TimestampMs::from_millis(0))
+            .await
+            .unwrap_err()
+        {
+            EngineError::Unavailable { op } => assert_eq!(op, "reconcile_quota_counters"),
             other => panic!("expected Unavailable, got {other:?}"),
         }
     }

--- a/crates/ff-engine/src/lib.rs
+++ b/crates/ff-engine/src/lib.rs
@@ -440,10 +440,11 @@ impl Engine {
 
         // Budget reconciler (iterates budget partitions). Filter
         // accepted but not applied — see BudgetReconciler::with_filter
-        // rustdoc.
-        let budget_reconciler = Arc::new(BudgetReconciler::with_filter(
+        // rustdoc. PR-7b Cluster 2b-A: routed through the trait.
+        let budget_reconciler = Arc::new(BudgetReconciler::with_filter_and_backend(
             config.budget_reconciler_interval,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             budget_reconciler,
@@ -487,10 +488,11 @@ impl Engine {
 
         // Quota reconciler (iterates quota partitions). Filter
         // accepted but not applied — see QuotaReconciler::with_filter
-        // rustdoc.
-        let quota_reconciler = Arc::new(QuotaReconciler::with_filter(
+        // rustdoc. PR-7b Cluster 2b-A: routed through the trait.
+        let quota_reconciler = Arc::new(QuotaReconciler::with_filter_and_backend(
             config.quota_reconciler_interval,
             scanner_filter.clone(),
+            backend.clone(),
         ));
         handles.push(supervised_spawn(
             quota_reconciler,

--- a/crates/ff-engine/src/scanner/budget_reconciler.rs
+++ b/crates/ff-engine/src/scanner/budget_reconciler.rs
@@ -11,11 +11,14 @@
 //!
 //! Reference: RFC-008 §Budget Reconciliation, RFC-010 §6.5
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::types::TimestampMs;
 
 use super::{ScanResult, Scanner};
 
@@ -24,6 +27,11 @@ pub struct BudgetReconciler {
     /// Issue #122: accepted for uniform API; not applied. See
     /// [`Self::with_filter`] rustdoc.
     filter: ScannerFilter,
+    /// PR-7b Cluster 2b-A: when set, `scan_partition` delegates the
+    /// whole pass to `EngineBackend::reconcile_budget_counters`.
+    /// `None` keeps the legacy direct-client path for unit tests that
+    /// construct via [`Self::new`] / [`Self::with_filter`].
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl BudgetReconciler {
@@ -40,7 +48,26 @@ impl BudgetReconciler {
     /// single `EngineConfig.scanner_filter` to every scanner
     /// constructor without special-casing.
     pub fn with_filter(interval: Duration, filter: ScannerFilter) -> Self {
-        Self { interval, filter }
+        Self {
+            interval,
+            filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 2b-A: wire an `EngineBackend` so the scan-and-fix
+    /// pass routes through `EngineBackend::reconcile_budget_counters`
+    /// instead of issuing Redis commands directly.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            filter,
+            backend: Some(backend),
+        }
     }
 }
 
@@ -75,6 +102,27 @@ impl Scanner for BudgetReconciler {
                 return ScanResult { processed: 0, errors: 1 };
             }
         };
+
+        // PR-7b Cluster 2b-A: delegate the whole pass to the trait
+        // when a backend is wired. The `now_ms` fetched above feeds
+        // both the trait path and the legacy fallback so the breach
+        // timestamp is consistent regardless of which arm runs.
+        if let Some(backend) = self.backend.as_ref() {
+            return match backend
+                .reconcile_budget_counters(p, TimestampMs::from_millis(now_ms as i64))
+                .await
+            {
+                Ok(counts) => ScanResult {
+                    processed: counts.processed,
+                    errors: counts.errors,
+                },
+                Err(e) => {
+                    tracing::warn!(partition, error = %e,
+                        "budget_reconciler: reconcile_budget_counters trait call failed");
+                    ScanResult { processed: 0, errors: 1 }
+                }
+            };
+        }
 
         // Discover budgets via partition-level index SET (cluster-safe).
         // Stream in SSCAN batches so partitions with many budgets do not

--- a/crates/ff-engine/src/scanner/index_reconciler.rs
+++ b/crates/ff-engine/src/scanner/index_reconciler.rs
@@ -87,6 +87,29 @@ impl Scanner for IndexReconciler {
             family: PartitionFamily::Execution,
             index: partition,
         };
+
+        // PR-7b Cluster 2b-A: when a backend is wired (normal engine
+        // path), delegate the whole scan-and-verify pass to the trait
+        // so the scanner does not touch `ferriskey::Client`. Legacy
+        // unit tests that construct via `IndexReconciler::new` keep
+        // the direct-client fallback below.
+        if let Some(backend) = self.backend.as_ref() {
+            return match backend
+                .reconcile_execution_index(p, &self.lanes, &self.filter)
+                .await
+            {
+                Ok(counts) => ScanResult {
+                    processed: counts.processed,
+                    errors: counts.errors,
+                },
+                Err(e) => {
+                    tracing::warn!(partition, error = %e,
+                        "index_reconciler: reconcile_execution_index trait call failed");
+                    ScanResult { processed: 0, errors: 1 }
+                }
+            };
+        }
+
         let idx = IndexKeys::new(&p);
         let all_exec_key = idx.all_executions();
 

--- a/crates/ff-engine/src/scanner/quota_reconciler.rs
+++ b/crates/ff-engine/src/scanner/quota_reconciler.rs
@@ -11,11 +11,14 @@
 //!
 //! Reference: RFC-008 §Quota Reconciliation, RFC-010 §6.6
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ff_core::backend::ScannerFilter;
+use ff_core::engine_backend::EngineBackend;
 use ff_core::keys;
 use ff_core::partition::{Partition, PartitionFamily};
+use ff_core::types::TimestampMs;
 
 use super::{ScanResult, Scanner};
 
@@ -23,6 +26,10 @@ pub struct QuotaReconciler {
     interval: Duration,
     /// Issue #122: accepted for uniform API; not applied.
     filter: ScannerFilter,
+    /// PR-7b Cluster 2b-A: when set, `scan_partition` delegates the
+    /// whole pass to `EngineBackend::reconcile_quota_counters`.
+    /// `None` keeps the legacy direct-client path for unit tests.
+    backend: Option<Arc<dyn EngineBackend>>,
 }
 
 impl QuotaReconciler {
@@ -36,7 +43,26 @@ impl QuotaReconciler {
     /// `namespace` / `instance_tag` filter dimensions do not map
     /// onto quota partitions.
     pub fn with_filter(interval: Duration, filter: ScannerFilter) -> Self {
-        Self { interval, filter }
+        Self {
+            interval,
+            filter,
+            backend: None,
+        }
+    }
+
+    /// PR-7b Cluster 2b-A: wire an `EngineBackend` so the scan-and-fix
+    /// pass routes through `EngineBackend::reconcile_quota_counters`
+    /// instead of issuing Redis commands directly.
+    pub fn with_filter_and_backend(
+        interval: Duration,
+        filter: ScannerFilter,
+        backend: Arc<dyn EngineBackend>,
+    ) -> Self {
+        Self {
+            interval,
+            filter,
+            backend: Some(backend),
+        }
     }
 }
 
@@ -71,6 +97,26 @@ impl Scanner for QuotaReconciler {
                 return ScanResult { processed: 0, errors: 1 };
             }
         };
+
+        // PR-7b Cluster 2b-A: delegate to the trait when a backend is
+        // wired. Fetched `now_ms` is passed through so window cutoffs
+        // match the legacy path exactly.
+        if let Some(backend) = self.backend.as_ref() {
+            return match backend
+                .reconcile_quota_counters(p, TimestampMs::from_millis(now_ms as i64))
+                .await
+            {
+                Ok(counts) => ScanResult {
+                    processed: counts.processed,
+                    errors: counts.errors,
+                },
+                Err(e) => {
+                    tracing::warn!(partition, error = %e,
+                        "quota_reconciler: reconcile_quota_counters trait call failed");
+                    ScanResult { processed: 0, errors: 1 }
+                }
+            };
+        }
 
         // Discover quota policies via partition-level index SET (cluster-safe)
         let policies_key = keys::quota_policies_index(&tag);


### PR DESCRIPTION
## Summary

Cluster **2b-A** of PR-7b: three tally-recompute reconciler scanners dispatch their full scan-and-fix pass through `EngineBackend` instead of issuing Redis commands against the scanner client.

- `scanner/index_reconciler`  → `EngineBackend::reconcile_execution_index`
- `scanner/budget_reconciler` → `EngineBackend::reconcile_budget_counters`
- `scanner/quota_reconciler`  → `EngineBackend::reconcile_quota_counters`

Per the 2b-A directive these trait methods take **coarse scope** (one full partition pass per call). Unlike cluster-2's per-candidate write hooks, these scanners do multi-round-trip discovery interleaved with conditional writes — atomising them would add abstraction without simplifying. The whole scan-loop body lives in the Valkey impl; command shape is verbatim parity with the pre-routing path.

### Backend status

| Backend  | Status | Rationale |
|----------|--------|-----------|
| Valkey   | Real impl | Same SSCAN / HMGET / HGETALL / ZSCORE / ZREMRANGEBYSCORE / SREM / GET / SET / HSET / HDEL as the pre-routing scanner body. `ScannerFilter` applied via new private `scanner_skip_candidate` helper that mirrors `ff_engine::scanner::should_skip_candidate`. |
| Postgres | `Unavailable` | PG mutates counters inside SERIALIZABLE txs and scheduler eligibility is live-SQL-evaluated — no persistent index / counter hash that can drift, hence nothing to reconcile. Engine PG scanner supervisor does not run these paths. |
| SQLite   | `Unavailable` | RFC-023: SQLite runs its own scanner supervisor; these FF-owned tally-recompute scanners are not registered on the SQLite path. |

### New API

```rust
pub struct ReconcileCounts { pub processed: u32, pub errors: u32 }

// All three default to Err(Unavailable) for non-Valkey backends.
async fn reconcile_execution_index(&self, partition, lanes, filter) -> Result<ReconcileCounts, _>;
async fn reconcile_budget_counters(&self, partition, now_ms)        -> Result<ReconcileCounts, _>;
async fn reconcile_quota_counters(&self, partition, now_ms)         -> Result<ReconcileCounts, _>;
```

### No migrations, no new Lua

All three trait methods are `Unavailable` on the PG backend by design — no schema changes needed. Valkey impl uses the same Redis commands the pre-routing scanner bodies used — no new FCALL / Lua function needed.

Migration range in `crates/ff-backend-postgres/migrations/` is untouched. Next available migration slot (currently `0018` on `origin/main` after PR #443) is reserved for cluster 2 (#445) / cluster 3 (#444) follow-ups.

### Cluster fan-out

Sibling PRs in flight:
- #443 (merged): PR-7b/1 foundation — trait-routed foundation scanners
- #444: PR-7b/3 cancel-family scanners
- #445: PR-7b/2 reconciler scanners (FCALL wrappers)
- #446: PR-7b/4 completion listener

Cluster 2b-**B** (flow_projector + retention_trimmer) is a follow-up PR in the same branch family — tracked separately.

### Test plan

- [x] `cargo check --workspace --tests` clean.
- [x] `cargo test -p ff-core --lib default_reconcile` — 3 new default-unavailable tests pass.
- [x] `cargo test -p ff-engine --lib` — existing lib tests unaffected.
- [x] `cargo test -p ff-backend-valkey --lib` — no regressions.
- [ ] CI: `ff-test` integration suite (`pr_c1_budget_reconciler_transient`, `e2e_lifecycle`) — constructs via `BudgetReconciler::new()` so rides the legacy direct-client fallback path unchanged.
- [ ] CI: Valkey integration coverage via engine's start path which now wires `with_filter_and_backend` for budget + quota reconcilers (index was already wired from cluster 1).

Closes (part of) cairn #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)