### PR TITLE
feat(ff-backend-postgres): #454 Phase 4a — record_spend + release_budget PG bodies (per-execution ledger)

### DIFF
--- a/crates/ff-backend-postgres/migrations/0020_budget_usage_by_exec.sql
+++ b/crates/ff-backend-postgres/migrations/0020_budget_usage_by_exec.sql
@@ -1,0 +1,44 @@
+-- no-transaction
+-- cairn #454 Phase 4a — per-execution budget ledger (option A).
+--
+-- Adds `ff_budget_usage_by_exec`, the per-execution attribution
+-- ledger that backs `record_spend` + `release_budget` on Postgres
+-- (parity with Valkey PR #464's `ff:budget:...:by_exec:<exec>` HASH).
+-- `record_spend` UPSERTs into this table alongside the `ff_budget_usage`
+-- aggregate; `release_budget` scans rows for a single execution,
+-- subtracts the `delta_total` from the aggregate (clamped at 0), and
+-- DELETEs the per-exec rows.
+--
+-- Partitioned by HASH(partition_key) with 256 children to match
+-- `ff_budget_usage` / `ff_budget_policy` (Wave 3b §Q5). Partition-
+-- child DDL uses one DO block with an explicit COMMIT boundary to
+-- stay under `max_locks_per_transaction` (same discipline as
+-- 0002_budget.sql §Section 2).
+
+CREATE TABLE ff_budget_usage_by_exec (
+    partition_key   smallint NOT NULL,
+    budget_id       text     NOT NULL,
+    execution_id    uuid     NOT NULL,
+    dimensions_key  text     NOT NULL,
+    delta_total     bigint   NOT NULL DEFAULT 0,
+    updated_at_ms   bigint   NOT NULL,
+    PRIMARY KEY (partition_key, budget_id, execution_id, dimensions_key)
+) PARTITION BY HASH (partition_key);
+
+COMMIT;
+DO $$ BEGIN FOR i IN 0..255 LOOP EXECUTE format('CREATE TABLE %I PARTITION OF ff_budget_usage_by_exec FOR VALUES WITH (MODULUS 256, REMAINDER %s)', 'ff_budget_usage_by_exec_p' || i, i); END LOOP; END $$;
+COMMIT;
+
+-- release_budget scan index: given (partition_key, budget_id,
+-- execution_id), list all dimensions with delta_total for SELECT
+-- FOR UPDATE + subsequent DELETE.
+CREATE INDEX ff_budget_usage_by_exec_release_idx
+    ON ff_budget_usage_by_exec (partition_key, budget_id, execution_id);
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    20,
+    '0020_budget_usage_by_exec',
+    (extract(epoch from clock_timestamp())*1000)::bigint,
+    true
+);

--- a/crates/ff-backend-postgres/src/budget.rs
+++ b/crates/ff-backend-postgres/src/budget.rs
@@ -30,14 +30,15 @@ use std::collections::{BTreeMap, HashMap};
 use ff_core::backend::UsageDimensions;
 use ff_core::contracts::{
     BudgetStatus, CreateBudgetArgs, CreateBudgetResult, CreateQuotaPolicyArgs,
-    CreateQuotaPolicyResult, ReportUsageAdminArgs, ReportUsageResult, ResetBudgetArgs,
-    ResetBudgetResult,
+    CreateQuotaPolicyResult, RecordSpendArgs, ReleaseBudgetArgs, ReportUsageAdminArgs,
+    ReportUsageResult, ResetBudgetArgs, ResetBudgetResult,
 };
 use ff_core::engine_error::{backend_context, EngineError, ValidationKind};
 use ff_core::partition::{budget_partition, quota_partition, PartitionConfig};
-use ff_core::types::{BudgetId, TimestampMs};
+use ff_core::types::{BudgetId, ExecutionId, TimestampMs};
 use serde_json::{json, Value as JsonValue};
 use sqlx::{PgPool, Row};
+use uuid::Uuid;
 
 use crate::error::map_sqlx_error;
 
