### PR TITLE
feat(ff-core): #454 Phase 2 — 4 trait methods + arg/result types

### DIFF
--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -4832,12 +4832,17 @@ impl ReportUsageAdminArgs {
 
 /// Args for [`crate::engine_backend::EngineBackend::record_spend`].
 ///
-/// Carries an **open-set** `HashMap<String, u64>` of dimension deltas
+/// Carries an **open-set** `BTreeMap<String, u64>` of dimension deltas
 /// per cairn's ground-truth shape at
 /// `cairn-fabric/src/engine/control_plane_types.rs`. Cairn budgets are
 /// per-tenant open-schema (tenant A tracks `"tokens"` + `"cost_cents"`,
 /// tenant B tracks `"egress_bytes"`), distinct from FF's fixed-shape
 /// [`UsageDimensions`] which encodes the internal usage-report surface.
+///
+/// `BTreeMap` (not `HashMap`) gives stable iteration order — consistent
+/// with `UsageDimensions::custom`, and critical for the PG body which
+/// updates multiple dimension rows per call (deterministic ordering
+/// prevents deadlocks under concurrent spend).
 ///
 /// Return shape reuses [`ReportUsageResult`] — same four variants
 /// (`Ok` / `SoftBreach` / `HardBreach` / `AlreadyApplied`) cairn's UI
@@ -4847,8 +4852,9 @@ impl ReportUsageAdminArgs {
 pub struct RecordSpendArgs {
     pub budget_id: BudgetId,
     pub execution_id: ExecutionId,
-    /// Per-dimension positive deltas. Tenant-defined keys.
-    pub deltas: std::collections::HashMap<String, u64>,
+    /// Per-dimension positive deltas. Tenant-defined keys; stable
+    /// iteration order.
+    pub deltas: BTreeMap<String, u64>,
     /// Caller-computed idempotency key (cairn uses SHA-256 hex of
     /// `budget_id || execution_id || sorted(deltas)`). FF does not
     /// interpret the bytes — dedup is a simple equality check against
@@ -4860,14 +4866,14 @@ impl RecordSpendArgs {
     pub fn new(
         budget_id: BudgetId,
         execution_id: ExecutionId,
-        deltas: std::collections::HashMap<String, u64>,
-        idempotency_key: String,
+        deltas: BTreeMap<String, u64>,
+        idempotency_key: impl Into<String>,
     ) -> Self {
         Self {
             budget_id,
             execution_id,
             deltas,
-            idempotency_key,
+            idempotency_key: idempotency_key.into(),
         }
     }
 }
@@ -4927,9 +4933,13 @@ pub struct DeliverApprovalSignalArgs {
     /// Dedup TTL in milliseconds.
     pub signal_dedup_ttl_ms: u64,
     /// Signal stream MAXLEN for the suspension stream.
-    pub maxlen: u64,
+    /// `None` ⇒ backend default (matches [`DeliverSignalArgs::signal_maxlen`]).
+    #[serde(default)]
+    pub maxlen: Option<u64>,
     /// Per-execution max signal cap (operator quota).
-    pub max_signals_per_execution: u64,
+    /// `None` ⇒ backend default (matches [`DeliverSignalArgs::max_signals_per_execution`]).
+    #[serde(default)]
+    pub max_signals_per_execution: Option<u64>,
 }
 
 impl DeliverApprovalSignalArgs {
@@ -4938,18 +4948,18 @@ impl DeliverApprovalSignalArgs {
         execution_id: ExecutionId,
         lane_id: LaneId,
         waitpoint_id: WaitpointId,
-        signal_name: String,
-        idempotency_suffix: String,
+        signal_name: impl Into<String>,
+        idempotency_suffix: impl Into<String>,
         signal_dedup_ttl_ms: u64,
-        maxlen: u64,
-        max_signals_per_execution: u64,
+        maxlen: Option<u64>,
+        max_signals_per_execution: Option<u64>,
     ) -> Self {
         Self {
             execution_id,
             lane_id,
             waitpoint_id,
-            signal_name,
-            idempotency_suffix,
+            signal_name: signal_name.into(),
+            idempotency_suffix: idempotency_suffix.into(),
             signal_dedup_ttl_ms,
             maxlen,
             max_signals_per_execution,

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -8,7 +8,7 @@ pub mod decode;
 use crate::policy::ExecutionPolicy;
 use crate::state::{AttemptType, PublicState, StateVector};
 use crate::types::{
-    AttemptId, AttemptIndex, CancelSource, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch,
+    AttemptId, AttemptIndex, BudgetId, CancelSource, EdgeId, ExecutionId, FlowId, LaneId, LeaseEpoch,
     LeaseFence, LeaseId, Namespace, SignalId, SuspensionId, TimestampMs, WaitpointId,
     WaitpointToken, WorkerId, WorkerInstanceId,
 };
@@ -4814,6 +4814,211 @@ impl ReportUsageAdminArgs {
     pub fn with_dedup_key(mut self, key: String) -> Self {
         self.dedup_key = Some(key);
         self
+    }
+}
+
+// ─── #454 — cairn ControlPlaneBackend peer methods ──────────────────
+//
+// Four trait methods from cairn-rs #454 that previously routed through
+// raw `ferriskey::*` FCALLs outside the `EngineBackend` trait. Cairn's
+// ground-truth shapes at `cairn-fabric/src/engine/control_plane_types.rs`
+// (commit `a4fdb638`) are mirrored below verbatim so the v0.13 trait
+// matches cairn's existing Valkey impls 1:1.
+//
+// Default bodies on the trait return `EngineError::Unavailable { op }`
+// at landing; Valkey bodies ship in Phase 3; PG + SQLite in Phases 4+5.
+
+// ─── record_spend ───
+
+/// Args for [`crate::engine_backend::EngineBackend::record_spend`].
+///
+/// Carries an **open-set** `HashMap<String, u64>` of dimension deltas
+/// per cairn's ground-truth shape at
+/// `cairn-fabric/src/engine/control_plane_types.rs`. Cairn budgets are
+/// per-tenant open-schema (tenant A tracks `"tokens"` + `"cost_cents"`,
+/// tenant B tracks `"egress_bytes"`), distinct from FF's fixed-shape
+/// [`UsageDimensions`] which encodes the internal usage-report surface.
+///
+/// Return shape reuses [`ReportUsageResult`] — same four variants
+/// (`Ok` / `SoftBreach` / `HardBreach` / `AlreadyApplied`) cairn's UI
+/// branches on. Not a new enum.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RecordSpendArgs {
+    pub budget_id: BudgetId,
+    pub execution_id: ExecutionId,
+    /// Per-dimension positive deltas. Tenant-defined keys.
+    pub deltas: std::collections::HashMap<String, u64>,
+    /// Caller-computed idempotency key (cairn uses SHA-256 hex of
+    /// `budget_id || execution_id || sorted(deltas)`). FF does not
+    /// interpret the bytes — dedup is a simple equality check against
+    /// the prior stamped key.
+    pub idempotency_key: String,
+}
+
+impl RecordSpendArgs {
+    pub fn new(
+        budget_id: BudgetId,
+        execution_id: ExecutionId,
+        deltas: std::collections::HashMap<String, u64>,
+        idempotency_key: String,
+    ) -> Self {
+        Self {
+            budget_id,
+            execution_id,
+            deltas,
+            idempotency_key,
+        }
+    }
+}
+
+// ─── release_budget ───
+
+/// Args for [`crate::engine_backend::EngineBackend::release_budget`].
+///
+/// **Per-execution release-my-attribution**, not whole-budget flush.
+/// Called when an execution terminates so the budget persists across
+/// executions but this execution's attribution is reversed. Per cairn
+/// clarification on #454.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ReleaseBudgetArgs {
+    pub budget_id: BudgetId,
+    pub execution_id: ExecutionId,
+}
+
+impl ReleaseBudgetArgs {
+    pub fn new(budget_id: BudgetId, execution_id: ExecutionId) -> Self {
+        Self {
+            budget_id,
+            execution_id,
+        }
+    }
+}
+
+// ─── deliver_approval_signal ───
+
+/// Args for [`crate::engine_backend::EngineBackend::deliver_approval_signal`].
+///
+/// Pre-shaped variant of [`crate::engine_backend::EngineBackend::deliver_signal`]
+/// for the operator-driven approval flow. Distinct from `deliver_signal`
+/// because the caller **does not carry the waitpoint token** — the backend
+/// reads the token from `ff_waitpoint_pending` (via
+/// [`crate::engine_backend::EngineBackend::read_waitpoint_token`],
+/// #434-shipped in v0.12), HMAC-verifies server-side, and dispatches. The
+/// operator API never handles the token bytes.
+///
+/// `signal_name` is a flat string (`"approved"` / `"rejected"` by
+/// convention; not an enum at the trait level — audit metadata like
+/// `decided_by` / `note` / `reason` sits in cairn's audit log, not in
+/// the FF signal surface).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DeliverApprovalSignalArgs {
+    pub execution_id: ExecutionId,
+    pub lane_id: LaneId,
+    pub waitpoint_id: WaitpointId,
+    /// Conventional values: `"approved"` / `"rejected"`. Stored raw on
+    /// the delivered signal; FF does not interpret.
+    pub signal_name: String,
+    /// Cairn-side per-decision idempotency suffix. Combined with
+    /// `execution_id` + `signal_name` to form the dedup key.
+    pub idempotency_suffix: String,
+    /// Dedup TTL in milliseconds.
+    pub signal_dedup_ttl_ms: u64,
+    /// Signal stream MAXLEN for the suspension stream.
+    pub maxlen: u64,
+    /// Per-execution max signal cap (operator quota).
+    pub max_signals_per_execution: u64,
+}
+
+impl DeliverApprovalSignalArgs {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        execution_id: ExecutionId,
+        lane_id: LaneId,
+        waitpoint_id: WaitpointId,
+        signal_name: String,
+        idempotency_suffix: String,
+        signal_dedup_ttl_ms: u64,
+        maxlen: u64,
+        max_signals_per_execution: u64,
+    ) -> Self {
+        Self {
+            execution_id,
+            lane_id,
+            waitpoint_id,
+            signal_name,
+            idempotency_suffix,
+            signal_dedup_ttl_ms,
+            maxlen,
+            max_signals_per_execution,
+        }
+    }
+}
+
+// ─── issue_grant_and_claim ───
+
+/// Args for [`crate::engine_backend::EngineBackend::issue_grant_and_claim`].
+///
+/// Composes `issue_claim_grant` + `claim_execution` into a single
+/// backend-atomic op per cairn #454 Q4. The composition **must** be
+/// backend-atomic (not caller-chained) to prevent leaking grants when
+/// `claim_execution` fails after `issue_claim_grant` succeeded.
+///
+/// Valkey: one `ff_issue_grant_and_claim` FCALL composing the two
+/// primitives in Lua.
+/// Postgres/SQLite: both primitives inside one tx.
+///
+/// Flattened shape (not `IssueClaimGrantArgs + ClaimExecutionArgs`
+/// composition) — the two arg types overlap on `execution_id` +
+/// `lane_id`; flattening drops the dup.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct IssueGrantAndClaimArgs {
+    pub execution_id: ExecutionId,
+    pub lane_id: LaneId,
+    /// Lease TTL in milliseconds. Threaded into both the grant TTL and
+    /// the claimed attempt's `lease_expires_at_ms`.
+    pub lease_duration_ms: u64,
+}
+
+impl IssueGrantAndClaimArgs {
+    pub fn new(execution_id: ExecutionId, lane_id: LaneId, lease_duration_ms: u64) -> Self {
+        Self {
+            execution_id,
+            lane_id,
+            lease_duration_ms,
+        }
+    }
+}
+
+/// Outcome of [`crate::engine_backend::EngineBackend::issue_grant_and_claim`].
+///
+/// Distinct from [`ClaimExecutionResult`] because the trait method
+/// intentionally hides the grant-issuance step — callers only see the
+/// resulting lease identity. If the backend's transparent dispatch
+/// routes through `ff_claim_resumed_execution` (when the execution was
+/// suspended), the return is identical.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ClaimGrantOutcome {
+    pub lease_id: LeaseId,
+    pub lease_epoch: LeaseEpoch,
+    pub attempt_index: AttemptIndex,
+}
+
+impl ClaimGrantOutcome {
+    pub fn new(
+        lease_id: LeaseId,
+        lease_epoch: LeaseEpoch,
+        attempt_index: AttemptIndex,
+    ) -> Self {
+        Self {
+            lease_id,
+            lease_epoch,
+            attempt_index,
+        }
     }
 }
 

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -1700,7 +1700,7 @@ pub trait EngineBackend: Send + Sync + 'static {
 
     /// Per-execution budget spend with tenant-open dimensions.
     ///
