### PR TITLE
feat(ff-sdk): un-gate claim_next_via_backend + drop direct-valkey-claim gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`FlowFabricWorker::claim_next_via_backend`** — un-gated
+  scheduler-bypass scanner that drives claim through the
+  `EngineBackend` trait. Replaces the `claim_next` feature-flag
+  requirement for demo / embedded / bench consumers that can't or
+  don't want to opt into `direct-valkey-claim`. `claim_next` is
+  preserved as a back-compat alias under the existing feature flag.
+  As the rustdoc emphasizes, this path bypasses scheduler admission
+  controls (budget / quota); production deployments should use
+  [`FlowFabricWorker::claim_from_grant`] with scheduler-issued
+  grants. Same chunked-scan semantics + `None`-means-"poll-soon"
+  contract as `claim_next`. Struct fields previously gated behind
+  `direct-valkey-claim` (`worker_capabilities_hash`, `lane_index`,
+  `scan_cursor`) are now always-compiled since they're pure Rust
+  state — no Valkey-specific dependencies.
 - **`ff_sdk::signal_bridge` module** — `SignalBridgeError` enum
   (`UnknownWaitpoint`, `TokenMismatch`, `Backend(SdkError)`) and
   `verify_and_deliver` / `verify_and_deliver_arc` helpers. Extracts the

--- a/crates/ff-sdk/src/valkey_preamble.rs
+++ b/crates/ff-sdk/src/valkey_preamble.rs
@@ -31,20 +31,18 @@ use crate::SdkError;
 /// Output of [`run`] — the bits `connect` threads back into the
 /// [`FlowFabricWorker`] struct.
 ///
-/// `capabilities_csv` / `capabilities_hash` fields are gated on the
-/// `direct-valkey-claim` feature because only the direct-claim code
-/// path reads them at claim time. The capability ingress validation,
-/// CSV compute, and `ff:worker:{id}:caps` + `ff:idx:workers`
-/// advertisement writes run on **every** worker (v0.13 ungate) — the
-/// unblock scanner needs the caps keys regardless of whether the
-/// worker uses direct-claim or server-routed claim.
+/// v0.14: `capabilities_csv` / `capabilities_hash` are always-on —
+/// `claim_next_via_backend` needs the hash for its per-mismatch log
+/// surface regardless of which claim path the worker uses.
+///
+/// The `ff:worker:{id}:caps` + `ff:idx:workers` advertisement writes
+/// also run on every worker (v0.13 ungate) so the unblock scanner has
+/// caps keys regardless of direct-claim vs server-routed claim.
 ///
 /// [`FlowFabricWorker`]: crate::FlowFabricWorker
 pub(crate) struct PreambleOutput {
     pub partition_config: PartitionConfig,
-    #[cfg(feature = "direct-valkey-claim")]
     pub capabilities_csv: String,
-    #[cfg(feature = "direct-valkey-claim")]
     pub capabilities_hash: String,
 }
 
@@ -195,10 +193,8 @@ pub(crate) async fn run(
         csv
     };
 
-    #[cfg(feature = "direct-valkey-claim")]
     let capabilities_hash = ff_core::hash::fnv1a_xor8hex(&capabilities_csv);
 