@@ -901,6 +902,353 @@ pub(crate) async fn budget_reset_reconciler_apply(
     .bind(budget_id)
     .bind(now)
     .bind(reset_interval_ms)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+// ───────────────────────────────────────────────────────────────────
+// cairn #454 Phase 4a — `record_spend` + `release_budget`
+// (per-execution ledger, option A; parity with Valkey PR #464).
+// ───────────────────────────────────────────────────────────────────
+
+/// Extract the bare UUID from an `ExecutionId` (formatted
+/// `{fp:N}:<uuid>`). `ff_budget_usage_by_exec.execution_id` is typed
+/// as `uuid`, not the wrapped hash-tag string, so we need the inner
+/// bytes. Mirrors `attempt::split_exec_id` but returns only the UUID.
+fn exec_uuid(eid: &ExecutionId) -> Result<Uuid, EngineError> {
+    let s = eid.as_str();
+    let rest = s.strip_prefix("{fp:").ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id missing `{{fp:` prefix: {s}"),
+    })?;
+    let close = rest.find("}:").ok_or_else(|| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id missing `}}:`: {s}"),
+    })?;
+    Uuid::parse_str(&rest[close + 2..]).map_err(|_| EngineError::Validation {
+        kind: ValidationKind::InvalidInput,
+        detail: format!("execution_id UUID invalid: {s}"),
+    })
+}
+
+/// cairn #454 Phase 4a — `EngineBackend::record_spend`.
+///
+/// Per-execution budget spend with open-set dimensions. Structurally
+/// identical to [`report_usage_and_check_core`] (dedup INSERT → policy
+/// lock → per-dim admission → apply increments → soft-breach book-
+/// keeping), with two deltas from option A:
+///
+/// 1. The idempotency key is `args.idempotency_key` (caller-computed
+///    SHA-256 hex per RFC cairn #454 Q1) instead of
+///    `UsageDimensions::dedup_key`.
+/// 2. After the aggregate UPSERT the same deltas land in the
+///    `ff_budget_usage_by_exec` per-execution ledger (new 0020 table)
+///    so `release_budget` can reverse just this execution's
+///    attribution. Matches Valkey's `HINCRBY` into
+///    `ff:budget:...:by_exec:<execution_id>`.
+pub(crate) async fn record_spend_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    args: RecordSpendArgs,
+) -> Result<ReportUsageResult, EngineError> {
+    let partition = budget_partition(&args.budget_id, partition_config);
+    let partition_key: i16 = partition.index as i16;
+    let budget_id_str = args.budget_id.to_string();
+    let exec_uuid = exec_uuid(&args.execution_id)?;
+    let now = now_ms();
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // ── Dedup (reuses the existing `ff_budget_usage_dedup` infra) ──
+    let dedup_owned: Option<String> = if args.idempotency_key.is_empty() {
+        None
+    } else {
+        let inserted = sqlx::query(
+            "INSERT INTO ff_budget_usage_dedup \
+                 (partition_key, dedup_key, outcome_json, applied_at_ms, expires_at_ms) \
+             VALUES ($1, $2, '{}'::jsonb, $3, $4) \
+             ON CONFLICT (partition_key, dedup_key) DO NOTHING \
+             RETURNING applied_at_ms",
+        )
+        .bind(partition_key)
+        .bind(&args.idempotency_key)
+        .bind(now)
+        .bind(now + DEDUP_TTL_MS)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if inserted.is_none() {
+            let row = sqlx::query(
+                "SELECT outcome_json FROM ff_budget_usage_dedup \
+                 WHERE partition_key = $1 AND dedup_key = $2",
+            )
+            .bind(partition_key)
+            .bind(&args.idempotency_key)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+            let outcome: JsonValue = row.get("outcome_json");
+            tx.commit().await.map_err(map_sqlx_error)?;
+            // cairn #454 Phase 3 parity with Valkey `ff_record_spend`:
+            // dedup-hit always returns `AlreadyApplied` regardless of
+            // the original outcome (SET `dedup_key "1"` in Lua —
+            // outcome is not replayed). We still consult the stored
+            // outcome only to verify the row isn't an orphaned empty
+            // placeholder (in which case a prior in-flight caller
+            // crashed; we treat it the same — AlreadyApplied).
+            let _ = outcome; // placeholder read, semantics match Valkey
+            return Ok(ReportUsageResult::AlreadyApplied);
+        }
+        Some(args.idempotency_key.clone())
+    };
+
+    // ── Load policy row with `FOR NO KEY UPDATE` (same lock-mode
+    //    discipline as `report_usage_and_check_core`). ──
+    let policy_row = sqlx::query(
+        "SELECT policy_json FROM ff_budget_policy \
+         WHERE partition_key = $1 AND budget_id = $2 FOR NO KEY UPDATE",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let policy: JsonValue = match policy_row {
+        Some(r) => r.get("policy_json"),
+        None => JsonValue::Object(Default::default()),
+    };
+    let hard_limits = limits_from_policy(&policy, "hard_limits");
+    let soft_limits = limits_from_policy(&policy, "soft_limits");
+
+    // ── Hard-breach pre-check: ANY dim over hard-limit rejects the
+    //    whole call (no increments applied, ledger untouched). ──
+    let mut per_dim_current: BTreeMap<String, u64> = BTreeMap::new();
+    for (dim, delta) in args.deltas.iter() {
+        let dim_key = dim_row_key(dim);
+        sqlx::query(
+            "INSERT INTO ff_budget_usage \
+                 (partition_key, budget_id, dimensions_key, current_value, updated_at_ms) \
+             VALUES ($1, $2, $3, 0, $4) \
+             ON CONFLICT (partition_key, budget_id, dimensions_key) DO NOTHING",
+        )
+        .bind(partition_key)
+        .bind(&budget_id_str)
+        .bind(&dim_key)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let row = sqlx::query(
+            "SELECT current_value FROM ff_budget_usage \
+             WHERE partition_key = $1 AND budget_id = $2 AND dimensions_key = $3 \
+             FOR UPDATE",
+        )
+        .bind(partition_key)
+        .bind(&budget_id_str)
+        .bind(&dim_key)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+        let cur: i64 = row.get("current_value");
+        let new_val = (cur as u64).saturating_add(*delta);
+
+        if let Some(hard) = hard_limits.get(dim)
+            && *hard > 0
+            && new_val > *hard
+        {
+            sqlx::query(
+                "UPDATE ff_budget_policy \
+                 SET breach_count      = breach_count + 1, \
+                     last_breach_at_ms = $3, \
+                     last_breach_dim   = $4, \
+                     updated_at_ms     = $3 \
+                 WHERE partition_key = $1 AND budget_id = $2",
+            )
+            .bind(partition_key)
+            .bind(&budget_id_str)
+            .bind(now)
+            .bind(dim)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            let outcome = ReportUsageResult::HardBreach {
+                dimension: dim.clone(),
+                current_usage: cur as u64,
+                hard_limit: *hard,
+            };
+            if let Some(dk) = dedup_owned.as_deref() {
+                finalize_dedup(&mut tx, partition_key, dk, &outcome).await?;
+            }
+            tx.commit().await.map_err(map_sqlx_error)?;
+            return Ok(outcome);
+        }
+        per_dim_current.insert(dim.clone(), new_val);
+    }
+
+    // ── Apply increments + soft-breach detection + mirror into the
+    //    per-execution ledger (new 0020 table). ──
+    let mut soft_breach: Option<ReportUsageResult> = None;
+    for (dim, delta) in args.deltas.iter() {
+        let dim_key = dim_row_key(dim);
+        let new_val = per_dim_current[dim];
+        sqlx::query(
+            "UPDATE ff_budget_usage \
+             SET current_value = current_value + $1, updated_at_ms = $2 \
+             WHERE partition_key = $3 AND budget_id = $4 AND dimensions_key = $5",
+        )
+        .bind(*delta as i64)
+        .bind(now)
+        .bind(partition_key)
+        .bind(&budget_id_str)
+        .bind(&dim_key)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        // Per-execution ledger UPSERT — additive on repeat
+        // `record_spend` for the same (budget, exec, dim).
+        sqlx::query(
+            "INSERT INTO ff_budget_usage_by_exec \
+                 (partition_key, budget_id, execution_id, dimensions_key, \
+                  delta_total, updated_at_ms) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (partition_key, budget_id, execution_id, dimensions_key) \
+             DO UPDATE SET delta_total = ff_budget_usage_by_exec.delta_total + EXCLUDED.delta_total, \
+                           updated_at_ms = EXCLUDED.updated_at_ms",
+        )
+        .bind(partition_key)
+        .bind(&budget_id_str)
+        .bind(exec_uuid)
+        .bind(&dim_key)
+        .bind(*delta as i64)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if soft_breach.is_none()
+            && let Some(soft) = soft_limits.get(dim)
+            && *soft > 0
+            && new_val > *soft
+        {
+            soft_breach = Some(ReportUsageResult::SoftBreach {
+                dimension: dim.clone(),
+                current_usage: new_val,
+                soft_limit: *soft,
+            });
+        }
+    }
+
+    if soft_breach.is_some() {
+        sqlx::query(
+            "UPDATE ff_budget_policy \
+             SET soft_breach_count = soft_breach_count + 1, \
+                 updated_at_ms     = $3 \
+             WHERE partition_key = $1 AND budget_id = $2",
+        )
+        .bind(partition_key)
+        .bind(&budget_id_str)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    let outcome = soft_breach.unwrap_or(ReportUsageResult::Ok);
+    if let Some(dk) = dedup_owned.as_deref() {
+        finalize_dedup(&mut tx, partition_key, dk, &outcome).await?;
+    }
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(outcome)
+}
+
+/// cairn #454 Phase 4a — `EngineBackend::release_budget`.
+///
+/// Reverses a single execution's contribution to a budget aggregate
+/// using the per-exec ledger from 0020. Scans all
+/// `ff_budget_usage_by_exec` rows for (budget, exec), subtracts each
+/// `delta_total` from the matching aggregate (clamped at 0 — matches
+/// the Valkey `math.max(0, ...)` semantics), then DELETEs the ledger
+/// rows. Idempotent: empty ledger ⇒ no-op `Ok(())`.
+pub(crate) async fn release_budget_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    args: ReleaseBudgetArgs,
+) -> Result<(), EngineError> {
+    let partition = budget_partition(&args.budget_id, partition_config);
+    let partition_key: i16 = partition.index as i16;
+    let budget_id_str = args.budget_id.to_string();
+    let exec_uuid = exec_uuid(&args.execution_id)?;
+    let now = now_ms();
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    // Scan the ledger under `FOR UPDATE` so concurrent
+    // `record_spend` on the same (budget, exec, dim) serialises
+    // on the row lock rather than racing the DELETE.
+    let rows = sqlx::query(
+        "SELECT dimensions_key, delta_total \
+         FROM ff_budget_usage_by_exec \
+         WHERE partition_key = $1 AND budget_id = $2 AND execution_id = $3 \
+         FOR UPDATE",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .bind(exec_uuid)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if rows.is_empty() {
+        // No prior record_spend for this execution ⇒ nothing to
+        // reverse. Idempotent no-op, matching Valkey's behaviour when
+        // `ff:budget:...:by_exec:<exec>` doesn't exist.
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(());
+    }
+
+    for row in &rows {
+        let dim: String = row.get("dimensions_key");
+        let delta: i64 = row.get("delta_total");
+        sqlx::query(
+            "UPDATE ff_budget_usage \
+             SET current_value = GREATEST(0::bigint, current_value - $1), \
+                 updated_at_ms = $2 \
+             WHERE partition_key = $3 AND budget_id = $4 AND dimensions_key = $5",
+        )
+        .bind(delta)
+        .bind(now)
+        .bind(partition_key)
+        .bind(&budget_id_str)
+        .bind(&dim)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    sqlx::query(
+        "DELETE FROM ff_budget_usage_by_exec \
+         WHERE partition_key = $1 AND budget_id = $2 AND execution_id = $3",
+    )
+    .bind(partition_key)
+    .bind(&budget_id_str)
+    .bind(exec_uuid)
     .execute(&mut *tx)
     .await
     .map_err(map_sqlx_error)?;

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1200,6 +1200,26 @@ impl EngineBackend for PostgresBackend {
         budget::report_usage_admin_impl(&self.pool, &self.partition_config, budget_id, args).await
     }
 
+    // ── cairn #454 Phase 4a — per-execution ledger (option A) ────────
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.record_spend", skip_all)]
+    async fn record_spend(
+        &self,
+        args: ff_core::contracts::RecordSpendArgs,
+    ) -> Result<ReportUsageResult, EngineError> {
+        budget::record_spend_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.release_budget", skip_all)]
+    async fn release_budget(
+        &self,
+        args: ff_core::contracts::ReleaseBudgetArgs,
+    ) -> Result<(), EngineError> {
+        budget::release_budget_impl(&self.pool, &self.partition_config, args).await
+    }
+
     // ── HMAC secret rotation (v0.7 migration-master Q4) ──
     //
     // Wave 4 replaces this stub with a single INSERT into

--- a/crates/ff-backend-postgres/tests/typed_record_spend.rs
+++ b/crates/ff-backend-postgres/tests/typed_record_spend.rs
@@ -1,0 +1,262 @@
+//! cairn #454 Phase 4a — live-Postgres coverage of the typed
+//! `EngineBackend::record_spend` body. Parity with the Valkey tests in
+//! `crates/ff-backend-valkey/tests/typed_record_spend.rs` (PR #464):
+//!
+//! 1. `Ok` on first application under the hard limit (mirror to
+//!    `ff_budget_usage_by_exec`).
+//! 2. `SoftBreach` when the increment crosses the soft limit (still
+//!    applied — soft is advisory).
+//! 3. `HardBreach` when the increment would cross the hard limit
+//!    (rejected — counter + ledger unchanged).
+//! 4. `AlreadyApplied` on a replay with the same `idempotency_key`.
+//!
+//! Ignore-gated (live Postgres at `FF_PG_TEST_URL`) following
+//! `pg_budget_admin.rs`. Run via:
+//!
+//! ```text
+//! FF_PG_TEST_URL=postgres://... cargo test -p ff-backend-postgres \
+//!     --test typed_record_spend -- --ignored --test-threads=1
+//! ```
+//!
+//! CI gates run with `FF_PG_TEST_URL` set; local sandboxed runs without
+//! PG just print "skipped" via `setup_or_skip`.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{
+    CreateBudgetArgs, CreateBudgetResult, RecordSpendArgs, ReportUsageResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{BudgetId, ExecutionId, LaneId, TimestampMs};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+
+const LANE: &str = "record-spend-pg-test-lane";
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+fn backend(pool: PgPool) -> Arc<PostgresBackend> {
+    PostgresBackend::from_pool(pool, PartitionConfig::default())
+}
+
+fn partition_config() -> PartitionConfig {
+    PartitionConfig::default()
+}
+
+/// Build a `CreateBudgetArgs` with the provided `(dim, hard, soft)`
+/// triples. Matches the shape used in `pg_budget_admin.rs`.
+fn budget_args(bid: &BudgetId, dims: &[(&str, u64, u64)]) -> CreateBudgetArgs {
+    CreateBudgetArgs {
+        budget_id: bid.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-1".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms: 0,
+        dimensions: dims.iter().map(|(d, _, _)| (*d).to_string()).collect(),
+        hard_limits: dims.iter().map(|(_, h, _)| *h).collect(),
+        soft_limits: dims.iter().map(|(_, _, s)| *s).collect(),
+        now: TimestampMs(now_ms()),
+    }
+}
+
+fn spend_args(
+    bid: &BudgetId,
+    exec: &ExecutionId,
+    deltas: &[(&str, u64)],
+    idem: &str,
+) -> RecordSpendArgs {
+    let mut m: BTreeMap<String, u64> = BTreeMap::new();
+    for (k, v) in deltas {
+        m.insert((*k).to_owned(), *v);
+    }
+    RecordSpendArgs::new(bid.clone(), exec.clone(), m, idem.to_owned())
+}
+
+async fn ledger_delta(pool: &PgPool, bid: &BudgetId, eid: &ExecutionId, dim: &str) -> Option<i64> {
+    use ff_core::partition::budget_partition;
+    use sqlx::Row;
+    let partition_key: i16 = budget_partition(bid, &partition_config()).index as i16;
+    let s = eid.as_str();
+    let uuid_str = &s[s.rfind("}:").unwrap() + 2..];
+    let exec_uuid = uuid::Uuid::parse_str(uuid_str).unwrap();
+    let row = sqlx::query(
+        "SELECT delta_total FROM ff_budget_usage_by_exec \
+         WHERE partition_key=$1 AND budget_id=$2 AND execution_id=$3 AND dimensions_key=$4",
+    )
+    .bind(partition_key)
+    .bind(bid.to_string())
+    .bind(exec_uuid)
+    .bind(dim)
+    .fetch_optional(pool)
+    .await
+    .unwrap();
+    row.map(|r| r.get::<i64, _>("delta_total"))
+}
+
+/// Path 1 — happy-path `Ok` under the hard limit with ledger mirror.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn record_spend_ok_path() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let r = be
+        .create_budget(budget_args(
+            &bid,
+            &[("tokens", 100, 50), ("cost_cents", 1000, 500)],
+        ))
+        .await
+        .expect("create_budget");
+    assert!(matches!(r, CreateBudgetResult::Created { .. }));
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let r = be
+        .record_spend(spend_args(
+            &bid,
+            &exec,
+            &[("tokens", 10), ("cost_cents", 20)],
+            "ok-1",
+        ))
+        .await
+        .expect("record_spend");
+    assert!(matches!(r, ReportUsageResult::Ok), "got {r:?}");
+
+    // Ledger mirrored.
+    assert_eq!(ledger_delta(&pool, &bid, &exec, "tokens").await, Some(10));
+    assert_eq!(ledger_delta(&pool, &bid, &exec, "cost_cents").await, Some(20));
+}
+
+/// Path 2 — idempotent replay returns `AlreadyApplied` and does NOT
+/// double-increment aggregate or ledger.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn record_spend_idempotent_replay() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be
+        .create_budget(budget_args(&bid, &[("tokens", 100, 50)]))
+        .await
+        .expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let args = spend_args(&bid, &exec, &[("tokens", 7)], "replay-me");
+    let r = be.record_spend(args.clone()).await.expect("first");
+    assert!(matches!(r, ReportUsageResult::Ok), "got {r:?}");
+
+    let r2 = be.record_spend(args).await.expect("replay");
+    assert!(matches!(r2, ReportUsageResult::AlreadyApplied), "got {r2:?}");
+
+    // Ledger unchanged (still 7, not 14).
+    assert_eq!(ledger_delta(&pool, &bid, &exec, "tokens").await, Some(7));
+}
+
+/// Path 3 — soft-breach applies the increment AND reports the breach.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn record_spend_soft_breach() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be
+        .create_budget(budget_args(&bid, &[("tokens", 100, 50)]))
+        .await
+        .expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    // current=0, +60 = 60 > soft(50), still < hard(100).
+    let r = be
+        .record_spend(spend_args(&bid, &exec, &[("tokens", 60)], "soft-1"))
+        .await
+        .expect("soft");
+    match r {
+        ReportUsageResult::SoftBreach {
+            dimension,
+            current_usage,
+            soft_limit,
+        } => {
+            assert_eq!(dimension, "tokens");
+            assert_eq!(current_usage, 60);
+            assert_eq!(soft_limit, 50);
+        }
+        other => panic!("expected SoftBreach, got {other:?}"),
+    }
+    // Ledger reflects the applied increment.
+    assert_eq!(ledger_delta(&pool, &bid, &exec, "tokens").await, Some(60));
+}
+
+/// Path 4 — hard-breach does NOT apply the increment and does NOT
+/// touch the ledger.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn record_spend_hard_breach() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be
+        .create_budget(budget_args(&bid, &[("tokens", 100, 50)]))
+        .await
+        .expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    // Seed to 40.
+    let _ = be
+        .record_spend(spend_args(&bid, &exec, &[("tokens", 40)], "hard-seed"))
+        .await
+        .expect("seed");
+
+    // +80 = 120 > hard(100) — reject.
+    let r = be
+        .record_spend(spend_args(&bid, &exec, &[("tokens", 80)], "hard-1"))
+        .await
+        .expect("hard");
+    match r {
+        ReportUsageResult::HardBreach {
+            dimension,
+            current_usage,
+            hard_limit,
+        } => {
+            assert_eq!(dimension, "tokens");
+            assert_eq!(current_usage, 40);
+            assert_eq!(hard_limit, 100);
+        }
+        other => panic!("expected HardBreach, got {other:?}"),
+    }
+
+    // Ledger still at the seed value — 40, not 120.
+    assert_eq!(ledger_delta(&pool, &bid, &exec, "tokens").await, Some(40));
+}

--- a/crates/ff-backend-postgres/tests/typed_release_budget.rs
+++ b/crates/ff-backend-postgres/tests/typed_release_budget.rs
@@ -1,0 +1,254 @@
+//! cairn #454 Phase 4a — live-Postgres coverage of the typed
+//! `EngineBackend::release_budget` body (option-A per-execution
+//! ledger). Parity with the Valkey tests in
+//! `crates/ff-backend-valkey/tests/typed_release_budget.rs` (PR #464):
+//!
+//! 1. A record_spend followed by release returns the aggregate to 0.
+//! 2. Multiple record_spend calls accumulate; one release reverses them.
+//! 3. Release on an execution that never recorded is an idempotent no-op.
+//! 4. Release itself is idempotent (safe to call twice).
+//! 5. Releasing one execution does not touch another's attribution.
+//!
+//! Ignore-gated (live Postgres at `FF_PG_TEST_URL`).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{CreateBudgetArgs, RecordSpendArgs, ReleaseBudgetArgs};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{BudgetId, ExecutionId, LaneId, TimestampMs};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use sqlx::Row;
+
+const LANE: &str = "release-budget-pg-test-lane";
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect to FF_PG_TEST_URL");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations clean");
+    Some(pool)
+}
+
+fn backend(pool: PgPool) -> Arc<PostgresBackend> {
+    PostgresBackend::from_pool(pool, PartitionConfig::default())
+}
+
+fn partition_config() -> PartitionConfig {
+    PartitionConfig::default()
+}
+
+fn budget_args(bid: &BudgetId) -> CreateBudgetArgs {
+    CreateBudgetArgs {
+        budget_id: bid.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-1".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms: 0,
+        dimensions: vec!["tokens".into()],
+        // High ceiling so multi-spend paths don't breach.
+        hard_limits: vec![1_000_000],
+        soft_limits: vec![999_999],
+        now: TimestampMs(now_ms()),
+    }
+}
+
+fn spend(
+    bid: &BudgetId,
+    exec: &ExecutionId,
+    tokens: u64,
+    idem: &str,
+) -> RecordSpendArgs {
+    let mut m = BTreeMap::new();
+    m.insert("tokens".to_string(), tokens);
+    RecordSpendArgs::new(bid.clone(), exec.clone(), m, idem.to_owned())
+}
+
+async fn aggregate_tokens(pool: &PgPool, bid: &BudgetId) -> i64 {
+    use ff_core::partition::budget_partition;
+    let partition_key: i16 = budget_partition(bid, &partition_config()).index as i16;
+    let row = sqlx::query(
+        "SELECT current_value FROM ff_budget_usage \
+         WHERE partition_key=$1 AND budget_id=$2 AND dimensions_key='tokens'",
+    )
+    .bind(partition_key)
+    .bind(bid.to_string())
+    .fetch_optional(pool)
+    .await
+    .unwrap();
+    row.map(|r| r.get::<i64, _>("current_value")).unwrap_or(0)
+}
+
+async fn ledger_row_count(pool: &PgPool, bid: &BudgetId, exec: &ExecutionId) -> i64 {
+    use ff_core::partition::budget_partition;
+    let partition_key: i16 = budget_partition(bid, &partition_config()).index as i16;
+    let s = exec.as_str();
+    let uuid_str = &s[s.rfind("}:").unwrap() + 2..];
+    let exec_uuid = uuid::Uuid::parse_str(uuid_str).unwrap();
+    let row = sqlx::query(
+        "SELECT COUNT(*) AS c FROM ff_budget_usage_by_exec \
+         WHERE partition_key=$1 AND budget_id=$2 AND execution_id=$3",
+    )
+    .bind(partition_key)
+    .bind(bid.to_string())
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    row.get::<i64, _>("c")
+}
+
+/// 1 — record 5 tokens, release, aggregate back to 0, ledger gone.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn release_after_record_zeros_aggregate() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be.create_budget(budget_args(&bid)).await.expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = be
+        .record_spend(spend(&bid, &exec, 5, "r-1"))
+        .await
+        .expect("record");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 5);
+    assert_eq!(ledger_row_count(&pool, &bid, &exec).await, 1);
+
+    be.release_budget(ReleaseBudgetArgs::new(bid.clone(), exec.clone()))
+        .await
+        .expect("release");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 0);
+    assert_eq!(ledger_row_count(&pool, &bid, &exec).await, 0);
+}
+
+/// 2 — multiple record_spend calls accumulate on the ledger; one
+/// release reverses the full accumulation.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn release_reverses_accumulated_spends() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be.create_budget(budget_args(&bid)).await.expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = be.record_spend(spend(&bid, &exec, 3, "a")).await.expect("a");
+    let _ = be.record_spend(spend(&bid, &exec, 7, "b")).await.expect("b");
+    let _ = be.record_spend(spend(&bid, &exec, 2, "c")).await.expect("c");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 12);
+
+    be.release_budget(ReleaseBudgetArgs::new(bid.clone(), exec.clone()))
+        .await
+        .expect("release");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 0);
+    assert_eq!(ledger_row_count(&pool, &bid, &exec).await, 0);
+}
+
+/// 3 — release on an execution that never recorded is an idempotent
+/// no-op (aggregate untouched).
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn release_without_prior_record_is_noop() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be.create_budget(budget_args(&bid)).await.expect("create_budget");
+
+    // Seed the aggregate with a DIFFERENT execution so we can prove
+    // the no-op doesn't touch it.
+    let seeded = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = be
+        .record_spend(spend(&bid, &seeded, 9, "seed"))
+        .await
+        .expect("seed");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 9);
+
+    let ghost = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    be.release_budget(ReleaseBudgetArgs::new(bid.clone(), ghost))
+        .await
+        .expect("noop release");
+    // Aggregate unchanged.
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 9);
+}
+
+/// 4 — release is itself idempotent: calling twice leaves aggregate
+/// at 0 and is safe.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn release_is_idempotent() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be.create_budget(budget_args(&bid)).await.expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = be
+        .record_spend(spend(&bid, &exec, 4, "x"))
+        .await
+        .expect("record");
+    be.release_budget(ReleaseBudgetArgs::new(bid.clone(), exec.clone()))
+        .await
+        .expect("release 1");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 0);
+
+    // Second release — no-op.
+    be.release_budget(ReleaseBudgetArgs::new(bid.clone(), exec.clone()))
+        .await
+        .expect("release 2 (noop)");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 0);
+}
+
+/// 5 — releasing one execution does not touch another's attribution.
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn release_isolated_between_executions() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let be = backend(pool.clone());
+    let bid = BudgetId::new();
+    let _ = be.create_budget(budget_args(&bid)).await.expect("create_budget");
+
+    let e1 = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let e2 = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = be.record_spend(spend(&bid, &e1, 5, "e1")).await.expect("e1");
+    let _ = be.record_spend(spend(&bid, &e2, 8, "e2")).await.expect("e2");
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 13);
+
+    be.release_budget(ReleaseBudgetArgs::new(bid.clone(), e1.clone()))
+        .await
+        .expect("release e1");
+    // Only e1's 5 reversed; e2's 8 stays.
+    assert_eq!(aggregate_tokens(&pool, &bid).await, 8);
+    assert_eq!(ledger_row_count(&pool, &bid, &e1).await, 0);
+    assert_eq!(ledger_row_count(&pool, &bid, &e2).await, 1);
+}