-    /// Cairn #454 Q1/Q2: takes an open-set `HashMap<String, u64>` of
+    /// Cairn #454 Q1/Q2: takes an open-set `BTreeMap<String, u64>` of
     /// deltas (distinct from the fixed-shape
     /// [`Self::report_usage`]/[`Self::report_usage_admin`] which use
     /// [`UsageDimensions`]). Return shape reuses [`ReportUsageResult`]
@@ -3589,8 +3589,8 @@ mod tests {
         let args = RecordSpendArgs::new(
             BudgetId::new(),
             eid,
-            std::collections::HashMap::new(),
-            "k".into(),
+            std::collections::BTreeMap::new(),
+            "k",
         );
         match b.record_spend(args).await.unwrap_err() {
             EngineError::Unavailable { op } => assert_eq!(op, "record_spend"),
@@ -3625,11 +3625,11 @@ mod tests {
             eid,
             LaneId::new("default"),
             WaitpointId::new(),
-            "approved".into(),
-            "sfx".into(),
+            "approved",
+            "sfx",
             1_000,
-            100,
-            10,
+            Some(100),
+            Some(10),
         );
         match b.deliver_approval_signal(args).await.unwrap_err() {
             EngineError::Unavailable { op } => assert_eq!(op, "deliver_approval_signal"),

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -72,13 +72,15 @@ use crate::contracts::{
     ClaimExecutionResult, ClaimForWorkerArgs, ClaimForWorkerOutcome, ClaimResumedExecutionArgs,
     ClaimResumedExecutionResult,
     BlockRouteArgs, BlockRouteOutcome, CheckAdmissionArgs, CheckAdmissionResult,
+    ClaimGrantOutcome,
     CompleteExecutionArgs, CompleteExecutionResult, CreateBudgetArgs, CreateBudgetResult,
     CreateExecutionArgs, CreateExecutionResult, CreateFlowArgs, CreateFlowResult,
     CreateQuotaPolicyArgs, CreateQuotaPolicyResult,
-    DeliverSignalArgs, DeliverSignalResult, EdgeDirection, EdgeSnapshot,
+    DeliverApprovalSignalArgs, DeliverSignalArgs, DeliverSignalResult, EdgeDirection, EdgeSnapshot,
     EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult, ExecutionInfo,
     FailExecutionArgs, FailExecutionResult,
-    IssueClaimGrantArgs, IssueClaimGrantOutcome, ScanEligibleArgs,
+    IssueClaimGrantArgs, IssueClaimGrantOutcome, IssueGrantAndClaimArgs,
+    RecordSpendArgs, ReleaseBudgetArgs, ScanEligibleArgs,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs,
     ListPendingWaitpointsResult, ListSuspendedPage, RenewLeaseArgs, RenewLeaseResult,
     ReplayExecutionArgs, ReplayExecutionResult,
@@ -1691,6 +1693,91 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<EvaluateFlowEligibilityResult, EngineError> {
         Err(EngineError::Unavailable {
             op: "evaluate_flow_eligibility",
+        })
+    }
+
+    // ── #454 — cairn typed-FCALL additions (4) ─────────────────
+
+    /// Per-execution budget spend with tenant-open dimensions.
+    ///
+    /// Cairn #454 Q1/Q2: takes an open-set `HashMap<String, u64>` of
+    /// deltas (distinct from the fixed-shape
+    /// [`Self::report_usage`]/[`Self::report_usage_admin`] which use
+    /// [`UsageDimensions`]). Return shape reuses [`ReportUsageResult`]
+    /// — same `Ok` / `SoftBreach` / `HardBreach` / `AlreadyApplied`
+    /// variants cairn's UI already branches on.
+    ///
+    /// The default impl returns [`EngineError::Unavailable`] so the
+    /// trait remains additive for backends that have not landed the
+    /// #454 body yet.
+    #[cfg(feature = "core")]
+    async fn record_spend(
+        &self,
+        _args: RecordSpendArgs,
+    ) -> Result<ReportUsageResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "record_spend",
+        })
+    }
+
+    /// Per-execution budget attribution release.
+    ///
+    /// Called on execution termination to reverse this execution's
+    /// contribution to a budget counter. Per cairn #454 clarification
+    /// this is **per-execution**, not a whole-budget flush — the
+    /// budget persists across executions.
+    ///
+    /// The default impl returns [`EngineError::Unavailable`].
+    #[cfg(feature = "core")]
+    async fn release_budget(
+        &self,
+        _args: ReleaseBudgetArgs,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Unavailable {
+            op: "release_budget",
+        })
+    }
+
+    /// Operator-driven approval-signal delivery.
+    ///
+    /// Pre-shaped variant of [`Self::deliver_signal`] where the caller
+    /// **does not carry the waitpoint token**. The backend reads the
+    /// token from `ff_waitpoint_pending`, HMAC-verifies server-side,
+    /// and dispatches. Operator API never sees the token bytes.
+    ///
+    /// Cairn #454 Q3 — `signal_name` is a flat string (conventional
+    /// values `"approved"` / `"rejected"`); audit metadata lives in
+    /// cairn's audit log, not on the FF surface.
+    ///
+    /// The default impl returns [`EngineError::Unavailable`].
+    #[cfg(feature = "core")]
+    async fn deliver_approval_signal(
+        &self,
+        _args: DeliverApprovalSignalArgs,
+    ) -> Result<DeliverSignalResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "deliver_approval_signal",
+        })
+    }
+
+    /// Backend-atomic `issue_claim_grant` + `claim_execution`.
+    ///
+    /// Cairn #454 Q4 — composing the two primitives caller-side risks
+    /// leaking a grant if `claim_execution` fails after
+    /// `issue_claim_grant` succeeded. This method's contract is that
+    /// the composition is backend-atomic: Valkey fuses them in one
+    /// FCALL; PG/SQLite fuse them in one tx.
+    ///
+    /// The default impl **must not** be a chained call — it returns
+    /// [`EngineError::Unavailable`] so consumers cannot accidentally
+    /// use a non-atomic fallback.
+    #[cfg(feature = "core")]
+    async fn issue_grant_and_claim(
+        &self,
+        _args: IssueGrantAndClaimArgs,
+    ) -> Result<ClaimGrantOutcome, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "issue_grant_and_claim",
         })
     }
 
