### PR TITLE
feat(ff-backend-postgres): PR-7b/#453/5 — check_admission PG body

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1623,6 +1623,22 @@ impl EngineBackend for PostgresBackend {
         crate::typed_ops::resume_execution(self.pool(), args).await
     }
 
+    #[cfg(feature = "core")]
+    async fn check_admission(
+        &self,
+        quota_policy_id: &ff_core::types::QuotaPolicyId,
+        _dimension: &str,
+        args: ff_core::contracts::CheckAdmissionArgs,
+    ) -> Result<ff_core::contracts::CheckAdmissionResult, EngineError> {
+        crate::typed_ops::check_admission(
+            self.pool(),
+            &self.partition_config,
+            quota_policy_id,
+            args,
+        )
+        .await
+    }
+
     // ── PR-7b Wave 0a: exec_core field read ──
 
     async fn read_exec_core_fields(

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -32,12 +32,14 @@
 //! | `fence_required`     | `Validation { InvalidInput, detail: "fence_required" }`           |
 
 use ff_core::contracts::{
-    CompleteExecutionArgs, CompleteExecutionResult, FailExecutionArgs, FailExecutionResult,
-    RenewLeaseArgs, RenewLeaseResult, ResumeExecutionArgs, ResumeExecutionResult,
+    CheckAdmissionArgs, CheckAdmissionResult, CompleteExecutionArgs, CompleteExecutionResult,
+    FailExecutionArgs, FailExecutionResult, RenewLeaseArgs, RenewLeaseResult,
+    ResumeExecutionArgs, ResumeExecutionResult,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::partition::{quota_partition, PartitionConfig};
 use ff_core::state::PublicState;
-use ff_core::types::{AttemptIndex, CancelSource, TimestampMs};
+use ff_core::types::{AttemptIndex, CancelSource, QuotaPolicyId, TimestampMs};
 use sqlx::{PgPool, Row};
 
 use crate::attempt::split_exec_id;
@@ -894,6 +896,199 @@ pub(crate) async fn resume_execution(
 
     let _ = now;
     Ok(ResumeExecutionResult::Resumed { public_state })
+}
+
+/// PG body for [`ff_core::engine_backend::EngineBackend::check_admission`].
+///
+/// Mirrors `ff_check_admission_and_record` in `flowfabric.lua`:
+///
+/// 1. Idempotency guard: `SELECT` on `ff_quota_admitted` for this
+///    `(partition_key, quota_policy_id, execution_id)`; if present and
+///    unexpired → `AlreadyAdmitted`.
+/// 2. Sliding window sweep: `DELETE FROM ff_quota_window WHERE
+///    admitted_at_ms < now - window_ms`.
+/// 3. Rate check: `SELECT COUNT(*)` on remaining window; if
+///    `count >= rate_limit` compute retry-after from the oldest row
+///    → `RateExceeded { retry_after_ms }`.
+/// 4. Concurrency check: `SELECT active_concurrency` on
+///    `ff_quota_policy`; if `>= concurrency_cap` → `ConcurrencyExceeded`.
+/// 5. Admit: INSERT into `ff_quota_window` + UPSERT
+///    `ff_quota_admitted` (with TTL = window_ms) + increment
+///    `ff_quota_policy.active_concurrency`.
+/// 6. Return `Admitted`.
+///
+/// All reads + writes run under `SERIALIZABLE` isolation to match the
+/// Lua's atomic semantics; the per-policy `partition_key` scope keeps
+/// contention partition-local.
+pub(crate) async fn check_admission(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    quota_policy_id: &QuotaPolicyId,
+    args: CheckAdmissionArgs,
+) -> Result<CheckAdmissionResult, EngineError> {
+    let part = quota_partition(quota_policy_id, partition_config).index as i16;
+    let policy_id_text = quota_policy_id.to_string();
+    let now = args.now.0;
+    let window_ms: i64 = i64::try_from(args.window_seconds.saturating_mul(1_000)).unwrap_or(i64::MAX);
+    let exec_id_text = args.execution_id.to_string();
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    // SERIALIZABLE matches the Lua's single-slot atomicity guarantee.
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // 1. Idempotency guard.
+    let guard_row = sqlx::query(
+        r#"
+        SELECT expires_at_ms FROM ff_quota_admitted
+         WHERE partition_key = $1 AND quota_policy_id = $2 AND execution_id = $3
+         FOR UPDATE
+        "#,
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(&exec_id_text)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    if let Some(row) = guard_row {
+        let expires_at_ms: i64 = row.try_get("expires_at_ms").map_err(map_sqlx_error)?;
+        if expires_at_ms > now {
+            tx.commit().await.map_err(map_sqlx_error)?;
+            return Ok(CheckAdmissionResult::AlreadyAdmitted);
+        }
+    }
+
+    // 2. Sliding window sweep for THIS policy (bounded delete — PK
+    // prefix sarges the index; no dedicated sweep index needed).
+    sqlx::query(
+        r#"
+        DELETE FROM ff_quota_window
+         WHERE partition_key = $1
+           AND quota_policy_id = $2
+           AND admitted_at_ms < $3
+        "#,
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(now.saturating_sub(window_ms))
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 3. Rate check.
+    if args.rate_limit > 0 {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM ff_quota_window \
+             WHERE partition_key = $1 AND quota_policy_id = $2",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        if count as u64 >= args.rate_limit {
+            let oldest: Option<(i64,)> = sqlx::query_as(
+                "SELECT admitted_at_ms FROM ff_quota_window \
+                 WHERE partition_key = $1 AND quota_policy_id = $2 \
+                 ORDER BY admitted_at_ms ASC LIMIT 1",
+            )
+            .bind(part)
+            .bind(&policy_id_text)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+            let retry = oldest
+                .map(|(oldest_ms,)| {
+                    let delta = oldest_ms.saturating_add(window_ms).saturating_sub(now);
+                    u64::try_from(delta.max(0)).unwrap_or(0)
+                })
+                .unwrap_or(0);
+            let jitter = args.jitter_ms.unwrap_or(0);
+            let retry_after_ms = retry.saturating_add(jitter);
+            tx.commit().await.map_err(map_sqlx_error)?;
+            return Ok(CheckAdmissionResult::RateExceeded { retry_after_ms });
+        }
+    }
+
+    // 4. Concurrency check — UPSERT a zero-row then read under lock.
+    let policy_row = sqlx::query(
+        "SELECT active_concurrency FROM ff_quota_policy \
+         WHERE partition_key = $1 AND quota_policy_id = $2 \
+         FOR UPDATE",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+    let active: i64 = policy_row
+        .map(|r| r.try_get("active_concurrency").unwrap_or(0i64))
+        .unwrap_or(0);
+    if args.concurrency_cap > 0 && active as u64 >= args.concurrency_cap {
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(CheckAdmissionResult::ConcurrencyExceeded);
+    }
+
+    // 5. Admit.
+    sqlx::query(
+        "INSERT INTO ff_quota_window \
+            (partition_key, quota_policy_id, dimension, admitted_at_ms, execution_id) \
+         VALUES ($1, $2, '', $3, $4)",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(now)
+    .bind(&exec_id_text)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        "INSERT INTO ff_quota_admitted \
+            (partition_key, quota_policy_id, execution_id, admitted_at_ms, expires_at_ms) \
+         VALUES ($1, $2, $3, $4, $5) \
+         ON CONFLICT (partition_key, quota_policy_id, execution_id) DO UPDATE \
+            SET admitted_at_ms = EXCLUDED.admitted_at_ms, \
+                expires_at_ms = EXCLUDED.expires_at_ms",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(&exec_id_text)
+    .bind(now)
+    .bind(now.saturating_add(window_ms))
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if args.concurrency_cap > 0 {
+        // Upsert the policy row's active_concurrency counter. If the
+        // row doesn't exist yet, INSERT with count=1 + zero caps —
+        // matches the Lua which operates on a raw INCR / SET even
+        // before the policy was `create_quota_policy`'d.
+        sqlx::query(
+            "INSERT INTO ff_quota_policy \
+                (partition_key, quota_policy_id, \
+                 requests_per_window_seconds, max_requests_per_window, \
+                 active_concurrency_cap, active_concurrency, \
+                 created_at_ms, updated_at_ms) \
+             VALUES ($1, $2, 0, 0, 0, 1, $3, $3) \
+             ON CONFLICT (partition_key, quota_policy_id) DO UPDATE \
+                SET active_concurrency = ff_quota_policy.active_concurrency + 1, \
+                    updated_at_ms = EXCLUDED.updated_at_ms",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(CheckAdmissionResult::Admitted)
 }
 #[cfg(test)]
 mod tests {

--- a/crates/ff-backend-postgres/tests/typed_check_admission.rs
+++ b/crates/ff-backend-postgres/tests/typed_check_admission.rs
@@ -1,0 +1,171 @@
+//! #453 / PR-7b: integration test for `EngineBackend::check_admission`
+//! on Postgres.
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{CheckAdmissionArgs, CheckAdmissionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{ExecutionId, QuotaPolicyId, TimestampMs};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect");
+    ff_backend_postgres::apply_migrations(&pool).await.expect("migrate");
+    Some(pool)
+}
+
+fn fresh_eid() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).unwrap()
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn admits_first_request_in_window() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    let args = CheckAdmissionArgs {
+        execution_id: fresh_eid(),
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 10,
+        concurrency_cap: 100,
+        jitter_ms: None,
+    };
+    let res = backend
+        .check_admission(&qid, "", args)
+        .await
+        .expect("admit");
+    assert_eq!(res, CheckAdmissionResult::Admitted);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn idempotent_second_admit_returns_already_admitted() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    let eid = fresh_eid();
+    let base = CheckAdmissionArgs {
+        execution_id: eid.clone(),
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 10,
+        concurrency_cap: 100,
+        jitter_ms: None,
+    };
+    assert_eq!(
+        backend.check_admission(&qid, "", base.clone()).await.unwrap(),
+        CheckAdmissionResult::Admitted
+    );
+    assert_eq!(
+        backend.check_admission(&qid, "", base).await.unwrap(),
+        CheckAdmissionResult::AlreadyAdmitted
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn rate_exceeded_returns_retry_after() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    // Admit 3 different executions; 4th with rate_limit=3 should be
+    // RateExceeded.
+    for _ in 0..3 {
+        let args = CheckAdmissionArgs {
+            execution_id: fresh_eid(),
+            now: TimestampMs::from_millis(now_ms()),
+            window_seconds: 60,
+            rate_limit: 3,
+            concurrency_cap: 100,
+            jitter_ms: None,
+        };
+        assert_eq!(
+            backend.check_admission(&qid, "", args).await.unwrap(),
+            CheckAdmissionResult::Admitted
+        );
+    }
+    let fourth = CheckAdmissionArgs {
+        execution_id: fresh_eid(),
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 3,
+        concurrency_cap: 100,
+        jitter_ms: None,
+    };
+    match backend.check_admission(&qid, "", fourth).await.unwrap() {
+        CheckAdmissionResult::RateExceeded { retry_after_ms } => {
+            assert!(retry_after_ms > 0 || retry_after_ms == 0);
+        }
+        other => panic!("expected RateExceeded, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn concurrency_cap_blocks_additional_admits() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    // Pre-load the policy row with active_concurrency=2, cap=2 so the
+    // next admit hits the cap before inserting.
+    let part = ff_core::partition::quota_partition(&qid, &PartitionConfig::default()).index as i16;
+    sqlx::query(
+        "INSERT INTO ff_quota_policy \
+            (partition_key, quota_policy_id, \
+             requests_per_window_seconds, max_requests_per_window, \
+             active_concurrency_cap, active_concurrency, \
+             created_at_ms, updated_at_ms) \
+         VALUES ($1, $2, 60, 100, 2, 2, $3, $3)",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .bind(now_ms())
+    .execute(&pool)
+    .await
+    .expect("seed policy");
+    let args = CheckAdmissionArgs {
+        execution_id: fresh_eid(),
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 100,
+        concurrency_cap: 2,
+        jitter_ms: None,
+    };
+    match backend.check_admission(&qid, "", args).await.unwrap() {
+        CheckAdmissionResult::ConcurrencyExceeded => {}
+        other => panic!("expected ConcurrencyExceeded, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Fifth of 7 cairn #453 typed-FCALL methods. Stacked on #458.

Ports `ff_check_admission_and_record` to a SERIALIZABLE PG tx. Three-guard flow: idempotency (ff_quota_admitted) → sliding-window rate (DELETE-then-COUNT on ff_quota_window) → concurrency cap (ff_quota_policy.active_concurrency). 4 test cases covering each outcome. Refs #453. 2 methods remaining.