--- a/crates/ff-backend-sqlite/migrations/0020_budget_usage_by_exec.sql
+++ b/crates/ff-backend-sqlite/migrations/0020_budget_usage_by_exec.sql
@@ -1,0 +1,30 @@
+-- RFC-023 — SQLite port of
+-- `crates/ff-backend-postgres/migrations/0020_budget_usage_by_exec.sql`.
+--
+-- cairn #454 Phase 4a/5 — per-execution budget ledger (option A).
+-- Flat table (no HASH partitioning, per RFC-023 §4.1 A3 single-writer).
+-- uuid → TEXT; bigint → INTEGER; smallint → INTEGER.
+
+CREATE TABLE ff_budget_usage_by_exec (
+    partition_key   INTEGER NOT NULL,
+    budget_id       TEXT    NOT NULL,
+    execution_id    TEXT    NOT NULL,
+    dimensions_key  TEXT    NOT NULL,
+    delta_total     INTEGER NOT NULL DEFAULT 0,
+    updated_at_ms   INTEGER NOT NULL,
+    PRIMARY KEY (partition_key, budget_id, execution_id, dimensions_key)
+);
+
+-- release_budget scan index: given (partition_key, budget_id,
+-- execution_id), list all dimensions with delta_total for the
+-- subsequent UPDATE (aggregate) + DELETE (ledger) pair.
+CREATE INDEX ff_budget_usage_by_exec_release_idx
+    ON ff_budget_usage_by_exec (partition_key, budget_id, execution_id);
+
+INSERT INTO ff_migration_annotation (version, name, applied_at_ms, backward_compatible)
+VALUES (
+    20,
+    '0020_budget_usage_by_exec',
+    CAST(strftime('%s','now') AS INTEGER) * 1000,
+    1
+);