@@ -3485,6 +3572,82 @@ mod tests {
             .unwrap_err()
         {
             EngineError::Unavailable { op } => assert_eq!(op, "reconcile_quota_counters"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    // ── #454 trait-additions default-impl tests (4) ────────────
+
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_record_spend_is_unavailable() {
+        use crate::contracts::RecordSpendArgs;
+        use crate::types::{BudgetId, ExecutionId, FlowId};
+        let b = DefaultBackend;
+        let config = crate::partition::PartitionConfig::default();
+        let eid = ExecutionId::for_flow(&FlowId::new(), &config);
+        let args = RecordSpendArgs::new(
+            BudgetId::new(),
+            eid,
+            std::collections::HashMap::new(),
+            "k".into(),
+        );
+        match b.record_spend(args).await.unwrap_err() {
+            EngineError::Unavailable { op } => assert_eq!(op, "record_spend"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_release_budget_is_unavailable() {
+        use crate::contracts::ReleaseBudgetArgs;
+        use crate::types::{BudgetId, ExecutionId, FlowId};
+        let b = DefaultBackend;
+        let config = crate::partition::PartitionConfig::default();
+        let eid = ExecutionId::for_flow(&FlowId::new(), &config);
+        let args = ReleaseBudgetArgs::new(BudgetId::new(), eid);
+        match b.release_budget(args).await.unwrap_err() {
+            EngineError::Unavailable { op } => assert_eq!(op, "release_budget"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_deliver_approval_signal_is_unavailable() {
+        use crate::contracts::DeliverApprovalSignalArgs;
+        use crate::types::{ExecutionId, FlowId, LaneId, WaitpointId};
+        let b = DefaultBackend;
+        let config = crate::partition::PartitionConfig::default();
+        let eid = ExecutionId::for_flow(&FlowId::new(), &config);
+        let args = DeliverApprovalSignalArgs::new(
+            eid,
+            LaneId::new("default"),
+            WaitpointId::new(),
+            "approved".into(),
+            "sfx".into(),
+            1_000,
+            100,
+            10,
+        );
+        match b.deliver_approval_signal(args).await.unwrap_err() {
+            EngineError::Unavailable { op } => assert_eq!(op, "deliver_approval_signal"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "core")]
+    #[tokio::test]
+    async fn default_issue_grant_and_claim_is_unavailable() {
+        use crate::contracts::IssueGrantAndClaimArgs;
+        use crate::types::{ExecutionId, FlowId, LaneId};
+        let b = DefaultBackend;
+        let config = crate::partition::PartitionConfig::default();
+        let eid = ExecutionId::for_flow(&FlowId::new(), &config);
+        let args = IssueGrantAndClaimArgs::new(eid, LaneId::new("default"), 30_000);
+        match b.issue_grant_and_claim(args).await.unwrap_err() {
+            EngineError::Unavailable { op } => assert_eq!(op, "issue_grant_and_claim"),
             other => panic!("expected Unavailable, got {other:?}"),
         }
     }

--- a/docs/CONSUMER_MIGRATION_0.13.md
+++ b/docs/CONSUMER_MIGRATION_0.13.md
@@ -482,16 +482,19 @@ from the default impl so out-of-tree backends compile unchanged.
 
 | Method | Args | Return |
 |---|---|---|
-| `record_spend` | [`RecordSpendArgs`] | [`ReportUsageResult`] |
-| `release_budget` | [`ReleaseBudgetArgs`] | `()` |
-| `deliver_approval_signal` | [`DeliverApprovalSignalArgs`] | [`DeliverSignalResult`] |
-| `issue_grant_and_claim` | [`IssueGrantAndClaimArgs`] | [`ClaimGrantOutcome`] |
+| `record_spend` | `RecordSpendArgs` | `ReportUsageResult` |
+| `release_budget` | `ReleaseBudgetArgs` | `()` |
+| `deliver_approval_signal` | `DeliverApprovalSignalArgs` | `DeliverSignalResult` |
+| `issue_grant_and_claim` | `IssueGrantAndClaimArgs` | `ClaimGrantOutcome` |
 
 **Shape notes (why these types, not the existing peers).**
 
-- `RecordSpendArgs.deltas` is `HashMap<String, u64>` — **open-set**
-  tenant-defined dimension keys, distinct from the fixed-shape
-  `UsageDimensions` used by `report_usage` / `report_usage_admin`.
+- `RecordSpendArgs.deltas` is `BTreeMap<String, u64>` — **open-set**
+  tenant-defined dimension keys with stable iteration order, distinct
+  from the fixed-shape `UsageDimensions` used by `report_usage` /
+  `report_usage_admin`. Stable ordering matches `UsageDimensions::custom`
+  and lets the PG body update multiple dimension rows in a fixed order
+  (avoids deadlocks under concurrent spend).
   Cairn budgets are per-tenant open-schema (tenant A tracks
   `"tokens"` + `"cost_cents"`; tenant B tracks `"egress_bytes"`).
   Return reuses `ReportUsageResult` — same four variants cairn's UI
@@ -532,9 +535,9 @@ per-backend phases merge.
 **After (v0.13):**
 
 ```rust,ignore
-let deltas = std::collections::HashMap::from([
-    ("tokens".into(), 1_500),
-    ("cost_cents".into(), 12),
+let deltas = std::collections::BTreeMap::from([
+    ("tokens".to_string(), 1_500),
+    ("cost_cents".to_string(), 12),
 ]);
 let outcome = backend
     .record_spend(RecordSpendArgs::new(

--- a/docs/CONSUMER_MIGRATION_0.13.md
+++ b/docs/CONSUMER_MIGRATION_0.13.md
@@ -464,6 +464,94 @@ let status = backend.evaluate_flow_eligibility(&flow_id).await?;
 `{q:<policy>}` partition (not derivable from `execution_id`); empty
 `dimension` is normalised to `"default"`.
 
+## cairn #454 trait additions — 4 new control-plane methods
+
+**Motivation.** cairn #454 asks for four additional control-plane
+methods that the current trait does not expose: per-execution
+**budget spend** with tenant-open dimensions, per-execution
+**budget-attribution release**, **operator approval-signal** delivery
+(token never leaves the server), and **backend-atomic
+`issue_claim_grant + claim_execution`** composition. v0.13 lands the
+trait surface + arg/result types + `Unavailable` defaults; per-backend
+bodies land in the subsequent phases of the same release window
+(Valkey → PG → SQLite).
+
+**New trait methods.** All four live on `EngineBackend` under
+`#[cfg(feature = "core")]` and return `EngineError::Unavailable`
+from the default impl so out-of-tree backends compile unchanged.
+
+| Method | Args | Return |
+|---|---|---|
+| `record_spend` | [`RecordSpendArgs`] | [`ReportUsageResult`] |
+| `release_budget` | [`ReleaseBudgetArgs`] | `()` |
+| `deliver_approval_signal` | [`DeliverApprovalSignalArgs`] | [`DeliverSignalResult`] |
+| `issue_grant_and_claim` | [`IssueGrantAndClaimArgs`] | [`ClaimGrantOutcome`] |
+
+**Shape notes (why these types, not the existing peers).**
+
+- `RecordSpendArgs.deltas` is `HashMap<String, u64>` — **open-set**
+  tenant-defined dimension keys, distinct from the fixed-shape
+  `UsageDimensions` used by `report_usage` / `report_usage_admin`.
+  Cairn budgets are per-tenant open-schema (tenant A tracks
+  `"tokens"` + `"cost_cents"`; tenant B tracks `"egress_bytes"`).
+  Return reuses `ReportUsageResult` — same four variants cairn's UI
+  already branches on. No new result enum.
+- `ReleaseBudgetArgs` is **per-execution**, not whole-budget flush.
+  Called on execution termination to reverse this execution's
+  attribution; the budget counter persists across executions.
+- `DeliverApprovalSignalArgs` is a pre-shaped variant of
+  `deliver_signal` where the caller **does not carry the waitpoint
+  token**. The backend reads the token from `ff_waitpoint_pending`
+  (via `read_waitpoint_token`, v0.12-shipped), HMAC-verifies
+  server-side, and dispatches. Operator API never touches the bytes.
+  `signal_name` is a flat string (`"approved"` / `"rejected"` by
+  convention); audit metadata (`decided_by`, `note`, `reason`) lives
+  in cairn's audit log, not on the FF surface.
+- `IssueGrantAndClaimArgs` + `ClaimGrantOutcome` compose
+  `issue_claim_grant` + `claim_execution` into a **backend-atomic**
+  op. Caller-chained composition risks leaking a grant when
+  `claim_execution` fails after `issue_claim_grant` succeeded; the
+  trait method's contract is that Valkey fuses them in one FCALL and
+  PG/SQLite fuse them inside one tx. The default impl is **not** a
+  fallback chained call — it returns `Unavailable` so consumers
+  cannot silently pick up a non-atomic path.
+
+**Parity status at v0.13.** Trait + types + Unavailable defaults
+land in this release. Valkey bodies land next (ship vehicle: #454
+Phase 3). PG + SQLite bodies follow (#454 Phases 4 + 5). Consumers
+compile-check against `Unavailable` on PG / SQLite until the
+per-backend phases merge.
+
+**Before (v0.12, cairn's pattern for record_spend):**
+
+```rust,ignore
+// cairn had no trait seat; budget spend went through ad-hoc ff-server
+// HTTP endpoints + cairn-local bookkeeping.
+```
+
+**After (v0.13):**
+
+```rust,ignore
+let deltas = std::collections::HashMap::from([
+    ("tokens".into(), 1_500),
+    ("cost_cents".into(), 12),
+]);
+let outcome = backend
+    .record_spend(RecordSpendArgs::new(
+        budget_id,
+        exec_id,
+        deltas,
+        idempotency_key,
+    ))
+    .await?;
+match outcome {
+    ReportUsageResult::Ok { .. } => { /* proceed */ }
+    ReportUsageResult::SoftBreach { .. } => { /* warn + proceed */ }
+    ReportUsageResult::HardBreach { .. } => { /* stop */ }
+    ReportUsageResult::AlreadyApplied { .. } => { /* dedup no-op */ }
+}
+```
+
 ## PR-7b scanner trait routing (#436 / cluster PRs)
 
 **Motivation.** The scanner supervisor (`ff-engine`) previously held


### PR DESCRIPTION
## Summary

- Adds 4 cairn-#454 control-plane trait methods to `EngineBackend` with `EngineError::Unavailable` default impls (additive; out-of-tree backends compile unchanged).
- Adds 4 arg structs + 1 outcome type in `ff-core::contracts` — all `#[non_exhaustive]` with `::new()` constructors.
- Adds 4 `default_*_is_unavailable` unit tests matching the precedent of existing default-impl tests.
- Documents the new surface in `CONSUMER_MIGRATION_0.13.md`.

## New trait methods

| Method | Args | Return |
|---|---|---|
| `record_spend` | `RecordSpendArgs` | `ReportUsageResult` |
| `release_budget` | `ReleaseBudgetArgs` | `()` |
| `deliver_approval_signal` | `DeliverApprovalSignalArgs` | `DeliverSignalResult` |
| `issue_grant_and_claim` | `IssueGrantAndClaimArgs` | `ClaimGrantOutcome` |

## Shape rationale

- **`record_spend` deltas** = `HashMap<String, u64>` open-set (tenant-defined keys), distinct from fixed-shape `UsageDimensions`. Return reuses `ReportUsageResult` — same four variants cairn's UI already branches on; no new result enum.
- **`release_budget`** is per-execution attribution release, not whole-budget flush. Budget counter persists across executions.
- **`deliver_approval_signal`** is a pre-shaped `deliver_signal` variant where the caller does not carry the waitpoint token. Backend reads from `ff_waitpoint_pending` (via `read_waitpoint_token`, v0.12-shipped) and HMAC-verifies server-side. `signal_name` is a flat string (`"approved"` / `"rejected"`); audit metadata lives in cairn's audit log.
- **`issue_grant_and_claim`** is backend-atomic (Valkey: one FCALL; PG/SQLite: one tx). Default impl deliberately NOT a chained fallback — returns `Unavailable` so consumers cannot silently pick up a non-atomic path (grant-leak hazard).

## Ground truth

Cairn confirmed types on #454 comment 4355865937 (`cairn-fabric/src/engine/control_plane_types.rs`): open-set HashMap for deltas, flat-string signal name, atomic grant+claim composition. `submit_task_execution` dropped from scope — `priority: i32` + `tags: HashMap<String, String>` already exist on `CreateExecutionArgs`.

## Test plan

- [x] `cargo check --workspace` clean (13 crates)
- [x] `cargo test -p ff-core --lib` — 242/242 green, including 4 new `default_*_is_unavailable` tests
- [ ] CI matrix green
- [ ] Valkey bodies (Phase 3), PG bodies (Phase 4), SQLite bodies (Phase 5) land on follow-up PRs

Refs: cairn #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)