### PR TITLE
feat(scripts): 3c.i — Valkey preflight + incident-remediation + v013-cairn-454

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`scripts/run-all-examples.sh` phase 3c.i** — two more live-runs
+  + a Valkey preflight helper. `incident-remediation` (SQLite embedded
+  path — the Valkey path errors out asking for a scheduler+scanner
+  deployment, per its own hint) and `v013-cairn-454-budget-ledger`
+  (Valkey trait-direct) both move from SKIP to PASS. New per-example
+  `requires()` metadata with a preflight dispatcher: missing fixtures
+  SKIP with an actionable "bring it up" message (e.g. "valkey
+  unreachable at localhost:6379 — start valkey-server and re-run")
+  instead of failing cryptically inside the example. The Valkey probe
+  prefers `valkey-cli`, falls back to `redis-cli`, falls back to a
+  bare `/dev/tcp` socket probe. Sweep today: 4 PASS / 9 SKIP / 0 FAIL.
 - **`scripts/run-all-examples.sh` phase 3b** — live-run coverage for
   the two examples that have no external dependency beyond the
   bundled SQLite: `ff-dev` (`FF_DEV_MODE=1`) and `external-callback

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -63,16 +63,24 @@ check_valkey() {
     elif command -v redis-cli >/dev/null 2>&1; then
         probe="redis-cli"
     else
-        # No CLI tool — fall through to a /dev/tcp probe. Bash opens
-        # TCP sockets via /dev/tcp/<host>/<port>; if the connect
-        # succeeds we treat Valkey as reachable (we can't PING without
-        # a client).
-        if (exec 3<>"/dev/tcp/$VALKEY_HOST/$VALKEY_PORT") 2>/dev/null; then
-            exec 3<&-; exec 3>&-
+        # No CLI tool — use a RESP-level probe over bash's /dev/tcp.
+        # Sends the inline `PING\r\n` command and checks for `+PONG`
+        # in the reply, so an unrelated process listening on the port
+        # is correctly reported as not-Valkey rather than a false
+        # ready. All inside a subshell so the FD is released on exit.
+        if (
+            exec 3<>"/dev/tcp/$VALKEY_HOST/$VALKEY_PORT" 2>/dev/null || exit 1
+            printf 'PING\r\n' >&3
+            # Short read with a timeout so we don't hang on a silent
+            # listener. `read -t` wants fractional seconds on Bash 4+;
+            # pass an integer for 3.2 compat.
+            IFS= read -r -t 2 reply <&3 || exit 2
+            case "$reply" in *PONG*) exit 0 ;; *) exit 3 ;; esac
+        ); then
             VALKEY_READY=1
-            return 0
+        else
+            VALKEY_READY=0
         fi
-        VALKEY_READY=0
         return 0
     fi
     if "$probe" -h "$VALKEY_HOST" -p "$VALKEY_PORT" PING 2>/dev/null | grep -q PONG; then
@@ -131,7 +139,12 @@ run_cmd() {
             # sqlite flag. Stay on the sqlite path for CI.
             echo "FF_DEV_MODE=1 ${t}cargo run --locked --release -- --backend sqlite" ;;
         v013-cairn-454-budget-ledger)
-            echo "${t}cargo run --locked --release --bin budget-ledger" ;;
+            # Pipe VALKEY_HOST/PORT through the example's own
+            # `FF_DEMO_VALKEY_HOST/PORT` knobs so a caller overriding
+            # FF_HOST/FF_PORT sees preflight and run hit the *same*
+            # socket. Without this, `FF_HOST=remote` would preflight
+            # against remote but run against localhost.
+            echo "FF_DEMO_VALKEY_HOST='$VALKEY_HOST' FF_DEMO_VALKEY_PORT='$VALKEY_PORT' ${t}cargo run --locked --release --bin budget-ledger" ;;
         *)
             echo "" ;;
     esac

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -45,6 +45,43 @@ else
     TIMEOUT=""
 fi
 
+# ── fixture preflights ────────────────────────────────────────────────
+#
+# Each per-example case can flag `requires_<X>`. The preflight runs
+# once per unique requirement, caches the result, and examples whose
+# fixture is unreachable SKIP with an actionable "bring it up" message
+# instead of failing cryptically inside the example.
+VALKEY_READY=""         # "1" ready, "0" down, "" unchecked
+VALKEY_HOST="${FF_HOST:-localhost}"
+VALKEY_PORT="${FF_PORT:-6379}"
+
+check_valkey() {
+    [ -n "$VALKEY_READY" ] && return 0
+    local probe
+    if command -v valkey-cli >/dev/null 2>&1; then
+        probe="valkey-cli"
+    elif command -v redis-cli >/dev/null 2>&1; then
+        probe="redis-cli"
+    else
+        # No CLI tool — fall through to a /dev/tcp probe. Bash opens
+        # TCP sockets via /dev/tcp/<host>/<port>; if the connect
+        # succeeds we treat Valkey as reachable (we can't PING without
+        # a client).
+        if (exec 3<>"/dev/tcp/$VALKEY_HOST/$VALKEY_PORT") 2>/dev/null; then
+            exec 3<&-; exec 3>&-
+            VALKEY_READY=1
+            return 0
+        fi
+        VALKEY_READY=0
+        return 0
+    fi
+    if "$probe" -h "$VALKEY_HOST" -p "$VALKEY_PORT" PING 2>/dev/null | grep -q PONG; then
+        VALKEY_READY=1
+    else
+        VALKEY_READY=0
+    fi
+}
+
 # Per-session opt-in filter. Empty = run everything.
 ONLY="${FF_EXAMPLES_ONLY:-}"
 MODE="both"   # both | build | run
@@ -68,9 +105,18 @@ skip_reason() {
     esac
 }
 
+# `requires` names the fixtures an example's live-run needs. Empty =
+# no external fixture (SQLite-only / FF_DEV_MODE). Values checked by
+# the dispatcher below: "valkey", "postgres", "ff-server" (future).
+requires() {
+    case "$1" in
+        v013-cairn-454-budget-ledger) echo "valkey" ;;
+        *) echo "" ;;
+    esac
+}
+
 # `run_cmd` emits the command-line for the example's live-run, or an
-# empty string for examples not yet covered in phase 3b (3c+ lands the
-# HITL orchestration + ff-server-dependent ones).
+# empty string for examples not yet covered.
 run_cmd() {
     local t="${TIMEOUT:+$TIMEOUT 60 }"
     case "$1" in
@@ -78,6 +124,14 @@ run_cmd() {
             echo "FF_DEV_MODE=1 ${t}cargo run --locked --release --bin ff-dev" ;;
         external-callback)
             echo "FF_DEV_MODE=1 ${t}cargo run --locked --release -- --backend sqlite" ;;
+        incident-remediation)
+            # Runs against the SQLite embedded path — Valkey path
+            # requires a full scheduler+scanner deployment and bails
+            # out with a loud error referring the operator to the
+            # sqlite flag. Stay on the sqlite path for CI.
+            echo "FF_DEV_MODE=1 ${t}cargo run --locked --release -- --backend sqlite" ;;
+        v013-cairn-454-budget-ledger)
+            echo "${t}cargo run --locked --release --bin budget-ledger" ;;
         *)
             echo "" ;;
     esac
@@ -91,12 +145,10 @@ run_reason() {
         llm-race) echo "phase 3d — LLM-dependent, pre-release-local only" ;;
         deploy-approval) echo "phase 3c — HITL multi-bin orchestration pending" ;;
         media-pipeline) echo "phase 3c — HITL multi-bin orchestration pending" ;;
-        incident-remediation) echo "phase 3c — requires ff-server choreography" ;;
         retry-and-cancel) echo "phase 3c — requires ff-server" ;;
         token-budget) echo "phase 3c — requires ff-server" ;;
         v010-read-side-ergonomics) echo "phase 3c — requires ff-server" ;;
-        v011-wave9-postgres) echo "phase 3c — requires ff-server + Postgres choreography" ;;
-        v013-cairn-454-budget-ledger) echo "phase 3c — requires Valkey (trait-direct, no ff-server)" ;;
+        v011-wave9-postgres) echo "phase 3c — requires Postgres (FF_PG_TEST_URL)" ;;
         *) echo "phase 3b does not cover this example yet" ;;
     esac
 }
@@ -177,13 +229,36 @@ for dir in "$EXAMPLES_DIR"/*/; do
         fi
     fi
 
-    # ── run (phase 3b) ──
+    # ── run (phase 3b/3c) ──
     cmd="$(run_cmd "$name")"
     if [ -z "$cmd" ]; then
         record_skip "$name" "$(run_reason "$name")"
         echo
         continue
     fi
+
+    # Fixture preflight — skip-not-fail when the required service
+    # isn't reachable so operators running without (e.g.) Valkey get
+    # a clear "bring it up" signal instead of a cryptic example
+    # failure deep inside the ferriskey handshake.
+    req="$(requires "$name")"
+    for dep in $req; do
+        case "$dep" in
+            valkey)
+                check_valkey
+                if [ "$VALKEY_READY" != "1" ]; then
+                    record_skip "$name" "valkey unreachable at $VALKEY_HOST:$VALKEY_PORT — start valkey-server and re-run"
+                    echo
+                    continue 2
+                fi
+                ;;
+            *)
+                record_skip "$name" "unknown requires: $dep"
+                echo
+                continue 2
+                ;;
+        esac
+    done
 
     echo "[run] $name …"
     echo "      $cmd"


### PR DESCRIPTION
## Summary

Phase 3c.i of the run-all-examples harness. Two more live-runs + a fixture-preflight dispatcher.

## Live-run additions

| Example | Path | Fixture |
|---|---|---|
| `incident-remediation` | `FF_DEV_MODE=1 -- --backend sqlite` | none (embedded SQLite) |
| `v013-cairn-454-budget-ledger` | `cargo run --bin budget-ledger` | Valkey |

**Why `incident-remediation` is on the SQLite path:** the example's Valkey branch **deliberately** errors out with \"Valkey path needs a live scheduler+scanner deployment; see README\" and refers the operator to `--backend sqlite`. Stay on SQLite for mechanical CI; the scheduler+scanner deployment version is a full-operator setup.

## Preflight dispatcher

New per-example `requires()` metadata — empty for SQLite-only, `\"valkey\"` for v013-cairn-454 today. Ready to take `\"postgres\"` (3c.ii) and `\"ff-server\"` (3c.iii) as later phases add them.

The dispatcher runs each unique fixture check **once**, caches the result, and **SKIPs with an actionable message** when a required fixture is unreachable — instead of failing cryptically deep inside the example's handshake. The Valkey probe:

1. Prefers `valkey-cli -h HOST -p PORT PING`
2. Falls back to `redis-cli`
3. Falls back to a bare `/dev/tcp/HOST/PORT` socket probe (works under bash without any client tool installed).

## Test plan

- [x] Full sweep with Valkey up: **4 PASS / 9 SKIP / 0 FAIL** (was 2/11/0 after 3b)
- [x] Preflight SKIP path: `FF_PORT=9999 ./scripts/run-all-examples.sh --run-only` correctly reports \"valkey unreachable at localhost:9999 — start valkey-server and re-run\"
- [x] Both new examples pass in isolation against live Valkey

## What SKIPs after 3c.i

- `retry-and-cancel`, `token-budget`, `v010-read-side-ergonomics` → phase 3c.iii-iv (ff-server)
- `v011-wave9-postgres` → phase 3c.ii (Postgres preflight)
- `deploy-approval` → phase 3c.v (HITL multi-bin)
- `coding-agent`, `llm-race`, `media-pipeline` → phase 3d (LLM / model-heavy, pre-release-local only)
- `grafana` → no Cargo workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)