### PR TITLE
feat(ff-backend-postgres): PR-7b/#453/2 — complete_execution PG body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **#453 / PR-7b: `EngineBackend::complete_execution` — Postgres body.**
+  Ports `ff_complete_execution` from `flowfabric.lua` to a PG tx that
+  flips `lifecycle_phase='terminal'`, `public_state='completed'`,
+  stores the result payload, nulls `ff_attempt.lease_expires_at_ms`,
+  and emits a completion outbox event (firing `pg_notify` for
+  downstream DAG dispatch) + RFC-019 Stage B lease-revoked event.
+  Fence-or-operator-override gate mirrors Valkey: `fence=None` +
+  `source != OperatorOverride` → `Validation{fence_required}`; the
+  override path skips the epoch fence but **does** enforce the
+  lifecycle gate (operator cannot re-terminate already-terminal).
+  Integration test at `typed_complete_execution.rs`.
 - **#453 / PR-7b: `EngineBackend::renew_lease` — Postgres body.**
   First typed-FCALL method from cairn's v0.13-blocker list to flip
   from `Unavailable` default to a real PG SQL transaction. Ports

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1599,6 +1599,14 @@ impl EngineBackend for PostgresBackend {
         crate::typed_ops::renew_lease(self.pool(), args).await
     }
 
+    #[cfg(feature = "core")]
+    async fn complete_execution(
+        &self,
+        args: ff_core::contracts::CompleteExecutionArgs,
+    ) -> Result<ff_core::contracts::CompleteExecutionResult, EngineError> {
+        crate::typed_ops::complete_execution(self.pool(), args).await
+    }
+
     // ── PR-7b Wave 0a: exec_core field read ──
 
     async fn read_exec_core_fields(

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -258,11 +258,70 @@ pub(crate) async fn complete_execution(
     }
 
     let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
-    let attempt_index = i32::try_from(args.attempt_index.0).unwrap_or(i32::MAX);
+    let attempt_index =
+        i32::try_from(args.attempt_index.0).map_err(|_| EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!(
+                "attempt_index {} exceeds PG i32 column bound",
+                args.attempt_index.0
+            ),
+        })?;
 
     let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
 
