### PR TITLE
RFC-025 Phase 3: Postgres worker-registry

### DIFF
--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -17,9 +17,15 @@ description = "FlowFabric EngineBackend impl — Postgres backend (RFC-v0.7, Wav
 # write surface; ff-backend-valkey takes the same stance via its
 # hard ff-core feature activation). `streaming` tracks ff-core's
 # `streaming` default.
-default = ["core", "streaming"]
+default = ["core", "streaming", "suspension"]
 core = ["ff-core/core"]
 streaming = ["ff-core/streaming"]
+# RFC-025 Phase 3: `list_expired_leases` trait method rides `ff-core`'s
+# `suspension` gate (the method reads lease/attempt state coupled with
+# suspend). Default-on so the in-tree release feature-set keeps parity
+# with Valkey + SQLite; downstream consumers can disable via
+# `default-features = false`.
+suspension = ["ff-core/suspension"]
 # Issue #154 — enable real OTEL metric emission via `ff-observability`.
 # Off by default; mirrors `ff-backend-valkey`.
 observability = ["ff-observability/enabled"]
@@ -28,7 +34,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-postgres/migrations/0021_worker_registry.sql
+++ b/crates/ff-backend-postgres/migrations/0021_worker_registry.sql
@@ -1,0 +1,78 @@
+-- RFC-025 Phase 3 — Postgres worker-registry tables.
+--
+-- Mirrors Valkey's `ff:worker:{ns}:{inst}:alive` + `:caps` + index set
+-- behind two tables: current-state and append-only audit event log.
+-- Shape follows §5.2 of rfcs/RFC-025-worker-registry.md.
+--
+-- `partition_key` derivation: `(fnv1a_u64(worker_instance_id.as_bytes()) % 256) as smallint`
+-- — identical to the Valkey-side hashing of `worker_instance_id`, so
+-- `register_worker`, `heartbeat_worker`, `mark_worker_dead`, and the
+-- TTL-sweep scanner all land on the same partition for the same id.
+--
+-- Partial-namespace pagination + lane[] equality rely on the columns
+-- named below. `lanes` is stored sorted so equality checks are stable
+-- across processes writing the same registration.
+CREATE TABLE ff_worker_registry (
+    partition_key          smallint NOT NULL,
+    namespace              text     NOT NULL,
+    worker_instance_id     text     NOT NULL,
+    worker_id              text     NOT NULL,
+    lanes                  text[]   NOT NULL,
+    capabilities_csv       text     NOT NULL,
+    last_heartbeat_ms      bigint   NOT NULL,
+    liveness_ttl_ms        bigint   NOT NULL,
+    registered_at_ms       bigint   NOT NULL,
+    PRIMARY KEY (partition_key, namespace, worker_instance_id)
+) PARTITION BY HASH (partition_key);
+
+-- 256 hash partitions, mirroring `ff_budget_usage_by_exec`
+-- (migration 0020) + the 256-partition family elsewhere.
+DO $$
+BEGIN
+  FOR i IN 0..255 LOOP
+    EXECUTE format(
+      'CREATE TABLE %I PARTITION OF ff_worker_registry FOR VALUES WITH (MODULUS 256, REMAINDER %s)',
+      'ff_worker_registry_p' || lpad(i::text, 3, '0'),
+      i
+    );
+  END LOOP;
+END$$;
+
+-- Append-only audit trail. Captures `registered` | `heartbeat` |
+-- `marked_dead` | `ttl_swept` transitions for future operator-tooling
+-- (recently-dead workers, registration bursts, TTL-driven cleanup
+-- trace). Unused by this RFC's bodies except as a sink from
+-- `register_worker`, `mark_worker_dead`, and the TTL-sweep scanner.
+CREATE TABLE ff_worker_registry_event (
+    partition_key          smallint NOT NULL,
+    namespace              text     NOT NULL,
+    worker_instance_id     text     NOT NULL,
+    event_kind             text     NOT NULL,
+    event_at_ms            bigint   NOT NULL,
+    reason                 text     NULL,
+    PRIMARY KEY (partition_key, namespace, worker_instance_id, event_at_ms)
+) PARTITION BY HASH (partition_key);
+
+DO $$
+BEGIN
+  FOR i IN 0..255 LOOP
+    EXECUTE format(
+      'CREATE TABLE %I PARTITION OF ff_worker_registry_event FOR VALUES WITH (MODULUS 256, REMAINDER %s)',
+      'ff_worker_registry_event_p' || lpad(i::text, 3, '0'),
+      i
+    );
+  END LOOP;
+END$$;
+
+-- `list_workers` paging cursor: ordered by `(namespace, worker_instance_id)`.
+-- The PK covers `(partition_key, namespace, worker_instance_id)`, but
+-- scans across all partitions (cross-namespace sweeps) still need a
+-- namespace-scoped projection. This index gives us a non-partitioned
+-- lookup by the `(namespace, worker_instance_id)` pair.
+CREATE INDEX ff_worker_registry_ns_inst_idx
+    ON ff_worker_registry (namespace, worker_instance_id);
+
+-- Lease-expiry sweep for `list_expired_leases` uses the existing
+-- `ff_attempt_lease_expiry_idx` from migration 0001 (partial index on
+-- `(partition_key, lease_expires_at_ms) WHERE lease_expires_at_ms IS
+-- NOT NULL`). No new index is required on `ff_attempt`.

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1883,7 +1883,11 @@ impl EngineBackend for PostgresBackend {
         worker_registry::mark_worker_dead(&self.pool, args).await
     }
 
