### PR TITLE
docs: complete v0.13 migration guide + fill POSTGRES_PARITY_MATRIX rows (release-gate)

### DIFF
--- a/docs/CONSUMER_MIGRATION_0.13.md
+++ b/docs/CONSUMER_MIGRATION_0.13.md
@@ -293,3 +293,329 @@ let config = WorkerConfig {
 };
 FlowFabricWorker::connect(config).await?;
 ```
+
+## Tag methods — `set_execution_tag` / `set_flow_tag` / `get_execution_tag` / `get_flow_tag` (#439 / cairn #433)
+
+**Motivation.** Pre-v0.13 consumers setting caller-namespaced tags
+(e.g. `cairn.session_id`) had to drop down to raw `ferriskey::Client`
+`HSET` calls against internal partition layouts. That bypassed
+FlowFabric's namespace validation, coupled cairn to the Valkey wire
+shape, and was unreachable from PG/SQLite consumers. v0.13 adds four
+trait-routed tag methods with identical shape across all three
+backends.
+
+**Namespace rule.** Tag keys MUST match the regex
+`^[a-z][a-z0-9_]*\.[a-z0-9_][a-z0-9_.]*$` — i.e. `<caller>.<field>`
+with a literal dot separator. The key carries its own namespace
+(`cairn.session_id`, not `session_id` + a separate namespace arg).
+Values are arbitrary UTF-8. The trait-side
+`ff_core::engine_backend::validate_tag_key` is the parity-of-record
+and runs on every backend before the wire hop; Valkey's Lua path
+additionally validates (more permissively, prefix-only) on the
+storage tier.
+
+**Before (v0.12, cairn's pattern):**
+
+```rust,ignore
+// Raw Valkey HSET bypassing FlowFabric's namespace rules.
+let mut client = ferriskey::Client::connect(valkey_url).await?;
+client
+    .hset(
+        format!("ff:exec:{{p:{}}}:{}:tags", partition, exec_id),
+        "cairn.session_id",
+        session_id.as_str(),
+    )
+    .await?;
+```
+
+**After (v0.13, trait-routed on any backend):**
+
+```rust,ignore
+let backend: Arc<dyn EngineBackend> = pg_backend.clone();
+backend
+    .set_execution_tag(&exec_id, "cairn.session_id", session_id.as_str())
+    .await?;
+
+// Read-side:
+let v = backend
+    .get_execution_tag(&exec_id, "cairn.session_id")
+    .await?;
+
+// Flow-scoped tags land on a separate store (see engine_backend rustdoc
+// for the per-backend shape — Valkey uses a dedicated :tags sub-hash;
+// PG/SQLite write the top-level raw_fields on ff_flow_core):
+backend
+    .set_flow_tag(&flow_id, "cairn.tenant", tenant.as_str())
+    .await?;
+```
+
+**Error mapping.**
+
+- Invalid key → `EngineError::Validation { kind: InvalidInput, detail }`
+  (short-circuits before the wire hop).
+- Missing execution → `EngineError::NotFound { entity: "execution" }`
+  (matches the Valkey FCALL `execution_not_found` mapping).
+- Missing flow → `EngineError::NotFound { entity: "flow" }`.
+- On read, missing tag **and** missing row both collapse to
+  `Ok(None)` — callers that need to distinguish must call
+  `describe_execution` / `describe_flow` first.
+
+**Describe-flow parity caveat.** `FlowSnapshot::tags` from
+Valkey's `describe_flow` snapshots `flow_core` fields only and does
+NOT today merge the `:tags` sub-hash; Postgres `describe_flow` surfaces
+flow tags via `extract_tags` on `raw_fields`. Consumers on Valkey that
+need the full flow-tag set should complement the snapshot with per-key
+`get_flow_tag` reads until the Valkey merge lands (additive
+post-v0.13).
+
+## Waitpoint-token read — `read_waitpoint_token` (#438 / cairn #434)
+
+**Motivation.** The signal-bridge (cairn's resume-on-signal harness)
+needs to read the stored waitpoint token at poll-on-resume to
+reconstruct the HMAC fingerprint. Pre-v0.13 the only path was
+Valkey-only `fetch_waitpoint_token_v07` (retired at v0.8.0) or raw
+`HGET` against an internal partition layout. v0.13 adds a
+backend-agnostic trait method — all three backends implement it.
+
+**Before (v0.12, Valkey-only):**
+
+```rust,ignore
+// Direct Valkey HGET bypassing the trait.
+let mut client = ferriskey::Client::connect(valkey_url).await?;
+let token: Option<String> = client
+    .hget(
+        format!("ff:wp:{{p:{}}}:{}", partition, waitpoint_id),
+        "token",
+    )
+    .await?;
+```
+
+**After (v0.13):**
+
+```rust,ignore
+let token = backend
+    .read_waitpoint_token(partition, &waitpoint_id)
+    .await?;
+```
+
+`partition` is the opaque `PartitionKey` the waitpoint was minted
+against — typically extracted from the `Handle` / `ResumeToken` the
+signal-bridge holds. Missing waitpoint surfaces as `Ok(None)` on all
+three backends.
+
+## Service-layer FCALL surface (#442 / cairn #389)
+
+**Motivation.** Control-plane callers (cairn's
+`valkey_control_plane_impl.rs` and future non-Handle consumers) were
+reaching into `ferriskey::Value::Array` matching + a manual
+`check_fcall_success` + `parse_*` for the full `complete` / `fail` /
+`renew` / `resume` / admission / eligibility surface. v0.13 adds six
+trait methods that mirror the existing Handle-taking peers but accept
+`(execution_id, fence)` tuples and return typed outcomes from
+`ff_core::contracts`.
+
+**Parity status at v0.13.** Valkey ships bodies at landing. PG +
+SQLite inherit the `EngineError::Unavailable { op: "<name>" }` default
+and receive real bodies in a follow-up (same staging as RFC-024
+reclaim + `claim_execution`). See
+[`POSTGRES_PARITY_MATRIX.md`](POSTGRES_PARITY_MATRIX.md) §cairn #389
+for the per-method row.
+
+**Before (v0.12):**
+
+```rust,ignore
+// Raw ferriskey Value matching against the FCALL response.
+let resp = client
+    .fcall(
+        "ff_complete_execution",
+        &keys_for_exec(&partition, &exec_id),
+        &args_for_complete(&fence, &result_payload),
+    )
+    .await?;
+let arr = match resp {
+    ferriskey::Value::Array(a) => a,
+    other => anyhow::bail!("unexpected FCALL shape: {other:?}"),
+};
+check_fcall_success(&arr)?;
+let outcome = parse_complete_execution_response(&arr)?;
+```
+
+**After (v0.13):**
+
+```rust,ignore
+let outcome = backend
+    .complete_execution(&exec_id, &fence, &result_payload)
+    .await?;
+
+// Sibling peers, same pattern:
+backend.fail_execution(&exec_id, &fence, &failure).await?;
+backend.renew_lease(&exec_id, &fence).await?;
+backend.resume_execution(&exec_id, &fence, &resume_args).await?;
+
+// Admission / eligibility — read-shaped:
+let admission = backend
+    .check_admission(&quota_policy_id, "default", &args)
+    .await?;
+let status = backend.evaluate_flow_eligibility(&flow_id).await?;
+```
+
+`check_admission` takes `quota_policy_id` + `dimension` outside the
+`CheckAdmissionArgs` struct because quota keys live on the
+`{q:<policy>}` partition (not derivable from `execution_id`); empty
+`dimension` is normalised to `"default"`.
+
+## PR-7b scanner trait routing (#436 / cluster PRs)
+
+**Motivation.** The scanner supervisor (`ff-engine`) previously held
+Valkey-specific FCALL dispatch logic for every scanner tick —
+foundation (`mark_lease_expired_if_due`, `promote_delayed`,
+`close_waitpoint`, `expire_execution`, `expire_suspension`),
+reconciler (`unblock_execution`), cancel-family
+(`drain_sibling_cancel_group`, `reconcile_sibling_cancel_group`),
+tally-recompute (`reconcile_{execution_index,budget_counters,quota_counters}`),
+projection (`project_flow_summary`), and retention (`trim_retention`).
+Consumers embedding `Engine` on Postgres or SQLite saw `Unsupported`
+from every tick. v0.13 routes every scanner tick through
+`EngineBackend::*` with backend-appropriate semantics.
+
+**Cluster index.**
+
+| Cluster | PR | Trait methods |
+|---|---|---|
+| 1 — Foundation | #441 + #443 | `mark_lease_expired_if_due`, `promote_delayed`, `close_waitpoint`, `expire_execution`, `expire_suspension`, `get_execution_namespace` |
+| 2 — Reconciler | #445 | `unblock_execution` |
+| 3 — Cancel family | #444 | `drain_sibling_cancel_group`, `reconcile_sibling_cancel_group` |
+| 2b-A — Tally-recompute | #447 | `reconcile_execution_index`, `reconcile_budget_counters`, `reconcile_quota_counters` |
+| 2b-B — Projection + retention | #449 (pending merge) | `project_flow_summary`, `trim_retention` |
+| 4 — Completion listener | #446 | `cascade_completion` (covered in the Cluster 4 section above) |
+
+**Consumer-visible shape.** Consumers embedding `Engine` get
+backend-agnostic scanner routing post-PR-7b final scaffolding:
+
+```rust,ignore
+// Post-PR-7b: Engine::start_with_completions is backend-agnostic.
+let pg_backend: Arc<PostgresBackend> = PostgresBackend::connect_with(...).await?;
+let engine = Engine::start_with_completions(
+    config,
+    pg_backend.clone().into_arc_dyn(),  // backend as Arc<dyn EngineBackend>
+    completion_stream,
+    shutdown,
+)
+.await?;
+```
+
+On Postgres + SQLite, the reconcile/cancel/tally scanner ticks that
+map to Valkey-only FCALL semantics surface `Unsupported` and the
+scanner supervisor skips them — **intentional**, because the PG
+scheduler and SQLite's `BEGIN IMMEDIATE` reconcilers re-evaluate the
+same state live via SQL. See
+[`POSTGRES_PARITY_MATRIX.md`](POSTGRES_PARITY_MATRIX.md) §PR-7b
+scanner additions for the per-method rationale.
+
+## cairn closed-issues index
+
+v0.13 closes the following cairn-originated ask items. Each row
+points to the tracking FlowFabric issue/PR pair.
+
+| cairn issue | FlowFabric resolution | Ship vehicle |
+|---|---|---|
+| #433 Tag methods on trait | #439 | v0.13 (this release) |
+| #434 Waitpoint-token read on trait | #438 | v0.13 |
+| #435 `pg.create_waitpoint` | #437 | v0.13 |
+| #387 `ferriskey` ReadOnly auto-refresh | #426 + #427 + #429 chain | v0.12 (realised) |
+| #389 Typed FCALL outcomes (service-layer) | #442 | v0.13 (Valkey); PG + SQLite bodies follow-up |
+| #436 PR-7b — `Engine` non-Valkey backend routing | #441 + #443 + #444 + #445 + #446 + #447 + #449 + final scaffolding | v0.13 |
+
+**Per-issue summary.**
+
+- **#433 (→ #439).** Caller-namespaced tag writes + reads now route
+  through `EngineBackend::{set,get}_{execution,flow}_tag` on all
+  three backends. Regex-validated at the trait edge. See §Tag
+  methods above.
+- **#434 (→ #438).** `read_waitpoint_token` implemented on all three
+  backends; replaces the retired `fetch_waitpoint_token_v07`. See
+  §Waitpoint-token read above.
+- **#435 (→ #437).** Postgres `create_waitpoint` landed as a trait
+  impl, closing the ingress-parity gap flagged during cairn's
+  signal-bridge port.
+- **#387 (→ #426 + #427 + #429 chain).** `ferriskey` ReadOnly clients
+  now auto-refresh on topology changes without caller intervention.
+  Realised in v0.12; kept in this index for completeness.
+- **#389 (→ #442).** Six service-layer trait methods added
+  (`complete_execution`, `fail_execution`, `renew_lease`,
+  `resume_execution`, `check_admission`,
+  `evaluate_flow_eligibility`). See §Service-layer FCALL surface
+  above. PG + SQLite parity is v0.13-follow-up scope.
+- **#436 (→ 7+ PRs).** PR-7b trait-routed scanner push lands every
+  cluster 1/2/3/2b-A/2b-B/4 scanner tick behind the `EngineBackend`
+  trait. Cluster 2b-B (projection + retention) depends on #449
+  merging.
+
+## Known limitations
+
+The following Postgres / SQLite `Unavailable` surfaces persist in
+v0.13 and are **not** closed by this release. All are tracked;
+consumers on PG or SQLite should compile-check against the matrix
+before relying on these methods.
+
+- **`claim_from_grant` / `claim_execution` / `claim_via_server`
+  still PG/SQLite `Unavailable`** per
+  `project_claim_from_grant_pg_sqlite_gap.md`. v0.13 does NOT
+  address this. PG's grant-consumer flow routes through
+  `PostgresScheduler::claim_for_worker`; SQLite has no
+  grant-consumer path today.
+- **`resolve_dependency` PG `Unavailable`** — PG uses an
+  outbox-per-event cascade (`ff_completion_event` +
+  `dispatch_completion`), not the Valkey per-edge shape. Not a bug;
+  an architectural divergence — the PG reconciler already drives
+  the equivalent work.
+- **`unblock_execution` PG `Unavailable`** — PG re-evaluates
+  eligibility live via SQL on every `claim_for_worker` tick; no
+  persisted blocked-index to reconcile. SQLite inherits the design.
+- **Scanner-bypass primitives Valkey-only** —
+  `scan_eligible_executions`, `issue_claim_grant`, `block_route`
+  remain Valkey-`impl` / PG + SQLite `Unavailable` (default). **Not
+  a regression** — design intent; gated behind the
+  `direct-valkey-claim` bench-only feature. PG/SQLite consumers use
+  the scheduler-routed `claim_for_worker` path.
+- **Retention overrides Valkey-only post-#449** —
+  `policy.stream_policy.retention_ttl_ms` per-policy overrides are
+  honoured only on Valkey's `trim_retention` FCALL. Postgres uses
+  the global default. Not a regression; documented when #449 lands.
+- **Scanner `Unavailable` on PG/SQLite by design** — the six
+  reconcile/cancel/tally scanner methods
+  (`drain_sibling_cancel_group`, `reconcile_sibling_cancel_group`,
+  `unblock_execution`, `reconcile_execution_index`,
+  `reconcile_budget_counters`, `reconcile_quota_counters`) return
+  `Unavailable` on PG/SQLite — **not a parity gap**, because these
+  backends' SERIALIZABLE transactions + live SQL eligibility
+  re-evaluation leave no counter drift to reconcile. See the matrix
+  for per-method rationale.
+
+## Deferred to v0.14
+
+The following items were scoped out of v0.13 and are on the v0.14
+track. Trackers listed inline.
+
+- **Broader `Duration` overflow harmonisation** — scattered
+  `u64::MAX` ms-to-`Duration` conversions need a project-wide
+  policy pass. Tracked on GitHub issues.
+- **Option B streaming trait split** — the streaming-feature-gated
+  subtrait split was considered but deferred; current
+  `#[cfg(feature = "streaming")]` gates on individual trait methods
+  ship v0.13 unchanged.
+- **PG / SQLite `claim_execution` parity** — grant-consumer flow
+  for the SDK `claim_from_grant` path. See
+  `project_claim_from_grant_pg_sqlite_gap.md`.
+- **SQLite `public_state = 'running'` on claim path** — see
+  `project_sqlite_claim_public_state_gap.md`. Normaliser handles
+  the read side; claim-write parity is a v0.14 fix.
+- **Remaining PG `Unavailable` surfaces on the service-layer family**
+  — bodies for `complete_execution`, `fail_execution`,
+  `renew_lease`, `resume_execution`, `check_admission`,
+  `evaluate_flow_eligibility` on PG + SQLite. Covered by #442
+  follow-up.
+- **Cluster 2b-B rows in the parity matrix** —
+  `project_flow_summary` and `trim_retention` rows merge
+  concurrently with PR #449; if #449 slips past the v0.13 tag,
+  the rows land in a point-release doc amendment.

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -538,3 +538,63 @@ Until the bodies land, consumers compiling against those backends
 receive `EngineError::Unavailable { op: "<name>" }` on dispatch — a
 terminal, non-retryable classification the `ErrorClass` mapping
 already handles.