-    // 2. Lock attempt row + epoch fence (when caller supplied one).
+    // 2. Lock exec_core FIRST (parity with Lua: lifecycle/ownership
+    // gates are the authoritative pre-conditions, checked before the
+    // attempt-row fence).
+    let exec_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, ownership_state, flow_id,
+               COALESCE(raw_fields->>'current_attempt_id', '') AS current_attempt_id
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let Some(exec_row) = exec_row else {
+        return Err(EngineError::NotFound { entity: "execution" });
+    };
+    let lifecycle_phase: String = exec_row
+        .try_get("lifecycle_phase")
+        .map_err(map_sqlx_error)?;
+    let ownership_state: String = exec_row
+        .try_get("ownership_state")
+        .map_err(map_sqlx_error)?;
+    // Valkey's `validate_lease_and_mark_expired` rejects revoked
+    // leases ahead of the lifecycle/attempt checks. PG signals
+    // revocation via `ownership_state = 'lease_revoked'`.
+    if ownership_state == "lease_revoked" {
+        return Err(EngineError::State(StateKind::LeaseRevoked));
+    }
+    if lifecycle_phase != "active" {
+        let current_attempt_id: String = exec_row
+            .try_get("current_attempt_id")
+            .map_err(map_sqlx_error)?;
+        // Terminal outcome for PG is derived from `ff_attempt.outcome`
+        // (schema of record — `raw_fields.terminal_outcome` is a
+        // denormalisation legacy row that not every migration has).
+        // Leave the wire-level detail blank when unknown rather than
+        // fabricating a stale string from raw_fields.
+        return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+            terminal_outcome: String::new(),
+            lease_epoch: String::new(),
+            lifecycle_phase,
+            attempt_id: current_attempt_id,
+        }));
+    }
+
+    // 3. Lock attempt row + epoch fence (when caller supplied one) +
+    // lease-live check. Lua's `validate_lease_and_mark_expired` rejects
+    // expired leases with `lease_expired`; PG mirrors that by checking
+    // `lease_expires_at_ms <= now` under the same lock.
     let attempt_row = sqlx::query(
         r#"
         SELECT lease_epoch, lease_expires_at_ms
@@ -284,6 +343,9 @@ pub(crate) async fn complete_execution(
 
     let observed_epoch_i: i64 = attempt_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
     let observed_epoch = u64::try_from(observed_epoch_i).unwrap_or(0);
+    let observed_expires_at: Option<i64> = attempt_row
+        .try_get("lease_expires_at_ms")
+        .map_err(map_sqlx_error)?;
 
     if let Some(fence) = &args.fence
         && observed_epoch != fence.lease_epoch.0
@@ -291,44 +353,16 @@ pub(crate) async fn complete_execution(
         return Err(EngineError::State(StateKind::StaleLease));
     }
 
-    // 3. Lifecycle gate (fires for both fence + operator-override paths).
-    let exec_row = sqlx::query(
-        r#"
-        SELECT lifecycle_phase,
-               COALESCE(raw_fields->>'current_attempt_id', '') AS current_attempt_id,
-               COALESCE(raw_fields->>'terminal_outcome', 'none') AS terminal_outcome
-          FROM ff_exec_core
-         WHERE partition_key = $1 AND execution_id = $2
-         FOR UPDATE
-        "#,
-    )
-    .bind(part)
-    .bind(exec_uuid)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(map_sqlx_error)?;
-
-    let Some(exec_row) = exec_row else {
-        return Err(EngineError::NotFound { entity: "execution" });
-    };
-    let lifecycle_phase: String = exec_row
-        .try_get("lifecycle_phase")
-        .map_err(map_sqlx_error)?;
-    if lifecycle_phase != "active" {
-        let terminal_outcome: String =
-            exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
-        let current_attempt_id: String = exec_row
-            .try_get("current_attempt_id")
-            .map_err(map_sqlx_error)?;
-        return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
-            terminal_outcome,
-            lease_epoch: observed_epoch.to_string(),
-            lifecycle_phase,
-            attempt_id: current_attempt_id,
-        }));
+    // Prefer the caller-supplied `args.now` for scanner/cluster time
+    // skew — PG-local `SystemTime::now()` is fine only if the caller
+    // hasn't passed a timestamp. All typed-contract call sites DO
+    // populate `args.now`, so this path is the norm.
+    let now = args.now.0;
+    if let Some(exp) = observed_expires_at
+        && exp <= now
+    {
+        return Err(EngineError::State(StateKind::LeaseExpired));
     }