-    #[cfg(feature = "direct-valkey-claim")]
     if !capabilities_csv.is_empty() {
         tracing::info!(
             worker_instance_id = %config.worker_instance_id,
@@ -264,9 +260,7 @@ pub(crate) async fn run(
 
     Ok(PreambleOutput {
         partition_config,
-        #[cfg(feature = "direct-valkey-claim")]
         capabilities_csv,
-        #[cfg(feature = "direct-valkey-claim")]
         capabilities_hash,
     })
 }

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -145,9 +145,11 @@ pub struct FlowFabricWorker {
         Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>,
 }
 
-/// Number of partitions scanned per `claim_next_via_backend()` poll.
-/// Keeps idle backend load at O(PARTITION_SCAN_CHUNK) per worker-second
-/// instead of O(num_flow_partitions).
+/// Number of partitions scanned per scheduler-bypass claim poll
+/// (`claim_next_via_backend` and its `direct-valkey-claim`-gated
+/// back-compat alias `claim_next`). Keeps idle backend load at
+/// O(PARTITION_SCAN_CHUNK) per worker-second instead of
+/// O(num_flow_partitions).
 const PARTITION_SCAN_CHUNK: usize = 32;
 
 impl FlowFabricWorker {

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-#[cfg(feature = "direct-valkey-claim")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -88,9 +87,7 @@ pub struct FlowFabricWorker {
     /// `valkey_preamble::run` for cross-reference; [`Self::connect_with`]-
     /// built workers compute the hash without the companion CSV log.
     /// Mirrors `ff-scheduler::claim::worker_caps_digest`.
-    #[cfg(feature = "direct-valkey-claim")]
     worker_capabilities_hash: String,
-    #[cfg(feature = "direct-valkey-claim")]
     lane_index: AtomicUsize,
     /// Concurrency cap for in-flight tasks. Permits are acquired or
     /// transferred by [`claim_next`] (feature-gated),
@@ -115,7 +112,6 @@ pub struct FlowFabricWorker {
     /// targets (wasm32, i686) `usize` is `u32` and wraps after ~4 years
     /// at 1 poll/sec — acceptable; on wrap, the modulo preserves
     /// correctness because the sequence simply restarts a new cycle.
-    #[cfg(feature = "direct-valkey-claim")]
     scan_cursor: AtomicUsize,
     /// The [`EngineBackend`] the Stage-1b trait forwarders route
     /// through.
@@ -149,10 +145,9 @@ pub struct FlowFabricWorker {
         Option<Arc<dyn ff_core::completion_backend::CompletionBackend>>,
 }
 
-/// Number of partitions scanned per `claim_next()` poll. Keeps idle Valkey
-/// load at O(PARTITION_SCAN_CHUNK) per worker-second instead of
-/// O(num_flow_partitions).
-#[cfg(feature = "direct-valkey-claim")]
+/// Number of partitions scanned per `claim_next_via_backend()` poll.
+/// Keeps idle backend load at O(PARTITION_SCAN_CHUNK) per worker-second
+/// instead of O(num_flow_partitions).
 const PARTITION_SCAN_CHUNK: usize = 32;
 
 impl FlowFabricWorker {
@@ -246,9 +241,7 @@ impl FlowFabricWorker {
         // preservation is load-bearing. See `valkey_preamble::run`.
         let crate::valkey_preamble::PreambleOutput {
             partition_config,
-            #[cfg(feature = "direct-valkey-claim")]
             capabilities_csv: _worker_capabilities_csv,
-            #[cfg(feature = "direct-valkey-claim")]
             capabilities_hash: worker_capabilities_hash,
         } = crate::valkey_preamble::run(&client, &config).await?;
 
@@ -262,7 +255,6 @@ impl FlowFabricWorker {
             "FlowFabricWorker connected"
         );
 
-        #[cfg(feature = "direct-valkey-claim")]
         let scan_cursor_init = scan_cursor_seed(
             config.worker_instance_id.as_str(),
             partition_config.num_flow_partitions.max(1) as usize,
@@ -288,12 +280,9 @@ impl FlowFabricWorker {
             client: Some(client),
             config,
             partition_config,
-            #[cfg(feature = "direct-valkey-claim")]
             worker_capabilities_hash,
-            #[cfg(feature = "direct-valkey-claim")]
             lane_index: AtomicUsize::new(0),
             concurrency_semaphore,
-            #[cfg(feature = "direct-valkey-claim")]
             scan_cursor: AtomicUsize::new(scan_cursor_init),
             backend,
             completion_backend_handle,
@@ -425,17 +414,16 @@ impl FlowFabricWorker {
         // missing data via the wrong partition index.
         let partition_config = config.partition_config.unwrap_or_default();
 
-        #[cfg(feature = "direct-valkey-claim")]
         let scan_cursor_init = scan_cursor_seed(
             config.worker_instance_id.as_str(),
             partition_config.num_flow_partitions.max(1) as usize,
         );
 
-        // Build the capabilities CSV / hash inline for the
-        // direct-valkey-claim path. The validation mirrors `connect`'s
-        // ingress so the two entry points refuse the same malformed
-        // tokens.
-        #[cfg(feature = "direct-valkey-claim")]
+        // Capability validation + CSV/hash compute mirrors `connect`'s
+        // preamble (valkey_preamble::run) so both entry points refuse
+        // the same malformed tokens and populate the same
+        // `worker_capabilities_hash` used by claim_next_via_backend's
+        // per-mismatch log.
         for cap in &config.capabilities {
             if cap.is_empty() {
                 return Err(SdkError::Config {
@@ -464,7 +452,6 @@ impl FlowFabricWorker {
                 });
             }
         }
-        #[cfg(feature = "direct-valkey-claim")]
         let worker_capabilities_hash = {
             let set: std::collections::BTreeSet<&str> = config
                 .capabilities
@@ -481,12 +468,9 @@ impl FlowFabricWorker {
             client: None,
             config,
             partition_config,
-            #[cfg(feature = "direct-valkey-claim")]
             worker_capabilities_hash,
-            #[cfg(feature = "direct-valkey-claim")]
             lane_index: AtomicUsize::new(0),
             concurrency_semaphore,
-            #[cfg(feature = "direct-valkey-claim")]
             scan_cursor: AtomicUsize::new(scan_cursor_init),
             backend,
             completion_backend_handle: completion,
@@ -555,21 +539,40 @@ impl FlowFabricWorker {
         &self.partition_config
     }
 
-    /// Attempt to claim the next eligible execution.
+    /// Back-compat alias for [`Self::claim_next_via_backend`]. Stays
+    /// behind the `direct-valkey-claim` feature to preserve the prior
+    /// opt-in ergonomics; new consumers should call
+    /// [`Self::claim_next_via_backend`] directly (no feature flag
+    /// required) — v0.14 un-gating of the scheduler-bypass scanner.
+    #[cfg(feature = "direct-valkey-claim")]
+    pub async fn claim_next(&self) -> Result<Option<ClaimedTask>, SdkError> {
+        self.claim_next_via_backend().await
+    }
+
+    /// Attempt to claim the next eligible execution through the
+    /// [`EngineBackend`] trait — works on any backend with
+    /// `scan_eligible_executions` + `issue_claim_grant` + `claim_execution`
+    /// trait bodies (Valkey today; Postgres/SQLite when their
+    /// grant-consumer RFC lands).
     ///
-    /// Phase 1 simplified claim flow:
+    /// Simplified claim flow:
     /// 1. Pick a lane (round-robin across configured lanes)
-    /// 2. Issue a claim grant via `ff_issue_claim_grant` on the execution's partition
-    /// 3. Claim the execution via `ff_claim_execution`
-    /// 4. Read execution payload + tags
+    /// 2. Scan a [`PARTITION_SCAN_CHUNK`] window of partitions for
+    ///    eligible executions via `backend.scan_eligible_executions`
+    /// 3. Issue a claim grant via `backend.issue_claim_grant`
+    /// 4. Claim the execution via `backend.claim_execution`
     /// 5. Return a [`ClaimedTask`] with auto lease renewal
     ///
-    /// Gated behind the `direct-valkey-claim` feature — bypasses the
-    /// scheduler's budget / quota / capability admission checks. Enable
-    /// with `ff-sdk = { ..., features = ["direct-valkey-claim"] }` when
-    /// the scheduler hop would be measurement noise (benches) or when
-    /// the test harness needs a deterministic worker-local path. Prefer
-    /// the scheduler-routed HTTP claim path in production.
+    /// # Scheduler bypass — read before production use
+    ///
+    /// This path **bypasses the scheduler's budget / quota admission
+    /// checks**. Enable only when the scheduler hop is measurement
+    /// noise (benches, single-tenant dev, examples demonstrating the
+    /// claim primitive) or when the test harness wants a deterministic
+    /// worker-local path. For production, consume scheduler-issued
+    /// grants via [`Self::claim_from_grant`] — the scheduler enforces
+    /// budget breach, quota sliding-window, concurrency cap, and
+    /// capability-match checks before issuing grants.
     ///
     /// # `None` semantics
     ///
@@ -585,9 +588,10 @@ impl FlowFabricWorker {
     /// time". Backing off too aggressively on `None` can starve workers
     /// when work lives on partitions outside the current window.
     ///
-    /// Returns `Err` on Valkey errors or script failures.
-    #[cfg(feature = "direct-valkey-claim")]
-    pub async fn claim_next(&self) -> Result<Option<ClaimedTask>, SdkError> {
+    /// Returns `Err` on backend errors or script failures.
+    ///
+    /// [`claim_from_grant`]: FlowFabricWorker::claim_from_grant
+    pub async fn claim_next_via_backend(&self) -> Result<Option<ClaimedTask>, SdkError> {
         // Enforce max_concurrent_tasks: try to acquire a semaphore permit.
         // try_acquire returns immediately — if no permits available, the worker
         // is at capacity and should not claim more work.
@@ -1392,14 +1396,12 @@ impl FlowFabricWorker {
         })
     }
 
-    #[cfg(feature = "direct-valkey-claim")]
     fn next_lane(&self) -> LaneId {
         let idx = self.lane_index.fetch_add(1, Ordering::Relaxed) % self.config.lanes.len();
         self.config.lanes[idx].clone()
     }
 }
 
-#[cfg(feature = "direct-valkey-claim")]
 fn is_retryable_claim_error(err: &crate::EngineError) -> bool {
     use ff_core::error::ErrorClass;
     matches!(
@@ -1412,7 +1414,6 @@ fn is_retryable_claim_error(err: &crate::EngineError) -> bool {
 /// instance id with FNV-1a to place distinct worker processes on different
 /// partition windows from their first poll. Zero is valid for single-worker
 /// clusters but spreads work in multi-worker deployments.
-#[cfg(feature = "direct-valkey-claim")]
 fn scan_cursor_seed(worker_instance_id: &str, num_partitions: usize) -> usize {
     if num_partitions == 0 {
         return 0;

--- a/crates/ff-test/tests/claim_next_via_backend.rs
+++ b/crates/ff-test/tests/claim_next_via_backend.rs
@@ -1,0 +1,125 @@
+//! Integration coverage for `FlowFabricWorker::claim_next_via_backend`
+//! (v0.14 P1.3 — un-gated scheduler-bypass scanner).
+//!
+//! Pins the basic round-trip on a live Valkey fixture. The goal is to
+//! confirm the un-gated method claims through the trait path
+//! end-to-end identically to the legacy `claim_next` back-compat alias
+//! — not to re-test the claim primitive's semantics (covered by
+//! `engine_backend_deliver_signal.rs` et al).
+//!
+//! Run with: cargo test -p ff-test --test claim_next_via_backend -- --test-threads=1
+
+use ferriskey::Value;
+use ff_core::keys::{ExecKeyContext, IndexKeys};
+use ff_core::partition::{execution_partition, PartitionConfig};
+use ff_core::types::*;
+use ff_test::fixtures::TestCluster;
+
+const LANE: &str = "cnvb-lane";
+const NS: &str = "cnvb-ns";
+const WORKER: &str = "cnvb-worker";
+const WORKER_INST: &str = "cnvb-worker-1";
+
+fn config() -> PartitionConfig {
+    ff_test::fixtures::TEST_PARTITION_CONFIG
+}
+
+async fn build_worker() -> ff_sdk::FlowFabricWorker {
+    let cfg = ff_sdk::WorkerConfig {
+        backend: Some(ff_test::fixtures::backend_config_from_env()),
+        worker_id: WorkerId::new(WORKER),
+        worker_instance_id: WorkerInstanceId::new(WORKER_INST),
+        namespace: Namespace::new(NS),
+        lanes: vec![LaneId::new(LANE)],
+        capabilities: Vec::new(),
+        lease_ttl_ms: 30_000,
+        claim_poll_interval_ms: 100,
+        max_concurrent_tasks: 10,
+        partition_config: None,
+    };
+    ff_sdk::FlowFabricWorker::connect(cfg).await.unwrap()
+}
+
+async fn seed_eligible_execution(tc: &TestCluster, eid: &ExecutionId) {
+    let partition = execution_partition(eid, &config());
+    let ctx = ExecKeyContext::new(&partition, eid);
+    let idx = IndexKeys::new(&partition);
+    let lane_id = LaneId::new(LANE);
+
+    let keys: Vec<String> = vec![
+        ctx.core(),
+        ctx.payload(),
+        ctx.policy(),
+        ctx.tags(),
+        idx.lane_eligible(&lane_id),
+        ctx.noop(),
+        idx.execution_deadline(),
+        idx.all_executions(),
+    ];
+    let args: Vec<String> = vec![
+        eid.to_string(),
+        NS.to_owned(),
+        LANE.to_owned(),
+        "cnvb".to_owned(),
+        "0".to_owned(),
+        "cnvb-runner".to_owned(),
+        "{}".to_owned(),
+        r#"{"test":true}"#.to_owned(),
+        String::new(),
+        String::new(),
+        "{}".to_owned(),
+        String::new(),
+        partition.index.to_string(),
+    ];
+    let kr: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let ar: Vec<&str> = args.iter().map(String::as_str).collect();
+    let _: Value = tc
+        .client()
+        .fcall("ff_create_execution", &kr, &ar)
+        .await
+        .expect("ff_create_execution");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn claim_next_via_backend_claims_eligible_execution() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let eid = tc.new_execution_id();
+    seed_eligible_execution(&tc, &eid).await;
+
+    let worker = build_worker().await;
+    // Scan multiple times — the scanner covers PARTITION_SCAN_CHUNK
+    // partitions per call; our eid may not be on the first window.
+    let max_polls = ((config().num_flow_partitions as usize) / 32) + 2;
+    let mut claimed = None;
+    for _ in 0..max_polls {
+        if let Some(task) = worker.claim_next_via_backend().await.expect("claim ok") {
+            claimed = Some(task);
+            break;
+        }
+    }
+    let task = claimed.expect("claim_next_via_backend must land the eligible execution");
+    assert_eq!(task.execution_id(), &eid);
+    task.complete(Some(b"done".to_vec()))
+        .await
+        .expect("complete");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn claim_next_via_backend_returns_none_when_idle() {
+    let tc = TestCluster::connect().await;
+    tc.cleanup().await;
+
+    let worker = build_worker().await;
+    // One poll on an empty cluster — expect None (no eligible work in
+    // this partition window). Full-sweep not needed to pin the idle
+    // semantic.
+    let result = worker.claim_next_via_backend().await.expect("claim ok");
+    assert!(
+        result.is_none(),
+        "idle cluster must return Ok(None), got Some(ClaimedTask)"
+    );
+}


### PR DESCRIPTION
## Summary

v0.14 P1.3 — the third and final SDK ergonomics headline item from the v0.13 queue. Adds `FlowFabricWorker::claim_next_via_backend`, an always-compiled scheduler-bypass scanner that drives claim through the `EngineBackend` trait. Demo / embedded / bench consumers that needed `direct-valkey-claim` (or gave up and dropped to `trait_obj.claim(...)` directly) now have a first-class SDK entry point that works on any backend without a feature flag.

## Changes

- **New:** `pub async fn claim_next_via_backend(&self) -> Result<Option<ClaimedTask>, SdkError>` — not feature-gated. Same chunked-scan + `None`-means-"poll-soon" semantics as the legacy `claim_next`.
- **Back-compat:** `claim_next` preserved as a thin `#[cfg(feature = "direct-valkey-claim")]` wrapper that forwards to `claim_next_via_backend`. No existing consumer breaks.
- **Un-gated struct fields:** `worker_capabilities_hash`, `lane_index`, `scan_cursor` — all pure Rust state (an FNV hash string + two `AtomicUsize`s), no Valkey-specific deps. The gate was semantic only; the scheduler-bypass caveat (budget/quota admission is skipped) moves to the `claim_next_via_backend` rustdoc.
- **Un-gated preamble:** `valkey_preamble::PreambleOutput::{capabilities_csv, capabilities_hash}` and the connect-time INFO log — always populated, completing the v0.13 ungate series on the preamble.

## Rustdoc

`claim_next_via_backend` explicitly calls out the scheduler-bypass caveat and points at `claim_from_grant` as the production entry point:

> This path **bypasses the scheduler's budget / quota admission checks**. Enable only when the scheduler hop is measurement noise (benches, single-tenant dev, examples demonstrating the claim primitive) or when the test harness wants a deterministic worker-local path. For production, consume scheduler-issued grants via `Self::claim_from_grant`.

## Test plan

- [x] 2 new ff-test integration tests against live Valkey:
  - `claim_next_via_backend_claims_eligible_execution` — seeds an eligible row, polls the scanner until it lands the claim, completes.
  - `claim_next_via_backend_returns_none_when_idle` — pins the `Ok(None)` contract on an empty cluster.
- [x] 48/48 ff-sdk unit tests green
- [x] `cargo clippy -p ff-sdk -- -D warnings` clean on default + `direct-valkey-claim` + `--no-default-features --features sqlite`
- [x] `cargo build --workspace` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)