### PR TITLE
feat(ff-backend-postgres): #454 Phase 4c — issue_grant_and_claim PG body (backend-atomic)

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1685,6 +1685,18 @@ impl EngineBackend for PostgresBackend {
         crate::typed_ops::claim_execution(self.pool(), &self.partition_config, args).await
     }
 
+    // Cairn #454 Phase 4c — backend-atomic `issue_claim_grant` +
+    // `claim_execution` composition. sqlx tx ensures a mid-op crash
+    // cannot leak a dangling grant (auto-rollback on drop).
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.issue_grant_and_claim", skip_all)]
+    async fn issue_grant_and_claim(
+        &self,
+        args: ff_core::contracts::IssueGrantAndClaimArgs,
+    ) -> Result<ff_core::contracts::ClaimGrantOutcome, EngineError> {
+        crate::typed_ops::issue_grant_and_claim(self.pool(), &self.partition_config, args).await
+    }
+
     // ── PR-7b Wave 0a: exec_core field read ──
 
     async fn read_exec_core_fields(

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -1529,7 +1529,7 @@ pub(crate) async fn claim_execution(
 /// PG body for [`ff_core::engine_backend::EngineBackend::issue_grant_and_claim`].
 ///
 /// Cairn #454 Phase 4c — backend-atomic composition of `issue_claim_grant`
-/// + `claim_execution` in a single sqlx transaction. Mirrors Valkey's
+/// and `claim_execution` in a single sqlx transaction. Mirrors Valkey's
 /// `ff_issue_grant_and_claim` FCALL (Phase 3d, `c884bac`) with PG's
 /// lease-epoch-only fence.
 ///

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -33,16 +33,19 @@
 
 use ff_core::contracts::{
     CheckAdmissionArgs, CheckAdmissionResult, ClaimExecutionArgs, ClaimExecutionResult,
-    ClaimedExecution, CompleteExecutionArgs, CompleteExecutionResult,
+    ClaimGrantOutcome, ClaimedExecution, CompleteExecutionArgs, CompleteExecutionResult,
     EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult, FailExecutionArgs,
-    FailExecutionResult, RenewLeaseArgs, RenewLeaseResult, ResumeExecutionArgs,
-    ResumeExecutionResult,
+    FailExecutionResult, IssueGrantAndClaimArgs, RenewLeaseArgs, RenewLeaseResult,
+    ResumeExecutionArgs, ResumeExecutionResult,
 };
 use ff_core::state::AttemptType;
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
 use ff_core::partition::{quota_partition, PartitionConfig};
 use ff_core::state::PublicState;
-use ff_core::types::{AttemptIndex, CancelSource, QuotaPolicyId, TimestampMs};
+use ff_core::types::{
+    AttemptId, AttemptIndex, CancelSource, LeaseEpoch, LeaseId, QuotaPolicyId, TimestampMs,
+    WorkerId, WorkerInstanceId,
+};
 use sqlx::{PgPool, Row};
 
 use crate::attempt::split_exec_id;
@@ -1522,6 +1525,353 @@ pub(crate) async fn claim_execution(
     );
     Ok(ClaimExecutionResult::Claimed(claimed))
 }
+
+/// PG body for [`ff_core::engine_backend::EngineBackend::issue_grant_and_claim`].
+///
+/// Cairn #454 Phase 4c — backend-atomic composition of `issue_claim_grant`
+/// + `claim_execution` in a single sqlx transaction. Mirrors Valkey's
+/// `ff_issue_grant_and_claim` FCALL (Phase 3d, `c884bac`) with PG's
+/// lease-epoch-only fence.
+///
+/// # Atomicity
+///
+/// `tx.begin()` … `tx.commit()`. sqlx `Transaction` auto-rolls back on
+/// drop, so any `?`-bubbled error discards the inserted grant row +
+/// attempt mutations — the PG equivalent of Valkey's Lua FCALL
+/// single-serial guarantee.
+///
+/// # Dispatch
+///
+/// Branches on `ff_exec_core.attempt_state`:
+///
+/// - `attempt_interrupted` → resume-claim body (mirrors
+///   [`crate::suspend_ops::claim_resumed_execution_impl`]): existing
+///   attempt row is re-leased with bumped epoch; `attempt_index` is
+///   reused.
+/// - anything else → fresh-claim body: same gates as `claim_execution`
+///   (`runnable` / `unowned` / `eligible_now`); mints a new attempt
+///   row at `ff_exec_core.attempt_index` and bumps the pointer.
+///
+/// # Operator identity
+///
+/// The trait-level args are operator-facing (`execution_id`, `lane_id`,
+/// `lease_duration_ms`); worker identity is synthesized as
+/// `WorkerId("operator")` / `WorkerInstanceId("operator")` to keep
+/// audit columns populated (matches Valkey Phase 3d decision).
+///
+/// # Grant row
+///
+/// Written with `grant_ttl_ms = lease_duration_ms`, then DELETE'd in
+/// the same tx. The TTL is redundant on the happy path but audit-
+/// consistent with Valkey's `PEXPIRE` on the Lua path.
+pub(crate) async fn issue_grant_and_claim(
+    pool: &PgPool,
+    _partition_config: &PartitionConfig,
+    args: IssueGrantAndClaimArgs,
+) -> Result<ClaimGrantOutcome, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let lease_ttl_i64 = i64::try_from(args.lease_duration_ms).unwrap_or(i64::MAX);
+    let now = now_ms();
+    let new_expires = now.saturating_add(lease_ttl_i64);
+
+    // Synthetic operator identity — mirrors Valkey Phase 3d.
+    let worker_id = WorkerId::new("operator");
+    let worker_instance_id = WorkerInstanceId::new("operator");
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // 1. Lock exec_core + read state.
+    let exec_row = sqlx::query(
+        r#"
+        SELECT lifecycle_phase, ownership_state, eligibility_state,
+               attempt_state, attempt_index,
+               COALESCE(raw_fields->>'terminal_outcome', 'none') AS terminal_outcome,
+               COALESCE(raw_fields->>'current_attempt_id', '') AS current_attempt_id
+          FROM ff_exec_core
+         WHERE partition_key = $1 AND execution_id = $2
+         FOR UPDATE
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(exec_row) = exec_row else {
+        return Err(EngineError::NotFound { entity: "execution" });
+    };
+    let lifecycle_phase: String = exec_row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+    let ownership_state: String = exec_row.try_get("ownership_state").map_err(map_sqlx_error)?;
+    let eligibility_state: String =
+        exec_row.try_get("eligibility_state").map_err(map_sqlx_error)?;
+    let attempt_state: String = exec_row.try_get("attempt_state").map_err(map_sqlx_error)?;
+    let current_attempt_index: i32 =
+        exec_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+    let is_resume = attempt_state == "attempt_interrupted";
+
+    if !is_resume {
+        // Fresh-claim gates — same as `claim_execution`.
+        if lifecycle_phase != "runnable" {
+            let terminal_outcome: String =
+                exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
+            let current_attempt_id: String = exec_row
+                .try_get("current_attempt_id")
+                .map_err(map_sqlx_error)?;
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+                terminal_outcome,
+                lease_epoch: String::new(),
+                lifecycle_phase,
+                attempt_id: current_attempt_id,
+            }));
+        }
+        if ownership_state != "unowned" {
+            return Err(EngineError::Contention(ContentionKind::LeaseConflict));
+        }
+        if eligibility_state != "eligible_now" && eligibility_state != "pending_claim" {
+            // Operator composition can run against both `eligible_now`
+            // (no grant yet) and `pending_claim` (a scheduler-issued
+            // grant already exists — our grant is additive and the
+            // caller semantics are unchanged).
+            return Err(EngineError::Contention(ContentionKind::ExecutionNotLeaseable));
+        }
+        if attempt_state == "running_attempt" {
+            return Err(EngineError::Conflict(
+                ff_core::engine_error::ConflictKind::ActiveAttemptExists,
+            ));
+        }
+    }
+
+    // 2. Insert grant row (audit trail). Random grant_id; upsert on
+    //    conflict so a re-issue on the same partition is idempotent.
+    let grant_id: Vec<u8> = uuid::Uuid::new_v4().as_bytes().to_vec();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_claim_grant (
+            partition_key, grant_id, execution_id, kind,
+            worker_id, worker_instance_id, lane_id,
+            capability_hash, worker_capabilities,
+            route_snapshot_json, admission_summary,
+            grant_ttl_ms, issued_at_ms, expires_at_ms
+        ) VALUES (
+            $1, $2, $3, 'claim',
+            $4, $5, $6,
+            NULL, '[]'::jsonb,
+            NULL, NULL,
+            $7, $8, $9
+        )
+        ON CONFLICT (partition_key, grant_id) DO NOTHING
+        "#,
+    )
+    .bind(part)
+    .bind(&grant_id)
+    .bind(exec_uuid)
+    .bind(worker_id.as_str())
+    .bind(worker_instance_id.as_str())
+    .bind(args.lane_id.as_str())
+    .bind(lease_ttl_i64)
+    .bind(now)
+    .bind(new_expires)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 3. Claim body — branch on attempt_state.
+    let (used_attempt_index_i32, new_epoch_i): (i32, i64) = if is_resume {
+        // Resume path: re-lease existing attempt row at the current
+        // index (matches `claim_resumed_execution_impl`).
+        sqlx::query(
+            "UPDATE ff_attempt \
+                SET worker_id = $1, worker_instance_id = $2, \
+                    lease_epoch = lease_epoch + 1, \
+                    lease_expires_at_ms = $3, started_at_ms = $4, outcome = NULL \
+              WHERE partition_key = $5 AND execution_id = $6 AND attempt_index = $7",
+        )
+        .bind(worker_id.as_str())
+        .bind(worker_instance_id.as_str())
+        .bind(new_expires)
+        .bind(now)
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(current_attempt_index)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        sqlx::query(
+            "UPDATE ff_exec_core \
+                SET lifecycle_phase = 'active', ownership_state = 'leased', \
+                    eligibility_state = 'not_applicable', \
+                    public_state = 'running', attempt_state = 'running_attempt', \
+                    started_at_ms = COALESCE(started_at_ms, $3) \
+              WHERE partition_key = $1 AND execution_id = $2",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let (epoch,): (i64,) = sqlx::query_as(
+            "SELECT lease_epoch FROM ff_attempt \
+              WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(current_attempt_index)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        (current_attempt_index, epoch)
+    } else {
+        // Fresh path: mint a new attempt row at
+        // `ff_exec_core.attempt_index` and bump the pointer.
+        let attempt_index_i32 = current_attempt_index;
+        let attempt_type = if attempt_state == "pending_retry_attempt" {
+            AttemptType::Retry
+        } else if attempt_state == "pending_replay_attempt" {
+            AttemptType::Replay
+        } else {
+            AttemptType::Initial
+        };
+        let attempt_type_str = match attempt_type {
+            AttemptType::Initial => "initial",
+            AttemptType::Retry => "retry",
+            AttemptType::Reclaim => "reclaim",
+            AttemptType::Replay => "replay",
+            AttemptType::Fallback => "fallback",
+        };
+        sqlx::query(
+            r#"
+            INSERT INTO ff_attempt (
+                partition_key, execution_id, attempt_index,
+                worker_id, worker_instance_id,
+                lease_epoch, lease_expires_at_ms, started_at_ms,
+                policy, raw_fields
+            ) VALUES (
+                $1, $2, $3,
+                $4, $5,
+                1, $6, $7,
+                NULL,
+                jsonb_build_object(
+                  'attempt_type', $8::text,
+                  'attempt_id', $9::text,
+                  'lease_id', $10::text
+                )
+            )
+            ON CONFLICT (partition_key, execution_id, attempt_index)
+            DO UPDATE SET
+                worker_id = EXCLUDED.worker_id,
+                worker_instance_id = EXCLUDED.worker_instance_id,
+                lease_epoch = ff_attempt.lease_epoch + 1,
+                lease_expires_at_ms = EXCLUDED.lease_expires_at_ms,
+                started_at_ms = COALESCE(ff_attempt.started_at_ms, EXCLUDED.started_at_ms),
+                raw_fields = ff_attempt.raw_fields || EXCLUDED.raw_fields,
+                terminal_at_ms = NULL,
+                outcome = NULL
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index_i32)
+        .bind(worker_id.as_str())
+        .bind(worker_instance_id.as_str())
+        .bind(new_expires)
+        .bind(now)
+        .bind(attempt_type_str)
+        .bind(attempt_id.to_string())
+        .bind(lease_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let (epoch,): (i64,) = sqlx::query_as(
+            "SELECT lease_epoch FROM ff_attempt \
+              WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = $3",
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .bind(attempt_index_i32)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let raw_patch = serde_json::json!({
+            "current_attempt_id": attempt_id.to_string(),
+            "current_lease_id": lease_id.to_string(),
+            "current_worker_id": worker_id.as_str(),
+            "current_worker_instance_id": worker_instance_id.as_str(),
+            "pending_retry_reason": "",
+            "pending_replay_reason": "",
+            "pending_replay_requested_by": "",
+            "pending_previous_attempt_index": "",
+        });
+        let next_attempt_index_i = attempt_index_i32.saturating_add(1);
+        sqlx::query(
+            r#"
+            UPDATE ff_exec_core
+               SET lifecycle_phase = 'active',
+                   ownership_state = 'leased',
+                   eligibility_state = 'not_applicable',
+                   attempt_state = 'running_attempt',
+                   public_state = 'running',
+                   attempt_index = $1,
+                   raw_fields = raw_fields || $2::jsonb
+             WHERE partition_key = $3 AND execution_id = $4
+            "#,
+        )
+        .bind(next_attempt_index_i)
+        .bind(raw_patch)
+        .bind(part)
+        .bind(exec_uuid)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        (attempt_index_i32, epoch)
+    };
+
+    // 4. DELETE the grant row (same tx). The random grant_id from
+    //    step 2 lives on only for audit purposes — composition is
+    //    complete so the row is reaped.
+    sqlx::query(
+        "DELETE FROM ff_claim_grant \
+         WHERE partition_key = $1 AND grant_id = $2",
+    )
+    .bind(part)
+    .bind(&grant_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    // 5. Outbox: lease acquired.
+    lease_event::emit(
+        &mut tx,
+        part,
+        exec_uuid,
+        Some(&lease_id.to_string()),
+        lease_event::EVENT_ACQUIRED,
+        now,
+    )
+    .await?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    let attempt_index =
+        AttemptIndex::new(u32::try_from(used_attempt_index_i32.max(0)).unwrap_or(0));
+    let new_epoch = u64::try_from(new_epoch_i).unwrap_or(0);
+    Ok(ClaimGrantOutcome::new(
+        lease_id,
+        LeaseEpoch(new_epoch),
+        attempt_index,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     // Integration tests live in `tests/typed_renew_lease.rs` +

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -1732,19 +1732,19 @@ pub(crate) async fn issue_grant_and_claim(
         // Fresh path: mint a new attempt row at
         // `ff_exec_core.attempt_index` and bump the pointer.
         let attempt_index_i32 = current_attempt_index;
-        let attempt_type = if attempt_state == "pending_retry_attempt" {
-            AttemptType::Retry
-        } else if attempt_state == "pending_replay_attempt" {
-            AttemptType::Replay
-        } else {
-            AttemptType::Initial
-        };
-        let attempt_type_str = match attempt_type {
-            AttemptType::Initial => "initial",
-            AttemptType::Retry => "retry",
-            AttemptType::Reclaim => "reclaim",
-            AttemptType::Replay => "replay",
-            AttemptType::Fallback => "fallback",
+        // Fresh path reaches this branch only when attempt_state is one
+        // of the four resume-clean variants below (earlier invariant
+        // check on line 1678). Any other value here is corrupt state.
+        let attempt_type_str: &'static str = match attempt_state.as_str() {
+            "pending_retry_attempt" => "retry",
+            "pending_replay_attempt" => "replay",
+            "pending_first_attempt" | "initial" => "initial",
+            other => {
+                return Err(EngineError::Validation {
+                    kind: ValidationKind::Corruption,
+                    detail: format!("issue_grant_and_claim: unrecognized attempt_state={other}"),
+                });
+            }
         };
         sqlx::query(
             r#"

--- a/crates/ff-backend-postgres/tests/typed_issue_grant_and_claim.rs
+++ b/crates/ff-backend-postgres/tests/typed_issue_grant_and_claim.rs
@@ -1,0 +1,227 @@
+//! Cairn #454 Phase 4c — integration test for
+//! `EngineBackend::issue_grant_and_claim` on Postgres.
+//!
+//! Mirrors the Valkey test suite
+//! (`crates/ff-backend-valkey/tests/typed_issue_grant_and_claim.rs`,
+//! PR #466) with PG-flavored assertions (lease_epoch fence only, no
+//! fence triple in `ff_exec_core`).
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::IssueGrantAndClaimArgs;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError};
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{ExecutionId, LaneId};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}
+
+async fn setup_or_skip() -> Option<PgPool> {
+    let url = std::env::var("FF_PG_TEST_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect");
+    ff_backend_postgres::apply_migrations(&pool).await.expect("migrate");
+    Some(pool)
+}
+
+async fn seed_runnable(pool: &PgPool) -> (i16, Uuid, ExecutionId) {
+    let part: i16 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id,
+            required_capabilities, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state,
+            priority, created_at_ms
+        ) VALUES (
+            $1, $2, NULL, 'default', '{}', 0,
+            'runnable', 'unowned', 'eligible_now',
+            'waiting', 'pending_first_attempt',
+            0, $3
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("seed exec");
+    (part, exec_uuid, eid)
+}
+
+fn args_for(eid: ExecutionId) -> IssueGrantAndClaimArgs {
+    IssueGrantAndClaimArgs::new(eid, LaneId::new("default"), 60_000)
+}
+
+async fn count_grants(pool: &PgPool, part: i16, exec_uuid: Uuid) -> i64 {
+    let (n,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_claim_grant \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    n
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn issue_grant_and_claim_happy_path() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let (part, exec_uuid, eid) = seed_runnable(&pool).await;
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+
+    let outcome = backend
+        .issue_grant_and_claim(args_for(eid))
+        .await
+        .expect("issue_grant_and_claim ok");
+    assert_eq!(outcome.lease_epoch.0, 1, "fresh claim starts at epoch 1");
+    assert_eq!(outcome.attempt_index.0, 0, "fresh claim at attempt 0");
+    assert!(!outcome.lease_id.to_string().is_empty());
+
+    // exec_core flipped to leased/running.
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, ownership_state, public_state, attempt_state, attempt_index \
+         FROM ff_exec_core WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.get::<String, _>("lifecycle_phase"), "active");
+    assert_eq!(row.get::<String, _>("ownership_state"), "leased");
+    assert_eq!(row.get::<String, _>("public_state"), "running");
+    assert_eq!(row.get::<String, _>("attempt_state"), "running_attempt");
+    assert_eq!(
+        row.get::<i32, _>("attempt_index"),
+        1,
+        "pointer bumped past the claimed attempt"
+    );
+
+    // Grant row cleaned up (DELETE inside same tx).
+    assert_eq!(
+        count_grants(&pool, part, exec_uuid).await,
+        0,
+        "grant row must be removed by composition"
+    );
+
+    // Attempt row exists at index 0 with matching lease identity.
+    let (worker_id, lease_epoch_i): (String, i64) = sqlx::query_as(
+        "SELECT worker_id, lease_epoch FROM ff_attempt \
+         WHERE partition_key = $1 AND execution_id = $2 AND attempt_index = 0",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(worker_id, "operator");
+    assert_eq!(lease_epoch_i, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn issue_grant_and_claim_rejects_already_leased() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let (part, exec_uuid, eid) = seed_runnable(&pool).await;
+    // Flip the exec to leased externally.
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state = 'leased' \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    match backend.issue_grant_and_claim(args_for(eid)).await {
+        Err(EngineError::Contention(ContentionKind::LeaseConflict)) => {}
+        other => panic!("expected LeaseConflict, got {other:?}"),
+    }
+    // No-dangling-grant invariant on the reject path — tx rollback.
+    assert_eq!(
+        count_grants(&pool, part, exec_uuid).await,
+        0,
+        "rejected composition must not leak a grant row"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn issue_grant_and_claim_rejects_missing_execution() {
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    // Construct a well-formed ExecutionId that points at no row.
+    let part: i16 = 0;
+    let fake_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{fake_uuid}")).unwrap();
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    match backend.issue_grant_and_claim(args_for(eid)).await {
+        Err(EngineError::NotFound { entity: "execution" }) => {}
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    assert_eq!(count_grants(&pool, part, fake_uuid).await, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn issue_grant_and_claim_no_dangling_grant_on_reject() {
+    // Explicit atomicity assertion: a rejected composition must leave
+    // `ff_claim_grant` empty for the execution. Force rejection via a
+    // terminal exec (ExecutionNotActive) and probe the grant table.
+    let Some(pool) = setup_or_skip().await else {
+        return;
+    };
+    let (part, exec_uuid, eid) = seed_runnable(&pool).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal' \
+         WHERE partition_key = $1 AND execution_id = $2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let backend: Arc<dyn EngineBackend> =
+        PostgresBackend::from_pool(pool.clone(), PartitionConfig::default());
+    match backend.issue_grant_and_claim(args_for(eid)).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive { .. })) => {}
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+    assert_eq!(
+        count_grants(&pool, part, exec_uuid).await,
+        0,
+        "rejected composition must not leak a grant row"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 4c of cairn #454. Composes `issue_claim_grant` + `claim_execution` in one sqlx transaction so a mid-op crash cannot leak a dangling grant row. Per cairn option (a) this is backend-atomic, not caller-chained — sqlx's Transaction auto-rollback on drop is the PG equivalent of Valkey's Lua FCALL single-serial guarantee (PR #466).

## What changed

- `crates/ff-backend-postgres/src/typed_ops.rs` — `issue_grant_and_claim` pub(crate) fn. Single sqlx tx: SELECT FOR UPDATE exec_core → branch on `attempt_state == 'attempt_interrupted'` (resume-claim vs fresh-claim body) → INSERT ff_claim_grant (audit trail) → run claim body → DELETE grant row → lease_event emit.
- `crates/ff-backend-postgres/src/lib.rs` — trait override forwarding to typed_ops.
- `crates/ff-backend-postgres/tests/typed_issue_grant_and_claim.rs` — 4 ignore-gated integration tests.

## Design notes

- **Synthetic identity**: `WorkerId("operator")` / `WorkerInstanceId("operator")` mirrors Valkey Phase 3d (#466). Keeps audit fields populated for dashboards.
- **Fence asymmetry**: PG (and SQLite) fence on `lease_epoch` only — not the Valkey `(lease_id, lease_epoch, attempt_id)` triple. The attempt upsert's `ON CONFLICT DO UPDATE` bumps epoch.
- **Eligibility**: fresh-claim path accepts `eligible_now` or `pending_claim` so an operator composition runs on both a never-scheduled exec AND one with a scheduler-issued grant (additive; no behavioral change for the non-composed paths).
- **Atomicity**: sqlx Transaction rollback-on-drop means any error between grant INSERT and claim INSERT unwinds both — no dangling grant.

## Test plan

- [x] `cargo check -p ff-backend-postgres --tests` clean
- [x] `cargo clippy -p ff-backend-postgres -- -D warnings` clean
- [x] 4/4 integration tests pass against live PG 17:
  - `issue_grant_and_claim_happy_path`
  - `issue_grant_and_claim_rejects_already_leased` → LeaseConflict + no dangling grant
  - `issue_grant_and_claim_rejects_missing_execution` → NotFound
  - `issue_grant_and_claim_no_dangling_grant_on_reject` → ExecutionNotActive + no dangling grant
- [ ] CI matrix green

Refs: cairn #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)