### PR TITLE
feat(ff-backend-postgres): #454 Phase 4b — deliver_approval_signal PG body

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -34,7 +34,8 @@ use ff_core::contracts::{
     AddExecutionToFlowArgs, AddExecutionToFlowResult, ApplyDependencyToChildArgs,
     ApplyDependencyToChildResult, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
     CreateExecutionArgs, CreateExecutionResult, CreateFlowArgs, CreateFlowResult,
-    DeliverSignalArgs, DeliverSignalResult, EdgeDependencyPolicy, EdgeDirection, EdgeSnapshot,
+    DeliverApprovalSignalArgs, DeliverSignalArgs, DeliverSignalResult, EdgeDependencyPolicy,
+    EdgeDirection, EdgeSnapshot,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs,
     ListPendingWaitpointsResult, ListSuspendedPage, SetEdgeGroupPolicyResult,
     StageDependencyEdgeArgs, StageDependencyEdgeResult,
@@ -778,6 +779,15 @@ impl EngineBackend for PostgresBackend {
         args: DeliverSignalArgs,
     ) -> Result<DeliverSignalResult, EngineError> {
         suspend_ops::deliver_signal_impl(&self.pool, &self.partition_config, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.deliver_approval_signal", skip_all)]
+    async fn deliver_approval_signal(
+        &self,
+        args: DeliverApprovalSignalArgs,
+    ) -> Result<DeliverSignalResult, EngineError> {
+        suspend_ops::deliver_approval_signal_impl(&self.pool, &self.partition_config, args).await
     }
 
     #[cfg(feature = "core")]

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -26,16 +26,17 @@ use ff_core::backend::{
 };
 use ff_core::contracts::{
     AdditionalWaitpointBinding, ClaimResumedExecutionArgs, ClaimResumedExecutionResult,
-    ClaimedResumedExecution, CompositeBody, DeliverSignalArgs, DeliverSignalResult,
-    ListPendingWaitpointsArgs, ListPendingWaitpointsResult, PendingWaitpointInfo, ResumeCondition,
-    SignalMatcher, SuspendArgs, SuspendOutcome, SuspendOutcomeDetails, WaitpointBinding,
+    ClaimedResumedExecution, CompositeBody, DeliverApprovalSignalArgs, DeliverSignalArgs,
+    DeliverSignalResult, ListPendingWaitpointsArgs, ListPendingWaitpointsResult,
+    PendingWaitpointInfo, ResumeCondition, SignalMatcher, SuspendArgs, SuspendOutcome,
+    SuspendOutcomeDetails, WaitpointBinding,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, ValidationKind};
 use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
 use ff_core::partition::PartitionConfig;
 use ff_core::types::{
-    AttemptId, AttemptIndex, ExecutionId, LeaseEpoch, LeaseFence, SignalId, SuspensionId,
-    TimestampMs, WaitpointId,
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseFence, SignalId, SuspensionId,
+    TimestampMs, WaitpointId, WaitpointToken,
 };
 use serde_json::{json, Value as JsonValue};
 use sqlx::{PgPool, Postgres, Transaction};
@@ -1318,4 +1319,94 @@ pub(crate) async fn read_waitpoint_token_impl(
     .await
     .map_err(map_sqlx_error)?;
     Ok(row.map(|(t,)| t).filter(|s| !s.is_empty()))
+}
+
+// ─── deliver_approval_signal ─────────────────────────────────────────────
+//
+// Cairn #454 Phase 4b (Postgres parity with the Valkey PR #465 body).
+//
+// The operator path never carries the waitpoint HMAC token — the
+// backend reads it server-side from `ff_waitpoint_pending`, verifies
+// the caller's `lane_id` matches `ff_exec_core.lane_id`, composes a
+// `DeliverSignalArgs` (signal_category="approval" / source_type=
+// "operator" / target_scope="execution" / idempotency_key=
+// "approval:<signal>:<suffix>"), and dispatches through the shared
+// `deliver_signal_impl`. The inner body re-verifies the HMAC token
+// we just read, and its SERIALIZABLE tx enforces dedup / capacity
+// invariants unchanged.
+
+pub(crate) async fn deliver_approval_signal_impl(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    args: DeliverApprovalSignalArgs,
+) -> Result<DeliverSignalResult, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+
+    // 1. Authoritative lane_id comes from exec_core, not the caller.
+    //    Matches the Valkey HGET lane_id guard (PR #465 Copilot review).
+    let lane_row: Option<(String,)> = sqlx::query_as(
+        "SELECT lane_id FROM ff_exec_core \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    let authoritative_lane = LaneId::new(
+        lane_row
+            .map(|(s,)| s)
+            .unwrap_or_else(|| "default".to_owned()),
+    );
+    if authoritative_lane.as_str() != args.lane_id.as_str() {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!(
+                "lane_mismatch: args.lane_id={} exec_core.lane_id={}",
+                args.lane_id.as_str(),
+                authoritative_lane.as_str()
+            ),
+        });
+    }
+
+    // 2. Server-side token lookup. Missing row → NotFound(waitpoint).
+    let partition = ff_core::partition::Partition {
+        family: ff_core::partition::PartitionFamily::Execution,
+        index: part as u16,
+    };
+    let pkey = ff_core::partition::PartitionKey::from(&partition);
+    let token_str = read_waitpoint_token_impl(pool, &pkey, &args.waitpoint_id)
+        .await?
+        .ok_or(EngineError::NotFound {
+            entity: "waitpoint",
+        })?;
+
+    // 3. Compose DeliverSignalArgs and dispatch. Single `now` sample
+    //    reused for `created_at` + `now` (PR #465 gemini review).
+    let now = TimestampMs::now();
+    let idempotency_key =
+        format!("approval:{}:{}", args.signal_name, args.idempotency_suffix);
+    let ds = DeliverSignalArgs {
+        execution_id: args.execution_id.clone(),
+        waitpoint_id: args.waitpoint_id.clone(),
+        signal_id: SignalId::new(),
+        signal_name: args.signal_name.clone(),
+        signal_category: "approval".to_owned(),
+        source_type: "operator".to_owned(),
+        source_identity: String::new(),
+        payload: None,
+        payload_encoding: None,
+        correlation_id: None,
+        idempotency_key: Some(idempotency_key),
+        target_scope: "execution".to_owned(),
+        created_at: Some(now),
+        dedup_ttl_ms: Some(args.signal_dedup_ttl_ms),
+        resume_delay_ms: None,
+        max_signals_per_execution: args.max_signals_per_execution,
+        signal_maxlen: args.maxlen,
+        waitpoint_token: WaitpointToken::new(token_str),
+        now,
+    };
+
+    deliver_signal_impl(pool, partition_config, ds).await
 }

