### PR TITLE
media-pipeline: fix setup model-size floor + demo.sh waitpoint-id parse (+ benches lockfile refresh)

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
@@ -802,11 +802,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",

--- a/examples/media-pipeline/scripts/demo.sh
+++ b/examples/media-pipeline/scripts/demo.sh
@@ -81,9 +81,28 @@ if [ -z "$SUMMARIZE_EID" ]; then
 fi
 
 echo "[demo] summarize eid = $SUMMARIZE_EID"
+
+# Wait for summarize worker to emit REVIEW_NEEDED with the
+# waitpoint_id — the review CLI needs it on the Suspended branch.
+WAITPOINT_ID=""
+for _ in $(seq 1 300); do
+    if grep -q "REVIEW_NEEDED.*wp=" "$LOGDIR/summarize.log" 2>/dev/null; then
+        WAITPOINT_ID="$(grep -oE 'wp=[^ ]+' "$LOGDIR/summarize.log" | head -1 | sed 's/^wp=//')"
+        break
+    fi
+    sleep 1
+done
+
+if [ -z "$WAITPOINT_ID" ]; then
+    echo "[demo] could not extract waitpoint_id — summarize worker never suspended" >&2
+    exit 1
+fi
+echo "[demo] waitpoint_id = $WAITPOINT_ID"
+
 echo "[demo] running review --auto-approve"
 ./target/debug/review \
     --execution-id "$SUMMARIZE_EID" \
+    --waitpoint-id "$WAITPOINT_ID" \
     --server "$SERVER" \
     --auto-approve \
     2>&1 | tee "$LOGDIR/review.log"

--- a/examples/media-pipeline/scripts/setup.sh
+++ b/examples/media-pipeline/scripts/setup.sh
@@ -82,7 +82,7 @@ fi
 #    magic (the exact 4 bytes vary by whisper.cpp version, so just
 #    range-check the size).
 mkdir -p "$ROOT/models"
-MIN_MODEL_BYTES=50000000  # 50 MiB floor; real file is ~77 MiB
+MIN_MODEL_BYTES=20000000  # 20 MiB floor; tiny.en-q5_1 is ~31 MiB
 model_looks_complete() {
     [ -f "$1" ] || return 1
     local size


### PR DESCRIPTION
## Summary

Two media-pipeline demo fixes uncovered by the pre-release-local LLM example gate for v0.14.0:

1. **`scripts/setup.sh` model-size floor** was 50 MiB, but `tiny.en-q5_1` is actually ~31 MiB. Every cold run treated the freshly-downloaded model as "truncated" and failed with `downloaded model is smaller than 50000000 bytes — network partial?`. Lowered to 20 MiB (real file is ~31).

2. **`scripts/demo.sh` missing `--waitpoint-id`**. PR #488 (v0.13) made the review CLI's `--waitpoint-id` required on the Suspended branch (cite: `examples/media-pipeline/src/bin/review.rs:189`). demo.sh still invoked `review --auto-approve` without it, so every run failed at the review step. Now parses `REVIEW_NEEDED eid=... wp=...` out of `summarize.log` before invoking review.

Also regenerates `benches/Cargo.lock` — stale vs the workspace 0.13 → 0.14 bump landed in PR #500.

## Live-run transcript (samples/story.wav)

```
[submit] flow_id=…
[submit] transcribe={fp:…}:…
[submit] transcribe execution created
[submit] transcribe done (231 chars, … ms)
[submit] summarize={fp:…}:…
[summary summary_token]  A  light  house  keeper  lives  alone  on  …
[summary summary_final] {"summary":"A light housekeeper lives alone on a rocky island. …","token_count":50}
[demo] waitpoint_id = …
[demo] running review --auto-approve
[review] execution suspended — fetching waitpoint token
[review] approved — resume signal sent
[submit] summarize done (50 tokens, 231 chars)
[submit] embed={fp:…}:…
[submit] embed done — pipeline complete
[demo] PASS — pipeline completed
```

## Scope note

This PR also unblocks the v0.14.0 release gate — all three LLM-heavy examples (coding-agent, llm-race, media-pipeline) now live-run green pre-release-local with an OpenRouter key. CI continues to SKIP them per CLAUDE.md §5 item 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)