### PR TITLE
feat(ff-sdk): AdminClient::read_waitpoint_token + HTTP/embedded dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`FlowFabricAdminClient::read_waitpoint_token`** — admin-surface
+  helper that fetches the raw HMAC `waitpoint_token` for a given
+  `(execution_id, waitpoint_id)`. Covers both the HTTP transport
+  (new route `GET /v1/executions/{id}/waitpoints/{wp_id}/token`,
+  bearer-auth gated via the server's existing `api_token` layer) and
+  the embedded transport (delegates to
+  `EngineBackend::read_waitpoint_token`). Returns `Ok(None)` when the
+  waitpoint is unknown, consumed, or expired. The sibling
+  `list_pending_waitpoints` endpoint intentionally continues to
+  sanitise the raw token (RFC-017 Stage E4); this new surface
+  re-exposes it only for operator tooling that holds the admin bearer.
+  The `deploy-approval/approve`, `media-pipeline/review`, and
+  `llm-race/approve` example CLIs drop their `--waitpoint-token` flag
+  and fetch through the admin client instead.
+
 ## [0.13.0] - 2026-05-01
 
 ### Changed

--- a/crates/ff-sdk/src/admin.rs
+++ b/crates/ff-sdk/src/admin.rs
@@ -304,6 +304,49 @@ impl FlowFabricAdminClient {
         }
     }
 
+    /// Read the raw HMAC `waitpoint_token` for a specific
+    /// `(execution_id, waitpoint_id)` pair.
+    ///
+    /// # Operator-only
+    ///
+    /// The sibling `list_pending_waitpoints` API intentionally sanitises
+    /// this field (RFC-017 Stage E4 / v0.8.0 §8) — consumers correlate
+    /// via `(token_kid, token_fingerprint)` and normally obtain the raw
+    /// token from their own worker's `SuspendOutcome` at suspend time.
+    /// This admin method re-exposes the token behind the server's
+    /// bearer-auth layer so operator tooling (approval CLIs,
+    /// external-callback bridges) can fetch a delivery credential
+    /// programmatically instead of copy-pasting from worker logs.
+    ///
+    /// Deployments MUST run `ff-server` with `api_token` configured
+    /// when exposing this endpoint to untrusted networks. The embedded
+    /// transport has no auth boundary — access is gated by whoever
+    /// holds the `Arc<dyn EngineBackend>`.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(token))` — HMAC token string suitable for
+    ///   `DeliverSignalArgs::waitpoint_token` / `/signal` request body.
+    /// * `Ok(None)` — waitpoint is unknown, consumed, expired, or the
+    ///   stored token column is empty.
+    /// * `Err(SdkError::AdminApi { status: 503, kind: Some("unavailable") })`
+    ///   — the backend (e.g. an out-of-tree implementation) has not
+    ///   overridden `EngineBackend::read_waitpoint_token`.
+    pub async fn read_waitpoint_token(
+        &self,
+        execution_id: &ff_core::types::ExecutionId,
+        waitpoint_id: &ff_core::types::WaitpointId,
+    ) -> Result<Option<String>, SdkError> {
+        match &self.transport {
+            AdminTransport::Http { http, base_url } => {
+                read_waitpoint_token_http(http, base_url, execution_id, waitpoint_id).await
+            }
+            AdminTransport::Embedded(backend) => {
+                read_waitpoint_token_embedded(backend.as_ref(), execution_id, waitpoint_id).await
+            }
+        }
+    }
+
     /// Request a lease-reclaim grant for an execution in
     /// `lease_expired_reclaimable` or `lease_revoked` state (RFC-024
     /// §3.5).
@@ -764,6 +807,92 @@ async fn issue_reclaim_grant_embedded(
             raw_body: String::new(),
         }),
     }
