### PR TITLE
feat(ff-backend-sqlite): Phase 1 — 7 SQLite typed-FCALL bodies (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,34 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **#33 / Phase 1: 7 SQLite typed-FCALL bodies (cairn parity).** Flips
+  `renew_lease`, `complete_execution`, `fail_execution`,
+  `resume_execution`, `check_admission`, `evaluate_flow_eligibility`,
+  `claim_execution` from the `Unavailable` default to real SQLite
+  bodies on `SqliteBackend`. Mirrors the PG shape at
+  `ff-backend-postgres/src/typed_ops.rs` modulo dialect:
+  - `FOR UPDATE` elided — `BEGIN IMMEDIATE` already holds RESERVED
+    lock, RFC-023 §4.1 A3 single-writer.
+  - `raw_fields->>'k'` → `json_extract(raw_fields, '$.k')`.
+  - PG `jsonb || patch` → SQLite `json_set(raw_fields, '$.k1', v1,
+    '$.k2', v2, ...)` (multi-key set in one call).
+  - `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE` dropped —
+    `BEGIN IMMEDIATE` + single-writer is implicitly serialisable.
+  - UPSERT uses `ON CONFLICT ... DO UPDATE SET … = excluded.col`
+    (SQLite lowercase keyword) instead of `EXCLUDED.col`.
+  - `flow_id` is BLOB (Uuid::as_bytes) on SQLite vs `uuid` on PG; sqlx
+    handles the bind via Uuid.
+  - `attempt_index` is INTEGER (i64) on SQLite vs integer (i32) on PG.
+  - All write paths wrapped in `retry_serializable(|| …)` to absorb
+    `SQLITE_BUSY` under contention.
+
+  Fence-asymmetry (epoch-only) note from PG carries over — SQLite's
+  `ff_attempt` persists only `lease_epoch`; `lease_id` and `attempt_id`
+  live on the worker-side `Handle`.
+
+  Integration tests: 38 tests across 7 files
+  (`crates/ff-backend-sqlite/tests/typed_*.rs`); run against `:memory:`
+  — no env var gate — and execute in every CI matrix cell.
 - **#453 / PR-7b: `EngineBackend::fail_execution` — Postgres body.**
   Ports `ff_fail_execution` from `flowfabric.lua` with both retry and
   terminal branches. Parses the retry policy JSON envelope (fixed /

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2615,6 +2615,24 @@ impl EngineBackend for SqliteBackend {
             .await
     }
 
+    async fn fail_execution(
+        &self,
+        args: ff_core::contracts::FailExecutionArgs,
+    ) -> Result<ff_core::contracts::FailExecutionResult, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| crate::typed_ops::fail_execution(pool, pubsub, args.clone())).await
+    }
+
+    async fn resume_execution(
+        &self,
+        args: ff_core::contracts::ResumeExecutionArgs,
+    ) -> Result<ff_core::contracts::ResumeExecutionResult, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| crate::typed_ops::resume_execution(pool, pubsub, args.clone())).await
+    }
+
     async fn progress(
         &self,
         handle: &Handle,

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2633,6 +2633,28 @@ impl EngineBackend for SqliteBackend {
         retry_serializable(|| crate::typed_ops::resume_execution(pool, pubsub, args.clone())).await
     }
 
+    async fn check_admission(
+        &self,
+        quota_policy_id: &ff_core::types::QuotaPolicyId,
+        _dimension: &str,
+        args: ff_core::contracts::CheckAdmissionArgs,
+    ) -> Result<ff_core::contracts::CheckAdmissionResult, EngineError> {
+        let pool = &self.inner.pool;
+        // SQLite is single-writer; quota bucketing under
+        // `num_quota_partitions` still hashes the quota_policy_id to a
+        // partition_key but all rows land in the same DB. Use the
+        // default PartitionConfig (same hash fn + `num_quota_partitions`
+        // as Valkey/PG) so the partition_key column value stays
+        // consistent across backends — `ff_quota_*` tables in SQLite
+        // don't HASH-partition the storage, but the column carries the
+        // same derived index for cross-backend read parity.
+        let pc = ff_core::partition::PartitionConfig::default();
+        retry_serializable(|| {
+            crate::typed_ops::check_admission(pool, &pc, quota_policy_id, args.clone())
+        })
+        .await
+    }
+
     async fn progress(
         &self,
         handle: &Handle,

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2661,14 +2661,9 @@ impl EngineBackend for SqliteBackend {
         args: ff_core::contracts::CheckAdmissionArgs,
     ) -> Result<ff_core::contracts::CheckAdmissionResult, EngineError> {
         let pool = &self.inner.pool;
-        // SQLite is single-writer; quota bucketing under
-        // `num_quota_partitions` still hashes the quota_policy_id to a
-        // partition_key but all rows land in the same DB. Use the
-        // default PartitionConfig (same hash fn + `num_quota_partitions`
-        // as Valkey/PG) so the partition_key column value stays
-        // consistent across backends — `ff_quota_*` tables in SQLite
-        // don't HASH-partition the storage, but the column carries the
-        // same derived index for cross-backend read parity.
+        // `partition_config` is ignored inside the body on SQLite
+        // (single-writer, partition_key=0); accepted for cross-backend
+        // signature parity. See typed_ops::check_admission rustdoc.
         let pc = ff_core::partition::PartitionConfig::default();
         retry_serializable(|| {
             crate::typed_ops::check_admission(pool, &pc, quota_policy_id, args.clone())

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2633,6 +2633,27 @@ impl EngineBackend for SqliteBackend {
         retry_serializable(|| crate::typed_ops::resume_execution(pool, pubsub, args.clone())).await
     }
 
+    async fn evaluate_flow_eligibility(
+        &self,
+        args: ff_core::contracts::EvaluateFlowEligibilityArgs,
+    ) -> Result<ff_core::contracts::EvaluateFlowEligibilityResult, EngineError> {
+        // Read-only; no retry_serializable needed.
+        crate::typed_ops::evaluate_flow_eligibility(&self.inner.pool, args).await
+    }
+
+    async fn claim_execution(
+        &self,
+        args: ff_core::contracts::ClaimExecutionArgs,
+    ) -> Result<ff_core::contracts::ClaimExecutionResult, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        let pc = ff_core::partition::PartitionConfig::default();
+        retry_serializable(|| {
+            crate::typed_ops::claim_execution(pool, &pc, pubsub, args.clone())
+        })
+        .await
+    }
+
     async fn check_admission(
         &self,
         quota_policy_id: &ff_core::types::QuotaPolicyId,

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -196,7 +196,7 @@ fn now_ms() -> i64 {
 /// Decompose an [`ff_core::types::ExecutionId`] formatted `{fp:N}:<uuid>`
 /// into `(partition_index, uuid_bytes)` — SQLite stores the UUID as a
 /// 16-byte `BLOB` (§4.1) so we bind via `uuid::Uuid`.
-fn split_exec_id(eid: &ff_core::types::ExecutionId) -> Result<(i64, Uuid), EngineError> {
+pub(crate) fn split_exec_id(eid: &ff_core::types::ExecutionId) -> Result<(i64, Uuid), EngineError> {
     let s = eid.as_str();
     let rest = s
         .strip_prefix("{fp:")
@@ -233,7 +233,7 @@ fn split_exec_id(eid: &ff_core::types::ExecutionId) -> Result<(i64, Uuid), Engin
 /// (no `IMMEDIATE` escalation on the public API today); we manage
 /// the lock here manually and the per-op helpers in this file close
 /// the rollback loop.
-async fn begin_immediate(
+pub(crate) async fn begin_immediate(
     pool: &SqlitePool,
 ) -> Result<sqlx::pool::PoolConnection<sqlx::Sqlite>, EngineError> {
     let mut conn = pool.acquire().await.map_err(map_sqlx_error)?;
@@ -250,7 +250,7 @@ async fn begin_immediate(
 /// A secondary rollback error is swallowed — SQLite auto-rolls-back
 /// on connection close, which happens when the pool drops an
 /// unhealthy connection, so correctness is preserved.
-async fn commit_or_rollback(
+pub(crate) async fn commit_or_rollback(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
 ) -> Result<(), EngineError> {
     if let Err(e) = sqlx::query("COMMIT")
@@ -266,7 +266,7 @@ async fn commit_or_rollback(
 
 /// Best-effort rollback on an error path. A failed rollback is
 /// swallowed so the original error surfaces unchanged.
-async fn rollback_quiet(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
+pub(crate) async fn rollback_quiet(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
     let _ = sqlx::query("ROLLBACK").execute(&mut **conn).await;
 }
 
@@ -676,7 +676,7 @@ async fn fail_inner(
 /// into the Rust post-commit dispatch landed in Phase 2b.1; durable
 /// replay via `event_id > cursor` continues to ride against this
 /// table.
-async fn insert_lease_event(
+pub(crate) async fn insert_lease_event(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     part: i64,
     exec_uuid: Uuid,
@@ -699,7 +699,7 @@ async fn insert_lease_event(
 
 /// Insert one completion outbox row (success / failed / cancelled /
 /// retry) and return the `event_id` wrapped in an [`OutboxEvent`].
-async fn insert_completion_event_ev(
+pub(crate) async fn insert_completion_event_ev(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     part: i64,
     exec_uuid: Uuid,
@@ -2592,6 +2592,27 @@ impl EngineBackend for SqliteBackend {
         let pool = &self.inner.pool;
         let pubsub = &self.inner.pubsub;
         retry_serializable(|| renew_impl(pool, pubsub, handle)).await
+    }
+
+    // ── PR-7b / #453: typed-FCALL trait methods ──
+
+    async fn renew_lease(
+        &self,
+        args: ff_core::contracts::RenewLeaseArgs,
+    ) -> Result<ff_core::contracts::RenewLeaseResult, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| crate::typed_ops::renew_lease(pool, pubsub, args.clone())).await
+    }
+
+    async fn complete_execution(
+        &self,
+        args: ff_core::contracts::CompleteExecutionArgs,
+    ) -> Result<ff_core::contracts::CompleteExecutionResult, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| crate::typed_ops::complete_execution(pool, pubsub, args.clone()))
+            .await
     }
 
     async fn progress(

--- a/crates/ff-backend-sqlite/src/lib.rs
+++ b/crates/ff-backend-sqlite/src/lib.rs
@@ -46,6 +46,7 @@ mod registry;
 pub mod retry;
 mod suspend_ops;
 mod tx_util;
+mod typed_ops;
 
 pub use backend::SqliteBackend;
 pub use errors::{MAX_ATTEMPTS, is_retryable_sqlite_busy};

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -42,11 +42,12 @@
 //! catches the same violations Valkey's full-triple check catches.
 
 use ff_core::contracts::{
-    CompleteExecutionArgs, CompleteExecutionResult, RenewLeaseArgs, RenewLeaseResult,
+    CompleteExecutionArgs, CompleteExecutionResult, FailExecutionArgs, FailExecutionResult,
+    RenewLeaseArgs, RenewLeaseResult, ResumeExecutionArgs, ResumeExecutionResult,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
 use ff_core::state::PublicState;
-use ff_core::types::{CancelSource, TimestampMs};
+use ff_core::types::{AttemptIndex, CancelSource, TimestampMs};
 use sqlx::Row;
 use sqlx::SqlitePool;
 
@@ -406,6 +407,408 @@ pub(crate) async fn complete_execution(
                 execution_id,
                 public_state: PublicState::Completed,
             })
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+/// Parsed retry policy envelope (mirror of PG helper at
+/// `ff-backend-postgres/src/typed_ops.rs::parse_retry_policy`).
+struct ParsedRetryPolicy {
+    max_retries: u32,
+    backoff: serde_json::Value,
+}
+
+fn parse_retry_policy(s: &str) -> ParsedRetryPolicy {
+    if s.is_empty() {
+        return ParsedRetryPolicy {
+            max_retries: 0,
+            backoff: serde_json::Value::Null,
+        };
+    }
+    let v: serde_json::Value = serde_json::from_str(s).unwrap_or(serde_json::Value::Null);
+    let max_retries = v
+        .get("max_retries")
+        .and_then(|x| x.as_u64())
+        .unwrap_or(0) as u32;
+    let backoff = v.get("backoff").cloned().unwrap_or(serde_json::Value::Null);
+    ParsedRetryPolicy {
+        max_retries,
+        backoff,
+    }
+}
+
+fn compute_retry_delay_ms(backoff: &serde_json::Value, retry_count: u32) -> u64 {
+    let kind = backoff.get("type").and_then(|x| x.as_str()).unwrap_or("");
+    match kind {
+        "exponential" => {
+            let initial = backoff
+                .get("initial_delay_ms")
+                .and_then(|x| x.as_u64())
+                .unwrap_or(1_000);
+            let max_d = backoff
+                .get("max_delay_ms")
+                .and_then(|x| x.as_u64())
+                .unwrap_or(60_000);
+            let mult = backoff
+                .get("multiplier")
+                .and_then(|x| x.as_f64())
+                .unwrap_or(2.0);
+            let exp = mult.powi(retry_count as i32);
+            let delay = (initial as f64) * exp;
+            (delay.min(max_d as f64)) as u64
+        }
+        "fixed" => backoff
+            .get("delay_ms")
+            .and_then(|x| x.as_u64())
+            .unwrap_or(1_000),
+        _ => 1_000,
+    }
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::fail_execution`].
+///
+/// Mirrors PG at `ff-backend-postgres/src/typed_ops.rs::fail_execution`
+/// with the retry/terminal branch split:
+///
+/// - Retry path (`retry_count < policy.max_retries`): flip exec_core
+///   to `runnable` / `delayed`; stash `pending_retry_reason`,
+///   `pending_previous_attempt_index`, bumped `retry_count`,
+///   `delay_until`, `failure_reason` in `raw_fields`. Return
+///   `RetryScheduled { delay_until, next_attempt_index }`.
+/// - Terminal path: flip exec_core to `terminal` / `failed`; emit
+///   completion outbox with `outcome='failed'` + lease-revoked outbox.
+///   Return `TerminalFailed`.
+///
+/// Fence-or-operator-override gate matches `complete_execution`.
+pub(crate) async fn fail_execution(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: FailExecutionArgs,
+) -> Result<FailExecutionResult, EngineError> {
+    let is_operator_override = matches!(args.source, CancelSource::OperatorOverride);
+    if args.fence.is_none() && !is_operator_override {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "fence_required".into(),
+        });
+    }
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let attempt_index = i64::from(args.attempt_index.0);
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        // Read attempt row for fence.
+        let attempt_row = sqlx::query(q_attempt::SELECT_ATTEMPT_EPOCH_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let Some(attempt_row) = attempt_row else {
+            return Err(EngineError::NotFound { entity: "attempt" });
+        };
+        let observed_epoch_i: i64 =
+            attempt_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+        let observed_epoch = u64::try_from(observed_epoch_i).unwrap_or(0);
+
+        if let Some(fence) = &args.fence
+            && observed_epoch != fence.lease_epoch.0
+        {
+            return Err(EngineError::State(StateKind::StaleLease));
+        }
+
+        // Read exec_core for lifecycle + retry_count.
+        let exec_row = sqlx::query(
+            r#"
+            SELECT lifecycle_phase,
+                   ownership_state,
+                   COALESCE(CAST(json_extract(raw_fields, '$.retry_count') AS INTEGER), 0)
+                       AS retry_count,
+                   COALESCE(json_extract(raw_fields, '$.current_attempt_id'), '')
+                       AS current_attempt_id,
+                   COALESCE(json_extract(raw_fields, '$.terminal_outcome'), 'none')
+                       AS terminal_outcome
+              FROM ff_exec_core
+             WHERE partition_key = ?1 AND execution_id = ?2
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let Some(exec_row) = exec_row else {
+            return Err(EngineError::NotFound { entity: "execution" });
+        };
+        let ownership_state: String = exec_row
+            .try_get("ownership_state")
+            .map_err(map_sqlx_error)?;
+        if ownership_state == "lease_revoked" {
+            return Err(EngineError::State(StateKind::LeaseRevoked));
+        }
+        let lifecycle_phase: String = exec_row
+            .try_get("lifecycle_phase")
+            .map_err(map_sqlx_error)?;
+        if lifecycle_phase != "active" {
+            let terminal_outcome: String =
+                exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
+            let current_attempt_id: String = exec_row
+                .try_get("current_attempt_id")
+                .map_err(map_sqlx_error)?;
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+                terminal_outcome,
+                lease_epoch: observed_epoch.to_string(),
+                lifecycle_phase,
+                attempt_id: current_attempt_id,
+            }));
+        }
+        let retry_count_i: i64 = exec_row.try_get("retry_count").map_err(map_sqlx_error)?;
+        let retry_count = u32::try_from(retry_count_i.max(0)).unwrap_or(0);
+
+        let policy = parse_retry_policy(&args.retry_policy_json);
+        let can_retry = retry_count < policy.max_retries;
+
+        let now = now_ms();
+
+        // Mark attempt terminal (both branches).
+        sqlx::query(
+            "UPDATE ff_attempt \
+                SET terminal_at_ms = ?1, outcome = 'failure', lease_expires_at_ms = NULL \
+              WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4",
+        )
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if can_retry {
+            let backoff_ms = compute_retry_delay_ms(&policy.backoff, retry_count);
+            let delay_until = now.saturating_add(backoff_ms as i64);
+            let next_attempt_index = attempt_index.saturating_add(1) as u32;
+
+            // Retry path: flip exec_core to runnable/delayed + stash
+            // pending retry lineage. SQLite `json_set` accepts multiple
+            // key/value pairs in one call — mirrors PG's
+            // `raw_fields || patch` semantic observably.
+            sqlx::query(
+                r#"
+                UPDATE ff_exec_core
+                   SET lifecycle_phase = 'runnable',
+                       ownership_state = 'unowned',
+                       eligibility_state = 'not_eligible_until_time',
+                       attempt_state = 'pending_retry_attempt',
+                       blocking_reason = 'waiting_for_retry_backoff',
+                       public_state = 'delayed',
+                       raw_fields = json_set(
+                           raw_fields,
+                           '$.pending_retry_reason', ?1,
+                           '$.pending_previous_attempt_index', ?2,
+                           '$.retry_count', ?3,
+                           '$.delay_until', ?4,
+                           '$.failure_reason', ?1
+                       )
+                 WHERE partition_key = ?5 AND execution_id = ?6
+                "#,
+            )
+            .bind(args.failure_reason.clone())
+            .bind(attempt_index.to_string())
+            .bind((retry_count + 1).to_string())
+            .bind(delay_until.to_string())
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            let lease_ev = insert_lease_event(&mut conn, part, exec_uuid, "revoked", now).await?;
+            let emits = vec![(OutboxChannel::LeaseHistory, lease_ev)];
+
+            return Ok::<_, EngineError>((
+                FailExecutionResult::RetryScheduled {
+                    delay_until: TimestampMs::from_millis(delay_until),
+                    next_attempt_index: AttemptIndex::new(next_attempt_index),
+                },
+                emits,
+            ));
+        }
+
+        // Terminal path.
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase = 'terminal',
+                   ownership_state = 'unowned',
+                   eligibility_state = 'not_applicable',
+                   attempt_state = 'attempt_terminal',
+                   public_state = 'failed',
+                   terminal_at_ms = ?1,
+                   raw_fields = json_set(
+                       raw_fields,
+                       '$.failure_reason', ?2,
+                       '$.terminal_outcome', 'failed'
+                   )
+             WHERE partition_key = ?3 AND execution_id = ?4
+            "#,
+        )
+        .bind(now)
+        .bind(args.failure_reason.clone())
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let completion_ev =
+            insert_completion_event_ev(&mut conn, part, exec_uuid, "failed", now).await?;
+        let lease_ev = insert_lease_event(&mut conn, part, exec_uuid, "revoked", now).await?;
+        let emits = vec![
+            (OutboxChannel::Completion, completion_ev),
+            (OutboxChannel::LeaseHistory, lease_ev),
+        ];
+
+        Ok((FailExecutionResult::TerminalFailed, emits))
+    }
+    .await;
+
+    match result {
+        Ok((outcome, emits)) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_emits(pubsub, emits);
+            Ok(outcome)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::resume_execution`].
+///
+/// Mirrors PG at `ff-backend-postgres/src/typed_ops.rs::resume_execution`.
+/// No fence (caller is operator or signal delivery). Validates
+/// suspended-state + suspension_current row presence, flips to
+/// runnable, clears waitpoint/suspension refs, DELETEs suspension row.
+pub(crate) async fn resume_execution(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: ResumeExecutionArgs,
+) -> Result<ResumeExecutionResult, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let exec_row = sqlx::query(
+            "SELECT lifecycle_phase FROM ff_exec_core \
+             WHERE partition_key = ?1 AND execution_id = ?2",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let Some(exec_row) = exec_row else {
+            return Err(EngineError::NotFound { entity: "execution" });
+        };
+        let lifecycle_phase: String = exec_row
+            .try_get("lifecycle_phase")
+            .map_err(map_sqlx_error)?;
+        if lifecycle_phase != "suspended" {
+            return Err(EngineError::State(StateKind::ExecutionNotSuspended));
+        }
+
+        let susp_row = sqlx::query(
+            "SELECT 1 FROM ff_suspension_current \
+             WHERE partition_key = ?1 AND execution_id = ?2",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        if susp_row.is_none() {
+            return Err(EngineError::State(StateKind::ExecutionNotSuspended));
+        }
+
+        let (eligibility_state, blocking_reason, public_state) = if args.resume_delay_ms > 0 {
+            (
+                "not_eligible_until_time",
+                "waiting_for_resume_delay",
+                PublicState::Delayed,
+            )
+        } else {
+            (
+                "eligible_now",
+                "waiting_for_worker",
+                PublicState::Waiting,
+            )
+        };
+        let public_state_str = match public_state {
+            PublicState::Delayed => "delayed",
+            PublicState::Waiting => "waiting",
+            _ => "waiting",
+        };
+
+        // `trigger_type` is advisory; recorded nowhere on the PG path
+        // and we match that here. Suppress unused-field lint:
+        let _ = &args.trigger_type;
+
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase = 'runnable',
+                   ownership_state = 'unowned',
+                   eligibility_state = ?1,
+                   attempt_state = 'attempt_interrupted',
+                   blocking_reason = ?2,
+                   public_state = ?3,
+                   raw_fields = json_set(
+                       raw_fields,
+                       '$.current_suspension_id', '',
+                       '$.current_waitpoint_id', ''
+                   )
+             WHERE partition_key = ?4 AND execution_id = ?5
+            "#,
+        )
+        .bind(eligibility_state)
+        .bind(blocking_reason)
+        .bind(public_state_str)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        sqlx::query(
+            "DELETE FROM ff_suspension_current \
+             WHERE partition_key = ?1 AND execution_id = ?2",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        Ok::<_, EngineError>(public_state)
+    }
+    .await;
+
+    match result {
+        Ok(public_state) => {
+            commit_or_rollback(&mut conn).await?;
+            let _ = pubsub;
+            Ok(ResumeExecutionResult::Resumed { public_state })
         }
         Err(e) => {
             rollback_quiet(&mut conn).await;

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -1,0 +1,415 @@
+//! PR-7b / #33: typed-FCALL EngineBackend bodies on SQLite.
+//!
+//! SQLite peers of the Postgres bodies at
+//! `ff-backend-postgres/src/typed_ops.rs`. Each function mirrors the
+//! PG shape modulo dialect: `FOR UPDATE` elided (implicit under
+//! `BEGIN IMMEDIATE` RESERVED lock, RFC-023 §4.1 A3 single-writer),
+//! `raw_fields->>'k'` → `json_extract(raw_fields, '$.k')`, PG
+//! `jsonb || patch` → SQLite `json_set(raw_fields, '$.k', v)` chain,
+//! `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE` dropped
+//! (`BEGIN IMMEDIATE` + single-writer is implicitly serialisable).
+//!
+//! # Transaction shape
+//!
+//! Each op:
+//!
+//! 1. Acquires a `BEGIN IMMEDIATE` connection via [`begin_immediate`]
+//!    — writer lock, RESERVED level.
+//! 2. Performs the op under that lock.
+//! 3. Commits via [`commit_or_rollback`] (or [`rollback_quiet`] on
+//!    error).
+//! 4. The `EngineBackend` trait wrapper at [`SqliteBackend`] calls
+//!    [`retry_serializable`](crate::retry::retry_serializable) around
+//!    the impl fn to absorb `SQLITE_BUSY` under lock contention.
+//!
+//! # Error mapping (parity with PG)
+//!
+//! | Lua err code           | EngineError                                       |
+//! |-----------------------|--------------------------------------------------|
+//! | `execution_not_found`  | `NotFound { entity: "execution" }`               |
+//! | `execution_not_active` | `Contention(ExecutionNotActive { … })`           |
+//! | `stale_lease`          | `State(StaleLease)`                              |
+//! | `lease_expired`        | `State(LeaseExpired)`                            |
+//! | `lease_revoked`        | `State(LeaseRevoked)`                            |
+//! | `fence_required`       | `Validation { InvalidInput, "fence_required" }`  |
+//!
+//! # Fencing asymmetry (same as PG)
+//!
+//! SQLite's `ff_attempt` schema persists only `lease_epoch`;
+//! `lease_id` and `attempt_id` live on the worker-side `Handle` and
+//! are never written to disk. `lease_epoch` is monotonically bumped
+//! on every claim/reclaim, so a stale caller's epoch ≠ stored epoch
+//! catches the same violations Valkey's full-triple check catches.
+
+use ff_core::contracts::{
+    CompleteExecutionArgs, CompleteExecutionResult, RenewLeaseArgs, RenewLeaseResult,
+};
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::state::PublicState;
+use ff_core::types::{CancelSource, TimestampMs};
+use sqlx::Row;
+use sqlx::SqlitePool;
+
+use crate::backend::{
+    begin_immediate, commit_or_rollback, insert_completion_event_ev, insert_lease_event,
+    rollback_quiet, split_exec_id, OutboxChannel, PendingEmit,
+};
+use crate::errors::map_sqlx_error;
+use crate::pubsub::PubSub;
+use crate::queries::{attempt as q_attempt, lease as q_lease};
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX)
+}
+
+/// Dispatch the accumulated pending emits after a successful commit.
+/// Mirrors `backend::dispatch_pending_emits` but inlined here to keep
+/// typed_ops decoupled from backend.rs's private helper.
+fn dispatch_emits(pubsub: &PubSub, emits: Vec<PendingEmit>) {
+    for (ch, ev) in emits {
+        match ch {
+            OutboxChannel::LeaseHistory => PubSub::emit(&pubsub.lease_history, ev),
+            OutboxChannel::Completion => PubSub::emit(&pubsub.completion, ev),
+            OutboxChannel::SignalDelivery => PubSub::emit(&pubsub.signal_delivery, ev),
+            OutboxChannel::StreamFrame => PubSub::emit(&pubsub.stream_frame, ev),
+            OutboxChannel::OperatorEvent => PubSub::emit(&pubsub.operator_event, ev),
+        }
+    }
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::renew_lease`].
+///
+/// Mirrors PG at `ff-backend-postgres/src/typed_ops.rs::renew_lease`:
+///
+/// 1. Fence required — `args.fence.is_none()` → `Validation{fence_required}`.
+/// 2. `BEGIN IMMEDIATE` acquires the writer lock.
+/// 3. Read attempt row; missing → `NotFound { entity: "attempt" }`.
+/// 4. Epoch-only fence (see module-level asymmetry note); mismatch →
+///    `State(StaleLease)`.
+/// 5. Read exec_core; missing → `NotFound { entity: "execution" }`.
+/// 6. `lifecycle_phase != 'active'` → `Contention(ExecutionNotActive{..})`.
+/// 7. NULL or expired `lease_expires_at_ms` → `State(LeaseExpired)`.
+/// 8. `UPDATE ff_attempt SET lease_expires_at_ms = now + ttl`.
+/// 9. Emit `insert_lease_event(.., "renewed", now)` to the lease outbox.
+/// 10. Return `RenewLeaseResult::Renewed { expires_at }`.
+pub(crate) async fn renew_lease(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: RenewLeaseArgs,
+) -> Result<RenewLeaseResult, EngineError> {
+    let fence = args.fence.as_ref().ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: "fence_required".into(),
+    })?;
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let attempt_index = i64::from(args.attempt_index.0);
+    let expected_epoch = fence.lease_epoch.0;
+    // Clamp u64 → i64 overflow to MAX rather than silently collapsing to 0.
+    let lease_ttl_i64 = i64::try_from(args.lease_ttl_ms).unwrap_or(i64::MAX);
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        // Read attempt row.
+        let row = sqlx::query(q_attempt::SELECT_ATTEMPT_EPOCH_SQL)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        let Some(row) = row else {
+            return Err(EngineError::NotFound { entity: "attempt" });
+        };
+        let observed_epoch_i: i64 = row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+        let observed_epoch = u64::try_from(observed_epoch_i).unwrap_or(0);
+        if observed_epoch != expected_epoch {
+            return Err(EngineError::State(StateKind::StaleLease));
+        }
+
+        // Read exec_core lifecycle + lease_expires_at (live-lease gate).
+        let exec_row = sqlx::query(
+            r#"
+            SELECT lifecycle_phase,
+                   ownership_state,
+                   COALESCE(json_extract(raw_fields, '$.current_attempt_id'), '')
+                       AS current_attempt_id,
+                   COALESCE(json_extract(raw_fields, '$.terminal_outcome'), 'none')
+                       AS terminal_outcome
+              FROM ff_exec_core
+             WHERE partition_key = ?1 AND execution_id = ?2
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let Some(exec_row) = exec_row else {
+            return Err(EngineError::NotFound { entity: "execution" });
+        };
+        let ownership_state: String = exec_row
+            .try_get("ownership_state")
+            .map_err(map_sqlx_error)?;
+        if ownership_state == "lease_revoked" {
+            return Err(EngineError::State(StateKind::LeaseRevoked));
+        }
+        let lifecycle_phase: String = exec_row
+            .try_get("lifecycle_phase")
+            .map_err(map_sqlx_error)?;
+        if lifecycle_phase != "active" {
+            let terminal_outcome: String =
+                exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
+            let current_attempt_id: String = exec_row
+                .try_get("current_attempt_id")
+                .map_err(map_sqlx_error)?;
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+                terminal_outcome,
+                lease_epoch: observed_epoch.to_string(),
+                lifecycle_phase,
+                attempt_id: current_attempt_id,
+            }));
+        }
+
+        let live_row = sqlx::query(
+            "SELECT lease_expires_at_ms FROM ff_attempt \
+             WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let observed_expires: Option<i64> = live_row
+            .try_get("lease_expires_at_ms")
+            .map_err(map_sqlx_error)?;
+
+        let now = now_ms();
+        match observed_expires {
+            Some(exp) if exp > now => {}
+            _ => return Err(EngineError::State(StateKind::LeaseExpired)),
+        }
+
+        // Update the lease.
+        let new_expires = now.saturating_add(lease_ttl_i64);
+        sqlx::query(q_lease::UPDATE_ATTEMPT_RENEW_SQL)
+            .bind(new_expires)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // Outbox: lease renewed.
+        let ev = insert_lease_event(&mut conn, part, exec_uuid, "renewed", now).await?;
+        let emits = vec![(OutboxChannel::LeaseHistory, ev)];
+
+        Ok::<_, EngineError>((
+            RenewLeaseResult::Renewed {
+                expires_at: TimestampMs::from_millis(new_expires),
+            },
+            emits,
+        ))
+    }
+    .await;
+
+    match result {
+        Ok((renewal, emits)) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_emits(pubsub, emits);
+            Ok(renewal)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::complete_execution`].
+///
+/// Mirrors PG at `ff-backend-postgres/src/typed_ops.rs::complete_execution`:
+///
+/// 1. Fence-or-operator-override gate. `args.fence.is_none()` with
+///    `source != OperatorOverride` → `Validation{fence_required}`.
+/// 2. `BEGIN IMMEDIATE` writer lock.
+/// 3. Read exec_core; missing → `NotFound { entity: "execution" }`.
+///    `ownership_state == 'lease_revoked'` → `State(LeaseRevoked)`.
+///    `lifecycle_phase != 'active'` → `Contention(ExecutionNotActive{..})`.
+/// 4. Read attempt row; missing → `NotFound { entity: "attempt" }`.
+/// 5. Epoch fence (when `args.fence` is `Some`); mismatch →
+///    `State(StaleLease)`. Skipped on operator override.
+/// 6. `lease_expires_at_ms` NULL or `<= now` → `State(LeaseExpired)`.
+/// 7. Mark attempt terminal.
+/// 8. Flip exec_core to terminal / completed; store result payload;
+///    stamp `terminal_outcome='success'` in `raw_fields`.
+/// 9. Emit completion outbox (carries namespace + instance_tag from
+///    raw_fields so RFC-019 filtered subscriptions receive the event).
+/// 10. Emit `lease_event::EVENT_REVOKED` on the lease outbox.
+pub(crate) async fn complete_execution(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: CompleteExecutionArgs,
+) -> Result<CompleteExecutionResult, EngineError> {
+    let is_operator_override = matches!(args.source, CancelSource::OperatorOverride);
+    if args.fence.is_none() && !is_operator_override {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "fence_required".into(),
+        });
+    }
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let attempt_index = i64::from(args.attempt_index.0);
+    let now = args.now.0;
+    let execution_id = args.execution_id.clone();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        // Read exec_core first — lifecycle + ownership gates are
+        // authoritative pre-conditions.
+        let exec_row = sqlx::query(
+            r#"
+            SELECT lifecycle_phase, ownership_state,
+                   COALESCE(json_extract(raw_fields, '$.current_attempt_id'), '')
+                       AS current_attempt_id
+              FROM ff_exec_core
+             WHERE partition_key = ?1 AND execution_id = ?2
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let Some(exec_row) = exec_row else {
+            return Err(EngineError::NotFound { entity: "execution" });
+        };
+        let ownership_state: String = exec_row
+            .try_get("ownership_state")
+            .map_err(map_sqlx_error)?;
+        if ownership_state == "lease_revoked" {
+            return Err(EngineError::State(StateKind::LeaseRevoked));
+        }
+        let lifecycle_phase: String = exec_row
+            .try_get("lifecycle_phase")
+            .map_err(map_sqlx_error)?;
+        if lifecycle_phase != "active" {
+            let current_attempt_id: String = exec_row
+                .try_get("current_attempt_id")
+                .map_err(map_sqlx_error)?;
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+                terminal_outcome: String::new(),
+                lease_epoch: String::new(),
+                lifecycle_phase,
+                attempt_id: current_attempt_id,
+            }));
+        }
+
+        // Attempt fence + lease-live check.
+        let attempt_row = sqlx::query(
+            "SELECT lease_epoch, lease_expires_at_ms FROM ff_attempt \
+             WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let Some(attempt_row) = attempt_row else {
+            return Err(EngineError::NotFound { entity: "attempt" });
+        };
+        let observed_epoch_i: i64 = attempt_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+        let observed_epoch = u64::try_from(observed_epoch_i).unwrap_or(0);
+        let observed_expires: Option<i64> = attempt_row
+            .try_get("lease_expires_at_ms")
+            .map_err(map_sqlx_error)?;
+
+        if let Some(fence) = &args.fence
+            && observed_epoch != fence.lease_epoch.0
+        {
+            return Err(EngineError::State(StateKind::StaleLease));
+        }
+        if let Some(exp) = observed_expires
+            && exp <= now
+        {
+            return Err(EngineError::State(StateKind::LeaseExpired));
+        }
+
+        // Mark attempt terminal.
+        sqlx::query(
+            "UPDATE ff_attempt \
+                SET terminal_at_ms = ?1, outcome = 'success', lease_expires_at_ms = NULL \
+              WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4",
+        )
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Flip exec_core to terminal/completed + stamp raw_fields.
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase = 'terminal',
+                   ownership_state = 'unowned',
+                   eligibility_state = 'not_applicable',
+                   attempt_state = 'attempt_terminal',
+                   public_state = 'completed',
+                   terminal_at_ms = ?1,
+                   result = ?2,
+                   raw_fields = json_set(raw_fields, '$.terminal_outcome', 'success')
+             WHERE partition_key = ?3 AND execution_id = ?4
+            "#,
+        )
+        .bind(now)
+        .bind(args.result_payload.as_deref())
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Completion outbox.
+        let completion_ev =
+            insert_completion_event_ev(&mut conn, part, exec_uuid, "success", now).await?;
+        let lease_ev = insert_lease_event(&mut conn, part, exec_uuid, "revoked", now).await?;
+        let emits = vec![
+            (OutboxChannel::Completion, completion_ev),
+            (OutboxChannel::LeaseHistory, lease_ev),
+        ];
+
+        Ok::<_, EngineError>(emits)
+    }
+    .await;
+
+    match result {
+        Ok(emits) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_emits(pubsub, emits);
+            Ok(CompleteExecutionResult::Completed {
+                execution_id,
+                public_state: PublicState::Completed,
+            })
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -42,12 +42,14 @@
 //! catches the same violations Valkey's full-triple check catches.
 
 use ff_core::contracts::{
-    CompleteExecutionArgs, CompleteExecutionResult, FailExecutionArgs, FailExecutionResult,
-    RenewLeaseArgs, RenewLeaseResult, ResumeExecutionArgs, ResumeExecutionResult,
+    CheckAdmissionArgs, CheckAdmissionResult, CompleteExecutionArgs, CompleteExecutionResult,
+    FailExecutionArgs, FailExecutionResult, RenewLeaseArgs, RenewLeaseResult,
+    ResumeExecutionArgs, ResumeExecutionResult,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::partition::{quota_partition, PartitionConfig};
 use ff_core::state::PublicState;
-use ff_core::types::{AttemptIndex, CancelSource, TimestampMs};
+use ff_core::types::{AttemptIndex, CancelSource, QuotaPolicyId, TimestampMs};
 use sqlx::Row;
 use sqlx::SqlitePool;
 
@@ -815,4 +817,169 @@ pub(crate) async fn resume_execution(
             Err(e)
         }
     }
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::check_admission`].
+///
+/// Mirrors PG at `ff-backend-postgres/src/typed_ops.rs::check_admission`.
+/// The PG `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE` is omitted —
+/// `BEGIN IMMEDIATE` + SQLite's single-writer invariant is implicitly
+/// serialisable for writers; the writer lock held across this tx gives
+/// the same atomicity guarantee the PG path needs to prevent concurrent
+/// admits from racing.
+///
+/// Four-exit decision tree: `AlreadyAdmitted`, `RateExceeded {
+/// retry_after_ms }`, `ConcurrencyExceeded`, `Admitted`.
+pub(crate) async fn check_admission(
+    pool: &SqlitePool,
+    partition_config: &PartitionConfig,
+    quota_policy_id: &QuotaPolicyId,
+    args: CheckAdmissionArgs,
+) -> Result<CheckAdmissionResult, EngineError> {
+    let part = quota_partition(quota_policy_id, partition_config).index as i64;
+    let policy_id_text = quota_policy_id.to_string();
+    let now = args.now.0;
+    let window_ms: i64 =
+        i64::try_from(args.window_seconds.saturating_mul(1_000)).unwrap_or(i64::MAX);
+    let exec_id_text = args.execution_id.to_string();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    // 1. Idempotency guard.
+    let guard_row = sqlx::query(
+        "SELECT expires_at_ms FROM ff_quota_admitted \
+         WHERE partition_key = ?1 AND quota_policy_id = ?2 AND execution_id = ?3",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(&exec_id_text)
+    .fetch_optional(&mut *conn)
+    .await
+    .map_err(map_sqlx_error)?;
+    if let Some(row) = guard_row {
+        let expires_at_ms: i64 = row.try_get("expires_at_ms").map_err(map_sqlx_error)?;
+        if expires_at_ms > now {
+            commit_or_rollback(&mut conn).await?;
+            return Ok(CheckAdmissionResult::AlreadyAdmitted);
+        }
+    }
+
+    // 2. Sliding window sweep for THIS policy.
+    sqlx::query(
+        "DELETE FROM ff_quota_window \
+         WHERE partition_key = ?1 AND quota_policy_id = ?2 AND admitted_at_ms < ?3",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(now.saturating_sub(window_ms))
+    .execute(&mut *conn)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 3. Rate check.
+    if args.rate_limit > 0 {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM ff_quota_window \
+             WHERE partition_key = ?1 AND quota_policy_id = ?2",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        if count as u64 >= args.rate_limit {
+            let oldest: Option<(i64,)> = sqlx::query_as(
+                "SELECT admitted_at_ms FROM ff_quota_window \
+                 WHERE partition_key = ?1 AND quota_policy_id = ?2 \
+                 ORDER BY admitted_at_ms ASC LIMIT 1",
+            )
+            .bind(part)
+            .bind(&policy_id_text)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+            let retry = oldest
+                .map(|(oldest_ms,)| {
+                    let delta = oldest_ms.saturating_add(window_ms).saturating_sub(now);
+                    u64::try_from(delta.max(0)).unwrap_or(0)
+                })
+                .unwrap_or(0);
+            let jitter = args.jitter_ms.unwrap_or(0);
+            let retry_after_ms = retry.saturating_add(jitter);
+            commit_or_rollback(&mut conn).await?;
+            return Ok(CheckAdmissionResult::RateExceeded { retry_after_ms });
+        }
+    }
+
+    // 4. Concurrency check.
+    let policy_row = sqlx::query(
+        "SELECT active_concurrency FROM ff_quota_policy \
+         WHERE partition_key = ?1 AND quota_policy_id = ?2",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .fetch_optional(&mut *conn)
+    .await
+    .map_err(map_sqlx_error)?;
+    let active: i64 = policy_row
+        .map(|r| r.try_get("active_concurrency").unwrap_or(0i64))
+        .unwrap_or(0);
+    if args.concurrency_cap > 0 && active as u64 >= args.concurrency_cap {
+        commit_or_rollback(&mut conn).await?;
+        return Ok(CheckAdmissionResult::ConcurrencyExceeded);
+    }
+
+    // 5. Admit.
+    sqlx::query(
+        "INSERT INTO ff_quota_window \
+            (partition_key, quota_policy_id, dimension, admitted_at_ms, execution_id) \
+         VALUES (?1, ?2, '', ?3, ?4)",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(now)
+    .bind(&exec_id_text)
+    .execute(&mut *conn)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        "INSERT INTO ff_quota_admitted \
+            (partition_key, quota_policy_id, execution_id, admitted_at_ms, expires_at_ms) \
+         VALUES (?1, ?2, ?3, ?4, ?5) \
+         ON CONFLICT (partition_key, quota_policy_id, execution_id) DO UPDATE \
+            SET admitted_at_ms = excluded.admitted_at_ms, \
+                expires_at_ms = excluded.expires_at_ms",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(&exec_id_text)
+    .bind(now)
+    .bind(now.saturating_add(window_ms))
+    .execute(&mut *conn)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if args.concurrency_cap > 0 {
+        sqlx::query(
+            "INSERT INTO ff_quota_policy \
+                (partition_key, quota_policy_id, \
+                 requests_per_window_seconds, max_requests_per_window, \
+                 active_concurrency_cap, active_concurrency, \
+                 created_at_ms, updated_at_ms) \
+             VALUES (?1, ?2, 0, 0, 0, 1, ?3, ?3) \
+             ON CONFLICT (partition_key, quota_policy_id) DO UPDATE \
+                SET active_concurrency = active_concurrency + 1, \
+                    updated_at_ms = excluded.updated_at_ms",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .bind(now)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    commit_or_rollback(&mut conn).await?;
+    Ok(CheckAdmissionResult::Admitted)
 }

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -983,3 +983,406 @@ pub(crate) async fn check_admission(
     commit_or_rollback(&mut conn).await?;
     Ok(CheckAdmissionResult::Admitted)
 }
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::evaluate_flow_eligibility`].
+///
+/// Read-only; no tx needed. Mirrors PG at
+/// `ff-backend-postgres/src/typed_ops.rs::evaluate_flow_eligibility`.
+/// Returns one of: `not_found`, `not_runnable`, `owned`, `terminal`,
+/// `impossible`, `blocked_by_dependencies`, `eligible`.
+///
+/// Required-edge counts derived live via JOIN on `ff_edge` + upstream
+/// `ff_exec_core.raw_fields.terminal_outcome`. SQLite swaps:
+///
+/// - `policy->>'kind'` → `json_extract(e.policy, '$.kind')`
+/// - `raw_fields->>'terminal_outcome'` → `json_extract(up.raw_fields,
+///   '$.terminal_outcome')`
+/// - `flow_id` is BLOB on SQLite (uuid-bytes stored raw)
+pub(crate) async fn evaluate_flow_eligibility(
+    pool: &SqlitePool,
+    args: ff_core::contracts::EvaluateFlowEligibilityArgs,
+) -> Result<ff_core::contracts::EvaluateFlowEligibilityResult, EngineError> {
+    use ff_core::contracts::EvaluateFlowEligibilityResult;
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+
+    let exec_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, ownership_state, flow_id,
+               COALESCE(json_extract(raw_fields, '$.terminal_outcome'), 'none')
+                   AS terminal_outcome
+          FROM ff_exec_core
+         WHERE partition_key = ?1 AND execution_id = ?2
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(exec_row) = exec_row else {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "not_found".into(),
+        });
+    };
+    let lifecycle_phase: String = exec_row
+        .try_get("lifecycle_phase")
+        .map_err(map_sqlx_error)?;
+    if lifecycle_phase != "runnable" {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "not_runnable".into(),
+        });
+    }
+    let ownership_state: String = exec_row
+        .try_get("ownership_state")
+        .map_err(map_sqlx_error)?;
+    if ownership_state != "unowned" {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "owned".into(),
+        });
+    }
+    let terminal_outcome: String = exec_row
+        .try_get("terminal_outcome")
+        .map_err(map_sqlx_error)?;
+    if terminal_outcome != "none" {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "terminal".into(),
+        });
+    }
+    let flow_id_opt: Option<uuid::Uuid> = exec_row.try_get("flow_id").map_err(map_sqlx_error)?;
+    let Some(flow_id) = flow_id_opt else {
+        return Ok(EvaluateFlowEligibilityResult::Status {
+            status: "eligible".into(),
+        });
+    };
+
+    // Walk incoming edges + classify upstreams.
+    let counts = sqlx::query(
+        r#"
+        SELECT
+          SUM(CASE
+                WHEN is_required = 1
+                  AND COALESCE(json_extract(up.raw_fields, '$.terminal_outcome'), 'none') = 'failed'
+                THEN 1 ELSE 0 END) AS impossible_count,
+          SUM(CASE
+                WHEN is_required = 1
+                  AND COALESCE(json_extract(up.raw_fields, '$.terminal_outcome'), 'none') NOT IN ('failed', 'success')
+                THEN 1 ELSE 0 END) AS unsatisfied_count
+        FROM (
+          SELECT e.upstream_eid,
+                 CASE WHEN json_extract(e.policy, '$.kind') IN ('required', 'AllOf', 'all_of')
+                      THEN 1 ELSE 0 END AS is_required
+            FROM ff_edge e
+           WHERE e.partition_key = ?1
+             AND e.flow_id = ?2
+             AND e.downstream_eid = ?3
+        ) edges
+        LEFT JOIN ff_exec_core up
+          ON up.partition_key = ?1 AND up.execution_id = edges.upstream_eid
+        "#,
+    )
+    .bind(part)
+    .bind(flow_id)
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let impossible: Option<i64> = counts.try_get("impossible_count").map_err(map_sqlx_error)?;
+    let unsatisfied: Option<i64> =
+        counts.try_get("unsatisfied_count").map_err(map_sqlx_error)?;
+    let status = if impossible.unwrap_or(0) > 0 {
+        "impossible"
+    } else if unsatisfied.unwrap_or(0) > 0 {
+        "blocked_by_dependencies"
+    } else {
+        "eligible"
+    };
+    Ok(EvaluateFlowEligibilityResult::Status {
+        status: status.into(),
+    })
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::claim_execution`].
+///
+/// Mirrors PG at `ff-backend-postgres/src/typed_ops.rs::claim_execution`.
+/// Consumes a claim grant, creates a new attempt row, transitions
+/// `runnable → active`.
+///
+/// Validates in order:
+/// 1. `lifecycle_phase == 'runnable'` → else `ExecutionNotActive`.
+/// 2. `ownership_state == 'unowned'` → else `LeaseConflict`.
+/// 3. `eligibility_state == 'eligible_now'` → else `ExecutionNotLeaseable`.
+/// 4. `attempt_state != 'running_attempt'` (defense-in-depth) →
+///    else `Conflict(ActiveAttemptExists)`.
+/// 5. `attempt_state != 'attempt_interrupted'` → else
+///    `ExecutionNotLeaseable` (caller must use
+///    `claim_resumed_execution`).
+/// 6. `ff_claim_grant` row exists for this (partition, exec_uuid,
+///    kind='claim') → else `InvalidClaimGrant`.
+/// 7. Grant's `worker_id` matches → else `InvalidClaimGrant`.
+/// 8. Grant's `expires_at_ms > now` (when set) → else
+///    `ClaimGrantExpired`.
+///
+/// On success: DELETE grant, INSERT/UPSERT ff_attempt with lease
+/// identity in raw_fields, flip exec_core to active/leased/running,
+/// emit lease-acquired outbox.
+pub(crate) async fn claim_execution(
+    pool: &SqlitePool,
+    _partition_config: &PartitionConfig,
+    pubsub: &PubSub,
+    args: ff_core::contracts::ClaimExecutionArgs,
+) -> Result<ff_core::contracts::ClaimExecutionResult, EngineError> {
+    use ff_core::contracts::{ClaimExecutionResult, ClaimedExecution};
+    use ff_core::state::AttemptType;
+    use ff_core::types::LeaseEpoch;
+
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let attempt_index = i64::from(args.expected_attempt_index.0);
+    let lease_ttl_i64 = i64::try_from(args.lease_ttl_ms).unwrap_or(i64::MAX);
+    let now = args.now.0;
+    let new_expires = now.saturating_add(lease_ttl_i64);
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let exec_row = sqlx::query(
+            r#"
+            SELECT lifecycle_phase, ownership_state, eligibility_state,
+                   attempt_state,
+                   COALESCE(json_extract(raw_fields, '$.terminal_outcome'), 'none')
+                       AS terminal_outcome,
+                   COALESCE(json_extract(raw_fields, '$.current_attempt_id'), '')
+                       AS current_attempt_id
+              FROM ff_exec_core
+             WHERE partition_key = ?1 AND execution_id = ?2
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let Some(exec_row) = exec_row else {
+            return Err(EngineError::NotFound { entity: "execution" });
+        };
+        let lifecycle_phase: String =
+            exec_row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+        let ownership_state: String = exec_row
+            .try_get("ownership_state")
+            .map_err(map_sqlx_error)?;
+        let eligibility_state: String = exec_row
+            .try_get("eligibility_state")
+            .map_err(map_sqlx_error)?;
+        let attempt_state: String =
+            exec_row.try_get("attempt_state").map_err(map_sqlx_error)?;
+
+        if lifecycle_phase != "runnable" {
+            let terminal_outcome: String =
+                exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
+            let current_attempt_id: String = exec_row
+                .try_get("current_attempt_id")
+                .map_err(map_sqlx_error)?;
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+                terminal_outcome,
+                lease_epoch: String::new(),
+                lifecycle_phase,
+                attempt_id: current_attempt_id,
+            }));
+        }
+        if ownership_state != "unowned" {
+            return Err(EngineError::Contention(ContentionKind::LeaseConflict));
+        }
+        if eligibility_state != "eligible_now" {
+            return Err(EngineError::Contention(
+                ContentionKind::ExecutionNotLeaseable,
+            ));
+        }
+        if attempt_state == "running_attempt" {
+            return Err(EngineError::Conflict(
+                ff_core::engine_error::ConflictKind::ActiveAttemptExists,
+            ));
+        }
+        if attempt_state == "attempt_interrupted" {
+            return Err(EngineError::Contention(
+                ContentionKind::ExecutionNotLeaseable,
+            ));
+        }
+
+        // Validate + consume claim grant.
+        let grant_row = sqlx::query(
+            "SELECT worker_id, expires_at_ms FROM ff_claim_grant \
+             WHERE partition_key = ?1 AND execution_id = ?2 AND kind = 'claim'",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let Some(grant_row) = grant_row else {
+            return Err(EngineError::Contention(ContentionKind::InvalidClaimGrant));
+        };
+        let grant_worker_id: String =
+            grant_row.try_get("worker_id").map_err(map_sqlx_error)?;
+        if grant_worker_id != args.worker_id.as_str() {
+            return Err(EngineError::Contention(ContentionKind::InvalidClaimGrant));
+        }
+        let grant_expires_at: i64 = grant_row
+            .try_get("expires_at_ms")
+            .map_err(map_sqlx_error)?;
+        if grant_expires_at > 0 && grant_expires_at < now {
+            return Err(EngineError::Contention(ContentionKind::ClaimGrantExpired));
+        }
+        sqlx::query(
+            "DELETE FROM ff_claim_grant \
+             WHERE partition_key = ?1 AND execution_id = ?2 AND kind = 'claim'",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Attempt type from existing attempt_state.
+        let attempt_type = if attempt_state == "pending_retry_attempt" {
+            AttemptType::Retry
+        } else if attempt_state == "pending_replay_attempt" {
+            AttemptType::Replay
+        } else {
+            AttemptType::Initial
+        };
+        let attempt_type_str = match attempt_type {
+            AttemptType::Initial => "initial",
+            AttemptType::Retry => "retry",
+            AttemptType::Reclaim => "reclaim",
+            AttemptType::Replay => "replay",
+            AttemptType::Fallback => "fallback",
+        };
+
+        // Insert / upsert the attempt row. SQLite `json_set(?, '$.k', v)`
+        // for multi-key patch; NULLIF for empty-policy.
+        sqlx::query(
+            r#"
+            INSERT INTO ff_attempt (
+                partition_key, execution_id, attempt_index,
+                worker_id, worker_instance_id,
+                lease_epoch, lease_expires_at_ms, started_at_ms,
+                policy, raw_fields
+            ) VALUES (
+                ?1, ?2, ?3,
+                ?4, ?5,
+                1, ?6, ?7,
+                NULLIF(?8, ''),
+                json_set('{}', '$.attempt_type', ?9, '$.attempt_id', ?10, '$.lease_id', ?11)
+            )
+            ON CONFLICT (partition_key, execution_id, attempt_index)
+            DO UPDATE SET
+                worker_id = excluded.worker_id,
+                worker_instance_id = excluded.worker_instance_id,
+                lease_epoch = ff_attempt.lease_epoch + 1,
+                lease_expires_at_ms = excluded.lease_expires_at_ms,
+                started_at_ms = COALESCE(ff_attempt.started_at_ms, excluded.started_at_ms),
+                policy = excluded.policy,
+                raw_fields = json_patch(ff_attempt.raw_fields, excluded.raw_fields),
+                terminal_at_ms = NULL,
+                outcome = NULL
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .bind(args.worker_id.as_str())
+        .bind(args.worker_instance_id.as_str())
+        .bind(new_expires)
+        .bind(now)
+        .bind(&args.attempt_policy_json)
+        .bind(attempt_type_str)
+        .bind(args.attempt_id.to_string())
+        .bind(args.lease_id.to_string())
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Read back the epoch (may be +1 on the conflict path).
+        let epoch_row = sqlx::query(
+            "SELECT lease_epoch FROM ff_attempt \
+             WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        let new_epoch_i: i64 = epoch_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+        let new_epoch = u64::try_from(new_epoch_i).unwrap_or(0);
+
+        // Flip exec_core to active + stash lease identity in raw_fields.
+        let next_attempt_index = attempt_index.saturating_add(1);
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase = 'active',
+                   ownership_state = 'leased',
+                   eligibility_state = 'not_applicable',
+                   attempt_state = 'running_attempt',
+                   public_state = 'active',
+                   attempt_index = ?1,
+                   deadline_at_ms = COALESCE(?2, deadline_at_ms),
+                   raw_fields = json_set(
+                       raw_fields,
+                       '$.current_attempt_id', ?3,
+                       '$.current_lease_id', ?4,
+                       '$.current_worker_id', ?5,
+                       '$.current_worker_instance_id', ?6,
+                       '$.pending_retry_reason', '',
+                       '$.pending_replay_reason', '',
+                       '$.pending_replay_requested_by', '',
+                       '$.pending_previous_attempt_index', ''
+                   )
+             WHERE partition_key = ?7 AND execution_id = ?8
+            "#,
+        )
+        .bind(next_attempt_index)
+        .bind(args.execution_deadline_at)
+        .bind(args.attempt_id.to_string())
+        .bind(args.lease_id.to_string())
+        .bind(args.worker_id.as_str())
+        .bind(args.worker_instance_id.as_str())
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Outbox: lease acquired.
+        let ev = insert_lease_event(&mut conn, part, exec_uuid, "acquired", now).await?;
+        let emits = vec![(OutboxChannel::LeaseHistory, ev)];
+
+        Ok::<_, EngineError>((new_epoch, attempt_type, emits))
+    }
+    .await;
+
+    match result {
+        Ok((new_epoch, attempt_type, emits)) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_emits(pubsub, emits);
+            let claimed = ClaimedExecution::new(
+                args.execution_id,
+                args.lease_id,
+                LeaseEpoch(new_epoch),
+                args.expected_attempt_index,
+                args.attempt_id,
+                attempt_type,
+                TimestampMs::from_millis(new_expires),
+                ff_core::backend::stub_handle_fresh(),
+            );
+            Ok(ClaimExecutionResult::Claimed(claimed))
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -47,7 +47,7 @@ use ff_core::contracts::{
     ResumeExecutionArgs, ResumeExecutionResult,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
-use ff_core::partition::{quota_partition, PartitionConfig};
+use ff_core::partition::PartitionConfig;
 use ff_core::state::PublicState;
 use ff_core::types::{AttemptIndex, CancelSource, QuotaPolicyId, TimestampMs};
 use sqlx::Row;
@@ -582,7 +582,7 @@ pub(crate) async fn fail_execution(
         // Mark attempt terminal (both branches).
         sqlx::query(
             "UPDATE ff_attempt \
-                SET terminal_at_ms = ?1, outcome = 'failure', lease_expires_at_ms = NULL \
+                SET terminal_at_ms = ?1, outcome = 'failed', lease_expires_at_ms = NULL \
               WHERE partition_key = ?2 AND execution_id = ?3 AND attempt_index = ?4",
         )
         .bind(now)
@@ -819,6 +819,15 @@ pub(crate) async fn resume_execution(
     }
 }
 
+/// Internal outcome sum for `check_admission` — funnels the four
+/// decision-tree endpoints through a single commit/rollback site.
+enum AdmitOutcome {
+    Admitted,
+    AlreadyAdmitted,
+    RateExceeded { retry_after_ms: u64 },
+    ConcurrencyExceeded,
+}
+
 /// SQLite body for [`ff_core::engine_backend::EngineBackend::check_admission`].
 ///
 /// Mirrors PG at `ff-backend-postgres/src/typed_ops.rs::check_admission`.
@@ -832,11 +841,17 @@ pub(crate) async fn resume_execution(
 /// retry_after_ms }`, `ConcurrencyExceeded`, `Admitted`.
 pub(crate) async fn check_admission(
     pool: &SqlitePool,
-    partition_config: &PartitionConfig,
+    _partition_config: &PartitionConfig,
     quota_policy_id: &QuotaPolicyId,
     args: CheckAdmissionArgs,
 ) -> Result<CheckAdmissionResult, EngineError> {
-    let part = quota_partition(quota_policy_id, partition_config).index as i64;
+    // RFC-023 §4.1 A3 single-writer: SQLite doesn't HASH-partition the
+    // quota tables; `create_quota_policy_impl` writes with
+    // `partition_key = 0` (see `crate::budget::PART`). Reads MUST use
+    // the same literal or the idempotency guard + rate check silently
+    // miss the policy's rows. `_partition_config` is ignored on SQLite;
+    // accepted in the signature for cross-backend call-site parity.
+    let part: i64 = 0;
     let policy_id_text = quota_policy_id.to_string();
     let now = args.now.0;
     let window_ms: i64 =
@@ -845,143 +860,163 @@ pub(crate) async fn check_admission(
 
     let mut conn = begin_immediate(pool).await?;
 
-    // 1. Idempotency guard.
-    let guard_row = sqlx::query(
-        "SELECT expires_at_ms FROM ff_quota_admitted \
-         WHERE partition_key = ?1 AND quota_policy_id = ?2 AND execution_id = ?3",
-    )
-    .bind(part)
-    .bind(&policy_id_text)
-    .bind(&exec_id_text)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(map_sqlx_error)?;
-    if let Some(row) = guard_row {
-        let expires_at_ms: i64 = row.try_get("expires_at_ms").map_err(map_sqlx_error)?;
-        if expires_at_ms > now {
-            commit_or_rollback(&mut conn).await?;
-            return Ok(CheckAdmissionResult::AlreadyAdmitted);
+    // Wrap the full decision tree in an async block so early-return
+    // error paths funnel through `rollback_quiet` instead of dropping
+    // the connection mid-transaction (Copilot PR #462 finding).
+    let result: Result<AdmitOutcome, EngineError> = async {
+        // 1. Idempotency guard.
+        let guard_row = sqlx::query(
+            "SELECT expires_at_ms FROM ff_quota_admitted \
+             WHERE partition_key = ?1 AND quota_policy_id = ?2 AND execution_id = ?3",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .bind(&exec_id_text)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+        if let Some(row) = guard_row {
+            let expires_at_ms: i64 = row.try_get("expires_at_ms").map_err(map_sqlx_error)?;
+            if expires_at_ms > now {
+                return Ok(AdmitOutcome::AlreadyAdmitted);
+            }
         }
-    }
 
-    // 2. Sliding window sweep for THIS policy.
-    sqlx::query(
-        "DELETE FROM ff_quota_window \
-         WHERE partition_key = ?1 AND quota_policy_id = ?2 AND admitted_at_ms < ?3",
-    )
-    .bind(part)
-    .bind(&policy_id_text)
-    .bind(now.saturating_sub(window_ms))
-    .execute(&mut *conn)
-    .await
-    .map_err(map_sqlx_error)?;
+        // 2. Sliding window sweep for THIS policy.
+        sqlx::query(
+            "DELETE FROM ff_quota_window \
+             WHERE partition_key = ?1 AND quota_policy_id = ?2 AND admitted_at_ms < ?3",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .bind(now.saturating_sub(window_ms))
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
 
-    // 3. Rate check.
-    if args.rate_limit > 0 {
-        let (count,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM ff_quota_window \
+        // 3. Rate check.
+        if args.rate_limit > 0 {
+            let (count,): (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM ff_quota_window \
+                 WHERE partition_key = ?1 AND quota_policy_id = ?2",
+            )
+            .bind(part)
+            .bind(&policy_id_text)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+            if count as u64 >= args.rate_limit {
+                let oldest: Option<(i64,)> = sqlx::query_as(
+                    "SELECT admitted_at_ms FROM ff_quota_window \
+                     WHERE partition_key = ?1 AND quota_policy_id = ?2 \
+                     ORDER BY admitted_at_ms ASC LIMIT 1",
+                )
+                .bind(part)
+                .bind(&policy_id_text)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+                let retry = oldest
+                    .map(|(oldest_ms,)| {
+                        let delta = oldest_ms.saturating_add(window_ms).saturating_sub(now);
+                        u64::try_from(delta.max(0)).unwrap_or(0)
+                    })
+                    .unwrap_or(0);
+                let jitter = args.jitter_ms.unwrap_or(0);
+                let retry_after_ms = retry.saturating_add(jitter);
+                return Ok(AdmitOutcome::RateExceeded { retry_after_ms });
+            }
+        }
+
+        // 4. Concurrency check.
+        let policy_row = sqlx::query(
+            "SELECT active_concurrency FROM ff_quota_policy \
              WHERE partition_key = ?1 AND quota_policy_id = ?2",
         )
         .bind(part)
         .bind(&policy_id_text)
-        .fetch_one(&mut *conn)
+        .fetch_optional(&mut *conn)
         .await
         .map_err(map_sqlx_error)?;
-        if count as u64 >= args.rate_limit {
-            let oldest: Option<(i64,)> = sqlx::query_as(
-                "SELECT admitted_at_ms FROM ff_quota_window \
-                 WHERE partition_key = ?1 AND quota_policy_id = ?2 \
-                 ORDER BY admitted_at_ms ASC LIMIT 1",
-            )
-            .bind(part)
-            .bind(&policy_id_text)
-            .fetch_optional(&mut *conn)
-            .await
-            .map_err(map_sqlx_error)?;
-            let retry = oldest
-                .map(|(oldest_ms,)| {
-                    let delta = oldest_ms.saturating_add(window_ms).saturating_sub(now);
-                    u64::try_from(delta.max(0)).unwrap_or(0)
-                })
-                .unwrap_or(0);
-            let jitter = args.jitter_ms.unwrap_or(0);
-            let retry_after_ms = retry.saturating_add(jitter);
-            commit_or_rollback(&mut conn).await?;
-            return Ok(CheckAdmissionResult::RateExceeded { retry_after_ms });
+        let active: i64 = policy_row
+            .map(|r| r.try_get("active_concurrency").unwrap_or(0i64))
+            .unwrap_or(0);
+        if args.concurrency_cap > 0 && active as u64 >= args.concurrency_cap {
+            return Ok(AdmitOutcome::ConcurrencyExceeded);
         }
-    }
 
-    // 4. Concurrency check.
-    let policy_row = sqlx::query(
-        "SELECT active_concurrency FROM ff_quota_policy \
-         WHERE partition_key = ?1 AND quota_policy_id = ?2",
-    )
-    .bind(part)
-    .bind(&policy_id_text)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(map_sqlx_error)?;
-    let active: i64 = policy_row
-        .map(|r| r.try_get("active_concurrency").unwrap_or(0i64))
-        .unwrap_or(0);
-    if args.concurrency_cap > 0 && active as u64 >= args.concurrency_cap {
-        commit_or_rollback(&mut conn).await?;
-        return Ok(CheckAdmissionResult::ConcurrencyExceeded);
-    }
-
-    // 5. Admit.
-    sqlx::query(
-        "INSERT INTO ff_quota_window \
-            (partition_key, quota_policy_id, dimension, admitted_at_ms, execution_id) \
-         VALUES (?1, ?2, '', ?3, ?4)",
-    )
-    .bind(part)
-    .bind(&policy_id_text)
-    .bind(now)
-    .bind(&exec_id_text)
-    .execute(&mut *conn)
-    .await
-    .map_err(map_sqlx_error)?;
-
-    sqlx::query(
-        "INSERT INTO ff_quota_admitted \
-            (partition_key, quota_policy_id, execution_id, admitted_at_ms, expires_at_ms) \
-         VALUES (?1, ?2, ?3, ?4, ?5) \
-         ON CONFLICT (partition_key, quota_policy_id, execution_id) DO UPDATE \
-            SET admitted_at_ms = excluded.admitted_at_ms, \
-                expires_at_ms = excluded.expires_at_ms",
-    )
-    .bind(part)
-    .bind(&policy_id_text)
-    .bind(&exec_id_text)
-    .bind(now)
-    .bind(now.saturating_add(window_ms))
-    .execute(&mut *conn)
-    .await
-    .map_err(map_sqlx_error)?;
-
-    if args.concurrency_cap > 0 {
+        // 5. Admit.
         sqlx::query(
-            "INSERT INTO ff_quota_policy \
-                (partition_key, quota_policy_id, \
-                 requests_per_window_seconds, max_requests_per_window, \
-                 active_concurrency_cap, active_concurrency, \
-                 created_at_ms, updated_at_ms) \
-             VALUES (?1, ?2, 0, 0, 0, 1, ?3, ?3) \
-             ON CONFLICT (partition_key, quota_policy_id) DO UPDATE \
-                SET active_concurrency = active_concurrency + 1, \
-                    updated_at_ms = excluded.updated_at_ms",
+            "INSERT INTO ff_quota_window \
+                (partition_key, quota_policy_id, dimension, admitted_at_ms, execution_id) \
+             VALUES (?1, ?2, '', ?3, ?4)",
         )
         .bind(part)
         .bind(&policy_id_text)
         .bind(now)
+        .bind(&exec_id_text)
         .execute(&mut *conn)
         .await
         .map_err(map_sqlx_error)?;
-    }
 
-    commit_or_rollback(&mut conn).await?;
-    Ok(CheckAdmissionResult::Admitted)
+        sqlx::query(
+            "INSERT INTO ff_quota_admitted \
+                (partition_key, quota_policy_id, execution_id, admitted_at_ms, expires_at_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5) \
+             ON CONFLICT (partition_key, quota_policy_id, execution_id) DO UPDATE \
+                SET admitted_at_ms = excluded.admitted_at_ms, \
+                    expires_at_ms = excluded.expires_at_ms",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .bind(&exec_id_text)
+        .bind(now)
+        .bind(now.saturating_add(window_ms))
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if args.concurrency_cap > 0 {
+            sqlx::query(
+                "INSERT INTO ff_quota_policy \
+                    (partition_key, quota_policy_id, \
+                     requests_per_window_seconds, max_requests_per_window, \
+                     active_concurrency_cap, active_concurrency, \
+                     created_at_ms, updated_at_ms) \
+                 VALUES (?1, ?2, 0, 0, 0, 1, ?3, ?3) \
+                 ON CONFLICT (partition_key, quota_policy_id) DO UPDATE \
+                    SET active_concurrency = active_concurrency + 1, \
+                        updated_at_ms = excluded.updated_at_ms",
+            )
+            .bind(part)
+            .bind(&policy_id_text)
+            .bind(now)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        }
+
+        Ok(AdmitOutcome::Admitted)
+    }
+    .await;
+
+    match result {
+        Ok(outcome) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(match outcome {
+                AdmitOutcome::Admitted => CheckAdmissionResult::Admitted,
+                AdmitOutcome::AlreadyAdmitted => CheckAdmissionResult::AlreadyAdmitted,
+                AdmitOutcome::RateExceeded { retry_after_ms } => {
+                    CheckAdmissionResult::RateExceeded { retry_after_ms }
+                }
+                AdmitOutcome::ConcurrencyExceeded => CheckAdmissionResult::ConcurrencyExceeded,
+            })
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
 }
 
 /// SQLite body for [`ff_core::engine_backend::EngineBackend::evaluate_flow_eligibility`].

--- a/crates/ff-backend-sqlite/tests/typed_check_admission.rs
+++ b/crates/ff-backend-sqlite/tests/typed_check_admission.rs
@@ -1,0 +1,153 @@
+//! #33 / Phase 1: integration test for SQLite
+//! `EngineBackend::check_admission`.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{CheckAdmissionArgs, CheckAdmissionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::types::{ExecutionId, QuotaPolicyId, TimestampMs};
+use serial_test::serial;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()).unwrap()
+}
+
+fn uuid_like() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:typed-admit-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+fn fresh_eid() -> ExecutionId {
+    ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).unwrap()
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn admits_first_request_in_window() {
+    let backend = fresh_backend().await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    let args = CheckAdmissionArgs {
+        execution_id: fresh_eid(),
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 10,
+        concurrency_cap: 100,
+        jitter_ms: None,
+    };
+    let res = be.check_admission(&qid, "", args).await.expect("admit");
+    assert_eq!(res, CheckAdmissionResult::Admitted);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn idempotent_second_admit_returns_already_admitted() {
+    let backend = fresh_backend().await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    let eid = fresh_eid();
+    let args = CheckAdmissionArgs {
+        execution_id: eid,
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 10,
+        concurrency_cap: 100,
+        jitter_ms: None,
+    };
+    assert_eq!(
+        be.check_admission(&qid, "", args.clone()).await.unwrap(),
+        CheckAdmissionResult::Admitted
+    );
+    assert_eq!(
+        be.check_admission(&qid, "", args).await.unwrap(),
+        CheckAdmissionResult::AlreadyAdmitted
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn rate_exceeded_returns_retry_after() {
+    let backend = fresh_backend().await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    for _ in 0..3 {
+        let args = CheckAdmissionArgs {
+            execution_id: fresh_eid(),
+            now: TimestampMs::from_millis(now_ms()),
+            window_seconds: 60,
+            rate_limit: 3,
+            concurrency_cap: 100,
+            jitter_ms: None,
+        };
+        assert_eq!(
+            be.check_admission(&qid, "", args).await.unwrap(),
+            CheckAdmissionResult::Admitted
+        );
+    }
+    let fourth = CheckAdmissionArgs {
+        execution_id: fresh_eid(),
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 3,
+        concurrency_cap: 100,
+        jitter_ms: None,
+    };
+    match be.check_admission(&qid, "", fourth).await.unwrap() {
+        CheckAdmissionResult::RateExceeded { .. } => {}
+        other => panic!("expected RateExceeded, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn concurrency_cap_blocks_additional_admits() {
+    let backend = fresh_backend().await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
+    // Pre-seed policy row with active_concurrency = 2, cap = 2.
+    let part = ff_core::partition::quota_partition(
+        &qid,
+        &ff_core::partition::PartitionConfig::default(),
+    )
+    .index as i64;
+    sqlx::query(
+        "INSERT INTO ff_quota_policy \
+            (partition_key, quota_policy_id, \
+             requests_per_window_seconds, max_requests_per_window, \
+             active_concurrency_cap, active_concurrency, \
+             created_at_ms, updated_at_ms) \
+         VALUES (?1, ?2, 60, 100, 2, 2, ?3, ?3)",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .bind(now_ms())
+    .execute(backend.pool_for_test())
+    .await
+    .expect("seed policy");
+    let args = CheckAdmissionArgs {
+        execution_id: fresh_eid(),
+        now: TimestampMs::from_millis(now_ms()),
+        window_seconds: 60,
+        rate_limit: 100,
+        concurrency_cap: 2,
+        jitter_ms: None,
+    };
+    match be.check_admission(&qid, "", args).await.unwrap() {
+        CheckAdmissionResult::ConcurrencyExceeded => {}
+        other => panic!("expected ConcurrencyExceeded, got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/typed_check_admission.rs
+++ b/crates/ff-backend-sqlite/tests/typed_check_admission.rs
@@ -119,11 +119,9 @@ async fn concurrency_cap_blocks_additional_admits() {
     let be: Arc<dyn EngineBackend> = backend.clone();
     let qid = QuotaPolicyId::from_uuid(Uuid::new_v4());
     // Pre-seed policy row with active_concurrency = 2, cap = 2.
-    let part = ff_core::partition::quota_partition(
-        &qid,
-        &ff_core::partition::PartitionConfig::default(),
-    )
-    .index as i64;
+    // SQLite `create_quota_policy_impl` writes partition_key = 0 under
+    // RFC-023 §4.1 A3 single-writer, so tests must match.
+    let part: i64 = 0;
     sqlx::query(
         "INSERT INTO ff_quota_policy \
             (partition_key, quota_policy_id, \

--- a/crates/ff-backend-sqlite/tests/typed_claim_execution.rs
+++ b/crates/ff-backend-sqlite/tests/typed_claim_execution.rs
@@ -1,0 +1,195 @@
+//! Phase 1 integration test for SQLite claim_execution.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{ClaimExecutionArgs, ClaimExecutionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError};
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseId, TimestampMs, WorkerId, WorkerInstanceId,
+};
+use serial_test::serial;
+use sqlx::Row;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()).unwrap()
+}
+
+fn uuid_like() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:typed-claim-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+async fn seed_runnable(backend: &SqliteBackend) -> (Uuid, ExecutionId) {
+    let pool = backend.pool_for_test();
+    let part: i64 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state, priority, created_at_ms, raw_fields
+        ) VALUES (
+            ?1, ?2, NULL, 'default', 0,
+            'runnable', 'unowned', 'eligible_now',
+            'waiting', 'pending_first_attempt', 0, ?3,
+            '{}'
+        )
+        "#,
+    )
+    .bind(part).bind(exec_uuid).bind(now_ms())
+    .execute(pool).await.expect("seed exec");
+    (exec_uuid, eid)
+}
+
+async fn seed_grant(backend: &SqliteBackend, exec_uuid: Uuid, worker_id: &str, expires_at_ms: i64) {
+    let pool = backend.pool_for_test();
+    let grant_id_bytes = Uuid::new_v4().as_bytes().to_vec();
+    sqlx::query(
+        "INSERT INTO ff_claim_grant (
+            partition_key, grant_id, execution_id, kind,
+            worker_id, worker_instance_id, lane_id,
+            capability_hash, worker_capabilities, route_snapshot_json,
+            admission_summary, grant_ttl_ms, issued_at_ms, expires_at_ms
+         ) VALUES (0, ?1, ?2, 'claim', ?3, 'wi', 'default',
+                   NULL, '[]', NULL, NULL,
+                   60000, ?4, ?5)",
+    )
+    .bind(grant_id_bytes).bind(exec_uuid).bind(worker_id).bind(now_ms()).bind(expires_at_ms)
+    .execute(pool).await.expect("seed grant");
+}
+
+fn fresh_args(eid: ExecutionId) -> ClaimExecutionArgs {
+    ClaimExecutionArgs::new(
+        eid,
+        WorkerId::new("worker-1"),
+        WorkerInstanceId::new("wi-1"),
+        LaneId::new("default"),
+        LeaseId::new(),
+        60_000,
+        AttemptId::new(),
+        AttemptIndex::new(0),
+        String::new(),
+        None,
+        None,
+        TimestampMs::from_millis(now_ms()),
+    )
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_happy_path() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&backend).await;
+    seed_grant(&backend, exec_uuid, "worker-1", now_ms() + 60_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let res = be.claim_execution(fresh_args(eid)).await.expect("claim ok");
+    match res {
+        ClaimExecutionResult::Claimed(_) => {}
+        #[allow(unreachable_patterns)]
+        other => panic!("expected Claimed, got {other:?}"),
+    }
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, ownership_state FROM ff_exec_core \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid).fetch_one(backend.pool_for_test()).await.unwrap();
+    assert_eq!(row.get::<String, _>("lifecycle_phase"), "active");
+    assert_eq!(row.get::<String, _>("ownership_state"), "leased");
+    let (cnt,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_claim_grant \
+         WHERE partition_key = 0 AND execution_id = ?1 AND kind='claim'",
+    )
+    .bind(exec_uuid).fetch_one(backend.pool_for_test()).await.unwrap();
+    assert_eq!(cnt, 0, "grant deleted");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_rejects_expired_grant() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&backend).await;
+    seed_grant(&backend, exec_uuid, "worker-1", now_ms() - 1_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    match be.claim_execution(fresh_args(eid)).await {
+        Err(EngineError::Contention(ContentionKind::ClaimGrantExpired)) => {}
+        other => panic!("expected ClaimGrantExpired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_rejects_wrong_worker_grant() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&backend).await;
+    seed_grant(&backend, exec_uuid, "someone-else", now_ms() + 60_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    match be.claim_execution(fresh_args(eid)).await {
+        Err(EngineError::Contention(ContentionKind::InvalidClaimGrant)) => {}
+        other => panic!("expected InvalidClaimGrant, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_rejects_missing_grant() {
+    let backend = fresh_backend().await;
+    let (_u, eid) = seed_runnable(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    match be.claim_execution(fresh_args(eid)).await {
+        Err(EngineError::Contention(ContentionKind::InvalidClaimGrant)) => {}
+        other => panic!("expected InvalidClaimGrant, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_rejects_non_runnable() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&backend).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='terminal' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid).execute(backend.pool_for_test()).await.unwrap();
+    seed_grant(&backend, exec_uuid, "worker-1", now_ms() + 60_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    match be.claim_execution(fresh_args(eid)).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive { .. })) => {}
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn claim_rejects_already_owned() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&backend).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state='leased' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid).execute(backend.pool_for_test()).await.unwrap();
+    seed_grant(&backend, exec_uuid, "worker-1", now_ms() + 60_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    match be.claim_execution(fresh_args(eid)).await {
+        Err(EngineError::Contention(ContentionKind::LeaseConflict)) => {}
+        other => panic!("expected LeaseConflict, got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/typed_complete_execution.rs
+++ b/crates/ff-backend-sqlite/tests/typed_complete_execution.rs
@@ -1,0 +1,286 @@
+//! #33 / Phase 1: integration test for SQLite
+//! `EngineBackend::complete_execution`.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{CompleteExecutionArgs, CompleteExecutionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::state::PublicState;
+use ff_core::types::{
+    AttemptId, AttemptIndex, CancelSource, ExecutionId, LeaseEpoch, LeaseFence, LeaseId,
+    TimestampMs,
+};
+use serial_test::serial;
+use sqlx::Row;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:typed-complete-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri)
+        .await
+        .expect("construct with migrations")
+}
+
+async fn seed_active_lease(
+    backend: &SqliteBackend,
+) -> (Uuid, ExecutionId, LeaseFence) {
+    let pool = backend.pool_for_test();
+    let part: i64 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+    let lease_epoch: i64 = 1;
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms, raw_fields
+        ) VALUES (
+            ?1, ?2, NULL, 'default',
+            0,
+            'active', 'leased', 'not_applicable',
+            'active', 'running_attempt',
+            0, ?3,
+            json_set('{}', '$.current_attempt_id', ?4)
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .bind(attempt_id.to_string())
+    .execute(pool)
+    .await
+    .expect("insert exec_core");
+    sqlx::query(
+        "INSERT INTO ff_attempt (partition_key, execution_id, attempt_index, \
+                                  worker_id, worker_instance_id, \
+                                  lease_epoch, lease_expires_at_ms, started_at_ms) \
+         VALUES (?1, ?2, 0, 'w', 'wi', ?3, ?4, ?5)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lease_epoch)
+    .bind(now_ms() + 60_000)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+    let fence = LeaseFence {
+        lease_id,
+        lease_epoch: LeaseEpoch(lease_epoch as u64),
+        attempt_id,
+    };
+    (exec_uuid, eid, fence)
+}
+
+async fn read_phase_and_public_state(
+    backend: &SqliteBackend,
+    exec_uuid: Uuid,
+) -> (String, String) {
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, public_state FROM ff_exec_core \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .expect("fetch");
+    (
+        row.try_get::<String, _>("lifecycle_phase").unwrap(),
+        row.try_get::<String, _>("public_state").unwrap(),
+    )
+}
+
+fn base_args(eid: ExecutionId, fence: Option<LeaseFence>) -> CompleteExecutionArgs {
+    CompleteExecutionArgs {
+        execution_id: eid,
+        fence,
+        attempt_index: AttemptIndex::new(0),
+        result_payload: None,
+        result_encoding: None,
+        source: CancelSource::LeaseHolder,
+        now: TimestampMs::from_millis(now_ms()),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_happy_path() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active_lease(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let mut args = base_args(eid.clone(), Some(fence));
+    args.result_payload = Some(b"ok".to_vec());
+    let res = be.complete_execution(args).await.expect("complete ok");
+    match res {
+        CompleteExecutionResult::Completed {
+            execution_id,
+            public_state,
+        } => {
+            assert_eq!(execution_id, eid);
+            assert_eq!(public_state, PublicState::Completed);
+        }
+    }
+    let (phase, ps) = read_phase_and_public_state(&backend, exec_uuid).await;
+    assert_eq!(phase, "terminal");
+    assert_eq!(ps, "completed");
+    let (cnt,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_completion_event \
+         WHERE partition_key = 0 AND execution_id = ?1 AND outcome = 'success'",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(cnt, 1);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_rejects_missing_fence_without_override() {
+    let backend = fresh_backend().await;
+    let (_uuid, eid, _fence) = seed_active_lease(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = base_args(eid, None);
+    match be.complete_execution(args).await {
+        Err(EngineError::Validation { kind, detail }) => {
+            assert_eq!(kind, ValidationKind::InvalidInput);
+            assert_eq!(detail, "fence_required");
+        }
+        other => panic!("expected Validation{{fence_required}}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_operator_override_skips_fence() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, _fence) = seed_active_lease(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let mut args = base_args(eid, None);
+    args.source = CancelSource::OperatorOverride;
+    be.complete_execution(args).await.expect("override ok");
+    let (phase, _) = read_phase_and_public_state(&backend, exec_uuid).await;
+    assert_eq!(phase, "terminal");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_stale_lease_on_wrong_epoch() {
+    let backend = fresh_backend().await;
+    let (_uuid, eid, fence) = seed_active_lease(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let bad = LeaseFence {
+        lease_epoch: LeaseEpoch(fence.lease_epoch.0 + 7),
+        ..fence
+    };
+    let args = base_args(eid, Some(bad));
+    match be.complete_execution(args).await {
+        Err(EngineError::State(StateKind::StaleLease)) => {}
+        other => panic!("expected StaleLease, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_execution_not_active_on_terminal() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active_lease(&backend).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .expect("flip");
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = base_args(eid, Some(fence));
+    match be.complete_execution(args).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+            lifecycle_phase,
+            ..
+        })) => {
+            assert_eq!(lifecycle_phase, "terminal");
+        }
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_lease_revoked_on_ownership_revoked() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active_lease(&backend).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state = 'lease_revoked' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .expect("flip");
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = base_args(eid, Some(fence));
+    match be.complete_execution(args).await {
+        Err(EngineError::State(StateKind::LeaseRevoked)) => {}
+        other => panic!("expected LeaseRevoked, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn complete_lease_expired_on_past_ttl() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active_lease(&backend).await;
+    // Backdate attempt's lease to already-expired.
+    sqlx::query(
+        "UPDATE ff_attempt SET lease_expires_at_ms = ?1 \
+         WHERE partition_key = 0 AND execution_id = ?2 AND attempt_index = 0",
+    )
+    .bind(now_ms() - 5_000)
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .expect("backdate");
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = base_args(eid, Some(fence));
+    match be.complete_execution(args).await {
+        Err(EngineError::State(StateKind::LeaseExpired)) => {}
+        other => panic!("expected LeaseExpired, got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/typed_evaluate_flow_eligibility.rs
+++ b/crates/ff-backend-sqlite/tests/typed_evaluate_flow_eligibility.rs
@@ -1,0 +1,159 @@
+//! Phase 1 integration test for SQLite evaluate_flow_eligibility.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::types::ExecutionId;
+use serial_test::serial;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()).unwrap()
+}
+
+fn uuid_like() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:typed-eval-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+async fn seed_exec(
+    backend: &SqliteBackend,
+    lifecycle_phase: &str,
+    ownership: &str,
+    flow_id: Option<Uuid>,
+    terminal_outcome: &str,
+) -> (Uuid, ExecutionId) {
+    let pool = backend.pool_for_test();
+    let part: i64 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state, priority, created_at_ms, raw_fields
+        ) VALUES (
+            ?1, ?2, ?3, 'default', 0,
+            ?4, ?5, 'eligible_now',
+            'waiting', 'pending_first_attempt', 0, ?6,
+            json_set('{}', '$.terminal_outcome', ?7)
+        )
+        "#,
+    )
+    .bind(part).bind(exec_uuid).bind(flow_id).bind(lifecycle_phase).bind(ownership).bind(now_ms()).bind(terminal_outcome)
+    .execute(pool).await.expect("seed");
+    (exec_uuid, eid)
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn eligible_when_standalone_runnable_unowned() {
+    let backend = fresh_backend().await;
+    let (_u, eid) = seed_exec(&backend, "runnable", "unowned", None, "none").await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let EvaluateFlowEligibilityResult::Status { status } = be
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: eid })
+        .await.expect("ok");
+    assert_eq!(status, "eligible");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn not_found_without_row() {
+    let backend = fresh_backend().await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let bogus = ExecutionId::parse("{fp:0}:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+    let EvaluateFlowEligibilityResult::Status { status } = be
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: bogus })
+        .await.expect("ok");
+    assert_eq!(status, "not_found");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn not_runnable_when_active() {
+    let backend = fresh_backend().await;
+    let (_u, eid) = seed_exec(&backend, "active", "leased", None, "none").await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let EvaluateFlowEligibilityResult::Status { status } = be
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: eid })
+        .await.expect("ok");
+    assert_eq!(status, "not_runnable");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn owned_when_ownership_not_unowned() {
+    let backend = fresh_backend().await;
+    let (_u, eid) = seed_exec(&backend, "runnable", "leased", None, "none").await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let EvaluateFlowEligibilityResult::Status { status } = be
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: eid })
+        .await.expect("ok");
+    assert_eq!(status, "owned");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn blocked_by_required_edge_with_non_terminal_upstream() {
+    let backend = fresh_backend().await;
+    let flow_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_flow_core (partition_key, flow_id, public_flow_state, created_at_ms) \
+         VALUES (0, ?1, 'running', ?2)",
+    )
+    .bind(flow_id).bind(now_ms()).execute(backend.pool_for_test()).await.expect("seed flow");
+    let (up_u, _) = seed_exec(&backend, "runnable", "unowned", Some(flow_id), "none").await;
+    let (down_u, down_eid) = seed_exec(&backend, "runnable", "unowned", Some(flow_id), "none").await;
+    sqlx::query(
+        "INSERT INTO ff_edge (partition_key, flow_id, edge_id, upstream_eid, downstream_eid, policy) \
+         VALUES (0, ?1, ?2, ?3, ?4, '{\"kind\":\"required\"}')",
+    )
+    .bind(flow_id).bind(Uuid::new_v4()).bind(up_u).bind(down_u)
+    .execute(backend.pool_for_test()).await.expect("seed edge");
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let EvaluateFlowEligibilityResult::Status { status } = be
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: down_eid })
+        .await.expect("ok");
+    assert_eq!(status, "blocked_by_dependencies");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn impossible_when_required_upstream_failed() {
+    let backend = fresh_backend().await;
+    let flow_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO ff_flow_core (partition_key, flow_id, public_flow_state, created_at_ms) \
+         VALUES (0, ?1, 'running', ?2)",
+    )
+    .bind(flow_id).bind(now_ms()).execute(backend.pool_for_test()).await.expect("seed flow");
+    let (up_u, _) = seed_exec(&backend, "terminal", "unowned", Some(flow_id), "failed").await;
+    let (down_u, down_eid) = seed_exec(&backend, "runnable", "unowned", Some(flow_id), "none").await;
+    sqlx::query(
+        "INSERT INTO ff_edge (partition_key, flow_id, edge_id, upstream_eid, downstream_eid, policy) \
+         VALUES (0, ?1, ?2, ?3, ?4, '{\"kind\":\"required\"}')",
+    )
+    .bind(flow_id).bind(Uuid::new_v4()).bind(up_u).bind(down_u)
+    .execute(backend.pool_for_test()).await.expect("seed edge");
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let EvaluateFlowEligibilityResult::Status { status } = be
+        .evaluate_flow_eligibility(EvaluateFlowEligibilityArgs { execution_id: down_eid })
+        .await.expect("ok");
+    assert_eq!(status, "impossible");
+}

--- a/crates/ff-backend-sqlite/tests/typed_fail_execution.rs
+++ b/crates/ff-backend-sqlite/tests/typed_fail_execution.rs
@@ -1,0 +1,209 @@
+//! #33 / Phase 1: integration test for SQLite `EngineBackend::fail_execution`.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{FailExecutionArgs, FailExecutionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::types::{
+    AttemptId, AttemptIndex, CancelSource, ExecutionId, LeaseEpoch, LeaseFence, LeaseId,
+};
+use serial_test::serial;
+use sqlx::Row;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:typed-fail-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+async fn seed_active(backend: &SqliteBackend) -> (Uuid, ExecutionId, LeaseFence) {
+    let pool = backend.pool_for_test();
+    let part: i64 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+    let lease_epoch: i64 = 1;
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state, priority, created_at_ms, raw_fields
+        ) VALUES (
+            ?1, ?2, NULL, 'default', 0,
+            'active', 'leased', 'not_applicable',
+            'active', 'running_attempt', 0, ?3,
+            json_set('{}', '$.current_attempt_id', ?4)
+        )
+        "#,
+    )
+    .bind(part).bind(exec_uuid).bind(now_ms()).bind(attempt_id.to_string())
+    .execute(pool).await.expect("seed exec");
+    sqlx::query(
+        "INSERT INTO ff_attempt (partition_key, execution_id, attempt_index, \
+                                  worker_id, worker_instance_id, \
+                                  lease_epoch, lease_expires_at_ms, started_at_ms) \
+         VALUES (?1, ?2, 0, 'w', 'wi', ?3, ?4, ?5)",
+    )
+    .bind(part).bind(exec_uuid).bind(lease_epoch).bind(now_ms() + 60_000).bind(now_ms())
+    .execute(pool).await.expect("seed attempt");
+    let fence = LeaseFence {
+        lease_id,
+        lease_epoch: LeaseEpoch(lease_epoch as u64),
+        attempt_id,
+    };
+    (exec_uuid, eid, fence)
+}
+
+fn base_args(eid: ExecutionId, fence: Option<LeaseFence>, retry_policy: &str) -> FailExecutionArgs {
+    FailExecutionArgs {
+        execution_id: eid,
+        fence,
+        attempt_index: AttemptIndex::new(0),
+        failure_reason: "boom".into(),
+        failure_category: "transient".into(),
+        retry_policy_json: retry_policy.into(),
+        next_attempt_policy_json: String::new(),
+        source: CancelSource::LeaseHolder,
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn fail_terminal_when_no_retries() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let res = be
+        .fail_execution(base_args(eid, Some(fence), ""))
+        .await
+        .expect("fail ok");
+    assert_eq!(res, FailExecutionResult::TerminalFailed);
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, public_state FROM ff_exec_core \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(row.get::<String, _>("lifecycle_phase"), "terminal");
+    assert_eq!(row.get::<String, _>("public_state"), "failed");
+    let (c,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_completion_event \
+         WHERE partition_key = 0 AND execution_id = ?1 AND outcome = 'failed'",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(c, 1);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn fail_schedules_retry_when_budget_remains() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let policy = r#"{"max_retries":3,"backoff":{"type":"fixed","delay_ms":500}}"#;
+    let res = be
+        .fail_execution(base_args(eid, Some(fence), policy))
+        .await
+        .expect("fail ok");
+    match res {
+        FailExecutionResult::RetryScheduled {
+            next_attempt_index, ..
+        } => assert_eq!(next_attempt_index, AttemptIndex::new(1)),
+        other => panic!("expected RetryScheduled, got {other:?}"),
+    }
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, public_state, \
+                json_extract(raw_fields, '$.retry_count') AS retry_count \
+         FROM ff_exec_core WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(row.get::<String, _>("lifecycle_phase"), "runnable");
+    assert_eq!(row.get::<String, _>("public_state"), "delayed");
+    assert_eq!(row.get::<String, _>("retry_count"), "1");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn fail_rejects_missing_fence_without_override() {
+    let backend = fresh_backend().await;
+    let (_u, eid, _f) = seed_active(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    match be.fail_execution(base_args(eid, None, "")).await {
+        Err(EngineError::Validation { kind, detail }) => {
+            assert_eq!(kind, ValidationKind::InvalidInput);
+            assert_eq!(detail, "fence_required");
+        }
+        other => panic!("expected fence_required, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn fail_stale_lease_on_wrong_epoch() {
+    let backend = fresh_backend().await;
+    let (_u, eid, fence) = seed_active(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let bad = LeaseFence {
+        lease_epoch: LeaseEpoch(fence.lease_epoch.0 + 9),
+        ..fence
+    };
+    match be.fail_execution(base_args(eid, Some(bad), "")).await {
+        Err(EngineError::State(StateKind::StaleLease)) => {}
+        other => panic!("expected StaleLease, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn fail_execution_not_active_on_terminal() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active(&backend).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='terminal' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .unwrap();
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    match be.fail_execution(base_args(eid, Some(fence), "")).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive { .. })) => {}
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/typed_renew_lease.rs
+++ b/crates/ff-backend-sqlite/tests/typed_renew_lease.rs
@@ -1,0 +1,288 @@
+//! #33 / Phase 1: integration test for SQLite
+//! `EngineBackend::renew_lease`.
+//!
+//! Mirrors `ff-backend-postgres/tests/typed_renew_lease.rs`:
+//!
+//! - happy path extends `ff_attempt.lease_expires_at_ms`
+//! - missing fence → `Validation{InvalidInput, "fence_required"}`
+//! - stale fence (wrong epoch) → `State(StaleLease)`
+//! - expired lease → `State(LeaseExpired)`
+//! - non-active lifecycle → `Contention(ExecutionNotActive{...})`
+//! - revoked ownership → `State(LeaseRevoked)`
+//!
+//! Runs against an in-memory `:memory:` DB (no env var gate). RFC-023
+//! §4.1 A3 single-writer: partition_key = 0 on every seed.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{RenewLeaseArgs, RenewLeaseResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseFence, LeaseId, TimestampMs,
+};
+use serial_test::serial;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    // SAFETY: serial_test::serial(ff_dev_mode) wraps all callers.
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:typed-renew-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri)
+        .await
+        .expect("construct with migrations")
+}
+
+/// Seed an `active` + leased execution ready to be renewed.
+/// Partition 0 per RFC-023 §4.1 A3. Returns the fence triple.
+async fn seed_active_lease(
+    backend: &SqliteBackend,
+    lease_ttl_ms: i64,
+) -> (Uuid, ExecutionId, LeaseFence) {
+    let pool = backend.pool_for_test();
+    let part: i64 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+    let lease_epoch: i64 = 1;
+    let expires_at = now_ms() + lease_ttl_ms;
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms, raw_fields
+        ) VALUES (
+            ?1, ?2, NULL, 'default',
+            0,
+            'active', 'leased', 'not_applicable',
+            'active', 'running_attempt',
+            0, ?3,
+            json_set('{}', '$.current_attempt_id', ?4)
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .bind(attempt_id.to_string())
+    .execute(pool)
+    .await
+    .expect("insert exec_core");
+
+    sqlx::query(
+        r#"
+        INSERT INTO ff_attempt (
+            partition_key, execution_id, attempt_index,
+            worker_id, worker_instance_id,
+            lease_epoch, lease_expires_at_ms, started_at_ms
+        ) VALUES (?1, ?2, 0, 'w', 'wi', ?3, ?4, ?5)
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lease_epoch)
+    .bind(expires_at)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("insert ff_attempt");
+
+    let fence = LeaseFence {
+        lease_id,
+        lease_epoch: LeaseEpoch(lease_epoch as u64),
+        attempt_id,
+    };
+    (exec_uuid, eid, fence)
+}
+
+async fn read_expires(backend: &SqliteBackend, exec_uuid: Uuid) -> i64 {
+    use sqlx::Row;
+    let pool = backend.pool_for_test();
+    let row = sqlx::query(
+        "SELECT lease_expires_at_ms FROM ff_attempt \
+         WHERE partition_key = 0 AND execution_id = ?1 AND attempt_index = 0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .expect("fetch");
+    row.try_get::<i64, _>("lease_expires_at_ms").unwrap()
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_lease_extends_expires_at_on_happy_path() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active_lease(&backend, 5_000).await;
+    let pre = read_expires(&backend, exec_uuid).await;
+
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    let res = be.renew_lease(args).await.expect("renew ok");
+    let RenewLeaseResult::Renewed { expires_at } = res;
+
+    let post = read_expires(&backend, exec_uuid).await;
+    assert!(post > pre, "expires_at should move forward pre={pre} post={post}");
+    assert_eq!(expires_at, TimestampMs::from_millis(post));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_lease_rejects_missing_fence() {
+    let backend = fresh_backend().await;
+    let (_uuid, eid, _fence) = seed_active_lease(&backend, 5_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: None,
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match be.renew_lease(args).await {
+        Err(EngineError::Validation { kind, detail }) => {
+            assert_eq!(kind, ValidationKind::InvalidInput);
+            assert_eq!(detail, "fence_required");
+        }
+        other => panic!("expected Validation{{fence_required}}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_lease_stale_lease_on_wrong_epoch() {
+    let backend = fresh_backend().await;
+    let (_uuid, eid, fence) = seed_active_lease(&backend, 5_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let bad = LeaseFence {
+        lease_epoch: LeaseEpoch(fence.lease_epoch.0 + 99),
+        ..fence
+    };
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(bad),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match be.renew_lease(args).await {
+        Err(EngineError::State(StateKind::StaleLease)) => {}
+        other => panic!("expected StaleLease, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_lease_expired_when_past_ttl() {
+    let backend = fresh_backend().await;
+    // Seed already-expired: negative TTL.
+    let (_uuid, eid, fence) = seed_active_lease(&backend, -5_000).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match be.renew_lease(args).await {
+        Err(EngineError::State(StateKind::LeaseExpired)) => {}
+        other => panic!("expected LeaseExpired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_lease_execution_not_active_on_terminal() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active_lease(&backend, 5_000).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .expect("flip terminal");
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match be.renew_lease(args).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+            lifecycle_phase,
+            ..
+        })) => {
+            assert_eq!(lifecycle_phase, "terminal");
+        }
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn renew_lease_revoked_when_ownership_lease_revoked() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid, fence) = seed_active_lease(&backend, 5_000).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state = 'lease_revoked' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .expect("flip revoked");
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = RenewLeaseArgs {
+        execution_id: eid,
+        attempt_index: AttemptIndex::new(0),
+        fence: Some(fence),
+        lease_ttl_ms: 60_000,
+        lease_history_grace_ms: 60_000,
+    };
+    match be.renew_lease(args).await {
+        Err(EngineError::State(StateKind::LeaseRevoked)) => {}
+        other => panic!("expected LeaseRevoked, got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/typed_resume_execution.rs
+++ b/crates/ff-backend-sqlite/tests/typed_resume_execution.rs
@@ -1,0 +1,183 @@
+//! #33 / Phase 1: integration test for SQLite
+//! `EngineBackend::resume_execution`.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{ResumeExecutionArgs, ResumeExecutionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{EngineError, StateKind};
+use ff_core::state::PublicState;
+use ff_core::types::ExecutionId;
+use serial_test::serial;
+use sqlx::Row;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()).unwrap()
+}
+
+fn uuid_like() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!("file:typed-resume-{}?mode=memory&cache=shared", uuid_like());
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+async fn seed_suspended(backend: &SqliteBackend) -> (Uuid, ExecutionId) {
+    let pool = backend.pool_for_test();
+    let part: i64 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state, priority, created_at_ms, raw_fields
+        ) VALUES (
+            ?1, ?2, NULL, 'default', 0,
+            'suspended', 'unowned', 'not_applicable',
+            'waiting', 'attempt_suspended', 0, ?3,
+            '{}'
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("seed exec");
+    sqlx::query(
+        "INSERT INTO ff_suspension_current (
+            partition_key, execution_id, suspension_id, suspended_at_ms,
+            timeout_at_ms, reason_code, condition
+         ) VALUES (?1, ?2, ?3, ?4, NULL, 'await_signal', '{}')",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(Uuid::new_v4())
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("seed suspension");
+    (exec_uuid, eid)
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn resume_happy_path_no_delay() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_suspended(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = ResumeExecutionArgs {
+        execution_id: eid,
+        trigger_type: "signal".into(),
+        resume_delay_ms: 0,
+    };
+    match be.resume_execution(args).await.expect("resume ok") {
+        ResumeExecutionResult::Resumed { public_state } => {
+            assert_eq!(public_state, PublicState::Waiting);
+        }
+    }
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, public_state FROM ff_exec_core \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(row.get::<String, _>("lifecycle_phase"), "runnable");
+    assert_eq!(row.get::<String, _>("public_state"), "waiting");
+    let (cnt,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_suspension_current \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(cnt, 0, "suspension_current row deleted");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn resume_with_delay_becomes_delayed() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_suspended(&backend).await;
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = ResumeExecutionArgs {
+        execution_id: eid,
+        trigger_type: "operator".into(),
+        resume_delay_ms: 5_000,
+    };
+    match be.resume_execution(args).await.expect("ok") {
+        ResumeExecutionResult::Resumed { public_state } => {
+            assert_eq!(public_state, PublicState::Delayed);
+        }
+    }
+    let row = sqlx::query(
+        "SELECT public_state FROM ff_exec_core \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(row.get::<String, _>("public_state"), "delayed");
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn resume_rejects_non_suspended() {
+    let backend = fresh_backend().await;
+    let (exec_uuid, eid) = seed_suspended(&backend).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='active' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(backend.pool_for_test())
+    .await
+    .unwrap();
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = ResumeExecutionArgs {
+        execution_id: eid,
+        trigger_type: "signal".into(),
+        resume_delay_ms: 0,
+    };
+    match be.resume_execution(args).await {
+        Err(EngineError::State(StateKind::ExecutionNotSuspended)) => {}
+        other => panic!("expected ExecutionNotSuspended, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn resume_not_found_without_exec_core() {
+    let backend = fresh_backend().await;
+    let bogus =
+        ExecutionId::parse("{fp:0}:99999999-9999-9999-9999-999999999999").unwrap();
+    let be: Arc<dyn EngineBackend> = backend.clone();
+    let args = ResumeExecutionArgs {
+        execution_id: bogus,
+        trigger_type: "signal".into(),
+        resume_delay_ms: 0,
+    };
+    match be.resume_execution(args).await {
+        Err(EngineError::NotFound { entity }) => assert_eq!(entity, "execution"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}

--- a/docs/POSTGRES_PARITY_MATRIX.md
+++ b/docs/POSTGRES_PARITY_MATRIX.md
@@ -583,13 +583,18 @@ as part of #449's own doc updates. Expected shape:
   [`CONSUMER_MIGRATION_0.13.md`](CONSUMER_MIGRATION_0.13.md) §Known
   limitations.
 
-**#453 / PR-7b — typed-FCALL bodies (cairn blocker):**
+**#453 / PR-7b — typed-FCALL bodies (cairn blocker):** SQLite bodies
+shipped in v0.13 Phase 1 (#33) mirroring PG with dialect swaps
+(`BEGIN IMMEDIATE` RESERVED lock; `json_set(doc, '$.k1', v1, '$.k2',
+v2, …)` multi-key patch; `excluded.col` UPSERT keyword lowercase).
+Tests in `crates/ff-backend-sqlite/tests/typed_*.rs`; 38 tests total,
+all run against `:memory:` in every CI matrix cell.
 
 | Method | Valkey | Postgres | SQLite | Notes |
 |---|---|---|---|---|
-| `renew_lease` | `impl` | `impl` | `Unavailable` (default, follow-up) | PG: `READ COMMITTED` tx + `FOR UPDATE` on `ff_attempt`. Fence validation is **epoch-only** (PG doesn't persist `lease_id`/`attempt_id` to disk; `lease_epoch` monotonic bump is sufficient to catch the same violations Valkey's full-triple check covers). Error map: `fence_required`→`Validation{InvalidInput}`, `stale_lease`→`State(StaleLease)`, `lease_expired`→`State(LeaseExpired)`, `execution_not_active`→`Contention(ExecutionNotActive{...})`. Integration test: `crates/ff-backend-postgres/tests/typed_renew_lease.rs`. |
-| `complete_execution` | `impl` | `impl` | `Unavailable` (default, follow-up) | PG: `READ COMMITTED` tx with `FOR UPDATE` on `ff_attempt` + `ff_exec_core`. Fence-or-operator-override gate matches Valkey — `source=OperatorOverride` skips epoch fence but lifecycle gate still fires. Flips `ff_exec_core` to terminal/completed + stores result payload; emits `ff_completion_event` (→ pg_notify DAG cascade) + `lease_event::EVENT_REVOKED`. Integration test: `crates/ff-backend-postgres/tests/typed_complete_execution.rs`. |
-| `fail_execution` | `impl` | `impl` | `Unavailable` (default, follow-up) | PG: retry/terminal branch mirrors Valkey. Retry policy JSON parsed into fixed/exponential backoff; `retry_count < max_retries` → `RetryScheduled { delay_until, next_attempt_index }`. Otherwise → `TerminalFailed` (flips to terminal/failed, emits completion outbox with `outcome='failed'`). Integration test: `crates/ff-backend-postgres/tests/typed_fail_execution.rs`. |
+| `renew_lease` | `impl` | `impl` | `impl` | PG: `READ COMMITTED` tx + `FOR UPDATE` on `ff_attempt`. Fence validation is **epoch-only** (PG doesn't persist `lease_id`/`attempt_id` to disk; `lease_epoch` monotonic bump is sufficient to catch the same violations Valkey's full-triple check covers). Error map: `fence_required`→`Validation{InvalidInput}`, `stale_lease`→`State(StaleLease)`, `lease_expired`→`State(LeaseExpired)`, `execution_not_active`→`Contention(ExecutionNotActive{...})`. Integration test: `crates/ff-backend-postgres/tests/typed_renew_lease.rs`. |
+| `complete_execution` | `impl` | `impl` | `impl` | PG: `READ COMMITTED` tx with `FOR UPDATE` on `ff_attempt` + `ff_exec_core`. Fence-or-operator-override gate matches Valkey — `source=OperatorOverride` skips epoch fence but lifecycle gate still fires. Flips `ff_exec_core` to terminal/completed + stores result payload; emits `ff_completion_event` (→ pg_notify DAG cascade) + `lease_event::EVENT_REVOKED`. Integration test: `crates/ff-backend-postgres/tests/typed_complete_execution.rs`. |
+| `fail_execution` | `impl` | `impl` | `impl` | PG: retry/terminal branch mirrors Valkey. Retry policy JSON parsed into fixed/exponential backoff; `retry_count < max_retries` → `RetryScheduled { delay_until, next_attempt_index }`. Otherwise → `TerminalFailed` (flips to terminal/failed, emits completion outbox with `outcome='failed'`). Integration test: `crates/ff-backend-postgres/tests/typed_fail_execution.rs`. |
 
 **PR-7b Wave 0a — backend-agnostic primitives + `start_*` no-panic (cairn #436):**
 


### PR DESCRIPTION
## Summary

**Phase 1 of the v0.13 delivery plan.** Flips all 7 typed-FCALL `EngineBackend` methods from the `Unavailable` default to real SQLite bodies. Mirrors the PG stack (#455–#461) that shipped cairn #453.

| Method | Status |
|---|---|
| `renew_lease` | impl |
| `complete_execution` | impl |
| `fail_execution` | impl (retry + terminal branches) |
| `resume_execution` | impl |
| `check_admission` | impl (four-exit tree) |
| `evaluate_flow_eligibility` | impl (read-only, live dep JOIN) |
| `claim_execution` | impl (8 invariants + grant consumption) |

## SQLite-specific adaptations

- **`FOR UPDATE` elided** — `BEGIN IMMEDIATE` already holds RESERVED lock for the full tx under RFC-023 §4.1 A3 single-writer
- `raw_fields->>'k'` → `json_extract(raw_fields, '$.k')`
- PG `jsonb || patch` → SQLite `json_set(raw_fields, '$.k1', v1, '$.k2', v2, …)` (multi-key set in one call)
- `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE` dropped — `BEGIN IMMEDIATE` + single-writer is implicitly serialisable
- UPSERT: `excluded.col` (SQLite lowercase) instead of PG `EXCLUDED.col`
- `flow_id` BLOB (Uuid::as_bytes) vs PG `uuid`; sqlx handles the bind
- `attempt_index` INTEGER (i64) vs PG integer (i32); use `i64::from(args.attempt_index.0)`
- All write paths wrapped in `retry_serializable(|| …)` to absorb `SQLITE_BUSY`

## Fence-asymmetry note

Same as PG — SQLite's `ff_attempt` persists only `lease_epoch`; `lease_id` and `attempt_id` live on the worker-side `Handle`. Epoch monotonicity catches the same violations Valkey's full-triple check catches. Documented at module level in `typed_ops.rs`.

## Files

- `crates/ff-backend-sqlite/src/typed_ops.rs` — new module, ~1,400 LOC
- 7 new test files `crates/ff-backend-sqlite/tests/typed_*.rs` — 38 tests total, all pass in `:memory:` with no env var gate
- `crates/ff-backend-sqlite/src/backend.rs` — 7 trait overrides, 6 helpers promoted to `pub(crate)`
- `crates/ff-backend-sqlite/src/lib.rs` — `mod typed_ops;`
- CHANGELOG + POSTGRES_PARITY_MATRIX rows flipped

## Test plan

- [x] `cargo test -p ff-backend-sqlite` — 25/25 test binaries green
- [x] `cargo clippy -p ff-backend-sqlite --all-targets -- -D warnings` — clean
- [x] All 38 Phase 1 integration tests pass in `:memory:` (no env gating)
- [ ] CI matrix green

Refs #33 / Phase 1 of v0.13 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)