-    #[cfg(feature = "suspension")]
+    // List-expired-leases joins ff_attempt+ff_exec_core, which live in
+    // the `worker_registry` module (gated on `core`). Require both
+    // features to keep the body's dep chain intact; a standalone
+    // suspension-only build has no lease-bearing tables to scan.
+    #[cfg(all(feature = "core", feature = "suspension"))]
     #[tracing::instrument(name = "pg.list_expired_leases", skip_all)]
     async fn list_expired_leases(
         &self,

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -123,6 +123,8 @@ pub mod suspend_ops;
 #[cfg(feature = "core")]
 pub(crate) mod typed_ops;
 pub mod version;
+#[cfg(feature = "core")]
+pub mod worker_registry;
 
 pub use completion::{PostgresCompletionStream, COMPLETION_CHANNEL};
 pub use error::{map_sqlx_error, PostgresTransportError};
@@ -213,6 +215,13 @@ fn postgres_supports_base() -> ff_core::capability::Supports {
     s.list_pending_waitpoints = true;
     s.cancel_flow_header = true;
     s.ack_cancel_member = true;
+
+    // ── RFC-025 Phase 3 — worker registry ──
+    s.register_worker = true;
+    s.heartbeat_worker = true;
+    s.mark_worker_dead = true;
+    s.list_expired_leases = true;
+    s.list_workers = true;
 
     s
 }
@@ -1839,6 +1848,57 @@ impl EngineBackend for PostgresBackend {
             });
         }
         Ok(ms as u64)
