### PR TITLE
RFC-025: SDK preamble + unblock scanner namespace cutover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "ff-observability",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "flowfabric"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ff-backend-postgres",
  "ff-backend-valkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -39,23 +39,23 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.13.0", path = "crates/ff-core" }
-ff-script = { version = "0.13.0", path = "crates/ff-script" }
-ff-engine = { version = "0.13.0", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.13.0", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.13.0", path = "crates/ff-sdk" }
-ff-server = { version = "0.13.0", path = "crates/ff-server" }
+ff-core = { version = "0.14.0", path = "crates/ff-core" }
+ff-script = { version = "0.14.0", path = "crates/ff-script" }
+ff-engine = { version = "0.14.0", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.14.0", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.14.0", path = "crates/ff-sdk" }
+ff-server = { version = "0.14.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.13.0", path = "crates/ff-backend-valkey" }
-ff-backend-postgres = { version = "0.13.0", path = "crates/ff-backend-postgres" }
-ff-backend-sqlite = { version = "0.13.0", path = "crates/ff-backend-sqlite" }
-ff-observability = { version = "0.13.0", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.13.0", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.13.0", path = "ferriskey" }
+ff-backend-valkey = { version = "0.14.0", path = "crates/ff-backend-valkey" }
+ff-backend-postgres = { version = "0.14.0", path = "crates/ff-backend-postgres" }
+ff-backend-sqlite = { version = "0.14.0", path = "crates/ff-backend-sqlite" }
+ff-observability = { version = "0.14.0", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.14.0", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.14.0", path = "ferriskey" }
 # Umbrella crate re-exporting the ff-* family (issue #279). Declared
 # at workspace scope so internal doc examples / dev-deps can name it
 # via `{ workspace = true }`.