### PR DESCRIPTION
## Summary

Postgres parity with Valkey PR #464 for cairn #454 **option A** (per-execution ledger). Ships PG bodies for `EngineBackend::record_spend` + `EngineBackend::release_budget` so both backends expose identical semantics, bundled in one PR per cairn decision on #454.

Phase 4b (`deliver_approval_signal`) and 4c (`issue_grant_and_claim`) on PG remain as follow-ups.

## Schema

- **New migration `0020_budget_usage_by_exec.sql`** — adds `ff_budget_usage_by_exec(partition_key, budget_id, execution_id, dimensions_key, delta_total, updated_at_ms)` partitioned 256-way by `HASH(partition_key)`, mirroring `ff_budget_usage` / `ff_budget_policy`.
  - `execution_id` typed as `uuid` (the bare UUID suffix of `{fp:N}:<uuid>`, not the wrapped string).
  - Scan index on `(partition_key, budget_id, execution_id)` for the release-path `SELECT FOR UPDATE`.
  - Additive, `backward_compatible=true`.

## Implementation (`src/budget.rs`)

- `record_spend_impl` — reuses `ff_budget_usage_dedup` (caller-supplied `idempotency_key` is the dedup key); hard-breach pre-check under `FOR NO KEY UPDATE` on the policy row + `FOR UPDATE` on each usage row; after the aggregate UPSERT, mirrors deltas into `ff_budget_usage_by_exec` with additive ON CONFLICT UPDATE so repeat-record for the same `(budget, exec, dim)` accumulates. Dedup-replay returns `AlreadyApplied` (Valkey parity — Lua `ff_record_spend` returns ALREADY_APPLIED regardless of original outcome).
- `release_budget_impl` — `SELECT FOR UPDATE` ledger rows for `(budget, exec)`, `UPDATE ff_budget_usage SET current_value = GREATEST(0, current_value - delta)` per dim, `DELETE` the ledger rows. Empty ledger ⇒ idempotent `Ok(())`. Single RC tx; row-level locking suffices.

