### PR TITLE
feat(ff-backend-sqlite): #454 Phase 5 — 4 SQLite typed-FCALL bodies

### DIFF
--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -3053,6 +3053,50 @@ impl EngineBackend for SqliteBackend {
         crate::budget::report_usage_admin_impl(&self.inner.pool, budget_id, args).await
     }
 
+    // ── cairn #454 Phase 5 — typed-FCALL bodies for SQLite ──────────
+
+    #[cfg(feature = "core")]
+    async fn record_spend(
+        &self,
+        args: ff_core::contracts::RecordSpendArgs,
+    ) -> Result<ReportUsageResult, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| crate::typed_ops::record_spend(pool, args.clone())).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn release_budget(
+        &self,
+        args: ff_core::contracts::ReleaseBudgetArgs,
+    ) -> Result<(), EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| crate::typed_ops::release_budget(pool, args.clone())).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn deliver_approval_signal(
+        &self,
+        args: ff_core::contracts::DeliverApprovalSignalArgs,
+    ) -> Result<ff_core::contracts::DeliverSignalResult, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| {
+            crate::typed_ops::deliver_approval_signal(pool, pubsub, args.clone())
+        })
+        .await
+    }
+
+    #[cfg(feature = "core")]
+    async fn issue_grant_and_claim(
+        &self,
+        args: ff_core::contracts::IssueGrantAndClaimArgs,
+    ) -> Result<ff_core::contracts::ClaimGrantOutcome, EngineError> {
+        let pool = &self.inner.pool;
+        let pubsub = &self.inner.pubsub;
+        retry_serializable(|| crate::typed_ops::issue_grant_and_claim(pool, pubsub, args.clone()))
+            .await
+    }
+
     #[cfg(feature = "streaming")]
     async fn read_stream(
         &self,

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -1546,7 +1546,10 @@ pub(crate) async fn record_spend(
         let policy: JsonValue = match policy_row {
             Some(r) => {
                 let text: String = r.try_get("policy_json").map_err(map_sqlx_error)?;
-                serde_json::from_str(&text).unwrap_or_else(|_| JsonValue::Object(Default::default()))
+                serde_json::from_str(&text).map_err(|e| EngineError::Validation {
+                    kind: ValidationKind::Corruption,
+                    detail: format!("record_spend: ff_budget_policy.policy_json parse error: {e}"),
+                })?
             }
             None => JsonValue::Object(Default::default()),
         };
@@ -1620,12 +1623,17 @@ pub(crate) async fn record_spend(
         for (dim, delta) in args.deltas.iter() {
             let dim_key = dim_row_key(dim);
             let new_val = per_dim_current[dim];
+            // SQLite INTEGER is i64; reject deltas that would wrap negative.
+            let delta_i64 = i64::try_from(*delta).map_err(|_| EngineError::Validation {
+                kind: ValidationKind::InvalidInput,
+                detail: format!("record_spend: delta for dim={dim} exceeds i64::MAX ({delta})"),
+            })?;
             sqlx::query(
                 "UPDATE ff_budget_usage \
                  SET current_value = current_value + ?1, updated_at_ms = ?2 \
                  WHERE partition_key = ?3 AND budget_id = ?4 AND dimensions_key = ?5",
             )
-            .bind(*delta as i64)
+            .bind(delta_i64)
             .bind(now)
             .bind(BUDGET_PART)
             .bind(&budget_id_str)
@@ -1647,7 +1655,7 @@ pub(crate) async fn record_spend(
             .bind(&budget_id_str)
             .bind(&exec_uuid_str)
             .bind(&dim_key)
-            .bind(*delta as i64)
+            .bind(delta_i64)
             .bind(now)
             .execute(&mut *conn)
             .await

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -42,16 +42,24 @@
 //! catches the same violations Valkey's full-triple check catches.
 
 use ff_core::contracts::{
-    CheckAdmissionArgs, CheckAdmissionResult, CompleteExecutionArgs, CompleteExecutionResult,
-    FailExecutionArgs, FailExecutionResult, RenewLeaseArgs, RenewLeaseResult,
-    ResumeExecutionArgs, ResumeExecutionResult,
+    CheckAdmissionArgs, CheckAdmissionResult, ClaimGrantOutcome, CompleteExecutionArgs,
+    CompleteExecutionResult, DeliverApprovalSignalArgs, DeliverSignalArgs, DeliverSignalResult,
+    FailExecutionArgs, FailExecutionResult, IssueGrantAndClaimArgs, RecordSpendArgs,
+    ReleaseBudgetArgs, RenewLeaseArgs, RenewLeaseResult, ReportUsageResult, ResumeExecutionArgs,
+    ResumeExecutionResult,
 };
 use ff_core::engine_error::{ContentionKind, EngineError, StateKind, ValidationKind};
 use ff_core::partition::PartitionConfig;
 use ff_core::state::PublicState;
-use ff_core::types::{AttemptIndex, CancelSource, QuotaPolicyId, TimestampMs};
+use ff_core::types::{
+    AttemptId, AttemptIndex, CancelSource, ExecutionId, LaneId, LeaseEpoch, LeaseId, QuotaPolicyId,
+    SignalId, TimestampMs, WaitpointToken, WorkerId, WorkerInstanceId,
+};
+use serde_json::{json, Value as JsonValue};
 use sqlx::Row;
 use sqlx::SqlitePool;
+use std::collections::BTreeMap;
+use uuid::Uuid;
 
 use crate::backend::{
     begin_immediate, commit_or_rollback, insert_completion_event_ev, insert_lease_event,
@@ -1414,6 +1422,747 @@ pub(crate) async fn claim_execution(
                 ff_core::backend::stub_handle_fresh(),
             );
             Ok(ClaimExecutionResult::Claimed(claimed))
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────
+// cairn #454 Phase 5 — SQLite bodies for the four typed-FCALL methods
+// (record_spend / release_budget / deliver_approval_signal /
+// issue_grant_and_claim). Mirrors the Postgres references in
+// `ff-backend-postgres/src/budget.rs`, `…/suspend_ops.rs`, and
+// `…/typed_ops.rs`. SQLite single-partition (partition_key = 0, per
+// `crate::budget::PART`) + single-writer (BEGIN IMMEDIATE + §4.1 A3)
+// replaces PG's partition-hash math, `FOR NO KEY UPDATE`, and
+// `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`.
+// ───────────────────────────────────────────────────────────────────
+
+const BUDGET_PART: i64 = 0;
+/// Dedup-expiry window. Same 24h constant as PG + SQLite budget.rs.
+const DEDUP_TTL_MS: i64 = 24 * 60 * 60 * 1_000;
+
+fn dim_row_key(name: &str) -> String {
+    name.to_string()
+}
+
+fn limits_from_policy(policy: &JsonValue, key: &str) -> BTreeMap<String, u64> {
+    policy
+        .get(key)
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_u64().map(|n| (k.clone(), n)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn outcome_to_json_text(r: &ReportUsageResult) -> String {
+    match r {
+        ReportUsageResult::Ok => json!({"kind": "Ok"}),
+        ReportUsageResult::AlreadyApplied => json!({"kind": "AlreadyApplied"}),
+        ReportUsageResult::SoftBreach {
+            dimension,
+            current_usage,
+            soft_limit,
+        } => json!({
+            "kind": "SoftBreach",
+            "dimension": dimension,
+            "current_usage": current_usage,
+            "soft_limit": soft_limit,
+        }),
+        ReportUsageResult::HardBreach {
+            dimension,
+            current_usage,
+            hard_limit,
+        } => json!({
+            "kind": "HardBreach",
+            "dimension": dimension,
+            "current_usage": current_usage,
+            "hard_limit": hard_limit,
+        }),
+        _ => json!({"kind": "Ok"}),
+    }
+    .to_string()
+}
+
+/// Extract the bare UUID-as-text for the `ff_budget_usage_by_exec.execution_id`
+/// TEXT column (migration 0020).
+fn exec_uuid_text(eid: &ExecutionId) -> Result<String, EngineError> {
+    let (_, uuid) = split_exec_id(eid)?;
+    Ok(uuid.to_string())
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::record_spend`].
+pub(crate) async fn record_spend(
+    pool: &SqlitePool,
+    args: RecordSpendArgs,
+) -> Result<ReportUsageResult, EngineError> {
+    let budget_id_str = args.budget_id.to_string();
+    let exec_uuid_str = exec_uuid_text(&args.execution_id)?;
+    let now = now_ms();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        // ── Dedup reservation ──
+        let dedup_owned: Option<String> = if args.idempotency_key.is_empty() {
+            None
+        } else {
+            let inserted = sqlx::query(
+                "INSERT INTO ff_budget_usage_dedup \
+                     (partition_key, dedup_key, outcome_json, applied_at_ms, expires_at_ms) \
+                 VALUES (?1, ?2, '{}', ?3, ?4) \
+                 ON CONFLICT (partition_key, dedup_key) DO NOTHING \
+                 RETURNING applied_at_ms",
+            )
+            .bind(BUDGET_PART)
+            .bind(&args.idempotency_key)
+            .bind(now)
+            .bind(now + DEDUP_TTL_MS)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+            if inserted.is_none() {
+                return Ok(ReportUsageResult::AlreadyApplied);
+            }
+            Some(args.idempotency_key.clone())
+        };
+
+        let policy_row = sqlx::query(
+            "SELECT policy_json FROM ff_budget_policy \
+             WHERE partition_key = ?1 AND budget_id = ?2",
+        )
+        .bind(BUDGET_PART)
+        .bind(&budget_id_str)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let policy: JsonValue = match policy_row {
+            Some(r) => {
+                let text: String = r.try_get("policy_json").map_err(map_sqlx_error)?;
+                serde_json::from_str(&text).unwrap_or_else(|_| JsonValue::Object(Default::default()))
+            }
+            None => JsonValue::Object(Default::default()),
+        };
+        let hard_limits = limits_from_policy(&policy, "hard_limits");
+        let soft_limits = limits_from_policy(&policy, "soft_limits");
+
+        let mut per_dim_current: BTreeMap<String, u64> = BTreeMap::new();
+        for (dim, delta) in args.deltas.iter() {
+            let dim_key = dim_row_key(dim);
+            sqlx::query(
+                "INSERT INTO ff_budget_usage \
+                     (partition_key, budget_id, dimensions_key, current_value, updated_at_ms) \
+                 VALUES (?1, ?2, ?3, 0, ?4) \
+                 ON CONFLICT (partition_key, budget_id, dimensions_key) DO NOTHING",
+            )
+            .bind(BUDGET_PART)
+            .bind(&budget_id_str)
+            .bind(&dim_key)
+            .bind(now)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            let row = sqlx::query(
+                "SELECT current_value FROM ff_budget_usage \
+                 WHERE partition_key = ?1 AND budget_id = ?2 AND dimensions_key = ?3",
+            )
+            .bind(BUDGET_PART)
+            .bind(&budget_id_str)
+            .bind(&dim_key)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+            let cur: i64 = row.try_get("current_value").map_err(map_sqlx_error)?;
+            let new_val = (cur as u64).saturating_add(*delta);
+
+            if let Some(hard) = hard_limits.get(dim)
+                && *hard > 0
+                && new_val > *hard
+            {
+                sqlx::query(
+                    "UPDATE ff_budget_policy \
+                     SET breach_count = breach_count + 1, \
+                         last_breach_at_ms = ?1, \
+                         last_breach_dim = ?2, \
+                         updated_at_ms = ?1 \
+                     WHERE partition_key = ?3 AND budget_id = ?4",
+                )
+                .bind(now)
+                .bind(dim)
+                .bind(BUDGET_PART)
+                .bind(&budget_id_str)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_sqlx_error)?;
+
+                let outcome = ReportUsageResult::HardBreach {
+                    dimension: dim.clone(),
+                    current_usage: cur as u64,
+                    hard_limit: *hard,
+                };
+                if let Some(dk) = dedup_owned.as_deref() {
+                    finalize_dedup_spend(&mut conn, dk, &outcome).await?;
+                }
+                return Ok(outcome);
+            }
+            per_dim_current.insert(dim.clone(), new_val);
+        }
+
+        let mut soft_breach: Option<ReportUsageResult> = None;
+        for (dim, delta) in args.deltas.iter() {
+            let dim_key = dim_row_key(dim);
+            let new_val = per_dim_current[dim];
+            sqlx::query(
+                "UPDATE ff_budget_usage \
+                 SET current_value = current_value + ?1, updated_at_ms = ?2 \
+                 WHERE partition_key = ?3 AND budget_id = ?4 AND dimensions_key = ?5",
+            )
+            .bind(*delta as i64)
+            .bind(now)
+            .bind(BUDGET_PART)
+            .bind(&budget_id_str)
+            .bind(&dim_key)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            sqlx::query(
+                "INSERT INTO ff_budget_usage_by_exec \
+                     (partition_key, budget_id, execution_id, dimensions_key, \
+                      delta_total, updated_at_ms) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT (partition_key, budget_id, execution_id, dimensions_key) \
+                 DO UPDATE SET delta_total = delta_total + excluded.delta_total, \
+                               updated_at_ms = excluded.updated_at_ms",
+            )
+            .bind(BUDGET_PART)
+            .bind(&budget_id_str)
+            .bind(&exec_uuid_str)
+            .bind(&dim_key)
+            .bind(*delta as i64)
+            .bind(now)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            if soft_breach.is_none()
+                && let Some(soft) = soft_limits.get(dim)
+                && *soft > 0
+                && new_val > *soft
+            {
+                soft_breach = Some(ReportUsageResult::SoftBreach {
+                    dimension: dim.clone(),
+                    current_usage: new_val,
+                    soft_limit: *soft,
+                });
+            }
+        }
+
+        if soft_breach.is_some() {
+            sqlx::query(
+                "UPDATE ff_budget_policy \
+                 SET soft_breach_count = soft_breach_count + 1, \
+                     updated_at_ms = ?1 \
+                 WHERE partition_key = ?2 AND budget_id = ?3",
+            )
+            .bind(now)
+            .bind(BUDGET_PART)
+            .bind(&budget_id_str)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        }
+
+        let outcome = soft_breach.unwrap_or(ReportUsageResult::Ok);
+        if let Some(dk) = dedup_owned.as_deref() {
+            finalize_dedup_spend(&mut conn, dk, &outcome).await?;
+        }
+        Ok::<_, EngineError>(outcome)
+    }
+    .await;
+
+    match result {
+        Ok(outcome) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(outcome)
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+async fn finalize_dedup_spend(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    dedup_key: &str,
+    outcome: &ReportUsageResult,
+) -> Result<(), EngineError> {
+    let text = outcome_to_json_text(outcome);
+    sqlx::query(
+        "UPDATE ff_budget_usage_dedup SET outcome_json = ?1 \
+         WHERE partition_key = ?2 AND dedup_key = ?3",
+    )
+    .bind(text)
+    .bind(BUDGET_PART)
+    .bind(dedup_key)
+    .execute(&mut **conn)
+    .await
+    .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::release_budget`].
+pub(crate) async fn release_budget(
+    pool: &SqlitePool,
+    args: ReleaseBudgetArgs,
+) -> Result<(), EngineError> {
+    let budget_id_str = args.budget_id.to_string();
+    let exec_uuid_str = exec_uuid_text(&args.execution_id)?;
+    let now = now_ms();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result: Result<(), EngineError> = async {
+        let rows = sqlx::query(
+            "SELECT dimensions_key, delta_total FROM ff_budget_usage_by_exec \
+             WHERE partition_key = ?1 AND budget_id = ?2 AND execution_id = ?3",
+        )
+        .bind(BUDGET_PART)
+        .bind(&budget_id_str)
+        .bind(&exec_uuid_str)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        for row in &rows {
+            let dim: String = row.try_get("dimensions_key").map_err(map_sqlx_error)?;
+            let delta: i64 = row.try_get("delta_total").map_err(map_sqlx_error)?;
+            sqlx::query(
+                "UPDATE ff_budget_usage \
+                 SET current_value = MAX(0, current_value - ?1), \
+                     updated_at_ms = ?2 \
+                 WHERE partition_key = ?3 AND budget_id = ?4 AND dimensions_key = ?5",
+            )
+            .bind(delta)
+            .bind(now)
+            .bind(BUDGET_PART)
+            .bind(&budget_id_str)
+            .bind(&dim)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+        }
+
+        sqlx::query(
+            "DELETE FROM ff_budget_usage_by_exec \
+             WHERE partition_key = ?1 AND budget_id = ?2 AND execution_id = ?3",
+        )
+        .bind(BUDGET_PART)
+        .bind(&budget_id_str)
+        .bind(&exec_uuid_str)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        Ok(())
+    }
+    .await;
+
+    match result {
+        Ok(()) => {
+            commit_or_rollback(&mut conn).await?;
+            Ok(())
+        }
+        Err(e) => {
+            rollback_quiet(&mut conn).await;
+            Err(e)
+        }
+    }
+}
+
+/// SQLite body for
+/// [`ff_core::engine_backend::EngineBackend::deliver_approval_signal`].
+pub(crate) async fn deliver_approval_signal(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: DeliverApprovalSignalArgs,
+) -> Result<DeliverSignalResult, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+
+    let lane_row: Option<(String,)> = sqlx::query_as(
+        "SELECT lane_id FROM ff_exec_core \
+         WHERE partition_key = ?1 AND execution_id = ?2",
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+    let authoritative_lane = match lane_row {
+        Some((s,)) => LaneId::new(s),
+        None => {
+            return Err(EngineError::NotFound {
+                entity: "execution",
+            });
+        }
+    };
+    if authoritative_lane.as_str() != args.lane_id.as_str() {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!(
+                "lane_mismatch: args.lane_id={} exec_core.lane_id={}",
+                args.lane_id.as_str(),
+                authoritative_lane.as_str()
+            ),
+        });
+    }
+
+    let partition = ff_core::partition::Partition {
+        family: ff_core::partition::PartitionFamily::Execution,
+        index: part as u16,
+    };
+    let pkey = ff_core::partition::PartitionKey::from(&partition);
+    let token_str = crate::reads::read_waitpoint_token_impl(pool, &pkey, &args.waitpoint_id)
+        .await?
+        .ok_or(EngineError::NotFound {
+            entity: "waitpoint",
+        })?;
+
+    let now = TimestampMs::now();
+    let idempotency_key = format!("approval:{}:{}", args.signal_name, args.idempotency_suffix);
+    let ds = DeliverSignalArgs {
+        execution_id: args.execution_id.clone(),
+        waitpoint_id: args.waitpoint_id.clone(),
+        signal_id: SignalId::new(),
+        signal_name: args.signal_name.clone(),
+        signal_category: "approval".to_owned(),
+        source_type: "operator".to_owned(),
+        source_identity: String::new(),
+        payload: None,
+        payload_encoding: None,
+        correlation_id: None,
+        idempotency_key: Some(idempotency_key),
+        target_scope: "execution".to_owned(),
+        created_at: Some(now),
+        dedup_ttl_ms: Some(args.signal_dedup_ttl_ms),
+        resume_delay_ms: None,
+        max_signals_per_execution: args.max_signals_per_execution,
+        signal_maxlen: args.maxlen,
+        waitpoint_token: WaitpointToken::new(token_str),
+        now,
+    };
+
+    crate::suspend_ops::deliver_signal_impl(pool, pubsub, ds).await
+}
+
+/// SQLite body for
+/// [`ff_core::engine_backend::EngineBackend::issue_grant_and_claim`].
+pub(crate) async fn issue_grant_and_claim(
+    pool: &SqlitePool,
+    pubsub: &PubSub,
+    args: IssueGrantAndClaimArgs,
+) -> Result<ClaimGrantOutcome, EngineError> {
+    let (part, exec_uuid) = split_exec_id(&args.execution_id)?;
+    let lease_ttl_i64 = i64::try_from(args.lease_duration_ms).unwrap_or(i64::MAX);
+    let now = now_ms();
+    let new_expires = now.saturating_add(lease_ttl_i64);
+
+    let worker_id = WorkerId::new("operator");
+    let worker_instance_id = WorkerInstanceId::new("operator");
+    let lease_id = LeaseId::new();
+    let attempt_id = AttemptId::new();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let result = async {
+        let exec_row = sqlx::query(
+            r#"
+            SELECT lifecycle_phase, ownership_state, eligibility_state,
+                   attempt_state, attempt_index,
+                   COALESCE(json_extract(raw_fields, '$.terminal_outcome'), 'none')
+                       AS terminal_outcome,
+                   COALESCE(json_extract(raw_fields, '$.current_attempt_id'), '')
+                       AS current_attempt_id
+              FROM ff_exec_core
+             WHERE partition_key = ?1 AND execution_id = ?2
+            "#,
+        )
+        .bind(part)
+        .bind(exec_uuid)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let Some(exec_row) = exec_row else {
+            return Err(EngineError::NotFound { entity: "execution" });
+        };
+        let lifecycle_phase: String =
+            exec_row.try_get("lifecycle_phase").map_err(map_sqlx_error)?;
+        let ownership_state: String =
+            exec_row.try_get("ownership_state").map_err(map_sqlx_error)?;
+        let eligibility_state: String =
+            exec_row.try_get("eligibility_state").map_err(map_sqlx_error)?;
+        let attempt_state: String =
+            exec_row.try_get("attempt_state").map_err(map_sqlx_error)?;
+        let current_attempt_index_i: i64 =
+            exec_row.try_get("attempt_index").map_err(map_sqlx_error)?;
+
+        let is_resume = attempt_state == "attempt_interrupted";
+
+        if !is_resume {
+            if lifecycle_phase != "runnable" {
+                let terminal_outcome: String =
+                    exec_row.try_get("terminal_outcome").map_err(map_sqlx_error)?;
+                let current_attempt_id: String = exec_row
+                    .try_get("current_attempt_id")
+                    .map_err(map_sqlx_error)?;
+                return Err(EngineError::Contention(ContentionKind::ExecutionNotActive {
+                    terminal_outcome,
+                    lease_epoch: String::new(),
+                    lifecycle_phase,
+                    attempt_id: current_attempt_id,
+                }));
+            }
+            if ownership_state != "unowned" {
+                return Err(EngineError::Contention(ContentionKind::LeaseConflict));
+            }
+            if eligibility_state != "eligible_now" && eligibility_state != "pending_claim" {
+                return Err(EngineError::Contention(
+                    ContentionKind::ExecutionNotLeaseable,
+                ));
+            }
+            if attempt_state == "running_attempt" {
+                return Err(EngineError::Conflict(
+                    ff_core::engine_error::ConflictKind::ActiveAttemptExists,
+                ));
+            }
+        }
+
+        let grant_id_bytes = Uuid::new_v4().as_bytes().to_vec();
+        sqlx::query(
+            r#"
+            INSERT INTO ff_claim_grant (
+                partition_key, grant_id, execution_id, kind,
+                worker_id, worker_instance_id, lane_id,
+                capability_hash, worker_capabilities,
+                route_snapshot_json, admission_summary,
+                grant_ttl_ms, issued_at_ms, expires_at_ms
+            ) VALUES (
+                ?1, ?2, ?3, 'claim',
+                ?4, ?5, ?6,
+                NULL, '[]',
+                NULL, NULL,
+                ?7, ?8, ?9
+            )
+            ON CONFLICT (partition_key, grant_id) DO NOTHING
+            "#,
+        )
+        .bind(part)
+        .bind(&grant_id_bytes)
+        .bind(exec_uuid)
+        .bind(worker_id.as_str())
+        .bind(worker_instance_id.as_str())
+        .bind(args.lane_id.as_str())
+        .bind(lease_ttl_i64)
+        .bind(now)
+        .bind(new_expires)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let (used_attempt_index, new_epoch_i): (i64, i64) = if is_resume {
+            sqlx::query(
+                "UPDATE ff_attempt \
+                    SET worker_id = ?1, worker_instance_id = ?2, \
+                        lease_epoch = lease_epoch + 1, \
+                        lease_expires_at_ms = ?3, started_at_ms = ?4, outcome = NULL \
+                  WHERE partition_key = ?5 AND execution_id = ?6 AND attempt_index = ?7",
+            )
+            .bind(worker_id.as_str())
+            .bind(worker_instance_id.as_str())
+            .bind(new_expires)
+            .bind(now)
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(current_attempt_index_i)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            sqlx::query(
+                "UPDATE ff_exec_core \
+                    SET lifecycle_phase = 'active', ownership_state = 'leased', \
+                        eligibility_state = 'not_applicable', \
+                        public_state = 'running', attempt_state = 'running_attempt', \
+                        started_at_ms = COALESCE(started_at_ms, ?3) \
+                  WHERE partition_key = ?1 AND execution_id = ?2",
+            )
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(now)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            let epoch_row = sqlx::query(
+                "SELECT lease_epoch FROM ff_attempt \
+                 WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3",
+            )
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(current_attempt_index_i)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+            let epoch: i64 = epoch_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+            (current_attempt_index_i, epoch)
+        } else {
+            let attempt_index_i = current_attempt_index_i;
+            let attempt_type_str: &'static str = match attempt_state.as_str() {
+                "pending_retry_attempt" => "retry",
+                "pending_replay_attempt" => "replay",
+                "pending_first_attempt" | "initial" => "initial",
+                other => {
+                    return Err(EngineError::Validation {
+                        kind: ValidationKind::Corruption,
+                        detail: format!(
+                            "issue_grant_and_claim: unrecognized attempt_state={other}"
+                        ),
+                    });
+                }
+            };
+            sqlx::query(
+                r#"
+                INSERT INTO ff_attempt (
+                    partition_key, execution_id, attempt_index,
+                    worker_id, worker_instance_id,
+                    lease_epoch, lease_expires_at_ms, started_at_ms,
+                    policy, raw_fields
+                ) VALUES (
+                    ?1, ?2, ?3,
+                    ?4, ?5,
+                    1, ?6, ?7,
+                    NULL,
+                    json_set('{}', '$.attempt_type', ?8, '$.attempt_id', ?9, '$.lease_id', ?10)
+                )
+                ON CONFLICT (partition_key, execution_id, attempt_index)
+                DO UPDATE SET
+                    worker_id = excluded.worker_id,
+                    worker_instance_id = excluded.worker_instance_id,
+                    lease_epoch = ff_attempt.lease_epoch + 1,
+                    lease_expires_at_ms = excluded.lease_expires_at_ms,
+                    started_at_ms = COALESCE(ff_attempt.started_at_ms, excluded.started_at_ms),
+                    raw_fields = json_patch(ff_attempt.raw_fields, excluded.raw_fields),
+                    terminal_at_ms = NULL,
+                    outcome = NULL
+                "#,
+            )
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index_i)
+            .bind(worker_id.as_str())
+            .bind(worker_instance_id.as_str())
+            .bind(new_expires)
+            .bind(now)
+            .bind(attempt_type_str)
+            .bind(attempt_id.to_string())
+            .bind(lease_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            let epoch_row = sqlx::query(
+                "SELECT lease_epoch FROM ff_attempt \
+                 WHERE partition_key = ?1 AND execution_id = ?2 AND attempt_index = ?3",
+            )
+            .bind(part)
+            .bind(exec_uuid)
+            .bind(attempt_index_i)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+            let epoch: i64 = epoch_row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+
+            let next_attempt_index = attempt_index_i.saturating_add(1);
+            sqlx::query(
+                r#"
+                UPDATE ff_exec_core
+                   SET lifecycle_phase = 'active',
+                       ownership_state = 'leased',
+                       eligibility_state = 'not_applicable',
+                       attempt_state = 'running_attempt',
+                       public_state = 'running',
+                       attempt_index = ?1,
+                       raw_fields = json_set(
+                           raw_fields,
+                           '$.current_attempt_id', ?2,
+                           '$.current_lease_id', ?3,
+                           '$.current_worker_id', ?4,
+                           '$.current_worker_instance_id', ?5,
+                           '$.pending_retry_reason', '',
+                           '$.pending_replay_reason', '',
+                           '$.pending_replay_requested_by', '',
+                           '$.pending_previous_attempt_index', ''
+                       )
+                 WHERE partition_key = ?6 AND execution_id = ?7
+                "#,
+            )
+            .bind(next_attempt_index)
+            .bind(attempt_id.to_string())
+            .bind(lease_id.to_string())
+            .bind(worker_id.as_str())
+            .bind(worker_instance_id.as_str())
+            .bind(part)
+            .bind(exec_uuid)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx_error)?;
+
+            (attempt_index_i, epoch)
+        };
+
+        sqlx::query(
+            "DELETE FROM ff_claim_grant \
+             WHERE partition_key = ?1 AND grant_id = ?2",
+        )
+        .bind(part)
+        .bind(&grant_id_bytes)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let ev = insert_lease_event(&mut conn, part, exec_uuid, "acquired", now).await?;
+        let emits = vec![(OutboxChannel::LeaseHistory, ev)];
+
+        Ok::<_, EngineError>((used_attempt_index, new_epoch_i, emits))
+    }
+    .await;
+
+    match result {
+        Ok((used_attempt_index, new_epoch_i, emits)) => {
+            commit_or_rollback(&mut conn).await?;
+            dispatch_emits(pubsub, emits);
+            let attempt_index =
+                AttemptIndex::new(u32::try_from(used_attempt_index.max(0)).unwrap_or(0));
+            let new_epoch = u64::try_from(new_epoch_i).unwrap_or(0);
+            Ok(ClaimGrantOutcome::new(
+                lease_id,
+                LeaseEpoch(new_epoch),
+                attempt_index,
+            ))
         }
         Err(e) => {
             rollback_quiet(&mut conn).await;

--- a/crates/ff-backend-sqlite/tests/migrations.rs
+++ b/crates/ff-backend-sqlite/tests/migrations.rs
@@ -127,8 +127,8 @@ async fn sqlx_migration_ledger_records_all_14() {
             .await
             .expect("query _sqlx_migrations");
     assert_eq!(
-        count, 17,
-        "expected 17 successful migrations (0001..=0014 + 0016 + 0017 + 0018), got {count}"
+        count, 18,
+        "expected 18 successful migrations (0001..=0014 + 0016 + 0017 + 0018 + 0020), got {count}"
     );
 }
 
@@ -193,5 +193,9 @@ async fn migration_annotation_ledger_populated() {
     let mut expected: Vec<i64> = (1..=14).collect();
     expected.push(16);
     expected.push(17);
+    // 0018: completion_event lookup idx (pre-existing). 0020: per-exec
+    // budget ledger (cairn #454 Phase 4a/5). Note: 0018_completion_event_lookup_idx
+    // does NOT insert into `ff_migration_annotation`; only 0020 is added here.
+    expected.push(20);
     assert_eq!(versions, expected);
 }

--- a/crates/ff-backend-sqlite/tests/typed_deliver_approval_signal.rs
+++ b/crates/ff-backend-sqlite/tests/typed_deliver_approval_signal.rs
@@ -1,0 +1,236 @@
+//! cairn #454 Phase 5 — SQLite coverage of
+//! `EngineBackend::deliver_approval_signal`. Parity with the PG tests
+//! at `ff-backend-postgres/tests/typed_deliver_approval_signal.rs`.
+
+#![cfg(feature = "core")]
+
+use std::sync::Arc;
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::backend::{CapabilitySet, ClaimPolicy, Handle};
+use ff_core::contracts::{
+    CreateExecutionArgs, CreateExecutionResult, DeliverApprovalSignalArgs, DeliverSignalResult,
+    ResumeCondition, ResumePolicy, SeedWaitpointHmacSecretArgs, SignalMatcher, SuspendArgs,
+    SuspensionReasonCode, WaitpointBinding,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::types::{
+    ExecutionId, LaneId, Namespace, SuspensionId, TimestampMs, WaitpointId, WorkerId,
+    WorkerInstanceId,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+const KID: &str = "kid-approval";
+fn secret_hex() -> String {
+    "cafebabe".repeat(8)
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:typed-deliver-approval-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    let b = SqliteBackend::new(&uri).await.expect("backend");
+    b.seed_waitpoint_hmac_secret(SeedWaitpointHmacSecretArgs::new(KID, secret_hex()))
+        .await
+        .expect("seed kid");
+    b
+}
+
+async fn create_and_claim(b: &Arc<SqliteBackend>) -> (ExecutionId, Handle) {
+    let exec_id = ExecutionId::parse(&format!("{{fp:0}}:{}", Uuid::new_v4())).expect("exec id");
+    let args = CreateExecutionArgs {
+        execution_id: exec_id.clone(),
+        namespace: Namespace::new("default"),
+        lane_id: LaneId::new("default"),
+        execution_kind: "op".into(),
+        input_payload: b"hello".to_vec(),
+        payload_encoding: None,
+        priority: 0,
+        creator_identity: "test".into(),
+        idempotency_key: None,
+        tags: Default::default(),
+        policy: None,
+        delay_until: None,
+        execution_deadline_at: None,
+        partition_id: 0,
+        now: TimestampMs::from_millis(now_ms()),
+    };
+    let r = b.create_execution(args).await.expect("create");
+    assert!(matches!(r, CreateExecutionResult::Created { .. }));
+    let exec_uuid = Uuid::parse_str(exec_id.as_str().split_once("}:").unwrap().1).unwrap();
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase='runnable', public_state='pending', \
+         attempt_state='initial' WHERE partition_key=0 AND execution_id=?1",
+    )
+    .bind(exec_uuid)
+    .execute(b.pool_for_test())
+    .await
+    .unwrap();
+    let policy = ClaimPolicy::new(
+        WorkerId::new("w1"),
+        WorkerInstanceId::new("w1-i1"),
+        30_000,
+        None,
+    );
+    let handle = b
+        .claim(&LaneId::new("default"), &CapabilitySet::default(), policy)
+        .await
+        .expect("claim")
+        .expect("handle");
+    (exec_id, handle)
+}
+
+async fn suspend_on(
+    b: &Arc<SqliteBackend>,
+    handle: &Handle,
+    wp_key: &str,
+    signal_name: &str,
+) -> WaitpointId {
+    let wp_id = WaitpointId::new();
+    let binding = WaitpointBinding::Fresh {
+        waitpoint_id: wp_id.clone(),
+        waitpoint_key: wp_key.to_owned(),
+    };
+    let cond = ResumeCondition::Single {
+        waitpoint_key: wp_key.to_owned(),
+        matcher: SignalMatcher::ByName(signal_name.to_owned()),
+    };
+    let args = SuspendArgs::new(
+        SuspensionId::new(),
+        binding,
+        cond,
+        ResumePolicy::normal(),
+        SuspensionReasonCode::WaitingForSignal,
+        TimestampMs::from_millis(now_ms()),
+    );
+    let _ = b.suspend(handle, args).await.expect("suspend");
+    wp_id
+}
+
+fn approval_args(
+    exec_id: &ExecutionId,
+    lane: &LaneId,
+    wp_id: &WaitpointId,
+    signal_name: &str,
+    suffix: &str,
+) -> DeliverApprovalSignalArgs {
+    DeliverApprovalSignalArgs::new(
+        exec_id.clone(),
+        lane.clone(),
+        wp_id.clone(),
+        signal_name,
+        suffix,
+        60_000,
+        None,
+        None,
+    )
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn approved_path_resumes_execution() {
+    let b = fresh_backend().await;
+    let lane = LaneId::new("default");
+    let (exec_id, handle) = create_and_claim(&b).await;
+    let wp_id = suspend_on(&b, &handle, "wpk:approval:ok", "approved").await;
+    let args = approval_args(&exec_id, &lane, &wp_id, "approved", "dec-1");
+    let eb: Arc<dyn EngineBackend> = b.clone();
+    let out = eb
+        .deliver_approval_signal(args)
+        .await
+        .expect("deliver_approval_signal ok");
+    match out {
+        DeliverSignalResult::Accepted { effect, .. } => {
+            assert_eq!(effect, "resume_condition_satisfied");
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn rejected_path_appends_without_resume() {
+    let b = fresh_backend().await;
+    let lane = LaneId::new("default");
+    let (exec_id, handle) = create_and_claim(&b).await;
+    // Condition requires "approved"; delivering "rejected" should be
+    // appended but does not satisfy the resume condition.
+    let wp_id = suspend_on(&b, &handle, "wpk:approval:reject", "approved").await;
+    let args = approval_args(&exec_id, &lane, &wp_id, "rejected", "dec-1");
+    let eb: Arc<dyn EngineBackend> = b.clone();
+    let out = eb
+        .deliver_approval_signal(args)
+        .await
+        .expect("deliver_approval_signal ok");
+    match out {
+        DeliverSignalResult::Accepted { effect, .. } => {
+            assert_eq!(effect, "appended_to_waitpoint");
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn missing_waitpoint_returns_not_found() {
+    let b = fresh_backend().await;
+    let lane = LaneId::new("default");
+    let (exec_id, _handle) = create_and_claim(&b).await;
+    let bogus = WaitpointId::new();
+    let args = approval_args(&exec_id, &lane, &bogus, "approved", "dec-1");
+    let eb: Arc<dyn EngineBackend> = b.clone();
+    match eb.deliver_approval_signal(args).await.unwrap_err() {
+        EngineError::NotFound { entity } => assert_eq!(entity, "waitpoint"),
+        other => panic!("expected NotFound(waitpoint), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn lane_mismatch_is_validation_error() {
+    let b = fresh_backend().await;
+    let lane = LaneId::new("default");
+    let (exec_id, handle) = create_and_claim(&b).await;
+    let wp_id = suspend_on(&b, &handle, "wpk:approval:lane", "approved").await;
+    let wrong_lane = LaneId::new("not-default");
+    let args = approval_args(&exec_id, &wrong_lane, &wp_id, "approved", "dec-1");
+    let _ = lane;
+    let eb: Arc<dyn EngineBackend> = b.clone();
+    match eb.deliver_approval_signal(args).await.unwrap_err() {
+        EngineError::Validation { kind, detail } => {
+            assert_eq!(kind, ValidationKind::InvalidInput);
+            assert!(
+                detail.starts_with("lane_mismatch:"),
+                "unexpected detail: {detail}"
+            );
+        }
+        other => panic!("expected Validation(InvalidInput), got {other:?}"),
+    }
+}

--- a/crates/ff-backend-sqlite/tests/typed_issue_grant_and_claim.rs
+++ b/crates/ff-backend-sqlite/tests/typed_issue_grant_and_claim.rs
@@ -1,0 +1,184 @@
+//! cairn #454 Phase 5 — SQLite coverage of
+//! `EngineBackend::issue_grant_and_claim`. Parity with the PG tests at
+//! `ff-backend-postgres/tests/typed_issue_grant_and_claim.rs`.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::IssueGrantAndClaimArgs;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::engine_error::{ContentionKind, EngineError};
+use ff_core::types::{ExecutionId, LaneId};
+use serial_test::serial;
+use sqlx::Row;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn now_ms() -> i64 {
+    i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()).unwrap()
+}
+
+fn uuid_like() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:typed-issue-grant-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+async fn seed_runnable(backend: &SqliteBackend) -> (Uuid, ExecutionId) {
+    let pool = backend.pool_for_test();
+    let part: i64 = 0;
+    let exec_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:{part}}}:{exec_uuid}")).unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO ff_exec_core (
+            partition_key, execution_id, flow_id, lane_id, attempt_index,
+            lifecycle_phase, ownership_state, eligibility_state,
+            public_state, attempt_state, priority, created_at_ms, raw_fields
+        ) VALUES (
+            ?1, ?2, NULL, 'default', 0,
+            'runnable', 'unowned', 'eligible_now',
+            'waiting', 'pending_first_attempt', 0, ?3,
+            '{}'
+        )
+        "#,
+    )
+    .bind(part)
+    .bind(exec_uuid)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("seed exec");
+    (exec_uuid, eid)
+}
+
+fn args_for(eid: ExecutionId) -> IssueGrantAndClaimArgs {
+    IssueGrantAndClaimArgs::new(eid, LaneId::new("default"), 60_000)
+}
+
+async fn count_grants(backend: &SqliteBackend, exec_uuid: Uuid) -> i64 {
+    let (n,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM ff_claim_grant \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(backend.pool_for_test())
+    .await
+    .unwrap();
+    n
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn issue_grant_and_claim_happy_path() {
+    let be = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&be).await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let outcome = eb
+        .issue_grant_and_claim(args_for(eid))
+        .await
+        .expect("issue_grant_and_claim ok");
+    assert_eq!(outcome.lease_epoch.0, 1, "fresh claim starts at epoch 1");
+    assert_eq!(outcome.attempt_index.0, 0, "fresh claim at attempt 0");
+    assert!(!outcome.lease_id.to_string().is_empty());
+
+    let row = sqlx::query(
+        "SELECT lifecycle_phase, ownership_state, public_state, attempt_state, attempt_index \
+         FROM ff_exec_core WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .fetch_one(be.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(row.get::<String, _>("lifecycle_phase"), "active");
+    assert_eq!(row.get::<String, _>("ownership_state"), "leased");
+    assert_eq!(row.get::<String, _>("public_state"), "running");
+    assert_eq!(row.get::<String, _>("attempt_state"), "running_attempt");
+    assert_eq!(row.get::<i64, _>("attempt_index"), 1);
+
+    assert_eq!(count_grants(&be, exec_uuid).await, 0, "grant cleaned up");
+
+    let (worker_id, lease_epoch_i): (String, i64) = sqlx::query_as(
+        "SELECT worker_id, lease_epoch FROM ff_attempt \
+         WHERE partition_key = 0 AND execution_id = ?1 AND attempt_index = 0",
+    )
+    .bind(exec_uuid)
+    .fetch_one(be.pool_for_test())
+    .await
+    .unwrap();
+    assert_eq!(worker_id, "operator");
+    assert_eq!(lease_epoch_i, 1);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn issue_grant_and_claim_rejects_already_leased() {
+    let be = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&be).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET ownership_state = 'leased' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(be.pool_for_test())
+    .await
+    .unwrap();
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    match eb.issue_grant_and_claim(args_for(eid)).await {
+        Err(EngineError::Contention(ContentionKind::LeaseConflict)) => {}
+        other => panic!("expected LeaseConflict, got {other:?}"),
+    }
+    assert_eq!(
+        count_grants(&be, exec_uuid).await,
+        0,
+        "rejected composition must not leak a grant row"
+    );
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn issue_grant_and_claim_rejects_missing_execution() {
+    let be = fresh_backend().await;
+    let fake_uuid = Uuid::new_v4();
+    let eid = ExecutionId::parse(&format!("{{fp:0}}:{fake_uuid}")).unwrap();
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    match eb.issue_grant_and_claim(args_for(eid)).await {
+        Err(EngineError::NotFound { entity: "execution" }) => {}
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    assert_eq!(count_grants(&be, fake_uuid).await, 0);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn issue_grant_and_claim_no_dangling_grant_on_reject() {
+    let be = fresh_backend().await;
+    let (exec_uuid, eid) = seed_runnable(&be).await;
+    sqlx::query(
+        "UPDATE ff_exec_core SET lifecycle_phase = 'terminal' \
+         WHERE partition_key = 0 AND execution_id = ?1",
+    )
+    .bind(exec_uuid)
+    .execute(be.pool_for_test())
+    .await
+    .unwrap();
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    match eb.issue_grant_and_claim(args_for(eid)).await {
+        Err(EngineError::Contention(ContentionKind::ExecutionNotActive { .. })) => {}
+        other => panic!("expected ExecutionNotActive, got {other:?}"),
+    }
+    assert_eq!(count_grants(&be, exec_uuid).await, 0);
+}

--- a/crates/ff-backend-sqlite/tests/typed_record_spend.rs
+++ b/crates/ff-backend-sqlite/tests/typed_record_spend.rs
@@ -1,0 +1,218 @@
+//! cairn #454 Phase 5 — SQLite coverage of the typed
+//! `EngineBackend::record_spend` body. Parity with the PG tests at
+//! `ff-backend-postgres/tests/typed_record_spend.rs`.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{
+    CreateBudgetArgs, CreateBudgetResult, RecordSpendArgs, ReportUsageResult,
+};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{BudgetId, ExecutionId, LaneId, TimestampMs};
+use serial_test::serial;
+use sqlx::Row;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const LANE: &str = "record-spend-sqlite-test-lane";
+
+fn now_ms() -> i64 {
+    i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()).unwrap()
+}
+
+fn uuid_like() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:typed-record-spend-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+fn partition_config() -> PartitionConfig {
+    PartitionConfig::default()
+}
+
+fn budget_args(bid: &BudgetId, dims: &[(&str, u64, u64)]) -> CreateBudgetArgs {
+    CreateBudgetArgs {
+        budget_id: bid.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-1".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms: 0,
+        dimensions: dims.iter().map(|(d, _, _)| (*d).to_string()).collect(),
+        hard_limits: dims.iter().map(|(_, h, _)| *h).collect(),
+        soft_limits: dims.iter().map(|(_, _, s)| *s).collect(),
+        now: TimestampMs(now_ms()),
+    }
+}
+
+fn spend_args(
+    bid: &BudgetId,
+    exec: &ExecutionId,
+    deltas: &[(&str, u64)],
+    idem: &str,
+) -> RecordSpendArgs {
+    let mut m: BTreeMap<String, u64> = BTreeMap::new();
+    for (k, v) in deltas {
+        m.insert((*k).to_owned(), *v);
+    }
+    RecordSpendArgs::new(bid.clone(), exec.clone(), m, idem.to_owned())
+}
+
+async fn ledger_delta(
+    backend: &SqliteBackend,
+    bid: &BudgetId,
+    eid: &ExecutionId,
+    dim: &str,
+) -> Option<i64> {
+    let s = eid.as_str();
+    let uuid_str = &s[s.rfind("}:").unwrap() + 2..];
+    let row = sqlx::query(
+        "SELECT delta_total FROM ff_budget_usage_by_exec \
+         WHERE partition_key=0 AND budget_id=?1 AND execution_id=?2 AND dimensions_key=?3",
+    )
+    .bind(bid.to_string())
+    .bind(uuid_str)
+    .bind(dim)
+    .fetch_optional(backend.pool_for_test())
+    .await
+    .unwrap();
+    row.map(|r| r.get::<i64, _>("delta_total"))
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn record_spend_ok_path() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let r = eb
+        .create_budget(budget_args(
+            &bid,
+            &[("tokens", 100, 50), ("cost_cents", 1000, 500)],
+        ))
+        .await
+        .expect("create_budget");
+    assert!(matches!(r, CreateBudgetResult::Created { .. }));
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let r = eb
+        .record_spend(spend_args(
+            &bid,
+            &exec,
+            &[("tokens", 10), ("cost_cents", 20)],
+            "ok-1",
+        ))
+        .await
+        .expect("record_spend");
+    assert!(matches!(r, ReportUsageResult::Ok), "got {r:?}");
+
+    assert_eq!(ledger_delta(&be, &bid, &exec, "tokens").await, Some(10));
+    assert_eq!(ledger_delta(&be, &bid, &exec, "cost_cents").await, Some(20));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn record_spend_idempotent_replay() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let _ = eb
+        .create_budget(budget_args(&bid, &[("tokens", 100, 50)]))
+        .await
+        .expect("create_budget");
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let args = spend_args(&bid, &exec, &[("tokens", 7)], "replay-me");
+    let r = eb.record_spend(args.clone()).await.expect("first");
+    assert!(matches!(r, ReportUsageResult::Ok), "got {r:?}");
+
+    let r2 = eb.record_spend(args).await.expect("replay");
+    assert!(
+        matches!(r2, ReportUsageResult::AlreadyApplied),
+        "got {r2:?}"
+    );
+    assert_eq!(ledger_delta(&be, &bid, &exec, "tokens").await, Some(7));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn record_spend_soft_breach() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let _ = eb
+        .create_budget(budget_args(&bid, &[("tokens", 100, 50)]))
+        .await
+        .expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let r = eb
+        .record_spend(spend_args(&bid, &exec, &[("tokens", 60)], "soft-1"))
+        .await
+        .expect("soft");
+    match r {
+        ReportUsageResult::SoftBreach {
+            dimension,
+            current_usage,
+            soft_limit,
+        } => {
+            assert_eq!(dimension, "tokens");
+            assert_eq!(current_usage, 60);
+            assert_eq!(soft_limit, 50);
+        }
+        other => panic!("expected SoftBreach, got {other:?}"),
+    }
+    assert_eq!(ledger_delta(&be, &bid, &exec, "tokens").await, Some(60));
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn record_spend_hard_breach() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let _ = eb
+        .create_budget(budget_args(&bid, &[("tokens", 100, 50)]))
+        .await
+        .expect("create_budget");
+
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = eb
+        .record_spend(spend_args(&bid, &exec, &[("tokens", 40)], "hard-seed"))
+        .await
+        .expect("seed");
+
+    let r = eb
+        .record_spend(spend_args(&bid, &exec, &[("tokens", 80)], "hard-1"))
+        .await
+        .expect("hard");
+    match r {
+        ReportUsageResult::HardBreach {
+            dimension,
+            current_usage,
+            hard_limit,
+        } => {
+            assert_eq!(dimension, "tokens");
+            assert_eq!(current_usage, 40);
+            assert_eq!(hard_limit, 100);
+        }
+        other => panic!("expected HardBreach, got {other:?}"),
+    }
+    // Ledger still at the seed value — 40, not 120.
+    assert_eq!(ledger_delta(&be, &bid, &exec, "tokens").await, Some(40));
+}

--- a/crates/ff-backend-sqlite/tests/typed_release_budget.rs
+++ b/crates/ff-backend-sqlite/tests/typed_release_budget.rs
@@ -1,0 +1,184 @@
+//! cairn #454 Phase 5 — SQLite coverage of the typed
+//! `EngineBackend::release_budget` body. Parity with the PG tests at
+//! `ff-backend-postgres/tests/typed_release_budget.rs`.
+
+use ff_backend_sqlite::SqliteBackend;
+use ff_core::contracts::{CreateBudgetArgs, RecordSpendArgs, ReleaseBudgetArgs};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::{BudgetId, ExecutionId, LaneId, TimestampMs};
+use serial_test::serial;
+use sqlx::Row;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const LANE: &str = "release-budget-sqlite-test-lane";
+
+fn now_ms() -> i64 {
+    i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()).unwrap()
+}
+
+fn uuid_like() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tid = std::thread::current().id();
+    format!("{ns}-{tid:?}").replace([':', ' '], "-")
+}
+
+async fn fresh_backend() -> Arc<SqliteBackend> {
+    unsafe {
+        std::env::set_var("FF_DEV_MODE", "1");
+    }
+    let uri = format!(
+        "file:typed-release-budget-{}?mode=memory&cache=shared",
+        uuid_like()
+    );
+    SqliteBackend::new(&uri).await.expect("construct")
+}
+
+fn partition_config() -> PartitionConfig {
+    PartitionConfig::default()
+}
+
+fn budget_args(bid: &BudgetId) -> CreateBudgetArgs {
+    CreateBudgetArgs {
+        budget_id: bid.clone(),
+        scope_type: "flow".into(),
+        scope_id: "flow-1".into(),
+        enforcement_mode: "strict".into(),
+        on_hard_limit: "fail".into(),
+        on_soft_limit: "warn".into(),
+        reset_interval_ms: 0,
+        dimensions: vec!["tokens".into()],
+        hard_limits: vec![1_000_000],
+        soft_limits: vec![999_999],
+        now: TimestampMs(now_ms()),
+    }
+}
+
+fn spend(bid: &BudgetId, exec: &ExecutionId, tokens: u64, idem: &str) -> RecordSpendArgs {
+    let mut m = BTreeMap::new();
+    m.insert("tokens".to_string(), tokens);
+    RecordSpendArgs::new(bid.clone(), exec.clone(), m, idem.to_owned())
+}
+
+async fn aggregate_tokens(be: &SqliteBackend, bid: &BudgetId) -> i64 {
+    let row = sqlx::query(
+        "SELECT current_value FROM ff_budget_usage \
+         WHERE partition_key=0 AND budget_id=?1 AND dimensions_key='tokens'",
+    )
+    .bind(bid.to_string())
+    .fetch_optional(be.pool_for_test())
+    .await
+    .unwrap();
+    row.map(|r| r.get::<i64, _>("current_value")).unwrap_or(0)
+}
+
+async fn ledger_row_count(be: &SqliteBackend, bid: &BudgetId, exec: &ExecutionId) -> i64 {
+    let s = exec.as_str();
+    let uuid_str = &s[s.rfind("}:").unwrap() + 2..];
+    let row = sqlx::query(
+        "SELECT COUNT(*) AS c FROM ff_budget_usage_by_exec \
+         WHERE partition_key=0 AND budget_id=?1 AND execution_id=?2",
+    )
+    .bind(bid.to_string())
+    .bind(uuid_str)
+    .fetch_one(be.pool_for_test())
+    .await
+    .unwrap();
+    row.get::<i64, _>("c")
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn release_after_record_zeros_aggregate() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let _ = eb.create_budget(budget_args(&bid)).await.expect("create");
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = eb
+        .record_spend(spend(&bid, &exec, 5, "r-1"))
+        .await
+        .expect("record");
+    assert_eq!(aggregate_tokens(&be, &bid).await, 5);
+    assert_eq!(ledger_row_count(&be, &bid, &exec).await, 1);
+
+    eb.release_budget(ReleaseBudgetArgs::new(bid.clone(), exec.clone()))
+        .await
+        .expect("release");
+    assert_eq!(aggregate_tokens(&be, &bid).await, 0);
+    assert_eq!(ledger_row_count(&be, &bid, &exec).await, 0);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn release_reverses_accumulated_spends() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let _ = eb.create_budget(budget_args(&bid)).await.expect("create");
+    let exec = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = eb.record_spend(spend(&bid, &exec, 3, "a")).await.unwrap();
+    let _ = eb.record_spend(spend(&bid, &exec, 7, "b")).await.unwrap();
+    let _ = eb.record_spend(spend(&bid, &exec, 2, "c")).await.unwrap();
+    assert_eq!(aggregate_tokens(&be, &bid).await, 12);
+
+    eb.release_budget(ReleaseBudgetArgs::new(bid.clone(), exec.clone()))
+        .await
+        .expect("release");
+    assert_eq!(aggregate_tokens(&be, &bid).await, 0);
+    assert_eq!(ledger_row_count(&be, &bid, &exec).await, 0);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn release_without_prior_record_is_noop() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let _ = eb.create_budget(budget_args(&bid)).await.expect("create");
+    let seeded = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = eb
+        .record_spend(spend(&bid, &seeded, 9, "seed"))
+        .await
+        .unwrap();
+    assert_eq!(aggregate_tokens(&be, &bid).await, 9);
+
+    let ghost = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    eb.release_budget(ReleaseBudgetArgs::new(bid.clone(), ghost))
+        .await
+        .expect("noop release");
+    assert_eq!(aggregate_tokens(&be, &bid).await, 9);
+}
+
+#[tokio::test]
+#[serial(ff_dev_mode)]
+async fn release_is_idempotent_and_isolated() {
+    let be = fresh_backend().await;
+    let eb: Arc<dyn EngineBackend> = be.clone();
+    let bid = BudgetId::new();
+    let _ = eb.create_budget(budget_args(&bid)).await.expect("create");
+
+    let e1 = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let e2 = ExecutionId::solo(&LaneId::new(LANE), &partition_config());
+    let _ = eb.record_spend(spend(&bid, &e1, 5, "e1")).await.unwrap();
+    let _ = eb.record_spend(spend(&bid, &e2, 8, "e2")).await.unwrap();
+    assert_eq!(aggregate_tokens(&be, &bid).await, 13);
+
+    eb.release_budget(ReleaseBudgetArgs::new(bid.clone(), e1.clone()))
+        .await
+        .expect("release e1");
+    assert_eq!(aggregate_tokens(&be, &bid).await, 8);
+    assert_eq!(ledger_row_count(&be, &bid, &e1).await, 0);
+    assert_eq!(ledger_row_count(&be, &bid, &e2).await, 1);
+
+    // Second release is a no-op.
+    eb.release_budget(ReleaseBudgetArgs::new(bid.clone(), e1.clone()))
+        .await
+        .expect("release e1 again");
+    assert_eq!(aggregate_tokens(&be, &bid).await, 8);
+}


### PR DESCRIPTION
## Summary

Cairn #454 Phase 5 — SQLite bodies for the four typed-FCALL methods. Flips the four `Unavailable` defaults to green on `SqliteBackend`, completing parity with the Valkey (PR #464/#465/#466) and PG (PR #467/#468/#469) bodies landed earlier.

- `record_spend` — per-execution budget spend with dedup + per-exec ledger mirror into `ff_budget_usage_by_exec` (migration 0020).
- `release_budget` — scan-and-reverse against the per-exec ledger, `MAX(0, aggregate - delta)` clamp for SQLite (vs PG `GREATEST`).
- `deliver_approval_signal` — server-side `lane_id` verification + server-side waitpoint token read + dispatch through the existing `deliver_signal_impl`.
- `issue_grant_and_claim` — backend-atomic composition of `issue_claim_grant` + `claim_execution` (fresh + resume branches) in a single `BEGIN IMMEDIATE` tx; DELETE grant in-tx on success; tx rollback on reject keeps the no-dangling-grant invariant.

Trait overrides on `SqliteBackend` wrap each impl in `retry_serializable` to absorb `SQLITE_BUSY` under writer contention, matching the Phase 1 typed-FCALL pattern.

## Test plan

16 new tests (4 per method) run in-memory + `#[serial(ff_dev_mode)]`:

- [x] `cargo test -p ff-backend-sqlite --test typed_record_spend` — 4/4
- [x] `cargo test -p ff-backend-sqlite --test typed_release_budget` — 4/4
- [x] `cargo test -p ff-backend-sqlite --test typed_deliver_approval_signal` — 4/4
- [x] `cargo test -p ff-backend-sqlite --test typed_issue_grant_and_claim` — 4/4
- [x] `cargo clippy -p ff-backend-sqlite --tests -- -D warnings`
- [x] `cargo test -p ff-backend-sqlite` — full suite green (migrations ledger expectations bumped to include 0020)

Cairn #454 Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)