-
-    let now = now_ms();
 
     // 4. Mark attempt terminal.
     sqlx::query(
@@ -348,7 +382,12 @@ pub(crate) async fn complete_execution(
     .await
     .map_err(map_sqlx_error)?;
 
-    // 5. Flip exec_core to terminal + store result payload.
+    // 5. Flip exec_core to terminal + store result payload + stamp
+    // `terminal_outcome=success` into `raw_fields` for backfills /
+    // legacy readers that still look at the denormalised copy.
+    let raw_patch = serde_json::json!({
+        "terminal_outcome": "success",
+    });
     sqlx::query(
         r#"
         UPDATE ff_exec_core
@@ -358,12 +397,14 @@ pub(crate) async fn complete_execution(
                attempt_state = 'attempt_terminal',
                public_state = 'completed',
                terminal_at_ms = $1,
-               result = $2
-         WHERE partition_key = $3 AND execution_id = $4
+               result = $2,
+               raw_fields = raw_fields || $3::jsonb
+         WHERE partition_key = $4 AND execution_id = $5
         "#,
     )
     .bind(now)
     .bind(args.result_payload.as_deref())
+    .bind(raw_patch)
     .bind(part)
     .bind(exec_uuid)
     .execute(&mut *tx)
@@ -371,6 +412,9 @@ pub(crate) async fn complete_execution(
     .map_err(map_sqlx_error)?;
 
     // 6. Completion outbox → pg_notify cascade for DAG dispatch.
+    // Carry `namespace` + `instance_tag` forward from `ff_exec_core`
+    // so downstream subscribers (RFC-019 filtered subscriptions)
+    // receive the events instead of silently dropping on NULL.
     sqlx::query(
         r#"
         INSERT INTO ff_completion_event (
@@ -378,7 +422,9 @@ pub(crate) async fn complete_execution(
             namespace, instance_tag, occurred_at_ms
         )
         SELECT partition_key, execution_id, flow_id, 'success',
-               NULL, NULL, $3
+               raw_fields->>'namespace',
+               raw_fields->>'instance_tag',
+               $3
           FROM ff_exec_core
          WHERE partition_key = $1 AND execution_id = $2
         "#,

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -31,8 +31,12 @@
 //! | `lease_revoked`      | `State(LeaseRevoked)`                                             |
 //! | `fence_required`     | `Validation { InvalidInput, detail: "fence_required" }`           |
 
-use ff_core::contracts::{RenewLeaseArgs, RenewLeaseResult};
+use ff_core::contracts::{
+    CompleteExecutionArgs, CompleteExecutionResult, RenewLeaseArgs, RenewLeaseResult,
+};
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::state::PublicState;
+use ff_core::types::CancelSource;
 use sqlx::{PgPool, Row};
 
 use crate::attempt::split_exec_id;
@@ -214,6 +218,194 @@ pub(crate) async fn renew_lease(
 
     Ok(RenewLeaseResult::Renewed {
         expires_at: ff_core::types::TimestampMs::from_millis(new_expires),
+    })
+}
+
+/// PG body for [`ff_core::engine_backend::EngineBackend::complete_execution`].
+///
+/// Mirrors `ff_complete_execution` in `flowfabric.lua`:
+///
+/// 1. Fence-or-operator-override gate. `args.fence.is_none()` with
+///    `source != OperatorOverride` → `Validation{fence_required}`.
+/// 2. Lock `ff_attempt FOR UPDATE` + epoch fence (when present).
+/// 3. Check `ff_exec_core.lifecycle_phase == 'active'`; otherwise
+///    `ExecutionNotActive` (typed carries phase/epoch detail).
+/// 4. Mark attempt terminal: `outcome='success'`, `terminal_at_ms=now`,
+///    `lease_expires_at_ms=NULL`.
+/// 5. Flip `ff_exec_core` to `lifecycle_phase='terminal'`,
+///    `ownership_state='unowned'`, `eligibility_state='not_applicable'`,
+///    `attempt_state='attempt_terminal'`, `public_state='completed'`,
+///    `terminal_at_ms=now`, store `result` payload.
+/// 6. Emit completion to `ff_completion_event` outbox (fires `pg_notify`
+///    to subscribed listeners).
+/// 7. Emit `lease_event::EVENT_REVOKED` to the lease outbox.
+/// 8. Return `Completed { execution_id, public_state: Completed }`.
+///
+/// Operator-override path bypasses the epoch fence but still enforces
+/// the lifecycle gate at step 3 — an operator cannot complete an
+/// execution that's already terminal.
+pub(crate) async fn complete_execution(
+    pool: &PgPool,
+    args: CompleteExecutionArgs,
+) -> Result<CompleteExecutionResult, EngineError> {
+    // 1. Fence-or-override gate.
+    let is_operator_override = matches!(args.source, CancelSource::OperatorOverride);
+    if args.fence.is_none() && !is_operator_override {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "fence_required".into(),
+        });
+    }
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let attempt_index = i32::try_from(args.attempt_index.0).unwrap_or(i32::MAX);
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // 2. Lock attempt row + epoch fence (when caller supplied one).
+    let attempt_row = sqlx::query(
+        r#"
+        SELECT lease_epoch, lease_expires_at_ms
+          FROM ff_attempt
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3
+         FOR UPDATE
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(attempt_row) = attempt_row else {
+        return Err(EngineError::NotFound { entity: "attempt" });
+    };
+
+    let observed_epoch_i: i64 = attempt_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+    let observed_epoch = u64::try_from(observed_epoch_i).unwrap_or(0);
+
+    if let Some(fence) = &args.fence
+        && observed_epoch != fence.lease_epoch.0
+    {
+        return Err(EngineError::State(StateKind::StaleLease));
+    }
+
+    // 3. Lifecycle gate (fires for both fence + operator-override paths).
+    let exec_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase,
+               COALESCE(raw_fields->>'current_attempt_id', '') AS current_attempt_id,
+               COALESCE(raw_fields->>'terminal_outcome', 'none') AS terminal_outcome
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(exec_row) = exec_row else {
+        return Err(EngineError::NotFound { entity: "execution" });
+    };
+    let lifecycle_phase: String = exec_row
+        .try_get("lifecycle_phase")
+        .map_err(map_sqlx_error)?;
+    if lifecycle_phase != "active" {
+        let terminal_outcome: String =
+            exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
+        let current_attempt_id: String = exec_row
+            .try_get("current_attempt_id")
+            .map_err(map_sqlx_error)?;
+        return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+            terminal_outcome,
+            lease_epoch: observed_epoch.to_string(),
+            lifecycle_phase,
+            attempt_id: current_attempt_id,
+        }));
+    }
+
+    let now = now_ms();
+
+    // 4. Mark attempt terminal.
+    sqlx::query(
+        r#"
+        UPDATE ff_attempt
+           SET terminal_at_ms = $1,
+               outcome = 'success',
+               lease_expires_at_ms = NULL
+         WHERE partition_key = $2 AND execution_id = $3 AND attempt_index = $4
+        "#,
+    )
+    .bind(now)
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(attempt_index)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 5. Flip exec_core to terminal + store result payload.
+    sqlx::query(
+        r#"
+        UPDATE ff_exec_core
+           SET lifecycle_phase = 'terminal',
+               ownership_state = 'unowned',
+               eligibility_state = 'not_applicable',
+               attempt_state = 'attempt_terminal',
+               public_state = 'completed',
+               terminal_at_ms = $1,
+               result = $2
+         WHERE partition_key = $3 AND execution_id = $4
+        "#,
+    )
+    .bind(now)
+    .bind(args.result_payload.as_deref())
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 6. Completion outbox → pg_notify cascade for DAG dispatch.
+    sqlx::query(
+        r#"
+        INSERT INTO ff_completion_event (
+            partition_key, execution_id, flow_id, outcome,
+            namespace, instance_tag, occurred_at_ms
+        )
+        SELECT partition_key, execution_id, flow_id, 'success',
+               NULL, NULL, $3
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 7. RFC-019 Stage B lease outbox: revoked (terminal success).
+    lease_event::emit(
+        &mut tx,
+        part,
+        exec_uuid,
+        None,
+        lease_event::EVENT_REVOKED,
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(CompleteExecutionResult::Completed {
+        execution_id: args.execution_id,
+        public_state: PublicState::Completed,
     })
 }
 

--- a/crates/ff-backend-postgres/tests/typed_complete_execution.rs
+++ b/crates/ff-backend-postgres/tests/typed_complete_execution.rs
@@ -1,0 +1,311 @@
+//! #453 / PR-7b: integration test for the typed-FCALL
+//! `EngineBackend::complete_execution` body on Postgres.
+//!
+//! Covers the invariant set mirrored from `ff_complete_execution` in
+//! `flowfabric.lua`:
+//!
+//! - happy path flips lifecycle_phase=terminal, public_state=completed,
+//!   stores result payload, marks attempt terminal, emits completion
+//!   outbox event
+//! - fence_required → `Validation{InvalidInput}` when fence=None and
+//!   source != OperatorOverride
+//! - operator override path: fence=None + OperatorOverride bypasses
+//!   epoch check but still honours lifecycle gate
+//! - stale fence → `State(StaleLease)`
+//! - non-active lifecycle → `Contention(ExecutionNotActive{...})`
+//!
+//! # Running
+//!
+//! `FF_PG_TEST_URL=postgres://... cargo test -p ff-backend-postgres \
+//!   --test typed_complete_execution -- --ignored`
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{CompleteExecutionArgs, CompleteExecutionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::partition::PartitionConfig;
+use ff_core::state::PublicState;
+use ff_core::types::{
+    AttemptId, AttemptIndex, CancelSource, ExecutionId, LeaseEpoch, LeaseFence, LeaseId,
+    TimestampMs,
+};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+/// Seed an `active`+leased execution ready to be completed.
+async fn seed_active_lease(
+    pool: &PgPool,
+) -> (i16, Uuid, ExecutionId, LeaseFence) {
+    let part: i16 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid =
+        ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+    let lease_epoch: i64 = 1;
+    let expires_at = now_ms() + 60_000;
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            required_capabilities, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms, raw_fields
+        ) VALUES (
+            $1, $2, NULL, 'default',
+            '{}', 0,
+            'active', 'leased', 'not_applicable',
+            'active', 'running_attempt',
+            0, $3,
+            jsonb_build_object('current_attempt_id', $4::text)
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .bind(attempt_id.to_string())
+    .execute(pool)
+    .await
+    .expect("insert ff_exec_core");
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_attempt (
+            partition_key, execution_id, attempt_index,
+            worker_id, worker_instance_id,
+            lease_epoch, lease_expires_at_ms, started_at_ms
+        ) VALUES (
+            $1, $2, 0, 'w', 'wi',
+            $3, $4, $5
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lease_epoch)
+    .bind(expires_at)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+
+    let fence = LeaseFence {
+        lease_id,
+        lease_epoch: LeaseEpoch(lease_epoch as u64),
+        attempt_id,
+    };
+    (part, exec_uuid, eid, fence)
+}
+
+async fn read_exec_state(pool: &PgPool, part: i16, exec_uuid: Uuid) -> (String, String) {
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, public_state FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("fetch exec_core");
+    (
+        row.try_get::<String, _>("lifecycle_phase").unwrap(),
+        row.try_get::<String, _>("public_state").unwrap(),
+    )
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn complete_happy_path() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (part, exec_uuid, eid, fence) = seed_active_lease(&pool).await;
+
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = CompleteExecutionArgs {
+        execution_id: eid.clone(),
+        fence: Some(fence),
+        attempt_index: AttemptIndex::new(0),
+        result_payload: Some(b"ok".to_vec()),
+        result_encoding: Some("text/plain".into()),
+        source: CancelSource::LeaseHolder,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let res = backend.complete_execution(args).await.expect("complete ok");
+    match res {
+        CompleteExecutionResult::Completed {
+            execution_id,
+            public_state,
+        } => {
+            assert_eq!(execution_id, eid);
+            assert_eq!(public_state, PublicState::Completed);
+        }
+    }
+
+    let (phase, pub_state) = read_exec_state(&pool, part, exec_uuid).await;
+    assert_eq!(phase, "terminal");
+    assert_eq!(pub_state, "completed");
+
+    // Completion outbox fired.
+    let (evt_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_completion_event \
+         WHERE partition_key = $1 AND execution_id = $2 AND outcome = 'success'",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .expect("count outbox");
+    assert_eq!(evt_count, 1, "completion outbox event must be emitted");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn complete_rejects_missing_fence_without_override() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (_part, _exec_uuid, eid, _fence) = seed_active_lease(&pool).await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = CompleteExecutionArgs {
+        execution_id: eid,
+        fence: None,
+        attempt_index: AttemptIndex::new(0),
+        result_payload: None,
+        result_encoding: None,
+        source: CancelSource::LeaseHolder,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    match backend.complete_execution(args).await {
+        Err(EngineError::Validation { kind, detail }) => {
+            assert_eq!(kind, ValidationKind::InvalidInput);
+            assert_eq!(detail, "fence_required");
+        }
+        other => panic!("expected Validation{{fence_required}}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn complete_operator_override_skips_fence() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (part, exec_uuid, eid, _fence) = seed_active_lease(&pool).await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = CompleteExecutionArgs {
+        execution_id: eid,
+        fence: None,
+        attempt_index: AttemptIndex::new(0),
+        result_payload: None,
+        result_encoding: None,
+        source: CancelSource::OperatorOverride,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    backend.complete_execution(args).await.expect("override ok");
+    let (phase, _) = read_exec_state(&pool, part, exec_uuid).await;
+    assert_eq!(phase, "terminal");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn complete_stale_lease_on_wrong_epoch() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (_part, _exec_uuid, eid, fence) = seed_active_lease(&pool).await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let bad_fence = LeaseFence {
+        lease_epoch: LeaseEpoch(fence.lease_epoch.0 + 7),
+        ..fence
+    };
+    let args = CompleteExecutionArgs {
+        execution_id: eid,
+        fence: Some(bad_fence),
+        attempt_index: AttemptIndex::new(0),
+        result_payload: None,
+        result_encoding: None,
+        source: CancelSource::LeaseHolder,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    match backend.complete_execution(args).await {
+        Err(EngineError::State(StateKind::StaleLease)) => {}
+        other => panic!("expected StaleLease, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn complete_execution_not_active_on_terminal() {
+    let Some(pool) = setup_or_skip().await else {
+        eprintln!("FF_PG_TEST_URL not set — skipping");
+        return;
+    };
+    let (part, exec_uuid, eid, fence) = seed_active_lease(&pool).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal' \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .expect("flip");
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let args = CompleteExecutionArgs {
+        execution_id: eid,
+        fence: Some(fence),
+        attempt_index: AttemptIndex::new(0),
+        result_payload: None,
+        result_encoding: None,
+        source: CancelSource::LeaseHolder,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    match backend.complete_execution(args).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+            lifecycle_phase,
+            ..
+        })) => {
+            assert_eq!(lifecycle_phase, "terminal");
+        }
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+}

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -588,6 +588,7 @@ as part of #449's own doc updates. Expected shape:
 | Method | Valkey | Postgres | SQLite | Notes |
 |---|---|---|---|---|
 | `renew_lease` | `impl` | `impl` | `Unavailable` (default, follow-up) | PG: `READ COMMITTED` tx + `FOR UPDATE` on `ff_attempt`. Fence validation is **epoch-only** (PG doesn't persist `lease_id`/`attempt_id` to disk; `lease_epoch` monotonic bump is sufficient to catch the same violations Valkey's full-triple check covers). Error map: `fence_required`→`Validation{InvalidInput}`, `stale_lease`→`State(StaleLease)`, `lease_expired`→`State(LeaseExpired)`, `execution_not_active`→`Contention(ExecutionNotActive{...})`. Integration test: `crates/ff-backend-postgres/tests/typed_renew_lease.rs`. |
+| `complete_execution` | `impl` | `impl` | `Unavailable` (default, follow-up) | PG: `READ COMMITTED` tx with `FOR UPDATE` on `ff_attempt` + `ff_exec_core`. Fence-or-operator-override gate matches Valkey — `source=OperatorOverride` skips epoch fence but lifecycle gate still fires. Flips `ff_exec_core` to terminal/completed + stores result payload; emits `ff_completion_event` (→ pg_notify DAG cascade) + `lease_event::EVENT_REVOKED`. Integration test: `crates/ff-backend-postgres/tests/typed_complete_execution.rs`. |
 
 **PR-7b Wave 0a — backend-agnostic primitives + `start_*` no-panic (cairn #436):**
 


### PR DESCRIPTION
## Summary

Second of 7 typed-FCALL methods from cairn #453's v0.13-blocker list.
Stacked on #455 — will rebase onto main after #455 merges.

Ports `ff_complete_execution` from `flowfabric.lua` to a PG SQL tx:
flips `ff_exec_core` to terminal/completed, stores the result payload,
nulls `ff_attempt.lease_expires_at_ms`, emits `ff_completion_event`
(→ `pg_notify` cascade for DAG dispatch) + RFC-019 Stage B
`EVENT_REVOKED` on the lease outbox.

## Invariants (mirrored from Lua)

1. `fence=None` + `source != OperatorOverride` → `Validation{fence_required}`
2. Under `FOR UPDATE` lock on `ff_attempt`: epoch-fence (when present) → `State(StaleLease)` on mismatch
3. Under `FOR UPDATE` lock on `ff_exec_core`: `lifecycle_phase != 'active'` → `Contention(ExecutionNotActive{...})`
4. Flip `ff_exec_core` to terminal/completed + store result; mark attempt terminal
5. Emit completion event (`ff_completion_event`) + lease revoked event (`ff_lease_event`)
6. Return `CompleteExecutionResult::Completed { execution_id, public_state: Completed }`

Operator-override path bypasses step 2 but **not** step 3 — an operator cannot re-terminate an already-terminal execution.

## Test plan

- [ ] `FF_PG_TEST_URL=... cargo test -p ff-backend-postgres --test typed_complete_execution -- --ignored` — 5 cases (happy path, fence_required, operator override, stale epoch, terminal lifecycle)
- [ ] CI green on stacked base; green on main after rebase

Refs #453. Does not close it — 5 methods remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)