+    }
+
+    // ── RFC-025 Phase 3 — worker registry ───────────────────────
+    //
+    // Bodies live in `crate::worker_registry`; the overrides here
+    // just forward to those free functions so the trait
+    // `#[cfg(feature = ..)]` gates match the module-level gate.
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.register_worker", skip_all)]
+    async fn register_worker(
+        &self,
+        args: ff_core::contracts::RegisterWorkerArgs,
+    ) -> Result<ff_core::contracts::RegisterWorkerOutcome, EngineError> {
+        worker_registry::register_worker(&self.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.heartbeat_worker", skip_all)]
+    async fn heartbeat_worker(
+        &self,
+        args: ff_core::contracts::HeartbeatWorkerArgs,
+    ) -> Result<ff_core::contracts::HeartbeatWorkerOutcome, EngineError> {
+        worker_registry::heartbeat_worker(&self.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.mark_worker_dead", skip_all)]
+    async fn mark_worker_dead(
+        &self,
+        args: ff_core::contracts::MarkWorkerDeadArgs,
+    ) -> Result<ff_core::contracts::MarkWorkerDeadOutcome, EngineError> {
+        worker_registry::mark_worker_dead(&self.pool, args).await
+    }
+
+    #[cfg(feature = "suspension")]
+    #[tracing::instrument(name = "pg.list_expired_leases", skip_all)]
+    async fn list_expired_leases(
+        &self,
+        args: ff_core::contracts::ListExpiredLeasesArgs,
+    ) -> Result<ff_core::contracts::ListExpiredLeasesResult, EngineError> {
+        worker_registry::list_expired_leases(&self.pool, args).await
+    }
+
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.list_workers", skip_all)]
+    async fn list_workers(
+        &self,
+        args: ff_core::contracts::ListWorkersArgs,
+    ) -> Result<ff_core::contracts::ListWorkersResult, EngineError> {
+        worker_registry::list_workers(&self.pool, args).await
     }
 }
 

--- a/crates/ff-backend-postgres/src/scanner_supervisor.rs
+++ b/crates/ff-backend-postgres/src/scanner_supervisor.rs
@@ -44,6 +44,11 @@ pub struct PostgresScannerConfig {
     /// `ff-server::config::budget_reset_interval` knob so the same
     /// env value drives both backends.
     pub budget_reset_interval: Duration,
+    /// RFC-025 Phase 3: cadence for the `worker_registry_ttl_sweep`
+    /// reconciler. Mirrors Valkey's native PEXPIRE cleanup for
+    /// worker-liveness keys on PG (Valkey doesn't need a scanner).
+    /// Defaults to 30s, matching `budget_reset_interval` convention.
+    pub worker_registry_ttl_interval: Duration,
     /// Stale-threshold for the dependency reconciler (ms). Matches
     /// the Valkey scanner's `stale_threshold_ms` knob.
     pub dependency_stale_threshold_ms: i64,
@@ -191,6 +196,30 @@ pub fn spawn_scanners(pool: PgPool, cfg: PostgresScannerConfig) -> PostgresScann
         },
     );
 
+    // ── RFC-025 Phase 3 — `worker_registry_ttl_sweep` ──
+    //
+    // Walks the 256-partition worker-registry space (keyed on
+    // `fnv1a_u64(worker_instance_id) % 256`, not the flow/exec
+    // partition family). 30s tick mirrors Valkey's native PEXPIRE
+    // cadence closely enough for operator-tooling latency.
+    spawn_partition_scan(
+        &js,
+        &tx,
+        rx.clone(),
+        pool.clone(),
+        cfg.worker_registry_ttl_interval,
+        256,
+        filter.clone(),
+        "pg.worker_registry_ttl_sweep",
+        |pool, part, _filter| {
+            Box::pin(async move {
+                crate::worker_registry::ttl_sweep_tick(&pool, part)
+                    .await
+                    .map(|_| ())
+            })
+        },
+    );
+
     // ── Global (non-partition-scoped) reconcilers ──
     let dep_stale = cfg.dependency_stale_threshold_ms;
     spawn_global_scan(
@@ -243,10 +272,10 @@ pub fn spawn_scanners(pool: PgPool, cfg: PostgresScannerConfig) -> PostgresScann
     );
 
     tracing::info!(
-        scanners = 7,
+        scanners = 8,
         num_partitions,
         num_budget_partitions,
-        "postgres scanner supervisor spawned (RFC-017 Stage E3 + RFC-020 Wave 9 budget_reset)"
+        "postgres scanner supervisor spawned (RFC-017 Stage E3 + RFC-020 Wave 9 budget_reset + RFC-025 Phase 3 worker_registry_ttl_sweep)"
     );
 
     PostgresScannerHandle {

--- a/crates/ff-backend-postgres/src/worker_registry.rs
+++ b/crates/ff-backend-postgres/src/worker_registry.rs
@@ -383,15 +383,27 @@ pub async fn list_workers(
     pool: &PgPool,
     args: ListWorkersArgs,
 ) -> Result<ListWorkersResult, EngineError> {
+    // RFC-025 §9.4: cross-namespace enumeration requires a two-key
+    // cursor (namespace, worker_instance_id) because instance_ids
+    // collide across namespaces. The Phase-1 contract's cursor is
+    // single-key `Option<WorkerInstanceId>`; expanding to a tuple
+    // would reopen Phase 1. Reject cross-ns with `Unavailable` to
+    // match Phase-2 Valkey behaviour; operator tooling can loop per
+    // namespace until the tuple-cursor RFC lands.
+    let Some(ns) = args.namespace.as_ref() else {
+        return Err(EngineError::Unavailable {
+            op: "list_workers (cross-namespace on Postgres — pass namespace explicitly)",
+        });
+    };
     let limit = args.limit.unwrap_or(1000) as i64;
-    let namespace_filter: Option<&str> = args.namespace.as_ref().map(|n| n.as_str());
+    let namespace_filter: &str = ns.as_str();
     let after_cursor: Option<&str> = args.after.as_ref().map(|w| w.as_str());
 
     let rows = sqlx::query(
         "SELECT worker_id, worker_instance_id, namespace, lanes, \
                 capabilities_csv, last_heartbeat_ms, liveness_ttl_ms, registered_at_ms \
            FROM ff_worker_registry \
-          WHERE ($1::text IS NULL OR namespace = $1) \
+          WHERE namespace = $1 \
             AND ($2::text IS NULL OR worker_instance_id > $2) \
           ORDER BY worker_instance_id ASC \
           LIMIT $3",
@@ -415,11 +427,11 @@ pub async fn list_workers(
         let registered_at_ms: i64 = row.try_get("registered_at_ms").map_err(map_sqlx_error)?;
 
         let lanes: BTreeSet<LaneId> = lanes_vec.into_iter().map(LaneId).collect();
-        let capabilities: BTreeSet<String> = if caps_csv.is_empty() {
-            BTreeSet::new()
-        } else {
-            caps_csv.split(',').map(str::to_owned).collect()
-        };
+        let capabilities: BTreeSet<String> = caps_csv
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
 
         entries.push(WorkerInfo::new(
             WorkerId::new(worker_id),

--- a/crates/ff-backend-postgres/src/worker_registry.rs
+++ b/crates/ff-backend-postgres/src/worker_registry.rs
@@ -1,0 +1,494 @@
+//! RFC-025 Phase 3 — Postgres worker-registry bodies + TTL-sweep.
+//!
+//! Backs the five `EngineBackend` worker-registry methods
+//! (`register_worker`, `heartbeat_worker`, `mark_worker_dead`,
+//! `list_expired_leases`, `list_workers`) on Postgres, plus the
+//! `worker_registry_ttl_sweep` reconciler that prunes rows whose
+//! `last_heartbeat_ms + liveness_ttl_ms` has elapsed.
+//!
+//! Schema shape lives in `migrations/0021_worker_registry.sql`
+//! (current-state table + append-only event log). Partition key is
+//! `(fnv1a_u64(worker_instance_id.as_bytes()) % 256) as i16` — identical
+//! to the Valkey-side hashing so `register` / `heartbeat` /
+//! `mark_dead` / `ttl_sweep` all land on the same row for the same
+//! instance id.
+
+use std::collections::BTreeSet;
+
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use ff_core::contracts::{
+    ExpiredLeaseInfo, ExpiredLeasesCursor, HeartbeatWorkerArgs, HeartbeatWorkerOutcome,
+    LIST_EXPIRED_LEASES_DEFAULT_LIMIT, LIST_EXPIRED_LEASES_MAX_LIMIT, ListExpiredLeasesArgs,
+    ListExpiredLeasesResult, ListWorkersArgs, ListWorkersResult, MARK_WORKER_DEAD_REASON_MAX_BYTES,
+    MarkWorkerDeadArgs, MarkWorkerDeadOutcome, RegisterWorkerArgs, RegisterWorkerOutcome,
+    WorkerInfo,
+};
+use ff_core::engine_error::{EngineError, ValidationKind};
+use ff_core::hash::fnv1a_u64;
+use ff_core::types::{
+    AttemptIndex, ExecutionId, LaneId, LeaseEpoch, LeaseId, Namespace, TimestampMs, WorkerId,
+    WorkerInstanceId,
+};
+
+use crate::error::map_sqlx_error;
+use crate::reconcilers::ScanReport;
+
+/// Derive the `ff_worker_registry.partition_key` for an instance id.
+/// Must match the Valkey-side hashing (both paths own the same row).
+pub fn worker_partition_key(worker_instance_id: &str) -> i16 {
+    (fnv1a_u64(worker_instance_id.as_bytes()) % 256) as i16
+}
+
+/// Postgres has no stable `lease_id` column on `ff_attempt` (identity
+/// is `(execution_id, attempt_index, lease_epoch)`; see
+/// `operator::synthetic_lease_id`). For `list_expired_leases` we need
+/// to surface a `LeaseId` — derive a deterministic UUID from the same
+/// triple so two callers that observe the same lease see the same id.
+fn synthetic_lease_uuid(exec_uuid: Uuid, attempt_index: i32, lease_epoch: i64) -> Uuid {
+    // 16 bytes of seed material: exec UUID (16) XOR-folded with
+    // attempt_index (4) + lease_epoch (8) packed into the tail. Not a
+    // cryptographic derivation — just stable + collision-resistant
+    // enough within a single execution's attempts.
+    let mut bytes = *exec_uuid.as_bytes();
+    let ai = attempt_index.to_be_bytes();
+    let le = lease_epoch.to_be_bytes();
+    for i in 0..4 {
+        bytes[8 + i] ^= ai[i];
+    }
+    for i in 0..8 {
+        bytes[i] ^= le[i];
+    }
+    Uuid::from_bytes(bytes)
+}
+
+// ── register_worker ──────────────────────────────────────────────
+
+pub async fn register_worker(
+    pool: &PgPool,
+    args: RegisterWorkerArgs,
+) -> Result<RegisterWorkerOutcome, EngineError> {
+    let partition_key = worker_partition_key(args.worker_instance_id.as_str());
+    let lanes_sorted: Vec<String> = args.lanes.iter().map(|l| l.0.clone()).collect();
+    let caps_csv: String = args
+        .capabilities
+        .iter()
+        .cloned()
+        .collect::<Vec<String>>()
+        .join(",");
+
+    // Single tx: (1) reject instance_id reassignment under a different
+    // `worker_id`; (2) upsert the row + return whether it was a fresh
+    // insert or an overwrite (`xmax = 0` returns true iff the row was
+    // inserted); (3) append a `registered` event.
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // Conflict check — if a row exists with the same (partition_key,
+    // namespace, worker_instance_id) but a different `worker_id`,
+    // reject per RFC-025 §4.
+    let existing_worker_id: Option<String> = sqlx::query_scalar(
+        "SELECT worker_id FROM ff_worker_registry \
+         WHERE partition_key = $1 AND namespace = $2 AND worker_instance_id = $3 \
+         FOR UPDATE",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if let Some(existing) = existing_worker_id.as_deref()
+        && existing != args.worker_id.as_str()
+    {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "instance_id reassigned".into(),
+        });
+    }
+
+    // `RETURNING (xmax = 0)` is the idiomatic "was this an insert?"
+    // signal on Postgres UPSERTs: `xmax` is 0 on an insert, non-zero
+    // on an update-path through ON CONFLICT.
+    let registered: bool = sqlx::query_scalar(
+        "INSERT INTO ff_worker_registry (\
+             partition_key, namespace, worker_instance_id, worker_id, \
+             lanes, capabilities_csv, last_heartbeat_ms, liveness_ttl_ms, \
+             registered_at_ms\
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) \
+         ON CONFLICT (partition_key, namespace, worker_instance_id) DO UPDATE SET \
+             worker_id = EXCLUDED.worker_id, \
+             lanes = EXCLUDED.lanes, \
+             capabilities_csv = EXCLUDED.capabilities_csv, \
+             last_heartbeat_ms = EXCLUDED.last_heartbeat_ms, \
+             liveness_ttl_ms = EXCLUDED.liveness_ttl_ms \
+         RETURNING (xmax = 0)",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .bind(args.worker_id.as_str())
+    .bind(&lanes_sorted)
+    .bind(caps_csv.as_str())
+    .bind(args.now.0)
+    .bind(args.liveness_ttl_ms as i64)
+    .bind(args.now.0)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
+        "INSERT INTO ff_worker_registry_event \
+             (partition_key, namespace, worker_instance_id, event_kind, event_at_ms, reason) \
+         VALUES ($1, $2, $3, 'registered', $4, NULL) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .bind(args.now.0)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    Ok(if registered {
+        RegisterWorkerOutcome::Registered
+    } else {
+        RegisterWorkerOutcome::Refreshed
+    })
+}
+
+// ── heartbeat_worker ─────────────────────────────────────────────
+
+pub async fn heartbeat_worker(
+    pool: &PgPool,
+    args: HeartbeatWorkerArgs,
+) -> Result<HeartbeatWorkerOutcome, EngineError> {
+    let partition_key = worker_partition_key(args.worker_instance_id.as_str());
+
+    // Refresh `last_heartbeat_ms` only when the row is still within
+    // its declared TTL window. If the TTL has lapsed, the TTL-sweep
+    // scanner will drop the row on its next tick — surface
+    // `NotRegistered` rather than re-upping a logically-dead worker.
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let ttl_row: Option<i64> = sqlx::query_scalar(
+        "UPDATE ff_worker_registry SET last_heartbeat_ms = $4 \
+         WHERE partition_key = $1 AND namespace = $2 AND worker_instance_id = $3 \
+           AND last_heartbeat_ms + liveness_ttl_ms > $4 \
+         RETURNING liveness_ttl_ms",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .bind(args.now.0)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(ttl_ms) = ttl_row else {
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(HeartbeatWorkerOutcome::NotRegistered);
+    };
+
+    sqlx::query(
+        "INSERT INTO ff_worker_registry_event \
+             (partition_key, namespace, worker_instance_id, event_kind, event_at_ms, reason) \
+         VALUES ($1, $2, $3, 'heartbeat', $4, NULL) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .bind(args.now.0)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+
+    let next_expiry_ms = TimestampMs::from_millis(args.now.0.saturating_add(ttl_ms));
+    Ok(HeartbeatWorkerOutcome::Refreshed { next_expiry_ms })
+}
+
+// ── mark_worker_dead ─────────────────────────────────────────────
+
+pub async fn mark_worker_dead(
+    pool: &PgPool,
+    args: MarkWorkerDeadArgs,
+) -> Result<MarkWorkerDeadOutcome, EngineError> {
+    // Mirrors the Valkey body's validation (§Rev-2 item 9): 256-byte
+    // reason cap + no control characters. Reject oversize / invalid
+    // before touching storage.
+    if args.reason.len() > MARK_WORKER_DEAD_REASON_MAX_BYTES {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: format!(
+                "reason: exceeds {} bytes (got {})",
+                MARK_WORKER_DEAD_REASON_MAX_BYTES,
+                args.reason.len()
+            ),
+        });
+    }
+    if args.reason.chars().any(|c| c.is_control()) {
+        return Err(EngineError::Validation {
+            kind: ValidationKind::InvalidInput,
+            detail: "reason: must not contain control characters".into(),
+        });
+    }
+
+    let partition_key = worker_partition_key(args.worker_instance_id.as_str());
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    let deleted: i64 = sqlx::query_scalar(
+        "WITH d AS (\
+             DELETE FROM ff_worker_registry \
+             WHERE partition_key = $1 AND namespace = $2 AND worker_instance_id = $3 \
+             RETURNING 1 AS x\
+         ) SELECT COUNT(*) FROM d",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if deleted == 0 {
+        tx.commit().await.map_err(map_sqlx_error)?;
+        return Ok(MarkWorkerDeadOutcome::NotRegistered);
+    }
+
+    sqlx::query(
+        "INSERT INTO ff_worker_registry_event \
+             (partition_key, namespace, worker_instance_id, event_kind, event_at_ms, reason) \
+         VALUES ($1, $2, $3, 'marked_dead', $4, $5) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .bind(args.now.0)
+    .bind(args.reason.as_str())
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(MarkWorkerDeadOutcome::Marked)
+}
+
+// ── list_expired_leases ──────────────────────────────────────────
+
+pub async fn list_expired_leases(
+    pool: &PgPool,
+    args: ListExpiredLeasesArgs,
+) -> Result<ListExpiredLeasesResult, EngineError> {
+    let limit = args
+        .limit
+        .unwrap_or(LIST_EXPIRED_LEASES_DEFAULT_LIMIT)
+        .min(LIST_EXPIRED_LEASES_MAX_LIMIT) as i64;
+    // `max_partitions_per_call` is a Valkey ZSET fan-out knob; on PG
+    // the partial index `ff_attempt_lease_expiry_idx` already covers
+    // all partitions in one scan, so the value is accepted-and-ignored.
+    let _ = args.max_partitions_per_call;
+
+    // Cursor tuple: `(expires_at_ms, execution_id)` strict-greater
+    // than `(cursor.expires_at_ms, cursor.execution_id)` so pagination
+    // is stable under equal-expiry.
+    let (cursor_expiry, cursor_eid_str): (Option<i64>, Option<String>) = match args.after.as_ref() {
+        Some(c) => (Some(c.expires_at_ms.0), Some(c.execution_id.to_string())),
+        None => (None, None),
+    };
+    let namespace_filter: Option<&str> = args.namespace.as_ref().map(|n| n.as_str());
+
+    // Join `ff_attempt` (lease state) with `ff_exec_core` (namespace
+    // filter + partition-prefix reconstruction of the ExecutionId
+    // wire form). `ff_attempt_lease_expiry_idx` (partial, from
+    // migration 0001) keys the scan on `(partition_key,
+    // lease_expires_at_ms)`. Cross-partition order is enforced at
+    // the `ORDER BY` level.
+    let rows = sqlx::query(
+        "SELECT a.partition_key, a.execution_id, a.attempt_index, a.lease_epoch, \
+                a.worker_instance_id, a.lease_expires_at_ms, c.namespace \
+           FROM ff_attempt a \
+           JOIN ff_exec_core c \
+             ON c.partition_key = a.partition_key AND c.execution_id = a.execution_id \
+          WHERE a.lease_expires_at_ms IS NOT NULL \
+            AND a.lease_expires_at_ms <= $1 \
+            AND a.worker_instance_id IS NOT NULL \
+            AND c.public_state IN ('claimed', 'running') \
+            AND ($2::text IS NULL OR c.namespace = $2) \
+            AND ($3::bigint IS NULL \
+                 OR (a.lease_expires_at_ms, a.execution_id::text) > ($3, $4)) \
+          ORDER BY a.lease_expires_at_ms ASC, a.execution_id ASC \
+          LIMIT $5",
+    )
+    .bind(args.as_of.0)
+    .bind(namespace_filter)
+    .bind(cursor_expiry)
+    .bind(cursor_eid_str.as_deref().unwrap_or(""))
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut entries: Vec<ExpiredLeaseInfo> = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let partition_key: i16 = row.try_get("partition_key").map_err(map_sqlx_error)?;
+        let exec_uuid: Uuid = row.try_get("execution_id").map_err(map_sqlx_error)?;
+        let attempt_index: i32 = row.try_get("attempt_index").map_err(map_sqlx_error)?;
+        let lease_epoch: i64 = row.try_get("lease_epoch").map_err(map_sqlx_error)?;
+        let worker_inst: String = row.try_get("worker_instance_id").map_err(map_sqlx_error)?;
+        let expires_at_ms: i64 = row.try_get("lease_expires_at_ms").map_err(map_sqlx_error)?;
+
+        let eid_str = format!("{{fp:{}}}:{}", partition_key, exec_uuid);
+        let execution_id = ExecutionId::parse(&eid_str).map_err(|e| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!("list_expired_leases: bad execution_id {eid_str:?}: {e}"),
+        })?;
+
+        let lease_id = LeaseId::from_uuid(synthetic_lease_uuid(exec_uuid, attempt_index, lease_epoch));
+        let attempt_index_u = u32::try_from(attempt_index.max(0)).unwrap_or(0);
+        let lease_epoch_u = u64::try_from(lease_epoch.max(0)).unwrap_or(0);
+
+        entries.push(ExpiredLeaseInfo::new(
+            execution_id,
+            lease_id,
+            LeaseEpoch::new(lease_epoch_u),
+            WorkerInstanceId::new(worker_inst),
+            TimestampMs::from_millis(expires_at_ms),
+            AttemptIndex::new(attempt_index_u),
+        ));
+    }
+
+    let page_full = rows.len() as i64 >= limit;
+    let cursor = if page_full {
+        entries
+            .last()
+            .map(|e| ExpiredLeasesCursor::new(e.expires_at_ms, e.execution_id.clone()))
+    } else {
+        None
+    };
+    Ok(ListExpiredLeasesResult::new(entries, cursor))
+}
+
+// ── list_workers ─────────────────────────────────────────────────
+
+pub async fn list_workers(
+    pool: &PgPool,
+    args: ListWorkersArgs,
+) -> Result<ListWorkersResult, EngineError> {
+    let limit = args.limit.unwrap_or(1000) as i64;
+    let namespace_filter: Option<&str> = args.namespace.as_ref().map(|n| n.as_str());
+    let after_cursor: Option<&str> = args.after.as_ref().map(|w| w.as_str());
+
+    let rows = sqlx::query(
+        "SELECT worker_id, worker_instance_id, namespace, lanes, \
+                capabilities_csv, last_heartbeat_ms, liveness_ttl_ms, registered_at_ms \
+           FROM ff_worker_registry \
+          WHERE ($1::text IS NULL OR namespace = $1) \
+            AND ($2::text IS NULL OR worker_instance_id > $2) \
+          ORDER BY worker_instance_id ASC \
+          LIMIT $3",
+    )
+    .bind(namespace_filter)
+    .bind(after_cursor)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let mut entries: Vec<WorkerInfo> = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let worker_id: String = row.try_get("worker_id").map_err(map_sqlx_error)?;
+        let worker_inst: String = row.try_get("worker_instance_id").map_err(map_sqlx_error)?;
+        let namespace: String = row.try_get("namespace").map_err(map_sqlx_error)?;
+        let lanes_vec: Vec<String> = row.try_get("lanes").map_err(map_sqlx_error)?;
+        let caps_csv: String = row.try_get("capabilities_csv").map_err(map_sqlx_error)?;
+        let last_hb_ms: i64 = row.try_get("last_heartbeat_ms").map_err(map_sqlx_error)?;
+        let liveness_ttl_ms: i64 = row.try_get("liveness_ttl_ms").map_err(map_sqlx_error)?;
+        let registered_at_ms: i64 = row.try_get("registered_at_ms").map_err(map_sqlx_error)?;
+
+        let lanes: BTreeSet<LaneId> = lanes_vec.into_iter().map(LaneId).collect();
+        let capabilities: BTreeSet<String> = if caps_csv.is_empty() {
+            BTreeSet::new()
+        } else {
+            caps_csv.split(',').map(str::to_owned).collect()
+        };
+
+        entries.push(WorkerInfo::new(
+            WorkerId::new(worker_id),
+            WorkerInstanceId::new(worker_inst),
+            Namespace::new(namespace),
+            lanes,
+            capabilities,
+            TimestampMs::from_millis(last_hb_ms),
+            u64::try_from(liveness_ttl_ms.max(0)).unwrap_or(0),
+            TimestampMs::from_millis(registered_at_ms),
+        ));
+    }
+
+    let page_full = rows.len() as i64 >= limit;
+    let cursor = if page_full {
+        entries.last().map(|w| w.worker_instance_id.clone())
+    } else {
+        None
+    };
+    Ok(ListWorkersResult::new(entries, cursor))
+}
+
+// ── TTL-sweep scanner ────────────────────────────────────────────
+
+/// Per-partition TTL sweep. Mirrors Valkey's native PEXPIRE behaviour
+/// for PG/SQLite: rows whose `last_heartbeat_ms + liveness_ttl_ms`
+/// falls strictly below `now_ms` are deleted and a `ttl_swept` event
+/// is appended to the audit log.
+///
+/// Returns a `ScanReport` for the supervisor's per-tick log.
+pub async fn ttl_sweep_tick(pool: &PgPool, partition_key: i16) -> Result<ScanReport, EngineError> {
+    let now_ms: i64 = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX);
+
+    // DELETE + append-to-event-log in a single statement via CTE so
+    // the sweep is atomic per row: never a row deleted without an
+    // event, never an event without a delete. Concurrent
+    // `mark_worker_dead` on the same row deletes first + writes its
+    // own event; the sweep's DELETE finds zero rows, the INSERT-SELECT
+    // inserts zero rows. Idempotent.
+    let report_rows = sqlx::query(
+        "WITH swept AS (\
+             DELETE FROM ff_worker_registry \
+             WHERE partition_key = $1 \
+               AND last_heartbeat_ms + liveness_ttl_ms < $2 \
+             RETURNING partition_key, namespace, worker_instance_id\
+         ), ev AS (\
+             INSERT INTO ff_worker_registry_event \
+                 (partition_key, namespace, worker_instance_id, event_kind, event_at_ms, reason) \
+             SELECT partition_key, namespace, worker_instance_id, 'ttl_swept', $2, NULL \
+               FROM swept \
+             ON CONFLICT DO NOTHING \
+             RETURNING 1\
+         ) SELECT COUNT(*) AS swept FROM swept",
+    )
+    .bind(partition_key)
+    .bind(now_ms)
+    .fetch_one(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let processed: i64 = report_rows.try_get("swept").map_err(map_sqlx_error)?;
+    Ok(ScanReport {
+        processed: u32::try_from(processed.max(0)).unwrap_or(u32::MAX),
+        errors: 0,
+    })
+}

--- a/crates/ff-backend-sqlite/migrations/0021_worker_registry.sql
+++ b/crates/ff-backend-sqlite/migrations/0021_worker_registry.sql
@@ -1,0 +1,35 @@
+-- RFC-025 Phase 4 — SQLite worker-registry tables.
+--
+-- Mirrors the Postgres sibling (0021) as flat tables per RFC-023
+-- §4.1 A3 (SQLite single-writer, no HASH partitioning). `lanes` is
+-- stored as a sorted-joined CSV since SQLite lacks `text[]`; encoding
+-- matches Valkey's CSV so downstream consumers see a consistent wire
+-- shape across backends.
+--
+-- Body implementations land in Phase 4 (rfc-025/phase-4-sqlite); this
+-- migration lands alongside Phase 3 to keep sqlite/postgres parity
+-- lint green.
+
+CREATE TABLE ff_worker_registry (
+    namespace              TEXT    NOT NULL,
+    worker_instance_id     TEXT    NOT NULL,
+    worker_id              TEXT    NOT NULL,
+    lanes                  TEXT    NOT NULL,  -- sorted-joined CSV (no text[] in SQLite)
+    capabilities_csv       TEXT    NOT NULL,
+    last_heartbeat_ms      INTEGER NOT NULL,
+    liveness_ttl_ms        INTEGER NOT NULL,
+    registered_at_ms       INTEGER NOT NULL,
+    PRIMARY KEY (namespace, worker_instance_id)
+);
+
+CREATE TABLE ff_worker_registry_event (
+    namespace              TEXT    NOT NULL,
+    worker_instance_id     TEXT    NOT NULL,
+    event_kind             TEXT    NOT NULL,  -- 'registered' | 'heartbeat' | 'marked_dead' | 'ttl_swept'
+    event_at_ms            INTEGER NOT NULL,
+    reason                 TEXT    NULL,
+    PRIMARY KEY (namespace, worker_instance_id, event_at_ms)
+);
+
+CREATE INDEX ff_worker_registry_ns_inst_idx
+  ON ff_worker_registry (namespace, worker_instance_id);

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -654,6 +654,10 @@ impl Server {
             edge_cancel_dispatcher_interval: config.engine_config.edge_cancel_dispatcher_interval,
             edge_cancel_reconciler_interval: config.engine_config.edge_cancel_reconciler_interval,
             budget_reset_interval: config.engine_config.budget_reset_interval,
+            // RFC-025 Phase 3 — 30s mirrors budget_reset cadence;
+            // tolerates Valkey's native PEXPIRE latency on the other
+            // backend for operator-tooling comparison.
+            worker_registry_ttl_interval: std::time::Duration::from_secs(30),
             dependency_stale_threshold_ms:
                 ff_backend_postgres::PostgresScannerConfig::DEFAULT_DEP_STALE_MS,
             scanner_filter: config.engine_config.scanner_filter.clone(),


### PR DESCRIPTION
## Summary

Lands Postgres-side worker-registry so every in-tree backend honours the 5-method trait surface introduced in RFC-025 Phase 1/2.

- **Migration `0021_worker_registry.sql`** — `ff_worker_registry` (current state, 256 hash partitions) + `ff_worker_registry_event` (append-only audit log, 256 hash partitions). Shape matches RFC-025 §5.2 exactly. Derivation rule: `partition_key = (fnv1a_u64(worker_instance_id) % 256) as smallint`.
- **New module `crates/ff-backend-postgres/src/worker_registry.rs`** — 5 bodies (`register_worker`, `heartbeat_worker`, `mark_worker_dead`, `list_expired_leases`, `list_workers`) + `ttl_sweep_tick` reconciler.
- **Trait overrides** in `src/lib.rs` forwarding to module fns. All 5 `Supports.*` flags flip to `true`.
- **Scanner supervisor** gains `pg.worker_registry_ttl_sweep` (30s tick, 256 partitions). `ff-server` wires the new `worker_registry_ttl_interval` field.
- **`ff-core/suspension` activated** on the PG backend Cargo so `list_expired_leases`' `#[cfg(feature = "suspension")]` trait gate lines up. New default-on `suspension` feature on `ff-backend-postgres` (sliceable via `default-features = false`).

## Schema grounding

Quoted from `crates/ff-backend-postgres/migrations/0001_initial.sql:161-181`:

    CREATE TABLE ff_attempt (
        partition_key        smallint NOT NULL,
        execution_id         uuid     NOT NULL,
        attempt_index        integer  NOT NULL,
        worker_id            text,
        worker_instance_id   text,
        lease_epoch          bigint   NOT NULL DEFAULT 0,
        lease_expires_at_ms  bigint,
        ...
    ) PARTITION BY HASH (partition_key);

    CREATE INDEX ff_attempt_lease_expiry_idx
        ON ff_attempt (partition_key, lease_expires_at_ms)
        WHERE lease_expires_at_ms IS NOT NULL;

`list_expired_leases` uses this existing partial index + joins `ff_exec_core.public_state IN ('claimed','running')` + `ff_exec_core.namespace` at the JOIN level (RFC §Rev-2 item 4 — `public_state` lives on exec_core, not attempt, so filtering stays out of the index predicate).

## Design notes

- **Synthetic `LeaseId`** — PG has no stable `lease_id` column (identity is `(execution_id, attempt_index, lease_epoch)`; see `operator.rs::synthetic_lease_id`). The new module folds that triple into a deterministic UUID so two callers observing the same expired lease see the same `LeaseId`.
- **`register_worker` idempotency** — `ON CONFLICT ... DO UPDATE ... RETURNING (xmax = 0)` distinguishes fresh insert (`Registered`) vs overwrite (`Refreshed`). Pre-upsert `SELECT ... FOR UPDATE` enforces the "instance_id reassigned" validation in the same tx.
- **`mark_worker_dead` reason validation** — 256-byte cap + no control chars, mirrored from Valkey body + `fail_execution` discipline (RFC §Rev-2 item 9).
- **TTL sweep atomicity** — single CTE: DELETE + INSERT-SELECT into event log. Never a row deleted without an event, never an event without a delete. Concurrent `mark_worker_dead` is idempotent (deletes 0 rows → inserts 0 events).
- **`max_partitions_per_call`** accepted-and-ignored on PG; the partial index already covers all partitions in one scan.

## Deferrals (call-outs)

- **Cross-partition `list_expired_leases` ordering** — query orders by `(lease_expires_at_ms, execution_id)` but partitioning means the index scan is per-partition. For the default page size (1000) this is bounded; extreme page sizes on many partitions could cost. Punt tuning to Phase 6 release-gate bench if the headline example surfaces it.
- **Lease-expiry index shape** — RFC §5.2 proposed a new `ff_attempt (partition_key, lease_expires_at_ms) WHERE lease_id IS NOT NULL AND public_state IN (...)` partial index. The existing `ff_attempt_lease_expiry_idx` (0001) already narrows on `lease_expires_at_ms IS NOT NULL`; the `public_state` gate cannot live in an attempt-level index (column is on exec_core). Judged adequate for Phase 3 — reassess at the Phase 6 release-gate bench.
- **SDK preamble compat-test** — Phase 2 landed the Valkey keyspace shape; PG has no preamble. Cross-crate byte-equality test stays inside Phase 2's surface.

## Test plan

- [x] `cargo check -p ff-backend-postgres --all-features` clean
- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-backend-postgres -p ff-server -p ff-core --all-features -- -D warnings` clean
- [x] `cargo run -p non-exhaustive-lint` — OK
- [x] `cargo test -p ff-core --all-features` — 243 passed
- [x] `cargo test -p ff-backend-postgres --all-features --no-run` — all binaries compile
- [ ] Live PG smoke (no PG reachable from agent sandbox; defer to release-gate / reviewer local run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)