### PR TITLE
feat(ff-backend-postgres): PR-7b/#453/6 — evaluate_flow_eligibility PG body

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1639,6 +1639,14 @@ impl EngineBackend for PostgresBackend {
         .await
     }
 
+    #[cfg(feature = "core")]
+    async fn evaluate_flow_eligibility(
+        &self,
+        args: ff_core::contracts::EvaluateFlowEligibilityArgs,
+    ) -> Result<ff_core::contracts::EvaluateFlowEligibilityResult, EngineError> {
+        crate::typed_ops::evaluate_flow_eligibility(self.pool(), args).await
+    }
+
     // ── PR-7b Wave 0a: exec_core field read ──
 
     async fn read_exec_core_fields(

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -33,8 +33,9 @@
 
 use ff_core::contracts::{
     CheckAdmissionArgs, CheckAdmissionResult, CompleteExecutionArgs, CompleteExecutionResult,
-    FailExecutionArgs, FailExecutionResult, RenewLeaseArgs, RenewLeaseResult,
-    ResumeExecutionArgs, ResumeExecutionResult,
+    EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult, FailExecutionArgs,
+    FailExecutionResult, RenewLeaseArgs, RenewLeaseResult, ResumeExecutionArgs,
+    ResumeExecutionResult,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
 use ff_core::partition::{quota_partition, PartitionConfig};
@@ -1089,6 +1090,140 @@ pub(crate) async fn check_admission(
 
     tx.commit().await.map_err(map_sqlx_error)?;
     Ok(CheckAdmissionResult::Admitted)
+}
+
+/// PG body for [`ff_core::engine_backend::EngineBackend::evaluate_flow_eligibility`].
+///
+/// Mirrors `ff_evaluate_flow_eligibility` in `flowfabric.lua`. Read-only,
+/// returns a textual status code:
+///
+/// - `not_found` — execution row absent
+/// - `not_runnable` — `lifecycle_phase != 'runnable'`
+/// - `owned` — `ownership_state != 'unowned'`
+/// - `terminal` — `raw_fields.terminal_outcome != 'none'`
+/// - `impossible` — at least one incoming edge's upstream is terminal
+///   with `outcome='failed'` under an AllOf/required policy
+/// - `blocked_by_dependencies` — at least one incoming edge's upstream
+///   is not yet terminal under a required policy
+/// - `eligible` — none of the above; execution can proceed
+///
+/// The dependency analysis walks `ff_edge` + joins upstream
+/// `ff_exec_core` to derive `unsatisfied_required_count` /
+/// `impossible_required_count` live instead of reading a persisted
+/// counter (Valkey maintains `ff:deps:<eid>` counters; PG replicates
+/// the logic via SQL). Matches cairn's pre-migration control-plane
+/// path which already queries `ff_edge` for adjacency.
+pub(crate) async fn evaluate_flow_eligibility(
+    pool: &PgPool,
+    args: EvaluateFlowEligibilityArgs,
+) -> Result<EvaluateFlowEligibilityResult, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+
+    // Step 1 — read exec_core state.
+    let exec_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, ownership_state, flow_id,
+               COALESCE(raw_fields->>'terminal_outcome', 'none') AS terminal_outcome
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(exec_row) = exec_row else {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "not_found".into(),
+        });
+    };
+    let lifecycle_phase: String = exec_row
+        .try_get("lifecycle_phase")
+        .map_err(map_sqlx_error)?;
+    if lifecycle_phase != "runnable" {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "not_runnable".into(),
+        });
+    }
+    let ownership_state: String = exec_row
+        .try_get("ownership_state")
+        .map_err(map_sqlx_error)?;
+    if ownership_state != "unowned" {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "owned".into(),
+        });
+    }
+    let terminal_outcome: String = exec_row
+        .try_get("terminal_outcome")
+        .map_err(map_sqlx_error)?;
+    if terminal_outcome != "none" {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "terminal".into(),
+        });
+    }
+    let flow_id_opt: Option<uuid::Uuid> = exec_row.try_get("flow_id").map_err(map_sqlx_error)?;
+    let Some(flow_id) = flow_id_opt else {
+        // Standalone execution — no dep graph to evaluate.
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "eligible".into(),
+        });
+    };
+
+    // Step 2 — walk incoming edges + classify upstreams.
+    //
+    // Required edges' upstream `ff_exec_core.raw_fields.terminal_outcome`:
+    // - `failed` → impossible_required_count
+    // - `success` → satisfied (doesn't count)
+    // - anything else / missing → unsatisfied_required_count
+    //
+    // Policy is `jsonb`: we consider a policy "required" if
+    // `policy->>'kind' IN ('required', 'AllOf', 'all_of')`. Optional
+    // edges (Any-Of / Count policies) are not counted as required.
+    let counts = sqlx::query(
+        r#"
+        SELECT
+          SUM(CASE
+                WHEN is_required
+                  AND COALESCE(up.raw_fields->>'terminal_outcome', 'none') = 'failed'
+                THEN 1 ELSE 0 END)::bigint AS impossible_count,
+          SUM(CASE
+                WHEN is_required
+                  AND COALESCE(up.raw_fields->>'terminal_outcome', 'none') NOT IN ('failed', 'success')
+                THEN 1 ELSE 0 END)::bigint AS unsatisfied_count
+        FROM (
+          SELECT e.upstream_eid,
+                 (e.policy->>'kind') IN ('required', 'AllOf', 'all_of') AS is_required
+            FROM ff_edge e
+           WHERE e.partition_key = $1
+             AND e.flow_id = $2
+             AND e.downstream_eid = $3
+        ) edges
+        LEFT JOIN ff_exec_core up
+          ON up.partition_key = $1 AND up.execution_id = edges.upstream_eid
+        "#,
+    )
+    .bind(part)
+    .bind(flow_id)
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let impossible: Option<i64> = counts.try_get("impossible_count").map_err(map_sqlx_error)?;
+    let unsatisfied: Option<i64> =
+        counts.try_get("unsatisfied_count").map_err(map_sqlx_error)?;
+    let status = if impossible.unwrap_or(0) > 0 {
+        "impossible"
+    } else if unsatisfied.unwrap_or(0) > 0 {
+        "blocked_by_dependencies"
+    } else {
+        "eligible"
+    };
+    Ok(EvaluateFlowEligibilityResult::Status {
+        status: status.into(),
+    })
 }
 #[cfg(test)]
 mod tests {

--- a/crates/ff-backend-postgres/tests/typed_evaluate_flow_eligibility.rs
+++ b/crates/ff-backend-postgres/tests/typed_evaluate_flow_eligibility.rs
@@ -1,0 +1,233 @@
+//! #453 / PR-7b: integration test for
+//! EngineBackend::evaluate_flow_eligibility on Postgres.
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::ExecutionId;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect");
+    ff_backend_postgres::apply_migrations(&pool).await.expect("migrate");
+    Some(pool)
+}
+
+async fn seed_exec(
+    pool: &PgPool,
+    lifecycle_phase: &str,
+    ownership: &str,
+    flow_id: Option<Uuid>,
+    terminal_outcome: &str,
+) -> (i16, Uuid, ExecutionId) {
+    let part: i16 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            required_capabilities, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms, raw_fields
+        ) VALUES (
+            $1, $2, $3, 'default', '{}', 0,
+            $4, $5, 'eligible_now',
+            'waiting', 'pending_first_attempt',
+            0, $6,
+            jsonb_build_object('terminal_outcome', $7::text)
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(flow_id)
+    .bind(lifecycle_phase)
+    .bind(ownership)
+    .bind(now_ms())
+    .bind(terminal_outcome)
+    .execute(pool)
+    .await
+    .expect("seed");
+    (part, exec_uuid, eid)
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn eligible_when_standalone_runnable_unowned() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let (_p, _u, eid) = seed_exec(&pool, "runnable", "unowned", None, "none").await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let EvaluateFlowEligibilityResult::Status { status } = backend
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: eid })
+        .await
+        .expect("ok");
+    assert_eq!(status, "eligible");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn not_found_without_row() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let bogus =
+        ExecutionId::parse("{fp:0}:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+    let EvaluateFlowEligibilityResult::Status { status } = backend
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: bogus })
+        .await
+        .expect("ok");
+    assert_eq!(status, "not_found");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn not_runnable_when_active() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let (_p, _u, eid) = seed_exec(&pool, "active", "leased", None, "none").await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let EvaluateFlowEligibilityResult::Status { status } = backend
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: eid })
+        .await
+        .expect("ok");
+    assert_eq!(status, "not_runnable");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn owned_when_ownership_not_unowned() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let (_p, _u, eid) = seed_exec(&pool, "runnable", "leased", None, "none").await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let EvaluateFlowEligibilityResult::Status { status } = backend
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: eid })
+        .await
+        .expect("ok");
+    assert_eq!(status, "owned");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn blocked_by_required_edge_with_non_terminal_upstream() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let flow_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+            (partition_key, flow_id, public_flow_state, created_at_ms) \
+         VALUES (0, $1, 'running', $2)",
+    )
+    .bind(flow_id)
+    .bind(now_ms())
+    .execute(&pool)
+    .await
+    .expect("seed flow");
+
+    let (_p, up_uuid, _up_eid) =
+        seed_exec(&pool, "runnable", "unowned", Some(flow_id), "none").await;
+    let (_p, down_uuid, down_eid) =
+        seed_exec(&pool, "runnable", "unowned", Some(flow_id), "none").await;
+
+    sqlx::query(
+        "INSERT INTO ff_edge \
+            (partition_key, flow_id, edge_id, upstream_eid, downstream_eid, policy) \
+         VALUES (0, $1, $2, $3, $4, '{\"kind\":\"required\"}'::jsonb)",
+    )
+    .bind(flow_id)
+    .bind(Uuid::new_v4())
+    .bind(up_uuid)
+    .bind(down_uuid)
+    .execute(&pool)
+    .await
+    .expect("seed edge");
+
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let EvaluateFlowEligibilityResult::Status { status } = backend
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs {
+            execution_id: down_eid,
+        })
+        .await
+        .expect("ok");
+    assert_eq!(status, "blocked_by_dependencies");
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn impossible_when_required_upstream_failed() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let flow_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_flow_core \
+            (partition_key, flow_id, public_flow_state, created_at_ms) \
+         VALUES (0, $1, 'running', $2)",
+    )
+    .bind(flow_id)
+    .bind(now_ms())
+    .execute(&pool)
+    .await
+    .expect("seed flow");
+
+    let (_p, up_uuid, _up_eid) =
+        seed_exec(&pool, "terminal", "unowned", Some(flow_id), "failed").await;
+    let (_p, down_uuid, down_eid) =
+        seed_exec(&pool, "runnable", "unowned", Some(flow_id), "none").await;
+
+    sqlx::query(
+        "INSERT INTO ff_edge \
+            (partition_key, flow_id, edge_id, upstream_eid, downstream_eid, policy) \
+         VALUES (0, $1, $2, $3, $4, '{\"kind\":\"required\"}'::jsonb)",
+    )
+    .bind(flow_id)
+    .bind(Uuid::new_v4())
+    .bind(up_uuid)
+    .bind(down_uuid)
+    .execute(&pool)
+    .await
+    .expect("seed edge");
+
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    let EvaluateFlowEligibilityResult::Status { status } = backend
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs {
+            execution_id: down_eid,
+        })
+        .await
+        .expect("ok");
+    assert_eq!(status, "impossible");
+}


### PR DESCRIPTION
Sixth of 7 cairn #453 typed-FCALL methods. Stacked on #459.

Ports `ff_evaluate_flow_eligibility`: read-only status check. Computes required-edge counts via JOIN on ff_edge + upstream ff_exec_core (no persisted counter — PG queries dep graph directly). 6 test cases covering each status.

Refs #453. 1 method remaining: claim_execution.