### PR TITLE
feat(ff-backend-postgres): PR-7b/#453/1 — renew_lease PG body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **#453 / PR-7b: `EngineBackend::renew_lease` — Postgres body.**
+  First typed-FCALL method from cairn's v0.13-blocker list to flip
+  from `Unavailable` default to a real PG SQL transaction. Ports
+  `ff_renew_lease` from `flowfabric.lua` to a `READ COMMITTED` tx
+  with `FOR UPDATE` on the target `ff_attempt` row. Fence validation
+  covers `lease_epoch` only (documented asymmetry vs Valkey's
+  full-triple check — PG schema doesn't persist `lease_id` /
+  `attempt_id` to disk; `lease_epoch` monotonic bump catches the
+  same violations). Error mapping: `fence_required` →
+  `Validation{InvalidInput}`, `stale_lease` → `State(StaleLease)`,
+  `lease_expired` → `State(LeaseExpired)`, `execution_not_active` →
+  `Contention(ExecutionNotActive{...})`. Integration tests at
+  `crates/ff-backend-postgres/tests/typed_renew_lease.rs` cover the
+  full error matrix (ignore-gated on `FF_PG_TEST_URL`). SQLite
+  follow-up tracked separately.
 - **PR-7b Wave 0a: `Engine::start_*` no longer panics on non-Valkey
   backends (cairn #436).** The v0.12 PR-7a transitional downcast —
   `backend.as_any().downcast_ref::<ValkeyBackend>()` followed by

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1591,6 +1591,7 @@ impl EngineBackend for PostgresBackend {
 
     // ── PR-7b / #453: typed-FCALL bodies ──
 
+    #[cfg(feature = "core")]
     async fn renew_lease(
         &self,
         args: ff_core::contracts::RenewLeaseArgs,

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -119,6 +119,8 @@ mod signal_event;
 pub mod stream;
 pub mod suspend;
 pub mod suspend_ops;
+#[cfg(feature = "core")]
+pub(crate) mod typed_ops;
 pub mod version;
 
 pub use completion::{PostgresCompletionStream, COMPLETION_CHANNEL};
@@ -1585,6 +1587,15 @@ impl EngineBackend for PostgresBackend {
             filter,
         )
         .await
+    }
+
+    // ── PR-7b / #453: typed-FCALL bodies ──
+
+    async fn renew_lease(
+        &self,
+        args: ff_core::contracts::RenewLeaseArgs,
+    ) -> Result<ff_core::contracts::RenewLeaseResult, EngineError> {
+        crate::typed_ops::renew_lease(self.pool(), args).await
     }
 
     // ── PR-7b Wave 0a: exec_core field read ──

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -9,9 +9,13 @@
 //! # Isolation
 //!
 //! Each op runs under the default `READ COMMITTED` isolation level
-//! with explicit `FOR UPDATE` row locks on `ff_exec_core` and/or
-//! `ff_attempt`. The fence triple (lease_id, lease_epoch, attempt_id)
-//! is the authoritative conflict token and is validated under lock.
+//! (some ops like `check_admission` upgrade to `SERIALIZABLE` per
+//! their rustdoc) with explicit `FOR UPDATE` row locks on
+//! `ff_exec_core` and/or `ff_attempt`. PG persists `lease_epoch` only;
+//! it's monotonically bumped on each claim/reclaim and is sufficient
+//! to detect the violations Valkey's full `(lease_id, lease_epoch,
+//! attempt_id)` triple catches. See each op's rustdoc for the
+//! specific fence shape.
 //!
 //! # Error mapping
 //!
@@ -21,7 +25,7 @@
 //! | Lua                  | EngineError                                                       |
 //! |----------------------|-------------------------------------------------------------------|
 //! | `execution_not_found`| `NotFound { entity: "execution" }`                                |
-//! | `execution_not_active`| `State(ExecutionNotActive { … })` (carries Lua-side detail)     |
+//! | `execution_not_active`| `Contention(ExecutionNotActive { … })` (carries Lua-side detail) |
 //! | `stale_lease`        | `State(StaleLease)`                                               |
 //! | `lease_expired`      | `State(LeaseExpired)`                                             |
 //! | `lease_revoked`      | `State(LeaseRevoked)`                                             |
@@ -87,7 +91,16 @@ pub(crate) async fn renew_lease(
     })?;
 
     let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
-    let attempt_index = i32::try_from(args.attempt_index.0).unwrap_or(i32::MAX);
+    // `attempt_index` is `u32`; PG column is `integer` (i32). A caller
+    // supplying an index beyond i32::MAX is a typed input error —
+    // surface it rather than silently querying a truncated row.
+    let attempt_index = i32::try_from(args.attempt_index.0).map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!(
+            "attempt_index {} exceeds PG i32 column bound",
+            args.attempt_index.0
+        ),
+    })?;
     let expected_epoch = fence.lease_epoch.0;
 
     let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
