### PR TITLE
feat(scripts): 3f — grafana dashboard JSON lint

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -122,7 +122,8 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             postgresql-client \
-            redis-tools
+            redis-tools \
+            jq
 
       - name: Run harness
         run: ./scripts/run-all-examples.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`scripts/lint-grafana-dashboard.sh`** (phase 3f) — jq-based
+  validation of `examples/grafana/flowfabric-ops.json`. Checks valid
+  JSON, required top-level keys (`title`, `panels`, `schemaVersion`,
+  `uid`), non-empty panel array, every panel has `id`/`title`/`type`/
+  `gridPos`, `uid` is non-empty, `schemaVersion >= 36` (Grafana 9+).
+  Invoked as grafana's `run_cmd` in the harness — flips grafana from
+  SKIP to PASS. Sweep today: **10 PASS / 3 SKIP / 0 FAIL**. Only
+  remaining SKIPs are 3d LLM-dependent (pre-release-local). CI
+  workflow grows `jq` in its `apt-get` step.
 - **`.github/workflows/examples.yml`** (phase 3e) — CI wiring for the
   run-all-examples harness. Single job on ubuntu-latest with Valkey 8
   (alpine) + Postgres 16 (alpine) services; triggers on PRs + pushes

--- a/scripts/lint-grafana-dashboard.sh
+++ b/scripts/lint-grafana-dashboard.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# lint-grafana-dashboard.sh — validates examples/grafana/flowfabric-ops.json.
+#
+# The dashboard is the only non-Cargo example, so run-all-examples.sh
+# SKIPs it. This script is the standalone gate the §5 item 3 release
+# check invokes for that one example — catches malformed JSON,
+# missing top-level keys, and panels with missing required fields.
+
+set -u
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DASHBOARD="$ROOT/examples/grafana/flowfabric-ops.json"
+
+if [ ! -f "$DASHBOARD" ]; then
+    echo "[grafana-lint] FATAL: $DASHBOARD not found" >&2
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[grafana-lint] FATAL: jq not installed" >&2
+    exit 2
+fi
+
+echo "[grafana-lint] $DASHBOARD"
+
+# 1. Valid JSON.
+if ! jq empty "$DASHBOARD" 2>/dev/null; then
+    echo "[grafana-lint] FAIL: invalid JSON"
+    jq . "$DASHBOARD" 2>&1 | tail -5
+    exit 1
+fi
+echo "[grafana-lint]   ✓ valid JSON"
+
+# 2. Required top-level keys — shape a Grafana import expects.
+required_top=(title panels schemaVersion uid)
+missing=()
+for key in "${required_top[@]}"; do
+    if ! jq -e --arg k "$key" 'has($k)' "$DASHBOARD" >/dev/null; then
+        missing+=("$key")
+    fi
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+    echo "[grafana-lint] FAIL: missing top-level keys: ${missing[*]}"
+    exit 1
+fi
+echo "[grafana-lint]   ✓ top-level keys present: ${required_top[*]}"
+
+# 3. Non-empty panel array.
+panel_count=$(jq '.panels | length' "$DASHBOARD")
+if [ "$panel_count" -lt 1 ]; then
+    echo "[grafana-lint] FAIL: .panels is empty"
+    exit 1
+fi
+echo "[grafana-lint]   ✓ $panel_count panels"
+
+# 4. Each panel has id, title, type, gridPos. Report the first
+#    offender + a summary count; don't stop at the first one so
+#    operators see the full picture.
+required_panel=(id title type gridPos)
+bad_panels=0
+for i in $(seq 0 $((panel_count - 1))); do
+    for key in "${required_panel[@]}"; do
+        if ! jq -e --arg k "$key" --argjson i "$i" '.panels[$i] | has($k)' "$DASHBOARD" >/dev/null; then
+            title=$(jq -r --argjson i "$i" '.panels[$i].title // "(untitled)"' "$DASHBOARD")
+            echo "[grafana-lint] FAIL: panel[$i] \"$title\" missing .$key"
+            bad_panels=$((bad_panels + 1))
+        fi
+    done
+done
+if [ "$bad_panels" -gt 0 ]; then
+    echo "[grafana-lint] $bad_panels panel/field failures"
+    exit 1
+fi
+echo "[grafana-lint]   ✓ every panel has: ${required_panel[*]}"
+
+# 5. uid is a non-empty string (Grafana requires a stable uid for
+#    provisioning / URL permalinks).
+uid=$(jq -r '.uid' "$DASHBOARD")
+if [ -z "$uid" ] || [ "$uid" = "null" ]; then
+    echo "[grafana-lint] FAIL: .uid is empty/null"
+    exit 1
+fi
+echo "[grafana-lint]   ✓ uid=$uid"
+
+# 6. schemaVersion is numeric + >= 36 (pins we're on a Grafana 9+ era
+#    schema; the dashboard file is authored against that surface).
+schema=$(jq -r '.schemaVersion' "$DASHBOARD")
+if ! [[ "$schema" =~ ^[0-9]+$ ]] || [ "$schema" -lt 36 ]; then
+    echo "[grafana-lint] FAIL: schemaVersion=$schema (expected integer >= 36)"
+    exit 1
+fi
+echo "[grafana-lint]   ✓ schemaVersion=$schema"
+
+echo "[grafana-lint] PASS"

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -509,10 +509,15 @@ done
 # ── per-example metadata ───────────────────────────────────────────────
 #
 # `skip_reason` short-circuits the build+run pair with a stable