-flowfabric = { version = "0.13.0", path = "crates/flowfabric" }
+flowfabric = { version = "0.14.0", path = "crates/flowfabric" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -34,7 +34,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
+ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -27,7 +27,7 @@ suspension = ["ff-core/suspension"]
 # impl honours the same `EngineBackend` method surface. Trait impl
 # bodies arrive in Phase 2+; Phase 1a returns `EngineError::Unavailable`
 # from every method except `capabilities()` + `prepare()`.
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
 
 # SQLite transport. Bundled SQLite is deliberately selected to decouple
 # the backend from the operating distro's libsqlite3 version — RFC-023

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
+ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -9352,9 +9352,10 @@ impl EngineBackend for ValkeyBackend {
         // Phase 2 scope: per-namespace listing only. Cross-namespace
         // enumeration (`args.namespace = None`) would need a
         // persistent namespace-registry on Valkey that doesn't exist
-        // today; the unblock scanner's `ff:idx:workers` global set
-        // predates RFC-025's namespace split and still mingles
-        // namespaces. Phase 3 (PG) lands the authoritative
+        // today; the unblock scanner's namespace-scoped
+        // `ff:idx:{ns}:workers` set (RFC-025 Phase 5 cutover) is the
+        // per-namespace enumerable, but there is no parent index of
+        // namespaces themselves. Phase 3 (PG) lands the authoritative
         // cross-namespace index via `ff_worker_registry` scan; until
         // then operators that need a cross-ns view iterate
         // namespaces out-of-band. Surfacing as `Unavailable` (not

--- a/crates/ff-core/src/keys.rs
+++ b/crates/ff-core/src/keys.rs
@@ -651,43 +651,12 @@ pub fn lane_counts_key(lane_id: &LaneId) -> String {
     format!("ff:lane:{}:counts", lane_id)
 }
 
-/// Worker registration key.
-pub fn worker_key(wid: &WorkerInstanceId) -> String {
-    format!("ff:worker:{}", wid)
-}
-
-/// Non-authoritative capability advertisement STRING for a worker
-/// (sorted CSV). Written by `ff-sdk::FlowFabricWorker::connect`, read by
-/// the engine's unblock scanner to decide whether a `blocked_by_route`
-/// execution has a matching worker. Cluster mode: the key lands on
-/// whatever slot CRC16 hashes to — enumeration goes through
-/// `workers_index_key()` rather than a keyspace SCAN, which would only
-/// hit one shard in cluster mode.
-///
-/// **Deprecation note (RFC-025 Phase 2):** this global helper builds a
-/// pre-namespace key shape. New worker-registry code paths use
-/// [`worker_caps_key_ns`] which includes the tenant namespace. The
-/// legacy helper stays for the SDK preamble and cairn's Valkey
-/// fast-path during the Phase 2→5 rollout; remove once cairn migrates
-/// in Phase 5.
-pub fn worker_caps_key(wid: &WorkerInstanceId) -> String {
-    format!("ff:worker:{}:caps", wid)
-}
-
-/// Global worker index — SET of connected worker_instance_ids. Single
-/// slot in cluster mode (no hash tag; CRC16 of the literal key). SADD on
-/// connect, SREM on empty-caps restart; SMEMBERS gives the enumerable
-/// universe the unblock scanner walks. Separate from `ff:worker:{id}`
-/// registration keys to keep the index membership cheap to read and
-/// independent of per-worker hash details.
-///
-/// **Deprecation note (RFC-025 Phase 2):** see [`worker_caps_key`].
-/// New code uses [`workers_index_key_ns`].
-pub fn workers_index_key() -> String {
-    "ff:idx:workers".to_owned()
-}
-
 // ─── RFC-025 namespace-scoped worker registry keys ───
+//
+// The pre-Phase-5 global helpers (`worker_key`, `worker_caps_key`,
+// `workers_index_key`) were removed with the SDK preamble + unblock
+// scanner cutover — every caller now threads a `Namespace` and uses
+// the `_ns`-suffixed helpers below.
 //
 // Locked in §9.1: all worker-registry writes live under a namespace
 // prefix so multi-tenant deployments can reuse the same

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -25,7 +25,7 @@ observability = ["ff-observability/enabled"]
 postgres = ["dep:ff-backend-postgres", "dep:sqlx"]
 
 [dependencies]
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
 ff-observability = { workspace = true }
 # v0.12 PR-7a transitional: `Engine::start_*` accepts
 # `Arc<dyn EngineBackend>` on the boundary but scanners still speak
@@ -38,7 +38,7 @@ ff-observability = { workspace = true }
 # silently defeat the explicit `ff-core` anchor on line 26
 # (`default-features = false, features = ["core"]`) and re-expose
 # streaming-gated trait methods on `ff-engine`.
-ff-backend-valkey = { version = "0.13.0", path = "../ff-backend-valkey", default-features = false }
+ff-backend-valkey = { version = "0.14.0", path = "../ff-backend-valkey", default-features = false }
 ferriskey = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ff-engine/src/scanner/unblock.rs
+++ b/crates/ff-engine/src/scanner/unblock.rs
@@ -7,15 +7,21 @@
 //! Cross-partition budget check is cached per scan cycle (MANDATORY —
 //! without it, 50K blocked executions = 50K budget reads).
 //!
-//! Capability sweep reads the union of non-authoritative worker cap sets
-//! (`ff:worker:*:caps` — written by `ff-sdk::FlowFabricWorker::connect`)
-//! ONCE per scan cycle and uses it to decide whether a `waiting_for_capable_worker`
-//! execution has a matching worker. This is best-effort: caps sets may
-//! be slightly stale (TTL-less STRING, overwrite on restart), but the
-//! promotion path is self-correcting — a promoted execution that still
-//! can't be claimed gets re-blocked on the next scheduler tick. RFC-009
-//! §7.5 documents the v1 sweep approach and defers connect-triggered
-//! sweeps to V2.
+//! Capability sweep reads the union of non-authoritative worker cap
+//! HASHes (`ff:worker:{ns}:{instance_id}:caps` — written by
+//! `ff-sdk::FlowFabricWorker::connect` and by the `ff_register_worker`
+//! FCALL) ONCE per scan cycle PER NAMESPACE, and uses it to decide
+//! whether a `waiting_for_capable_worker` execution has a matching
+//! worker. This is best-effort: caps HASHes may be slightly stale
+//! (TTL'd, refreshed on connect), but the promotion path is
+//! self-correcting — a promoted execution that still can't be claimed
+//! gets re-blocked on the next scheduler tick. RFC-009 §7.5 documents
+//! the v1 sweep approach and defers connect-triggered sweeps to V2.
+//!
+//! RFC-025 Phase 5 cutover: caps reads go through the namespace-scoped
+//! `ff:idx:{ns}:workers` + `ff:worker:{ns}:{id}:caps` helpers; the
+//! cache keys off `Namespace` so multi-tenant deployments don't mix
+//! capability sets across tenants.
 //!
 //! MUST skip `paused_by_flow_cancel` — only cancel_flow clears that.
 //!
@@ -32,7 +38,7 @@ use ff_core::backend::ScannerFilter;
 use ff_core::engine_backend::EngineBackend;
 use ff_core::keys::IndexKeys;
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, budget_partition};
-use ff_core::types::{BudgetId, ExecutionId, LaneId, TimestampMs};
+use ff_core::types::{BudgetId, ExecutionId, LaneId, Namespace, TimestampMs};
 
 use super::{should_skip_candidate, ScanResult, Scanner};
 
@@ -73,13 +79,28 @@ pub struct UnblockScanner {
     backend: Option<Arc<dyn EngineBackend>>,
 }
 
-/// Worker-caps union snapshot with a monotonic freshness timestamp.
-/// `None` on first scan; filled by `get_or_load`. Invalidated when
-/// `Instant::now() - fetched_at >= ttl`.
+/// Per-namespace worker-caps union cache. Every blocked execution
+/// carries a `namespace` field on `exec_core`; the scanner reads that
+/// alongside `blocking_reason` and routes the subset check to the
+/// union of caps advertised by workers in THAT namespace only. Absent
+/// this partitioning, a tenant-A worker advertising
+/// `required_caps=[gpu]` would unblock a tenant-B execution waiting on
+/// the same token.
 struct CapsUnionCache {
+    /// TTL applied uniformly to every namespace entry — same cadence
+    /// as `UnblockScanner::interval`, so a freshly-connected worker
+    /// propagates into its namespace's union on the next scan cycle.
+    ttl: Duration,
+    /// Entry per observed namespace. Grows as new namespaces surface
+    /// on blocked executions; entries do NOT expire (the bounded fleet
+    /// of namespaces is small and refreshing an unused entry on next
+    /// visit costs one SSCAN). Cleared on scanner restart.
+    entries: HashMap<Namespace, CapsUnionEntry>,
+}
+
+struct CapsUnionEntry {
     snapshot: Option<BTreeSet<String>>,
     fetched_at: Option<Instant>,
-    ttl: Duration,
 }
 
 impl UnblockScanner {
@@ -101,9 +122,8 @@ impl UnblockScanner {
             partition_config,
             filter,
             caps_cache: Arc::new(AsyncMutex::new(CapsUnionCache {
-                snapshot: None,
-                fetched_at: None,
                 ttl: interval,
+                entries: HashMap::new(),
             })),
             backend: None,
         }
@@ -124,9 +144,8 @@ impl UnblockScanner {
             partition_config,
             filter,
             caps_cache: Arc::new(AsyncMutex::new(CapsUnionCache {
-                snapshot: None,
-                fetched_at: None,
                 ttl: interval,
+                entries: HashMap::new(),
             })),
             backend: Some(backend),
         }
@@ -270,12 +289,16 @@ async fn scan_blocked_set(
         if should_skip_candidate(backend, filter, partition.index, eid_str).await {
             continue;
         }
-        // Read blocking_reason from exec_core to confirm still blocked
+        // Read blocking_reason + namespace from exec_core. Namespace
+        // gates the caps-union subset check so tenant-A worker caps
+        // never unblock a tenant-B `blocked_by_route` execution —
+        // RFC-025 Phase 5 multi-tenant safety property.
         let core_key = format!("ff:exec:{}:{}:core", tag, eid_str);
-        let reason: Option<String> = match client
-            .cmd("HGET")
+        let fields: Vec<Option<String>> = match client
+            .cmd("HMGET")
             .arg(&core_key)
             .arg("blocking_reason")
+            .arg("namespace")
             .execute()
             .await
         {
@@ -284,14 +307,38 @@ async fn scan_blocked_set(
                 tracing::warn!(
                     execution_id = eid_str.as_str(),
                     error = %e,
-                    "unblock_scanner: HGET blocking_reason failed, skipping"
+                    "unblock_scanner: HMGET blocking_reason/namespace failed, skipping"
                 );
                 errors += 1;
                 continue;
             }
         };
-
-        let reason = reason.unwrap_or_default();
+        if fields.len() < 2 {
+            tracing::warn!(
+                execution_id = eid_str.as_str(),
+                returned_fields = fields.len(),
+                "unblock_scanner: HMGET returned < 2 fields, skipping"
+            );
+            errors += 1;
+            continue;
+        }
+        let reason = fields[0].clone().unwrap_or_default();
+        let namespace = match fields[1].as_deref().filter(|s| !s.is_empty()) {
+            Some(ns_str) => Namespace::new(ns_str),
+            None => {
+                // Every execution gets a namespace at create-time
+                // (`ff_create_execution` HSETs it). Missing here = data
+                // integrity defect; skip rather than risk a
+                // cross-tenant promotion.
+                tracing::warn!(
+                    execution_id = eid_str.as_str(),
+                    core_key = %core_key,
+                    "unblock_scanner: exec_core missing namespace field, skipping"
+                );
+                errors += 1;
+                continue;
+            }
+        };
 
         // Skip if not blocked by the expected reason (e.g. paused_by_flow_cancel)
         if reason != expected_reason {
@@ -307,7 +354,7 @@ async fn scan_blocked_set(
                 check_quota_cleared(client, backend, &core_key, eid_str, partition_config).await
             }
             "waiting_for_capable_worker" => {
-                check_route_cleared(client, &core_key, caps_cache).await
+                check_route_cleared(client, &core_key, caps_cache, &namespace).await
             }
             _ => false,
         };
@@ -663,6 +710,7 @@ async fn check_route_cleared(
     client: &ferriskey::Client,
     core_key: &str,
     caps_cache: &Arc<AsyncMutex<CapsUnionCache>>,
+    namespace: &Namespace,
 ) -> bool {
     let required_csv: Option<String> = client
         .cmd("HGET")
@@ -681,21 +729,34 @@ async fn check_route_cleared(
     // n is bounded by total caps across the fleet — typically tens).
     // Holding the mutex across the subset loop would serialize every
     // partition's capability-block decision behind this one mutex.
+    //
+    // Per-namespace entries: cache refresh decision keys off the
+    // execution's namespace, so tenants with very different update
+    // cadences don't invalidate each other.
     let snapshot: BTreeSet<String> = {
         let mut guard = caps_cache.lock().await;
-        let stale = guard
+        let ttl = guard.ttl;
+        let entry = guard
+            .entries
+            .entry(namespace.clone())
+            .or_insert(CapsUnionEntry {
+                snapshot: None,
+                fetched_at: None,
+            });
+        let stale = entry
             .fetched_at
-            .map(|t| t.elapsed() >= guard.ttl)
+            .map(|t| t.elapsed() >= ttl)
             .unwrap_or(true);
         if stale {
-            match load_worker_caps_union(client).await {
+            match load_worker_caps_union(client, namespace).await {
                 Ok(union) => {
-                    guard.snapshot = Some(union);
-                    guard.fetched_at = Some(Instant::now());
+                    entry.snapshot = Some(union);
+                    entry.fetched_at = Some(Instant::now());
                 }
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
+                        namespace = %namespace,
                         "unblock_scanner: failed to read worker caps union — \
                          assuming match possible (fail-open to preserve liveness)"
                     );
@@ -703,7 +764,7 @@ async fn check_route_cleared(
                 }
             }
         }
-        guard.snapshot.clone().unwrap_or_default()
+        entry.snapshot.clone().unwrap_or_default()
     };
 
     // Subset check: every non-empty token in required_csv present in union.
@@ -713,37 +774,47 @@ async fn check_route_cleared(
         .all(|t| snapshot.contains(t))
 }
 
-/// Union of every connected worker's advertised capabilities.
+/// Union of every connected worker's advertised capabilities within
+/// the given namespace.
 ///
 /// Cluster-safe enumeration pattern (matches Batch A's index SETs for
-/// budget/flow/deps): SSCAN the `workers_index_key()` SET (single-slot,
-/// no hash tag needed — the key name literally hashes to one slot), then
-/// fan-out concurrent `GET ff:worker:<id>:caps` with a bounded concurrency
-/// cap. A keyspace `SCAN MATCH ff:worker:*:caps` in cluster mode visits
-/// only one shard per call and silently drops workers on other shards —
-/// exactly the class of bug Batch A Issue #11 fixed.
+/// budget/flow/deps): SSCAN the namespace-scoped
+/// `workers_index_key_ns(namespace)` SET (single-slot, no hash tag
+/// needed — the key name literally hashes to one slot), then fan-out
+/// concurrent `HGET ff:worker:{ns}:{id}:caps caps_csv` with a bounded
+/// concurrency cap. A keyspace `SCAN MATCH ff:worker:*:caps` in
+/// cluster mode visits only one shard per call and silently drops
+/// workers on other shards — exactly the class of bug Batch A Issue
+/// #11 fixed.
+///
+/// Caps storage is a HASH (RFC-025 Phase 5 post-cutover — shape
+/// matches `ff_register_worker` FCALL + the SDK preamble), and only
+/// the `caps_csv` field drives the union. Per-worker HGET is a
+/// single-field read, not HGETALL, so the scanner pays only the bytes
+/// it uses.
 ///
 /// SSCAN is used instead of SMEMBERS so a fleet of thousands of workers
 /// doesn't round-trip the entire member list in one reply. `COUNT = 100`
 /// matches the convention in budget_reconciler / flow_projector.
 ///
-/// Empty caps STRING or missing key = "no caps for that worker"; scanner
-/// keeps accumulating. Per-worker GET error, in contrast, PROPAGATES — a
-/// previous version used `.unwrap_or(None)` which silently merged error
-/// and empty into the same branch, making a transient error look like
-/// "this worker has no caps". In a single-capable-worker fleet that
-/// produced false-negative unions and left executions blocked even
-/// though a matching worker existed, contradicting the scanner's
-/// documented fail-open behavior. Now an error bubbles up; the only
-/// caller (`check_route_cleared`) treats `Err` by returning `true`
-/// (unblock — "we don't know, let the scheduler re-decide next tick"),
-/// which preserves liveness uniformly whether the fault is SSCAN, GET,
-/// or deeper transport.
+/// Empty `caps_csv` or missing key = "no caps for that worker";
+/// scanner keeps accumulating. Per-worker HGET error, in contrast,
+/// PROPAGATES — a previous version used `.unwrap_or(None)` which
+/// silently merged error and empty into the same branch, making a
+/// transient error look like "this worker has no caps". In a
+/// single-capable-worker fleet that produced false-negative unions and
+/// left executions blocked even though a matching worker existed,
+/// contradicting the scanner's documented fail-open behavior. Now an
+/// error bubbles up; the only caller (`check_route_cleared`) treats
+/// `Err` by returning `true` (unblock — "we don't know, let the
+/// scheduler re-decide next tick"), which preserves liveness uniformly
+/// whether the fault is SSCAN, HGET, or deeper transport.
 async fn load_worker_caps_union(
     client: &ferriskey::Client,
+    namespace: &Namespace,
 ) -> Result<BTreeSet<String>, ferriskey::Error> {
     let mut union = BTreeSet::new();
-    let index_key = ff_core::keys::workers_index_key();
+    let index_key = ff_core::keys::workers_index_key_ns(namespace);
 
     // Helper: drain one completed future and fold its caps into the
     // union, or propagate its error. Centralizing keeps the in-loop +
@@ -779,7 +850,7 @@ async fn load_worker_caps_union(
         cursor = reply.0;
         let worker_ids = reply.1;
 
-        // Bounded concurrent GETs per SSCAN page. FuturesUnordered with
+        // Bounded concurrent HGETs per SSCAN page. FuturesUnordered with
         // a buffered stream caps in-flight work at CAPS_GET_CONCURRENCY —
         // enough parallelism to amortize round-trip latency, bounded so
         // one scanner tick can't flood the shared Valkey client. Each
@@ -789,11 +860,15 @@ async fn load_worker_caps_union(
         let mut pending: FuturesUnordered<_> = FuturesUnordered::new();
         for id in worker_ids {
             let client = client.clone();
+            let namespace = namespace.clone();
             pending.push(async move {
-                let caps_key = format!("ff:worker:{}:caps", id);
+                let instance = ff_core::types::WorkerInstanceId::new(id);
+                let caps_key =
+                    ff_core::keys::worker_caps_key_ns(&namespace, &instance);
                 let csv: Option<String> = client
-                    .cmd("GET")
+                    .cmd("HGET")
                     .arg(&caps_key)
+                    .arg("caps_csv")
                     .execute()
                     .await?;
                 Ok::<Option<String>, ferriskey::Error>(csv)

--- a/crates/ff-scheduler/Cargo.toml
+++ b/crates/ff-scheduler/Cargo.toml
@@ -16,7 +16,7 @@ description = "FlowFabric claim-grant scheduler"
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-scheduler's claim dispatcher uses FCALL helpers from
 # ff-script, so explicitly enable `valkey-client`.
 ff-script = { workspace = true, features = ["valkey-client"] }

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -49,7 +49,7 @@ valkey-client = ["dep:ferriskey"]
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: optional so `--no-default-features` drops the transport edge.
 ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -84,7 +84,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.13.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-script's defaults are empty — the `valkey-client`
 # feature (which owns the `ferriskey` dep edge) is activated below by
 # the `valkey-default` feature, NOT here. This keeps
@@ -102,7 +102,7 @@ ferriskey = { workspace = true, optional = true }
 # RFC-023 Phase 1a: optional SQLite backend edge, activated by the
 # `sqlite` feature above. Off by default so Valkey consumers pay no
 # sqlx compile cost.
-ff-backend-sqlite = { version = "0.13.0", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
+ff-backend-sqlite = { version = "0.14.0", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/crates/ff-sdk/src/valkey_preamble.rs
+++ b/crates/ff-sdk/src/valkey_preamble.rs
@@ -1,22 +1,22 @@
 //! Valkey-specific connect preamble for [`FlowFabricWorker::connect`].
 //!
-//! v0.12 backend-agnostic SDK PR-6: the Valkey-specific observable work
-//! that `connect` used to do inline — PING, SET-NX alive-key guard,
-//! `ff:config:partitions` HGETALL, capability ingress validation + CSV
-//! compute, and the `ff:worker:{id}:caps` advertisement / `ff:idx:workers`
-//! index write — lives here as a single [`run`] entry point so
-//! `connect`'s body shrinks to three statements (build_client, run
-//! preamble, wrap backend).
+//! v0.12 backend-agnostic SDK PR-6 extracted the inline preamble body
+//! (PING, SET-NX alive-key guard, `ff:config:partitions` HGETALL,
+//! capability ingress validation + CSV compute, caps advertisement +
+//! index SADD) into this module so `connect` shrinks to three statements
+//! (build_client, run preamble, wrap backend).
+//!
+//! RFC-025 Phase 5 cutover: the caps advertisement now writes the same
+//! namespaced HASH shape as the trait-route `ff_register_worker` FCALL
+//! (`ff:worker:{ns}:{instance_id}:caps`, fields
+//! `worker_id,lanes_csv,caps_csv,ttl_ms,registered_at_ms`) and the
+//! index SADD targets `ff:idx:{ns}:workers`. This closes the preamble /
+//! FCALL shape divergence so the unblock scanner and `list_workers` see
+//! an identical surface regardless of which path registered the worker.
 //!
 //! The module is `#[cfg(feature = "valkey-default")]`-gated: a
 //! `--no-default-features --features sqlite` build does not compile it,
 //! matching the gate on [`FlowFabricWorker::connect`] itself.
-//!
-//! **Behaviour preservation.** The write order is observable from the
-//! scheduler side (`unblock` scanner reads `ff:idx:workers` then GETs
-//! `ff:worker:{id}:caps`). The extraction is byte-for-byte identical to
-//! the pre-PR-6 inline body — see the PR-6 description in the archive
-//! repo for the key-write diff.
 //!
 //! [`FlowFabricWorker::connect`]: crate::FlowFabricWorker::connect
 
@@ -35,9 +35,11 @@ use crate::SdkError;
 /// `claim_next_via_backend` needs the hash for its per-mismatch log
 /// surface regardless of which claim path the worker uses.
 ///
-/// The `ff:worker:{id}:caps` + `ff:idx:workers` advertisement writes
-/// also run on every worker (v0.13 ungate) so the unblock scanner has
-/// caps keys regardless of direct-claim vs server-routed claim.
+/// The `ff:worker:{ns}:{id}:caps` HASH + `ff:idx:{ns}:workers` SET
+/// advertisement writes also run on every worker (v0.13 ungate) so the
+/// unblock scanner has caps keys regardless of direct-claim vs
+/// server-routed claim. Shape matches the `ff_register_worker` FCALL
+/// post-RFC-025 Phase 5.
 ///
 /// [`FlowFabricWorker`]: crate::FlowFabricWorker
 pub(crate) struct PreambleOutput {
@@ -51,18 +53,20 @@ pub(crate) struct PreambleOutput {
 ///
 /// Executes (in order — the order is observable from scheduler reads):
 /// 1. `PING` connectivity probe.
-/// 2. `SET NX PX` on `ff:worker:{instance_id}:alive` (duplicate-instance
-///    guard, TTL = 2 × `lease_ttl_ms`).
+/// 2. `SET NX PX` on `ff:worker:{ns}:{instance_id}:alive`
+///    (duplicate-instance guard, TTL = 2 × `lease_ttl_ms`).
 /// 3. `HGETALL ff:config:partitions` (falls back to `PartitionConfig::default()`
 ///    on absence, which is the SDK-only-test shape).
 /// 4. Capability ingress validation + sorted-dedup CSV compute
 ///    (always-on; v0.13 ungate). Under `direct-valkey-claim` the FNV-1a
 ///    digest + full-CSV connect-time log also run.
-/// 5. `SET`/`DEL` of `ff:worker:{instance_id}:caps` + `SADD`/`SREM` of
-///    the `ff:idx:workers` index (always-on; v0.13 ungate — needed by
-///    the unblock scanner's `load_worker_caps_union` on both
-///    direct-claim and server-routed worker paths). Caps-first write
-///    order is load-bearing.
+/// 5. `HSET`+`PEXPIRE`/`DEL` of `ff:worker:{ns}:{instance_id}:caps`
+///    (HASH — fields `worker_id,lanes_csv,caps_csv,ttl_ms,registered_at_ms`
+///    matching `ff_register_worker`) + `SADD`/`SREM` of
+///    `ff:idx:{ns}:workers` (always-on; v0.13 ungate — needed by the
+///    unblock scanner's `load_worker_caps_union` on both direct-claim
+///    and server-routed worker paths). Caps-first write order is
+///    load-bearing.
 pub(crate) async fn run(
     client: &Client,
     config: &WorkerConfig,
@@ -85,7 +89,8 @@ pub(crate) async fn run(
     // `worker_instance_id`. See `FlowFabricWorker::connect` rustdoc for
     // the full three limitations (startup-only, restart delay, no
     // graceful cleanup) — documented at the caller.
-    let alive_key = format!("ff:worker:{}:alive", config.worker_instance_id);
+    let alive_key =
+        ff_core::keys::worker_alive_key_ns(&config.namespace, &config.worker_instance_id);
     let alive_ttl_ms = (config.lease_ttl_ms.saturating_mul(2)).max(1_000);
     let set_result: Option<String> = client
         .cmd("SET")
@@ -210,13 +215,20 @@ pub(crate) async fn run(
     // `blocked_by_route → runnable` promotion; server-routed workers
     // need these keys populated too, not just `direct-valkey-claim`
     // ones. The AUTHORITATIVE source for scheduling decisions at
-    // claim-time is still ARGV[9] on each claim. The caps STRING is
+    // claim-time is still ARGV[9] on each claim.
+    //
+    // RFC-025 Phase 5: shape matches the `ff_register_worker` FCALL —
+    // HASH with `worker_id, lanes_csv, caps_csv, ttl_ms,
+    // registered_at_ms` under a namespace-scoped key. The caps HASH is
     // written BEFORE the index SADD so that when the scheduler's
     // unblock scanner observes the id in the index, the caps key is
-    // guaranteed to resolve to a non-stale CSV.
+    // guaranteed to resolve to a non-stale HASH.
     {
-        let caps_key = ff_core::keys::worker_caps_key(&config.worker_instance_id);
-        let index_key = ff_core::keys::workers_index_key();
+        let caps_key = ff_core::keys::worker_caps_key_ns(
+            &config.namespace,
+            &config.worker_instance_id,
+        );
+        let index_key = ff_core::keys::workers_index_key_ns(&config.namespace);
         let instance_id = config.worker_instance_id.to_string();
         if capabilities_csv.is_empty() {
             let _ = client
@@ -235,15 +247,49 @@ pub(crate) async fn run(
                     "SREM workers-index failed; continuing (non-authoritative)");
             }
         } else {
+            // Sorted + joined lanes CSV — mirrors how `capabilities_csv`
+            // is built above, and matches the shape
+            // `ff_register_worker` writes via `RegisterWorkerArgv.lanes_csv`.
+            let lanes_csv: String = {
+                let set: std::collections::BTreeSet<&str> =
+                    config.lanes.iter().map(|l| l.as_str()).collect();
+                set.into_iter().collect::<Vec<_>>().join(",")
+            };
+            let now_ms: u64 = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            let ttl_ms_str = alive_ttl_ms.to_string();
+            let now_ms_str = now_ms.to_string();
+            let worker_id_str = config.worker_id.to_string();
             if let Err(e) = client
-                .cmd("SET")
+                .cmd("HSET")
                 .arg(&caps_key)
-                .arg(&capabilities_csv)
-                .execute::<Option<String>>()
+                .arg("worker_id")
+                .arg(worker_id_str.as_str())
+                .arg("lanes_csv")
+                .arg(lanes_csv.as_str())
+                .arg("caps_csv")
+                .arg(capabilities_csv.as_str())
+                .arg("ttl_ms")
+                .arg(ttl_ms_str.as_str())
+                .arg("registered_at_ms")
+                .arg(now_ms_str.as_str())
+                .execute::<Option<i64>>()
                 .await
             {
                 tracing::warn!(error = %e, key = %caps_key,
-                    "SET worker caps advertisement failed; continuing");
+                    "HSET worker caps advertisement failed; continuing");
+            }
+            if let Err(e) = client
+                .cmd("PEXPIRE")
+                .arg(&caps_key)
+                .arg(ttl_ms_str.as_str())
+                .execute::<Option<i64>>()
+                .await
+            {
+                tracing::warn!(error = %e, key = %caps_key,
+                    "PEXPIRE worker caps HASH failed; continuing");
             }
             if let Err(e) = client
                 .cmd("SADD")

--- a/crates/ff-sdk/src/worker.rs
+++ b/crates/ff-sdk/src/worker.rs
@@ -235,12 +235,14 @@ impl FlowFabricWorker {
 
         // v0.12 PR-6: the Valkey-specific preamble (PING, alive-key
         // SET-NX, `ff:config:partitions` HGETALL, caps ingress +
-        // sorted-dedup CSV, caps STRING + workers-index writes) lives
-        // in `crate::valkey_preamble`. Extracted byte-for-byte from
-        // the pre-PR-6 inline body; the write order is observable
-        // from scheduler-side reads (unblock scanner:
-        // SMEMBERS ff:idx:workers → GET ff:worker:{id}:caps) so
-        // preservation is load-bearing. See `valkey_preamble::run`.
+        // sorted-dedup CSV, caps HASH + workers-index writes) lives
+        // in `crate::valkey_preamble`. RFC-025 Phase 5 cutover: the
+        // caps write is now a namespaced HASH matching the
+        // `ff_register_worker` FCALL shape. The write order is
+        // observable from scheduler-side reads (unblock scanner:
+        // SMEMBERS ff:idx:{ns}:workers → HGET ff:worker:{ns}:{id}:caps
+        // caps_csv) so preservation is load-bearing. See
+        // `valkey_preamble::run`.
         let crate::valkey_preamble::PreambleOutput {
             partition_config,
             capabilities_csv: _worker_capabilities_csv,

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -8632,27 +8632,31 @@ async fn test_capable_worker_unblocks_route_blocked() {
         .await
         .expect("scheduler claim should not error");
 
-    // 2. Simulate a capable worker registering by writing the SAME two
-    //    cluster-safe entries the SDK writes on connect: the per-worker
-    //    caps STRING at ff:worker:<id>:caps, AND a SADD into the global
-    //    workers-index SET `ff:idx:workers`. The scanner enumerates
-    //    through the index in cluster mode (a keyspace SCAN would miss
-    //    workers whose caps key hashes to other shards).
-    let instance_id = "capable-gpu-worker";
-    let caps_key = format!("ff:worker:{instance_id}:caps");
-    let _: Option<String> = tc
+    // 2. Simulate a capable worker registering with the same HASH +
+    //    index shape the SDK preamble + `ff_register_worker` FCALL
+    //    write post-RFC-025 cutover: namespace-prefixed caps HASH at
+    //    `ff:worker:{ns}:{inst}:caps` (with `caps_csv` field) + SADD
+    //    into `ff:idx:{ns}:workers`. The scanner HMGETs
+    //    `[blocking_reason, namespace]` off the execution's core hash
+    //    and looks up the per-namespace index.
+    let instance_id = ff_core::types::WorkerInstanceId::new("capable-gpu-worker");
+    let ns = ff_core::types::Namespace::new(NS);
+    let caps_key = ff_core::keys::worker_caps_key_ns(&ns, &instance_id);
+    let index_key = ff_core::keys::workers_index_key_ns(&ns);
+    let _: Option<i64> = tc
         .client()
-        .cmd("SET")
+        .cmd("HSET")
         .arg(caps_key.as_str())
+        .arg("caps_csv")
         .arg("cuda,gpu")
         .execute()
         .await
-        .expect("SET worker caps");
+        .expect("HSET worker caps_csv");
     let _: Option<i64> = tc
         .client()
         .cmd("SADD")
-        .arg("ff:idx:workers")
-        .arg(instance_id)
+        .arg(index_key.as_str())
+        .arg(instance_id.as_str())
         .execute()
         .await
         .expect("SADD workers-index");
@@ -8776,26 +8780,28 @@ async fn test_capable_worker_unblocks_on_get_error_failopen() {
         .await
         .expect("scheduler claim should not error");
 
-    // 2. Register a worker in the index but corrupt its caps key with a
-    //    HSET instead of SET. A subsequent GET on that key returns
-    //    WRONGTYPE — the concrete shape of "per-worker GET error" this
-    //    test is guarding against.
-    let instance_id = "wrongtype-gpu-worker";
-    let caps_key = format!("ff:worker:{instance_id}:caps");
-    let _: i64 = tc
+    // 2. Register a worker in the index but corrupt its caps key with
+    //    a STRING instead of a HASH. Post-RFC-025 the scanner's
+    //    per-worker read is `HGET caps_key caps_csv`; against a STRING
+    //    key that returns WRONGTYPE — the concrete shape of
+    //    "per-worker read error" this test is guarding against.
+    let instance_id = ff_core::types::WorkerInstanceId::new("wrongtype-gpu-worker");
+    let ns = ff_core::types::Namespace::new(NS);
+    let caps_key = ff_core::keys::worker_caps_key_ns(&ns, &instance_id);
+    let index_key = ff_core::keys::workers_index_key_ns(&ns);
+    let _: Option<String> = tc
         .client()
-        .cmd("HSET")
+        .cmd("SET")
         .arg(caps_key.as_str())
-        .arg("corrupted")
-        .arg("by-test")
+        .arg("not-a-hash")
         .execute()
         .await
-        .expect("HSET plant WRONGTYPE");
+        .expect("SET plant WRONGTYPE");
     let _: Option<i64> = tc
         .client()
         .cmd("SADD")
-        .arg("ff:idx:workers")
-        .arg(instance_id)
+        .arg(index_key.as_str())
+        .arg(instance_id.as_str())
         .execute()
         .await
         .expect("SADD workers-index");

--- a/crates/flowfabric/Cargo.toml
+++ b/crates/flowfabric/Cargo.toml
@@ -53,7 +53,7 @@ ff-core = { workspace = true }
 # dep's default-features at the consumer site. Pinning version +
 # path here matches the workspace.dependencies entry; `cargo release`
 # keeps both in lockstep via `shared-version = true`.
-ff-sdk = { version = "0.13.0", path = "../ff-sdk", default-features = false }
+ff-sdk = { version = "0.14.0", path = "../ff-sdk", default-features = false }
 
 ff-backend-valkey = { workspace = true, optional = true }
 ff-backend-postgres = { workspace = true, optional = true }

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

Closes the RFC-025 Phase 5 deferral: the SDK preamble + unblock scanner were still writing / reading the pre-namespace global key shape (`ff:worker:{id}:caps` STRING, `ff:idx:workers` SET) while the trait-route `ff_register_worker` FCALL shipped the namespaced HASH shape in Phase 2. This PR makes the preamble byte-identical to the FCALL and threads `Namespace` through the scanner so multi-tenant deployments don't cross-pollinate capability unions.

## Changes landed

- **SDK preamble** (`crates/ff-sdk/src/valkey_preamble.rs`): alive/caps/index keys now go through the `_ns` helpers. Caps is an HSET HASH with fields `worker_id, lanes_csv, caps_csv, ttl_ms, registered_at_ms` + `PEXPIRE` — same bytes as `ff_register_worker`.
- **Unblock scanner** (`crates/ff-engine/src/scanner/unblock.rs`): `HMGET blocking_reason namespace` per blocked exec; `check_route_cleared` takes a `&Namespace`; `CapsUnionCache` is a `HashMap<Namespace, CapsUnionEntry>`; `load_worker_caps_union` reads `workers_index_key_ns(ns)` + `HGET ff:worker:{ns}:{id}:caps caps_csv` (single-field, not HGETALL).
- **Legacy helper deletion** (`crates/ff-core/src/keys.rs`): `worker_key`, `worker_caps_key`, `workers_index_key` removed — every caller migrated.
- **Doc-comment fixups**: SDK `worker.rs` + Valkey backend `list_workers` rustdoc reference the namespaced shape.

## Architectural upgrade

The unblock scanner is now multi-tenant-safe for the first time: tenant-A worker caps can no longer unblock tenant-B `blocked_by_route` executions advertising the same capability token.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy -p ff-core -p ff-sdk -p ff-engine --all-features --no-deps -- -D warnings` clean
- [x] `cargo test -p ff-core --all-features` — 243 passed
- [x] `cargo test -p ff-engine --all-features` — 5 + 1 doc passed
- [x] `cargo test -p ff-sdk --all-features` — all targets clean
- [x] Live-run: `valkey-cli FLUSHDB` + `cargo run --manifest-path examples/v014-rfc025-worker-registry/Cargo.toml` — all 7 checkpoints pass
  ```
  register_worker → Registered (fresh)
  re-register with new caps → Refreshed (caps overwritten in place)
  heartbeat_worker → Refreshed next_expiry_ms=...
  list_workers(ns=Namespace("rfc025-demo")) → 1 entries
    - instance=demo-... worker_id=gpu-pool-1 lanes={default} caps={cuda, fp16, tensor-cores}
  mark_worker_dead → Marked
  mark_worker_dead (replay) → NotRegistered (idempotent)
  heartbeat_worker post-mark → NotRegistered (re-register required)
  == demo PASS ==
  ```

## Follow-up TODO

Integration test asserting preamble-written HASH fields are byte-identical to `ff_register_worker` output. Both paths demonstrably call the same HSET field sequence, but a harness would pin it against future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)