### PR TITLE
fix(sdk): WorkerConfig.backend is Option<BackendConfig> (ergonomics, cairn-reported via feedback_sdk_reclaim_ergonomics.md Finding 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`WorkerConfig.backend` is now `Option<BackendConfig>` (SC-10
+  ergonomics follow-up, cairn-reported via
+  `feedback_sdk_reclaim_ergonomics.md` Finding 2).** Pre-v0.13 the
+  field was eager `BackendConfig`, but only
+  [`FlowFabricWorker::connect`] consumed it; the backend-agnostic
+  [`FlowFabricWorker::connect_with`] path ignored it entirely,
+  forcing `connect_with` callers to carry a placeholder
+  `BackendConfig::valkey(...)` just to satisfy the struct literal.
+  The v0.12 SC-10 `incident-remediation` example surfaced this as a
+  rough edge for the SQLite supervisor path. Semantics:
+  - `Some(cfg)` + `connect` — unchanged (dial using `cfg`).
+  - `None` + `connect` — rejected with `SdkError::Config` (the
+    URL-based path needs a `BackendConfig` to dial).
+  - `None` + `connect_with` — clean, no placeholder needed.
+  - `Some(cfg)` + `connect_with` — accepted, logs a `tracing::warn!`
+    because `cfg` is ignored (the injected backend is authoritative).
+  Existing `connect` callers migrate by wrapping their existing
+  `BackendConfig` in `Some(...)`; `connect_with` callers can drop
+  the placeholder and pass `None`. See
+  [`docs/CONSUMER_MIGRATION_0.13.md`](docs/CONSUMER_MIGRATION_0.13.md)
+  for the before/after snippet.
+
 ### Added
 
 - **PR-7b Cluster 1: foundation scanner operations on `EngineBackend`

--- a/benches/harness/benches/submit_claim_complete.rs
+++ b/benches/harness/benches/submit_claim_complete.rs
@@ -182,10 +182,10 @@ async fn drive_worker(
     use std::sync::atomic::Ordering;
 
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(
+        backend: Some(ff_core::backend::BackendConfig::valkey(
             env.valkey_host.clone(),
             env.valkey_port,
-        ),
+        )),
         worker_id: ff_core::types::WorkerId::new(format!("bench-worker-{wi}")),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "bench-worker-{wi}-{}",

--- a/benches/harness/benches/suspend_signal_resume.rs
+++ b/benches/harness/benches/suspend_signal_resume.rs
@@ -344,10 +344,10 @@ async fn measure_one_inner(
     // cleaner for latency sampling.
     let instance_id = format!("bench-susp-{}", uuid::Uuid::new_v4());
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(
+        backend: Some(ff_core::backend::BackendConfig::valkey(
             env.valkey_host.clone(),
             env.valkey_port,
-        ),
+        )),
         worker_id: ff_core::types::WorkerId::new("bench-susp-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
         namespace: ff_core::types::Namespace::new(&env.namespace),

--- a/benches/harness/src/bin/cap_routed.rs
+++ b/benches/harness/src/bin/cap_routed.rs
@@ -778,10 +778,10 @@ async fn drive_worker(
     let worker_caps: BTreeSet<String> = caps.iter().cloned().collect();
     let instance_id = format!("cap-w{wi}-{}", uuid::Uuid::new_v4());
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(
+        backend: Some(ff_core::backend::BackendConfig::valkey(
             env.valkey_host.clone(),
             env.valkey_port,
-        ),
+        )),
         worker_id: ff_core::types::WorkerId::new(format!("cap-w{wi}")),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
         namespace: ff_core::types::Namespace::new(&env.namespace),

--- a/benches/harness/src/bin/long_running.rs
+++ b/benches/harness/src/bin/long_running.rs
@@ -1051,10 +1051,10 @@ async fn drive_worker(
 ) -> Result<WorkerOutcome> {
     let instance_id = format!("bench-worker-{wi}-{}", uuid::Uuid::new_v4());
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(
+        backend: Some(ff_core::backend::BackendConfig::valkey(
             env.valkey_host.clone(),
             env.valkey_port,
-        ),
+        )),
         worker_id: ff_core::types::WorkerId::new(format!("bench-worker-{wi}")),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(instance_id),
         namespace: ff_core::types::Namespace::new(&env.namespace),

--- a/benches/harness/src/runners/flowfabric.rs
+++ b/benches/harness/src/runners/flowfabric.rs
@@ -523,10 +523,10 @@ async fn echo_worker_loop(
     shutdown_rx: Arc<tokio::sync::watch::Receiver<bool>>,
 ) -> Result<()> {
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(
+        backend: Some(ff_core::backend::BackendConfig::valkey(
             env.valkey_host.clone(),
             env.valkey_port,
-        ),
+        )),
         worker_id: ff_core::types::WorkerId::new(format!("bench-echo-{wi}")),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "bench-echo-{wi}-{}",

--- a/crates/ff-readiness-tests/tests/bug_b_repro.rs
+++ b/crates/ff-readiness-tests/tests/bug_b_repro.rs
@@ -55,7 +55,7 @@ async fn bug_b_resume_via_server_claim() {
 
     // Worker config. Server-routed claim — no direct-valkey-claim feature reliance.
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_readiness_tests::valkey::backend_config_from_env(),
+        backend: Some(ff_readiness_tests::valkey::backend_config_from_env()),
         worker_id: WorkerId::new("bug-b-worker"),
         worker_instance_id: WorkerInstanceId::new("bug-b-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-readiness-tests/tests/common/mod.rs
+++ b/crates/ff-readiness-tests/tests/common/mod.rs
@@ -42,7 +42,7 @@ pub struct Dag {
 /// Spawn an SDK worker against the lane + namespace.
 pub async fn spawn_worker(lane: &str, ns: &str, suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_readiness_tests::valkey::backend_config_from_env(),
+        backend: Some(ff_readiness_tests::valkey::backend_config_from_env()),
         worker_id: WorkerId::new(format!("readiness-fanout-worker-{suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("readiness-fanout-inst-{suffix}")),
         namespace: Namespace::new(ns),

--- a/crates/ff-readiness-tests/tests/inprocess_multi_test.rs
+++ b/crates/ff-readiness-tests/tests/inprocess_multi_test.rs
@@ -99,7 +99,7 @@ async fn drive_one_execution(tag: &str) {
         .expect("add_execution_to_flow");
 
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_readiness_tests::valkey::backend_config_from_env(),
+        backend: Some(ff_readiness_tests::valkey::backend_config_from_env()),
         worker_id: WorkerId::new(format!("readiness-multi-worker-{tag}")),
         worker_instance_id: WorkerInstanceId::new(format!("readiness-multi-inst-{tag}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
+++ b/crates/ff-readiness-tests/tests/lifecycle_happy_path.rs
@@ -100,7 +100,7 @@ async fn lifecycle_happy_path() {
 
     // 6. Spawn in-process SDK worker using direct-valkey-claim.
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_readiness_tests::valkey::backend_config_from_env(),
+        backend: Some(ff_readiness_tests::valkey::backend_config_from_env()),
         worker_id: WorkerId::new("readiness-happy-worker"),
         worker_instance_id: WorkerInstanceId::new("readiness-happy-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-readiness-tests/tests/lifecycle_retry_backoff.rs
+++ b/crates/ff-readiness-tests/tests/lifecycle_retry_backoff.rs
@@ -132,7 +132,7 @@ async fn lifecycle_retry_backoff() {
 
     // 6. Spawn in-process SDK worker.
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_readiness_tests::valkey::backend_config_from_env(),
+        backend: Some(ff_readiness_tests::valkey::backend_config_from_env()),
         worker_id: WorkerId::new("readiness-retry-worker"),
         worker_instance_id: WorkerInstanceId::new("readiness-retry-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-readiness-tests/tests/runtime_smoke.rs
+++ b/crates/ff-readiness-tests/tests/runtime_smoke.rs
@@ -32,7 +32,7 @@ fn suffix() -> String {
 
 async fn spawn_worker(lane: &str, ns: &str, sfx: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = WorkerConfig {
-        backend: ff_readiness_tests::valkey::backend_config_from_env(),
+        backend: Some(ff_readiness_tests::valkey::backend_config_from_env()),
         worker_id: WorkerId::new(format!("rs-smoke-w-{sfx}")),
         worker_instance_id: WorkerInstanceId::new(format!("rs-smoke-i-{sfx}")),
         namespace: Namespace::new(ns),

--- a/crates/ff-readiness-tests/tests/waitpoint_hmac_roundtrip.rs
+++ b/crates/ff-readiness-tests/tests/waitpoint_hmac_roundtrip.rs
@@ -80,7 +80,7 @@ async fn waitpoint_hmac_roundtrip() {
 
     // 2. Spawn the SDK worker once — all four executions below share it.
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_readiness_tests::valkey::backend_config_from_env(),
+        backend: Some(ff_readiness_tests::valkey::backend_config_from_env()),
         worker_id: WorkerId::new("readiness-hmac-worker"),
         worker_instance_id: WorkerInstanceId::new("readiness-hmac-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-sdk/src/config.rs
+++ b/crates/ff-sdk/src/config.rs
@@ -22,7 +22,34 @@ use ff_core::types::{LaneId, Namespace, WorkerId, WorkerInstanceId};
 /// break); construct via struct literal.
 pub struct WorkerConfig {
     /// Backend connection + shared timeouts / retry policy.
-    pub backend: BackendConfig,
+    ///
+    /// **v0.13 ergonomics fix (cairn, feedback_sdk_reclaim_ergonomics
+    /// Finding 2):** this field is only consumed by
+    /// [`FlowFabricWorker::connect`] (the URL-based Valkey-native
+    /// entry point that dials a fresh `ferriskey::Client`).
+    /// [`FlowFabricWorker::connect_with`] — the backend-agnostic
+    /// entry point that takes a pre-built `Arc<dyn EngineBackend>` —
+    /// ignores it entirely. Pre-v0.13 this field was required and
+    /// `connect_with` callers had to supply a placeholder
+    /// `BackendConfig::valkey(...)` just to satisfy the struct
+    /// literal; the SC-10 `incident-remediation` example surfaced
+    /// this as a rough edge.
+    ///
+    /// * `Some(cfg)` + [`FlowFabricWorker::connect`]: dial using
+    ///   `cfg` (unchanged behaviour).
+    /// * `None` + [`FlowFabricWorker::connect`]: rejected with
+    ///   [`SdkError::Config`]. The URL-based path needs a
+    ///   `BackendConfig` to dial.
+    /// * `None` + [`FlowFabricWorker::connect_with`]: clean —
+    ///   the injected backend is authoritative.
+    /// * `Some(cfg)` + [`FlowFabricWorker::connect_with`]:
+    ///   accepted but logs a WARN (`cfg` is ignored — the
+    ///   injected backend is authoritative).
+    ///
+    /// [`FlowFabricWorker::connect`]: crate::FlowFabricWorker::connect
+    /// [`FlowFabricWorker::connect_with`]: crate::FlowFabricWorker::connect_with
+    /// [`SdkError::Config`]: crate::SdkError::Config
+    pub backend: Option<BackendConfig>,
     /// Logical worker identity (e.g., "gpu-worker-pool-1").
     pub worker_id: WorkerId,
     /// Concrete worker process/runtime instance identity (e.g., container ID).

--- a/crates/ff-sdk/src/lib.rs
+++ b/crates/ff-sdk/src/lib.rs
@@ -24,7 +24,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), ff_sdk::SdkError> {
 //!     let config = WorkerConfig {
-//!         backend: BackendConfig::valkey("localhost", 6379),
+//!         backend: Some(BackendConfig::valkey("localhost", 6379)),
 //!         worker_id: WorkerId::new("my-worker"),
 //!         worker_instance_id: WorkerInstanceId::new("my-worker-instance-1"),
 //!         namespace: Namespace::new("default"),

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -41,7 +41,7 @@ use crate::SdkError;
 /// use ff_sdk::{FlowFabricWorker, WorkerConfig};
 ///
 /// let config = WorkerConfig {
-///     backend: BackendConfig::valkey("localhost", 6379),
+///     backend: Some(BackendConfig::valkey("localhost", 6379)),
 ///     worker_id: WorkerId::new("w1"),
 ///     worker_instance_id: WorkerInstanceId::new("w1-i1"),
 ///     namespace: Namespace::new("default"),
@@ -219,7 +219,22 @@ impl FlowFabricWorker {
         // Delegates to `ff_backend_valkey::build_client` so host/port +
         // TLS + cluster + `BackendTimeouts::request` + `BackendRetry`
         // wiring lives in exactly one place (RFC-012 Stage 1c tranche 1).
-        let client = ff_backend_valkey::build_client(&config.backend).await?;
+        //
+        // v0.13 ergonomics fix (feedback_sdk_reclaim_ergonomics
+        // Finding 2): `WorkerConfig.backend` is `Option<BackendConfig>`
+        // because `connect_with` ignores it. The URL-based `connect`
+        // path still requires a concrete `BackendConfig` to dial;
+        // reject `None` up front with a typed Config error instead of
+        // silently using a default that would hide a caller mistake.
+        let backend_config = config.backend.as_ref().ok_or_else(|| SdkError::Config {
+            context: "worker_config".into(),
+            field: Some("backend".into()),
+            message: "FlowFabricWorker::connect requires WorkerConfig.backend = \
+                Some(BackendConfig::...); use FlowFabricWorker::connect_with for \
+                the backend-agnostic path that takes a pre-built \
+                Arc<dyn EngineBackend>".into(),
+        })?;
+        let client = ff_backend_valkey::build_client(backend_config).await?;
 
         // v0.12 PR-6: the Valkey-specific preamble (PING, alive-key
         // SET-NX, `ff:config:partitions` HGETALL, caps ingress +
@@ -383,6 +398,22 @@ impl FlowFabricWorker {
                 field: None,
                 message: "at least one lane is required".into(),
             });
+        }
+
+        // v0.13 ergonomics fix (feedback_sdk_reclaim_ergonomics
+        // Finding 2): `WorkerConfig.backend` is ignored on this path —
+        // the caller-supplied `Arc<dyn EngineBackend>` is authoritative.
+        // If the caller left behind a `Some(..)` from an earlier
+        // `connect(..)` template, warn so the ambiguity is visible.
+        if config.backend.is_some() {
+            tracing::warn!(
+                worker_id = %config.worker_id,
+                instance_id = %config.worker_instance_id,
+                "WorkerConfig.backend is Some(..) but FlowFabricWorker::connect_with \
+                 was invoked — BackendConfig is ignored, the injected \
+                 Arc<dyn EngineBackend> is authoritative. Set WorkerConfig.backend = \
+                 None on the connect_with path to silence this warning."
+            );
         }
 
         let max_tasks = config.max_concurrent_tasks.max(1);

--- a/crates/ff-test/tests/describe_edge_api.rs
+++ b/crates/ff-test/tests/describe_edge_api.rs
@@ -41,7 +41,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new(format!("desc-edge-worker-{name_suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-edge-inst-{name_suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/describe_execution_api.rs
+++ b/crates/ff-test/tests/describe_execution_api.rs
@@ -41,7 +41,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new(format!("desc-exec-worker-{name_suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-exec-inst-{name_suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/describe_flow_api.rs
+++ b/crates/ff-test/tests/describe_flow_api.rs
@@ -40,7 +40,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new(format!("desc-flow-worker-{name_suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-flow-inst-{name_suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4370,7 +4370,7 @@ async fn test_max_concurrent_tasks_enforcement() {
 
     // Build a worker with max_concurrent_tasks = 2
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new("concurrency-test-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("concurrency-test-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -4956,7 +4956,7 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     // is guaranteed to saturate. Use the standard worker identity
     // so both grants are issued to this worker_id.
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new(WORKER),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(WORKER_INST),
         namespace: ff_core::types::Namespace::new(NS),
@@ -5039,7 +5039,7 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     // on the grant passes — we're modelling a retry from a fresh
     // worker process with free capacity, not a different identity.
     let second_worker_config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new(WORKER),
         // Distinct instance id so the alive-key SET NX guard in
         // `FlowFabricWorker::connect` doesn't reject us as a
@@ -5536,7 +5536,7 @@ async fn test_sdk_suspend_signal_resume_reclaim() {
 
     // Build SDK worker
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new("suspend-test-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("suspend-test-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -5727,7 +5727,7 @@ async fn test_sdk_all_methods_smoke() {
         .unwrap();
 
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new("sdk-smoke-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("sdk-smoke-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -5817,7 +5817,7 @@ async fn test_sdk_claim_retry_attempt_index() {
         .unwrap();
 
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new("retry-idx-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("retry-idx-inst"),
         namespace: ff_core::types::Namespace::new(NS),
@@ -8863,7 +8863,7 @@ async fn build_reclaim_test_worker(
     worker_instance_id: &str,
 ) -> ff_sdk::FlowFabricWorker {
     let config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new(worker_id),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(worker_instance_id),
         namespace: ff_core::types::Namespace::new(NS),
@@ -9241,7 +9241,7 @@ async fn test_claim_from_resume_grant_rejects_at_capacity() {
     // Build a worker with max_concurrent_tasks=1 so the second
     // reclaim is guaranteed to saturate.
     let worker_config = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new(WORKER),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(WORKER_INST),
         namespace: ff_core::types::Namespace::new(NS),

--- a/crates/ff-test/tests/engine_backend_describe.rs
+++ b/crates/ff-test/tests/engine_backend_describe.rs
@@ -60,7 +60,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new(format!("desc-trait-worker-{suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-trait-inst-{suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/engine_backend_describe_edge_resolve.rs
+++ b/crates/ff-test/tests/engine_backend_describe_edge_resolve.rs
@@ -50,7 +50,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new(format!("desc-edge-worker-{suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("desc-edge-inst-{suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/engine_backend_list_edges.rs
+++ b/crates/ff-test/tests/engine_backend_list_edges.rs
@@ -49,7 +49,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new(format!("list-edges-worker-{suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("list-edges-inst-{suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/engine_backend_list_flows.rs
+++ b/crates/ff-test/tests/engine_backend_list_flows.rs
@@ -45,7 +45,7 @@ async fn seed_partition_config(tc: &TestCluster) {
 
 async fn build_worker(suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new(format!("list-flows-worker-{suffix}")),
         worker_instance_id: WorkerInstanceId::new(format!("list-flows-inst-{suffix}")),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/engine_backend_list_lanes.rs
+++ b/crates/ff-test/tests/engine_backend_list_lanes.rs
@@ -48,7 +48,7 @@ async fn seed_lanes(tc: &TestCluster, lanes: &[&str]) {
 
 async fn build_sdk_worker() -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new("list-lanes-worker"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new("list-lanes-inst"),
         namespace: ff_core::types::Namespace::new("list-lanes-ns"),

--- a/crates/ff-test/tests/flow_edge_policies_stage_a.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_a.rs
@@ -78,7 +78,7 @@ async fn start_server(
 
 async fn build_worker() -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new("edgepol-worker"),
         worker_instance_id: WorkerInstanceId::new("edgepol-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/flow_edge_policies_stage_b.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_b.rs
@@ -77,7 +77,7 @@ async fn start_server(
 
 async fn build_worker() -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new("edgepol-b-worker"),
         worker_instance_id: WorkerInstanceId::new("edgepol-b-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/flow_edge_policies_stage_c.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_c.rs
@@ -82,7 +82,7 @@ async fn start_server(
 
 async fn build_worker() -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new("edgepol-c-worker"),
         worker_instance_id: WorkerInstanceId::new("edgepol-c-inst"),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/flow_edge_policies_stage_e.rs
+++ b/crates/ff-test/tests/flow_edge_policies_stage_e.rs
@@ -123,7 +123,7 @@ async fn start_server(tc: &TestCluster) -> std::sync::Arc<ff_server::server::Ser
 
 async fn build_worker(instance: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: WorkerId::new("edgepol-e-worker"),
         worker_instance_id: WorkerInstanceId::new(instance),
         namespace: Namespace::new(NS),

--- a/crates/ff-test/tests/resume_signals_integration.rs
+++ b/crates/ff-test/tests/resume_signals_integration.rs
@@ -26,7 +26,7 @@ const NS: &str = "resume-sig-ns";
 
 async fn build_worker(name_suffix: &str) -> ff_sdk::FlowFabricWorker {
     let cfg = ff_sdk::WorkerConfig {
-        backend: ff_test::fixtures::backend_config_from_env(),
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
         worker_id: ff_core::types::WorkerId::new(format!("resume-sig-worker-{name_suffix}")),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "resume-sig-inst-{name_suffix}"

--- a/docs/CONSUMER_MIGRATION_0.13.md
+++ b/docs/CONSUMER_MIGRATION_0.13.md
@@ -1,11 +1,15 @@
 # Consumer migration — v0.12 → v0.13
 
 **Scope.** v0.13 is an ergonomics release on top of v0.12. This doc
-covers the one consumer-visible SDK change in the release:
-`FlowFabricAdminClient` is now a **backend-agnostic facade**,
-constructible either over HTTP (existing behaviour) or directly over
-a backend trait object (new). No breaking changes — existing
-`connect` / `with_token` call-sites compile and behave identically.
+covers two consumer-visible SDK changes in the release:
+1. `FlowFabricAdminClient` is now a **backend-agnostic facade**,
+   constructible either over HTTP (existing behaviour) or directly
+   over a backend trait object (new). No breaking changes — existing
+   `connect` / `with_token` call-sites compile and behave identically.
+2. `WorkerConfig.backend` is now `Option<BackendConfig>` so
+   `FlowFabricWorker::connect_with` callers no longer need a
+   placeholder `BackendConfig`. Breaking for struct-literal
+   `connect` callers (wrap existing `BackendConfig` in `Some(...)`).
 
 A per-change CHANGELOG listing is the source of truth; this doc
 focuses on the ergonomic upgrade path.
@@ -166,6 +170,69 @@ per-deployment values:
 - `rotate_waitpoint_hmac_secret_all_partitions` free fn stays
   Valkey-gated (Valkey-specific FCALL fan-out; use the facade's
   `rotate_waitpoint_secret` for the agnostic path).
-- `WorkerConfig.backend: BackendConfig` dead-field under
-  `connect_with` — unresolved from v0.12 `feedback_sdk_reclaim_ergonomics.md`
-  Finding 2; separate follow-up.
+(Closed in this release: `WorkerConfig.backend: BackendConfig` dead
+under `connect_with` — see the dedicated section below.)
+
+## What also changed
+
+### `WorkerConfig.backend` is now `Option<BackendConfig>` (SC-10 follow-up)
+
+**Motivation.** The v0.12 SC-10 `incident-remediation` example
+surfaced a second rough edge on top of the admin-HTTP-only one:
+`WorkerConfig.backend` was eagerly required, but only consumed by
+`FlowFabricWorker::connect` (URL-based Valkey dial). The
+`connect_with` path — backend-agnostic, takes a pre-built
+`Arc<dyn EngineBackend>` — ignored the field entirely, forcing
+every `connect_with` caller (including the SC-10 SQLite supervisor)
+to carry a placeholder `BackendConfig::valkey("127.0.0.1", 6379)`
+just to satisfy the struct literal. Cairn flagged this as Finding 2
+in `feedback_sdk_reclaim_ergonomics.md`; v0.13 closes it.
+
+**Shape.** The field type changes from `BackendConfig` to
+`Option<BackendConfig>`. Semantics:
+
+- `Some(cfg)` + `FlowFabricWorker::connect` — unchanged. `cfg`
+  drives the dial.
+- `None` + `FlowFabricWorker::connect` — rejected with
+  `SdkError::Config { context: "worker_config", field:
+  Some("backend"), .. }`. The URL-based path needs a
+  `BackendConfig` to dial; silently defaulting would hide caller
+  mistakes.
+- `None` + `FlowFabricWorker::connect_with` — the clean path.
+  The injected backend is authoritative.
+- `Some(cfg)` + `FlowFabricWorker::connect_with` — accepted, but
+  logs a `tracing::warn!` noting that `cfg` is ignored. Useful
+  for callers mid-migration; set the field to `None` to silence.
+
+**Before (v0.12, `connect_with` path):**
+
+```rust,ignore
+let config = WorkerConfig {
+    backend: BackendConfig::valkey("127.0.0.1", 6379), // placeholder — ignored
+    worker_id: WorkerId::new("w1"),
+    // …
+};
+FlowFabricWorker::connect_with(config, backend, None).await?;
+```
+
+**After (v0.13, `connect_with` path):**
+
+```rust,ignore
+let config = WorkerConfig {
+    backend: None, // explicit: this path takes the injected backend
+    worker_id: WorkerId::new("w1"),
+    // …
+};
+FlowFabricWorker::connect_with(config, backend, None).await?;
+```
+
+**After (v0.13, `connect` path — minimal change):**
+
+```rust,ignore
+let config = WorkerConfig {
+    backend: Some(BackendConfig::valkey("localhost", 6379)), // wrap in Some
+    worker_id: WorkerId::new("w1"),
+    // …
+};
+FlowFabricWorker::connect(config).await?;
+```

--- a/examples/coding-agent/src/worker.rs
+++ b/examples/coding-agent/src/worker.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("coding-agent"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "coding-agent-{}",

--- a/examples/deploy-approval/src/bin/build_worker.rs
+++ b/examples/deploy-approval/src/bin/build_worker.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("deploy-build"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "deploy-build-{}",

--- a/examples/deploy-approval/src/bin/deploy.rs
+++ b/examples/deploy-approval/src/bin/deploy.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("deploy-rollout"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "deploy-rollout-{}",

--- a/examples/deploy-approval/src/bin/submit.rs
+++ b/examples/deploy-approval/src/bin/submit.rs
@@ -188,7 +188,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Default AllOf policy on all inbound edge groups (RFC-007). Seed
     // graph_revision from describe_flow (SDK, no REST route).
     let sdk = FlowFabricWorker::connect(WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: WorkerId::new("deploy-submit"),
         worker_instance_id: WorkerInstanceId::new(format!(
             "deploy-submit-{}",

--- a/examples/deploy-approval/src/bin/test_worker.rs
+++ b/examples/deploy-approval/src/bin/test_worker.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new(format!("deploy-test-{}", args.kind)),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "deploy-test-{}-{}",

--- a/examples/deploy-approval/src/bin/verify.rs
+++ b/examples/deploy-approval/src/bin/verify.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("deploy-verify"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "deploy-verify-{}",

--- a/examples/incident-remediation/src/main.rs
+++ b/examples/incident-remediation/src/main.rs
@@ -387,11 +387,16 @@ async fn build_worker(
     worker_instance_id: &str,
     lane: &LaneId,
 ) -> Result<FlowFabricWorker> {
-    // `BackendConfig` is only consulted by `FlowFabricWorker::connect`
-    // (the Valkey-native entry point); `connect_with` ignores it and
-    // relies entirely on the injected `Arc<dyn EngineBackend>`.
+    // v0.13 ergonomics fix (feedback_sdk_reclaim_ergonomics Finding 2):
+    // `WorkerConfig.backend` is `Option<BackendConfig>` and the
+    // `connect_with` path — which takes a pre-built
+    // `Arc<dyn EngineBackend>` — accepts `None`. Pre-v0.13 this
+    // example carried a placeholder `BackendConfig::valkey("127.0.0.1",
+    // 6379)` here purely to satisfy the struct literal even though
+    // the SQLite supervisor never dialed Valkey. Passing `None` makes
+    // the intent explicit.
     let config = WorkerConfig {
-        backend: BackendConfig::valkey("127.0.0.1", 6379),
+        backend: None,
         worker_id: WorkerId::new(worker_id),
         worker_instance_id: WorkerInstanceId::new(worker_instance_id),
         namespace: Namespace::new("incidents"),

--- a/examples/llm-race/src/bin/aggregator.rs
+++ b/examples/llm-race/src/bin/aggregator.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("llm-race-aggregator"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "llm-race-aggregator-{}",

--- a/examples/llm-race/src/bin/provider.rs
+++ b/examples/llm-race/src/bin/provider.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("llm-race-provider"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "llm-race-provider-{}",

--- a/examples/llm-race/src/bin/submit.rs
+++ b/examples/llm-race/src/bin/submit.rs
@@ -193,7 +193,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // RFC-016 Stage B requires the policy be set BEFORE the first
     // `add_dependency(... -> aggregator)` edge lands.
     let sdk = FlowFabricWorker::connect(WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: WorkerId::new("llm-race-submit"),
         worker_instance_id: WorkerInstanceId::new(format!(
             "llm-race-submit-{}",

--- a/examples/media-pipeline/src/bin/embed.rs
+++ b/examples/media-pipeline/src/bin/embed.rs
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
 
     let instance_id = format!("embed-{}", uuid::Uuid::new_v4());
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("embed"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
         namespace: ff_core::types::Namespace::new(&args.namespace),

--- a/examples/media-pipeline/src/bin/summarize.rs
+++ b/examples/media-pipeline/src/bin/summarize.rs
@@ -115,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
 
     let instance_id = format!("summarize-{}", uuid::Uuid::new_v4());
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("summarize"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
         namespace: ff_core::types::Namespace::new(&args.namespace),

--- a/examples/media-pipeline/src/bin/transcribe.rs
+++ b/examples/media-pipeline/src/bin/transcribe.rs
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 
     let instance_id = format!("transcribe-{}", uuid::Uuid::new_v4());
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(&args.host, args.port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(&args.host, args.port)),
         worker_id: ff_core::types::WorkerId::new("transcribe"),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(&instance_id),
         namespace: ff_core::types::Namespace::new(&args.namespace),

--- a/examples/retry-and-cancel/src/main.rs
+++ b/examples/retry-and-cancel/src/main.rs
@@ -297,7 +297,7 @@ async fn run_worker(
     done: Arc<Notify>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = WorkerConfig {
-        backend: ff_core::backend::BackendConfig::valkey(host, port),
+        backend: Some(ff_core::backend::BackendConfig::valkey(host, port)),
         worker_id: ff_core::types::WorkerId::new(WORKER_POOL),
         worker_instance_id: ff_core::types::WorkerInstanceId::new(format!(
             "{WORKER_POOL}-{}",

--- a/examples/token-budget/src/main.rs
+++ b/examples/token-budget/src/main.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
     // use below for `create_budget` / `get_budget_status` / `cancel_flow`
     // — no second Valkey connection.
     let worker = FlowFabricWorker::connect(WorkerConfig {
-        backend: flowfabric::core::backend::BackendConfig::valkey(host.clone(), port),
+        backend: Some(flowfabric::core::backend::BackendConfig::valkey(host.clone(), port)),
         worker_id: WorkerId::new(WORKER_POOL),
         worker_instance_id: WorkerInstanceId::new(format!(
             "{WORKER_POOL}-{}",

--- a/examples/v010-read-side-ergonomics/src/main.rs
+++ b/examples/v010-read-side-ergonomics/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // produces events.
     let done = Arc::new(Notify::new());
     let worker = FlowFabricWorker::connect(WorkerConfig {
-        backend: BackendConfig::valkey(host.clone(), port),
+        backend: Some(BackendConfig::valkey(host.clone(), port)),
         worker_id: WorkerId::new(WORKER_POOL),
         worker_instance_id: WorkerInstanceId::new(format!(
             "{WORKER_POOL}-{}",


### PR DESCRIPTION
## Summary

Closes `feedback_sdk_reclaim_ergonomics.md` Finding 2. Pre-v0.13
`WorkerConfig.backend: BackendConfig` was eager but only consumed by
`FlowFabricWorker::connect` (the URL-based Valkey dial). The
backend-agnostic `FlowFabricWorker::connect_with` path ignored it
entirely, forcing every `connect_with` caller — including the
v0.12 SC-10 `incident-remediation` SQLite supervisor that cairn
flagged — to carry a placeholder `BackendConfig::valkey("127.0.0.1",
6379)` just to satisfy the struct literal.

This PR changes the field to `Option<BackendConfig>`:

| state | `connect` (URL-based) | `connect_with` (injected backend) |
|---|---|---|
| `Some(cfg)` | dial using `cfg` (unchanged) | accepted, logs `tracing::warn!` that `cfg` is ignored |
| `None` | rejected with `SdkError::Config` | clean — no placeholder needed |

## Before / after (`connect_with` path — cairn's pain point)

Before (v0.12):
```rust
let config = WorkerConfig {
    backend: BackendConfig::valkey("127.0.0.1", 6379), // placeholder — ignored
    worker_id: WorkerId::new("w1"),
    // …
};
FlowFabricWorker::connect_with(config, backend, None).await?;
```

After (v0.13):
```rust
let config = WorkerConfig {
    backend: None, // explicit: this path takes the injected backend
    worker_id: WorkerId::new("w1"),
    // …
};
FlowFabricWorker::connect_with(config, backend, None).await?;
```

`connect` callers migrate mechanically: wrap existing `BackendConfig`
in `Some(...)`.

`examples/incident-remediation` updated to the new shape (no more
dummy `BackendConfig::valkey` on the SQLite supervisor path).

## Scope

- `crates/ff-sdk/src/config.rs` — field type + rustdoc.
- `crates/ff-sdk/src/worker.rs` — `connect` rejects `None`; `connect_with` warns on `Some`.
- All in-workspace struct-literal call sites updated (benches, tests, examples — wrapped in `Some(...)` for `connect` paths; `incident-remediation` uses `None` on its `connect_with` path).
- `CHANGELOG.md` + `docs/CONSUMER_MIGRATION_0.13.md` — before/after snippets and migration note.

## Test plan

- [x] `cargo test -p ff-sdk --lib` — 44 passed, 0 failed.
- [x] `cargo test --workspace --lib` — all green.
- [x] `cargo check --workspace --all-targets` — clean (only pre-existing warnings).
- [x] `cargo check -p ff-sdk --no-default-features --features sqlite` — clean.
- [x] `cargo clippy -p ff-sdk --all-targets -- -D warnings` — clean.
- [x] `cargo build --bins` in every `examples/` subdir — clean.

Expected-red CI checks: `cargo-semver-checks` (field type change is a
semver-minor break pre-1.0), `quality-gates-complete` (cargo-semver-checks gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)