-# rationale (grafana has no Cargo workspace).
+# rationale. Empty string = proceed normally. Populated = skip both
+# build and run.
 skip_reason() {
     case "$1" in
-        grafana) echo "dashboard JSON only — no Cargo workspace" ;;
+        # grafana has no Cargo workspace but is NOT skipped anymore —
+        # its run_cmd invokes scripts/lint-grafana-dashboard.sh which
+        # validates JSON shape. Left here (empty) so the dispatcher
+        # doesn't try to `cargo build` it.
+        grafana) echo "" ;;
         *) echo "" ;;
     esac
 }
@@ -588,6 +593,10 @@ run_cmd() {
             # All three call the harness-spawned ff-server via HTTP
             # and talk to Valkey directly for worker-side ops.
             echo "${t}cargo run --locked --release" ;;
+        grafana)
+            # Dashboard JSON only — lints the shape with jq. Runs at
+            # repo root (the lint script resolves its own path).
+            echo "$ROOT/scripts/lint-grafana-dashboard.sh" ;;
         *)
             echo "" ;;
     esac
@@ -698,13 +707,26 @@ for dir in "$EXAMPLES_DIR"/*/; do
         continue
     fi
 
-    if [ ! -f "$dir/Cargo.toml" ]; then
+    # grafana has no Cargo workspace — its run_cmd invokes the
+    # dashboard lint directly. Other no-Cargo dirs still SKIP with a
+    # "no Cargo.toml" reason.
+    if [ "$name" != "grafana" ] && [ ! -f "$dir/Cargo.toml" ]; then
         record_skip "$name" "no Cargo.toml"
         continue
     fi
 
+    # Build-only mode: grafana has no cargo artifact to produce —
+    # the run phase is its only real work. Record PASS and continue.
+    if [ "$MODE" = "build" ] && [ "$name" = "grafana" ]; then
+        record_pass "$name"
+        echo
+        continue
+    fi
+
     # ── build (phase 3a) ──
-    if [ "$MODE" = "both" ] || [ "$MODE" = "build" ]; then
+    # grafana has no Cargo workspace, so the build phase is a no-op
+    # for it; drop straight into the run phase (which lints its JSON).
+    if { [ "$MODE" = "both" ] || [ "$MODE" = "build" ]; } && [ "$name" != "grafana" ]; then
         echo "[build] $name …"
         # --release matches what the phase-3b run commands use below, so
         # the default `both` mode compiles each example exactly once


### PR DESCRIPTION
## Summary

Final run-all-examples phase. Flips `grafana` from SKIP → PASS via a jq-based dashboard lint.

## What it checks

1. Valid JSON (`jq empty`)
2. Required top-level keys: `title`, `panels`, `schemaVersion`, `uid`
3. Non-empty `.panels` array
4. Every panel has `id`, `title`, `type`, `gridPos`
5. `.uid` non-empty/non-null
6. `.schemaVersion >= 36` (Grafana 9+ era)

Failures print per-panel / per-field context instead of a single opaque "bad JSON".

## Test plan

- [x] Lint script PASSes on current `flowfabric-ops.json` (11 panels, schemaVersion 39, uid=flowfabric-ops)
- [x] Harness: grafana run_cmd invokes the lint; no-Cargo dispatch paths bypassed for grafana specifically
- [x] `--build-only` mode records grafana as PASS (no cargo artifact to build)
- [x] Full sweep: **10 PASS / 3 SKIP / 0 FAIL**
- [x] CI workflow grows `jq` in `apt-get install`

## What's left

- 3 LLM-dependent examples (coding-agent, llm-race, media-pipeline) stay pre-release-local per owner scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)