@@ -167,8 +180,10 @@ pub(crate) async fn renew_lease(
         _ => return Err(EngineError::State(StateKind::LeaseExpired)),
     }
 
-    // 6. Extend the lease.
-    let new_expires = now.saturating_add(i64::try_from(args.lease_ttl_ms).unwrap_or(0));
+    // 6. Extend the lease. Clamp `lease_ttl_ms` overflow to `i64::MAX`
+    // so a huge TTL extends the lease by as much as PG can represent
+    // rather than silently collapsing to now (unwrap_or(0) bug).
+    let new_expires = now.saturating_add(i64::try_from(args.lease_ttl_ms).unwrap_or(i64::MAX));
     sqlx::query(
         r#"
         UPDATE ff_attempt
@@ -204,40 +219,21 @@ pub(crate) async fn renew_lease(
 
 #[cfg(test)]
 mod tests {
-    // Integration tests live in `tests/typed_ops_renew_lease.rs` —
-    // they require a live Postgres (`FF_PG_TEST_URL`). This module
-    // holds unit tests that don't touch the DB.
+    // Integration tests live in `tests/typed_renew_lease.rs` +
+    // sibling files per-method; they require a live Postgres
+    // (`FF_PG_TEST_URL`). This module holds unit tests that don't
+    // touch the DB.
 
     use super::*;
     use ff_core::types::{AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseFence, LeaseId};
 
-    #[tokio::test]
-    async fn renew_lease_rejects_missing_fence() {
-        // Use a dummy pool — the fence-required check short-circuits
-        // before any DB I/O. `begin()` is never called because the
-        // `ok_or_else` returns first.
-        //
-        // We can't easily construct a `PgPool` without connecting,
-        // so instead we hand-build the args + call the fence gate
-        // mirror as a standalone assertion.
-        let args = RenewLeaseArgs {
-            execution_id: ExecutionId::parse(
-                "{fp:0}:00000000-0000-0000-0000-000000000001",
-            )
-            .unwrap(),
-            attempt_index: AttemptIndex::new(0),
-            fence: None,
-            lease_ttl_ms: 60_000,
-            lease_history_grace_ms: 60_000,
-        };
-        // Fence gate is the first guard in `renew_lease`; with
-        // `fence = None` the function must return
-        // `Validation{InvalidInput, fence_required}` without
-        // touching the pool. We can't call the function without a
-        // pool, so we instead assert the fence-argument shape — any
-        // `Some(fence)` later is an invariant on the caller.
-        assert!(args.fence.is_none());
-    }
+    // NOTE: the `renew_lease` fence-missing short-circuit is behavior-
+    // covered by the ignore-gated integration test
+    // `renew_lease_rejects_missing_fence` in
+    // `tests/typed_renew_lease.rs`, which executes `renew_lease` end-to-
+    // end with a live PG pool. A pool-free unit test of that gate can't
+    // exercise the function body (we can't construct a `PgPool`), so
+    // we don't inline a placeholder here.
 
     #[test]
     fn lease_fence_shape() {

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -1,0 +1,254 @@
+//! PR-7b / #453: typed-FCALL EngineBackend bodies on Postgres.
+//!
+//! Ports the Valkey `ff_*` Lua functions that landed with typed args
+//! (`ClaimExecutionArgs`, `CompleteExecutionArgs`, …) to Postgres
+//! SQL transactions. Each function here mirrors the Lua invariants in
+//! `flowfabric.lua` precisely — the Lua is authoritative; the PG
+//! transaction is a deterministic retelling in SQL.
+//!
+//! # Isolation
+//!
+//! Each op runs under the default `READ COMMITTED` isolation level
+//! with explicit `FOR UPDATE` row locks on `ff_exec_core` and/or
+//! `ff_attempt`. The fence triple (lease_id, lease_epoch, attempt_id)
+//! is the authoritative conflict token and is validated under lock.
+//!
+//! # Error mapping
+//!
+//! Lua `err("X")` codes map to `EngineError` per the established
+//! `ff-script` → `ff-core::engine_error` conversion:
+//!
+//! | Lua                  | EngineError                                                       |
+//! |----------------------|-------------------------------------------------------------------|
+//! | `execution_not_found`| `NotFound { entity: "execution" }`                                |
+//! | `execution_not_active`| `State(ExecutionNotActive { … })` (carries Lua-side detail)     |
+//! | `stale_lease`        | `State(StaleLease)`                                               |
+//! | `lease_expired`      | `State(LeaseExpired)`                                             |
+//! | `lease_revoked`      | `State(LeaseRevoked)`                                             |
+//! | `fence_required`     | `Validation { InvalidInput, detail: "fence_required" }`           |
+
+use ff_core::contracts::{RenewLeaseArgs, RenewLeaseResult};
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use sqlx::{PgPool, Row};
+
+use crate::attempt::split_exec_id;
+use crate::error::map_sqlx_error;
+use crate::lease_event;
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX)
+}
+
+/// PG body for [`ff_core::engine_backend::EngineBackend::renew_lease`].
+///
+/// Mirrors `ff_renew_lease` in `flowfabric.lua` (Valkey authoritative):
+///
+/// 1. Fence required — `args.fence.is_none()` → `Validation{fence_required}`.
+/// 2. Lock `ff_attempt (partition, exec_uuid, attempt_index) FOR UPDATE`.
+/// 3. Compare stored `lease_epoch` to the fence triple's `lease_epoch`;
+///    mismatch → `StaleLease`.
+///
+///    **Fencing asymmetry vs Valkey.** Valkey fences on the full
+///    `(lease_id, lease_epoch, attempt_id)` triple because the Lua
+///    stores all three on the `exec_core` hash. PG's `ff_attempt`
+///    schema only persists `lease_epoch`; `lease_id` and `attempt_id`
+///    live on the worker-side `Handle` (opaque blob, never written
+///    to disk). `lease_epoch` is monotonically bumped by every
+///    claim/reclaim, so a stale caller's epoch ≠ stored epoch is
+///    sufficient to detect the same violations Valkey's triple
+///    catches. Promoting to a full triple would require a
+///    `lease_id`/`attempt_id` column migration; deferred per cairn
+///    #453 §"Matrix asymmetry".
+///
+/// 4. Check lifecycle_phase on `ff_exec_core`; non-active →
+///    `ExecutionNotActive`. Note: PG surface does not publish
+///    `lease_revoked` as a separate state today (the revoke op would
+///    null out `lease_expires_at_ms`), so revocation is detected via
+///    the same NULL / expired check as expiry → `LeaseExpired`.
+/// 5. Check existing `lease_expires_at_ms > now`; otherwise `LeaseExpired`.
+/// 6. `UPDATE ff_attempt SET lease_expires_at_ms = now + ttl`.
+/// 7. Emit `lease_event::EVENT_RENEWED` to the outbox.
+/// 8. Return `RenewLeaseResult::Renewed { expires_at: new_expires }`.
+pub(crate) async fn renew_lease(
+    pool: &PgPool,
+    args: RenewLeaseArgs,
+) -> Result<RenewLeaseResult, EngineError> {
+    // 1. Fence required.
+    let fence = args.fence.as_ref().ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: "fence_required".into(),
+    })?;
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let attempt_index = i32::try_from(args.attempt_index.0).unwrap_or(i32::MAX);
+    let expected_epoch = fence.lease_epoch.0;
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // 2 + 3. Lock attempt row + validate fence (epoch only — see rustdoc
+    // for the Valkey→PG fencing asymmetry).
+    let attempt_row = sqlx::query(
+        r#"
+        SELECT lease_epoch, lease_expires_at_ms
+          FROM ff_attempt
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+         FOR UPDATE
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(attempt_row) = attempt_row else {
+        return Err(EngineError::NotFound { entity: "attempt" });
+    };
+
+    let observed_epoch_i: i64 = attempt_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+    let observed_epoch = u64::try_from(observed_epoch_i).unwrap_or(0);
+    let observed_expires_at: Option<i64> = attempt_row
+        .try_get("lease_expires_at_ms")
+        .map_err(map_sqlx_error)?;
+
+    if observed_epoch != expected_epoch {
+        return Err(EngineError::State(StateKind::StaleLease));
+    }
+
+    // 4. Lifecycle check.
+    let exec_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase,
+               attempt_state,
+               COALESCE(raw_fields->>'current_attempt_id', '') AS current_attempt_id,
+               COALESCE(raw_fields->>'terminal_outcome', 'none') AS terminal_outcome
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(exec_row) = exec_row else {
+        return Err(EngineError::NotFound { entity: "execution" });
+    };
+    let lifecycle_phase: String = exec_row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    if lifecycle_phase != "active" {
+        let terminal_outcome: String =
+            exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
+        let current_attempt_id: String = exec_row
+            .try_get("current_attempt_id")
+            .map_err(map_sqlx_error)?;
+        return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+            terminal_outcome,
+            lease_epoch: observed_epoch.to_string(),
+            lifecycle_phase,
+            attempt_id: current_attempt_id,
+        }));
+    }
+
+    let now = now_ms();
+    // 5. Expiry / revocation check. A NULL `lease_expires_at_ms`
+    // indicates the lease has been released (revoke/reclaim path);
+    // treat as LeaseExpired for typed-surface consumers.
+    match observed_expires_at {
+        Some(exp) if exp > now => {}
+        _ => return Err(EngineError::State(StateKind::LeaseExpired)),
+    }
+
+    // 6. Extend the lease.
+    let new_expires = now.saturating_add(i64::try_from(args.lease_ttl_ms).unwrap_or(0));
+    sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET lease_expires_at_ms = $1
+         WHERE partition_key = $2 AND execution_id = $3 AND attempt_index = $4
+        "#,
+    )
+    .bind(new_expires)
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 7. Outbox: lease renewed (mirrors RFC-019 Stage B event shape).
+    lease_event::emit(
+        &mut tx,
+        part,
+        exec_uuid,
+        None,
+        lease_event::EVENT_RENEWED,
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(RenewLeaseResult::Renewed {
+        expires_at: ff_core::types::TimestampMs::from_millis(new_expires),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests live in `tests/typed_ops_renew_lease.rs` —
+    // they require a live Postgres (`FF_PG_TEST_URL`). This module
+    // holds unit tests that don't touch the DB.
+
+    use super::*;
+    use ff_core::types::{AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseFence, LeaseId};
+
+    #[tokio::test]
+    async fn renew_lease_rejects_missing_fence() {
+        // Use a dummy pool — the fence-required check short-circuits
+        // before any DB I/O. `begin()` is never called because the
+        // `ok_or_else` returns first.
+        //
+        // We can't easily construct a `PgPool` without connecting,
+        // so instead we hand-build the args + call the fence gate
+        // mirror as a standalone assertion.
+        let args = RenewLeaseArgs {
+            execution_id: ExecutionId::parse(
+                "{fp:0}:00000000-0000-0000-0000-000000000001",
+            )
+            .unwrap(),
+            attempt_index: AttemptIndex::new(0),
+            fence: None,
+            lease_ttl_ms: 60_000,
+            lease_history_grace_ms: 60_000,
+        };
+        // Fence gate is the first guard in `renew_lease`; with
+        // `fence = None` the function must return
+        // `Validation{InvalidInput, fence_required}` without
+        // touching the pool. We can't call the function without a
+        // pool, so we instead assert the fence-argument shape — any
+        // `Some(fence)` later is an invariant on the caller.
+        assert!(args.fence.is_none());
+    }
+
+    #[test]
+    fn lease_fence_shape() {
+        // Cheap compile-time check that the fence triple shape
+        // matches what the PG body reads out of raw_fields.
+        let f = LeaseFence {
+            lease_id: LeaseId::new(),
+            lease_epoch: LeaseEpoch(1),
+            attempt_id: AttemptId::new(),
+        };
+        assert!(!f.lease_id.to_string().is_empty());
+        assert!(!f.attempt_id.to_string().is_empty());
+    }
+}

--- a/crates/ff-backend-postgres/tests/typed_renew_lease.rs
+++ b/crates/ff-backend-postgres/tests/typed_renew_lease.rs
@@ -1,0 +1,284 @@
+//! #453 / PR-7b: integration test for the typed-FCALL
+//! `EngineBackend::renew_lease` body on Postgres.
+//!
+//! Covers the invariant set mirrored from `ff_renew_lease` in
+//! `flowfabric.lua`:
+//!
+//! - happy path extends `ff_attempt.lease_expires_at_ms`
+//! - missing fence → `Validation{InvalidInput, "fence_required"}`
+//! - stale fence (wrong epoch) → `State(StaleLease)`
+//! - expired lease → `State(LeaseExpired)`
+//! - non-active lifecycle → `Contention(ExecutionNotActive { .. })`
+//!
+//! # Running
+//!
+//! `FF_PG_TEST_URL=postgres://... cargo test -p ff-backend-postgres \
+//!   --test typed_renew_lease -- --ignored`
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{RenewLeaseArgs, RenewLeaseResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseFence, LeaseId, TimestampMs,
+};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+/// Seed an `ff_exec_core` row in `active` state plus a matching
+/// `ff_attempt` row carrying a live lease (fence triple embedded in
+/// `raw_fields`). Returns the triple the test will pass as `fence`.
+async fn seed_active_lease(
+    pool: &PgPool,
+    lease_ttl_ms: i64,
+) -> (i16, Uuid, ExecutionId, LeaseFence) {
+    let part: i16 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid =
+        ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+    let lease_epoch: i64 = 1;
+    let expires_at = now_ms() + lease_ttl_ms;
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            required_capabilities, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms, raw_fields
+        ) VALUES (
+            $1, $2, NULL, 'default',
+            '{}', 0,
+            'active', 'leased', 'not_applicable',
+            'active', 'running_attempt',
+            0, $3,
+            jsonb_build_object('current_attempt_id', $4::text)
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .bind(attempt_id.to_string())
+    .execute(pool)
+    .await
+    .expect("insert ff_exec_core");
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_attempt (
+            partition_key, execution_id, attempt_index,
+            worker_id, worker_instance_id,
+            lease_epoch, lease_expires_at_ms, started_at_ms
+        ) VALUES (
+            $1, $2, 0,
+            'w', 'wi',
+            $3, $4, $5
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lease_epoch)
+    .bind(expires_at)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+
+    let fence = LeaseFence {
+        lease_id,
+        lease_epoch: LeaseEpoch(lease_epoch as u64),
+        attempt_id,
+    };
+    (part, exec_uuid, eid, fence)
+}
+
+async fn read_expires(pool: &PgPool, part: i16, exec_uuid: Uuid) -> i64 {
+    use sqlx::Row;
+    let row = sqlx::query(
+        "SELECT lease_expires_at_ms FROM ff_attempt \
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = 0",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("fetch");
+    row.try_get::<i64, _>("lease_expires_at_ms").unwrap()
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn renew_lease_extends_expires_at_on_happy_path() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (part, exec_uuid, eid, fence) = seed_active_lease(&pool, 5_000).await;
+    let pre = read_expires(&pool, part, exec_uuid).await;
+
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    let res = backend.renew_lease(args).await.expect("renew ok");
+    let RenewLeaseResult::Renewed { expires_at } = res;
+    let post = read_expires(&pool, part, exec_uuid).await;
+    assert!(
+        post > pre,
+        "lease_expires_at_ms should move forward (pre={pre}, post={post})"
+    );
+    assert_eq!(expires_at, TimestampMs::from_millis(post));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn renew_lease_rejects_missing_fence() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (_part, _exec_uuid, eid, _fence) = seed_active_lease(&pool, 5_000).await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: None,
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match backend.renew_lease(args).await {
+        Err(EngineError::Validation { kind, detail }) => {
+            assert_eq!(kind, ValidationKind::InvalidInput);
+            assert_eq!(detail, "fence_required");
+        }
+        other => panic!("expected Validation{{fence_required}}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn renew_lease_stale_lease_on_wrong_epoch() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (_part, _exec_uuid, eid, fence) = seed_active_lease(&pool, 5_000).await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let bad_fence = LeaseFence {
+        lease_epoch: LeaseEpoch(fence.lease_epoch.0 + 99),
+        ..fence
+    };
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(bad_fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match backend.renew_lease(args).await {
+        Err(EngineError::State(StateKind::StaleLease)) => {}
+        other => panic!("expected StaleLease, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn renew_lease_expired_when_past_ttl() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    // Seed an already-expired lease by passing a negative TTL relative
+    // to now. Simulates a lease that aged out before the worker
+    // called renew.
+    let (_part, _exec_uuid, eid, fence) = seed_active_lease(&pool, -5_000).await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match backend.renew_lease(args).await {
+        Err(EngineError::State(StateKind::LeaseExpired)) => {}
+        other => panic!("expected LeaseExpired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn renew_lease_execution_not_active_on_terminal() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (part, exec_uuid, eid, fence) = seed_active_lease(&pool, 5_000).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal' \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .expect("flip to terminal");
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match backend.renew_lease(args).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+            lifecycle_phase,
+            ..
+        })) => {
+            assert_eq!(lifecycle_phase, "terminal");
+        }
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/migrations.rs
+++ b/crates/ff-backend-sqlite/tests/migrations.rs
@@ -127,8 +127,8 @@ async fn sqlx_migration_ledger_records_all_14() {
             .await
             .expect("query _sqlx_migrations");
     assert_eq!(
-        count, 16,
-        "expected 16 successful migrations (0001..=0014 + 0016 + 0017), got {count}"
+        count, 17,
+        "expected 17 successful migrations (0001..=0014 + 0016 + 0017 + 0018), got {count}"
     );
 }
 

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -583,6 +583,12 @@ as part of #449's own doc updates. Expected shape:
   [`CONSUMER_MIGRATION_0.13.md`](CONSUMER_MIGRATION_0.13.md) §Known
   limitations.
 
+**#453 / PR-7b — typed-FCALL bodies (cairn blocker):**
+
+| Method | Valkey | Postgres | SQLite | Notes |
+|---|---|---|---|---|
+| `renew_lease` | `impl` | `impl` | `Unavailable` (default, follow-up) | PG: `READ COMMITTED` tx + `FOR UPDATE` on `ff_attempt`. Fence validation is **epoch-only** (PG doesn't persist `lease_id`/`attempt_id` to disk; `lease_epoch` monotonic bump is sufficient to catch the same violations Valkey's full-triple check covers). Error map: `fence_required`→`Validation{InvalidInput}`, `stale_lease`→`State(StaleLease)`, `lease_expired`→`State(LeaseExpired)`, `execution_not_active`→`Contention(ExecutionNotActive{...})`. Integration test: `crates/ff-backend-postgres/tests/typed_renew_lease.rs`. |
+
 **PR-7b Wave 0a — backend-agnostic primitives + `start_*` no-panic (cairn #436):**
 
 | Method | Valkey | Postgres | SQLite | Notes |


### PR DESCRIPTION
## Summary

First of 7 typed-FCALL methods from cairn #453's v0.13-blocker list. Flips `EngineBackend::renew_lease` on Postgres from the `Unavailable` default to a real SQL transaction that mirrors `ff_renew_lease` in `flowfabric.lua`.

Refs #453. Does NOT close #453 — sibling PRs land the other 6 methods (complete_execution, fail_execution, claim_execution, resume_execution, check_admission, evaluate_flow_eligibility). This PR establishes the per-method template.

## What's in the tx

1. `fence.is_none()` → `Validation{InvalidInput, "fence_required"}` (gate before any I/O)
2. `ff_attempt FOR UPDATE` + epoch check → `State(StaleLease)` on mismatch
3. `ff_exec_core.lifecycle_phase != 'active'` → `Contention(ExecutionNotActive{...})` with Lua-side detail payload
4. `lease_expires_at_ms IS NULL OR <= now` → `State(LeaseExpired)` (covers both real-expiry and revocation-clears-expires)
5. `UPDATE ff_attempt SET lease_expires_at_ms = now + ttl`
6. Emit `lease_event::EVENT_RENEWED` to outbox (RFC-019 Stage B parity)
7. Return `RenewLeaseResult::Renewed { expires_at }`

## Fencing asymmetry (documented)

Valkey fences on the full `(lease_id, lease_epoch, attempt_id)` triple because the Lua stores all three on the `exec_core` hash. PG's `ff_attempt` schema only persists `lease_epoch`; `lease_id` and `attempt_id` live on the worker-side `Handle` and are never written to disk. `lease_epoch` is monotonically bumped by every claim/reclaim, so a stale caller's epoch ≠ stored epoch catches the same violations Valkey's triple catches.

Promoting to a full triple would require a `lease_id` / `attempt_id` column migration — deferred. Called out in the impl's rustdoc + POSTGRES_PARITY_MATRIX notes.

## Test plan

- [ ] `cargo check --workspace` — pass
- [ ] `cargo clippy --workspace -- -D warnings` — pass
- [ ] `FF_PG_TEST_URL=... cargo test -p ff-backend-postgres --test typed_renew_lease -- --ignored` — pass on live PG (5 tests: happy path + 4 error arms)
- [ ] `cargo test --workspace --lib` — no regressions
- [ ] CI green on matrix

## Drive-by

Fixed `ff_backend_sqlite migrations` test: ledger-count drifted 16 → 17 after migration 0018 landed in PR #446. Pre-existing failure caught during `--workspace --tests` sweep; tightly scoped (1-line count change) so included here rather than parking on a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)