+
+### PR-7b scanner + cairn #434 additions (v0.13)
+
+Seven new trait methods landed during the PR-7b trait-routed scanner
+push (cairn #436) plus cairn #434 (waitpoint-token read). Row values
+reflect bodies on `main` at v0.13 tag-prep time.
+
+**Cluster 2 — reconciler scanners (#445):**
+
+| Method | Valkey | Postgres | SQLite | Notes |
+|---|---|---|---|---|
+| `unblock_execution` | `impl` | `Unavailable` (default, intentional) | `Unavailable` (default) | Valkey: `FCALL ff_unblock_execution` — scanner-driven move from `blocked_route` ZSET back to lane-eligible after a capability change. Postgres is architecturally `Unavailable`: the PG scheduler re-evaluates eligibility live via SQL on every `claim_for_worker` tick (`ff_exec_core` eligibility columns + `ff_lane` routing join), so there is no persisted blocked-index to reconcile. SQLite inherits PG's live-SQL approach; same rationale. |
+
+**Cluster 3 — cancel-family scanners (#444):**
+
+| Method | Valkey | Postgres | SQLite | Notes |
+|---|---|---|---|---|
+| `drain_sibling_cancel_group` | `impl` | `Unavailable` (default, intentional) | `Unavailable` (default) | Valkey: `FCALL ff_drain_sibling_cancel_group` — scanner drains the per-group sibling-cancel backlog into per-member cancel writes. Postgres `cancel_flow_header` + `ack_cancel_member` already use `ff_cancel_backlog` (migration 0014) and the PG cancel-backlog reconciler drives per-member writes directly from the table; no separate drain step exists. SQLite mirrors the PG cancel-backlog design (RFC-023 Phase 3.3). |
+| `reconcile_sibling_cancel_group` | `impl` | `Unavailable` (default, intentional) | `Unavailable` (default) | Valkey: `FCALL ff_reconcile_sibling_cancel_group` — scanner recounts `group_pending` vs `group_active` and flips group-terminal transitions. Postgres + SQLite derive group state from SQL aggregates over `ff_cancel_backlog` + `ff_exec_core` at read time; no persisted group counter to reconcile. |
+
+**Cluster 2b-A — tally-recompute scanners (#447):**
+
+| Method | Valkey | Postgres | SQLite | Notes |
+|---|---|---|---|---|
+| `reconcile_execution_index` | `impl` | `Unavailable` (default, intentional) | `Unavailable` (default) | Valkey: `FCALL ff_reconcile_execution_index` — recomputes per-lane eligible ZSET counters to repair drift from crash-in-middle-of-FCALL sequences. Postgres runs SERIALIZABLE-tx counters under `ff_exec_core` + live SQL eligibility evaluation on every claim; no persisted counter to drift, nothing to reconcile. SQLite inherits the PG design under `BEGIN IMMEDIATE`. |
+| `reconcile_budget_counters` | `impl` | `Unavailable` (default, intentional) | `Unavailable` (default) | Valkey: `FCALL ff_reconcile_budget_counters` — recomputes `ff:budget:*` hash counters from `ff_budget_usage` entries. Postgres maintains breach counters + `next_reset_at_ms` in-tx on `ff_budget_policy` + `ff_budget_usage` (migration 0013) under READ-COMMITTED INSERT-or-UPDATE; drift-free by construction. SQLite mirrors PG (RFC-023 Phase 3.4). |
+| `reconcile_quota_counters` | `impl` | `Unavailable` (default, intentional) | `Unavailable` (default) | Valkey: `FCALL ff_reconcile_quota_counters` — recomputes per-window quota counters after partial-apply crashes. Postgres maintains `ff_quota_window` + `ff_quota_admitted` in-tx (migration 0012, 256-way HASH-partitioned); drift-free by construction. SQLite mirrors PG. |
+
+**Cluster 2b-B — projection + retention scanners (#449, pending merge):**
+
+Rows for `project_flow_summary` and `trim_retention` depend on PR #449
+merging. They will be added in a follow-up commit once #449 lands, OR
+as part of #449's own doc updates. Expected shape:
+
+- `project_flow_summary` — Valkey `impl`, Postgres `impl` (migration
+  `0019_flow_summary.sql`), SQLite default `Unavailable`.
+- `trim_retention` — Valkey `impl`, Postgres `impl`, SQLite default
+  `Unavailable`. Retention overrides
+  (`policy.stream_policy.retention_ttl_ms`) are Valkey-only; PG uses
+  the global default. Not a regression — design intent documented in
+  [`CONSUMER_MIGRATION_0.13.md`](CONSUMER_MIGRATION_0.13.md) §Known
+  limitations.
+
+**cairn #434 — waitpoint-token read (#438):**
+
+| Method | Valkey | Postgres | SQLite | Notes |
+|---|---|---|---|---|
+| `read_waitpoint_token` | `impl` | `impl` | `impl` | Non-mutating point read of the stored waitpoint token. Replaces the Valkey-only `fetch_waitpoint_token_v07` retired at v0.8.0 with a backend-agnostic surface. Valkey: HGET on the partition-local waitpoint hash. Postgres: `SELECT token FROM ff_waitpoint_pending WHERE partition = $1 AND waitpoint_id = $2` (`suspend_ops::read_waitpoint_token_impl`). SQLite: same shape via `crates/ff-backend-sqlite/src/reads.rs::read_waitpoint_token_impl`. Missing row surfaces as `Ok(None)` on all three backends (signal-bridge poll-on-resume pattern relies on this). |
+
+**Summary of Valkey-scanner asymmetry (PG/SQLite `Unavailable`).** The
+6 scanner methods above are all Valkey-`impl` / PG+SQLite `Unavailable`
+by design. This is **not a parity gap** — the reconcile-drift pattern
+these scanners implement only exists on the Valkey backend's CRDT-ish
+counter topology. Postgres uses SERIALIZABLE transactions + live SQL
+eligibility re-evaluation; SQLite uses `BEGIN IMMEDIATE` + the same
+PG reconciler shapes. Neither backend can drift, so neither needs a
+reconcile hook. Consumers embedding `Engine` get backend-agnostic
+scanner routing: PR-7b final scaffolding asserts `Unsupported` on
+PG/SQLite for scanner-shaped calls, and the engine's scanner
+supervisor skips the tick entirely on those backends.


### PR DESCRIPTION
## Summary

Addresses two v0.13 release-audit blockers.

### Blocker 1 — POSTGRES_PARITY_MATRIX.md missing rows

Added 7 rows under a new **PR-7b scanner + cairn #434 additions (v0.13)** section:

- `unblock_execution` (Cluster 2, #445) — Valkey `impl`, PG/SQLite `Unavailable` (live SQL eligibility re-evaluation).
- `drain_sibling_cancel_group` + `reconcile_sibling_cancel_group` (Cluster 3, #444) — Valkey `impl`, PG/SQLite `Unavailable` (PG uses `ff_cancel_backlog` + reconciler; SQLite mirrors).
- `reconcile_execution_index` + `reconcile_budget_counters` + `reconcile_quota_counters` (Cluster 2b-A, #447) — Valkey `impl`, PG/SQLite `Unavailable` (SERIALIZABLE-tx counters + live SQL leave no drift to reconcile).
- `read_waitpoint_token` (cairn #434 / #438) — **`impl` on all three backends**.

Cluster 2b-B rows (`project_flow_summary`, `trim_retention`) **deferred pending PR #449 merge**; expected shape documented inline so they land as a follow-up commit once #449 lands.

Rationale: every Valkey-only scanner row is **intentional design**, not a parity gap — PG's SERIALIZABLE + live SQL + SQLite's `BEGIN IMMEDIATE` reconcilers cannot drift, so no reconcile hook is needed.

### Blocker 2 — CONSUMER_MIGRATION_0.13.md substantially incomplete

Extended the guide with 7 new sections (≈326 lines added):

1. **Tag methods** (#439 / cairn #433) — `set_execution_tag` / `set_flow_tag` / `get_execution_tag` / `get_flow_tag`. Before/after vs raw `ferriskey::Client::hset`; namespace regex (`^[a-z][a-z0-9_]*\.[a-z0-9_][a-z0-9_.]*$`); `describe_flow` parity caveat.
2. **Waitpoint-token read** (#438 / cairn #434) — `read_waitpoint_token`; signal-bridge migration pattern.
3. **Service-layer FCALL surface** (#442 / cairn #389) — 6 typed methods replacing raw `Value::Array` matching; Valkey bodies ship at v0.13, PG+SQLite parity is follow-up scope.
4. **PR-7b scanner trait routing** (#436) — cluster-index table, `Engine::start_with_completions` backend-agnostic shape post-PR-7b final.
5. **cairn closed-issues index** — table + per-issue summaries for #433, #434, #435, #387, #389, #436.
6. **Known limitations** — `claim_from_grant`, `resolve_dependency`, `unblock_execution`, scanner-bypass primitives, retention overrides, scanner `Unavailable` by design.
7. **Deferred to v0.14** — Duration overflow, Option B streaming split, PG/SQLite `claim_execution`, SQLite `public_state='running'` on claim, service-layer PG/SQLite bodies, Cluster 2b-B matrix rows.

## Parallel-safety

Docs-only; no code files touched. Safe to merge alongside PR-7b final (#449) and other in-flight work.

## Coordination with PR #449

If #449 merges first, this PR's §Cluster 2b-B sections and Deferred-to-v0.14 row for the matrix become accurate-as-shipped. If #449 slips past v0.13 tag, this PR's pending-merge language stands and the 2 matrix rows land in a point-release doc amendment.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] Cross-reference links sanity-checked (memory file names, PR #s).
- [x] Legend + table formats match existing matrix conventions (cluster-1 section as reference).
- [x] Before/after code blocks compile-shape-correct against current trait signatures.

## Release-gate

Closes 2 of the v0.13 release-audit blockers. Per CLAUDE.md §5 release gate #7 ("POSTGRES_PARITY_MATRIX.md current") this is a hard release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)