### PR TITLE
chore(release): v0.14.1 — PG 16 register_worker fix + docs drift sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-05-03
+
+### Fixed
+
+- **PG 16 `register_worker` regression (#508, reported by cairn).** The
+  v0.14.0 body issued `RETURNING (xmax = 0)` to distinguish Registered
+  vs Refreshed. Postgres 16 + sqlx 0.8.x reject that projection with
+  SQLSTATE 0A000 ("cannot retrieve a system column in this context",
+  `tts_virtual_getsysattr`) because sqlx's portal path evaluates
+  RETURNING through a virtual tuple slot. Casts (`xmax::text`,
+  `(xmax = 0)::bool`) don't help — same slot. Replaced with a
+  transactionally-consistent preflight `SELECT 1` + INSERT ... ON
+  CONFLICT DO UPDATE without RETURNING. Regression test
+  `crates/ff-backend-postgres/tests/worker_registry_pg16.rs` pins the
+  behaviour on PG 16+.
+
+### Changed
+
+- **Docs drift sweep (post-v0.14).** `docs/CONSUMER_MIGRATION_0.14_worker_registry.md`
+  + `docs/POSTGRES_PARITY_MATRIX.md` caught up with the actual shipped
+  shape: Lua library version is v34 (not v32), `register_worker` caps
+  HASH carries 6 fields (`last_heartbeat_ms` added at v33),
+  `heartbeat_worker` is a single atomic `ff_heartbeat_worker` FCALL
+  (not client-side HGET→PEXPIRE), `list_workers` Valkey body uses SSCAN
+  + concurrency-capped parallel HGETALL (not SMEMBERS + sequential).
+  Also removed a stale "TODO(RFC-025 Phase 2)" comment in
+  `ff-backend-valkey::mark_worker_dead`.
+
 ## [0.14.0] - 2026-05-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "axum",
  "ff-observability",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "flowfabric"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ff-backend-postgres",
  "ff-backend-valkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -39,23 +39,23 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.14.0", path = "crates/ff-core" }
-ff-script = { version = "0.14.0", path = "crates/ff-script" }
-ff-engine = { version = "0.14.0", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.14.0", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.14.0", path = "crates/ff-sdk" }
-ff-server = { version = "0.14.0", path = "crates/ff-server" }
+ff-core = { version = "0.14.1", path = "crates/ff-core" }
+ff-script = { version = "0.14.1", path = "crates/ff-script" }
+ff-engine = { version = "0.14.1", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.14.1", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.14.1", path = "crates/ff-sdk" }
+ff-server = { version = "0.14.1", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.14.0", path = "crates/ff-backend-valkey" }
-ff-backend-postgres = { version = "0.14.0", path = "crates/ff-backend-postgres" }
-ff-backend-sqlite = { version = "0.14.0", path = "crates/ff-backend-sqlite" }
-ff-observability = { version = "0.14.0", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.14.0", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.14.0", path = "ferriskey" }
+ff-backend-valkey = { version = "0.14.1", path = "crates/ff-backend-valkey" }
+ff-backend-postgres = { version = "0.14.1", path = "crates/ff-backend-postgres" }
+ff-backend-sqlite = { version = "0.14.1", path = "crates/ff-backend-sqlite" }
+ff-observability = { version = "0.14.1", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.14.1", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.14.1", path = "ferriskey" }
 # Umbrella crate re-exporting the ff-* family (issue #279). Declared
 # at workspace scope so internal doc examples / dev-deps can name it
 # via `{ workspace = true }`.
-flowfabric = { version = "0.14.0", path = "crates/flowfabric" }
+flowfabric = { version = "0.14.1", path = "crates/flowfabric" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -34,7 +34,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
+ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -27,7 +27,7 @@ suspension = ["ff-core/suspension"]
 # impl honours the same `EngineBackend` method surface. Trait impl
 # bodies arrive in Phase 2+; Phase 1a returns `EngineError::Unavailable`
 # from every method except `capabilities()` + `prepare()`.
-ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
 
 # SQLite transport. Bundled SQLite is deliberately selected to decouple
 # the backend from the operating distro's libsqlite3 version — RFC-023

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
+ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -25,7 +25,7 @@ observability = ["ff-observability/enabled"]
 postgres = ["dep:ff-backend-postgres", "dep:sqlx"]
 
 [dependencies]
-ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
 ff-observability = { workspace = true }
 # v0.12 PR-7a transitional: `Engine::start_*` accepts
 # `Arc<dyn EngineBackend>` on the boundary but scanners still speak
@@ -38,7 +38,7 @@ ff-observability = { workspace = true }
 # silently defeat the explicit `ff-core` anchor on line 26
 # (`default-features = false, features = ["core"]`) and re-expose
 # streaming-gated trait methods on `ff-engine`.
-ff-backend-valkey = { version = "0.14.0", path = "../ff-backend-valkey", default-features = false }
+ff-backend-valkey = { version = "0.14.1", path = "../ff-backend-valkey", default-features = false }
 ferriskey = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ff-scheduler/Cargo.toml
+++ b/crates/ff-scheduler/Cargo.toml
@@ -16,7 +16,7 @@ description = "FlowFabric claim-grant scheduler"
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-scheduler's claim dispatcher uses FCALL helpers from
 # ff-script, so explicitly enable `valkey-client`.
 ff-script = { workspace = true, features = ["valkey-client"] }

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -49,7 +49,7 @@ valkey-client = ["dep:ferriskey"]
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: optional so `--no-default-features` drops the transport edge.
 ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -84,7 +84,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.14.0", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-script's defaults are empty — the `valkey-client`
 # feature (which owns the `ferriskey` dep edge) is activated below by
 # the `valkey-default` feature, NOT here. This keeps
@@ -102,7 +102,7 @@ ferriskey = { workspace = true, optional = true }
 # RFC-023 Phase 1a: optional SQLite backend edge, activated by the
 # `sqlite` feature above. Off by default so Valkey consumers pay no
 # sqlx compile cost.
-ff-backend-sqlite = { version = "0.14.0", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
+ff-backend-sqlite = { version = "0.14.1", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/crates/flowfabric/Cargo.toml
+++ b/crates/flowfabric/Cargo.toml
@@ -53,7 +53,7 @@ ff-core = { workspace = true }
 # dep's default-features at the consumer site. Pinning version +
 # path here matches the workspace.dependencies entry; `cargo release`
 # keeps both in lockstep via `shared-version = true`.
-ff-sdk = { version = "0.14.0", path = "../ff-sdk", default-features = false }
+ff-sdk = { version = "0.14.1", path = "../ff-sdk", default-features = false }
 
 ff-backend-valkey = { workspace = true, optional = true }
 ff-backend-postgres = { workspace = true, optional = true }

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

Patch release v0.14.1 for two items shipped on main post-v0.14.0:

- **PR #509 / #508** — PG 16 `register_worker` SQLSTATE 0A000 regression. Preflight SELECT replaces `RETURNING (xmax = 0)` to dodge the virtual-tuple-slot system-column rejection.
- **PR #507** — post-release deslop + docs drift sweep (Lua library v34 refs + `heartbeat_worker` FCALL + `list_workers` SSCAN + caps HASH 6 fields).

Workspace version bump 0.14.0 → 0.14.1.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] PR #509's regression test `worker_registry_pg16.rs` PASS on PG 16.13
- [ ] CI green

## Next

Once merged, tag `v0.14.1` + push (owner-auth per CLAUDE.md §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)