### PR TITLE
fix(#483): CancellationToken replaces Notify in retry-and-cancel + token-budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **`examples/{retry-and-cancel,token-budget}`**: swap the
+  `tokio::sync::Notify`-based worker-shutdown path for
+  `tokio_util::sync::CancellationToken` (level-triggered). Fixes
+  #483 — the notify-waiters shape was edge-triggered and dropped a
+  cancel fired while the worker was `tokio::time::sleep`-ing between
+  polls, leaving `worker_handle.await` hung after the scenes
+  completed. Both examples now exit cleanly (rc=0) instead of
+  needing the harness's success-marker escape hatch.
 - **`examples/media-pipeline/review`**: `--waitpoint-id` is now
   `Option<String>`. Required only on the Suspended path (where it's
   load-bearing); on the `AlreadyCompleted` early-exit (peer reviewer

--- a/examples/retry-and-cancel/Cargo.lock
+++ b/examples/retry-and-cancel/Cargo.lock
@@ -1427,6 +1427,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/examples/retry-and-cancel/Cargo.toml
+++ b/examples/retry-and-cancel/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 ff-core = { path = "../../crates/ff-core" }
 ff-sdk = { path = "../../crates/ff-sdk" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal"] }
+tokio-util = { version = "0.7", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/retry-and-cancel/src/main.rs
+++ b/examples/retry-and-cancel/src/main.rs
@@ -41,8 +41,8 @@ use ff_core::policy::{BackoffStrategy, ExecutionPolicy, RetryPolicy};
 use ff_core::types::{ExecutionId, FlowId, LaneId};
 use ff_sdk::{FailOutcome, FlowFabricAdminClient, FlowFabricWorker, WorkerConfig};
 use flaky_api::FlakyPayload;
-use tokio::sync::Notify;
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 const NAMESPACE: &str = "demo";
@@ -86,15 +86,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let http = reqwest::Client::new();
 
     // Spawn the worker loop. The orchestrator signals shutdown via
-    // `done` once both scenes finish; the worker then exits its select
-    // loop cleanly.
-    let done = Arc::new(Notify::new());
+    // `shutdown` once both scenes finish; the worker then exits its
+    // select loop cleanly.
+    //
+    // Uses a tokio-util CancellationToken rather than
+    // tokio::sync::Notify: notify_waiters only wakes waiters that
+    // were registered at call time, so a notification fired while
+    // the worker is sleeping between polls gets dropped (#483).
+    // CancellationToken is level-triggered — once cancelled,
+    // subsequent `.cancelled()` futures resolve immediately — so
+    // the worker's next select iteration exits regardless of when
+    // the cancel signal arrived relative to the poll cycle.
+    let shutdown = CancellationToken::new();
     let worker_handle = {
         let admin = Arc::clone(&admin);
-        let done = Arc::clone(&done);
+        let shutdown = shutdown.clone();
         let host = host.clone();
         tokio::spawn(async move {
-            if let Err(e) = run_worker(host, port, admin, done).await {
+            if let Err(e) = run_worker(host, port, admin, shutdown).await {
                 tracing::error!(error = %e, "worker loop failed");
             }
         })
@@ -109,7 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Shut the worker down before surfacing any scene error so the
     // background task doesn't leak past `main`.
-    done.notify_waiters();
+    shutdown.cancel();
     let _ = worker_handle.await;
 
     match scene_result {
@@ -294,7 +303,7 @@ async fn run_worker(
     host: String,
     port: u16,
     admin: Arc<FlowFabricAdminClient>,
-    done: Arc<Notify>,
+    shutdown: CancellationToken,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = WorkerConfig {
         backend: Some(ff_core::backend::BackendConfig::valkey(host, port)),
@@ -316,8 +325,16 @@ async fn run_worker(
 
     info!("worker loop started");
     loop {
+        // Short-circuit if the shutdown token was already cancelled
+        // between iterations (e.g. while the sleep in the Ok(None)
+        // arm was running). `.cancelled()` is level-triggered so a
+        // cancel fired during the sleep isn't lost.
+        if shutdown.is_cancelled() {
+            info!("worker shutdown requested");
+            return Ok(());
+        }
         tokio::select! {
-            _ = done.notified() => {
+            _ = shutdown.cancelled() => {
                 info!("worker shutdown requested");
                 return Ok(());
             }
@@ -350,11 +367,19 @@ async fn run_worker(
                     Ok(None) => {
                         // Nothing to claim — short sleep keeps the
                         // demo responsive without hammering the server.
-                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        // Race the sleep against shutdown so a cancel
+                        // fired during the wait exits promptly.
+                        tokio::select! {
+                            _ = shutdown.cancelled() => return Ok(()),
+                            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+                        }
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "claim failed");
-                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        tokio::select! {
+                            _ = shutdown.cancelled() => return Ok(()),
+                            _ = tokio::time::sleep(Duration::from_millis(500)) => {}
+                        }
                     }
                 }
             }

--- a/examples/retry-and-cancel/src/main.rs
+++ b/examples/retry-and-cancel/src/main.rs
@@ -117,9 +117,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     .await;
 
     // Shut the worker down before surfacing any scene error so the
-    // background task doesn't leak past `main`.
+    // background task doesn't leak past `main`. Outer timeout guards
+    // against a wedged `claim_via_server` — the loop's 10s block_ms
+    // + CancellationToken polling means 15s is generous headroom.
+    // JoinError handling:
+    //   * Ok(Ok(()))            — worker exited cleanly
+    //   * Ok(Err(JoinError))    — cancelled (expected on the abort
+    //                             paths we might add later) or panic
+    //                             (re-raise loud)
+    //   * Err(Elapsed)          — outer timeout; the task handle is
+    //                             dropped, which cancels the task
     shutdown.cancel();
-    let _ = worker_handle.await;
+    match timeout(Duration::from_secs(15), worker_handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) if e.is_cancelled() => {}
+        Ok(Err(e)) => panic!("worker task failed unexpectedly: {e:?}"),
+        Err(_) => tracing::warn!("worker shutdown exceeded 15s — dropping handle"),
+    }
 
     match scene_result {
         Ok(Ok(())) => {

--- a/examples/token-budget/Cargo.lock
+++ b/examples/token-budget/Cargo.lock
@@ -1854,6 +1854,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]

--- a/examples/token-budget/Cargo.toml
+++ b/examples/token-budget/Cargo.toml
@@ -21,6 +21,7 @@ flowfabric = { path = "../../crates/flowfabric", default-features = false, featu
 
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal"] }
+tokio-util = { version = "0.7", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/token-budget/src/main.rs
+++ b/examples/token-budget/src/main.rs
@@ -47,8 +47,8 @@ use flowfabric::sdk::{
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Notify;
 use tokio::time::{sleep, timeout, Instant};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 const NAMESPACE: &str = "demo";
@@ -158,15 +158,19 @@ async fn main() -> Result<()> {
 
     // Worker loop drains claims in the background; submit polls the
     // budget and owns the cancel decision.
-    let done = Arc::new(Notify::new());
+    //
+    // Uses tokio-util CancellationToken (level-triggered) rather
+    // than tokio::sync::Notify (edge-triggered, loses cancels fired
+    // while the worker is between polls — #483).
+    let shutdown = CancellationToken::new();
     let worker_handle = {
-        let done = Arc::clone(&done);
+        let shutdown = shutdown.clone();
         let admin = Arc::clone(&admin);
         let budget_id = budget_id.clone();
         let worker = Arc::new(worker);
         let worker_for_task = Arc::clone(&worker);
         tokio::spawn(async move {
-            if let Err(e) = run_worker_loop(worker_for_task, admin, budget_id, done).await {
+            if let Err(e) = run_worker_loop(worker_for_task, admin, budget_id, shutdown).await {
                 tracing::error!(error = %e, "worker loop failed");
             }
         })
@@ -180,13 +184,13 @@ async fn main() -> Result<()> {
 
     // Give in-flight reports time to drain, then stop the worker.
     sleep(Duration::from_millis(500)).await;
-    done.notify_waiters();
+    shutdown.cancel();
     // Bound the worker-shutdown wait so the example can't hang past
-    // the demo budget. `claim_via_server` blocks up to its block_ms,
-    // and `notify_waiters` only wakes current waiters, so a freshly-
-    // spawned claim round has to return naturally before select! can
-    // re-poll `done`. 5s covers that worst case comfortably.
-    let _ = timeout(Duration::from_secs(5), worker_handle).await;
+    // the demo budget. `claim_via_server` blocks up to its block_ms;
+    // since CancellationToken is level-triggered the in-flight claim
+    // will exit promptly once its block finishes, but we still cap
+    // the join at a generous ceiling to guard against a wedged call.
+    let _ = timeout(Duration::from_secs(15), worker_handle).await;
 
     // ── Post-mortem: per-child LeaseSummary (v0.9 #278). Even a
     // terminal exec carries its last-seen lease fields in the snapshot,
@@ -420,13 +424,19 @@ async fn run_worker_loop(
     worker: Arc<FlowFabricWorker>,
     admin: Arc<FlowFabricAdminClient>,
     budget_id: BudgetId,
-    done: Arc<Notify>,
+    shutdown: CancellationToken,
 ) -> Result<()> {
     let lane = LaneId::new(LANE);
     info!("worker loop started");
     loop {
+        // Level-triggered short-circuit — catches cancels fired
+        // between iterations when no `.cancelled()` waiter was armed.
+        if shutdown.is_cancelled() {
+            info!("worker shutdown requested");
+            return Ok(());
+        }
         tokio::select! {
-            _ = done.notified() => {
+            _ = shutdown.cancelled() => {
                 info!("worker shutdown requested");
                 return Ok(());
             }

--- a/examples/token-budget/src/main.rs
+++ b/examples/token-budget/src/main.rs
@@ -187,10 +187,15 @@ async fn main() -> Result<()> {
     shutdown.cancel();
     // Bound the worker-shutdown wait so the example can't hang past
     // the demo budget. `claim_via_server` blocks up to its block_ms;
-    // since CancellationToken is level-triggered the in-flight claim
-    // will exit promptly once its block finishes, but we still cap
-    // the join at a generous ceiling to guard against a wedged call.
-    let _ = timeout(Duration::from_secs(15), worker_handle).await;
+    // CancellationToken is level-triggered so the in-flight claim
+    // exits promptly once its block finishes, but cap the join at a
+    // generous ceiling to guard against a wedged call.
+    match timeout(Duration::from_secs(15), worker_handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) if e.is_cancelled() => {}
+        Ok(Err(e)) => panic!("worker task failed unexpectedly: {e:?}"),
+        Err(_) => warn!("worker shutdown exceeded 15s — dropping handle"),
+    }
 
     // ── Post-mortem: per-child LeaseSummary (v0.9 #278). Even a
     // terminal exec carries its last-seen lease fields in the snapshot,
@@ -527,13 +532,20 @@ async fn run_worker_loop(
                         }
                     }
                     Ok(None) => {
-                        // No claim ready. Short sleep — the poll loop is
-                        // driven by the submitter's deadline, not by us.
-                        sleep(Duration::from_millis(100)).await;
+                        // No claim ready. Short sleep raced against
+                        // shutdown so a cancel fired during the wait
+                        // exits promptly (mirrors retry-and-cancel).
+                        tokio::select! {
+                            _ = shutdown.cancelled() => return Ok(()),
+                            _ = sleep(Duration::from_millis(100)) => {}
+                        }
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "claim_via_server returned error (likely flow cancelled)");
-                        sleep(Duration::from_millis(200)).await;
+                        tokio::select! {
+                            _ = shutdown.cancelled() => return Ok(()),
+                            _ = sleep(Duration::from_millis(200)) => {}
+                        }
                     }
                 }
             }

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -543,20 +543,16 @@ requires() {
 # logic itself completed and the marker proves it.
 success_marker() {
     # Marker substrings emitted AFTER the scenario body completes but
-    # BEFORE the example's shutdown path (which can hang on a
-    # notify_waiters race between `main` and a background worker —
-    # filed as a follow-up example bug). Matching the body-complete
-    # marker lets the harness record PASS even if the process then
-    # needs a SIGTERM to actually exit.
+    # BEFORE the example's shutdown path. Kept as defensive
+    # infrastructure — retry-and-cancel + token-budget used to rely
+    # on this because of a `Notify::notify_waiters` race on shutdown
+    # (#483, fixed via CancellationToken) — so both exit cleanly now.
+    # Left empty by default; any future example that hits a similar
+    # cleanup-path quirk can opt in via a new case arm without
+    # having to rebuild the mechanism.
     case "$1" in
-        # Last log line scene 2 emits before returning Ok(()). Scenes
-        # are sequential so reaching this proves scene 1 also
-        # completed.
-        retry-and-cancel) echo "member cancelled" ;;
         # Emitted just before main's scene_result match arm runs.
         v010-read-side-ergonomics) echo "demo complete — capabilities() read" ;;
-        # Emitted at the last info! in main's happy path.
-        token-budget) echo "demo complete" ;;
         *) echo "" ;;
     esac
 }


### PR DESCRIPTION
## Summary

Closes #483. The two example CLIs used `tokio::sync::Notify::notify_waiters()` for worker shutdown:

```rust
// main
done.notify_waiters();        // (A)
let _ = worker_handle.await;  // hangs forever

// worker
loop {
    tokio::select! {
        _ = done.notified() => return Ok(()),
        claim = worker.claim_via_server(...) => {
            // on Ok(None):
            tokio::time::sleep(Duration::from_millis(100)).await;  // (B)
        }
    }
}
```

`notify_waiters()` only wakes waiters **registered at the moment of call**. If the worker is at (B), the notification is dropped. The next select! iteration registers a fresh `done.notified()` future that never sees that prior notification. `worker_handle.await` hangs.

## Fix

`tokio_util::sync::CancellationToken` is **level-triggered**:
- Once `cancel()` is called, subsequent `.cancelled()` futures resolve immediately
- `is_cancelled()` returns true permanently

Both worker loops now:
1. Short-circuit with `if shutdown.is_cancelled() { return }` at the top of each iteration (catches cancels landed during sleeps)
2. Race `shutdown.cancelled()` in `tokio::select!` alongside the claim path
3. Wrap their between-poll `tokio::time::sleep(100ms)` / `sleep(500ms)` in a `select!` with `.cancelled()` so the sleep can't hold the worker past main's cancel

## Harness cleanup

`scripts/run-all-examples.sh` no longer needs `success_marker` entries for these two — they now exit rc=0. Infrastructure kept for any future example with its own cleanup quirk.

## Test plan

- [x] `retry-and-cancel` passes with rc=0 (no more "exit 124 but marker found")
- [x] `token-budget` passes with rc=0
- [x] Full local sweep: **10 PASS / 3 SKIP / 0 FAIL**
- [x] Both examples' `cargo build --release` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)