--- a/crates/ff-backend-postgres/src/suspend_ops.rs
+++ b/crates/ff-backend-postgres/src/suspend_ops.rs
@@ -1353,11 +1353,14 @@ pub(crate) async fn deliver_approval_signal_impl(
     .fetch_optional(pool)
     .await
     .map_err(map_sqlx_error)?;
-    let authoritative_lane = LaneId::new(
-        lane_row
-            .map(|(s,)| s)
-            .unwrap_or_else(|| "default".to_owned()),
-    );
+    let authoritative_lane = match lane_row {
+        Some((s,)) => LaneId::new(s),
+        None => {
+            return Err(EngineError::NotFound {
+                entity: "execution",
+            });
+        }
+    };
     if authoritative_lane.as_str() != args.lane_id.as_str() {
         return Err(EngineError::Validation {
             kind: ValidationKind::InvalidInput,

--- a/crates/ff-backend-postgres/tests/typed_deliver_approval_signal.rs
+++ b/crates/ff-backend-postgres/tests/typed_deliver_approval_signal.rs
@@ -1,0 +1,288 @@
+//! Cairn #454 Phase 4b — integration tests for `EngineBackend::
+//! deliver_approval_signal` on Postgres.
+//!
+//! Four `#[ignore]` + `FF_PG_TEST_URL`-gated scenarios that mirror
+//! the Valkey coverage landed in PR #465:
+//!
+//! * approved path — operator delivers `"approved"`, execution
+//!   resumes (matching waitpoint signal, resume-condition satisfied).
+//! * rejected path — operator delivers `"rejected"` without a
+//!   matching condition, signal is appended to the waitpoint but
+//!   does not resume.
+//! * missing waitpoint — unknown `waitpoint_id` → `NotFound`.
+//! * lane mismatch — caller lane ≠ `ff_exec_core.lane_id` →
+//!   `Validation(InvalidInput, "lane_mismatch: ...")`.
+//!
+//! The fixture pattern (per-test `ffpg_test_<uuid>` schema for the
+//! global HMAC keystore, canonical partitioned tables in `public`)
+//! matches `tests/suspend_signal.rs` — same `setup_or_skip` +
+//! `setup_exec_or_skip` shape.
+
+use ff_backend_postgres::signal::rotate_waitpoint_hmac_secret_all_impl;
+use ff_backend_postgres::PostgresBackend;
+use ff_core::backend::{BackendTag, Handle, HandleKind};
+use ff_core::contracts::{
+    DeliverApprovalSignalArgs, DeliverSignalResult, ResumeCondition, ResumePolicy,
+    RotateWaitpointHmacSecretAllArgs, SignalMatcher, SuspendArgs, SuspendOutcome,
+    SuspensionReasonCode, WaitpointBinding,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::handle_codec::{encode as encode_opaque, HandlePayload};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{
+    AttemptId, AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, SuspensionId, TimestampMs,
+    WaitpointId, WorkerInstanceId,
+};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+// Per-test isolation: apply migrations to `public`, create a
+// throwaway schema that shadows `ff_waitpoint_hmac` so parallel tests
+// don't race on the global kid rotation table.
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let bootstrap = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect");
+    ff_backend_postgres::apply_migrations(&bootstrap)
+        .await
+        .expect("migrate");
+    let schema = format!("ffpg_test_{}", Uuid::new_v4().simple());
+    sqlx::query(&format!("CREATE SCHEMA {schema}"))
+        .execute(&bootstrap)
+        .await
+        .expect("create schema");
+    sqlx::query(&format!(
+        "CREATE TABLE {schema}.ff_waitpoint_hmac \
+         (LIKE public.ff_waitpoint_hmac INCLUDING ALL)"
+    ))
+    .execute(&bootstrap)
+    .await
+    .expect("shadow ff_waitpoint_hmac");
+    bootstrap.close().await;
+
+    let schema_for_hook = schema.clone();
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .after_connect(move |conn, _meta| {
+            let schema = schema_for_hook.clone();
+            Box::pin(async move {
+                sqlx::query(&format!("SET search_path TO {schema}, public"))
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(&url)
+        .await
+        .expect("connect");
+    Some(pool)
+}
+
+struct Fixture {
+    backend: Arc<dyn EngineBackend>,
+    #[allow(dead_code)]
+    pool: PgPool,
+    exec_id: ExecutionId,
+    handle: Handle,
+    lane: LaneId,
+}
+
+async fn setup_exec_or_skip() -> Option<Fixture> {
+    let pool = setup_or_skip().await?;
+    rotate_waitpoint_hmac_secret_all_impl(
+        &pool,
+        RotateWaitpointHmacSecretAllArgs::new("kid-approval-1", "ab".repeat(32), 0),
+        1_000_000,
+    )
+    .await
+    .unwrap();
+
+    let lane = LaneId::new("default");
+    let exec_id = ExecutionId::solo(&lane, &PartitionConfig::default());
+    let part = exec_id.partition() as i16;
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+
+    let now = TimestampMs::now().0;
+    sqlx::query(
+        "INSERT INTO ff_exec_core \
+           (partition_key, execution_id, lane_id, attempt_index, \
+            lifecycle_phase, ownership_state, eligibility_state, \
+            public_state, attempt_state, created_at_ms) \
+         VALUES ($1, $2, $3, 0, 'active', 'leased', 'not_applicable', \
+                 'running', 'running_attempt', $4)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(lane.as_str())
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert exec_core");
+
+    let attempt_index = AttemptIndex::new(0);
+    let lease_epoch = LeaseEpoch(1);
+    sqlx::query(
+        "INSERT INTO ff_attempt \
+           (partition_key, execution_id, attempt_index, worker_id, \
+            worker_instance_id, lease_epoch, lease_expires_at_ms, started_at_ms) \
+         VALUES ($1, $2, 0, 'w1', 'wi1', 1, $3, $4)",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now + 30_000)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert attempt");
+
+    let payload = HandlePayload::new(
+        exec_id.clone(),
+        attempt_index,
+        AttemptId::new(),
+        LeaseId::new(),
+        lease_epoch,
+        30_000,
+        lane.clone(),
+        WorkerInstanceId::new("wi1"),
+    );
+    let opaque = encode_opaque(BackendTag::Postgres, &payload);
+    let handle = Handle::new(BackendTag::Postgres, HandleKind::Fresh, opaque);
+
+    let backend = PostgresBackend::from_pool(pool.clone(), PartitionConfig::default())
+        as Arc<dyn EngineBackend>;
+
+    Some(Fixture {
+        backend,
+        pool,
+        exec_id,
+        handle,
+        lane,
+    })
+}
+
+async fn suspend_on(fx: &Fixture, wp_key: &str, signal_name: &str) -> WaitpointId {
+    let wp_id = WaitpointId::new();
+    let binding = WaitpointBinding::Fresh {
+        waitpoint_id: wp_id.clone(),
+        waitpoint_key: wp_key.to_owned(),
+    };
+    let cond = ResumeCondition::Single {
+        waitpoint_key: wp_key.to_owned(),
+        matcher: SignalMatcher::ByName(signal_name.to_owned()),
+    };
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        binding,
+        cond,
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::now(),
+    );
+    let outcome = fx.backend.suspend(&fx.handle, args).await.expect("suspend");
+    assert!(matches!(outcome, SuspendOutcome::Suspended { .. }));
+    wp_id
+}
+
+fn approval_args(
+    exec_id: &ExecutionId,
+    lane: &LaneId,
+    wp_id: &WaitpointId,
+    signal_name: &str,
+    suffix: &str,
+) -> DeliverApprovalSignalArgs {
+    DeliverApprovalSignalArgs::new(
+        exec_id.clone(),
+        lane.clone(),
+        wp_id.clone(),
+        signal_name,
+        suffix,
+        60_000,
+        None,
+        None,
+    )
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn approved_path_resumes_execution() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+    let wp_id = suspend_on(&fx, "wpk:approval:ok", "approved").await;
+    let args = approval_args(&fx.exec_id, &fx.lane, &wp_id, "approved", "dec-1");
+    let out = fx
+        .backend
+        .deliver_approval_signal(args)
+        .await
+        .expect("deliver_approval_signal ok");
+    match out {
+        DeliverSignalResult::Accepted { effect, .. } => {
+            assert_eq!(effect, "resume_condition_satisfied");
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn rejected_path_appends_without_resume() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+    // Condition requires "approved"; delivering "rejected" should be
+    // appended but does not satisfy the resume condition.
+    let wp_id = suspend_on(&fx, "wpk:approval:reject", "approved").await;
+    let args = approval_args(&fx.exec_id, &fx.lane, &wp_id, "rejected", "dec-1");
+    let out = fx
+        .backend
+        .deliver_approval_signal(args)
+        .await
+        .expect("deliver_approval_signal ok");
+    match out {
+        DeliverSignalResult::Accepted { effect, .. } => {
+            assert_eq!(effect, "appended_to_waitpoint");
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn missing_waitpoint_returns_not_found() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+    let bogus = WaitpointId::new();
+    let args = approval_args(&fx.exec_id, &fx.lane, &bogus, "approved", "dec-1");
+    match fx.backend.deliver_approval_signal(args).await.unwrap_err() {
+        EngineError::NotFound { entity } => assert_eq!(entity, "waitpoint"),
+        other => panic!("expected NotFound(waitpoint), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn lane_mismatch_is_validation_error() {
+    let Some(fx) = setup_exec_or_skip().await else {
+        return;
+    };
+    let wp_id = suspend_on(&fx, "wpk:approval:lane", "approved").await;
+    let wrong_lane = LaneId::new("not-default");
+    let args = approval_args(&fx.exec_id, &wrong_lane, &wp_id, "approved", "dec-1");
+    match fx.backend.deliver_approval_signal(args).await.unwrap_err() {
+        EngineError::Validation { kind, detail } => {
+            assert_eq!(kind, ValidationKind::InvalidInput);
+            assert!(
+                detail.starts_with("lane_mismatch:"),
+                "unexpected detail: {detail}"
+            );
+        }
+        other => panic!("expected Validation(InvalidInput), got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Cairn #454 Phase 4b — Postgres body for `EngineBackend::deliver_approval_signal`, mirroring the Valkey PR #465 shape.

- Read authoritative `lane_id` from `ff_exec_core`; caller/exec lane mismatch returns `Validation(InvalidInput, "lane_mismatch: ...")` (`deliver_signal_impl` trusts the lane on `DeliverSignalArgs`, so we have to enforce here).
- Look up the waitpoint HMAC token via the existing PG `read_waitpoint_token_impl` (v0.12, PR #438). Missing row → `NotFound(waitpoint)`.
- Compose `DeliverSignalArgs` (`signal_category="approval"`, `source_type="operator"`, `target_scope="execution"`, `idempotency_key="approval:<signal>:<suffix>"`, single `now` reused for `created_at` + `now`) and dispatch through `suspend_ops::deliver_signal_impl` — SERIALIZABLE tx + HMAC re-verification + dedup/capacity invariants stay unchanged.

Independent of PR #467.

## Test plan

- [x] `cargo check -p ff-backend-postgres --tests` clean
- [x] `cargo clippy -p ff-backend-postgres --tests` no new findings
- [x] 4 `#[ignore]` + `FF_PG_TEST_URL` integration tests green against PG 16:
  - `approved_path_resumes_execution` → `resume_condition_satisfied`
  - `rejected_path_appends_without_resume` → `appended_to_waitpoint`
  - `missing_waitpoint_returns_not_found` → `EngineError::NotFound { entity: "waitpoint" }`
  - `lane_mismatch_is_validation_error` → `Validation(InvalidInput, "lane_mismatch: ...")`
- [ ] CI green

Test output (serial, `--test-threads=1`):
```
running 4 tests
test approved_path_resumes_execution ... ok
test lane_mismatch_is_validation_error ... ok
test missing_waitpoint_returns_not_found ... ok
test rejected_path_appends_without_resume ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.69s
```

Refs cairn #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)