### PR TITLE
feat(ci): examples harness workflow (phase 3e)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -49,10 +49,13 @@ jobs:
   examples-harness:
     name: examples-harness (ubuntu-latest · valkey 8 · postgres 16)
     runs-on: ubuntu-latest
-    # 13 examples × ~1-2min each + ff-server boot + deploy-approval's
-    # 10min budget → ~30min upper bound. 45 keeps headroom for cache
-    # misses on cold runners.
-    timeout-minutes: 45
+    # First-run budget:
+    #   * 13 examples × cold-cache build (~3min each)  → ~35min
+    #   * + ff-server release build                    → ~5min
+    #   * + live-runs (SQLite ~30s, ff-server ~1-3min, HITL ~3-5min)
+    # Total upper bound observed on GH hosted runners: ~70min on the
+    # first run. Cached subsequent runs drop to ~15-25min.
+    timeout-minutes: 90
     services:
       # Valkey — reference deployment per matrix.yml's primary cell.
       valkey:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,125 @@
+name: Examples Harness
+
+# Runs scripts/run-all-examples.sh — the mechanical enforcement of the
+# CLAUDE.md §5 item 3 pre-tag release check. Catches feature-propagation
+# drift in examples' independent Cargo workspaces + exercises each
+# example's live-run against real Valkey + Postgres fixtures.
+#
+# Single job, single runner: ubuntu-latest + Valkey 8 standalone +
+# Postgres 16. Mirrors the preferred dev-loop shape (reference
+# deployment for cairn-fabric too).
+#
+# Scope cut: LLM-dependent examples (coding-agent, llm-race,
+# media-pipeline) are intentionally excluded — they're pre-release-
+# local runs against OpenRouter / z.ai. CI has no provider keys and
+# mocking defeats real-fidelity smoke. Those examples SKIP cleanly
+# with an actionable rationale in the harness.
+#
+# Branch protection: `examples-harness` SHOULD be added as a required
+# check on the `main` branch ruleset once the workflow has a stable
+# signal (first few runs green).
+#
+# No `run:` step in this workflow interpolates `github.event.*` fields
+# directly — only a static script invocation + apt-get — so the usual
+# command-injection surface from untrusted PR titles/bodies is absent.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/**'
+      - 'crates/ff-*/**'
+      - 'scripts/run-all-examples.sh'
+      - '.github/workflows/examples.yml'
+  pull_request:
+    paths:
+      - 'examples/**'
+      - 'crates/ff-*/**'
+      - 'scripts/run-all-examples.sh'
+      - '.github/workflows/examples.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: ""
+
+permissions:
+  contents: read
+
+jobs:
+  examples-harness:
+    name: examples-harness (ubuntu-latest · valkey 8 · postgres 16)
+    runs-on: ubuntu-latest
+    # 13 examples × ~1-2min each + ff-server boot + deploy-approval's
+    # 10min budget → ~30min upper bound. 45 keeps headroom for cache
+    # misses on cold runners.
+    timeout-minutes: 45
+    services:
+      # Valkey — reference deployment per matrix.yml's primary cell.
+      valkey:
+        image: valkey/valkey:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli PING"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      # Postgres — v011-wave9-postgres needs this.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ff_v011_demo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      # The harness reads these; keep the defaults aligned with the
+      # service image env above so preflight + run target the same
+      # socket.
+      FF_HOST: localhost
+      FF_PORT: "6379"
+      FF_PG_TEST_URL: postgres://postgres:postgres@localhost:5432/ff_v011_demo
+    steps:
+      # Free ~22 GB on ubuntu-latest before cargo link stages. The
+      # 13 examples each have their own Cargo workspace (publish = false)
+      # so the aggregate target directory is large; without this step
+      # `cargo build --locked --release` can ENOSPC partway through.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+        with:
+          key: examples-harness
+
+      # Tool preflights the harness itself checks at runtime. Install
+      # postgresql-client + redis-tools up front so the preflight's
+      # preferred probes (psql SELECT 1, redis-cli PING) light up
+      # instead of falling back to /dev/tcp. python3 + curl are
+      # preinstalled on ubuntu-latest. `valkey-tools` isn't packaged
+      # for 24.04 yet; the harness falls back to `redis-cli` which
+      # still speaks the Valkey wire protocol.
+      - name: Install client tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            postgresql-client \
+            redis-tools
+
+      - name: Run harness
+        run: ./scripts/run-all-examples.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`.github/workflows/examples.yml`** (phase 3e) — CI wiring for the
+  run-all-examples harness. Single job on ubuntu-latest with Valkey 8
+  (alpine) + Postgres 16 (alpine) services; triggers on PRs + pushes
+  to main that touch `examples/**`, `crates/ff-*/**`,
+  `scripts/run-all-examples.sh`, or the workflow itself. Installs
+  `postgresql-client` + `redis-tools` so the harness's preflight probes
+  (psql SELECT 1 / redis-cli PING) light up instead of falling back to
+  /dev/tcp. `valkey-tools` isn't packaged for Ubuntu 24.04 yet; the
+  harness's CLI-preference chain falls back to `redis-cli` which still
+  speaks the Valkey wire protocol. `FF_HOST`/`FF_PORT`/`FF_PG_TEST_URL`
+  env vars steer preflight + run at the same services. LLM-dependent
+  examples stay pre-release-local per the scope decision (the harness
+  SKIPs them with a clean rationale). Branch protection not added yet —
+  gate on a few green runs first.
 - **`scripts/run-all-examples.sh` phase 3c.v** — `deploy-approval`
   HITL orchestration. New `run_deploy_approval()` function spawns
   the 6-worker choreography (build + 3× test kinds + deploy +

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -262,8 +262,23 @@ start_ff_server() {
     # `default` (most), plus `build,test,deploy,verify` for
     # deploy-approval. Including unused lanes is harmless — the
     # scheduler just ranges zero-length ZSETs.
+    #
+    # FF_WAITPOINT_HMAC_SECRET — random 32-byte hex per run. Fresh
+    # material keeps generic entropy-based secret scanners quiet on
+    # the repo (GitGuardian flagged the previous all-zeros sentinel
+    # once the workflow landed) and costs nothing at run time. Caller
+    # can override with an explicit value via env.
+    local hmac_secret="${FF_WAITPOINT_HMAC_SECRET:-}"
+    if [ -z "$hmac_secret" ]; then
+        if command -v openssl >/dev/null 2>&1; then
+            hmac_secret="$(openssl rand -hex 32)"
+        else
+            # /dev/urandom fallback; 32 bytes → 64 hex chars via xxd.
+            hmac_secret="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+        fi
+    fi
     FF_LISTEN_ADDR="127.0.0.1:$FF_SERVER_PORT" \
-    FF_WAITPOINT_HMAC_SECRET="0000000000000000000000000000000000000000000000000000000000000000" \
+    FF_WAITPOINT_HMAC_SECRET="$hmac_secret" \
     FF_LANES="default,build,test,deploy,verify" \
     FF_HOST="$VALKEY_HOST" \
     FF_PORT="$VALKEY_PORT" \

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -429,9 +429,12 @@ run_deploy_approval() {
     pids+=($!)
 
     # Parse deploy_eid + flow_id + waitpoint_id from the logs as they
-    # become available.
+    # become available. 300s budget rather than 120: CI runners see
+    # slower scheduler reconciler ticks under cold caches + shared
+    # containers, and we'd rather wait than false-fail when the flow
+    # is healthy but the unblock scanner hasn't promoted yet.
     local deploy_eid="" flow_id="" wp_id=""
-    local t_end=$((started + 120))
+    local t_end=$((started + 300))
     while [ "$(date +%s)" -lt "$t_end" ]; do
         if [ -z "$flow_id" ]; then
             flow_id="$(grep -oE 'flow_created flow_id=[^ ]+' "$logdir/submit.log" 2>/dev/null | head -1 | sed 's/^.*=//')"


### PR DESCRIPTION
## Summary

Phase 3e — CI wiring for the run-all-examples harness. Single job on ubuntu-latest with Valkey 8 (alpine) + Postgres 16 (alpine) services.

## Triggers

- PR
- Push to `main`

Both path-filtered to `examples/**`, `crates/ff-*/**`, `scripts/run-all-examples.sh`, `.github/workflows/examples.yml`.

## Scope

- **In:** the 9 examples the harness can live-run mechanically today (ff-dev, external-callback, incident-remediation, v013-cairn-454, v010-read-side, v011-wave9-pg, retry-and-cancel, token-budget, deploy-approval).
- **Out:** LLM-dependent examples (coding-agent, llm-race, media-pipeline) — pre-release-local only per the owner's scope decision (per `feedback_real_llm_not_mock`). They SKIP cleanly with a phase-3d rationale.

## Tool install

`postgresql-client` + `redis-tools` via apt. The harness's CLI-preference chain is `valkey-cli` → `redis-cli` → `/dev/tcp`; `valkey-tools` isn't packaged for Ubuntu 24.04 yet, so `redis-cli` is the actual probe used. Same wire protocol.

## First run is this PR

The workflow fires on this PR (touches `.github/workflows/examples.yml`). If it goes green, we'll have a fresh data point on runtime + any CI-specific breakage; if it reveals anything we iterate in-PR.

## Branch protection

**NOT added in this PR.** Safer to let the workflow run a few times (main merges, operator PRs) before requiring it — the harness has 13 examples in production env differences, and a first-run yellow on e.g. a docker-image pull hiccup would block unrelated PRs.

## Test plan

- [x] YAML syntax validated (`python3 -c yaml.safe_load`)
- [x] Local full sweep still 9 PASS / 4 SKIP / 0 FAIL
- [ ] First CI run — we'll find out on this PR

## No injection surface

No `run:` step interpolates `github.event.*` fields (only `./scripts/run-all-examples.sh` + apt-get).

🤖 Generated with [Claude Code](https://claude.com/claude-code)