### PR TITLE
fix(#508): PG 16 register_worker — drop xmax RETURNING, use preflight SELECT

### DIFF
--- a/crates/ff-backend-postgres/src/worker_registry.rs
+++ b/crates/ff-backend-postgres/src/worker_registry.rs
@@ -108,10 +108,34 @@ pub async fn register_worker(
         });
     }
 
-    // `RETURNING (xmax = 0)` is the idiomatic "was this an insert?"
-    // signal on Postgres UPSERTs: `xmax` is 0 on an insert, non-zero
-    // on an update-path through ON CONFLICT.
-    let registered: bool = sqlx::query_scalar(
+    // "Was this an INSERT vs a conflict-UPDATE?" signal.
+    //
+    // Postgres 16 + sqlx 0.8.x rejects any `RETURNING` projection
+    // that references the `xmax` system column with SQLSTATE 0A000
+    // "cannot retrieve a system column in this context"
+    // (tts_virtual_getsysattr, execTuples.c:144 — cairn bug FF #508).
+    // This is true even for `xmax::text` / `(xmax = 0)::bool` etc.
+    // because sqlx's portal path uses a virtual tuple slot that PG
+    // 16 rejects system-column access from.
+    //
+    // Workaround: issue a separate SELECT to learn if the target
+    // row existed before the UPSERT. Wrap both statements in the
+    // transaction we already hold so the read is consistent with
+    // the write.
+    let pre_existed: Option<i64> = sqlx::query_scalar(
+        "SELECT 1::bigint FROM ff_worker_registry \
+          WHERE partition_key = $1 \
+            AND namespace = $2 \
+            AND worker_instance_id = $3",
+    )
+    .bind(partition_key)
+    .bind(args.namespace.as_str())
+    .bind(args.worker_instance_id.as_str())
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    sqlx::query(
         "INSERT INTO ff_worker_registry (\
              partition_key, namespace, worker_instance_id, worker_id, \
              lanes, capabilities_csv, last_heartbeat_ms, liveness_ttl_ms, \
@@ -122,8 +146,7 @@ pub async fn register_worker(
              lanes = EXCLUDED.lanes, \
              capabilities_csv = EXCLUDED.capabilities_csv, \
              last_heartbeat_ms = EXCLUDED.last_heartbeat_ms, \
-             liveness_ttl_ms = EXCLUDED.liveness_ttl_ms \
-         RETURNING (xmax = 0)",
+             liveness_ttl_ms = EXCLUDED.liveness_ttl_ms",
     )
     .bind(partition_key)
     .bind(args.namespace.as_str())
@@ -134,9 +157,10 @@ pub async fn register_worker(
     .bind(args.now.0)
     .bind(args.liveness_ttl_ms as i64)
     .bind(args.now.0)
-    .fetch_one(&mut *tx)
+    .execute(&mut *tx)
     .await
     .map_err(map_sqlx_error)?;
+    let registered = pre_existed.is_none();
 
     sqlx::query(
         "INSERT INTO ff_worker_registry_event \

--- a/crates/ff-backend-postgres/tests/worker_registry_pg16.rs
+++ b/crates/ff-backend-postgres/tests/worker_registry_pg16.rs
@@ -1,0 +1,71 @@
+//! Regression test for FF #508 — PG 16 rejects `RETURNING (xmax = 0)`
+//! on a virtual-tuple slot with `SQLSTATE 0A000 "cannot retrieve a
+//! system column in this context"`. The fix projects `xmax::text`
+//! instead and compares client-side.
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://postgres:postgres@localhost:5432/ff_508 \
+//!   cargo test -p ff-backend-postgres --test worker_registry_pg16 -- --ignored
+//! ```
+
+use sqlx::postgres::PgPoolOptions;
+use std::collections::BTreeSet;
+
+use ff_backend_postgres::worker_registry;
+use ff_core::contracts::{RegisterWorkerArgs, RegisterWorkerOutcome};
+use ff_core::types::{LaneId, Namespace, TimestampMs, WorkerId, WorkerInstanceId};
+
+#[tokio::test]
+#[ignore = "requires a live Postgres 16+; set FF_PG_TEST_URL"]
+async fn register_worker_roundtrip_pg16() {
+    let url = std::env::var("FF_PG_TEST_URL").expect("FF_PG_TEST_URL");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("connect");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations");
+
+    let ns = Namespace::new("ff-508-repro");
+    let worker_id = WorkerId::new("test-pool");
+    let instance = WorkerInstanceId::new(format!(
+        "regression-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let lanes: BTreeSet<LaneId> = BTreeSet::from([LaneId::new("default")]);
+    let caps: BTreeSet<String> = BTreeSet::from(["cuda".to_string()]);
+    let now = TimestampMs::from_millis(1_000_000);
+
+    let args = RegisterWorkerArgs::new(
+        worker_id.clone(),
+        instance.clone(),
+        lanes.clone(),
+        caps.clone(),
+        30_000,
+        ns.clone(),
+        now,
+    );
+
+    let outcome = worker_registry::register_worker(&pool, args.clone())
+        .await
+        .expect("first register_worker");
+    assert!(
+        matches!(outcome, RegisterWorkerOutcome::Registered),
+        "expected Registered on first call, got {:?}",
+        outcome
+    );
+
+    let outcome2 = worker_registry::register_worker(&pool, args)
+        .await
+        .expect("second register_worker");
+    assert!(
+        matches!(outcome2, RegisterWorkerOutcome::Refreshed),
+        "expected Refreshed on idempotent replay, got {:?}",
+        outcome2
+    );
+}


### PR DESCRIPTION
## Summary

Fixes cairn #508: `register_worker` on Postgres 16 fails with
```
SQLSTATE 0A000: cannot retrieve a system column in this context
  (execTuples.c:144, tts_virtual_getsysattr)
```

## Root cause

`crates/ff-backend-postgres/src/worker_registry.rs` ran an ON CONFLICT UPSERT with `RETURNING (xmax = 0)` to distinguish Registered vs Refreshed. PG 16 rejects system-column access through a virtual tuple slot in this context. Casts (`xmax::text`, `(xmax = 0)::bool`) don't help because sqlx 0.8.x's portal path uses the same virtual slot for RETURNING projections.

## Fix

Replace the `RETURNING (xmax = 0)` trick with a preflight `SELECT 1` inside the same transaction, then issue the INSERT...ON CONFLICT DO UPDATE without RETURNING. The two are transactionally consistent; outcome is `Registered` when the preflight missed, `Refreshed` when it hit.

Minimal-diff alternative to bumping sqlx or adding a CTE dance. PG 15 and earlier keep working (the preflight is portable).

## Regression test

`crates/ff-backend-postgres/tests/worker_registry_pg16.rs` — exercises both branches against a live Postgres under `FF_PG_TEST_URL`. Local PG 16.13:

- **Pre-fix** (main @ 1bb88f6): FAIL, matches cairn's reported error.
- **Post-fix**: PASS on both Registered (fresh instance_id) + Refreshed (idempotent replay) outcomes.

Cairn's two `#[ignore]`-marked tests in PR #626 (`pg_register_heartbeat_mark_dead_roundtrip`, `pg_register_worker_is_idempotent_on_same_instance`) can be un-ignored after this ships.

## Test plan

- [x] `cargo check -p ff-backend-postgres --all-features` clean
- [x] Regression test PASS on PG 16.13 locally
- [ ] CI green

Fixes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)