## Wire-up

Trait overrides on `impl EngineBackend for PostgresBackend` behind `#[cfg(feature = "core")]` with tracing spans `pg.record_spend` / `pg.release_budget`.

## Tests

- `tests/typed_record_spend.rs` — 4 `#[ignore]`+env-gated tests (`FF_PG_TEST_URL`): Ok with ledger mirror; SoftBreach applies; HardBreach rejects + ledger untouched; idempotent replay returns AlreadyApplied without double-writing ledger.
- `tests/typed_release_budget.rs` — 5 tests: release zeros aggregate + removes ledger; multi-record accumulation reverses in one release; release without prior record is no-op; release is idempotent; isolated between executions.

## Verify

- `cargo check --workspace` + `cargo clippy -p ff-backend-postgres -- -D warnings` clean.
- `FF_PG_TEST_URL=postgres://... cargo test -p ff-backend-postgres --test typed_record_spend --test typed_release_budget -- --ignored --test-threads=1` → **9/9 green** against live Postgres 17.

## Test plan

- [ ] CI green on all existing tests (no behavior change for pre-existing trait methods).
- [ ] CI runs ignored PG integration tests with `FF_PG_TEST_URL` set.
- [ ] Cairn migration applies cleanly (smoke against a fresh DB).

Refs cairn #454 Phase 4a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)