+}
+
+async fn read_waitpoint_token_http(
+    http: &reqwest::Client,
+    base_url: &str,
+    execution_id: &ff_core::types::ExecutionId,
+    waitpoint_id: &ff_core::types::WaitpointId,
+) -> Result<Option<String>, SdkError> {
+    // Percent-encode both path segments: execution_id carries `{fp:N}:`
+    // hash-tag punctuation; waitpoint_id is a UUID but be defensive.
+    let mut url = reqwest::Url::parse(base_url).map_err(|e| SdkError::Config {
+        context: "admin_client: read_waitpoint_token".into(),
+        field: Some("base_url".into()),
+        message: format!("invalid base_url '{}': {e}", base_url),
+    })?;
+    url.path_segments_mut()
+        .map_err(|_| SdkError::Config {
+            context: "admin_client: read_waitpoint_token".into(),
+            field: Some("base_url".into()),
+            message: format!("base_url '{}' cannot be a base", base_url),
+        })?
+        .extend(&[
+            "v1",
+            "executions",
+            execution_id.as_str(),
+            "waitpoints",
+            &waitpoint_id.to_string(),
+            "token",
+        ]);
+
+    let resp = http
+        .get(url.clone())
+        .send()
+        .await
+        .map_err(|e| SdkError::Http {
+            source: e,
+            context: format!("GET {url}"),
+        })?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if status.is_success() {
+        #[derive(Deserialize)]
+        struct Body {
+            token: String,
+        }
+        let body: Body = resp.json().await.map_err(|e| SdkError::Http {
+            source: e,
+            context: "decode read_waitpoint_token response body".into(),
+        })?;
+        return Ok(Some(body.token));
+    }
+
+    let status_u16 = status.as_u16();
+    let raw = resp.text().await.map_err(|e| SdkError::Http {
+        source: e,
+        context: format!("read read_waitpoint_token error body (status {status_u16})"),
+    })?;
+    let parsed = serde_json::from_str::<AdminErrorBody>(&raw).ok();
+    Err(SdkError::AdminApi {
+        status: status_u16,
+        message: parsed
+            .as_ref()
+            .map(|b| b.error.clone())
+            .unwrap_or_else(|| raw.clone()),
+        kind: parsed.as_ref().and_then(|b| b.kind.clone()),
+        retryable: parsed.as_ref().and_then(|b| b.retryable),
+        raw_body: raw,
+    })
+}
+
+async fn read_waitpoint_token_embedded(
+    backend: &dyn EngineBackend,
+    execution_id: &ff_core::types::ExecutionId,
+    waitpoint_id: &ff_core::types::WaitpointId,
+) -> Result<Option<String>, SdkError> {
+    let partition =
+        ff_core::partition::PartitionKey::from(&ff_core::partition::Partition {
+            family: ff_core::partition::PartitionFamily::Flow,
+            index: execution_id.partition(),
+        });
+    backend
+        .read_waitpoint_token(partition, waitpoint_id)
+        .await
+        .map_err(|e| engine_err_to_admin(e, "read_waitpoint_token"))
 }
 
 async fn rotate_waitpoint_secret_embedded(
@@ -1381,6 +1510,38 @@ mod tests {
     // RESP handshake on `ClientBuilder::build`, so a local TCP
     // listener alone isn't sufficient) — expensive to construct for
     // one-line iteration-count coverage.
+
+    #[test]
+    fn read_waitpoint_token_url_percent_encodes_path_segments() {
+        // The execution id carries `{fp:N}:` literal punctuation;
+        // a naïve `format!` splice would ship those chars unencoded
+        // and the server would match the wrong route. Pin that the
+        // reqwest URL builder percent-encodes each segment.
+        use ff_core::types::{ExecutionId, WaitpointId};
+
+        let mut url = reqwest::Url::parse("http://x").unwrap();
+        let execution_id = ExecutionId::parse(
+            "{fp:7}:11111111-1111-1111-1111-111111111111",
+        )
+        .unwrap();
+        let waitpoint_id = WaitpointId::parse("22222222-2222-2222-2222-222222222222")
+            .unwrap();
+        url.path_segments_mut()
+            .unwrap()
+            .extend(&[
+                "v1",
+                "executions",
+                execution_id.as_str(),
+                "waitpoints",
+                &waitpoint_id.to_string(),
+                "token",
+            ]);
+        assert_eq!(
+            url.as_str(),
+            "http://x/v1/executions/%7Bfp:7%7D:11111111-1111-1111-1111-111111111111\
+             /waitpoints/22222222-2222-2222-2222-222222222222/token"
+        );
+    }
 
     #[test]
     fn claim_for_worker_response_deserialises_opaque_partition_key() {

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -587,6 +587,10 @@ pub fn router_with_metrics(
             "/v1/executions/{id}/pending-waitpoints",
             get(list_pending_waitpoints),
         )
+        .route(
+            "/v1/executions/{id}/waitpoints/{waitpoint_id}/token",
+            get(get_waitpoint_token),
+        )
         .route("/v1/executions/{id}/result", get(get_execution_result))
         .route(
             "/v1/executions/{id}/cancel",
@@ -935,6 +939,52 @@ async fn list_pending_waitpoints(
     let args = ff_core::contracts::ListPendingWaitpointsArgs::new(eid);
     let page = server.backend().list_pending_waitpoints(args).await?;
     Ok(Json(page.entries).into_response())
+}
+
+#[derive(Serialize)]
+struct WaitpointTokenResponse {
+    token: String,
+}
+
+/// Operator-only read of the raw HMAC `waitpoint_token` for a specific
+/// `(execution_id, waitpoint_id)`. Dispatches through
+/// [`EngineBackend::read_waitpoint_token`]; partition is derived from
+/// the path-parsed `ExecutionId`.
+///
+/// The sibling `/pending-waitpoints` route intentionally sanitises this
+/// field (RFC-017 Stage E4). This endpoint re-exposes it behind the
+/// server's bearer-auth layer so operator tooling (approval CLIs,
+/// external-callback bridges) can fetch a delivery credential
+/// programmatically instead of copy-pasting from worker logs. Without
+/// `api_token` configured the server accepts the call unauthenticated —
+/// production deployments MUST run with `api_token` set.
+///
+/// Returns 200 `{"token": "..."}` when present; 404 when the backend
+/// reports `Ok(None)` (waitpoint consumed, expired, or never existed).
+async fn get_waitpoint_token(
+    State(server): State<Arc<Server>>,
+    Path((id, waitpoint_id)): Path<(String, String)>,
+) -> Result<Response, ApiError> {
+    let eid = parse_execution_id(&id)?;
+    let wp_id = WaitpointId::parse(&waitpoint_id).map_err(|e| {
+        ApiError::from(ServerError::InvalidInput(format!(
+            "waitpoint_id: {e}"
+        )))
+    })?;
+    let partition = ff_core::partition::PartitionKey::from(&ff_core::partition::Partition {
+        family: ff_core::partition::PartitionFamily::Flow,
+        index: eid.partition(),
+    });
+    match server.backend().read_waitpoint_token(partition, &wp_id).await? {
+        Some(token) => Ok(Json(WaitpointTokenResponse { token }).into_response()),
+        None => Ok((
+            StatusCode::NOT_FOUND,
+            Json(ErrorBody::plain(
+                "waitpoint token not found (consumed, expired, or unknown id)".to_owned(),
+            )),
+        )
+            .into_response()),
+    }
 }
 
 /// Returns the raw result payload bytes written by the worker's

--- a/crates/ff-server/src/api.rs
+++ b/crates/ff-server/src/api.rs
@@ -975,16 +975,28 @@ async fn get_waitpoint_token(
         family: ff_core::partition::PartitionFamily::Flow,
         index: eid.partition(),
     });
-    match server.backend().read_waitpoint_token(partition, &wp_id).await? {
-        Some(token) => Ok(Json(WaitpointTokenResponse { token }).into_response()),
-        None => Ok((
+    let mut response = match server.backend().read_waitpoint_token(partition, &wp_id).await? {
+        Some(token) => Json(WaitpointTokenResponse { token }).into_response(),
+        None => (
             StatusCode::NOT_FOUND,
             Json(ErrorBody::plain(
                 "waitpoint token not found (consumed, expired, or unknown id)".to_owned(),
             )),
         )
-            .into_response()),
-    }
+            .into_response(),
+    };
+    // The token is a bearer-equivalent HMAC credential — disable HTTP
+    // caching on BOTH the 200 and 404 paths so intermediaries or
+    // browser-like clients don't persist the body, and also so the
+    // 404 (which is negative-cacheable by default) can't leak a
+    // "this waitpoint id is unknown" signal past its consumption.
+    response
+        .headers_mut()
+        .insert(
+            axum::http::header::CACHE_CONTROL,
+            axum::http::HeaderValue::from_static("no-store"),
+        );
+    Ok(response)
 }
 
 /// Returns the raw result payload bytes written by the worker's

--- a/crates/ff-test/tests/pending_waitpoints_api.rs
+++ b/crates/ff-test/tests/pending_waitpoints_api.rs
@@ -515,6 +515,58 @@ async fn test_signal_delivery_with_tampered_token_rejected() {
     );
 }
 
+/// v0.14 — `GET /v1/executions/{id}/waitpoints/{wp_id}/token` returns
+/// the raw HMAC token for an existing waitpoint. Admin-surface parity
+/// with `EngineBackend::read_waitpoint_token`.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_get_waitpoint_token_returns_token_after_suspend() {
+    let api = TestApi::setup().await;
+    let tc = TestCluster::connect().await;
+
+    let eid = tc.new_execution_id();
+    let (lease_id, epoch, attempt_id) = fcall_create_and_claim(&tc, &eid).await;
+    let (wp_id, _wp_key, expected_token) =
+        fcall_suspend(&tc, &eid, &lease_id, &epoch, &attempt_id).await;
+
+    let resp = api
+        .client
+        .get(api.url(&format!("/v1/executions/{eid}/waitpoints/{wp_id}/token")))
+        .send()
+        .await
+        .expect("waitpoint-token request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await.expect("body parse");
+    let token = body
+        .get("token")
+        .and_then(|v| v.as_str())
+        .expect("response must carry `token` field");
+    assert_eq!(token, expected_token);
+}
+
+/// Unknown waitpoint id → 404 (backend returns Ok(None)).
+#[tokio::test]
+#[serial_test::serial]
+async fn test_get_waitpoint_token_unknown_id_returns_404() {
+    let api = TestApi::setup().await;
+    let tc = TestCluster::connect().await;
+
+    let eid = tc.new_execution_id();
+    let _ = fcall_create_and_claim(&tc, &eid).await;
+    let unknown_wp = WaitpointId::new();
+
+    let resp = api
+        .client
+        .get(api.url(&format!(
+            "/v1/executions/{eid}/waitpoints/{unknown_wp}/token"
+        )))
+        .send()
+        .await
+        .expect("waitpoint-token request failed");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
 /// A nonexistent execution returns 404.
 #[tokio::test]
 #[serial_test::serial]

--- a/crates/ff-test/tests/pending_waitpoints_api.rs
+++ b/crates/ff-test/tests/pending_waitpoints_api.rs
@@ -537,6 +537,17 @@ async fn test_get_waitpoint_token_returns_token_after_suspend() {
         .expect("waitpoint-token request failed");
     assert_eq!(resp.status(), StatusCode::OK);
 
+    // Pin the no-store header on the success path: the token is a
+    // bearer-equivalent HMAC credential and must not be persisted by
+    // intermediaries.
+    assert_eq!(
+        resp.headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok()),
+        Some("no-store"),
+        "waitpoint_token response must carry Cache-Control: no-store"
+    );
+
     let body: serde_json::Value = resp.json().await.expect("body parse");
     let token = body
         .get("token")
@@ -565,6 +576,15 @@ async fn test_get_waitpoint_token_unknown_id_returns_404() {
         .await
         .expect("waitpoint-token request failed");
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    // no-store also on the 404 path so intermediaries can't cache
+    // negative lookups (would leak "waitpoint id {X} unknown" signal).
+    assert_eq!(
+        resp.headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok()),
+        Some("no-store"),
+        "404 response must also carry Cache-Control: no-store"
+    );
 }
 
 /// A nonexistent execution returns 404.

--- a/examples/deploy-approval/README.md
+++ b/examples/deploy-approval/README.md
@@ -289,28 +289,26 @@ line — approvers need it.
 When the deploy worker suspends it prints a line like:
 
 ```
-[timeline] deploy_suspended execution_id=<eid> waitpoint_key=approval waitpoint_id=<wp-id> waitpoint_token=<token>
+[timeline] deploy_suspended execution_id=<eid> waitpoint_key=approval waitpoint_id=<wp-id>
 ```
 
-Copy `waitpoint_id` and `waitpoint_token` from that line — ff-server
-stopped exposing the token on the pending-waitpoints read endpoint in
-v0.8.0 (RFC-017 Stage E4), so approve takes it explicitly. v0.14 is
-adding an admin-surface `read_waitpoint_token` so a future version of
-this example can fetch it back.
+Copy `waitpoint_id` from that line. The raw HMAC `waitpoint_token` is
+fetched automatically via the ff-sdk admin client
+(`FlowFabricAdminClient::read_waitpoint_token`) — operators no longer
+paste it from the worker log. Set `FF_API_TOKEN` when the server runs
+with bearer auth.
 
 ```bash
 cargo run --release --bin approve -- \
   --flow-id <flow-id-from-submit> \
   --execution-id <deploy-execution-id> \
   --waitpoint-id <wp-id-from-deploy> \
-  --waitpoint-token <token-from-deploy> \
   --reviewer alice
 
 cargo run --release --bin approve -- \
   --flow-id <flow-id-from-submit> \
   --execution-id <deploy-execution-id> \
   --waitpoint-id <wp-id-from-deploy> \
-  --waitpoint-token <token-from-deploy> \
   --reviewer bob
 ```
 

--- a/examples/deploy-approval/src/bin/approve.rs
+++ b/examples/deploy-approval/src/bin/approve.rs
@@ -7,6 +7,8 @@
 
 use clap::Parser;
 use deploy_approval_example::{ApprovalPayload, DEFAULT_SERVER_URL, SIGNAL_NAME_APPROVAL};
+use ff_core::types::{ExecutionId, WaitpointId};
+use ff_sdk::admin::FlowFabricAdminClient;
 
 #[derive(Parser)]
 #[command(name = "approve", about = "deploy-approval reviewer CLI")]
@@ -22,16 +24,12 @@ struct Args {
     #[arg(long)]
     execution_id: String,
     /// Waitpoint id printed by `deploy` on suspend (look for
-    /// `[timeline] deploy_suspended ... waitpoint_id=...`).
+    /// `[timeline] deploy_suspended ... waitpoint_id=...`). v0.14 the
+    /// raw `waitpoint_token` is fetched through the admin client's
+    /// `read_waitpoint_token` helper — callers no longer copy it from
+    /// the worker log.
     #[arg(long)]
     waitpoint_id: String,
-    /// Waitpoint token printed by `deploy` on suspend (look for
-    /// `waitpoint_token=...`). ff-server dropped the token from the
-    /// pending-waitpoints read endpoint in v0.8.0 (RFC-017 Stage E4);
-    /// operators pass it explicitly here. v0.14 adds an admin-surface
-    /// `read_waitpoint_token` so this can go back to a fetch.
-    #[arg(long)]
-    waitpoint_token: String,
     /// Unique reviewer identity — `Count{DistinctSources}` keys on this.
     #[arg(long)]
     reviewer: String,
@@ -45,6 +43,25 @@ struct Args {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let http = reqwest::Client::new();
+
+    // v0.14: fetch the raw waitpoint HMAC token through the admin
+    // client so operator tooling doesn't depend on the worker's log
+    // output. The bearer token (if any) gates access server-side.
+    let admin = match args.api_token.as_deref() {
+        Some(t) => FlowFabricAdminClient::with_token(&args.server, t)?,
+        None => FlowFabricAdminClient::new(&args.server)?,
+    };
+    let execution_id = ExecutionId::parse(&args.execution_id)?;
+    let waitpoint_id = WaitpointId::parse(&args.waitpoint_id)?;
+    let waitpoint_token = admin
+        .read_waitpoint_token(&execution_id, &waitpoint_id)
+        .await?
+        .ok_or_else(|| {
+            format!(
+                "waitpoint {} token not found on server (consumed, expired, or unknown)",
+                args.waitpoint_id
+            )
+        })?;
 
     let payload = ApprovalPayload {
         approved: args.approve,
@@ -61,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "payload": serde_json::to_vec(&payload)?,
         "payload_encoding": "json",
         "target_scope": "execution",
-        "waitpoint_token": args.waitpoint_token,
+        "waitpoint_token": waitpoint_token,
         "now": std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_millis() as i64,

--- a/examples/deploy-approval/src/bin/approve.rs
+++ b/examples/deploy-approval/src/bin/approve.rs
@@ -24,7 +24,7 @@ struct Args {
     #[arg(long)]
     execution_id: String,
     /// Waitpoint id printed by `deploy` on suspend (look for
-    /// `[timeline] deploy_suspended ... waitpoint_id=...`). v0.14 the
+    /// `[timeline] deploy_suspended ... waitpoint_id=...`). In v0.14 the
     /// raw `waitpoint_token` is fetched through the admin client's
     /// `read_waitpoint_token` helper — callers no longer copy it from
     /// the worker log.

--- a/examples/llm-race/README.md
+++ b/examples/llm-race/README.md
@@ -278,20 +278,17 @@ Expected timeline output (times approximate):
 # Terminal 6:
 cargo run --release --bin submit -- --prompt "..." --review
 
-# Aggregator will suspend. Watch its log for a line like
-#   waitpoint_id=<wp-id> waitpoint_token=<hex>
-# and pass both to each reviewer invocation (ff-server dropped the
-# token from the pending-waitpoints read endpoint in v0.8.0 per
-# RFC-017 Stage E4; v0.14 adds an admin read-path):
+# Aggregator will suspend. Watch its log for `waitpoint_id=<wp-id>`;
+# the raw HMAC token is fetched via the ff-sdk admin client
+# (`FlowFabricAdminClient::read_waitpoint_token`, v0.14) — no
+# copy-paste from the worker log:
 cargo run --release --bin approve -- \
     --execution-id <aggregator-eid> \
     --waitpoint-id <wp-id> \
-    --waitpoint-token <hex> \
     --reviewer alice
 cargo run --release --bin approve -- \
     --execution-id <aggregator-eid> \
     --waitpoint-id <wp-id> \
-    --waitpoint-token <hex> \
     --reviewer bob
 ```
 

--- a/examples/llm-race/src/bin/approve.rs
+++ b/examples/llm-race/src/bin/approve.rs
@@ -5,15 +5,14 @@
 //! `Count { n: 2, DistinctSources }` resume condition counts it as a
 //! unique satisfier.
 //!
-//! The `--waitpoint-id` + `--waitpoint-token` pair is printed by the
-//! aggregator worker on suspend (look for
-//! `waitpoint_id=... waitpoint_token=...` in its log). ff-server dropped
-//! the token from `GET /v1/executions/{id}/pending-waitpoints` in v0.8.0
-//! (RFC-017 Stage E4); operators copy the values from the suspending
-//! worker's log. v0.14 adds an admin-surface `read_waitpoint_token` so
-//! this can go back to a fetch.
+//! The `--waitpoint-id` is printed by the aggregator worker on suspend.
+//! The raw HMAC `waitpoint_token` is fetched through the admin client's
+//! `read_waitpoint_token` helper (ff-sdk v0.14) — operators no longer
+//! copy it out of the worker's log.
 
 use clap::Parser;
+use ff_core::types::{ExecutionId, WaitpointId};
+use ff_sdk::admin::FlowFabricAdminClient;
 use llm_race_example::{ReviewPayload, DEFAULT_SERVER_URL};
 
 #[derive(Parser)]
@@ -27,9 +26,6 @@ struct Args {
     /// Waitpoint id printed by the aggregator on suspend.
     #[arg(long)]
     waitpoint_id: String,
-    /// Waitpoint HMAC token printed by the aggregator on suspend.
-    #[arg(long)]
-    waitpoint_token: String,
     /// Unique reviewer identity — the `Count { DistinctSources }`
     /// counter keys on this.
     #[arg(long)]
@@ -46,6 +42,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let http = reqwest::Client::new();
 
+    let admin = match args.api_token.as_deref() {
+        Some(t) => FlowFabricAdminClient::with_token(&args.server, t)?,
+        None => FlowFabricAdminClient::new(&args.server)?,
+    };
+    let execution_id = ExecutionId::parse(&args.execution_id)?;
+    let waitpoint_id = WaitpointId::parse(&args.waitpoint_id)?;
+    let waitpoint_token = admin
+        .read_waitpoint_token(&execution_id, &waitpoint_id)
+        .await?
+        .ok_or_else(|| {
+            format!(
+                "waitpoint {} token not found on server (consumed, expired, or unknown)",
+                args.waitpoint_id
+            )
+        })?;
+
     let payload = ReviewPayload {
         approved: args.approve,
         reviewer: args.reviewer.clone(),
@@ -61,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "payload": serde_json::to_vec(&payload)?,
         "payload_encoding": "json",
         "target_scope": "execution",
-        "waitpoint_token": args.waitpoint_token,
+        "waitpoint_token": waitpoint_token,
         "now": std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_millis() as i64,

--- a/examples/media-pipeline/README.md
+++ b/examples/media-pipeline/README.md
@@ -6,7 +6,7 @@ This example exercises three mechanisms shipped in Batch B:
 
 - **Capability routing** (RFC-009): each execution declares `required_capabilities`; each worker advertises its `capabilities`. The scheduler subset-matches so transcribe tasks never reach the embed worker, etc. Executions that cannot be matched to any capable worker block in `lane_blocked_route` and are promoted by the unblock scanner when a capable worker appears.
 - **Stream tail with terminal signal** (RFC-006): workers stream incremental output (transcribe lines, LLM tokens, embed completion) as frames; the submit and review CLIs tail concurrently and stop cleanly on the stream's `closed_at` / `closed_reason` terminal markers instead of timeout fallbacks.
-- **HMAC-signed waitpoint signals** (RFC-004): the summarize worker suspends and receives a `waitpoint_token`, which it prints as `WAITPOINT_TOKEN=...` alongside `REVIEW_NEEDED eid=... wp=...`. The review CLI takes both values as `--waitpoint-id` + `--waitpoint-token` flags (ff-server dropped the token from `GET /v1/executions/{id}/pending-waitpoints` in v0.8.0 per RFC-017 Stage E4; v0.14 adds an admin read-path). Tampering with the token (via `--tamper-token`) surfaces as a server-side `invalid_token` rejection.
+- **HMAC-signed waitpoint signals** (RFC-004): the summarize worker suspends and logs `REVIEW_NEEDED eid=... wp=...`. The review CLI takes just the waitpoint id and fetches the raw HMAC token via the ff-sdk admin client (`FlowFabricAdminClient::read_waitpoint_token`, added in v0.14) — no copy-paste from the worker log. Tampering with the fetched token (via `--tamper-token`) surfaces as a server-side `invalid_token` rejection.
 
 ## Architecture
 
@@ -92,12 +92,11 @@ cargo run --bin submit -- --audio samples/story.wav --title demo
 # Terminal C — as soon as submit prints "[submit] summarize=<uuid>",
 # start the reviewer. Watch the summarize worker log for
 #   REVIEW_NEEDED eid=<uuid> wp=<waitpoint-id>
-#   WAITPOINT_TOKEN=<hex>
-# and pass both through:
+# and pass the waitpoint id through; the HMAC token is fetched via
+# the ff-sdk admin client (`read_waitpoint_token`).
 cargo run --bin review -- \
     --execution-id <uuid> \
-    --waitpoint-id <waitpoint-id> \
-    --waitpoint-token <hex>
+    --waitpoint-id <waitpoint-id>
 ```
 
 The review CLI prints incoming `summary_token` frames while waiting for the suspend, then prompts `Approve? [y/n]:`.
@@ -133,7 +132,6 @@ cargo run --bin submit -- --audio samples/story.wav &
 cargo run --bin review -- \
     --execution-id <uuid> \
     --waitpoint-id <waitpoint-id> \
-    --waitpoint-token <hex> \
     --auto-approve
 
 # submit output stalls after "summarize done" because embed has no claimer.
@@ -149,7 +147,6 @@ cargo run --bin embed
 cargo run --bin review -- \
     --execution-id <summarize-uuid> \
     --waitpoint-id <waitpoint-id> \
-    --waitpoint-token <hex> \
     --tamper-token \
     --auto-approve
 ```

--- a/examples/media-pipeline/src/bin/review.rs
+++ b/examples/media-pipeline/src/bin/review.rs
@@ -5,13 +5,11 @@
 //! token. The `--tamper-token` flag mutates the token before send so the
 //! user can watch the server reject it with `invalid_token`.
 //!
-//! The `--waitpoint-id` + `--waitpoint-token` pair is printed by the
-//! summarize worker on suspend (look for `REVIEW_NEEDED ... wp=...` and
-//! `WAITPOINT_TOKEN=...`). ff-server dropped the token from
-//! `GET /v1/executions/{id}/pending-waitpoints` in v0.8.0 (RFC-017 Stage
-//! E4); operators copy the values from the suspending worker's log.
-//! v0.14 adds an admin-surface `read_waitpoint_token` so this can go
-//! back to a fetch.
+//! The `--waitpoint-id` is printed by the summarize worker on suspend
+//! (look for `REVIEW_NEEDED ... wp=...`). The raw HMAC
+//! `waitpoint_token` is fetched through the admin client's
+//! `read_waitpoint_token` helper (ff-sdk v0.14) — operators no longer
+//! copy it out of the worker's log.
 //!
 //! # Decision protocol: both approve AND reject deliver a signed signal
 //!
@@ -40,6 +38,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use ff_core::types::{ExecutionId, WaitpointId};
+use ff_sdk::admin::FlowFabricAdminClient;
 use media_pipeline::{
     ApprovalDecision, FRAME_FIELD_PAYLOAD, FRAME_FIELD_TYPE, SIGNAL_NAME_APPROVAL,
 };
@@ -60,16 +60,10 @@ struct Args {
     execution_id: String,
 
     /// Waitpoint id printed by the summarize worker on suspend (look for
-    /// `REVIEW_NEEDED eid=... wp=...`).
+    /// `REVIEW_NEEDED eid=... wp=...`). The raw HMAC `waitpoint_token`
+    /// is resolved through the admin client at runtime (v0.14).
     #[arg(long)]
     waitpoint_id: String,
-
-    /// HMAC waitpoint token printed by the summarize worker on suspend
-    /// (look for `WAITPOINT_TOKEN=...`). Required because ff-server
-    /// dropped the token from the pending-waitpoints read endpoint in
-    /// v0.8.0 (RFC-017 Stage E4).
-    #[arg(long)]
-    waitpoint_token: String,
 
     /// Non-interactive: skip the prompt and approve immediately.
     #[arg(long)]
@@ -169,7 +163,7 @@ async fn main() -> Result<()> {
     // "completed" is an OK outcome — the pipeline moved on without us.
     match wait_for_review_window(&client, &args).await? {
         ReviewOutcome::Suspended => {
-            println!("[review] execution suspended — using CLI-supplied waitpoint token");
+            println!("[review] execution suspended — fetching waitpoint token");
         }
         ReviewOutcome::AlreadyCompleted => {
             println!(
@@ -180,14 +174,49 @@ async fn main() -> Result<()> {
         }
     }
 
+    // v0.14: fetch the HMAC waitpoint_token through the admin client.
+    // Only reached on the Suspended branch, so a missing token here is
+    // a legitimate error (race: peer reviewer consumed it between our
+    // state poll and this fetch — the state recheck paths below catch
+    // the concrete outcome).
+    let admin = match args.api_token.as_deref() {
+        Some(t) => FlowFabricAdminClient::with_token(&args.server, t)?,
+        None => FlowFabricAdminClient::new(&args.server)?,
+    };
+    let execution_id_parsed = ExecutionId::parse(&args.execution_id)?;
+    let waitpoint_id_parsed = WaitpointId::parse(&args.waitpoint_id)?;
+    let fetched_waitpoint_token = match admin
+        .read_waitpoint_token(&execution_id_parsed, &waitpoint_id_parsed)
+        .await?
+    {
+        Some(t) => t,
+        None => {
+            // Race: peer already consumed the waitpoint. Re-check state
+            // and surface the same "peer won" exit-0 path the /signal
+            // error handlers use below.
+            let recheck = recheck_state(&client, &args).await.unwrap_or_default();
+            if recheck == "completed" || recheck == "failed" || recheck == "cancelled" {
+                println!(
+                    "[review] waitpoint token missing and state={recheck} — peer won; exiting 0"
+                );
+                drain_and_stop(tail).await;
+                return Ok(());
+            }
+            anyhow::bail!(
+                "waitpoint token fetch returned None but state={recheck}; \
+                 this indicates waitpoint id drift or an expired waitpoint"
+            );
+        }
+    };
+
     let decision = prompt_decision(&args)?;
 
     match decision {
         ApprovalDecision::Approve => {
             let token = if args.tamper_token {
-                tamper(&args.waitpoint_token)
+                tamper(&fetched_waitpoint_token)
             } else {
-                args.waitpoint_token.clone()
+                fetched_waitpoint_token.clone()
             };
             let signal_payload = serde_json::to_vec(&ApprovalDecision::Approve)?;
 
@@ -302,9 +331,9 @@ async fn main() -> Result<()> {
             // reason). This is symmetric with --approve, so --tamper-token
             // exercises HMAC rejection on both outcomes.
             let token = if args.tamper_token {
-                tamper(&args.waitpoint_token)
+                tamper(&fetched_waitpoint_token)
             } else {
-                args.waitpoint_token.clone()
+                fetched_waitpoint_token.clone()
             };
             let signal_payload = serde_json::to_vec(&ApprovalDecision::Reject {
                 reason: reason.clone(),

--- a/examples/media-pipeline/src/bin/review.rs
+++ b/examples/media-pipeline/src/bin/review.rs
@@ -203,8 +203,12 @@ async fn main() -> Result<()> {
                 return Ok(());
             }
             anyhow::bail!(
-                "waitpoint token fetch returned None but state={recheck}; \
-                 this indicates waitpoint id drift or an expired waitpoint"
+                "waitpoint token fetch returned None (execution_id={}, \
+                 waitpoint_id={}) but state={recheck}; this indicates \
+                 waitpoint id drift or an expired waitpoint — re-check \
+                 the `REVIEW_NEEDED eid=... wp=...` line from the summarize worker",
+                args.execution_id,
+                args.waitpoint_id,
             );
         }
     };

--- a/examples/media-pipeline/src/bin/review.rs
+++ b/examples/media-pipeline/src/bin/review.rs
@@ -193,8 +193,18 @@ async fn main() -> Result<()> {
         None => {
             // Race: peer already consumed the waitpoint. Re-check state
             // and surface the same "peer won" exit-0 path the /signal
-            // error handlers use below.
-            let recheck = recheck_state(&client, &args).await.unwrap_or_default();
+            // error handlers use below. Propagate the recheck error —
+            // the decision between "peer won" and "drift" depends on
+            // an authoritative state read; silently defaulting to ""
+            // on a network blip would misclassify it as drift.
+            let recheck = recheck_state(&client, &args).await.with_context(|| {
+                format!(
+                    "waitpoint token fetch returned None for execution_id={}, \
+                     waitpoint_id={}; state recheck also failed, cannot \
+                     distinguish peer-won from waitpoint drift",
+                    args.execution_id, args.waitpoint_id,
+                )
+            })?;
             if recheck == "completed" || recheck == "failed" || recheck == "cancelled" {
                 println!(
                     "[review] waitpoint token missing and state={recheck} — peer won; exiting 0"


### PR DESCRIPTION
## Summary

- v0.14 P1.1 — admin-surface helper that fetches the raw HMAC `waitpoint_token` for a given `(execution_id, waitpoint_id)` through `FlowFabricAdminClient`, covering both the HTTP transport (new `GET /v1/executions/{id}/waitpoints/{wp_id}/token` route, bearer-auth gated) and the embedded transport (delegates to `EngineBackend::read_waitpoint_token`).
- Unblocks the three example CLIs (`deploy-approval/approve`, `media-pipeline/review`, `llm-race/approve`) that previously required operators to copy-paste the token from the suspending worker's log — they now fetch it programmatically.

## Security context

The sibling `list_pending_waitpoints` endpoint intentionally dropped the raw token in v0.8.0 / RFC-017 Stage E4. This new route re-exposes it only behind the server's bearer-auth layer, keeping the default posture (deployments without `api_token` accept the call unauthenticated — a knowing dev-mode tradeoff, called out in rustdoc).

## Test plan

- [x] ff-test integration: `test_get_waitpoint_token_returns_token_after_suspend` (live Valkey, round-trips an FCALL-minted token through the route)
- [x] ff-test integration: `test_get_waitpoint_token_unknown_id_returns_404` (backend returns Ok(None))
- [x] ff-sdk unit: `read_waitpoint_token_url_percent_encodes_path_segments` (pins `{fp:N}:` encoding)
- [x] `cargo clippy -p ff-server -p ff-sdk -- -D warnings` clean
- [x] All three example bins (`deploy-approval/approve`, `media-pipeline/review`, `llm-race/approve`) build clean
- [x] `cargo build --workspace` green

## Example migrations (bundled)

All three approval CLIs drop their `--waitpoint-token` flag:
- `--waitpoint-id` still required (printed by the suspending worker)
- `FF_API_TOKEN` respected for the admin fetch
- `media-pipeline/review` handles the race where a peer consumes the waitpoint between our state poll and the token fetch (state recheck → peer-won exit 0)

READMEs updated to reflect the new flag shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)