### PR TITLE
feat(#511) Phase 1: release_admission trait method + 3 backend bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferriskey"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ff-observability-http"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum",
  "ff-observability",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ff-readiness-tests"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ferriskey",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "flowfabric"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "ff-backend-postgres",
  "ff-backend-valkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]
@@ -39,23 +39,23 @@ categories = ["database", "asynchronous"]
 # Cargo uses `path` locally and falls back to the registry version
 # when a dependent is published. Keep these in sync with
 # `[workspace.package] version`.
-ff-core = { version = "0.14.1", path = "crates/ff-core" }
-ff-script = { version = "0.14.1", path = "crates/ff-script" }
-ff-engine = { version = "0.14.1", path = "crates/ff-engine" }
-ff-scheduler = { version = "0.14.1", path = "crates/ff-scheduler" }
-ff-sdk = { version = "0.14.1", path = "crates/ff-sdk" }
-ff-server = { version = "0.14.1", path = "crates/ff-server" }
+ff-core = { version = "0.15.0", path = "crates/ff-core" }
+ff-script = { version = "0.15.0", path = "crates/ff-script" }
+ff-engine = { version = "0.15.0", path = "crates/ff-engine" }
+ff-scheduler = { version = "0.15.0", path = "crates/ff-scheduler" }
+ff-sdk = { version = "0.15.0", path = "crates/ff-sdk" }
+ff-server = { version = "0.15.0", path = "crates/ff-server" }
 ff-test = { path = "crates/ff-test" }
-ff-backend-valkey = { version = "0.14.1", path = "crates/ff-backend-valkey" }
-ff-backend-postgres = { version = "0.14.1", path = "crates/ff-backend-postgres" }
-ff-backend-sqlite = { version = "0.14.1", path = "crates/ff-backend-sqlite" }
-ff-observability = { version = "0.14.1", path = "crates/ff-observability" }
-ff-observability-http = { version = "0.14.1", path = "crates/ff-observability-http" }
-ferriskey = { version = "0.14.1", path = "ferriskey" }
+ff-backend-valkey = { version = "0.15.0", path = "crates/ff-backend-valkey" }
+ff-backend-postgres = { version = "0.15.0", path = "crates/ff-backend-postgres" }
+ff-backend-sqlite = { version = "0.15.0", path = "crates/ff-backend-sqlite" }
+ff-observability = { version = "0.15.0", path = "crates/ff-observability" }
+ff-observability-http = { version = "0.15.0", path = "crates/ff-observability-http" }
+ferriskey = { version = "0.15.0", path = "ferriskey" }
 # Umbrella crate re-exporting the ff-* family (issue #279). Declared
 # at workspace scope so internal doc examples / dev-deps can name it
 # via `{ workspace = true }`.
-flowfabric = { version = "0.14.1", path = "crates/flowfabric" }
+flowfabric = { version = "0.15.0", path = "crates/flowfabric" }
 
 # Shared external deps
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ff-backend-postgres/Cargo.toml
+++ b/crates/ff-backend-postgres/Cargo.toml
@@ -34,7 +34,7 @@ observability = ["ff-observability/enabled"]
 # Wave 0: `core`, `suspension`, `budget` match ff-backend-valkey's
 # ff-core feature set so the Postgres backend honours the same
 # `EngineBackend` method surface.
-ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
+ff-core = { version = "0.15.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
 # Always-present observability shim (no-op unless `observability`
 # feature flips the shim to real OTEL). Mirrors ff-backend-valkey.
 ff-observability = { workspace = true }

--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1239,6 +1239,15 @@ impl EngineBackend for PostgresBackend {
         budget::release_budget_impl(&self.pool, &self.partition_config, args).await
     }
 
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.release_admission", skip_all)]
+    async fn release_admission(
+        &self,
+        args: ff_core::contracts::ReleaseAdmissionArgs,
+    ) -> Result<ff_core::contracts::ReleaseAdmissionResult, EngineError> {
+        crate::typed_ops::release_admission(&self.pool, &self.partition_config, args).await
+    }
+
     // ── HMAC secret rotation (v0.7 migration-master Q4) ──
     //
     // Wave 4 replaces this stub with a single INSERT into

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -1872,6 +1872,59 @@ pub(crate) async fn issue_grant_and_claim(
     ))
 }
 
+/// PG body for [`ff_core::engine_backend::EngineBackend::release_admission`].
+///
+/// Mirrors the Valkey `ff_release_admission` FCALL: idempotent DEL of
+/// the admitted-guard row + SREM-equivalent (no separate set on PG;
+/// the admitted row IS the set) + DECR-if-positive on the policy's
+/// concurrency counter. Wrapped in a transaction so the delete and
+/// decrement land atomically. FF #511 Phase 1.
+pub(crate) async fn release_admission(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    args: ff_core::contracts::ReleaseAdmissionArgs,
+) -> Result<ff_core::contracts::ReleaseAdmissionResult, EngineError> {
+    let part = quota_partition(&args.quota_policy_id, partition_config).index as i16;
+    let policy_id_text = args.quota_policy_id.to_string();
+    let exec_id_text = args.execution_id.to_string();
+
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+
+    // Delete the admitted-guard row. `DELETE` returns 0 rows if absent;
+    // we use that as the idempotency signal without treating it as an
+    // error — matches the Lua's `DEL`-returns-0-on-absent behaviour.
+    let deleted = sqlx::query(
+        "DELETE FROM ff_quota_admitted \
+          WHERE partition_key = $1 AND quota_policy_id = $2 AND execution_id = $3",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(&exec_id_text)
+    .execute(&mut *tx)
+    .await
+    .map_err(map_sqlx_error)?
+    .rows_affected();
+
+    // Decrement concurrency only if we actually removed an admission
+    // row. Floor-at-zero invariant via the `GREATEST(..., 0)` clamp
+    // so a double-release can't drive the counter below zero.
+    if deleted > 0 {
+        sqlx::query(
+            "UPDATE ff_quota_policy SET \
+                 active_concurrency = GREATEST(active_concurrency - 1, 0) \
+              WHERE partition_key = $1 AND quota_policy_id = $2",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(ff_core::contracts::ReleaseAdmissionResult::Released)
+}
+
 #[cfg(test)]
 mod tests {
     // Integration tests live in `tests/typed_renew_lease.rs` +

--- a/crates/ff-backend-postgres/tests/release_admission.rs
+++ b/crates/ff-backend-postgres/tests/release_admission.rs
@@ -1,0 +1,123 @@
+//! FF #511 Phase 1 — PG `release_admission` trait-method regression test.
+//!
+//! Mirrors the Valkey Lua body: idempotent DEL + DECR-if-positive.
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://postgres:postgres@localhost:5432/ff_511 \
+//!   cargo test -p ff-backend-postgres --test release_admission -- --ignored
+//! ```
+
+use sqlx::postgres::PgPoolOptions;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::contracts::{ReleaseAdmissionArgs, ReleaseAdmissionResult};
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::{quota_partition, PartitionConfig};
+use ff_core::types::{ExecutionId, FlowId, QuotaPolicyId};
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn release_admission_idempotent() {
+    let url = std::env::var("FF_PG_TEST_URL").expect("FF_PG_TEST_URL");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("connect");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations");
+
+    let config = PartitionConfig::default();
+    let backend = PostgresBackend::from_pool(pool.clone(), config.clone());
+    let qid = QuotaPolicyId::new();
+    let flow = FlowId::new();
+    let eid = ExecutionId::for_flow(&flow, &config);
+    let part = quota_partition(&qid, &config).index as i16;
+
+    // Seed: insert an admitted row + bump active_concurrency to 1.
+    sqlx::query(
+        "INSERT INTO ff_quota_admitted \
+             (partition_key, quota_policy_id, execution_id, admitted_at_ms, expires_at_ms) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .bind(eid.to_string())
+    .bind(1_000_000i64)
+    .bind(1_000_000i64 + 60_000)
+    .execute(&pool)
+    .await
+    .expect("seed admitted");
+
+    sqlx::query(
+        "INSERT INTO ff_quota_policy \
+             (partition_key, quota_policy_id, \
+              requests_per_window_seconds, max_requests_per_window, \
+              active_concurrency_cap, active_concurrency, \
+              created_at_ms, updated_at_ms) \
+         VALUES ($1, $2, 0, 0, 0, 1, 1_000_000, 1_000_000)",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .execute(&pool)
+    .await
+    .expect("seed policy");
+
+    // Release: first call deletes the row + decrements.
+    let outcome = backend
+        .release_admission(ReleaseAdmissionArgs::new(qid.clone(), eid.clone()))
+        .await
+        .expect("first release_admission");
+    assert_eq!(outcome, ReleaseAdmissionResult::Released);
+
+    let conc: i64 = sqlx::query_scalar(
+        "SELECT active_concurrency FROM ff_quota_policy \
+          WHERE partition_key = $1 AND quota_policy_id = $2",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .fetch_one(&pool)
+    .await
+    .expect("read concurrency");
+    assert_eq!(conc, 0, "concurrency should decrement to 0 after release");
+
+    let present: Option<i64> = sqlx::query_scalar(
+        "SELECT 1::bigint FROM ff_quota_admitted \
+          WHERE partition_key = $1 AND quota_policy_id = $2 AND execution_id = $3",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .bind(eid.to_string())
+    .fetch_optional(&pool)
+    .await
+    .expect("read admitted");
+    assert!(present.is_none(), "admitted row should be gone");
+
+    // Idempotent replay: second call is a no-op, concurrency stays at 0
+    // (not -1 — the floor clamp holds).
+    let outcome2 = backend
+        .release_admission(ReleaseAdmissionArgs::new(qid.clone(), eid.clone()))
+        .await
+        .expect("second release_admission");
+    assert_eq!(outcome2, ReleaseAdmissionResult::Released);
+
+    let conc2: i64 = sqlx::query_scalar(
+        "SELECT active_concurrency FROM ff_quota_policy \
+          WHERE partition_key = $1 AND quota_policy_id = $2",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .fetch_one(&pool)
+    .await
+    .expect("read concurrency 2");
+    assert_eq!(conc2, 0, "idempotent replay must not underflow concurrency");
+
+    // Cleanup.
+    sqlx::query("DELETE FROM ff_quota_policy WHERE partition_key = $1 AND quota_policy_id = $2")
+        .bind(part)
+        .bind(qid.to_string())
+        .execute(&pool)
+        .await
+        .ok();
+}

--- a/crates/ff-backend-sqlite/Cargo.toml
+++ b/crates/ff-backend-sqlite/Cargo.toml
@@ -27,7 +27,7 @@ suspension = ["ff-core/suspension"]
 # impl honours the same `EngineBackend` method surface. Trait impl
 # bodies arrive in Phase 2+; Phase 1a returns `EngineError::Unavailable`
 # from every method except `capabilities()` + `prepare()`.
-ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.15.0", path = "../ff-core", default-features = false, features = ["core"] }
 
 # SQLite transport. Bundled SQLite is deliberately selected to decouple
 # the backend from the operating distro's libsqlite3 version — RFC-023

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2316,6 +2316,9 @@ fn sqlite_supports_base() -> Supports {
     s.list_expired_leases = true;
     s.list_workers = true;
 
+    // ── FF #511 Phase 1 scheduler primitive ──
+    s.release_admission = true;
+
     // ── Stay `false` (see struct-level rustdoc above) ──
     // s.claim_for_worker — RFC-023 §5 non-goal
     // s.subscribe_instance_tags — #311 all-backends
@@ -3080,6 +3083,15 @@ impl EngineBackend for SqliteBackend {
     ) -> Result<(), EngineError> {
         let pool = &self.inner.pool;
         retry_serializable(|| crate::typed_ops::release_budget(pool, args.clone())).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn release_admission(
+        &self,
+        args: ff_core::contracts::ReleaseAdmissionArgs,
+    ) -> Result<ff_core::contracts::ReleaseAdmissionResult, EngineError> {
+        let pool = &self.inner.pool;
+        retry_serializable(|| crate::typed_ops::release_admission(pool, args.clone())).await
     }
 
     #[cfg(feature = "core")]

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -2178,3 +2178,46 @@ pub(crate) async fn issue_grant_and_claim(
         }
     }
 }
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::release_admission`].
+///
+/// Mirrors the Valkey + PG idempotent DEL + DECR-if-positive
+/// semantics. FF #511 Phase 1.
+pub(crate) async fn release_admission(
+    pool: &SqlitePool,
+    args: ff_core::contracts::ReleaseAdmissionArgs,
+) -> Result<ff_core::contracts::ReleaseAdmissionResult, EngineError> {
+    let part: i64 = 0; // SQLite single-writer flat layout per RFC-023 §4.1 A3
+    let policy_id_text = args.quota_policy_id.to_string();
+    let exec_id_text = args.execution_id.to_string();
+
+    let mut conn = begin_immediate(pool).await?;
+
+    let deleted = sqlx::query(
+        "DELETE FROM ff_quota_admitted \
+          WHERE partition_key = ?1 AND quota_policy_id = ?2 AND execution_id = ?3",
+    )
+    .bind(part)
+    .bind(&policy_id_text)
+    .bind(&exec_id_text)
+    .execute(&mut *conn)
+    .await
+    .map_err(map_sqlx_error)?
+    .rows_affected();
+
+    if deleted > 0 {
+        sqlx::query(
+            "UPDATE ff_quota_policy SET \
+                 active_concurrency = MAX(active_concurrency - 1, 0) \
+              WHERE partition_key = ?1 AND quota_policy_id = ?2",
+        )
+        .bind(part)
+        .bind(&policy_id_text)
+        .execute(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    }
+
+    commit_or_rollback(&mut conn).await?;
+    Ok(ff_core::contracts::ReleaseAdmissionResult::Released)
+}

--- a/crates/ff-backend-valkey/Cargo.toml
+++ b/crates/ff-backend-valkey/Cargo.toml
@@ -25,7 +25,7 @@ streaming = ["ff-core/streaming"]
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
+ff-core = { version = "0.15.0", path = "../ff-core", default-features = false, features = ["core", "suspension"] }
 # Issue #154 — metric emission on `EngineBackend` impls. Always-present
 # so no cfg-gated field on `ValkeyBackend`; the `observability` feature
 # selects shim vs. real OTEL implementation.

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -176,6 +176,7 @@ fn valkey_supports_base() -> ff_core::capability::Supports {
     s.mark_worker_dead = true;
     s.list_expired_leases = true;
     s.list_workers = true;
+    s.release_admission = true;
     s.prepare = true;
     s.subscribe_lease_history = true;
     s.subscribe_completion = true;
@@ -6087,6 +6088,41 @@ impl EngineBackend for ValkeyBackend {
                 ff_core::engine_error::backend_context(
                     e,
                     "release_budget: FCALL ff_release_budget",
+                )
+            })
+    }
+
+    /// FF #511 Phase 1 — idempotent quota-admission slot release.
+    ///
+    /// Wraps the existing `ff_release_admission` FCALL (DEL guard +
+    /// SREM admitted_set + DECR-if-positive concurrency counter).
+    /// Used by `ff_scheduler::Scheduler` on the claim-fail rollback
+    /// path once Phase 2 trait-routes the scheduler.
+    async fn release_admission(
+        &self,
+        args: ff_core::contracts::ReleaseAdmissionArgs,
+    ) -> Result<ff_core::contracts::ReleaseAdmissionResult, EngineError> {
+        use ff_core::keys::QuotaKeyContext;
+        use ff_core::partition::quota_partition;
+        use ff_script::functions::quota::QuotaOpKeys;
+
+        let partition = quota_partition(&args.quota_policy_id, &self.partition_config);
+        let ctx = QuotaKeyContext::new(&partition, &args.quota_policy_id);
+        let keys = QuotaOpKeys {
+            ctx: &ctx,
+            // `dimension` is unused by ff_release_admission (it only
+            // touches admitted_guard / admitted_set / concurrency);
+            // any non-empty placeholder satisfies the QuotaOpKeys
+            // shape shared with check/create which do read it.
+            dimension: "admission",
+            execution_id: &args.execution_id,
+        };
+        ff_script::functions::quota::ff_release_admission(&self.client, &keys, &args)
+            .await
+            .map_err(|e| {
+                ff_core::engine_error::backend_context(
+                    transport_script(e),
+                    "release_admission: FCALL ff_release_admission",
                 )
             })
     }

--- a/crates/ff-core/src/capability.rs
+++ b/crates/ff-core/src/capability.rs
@@ -155,6 +155,12 @@ pub struct Supports {
     pub list_expired_leases: bool,
     /// `list_workers` (RFC-025 Phase 6, §9.4).
     pub list_workers: bool,
+
+    // ── Scheduler (FF #511) ──
+    /// `release_admission` — idempotent quota-admission slot release
+    /// used by `ff_scheduler` on the claim-fail rollback path. `true`
+    /// on every in-tree backend post-FF-#511.
+    pub release_admission: bool,
     // Add new fields here, preserving parity-matrix order.
 }
 
@@ -204,6 +210,7 @@ impl Supports {
             mark_worker_dead: false,
             list_expired_leases: false,
             list_workers: false,
+            release_admission: false,
         }
     }
 }

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2032,12 +2032,40 @@ pub enum CheckAdmissionResult {
 
 // ─── release_admission ───
 
+/// Args for [`crate::engine_backend::EngineBackend::release_admission`].
+///
+/// Called when `issue_claim_grant` fails after admission was recorded,
+/// to prevent leaked concurrency slots. Semantics are idempotent: a
+/// release against an already-released slot is a no-op (matches the
+/// Valkey Lua body's DEL-is-idempotent + DECR-if-positive discipline).
+///
+/// FF #511 Phase 1 extended this with `quota_policy_id` so PG/SQLite
+/// bodies can locate the admission row without reverse-mapping from
+/// the execution. Valkey still derives its quota key from the
+/// `{p:N}` partition tag + quota id.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ReleaseAdmissionArgs {
+    /// The quota policy whose admission slot should be released.
+    pub quota_policy_id: crate::types::QuotaPolicyId,
+    /// The execution whose slot was admitted.
     pub execution_id: ExecutionId,
 }
 
+impl ReleaseAdmissionArgs {
+    pub fn new(
+        quota_policy_id: crate::types::QuotaPolicyId,
+        execution_id: ExecutionId,
+    ) -> Self {
+        Self {
+            quota_policy_id,
+            execution_id,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ReleaseAdmissionResult {
     Released,
 }

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -80,7 +80,8 @@ use crate::contracts::{
     EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult, ExecutionInfo,
     FailExecutionArgs, FailExecutionResult,
     IssueClaimGrantArgs, IssueClaimGrantOutcome, IssueGrantAndClaimArgs,
-    RecordSpendArgs, ReleaseBudgetArgs, ScanEligibleArgs,
+    RecordSpendArgs, ReleaseAdmissionArgs, ReleaseAdmissionResult, ReleaseBudgetArgs,
+    ScanEligibleArgs,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs,
     ListPendingWaitpointsResult, ListSuspendedPage, RenewLeaseArgs, RenewLeaseResult,
     ReplayExecutionArgs, ReplayExecutionResult,
@@ -1743,6 +1744,28 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<(), EngineError> {
         Err(EngineError::Unavailable {
             op: "release_budget",
+        })
+    }
+
+    /// Release a quota-admission slot that was recorded via
+    /// [`Self::check_admission`] / `ff_check_admission_and_record` but
+    /// for which `issue_claim_grant` subsequently failed. Idempotent:
+    /// releasing an already-released slot is a no-op.
+    ///
+    /// Valkey wraps the existing `ff_release_admission` FCALL (DEL
+    /// guard + SREM admitted_set + DECR-if-positive concurrency
+    /// counter). PG/SQLite write to their admission-tracking rows.
+    ///
+    /// Used by `ff_scheduler::Scheduler` on the claim-fail rollback
+    /// path (FF #511). The default impl returns
+    /// [`EngineError::Unavailable`].
+    #[cfg(feature = "core")]
+    async fn release_admission(
+        &self,
+        _args: ReleaseAdmissionArgs,
+    ) -> Result<ReleaseAdmissionResult, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "release_admission",
         })
     }
 

--- a/crates/ff-engine/Cargo.toml
+++ b/crates/ff-engine/Cargo.toml
@@ -25,7 +25,7 @@ observability = ["ff-observability/enabled"]
 postgres = ["dep:ff-backend-postgres", "dep:sqlx"]
 
 [dependencies]
-ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.15.0", path = "../ff-core", default-features = false, features = ["core"] }
 ff-observability = { workspace = true }
 # v0.12 PR-7a transitional: `Engine::start_*` accepts
 # `Arc<dyn EngineBackend>` on the boundary but scanners still speak
@@ -38,7 +38,7 @@ ff-observability = { workspace = true }
 # silently defeat the explicit `ff-core` anchor on line 26
 # (`default-features = false, features = ["core"]`) and re-expose
 # streaming-gated trait methods on `ff-engine`.
-ff-backend-valkey = { version = "0.14.1", path = "../ff-backend-valkey", default-features = false }
+ff-backend-valkey = { version = "0.15.0", path = "../ff-backend-valkey", default-features = false }
 ferriskey = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ff-scheduler/Cargo.toml
+++ b/crates/ff-scheduler/Cargo.toml
@@ -16,7 +16,7 @@ description = "FlowFabric claim-grant scheduler"
 observability = ["ff-observability/enabled"]
 
 [dependencies]
-ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.15.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-scheduler's claim dispatcher uses FCALL helpers from
 # ff-script, so explicitly enable `valkey-client`.
 ff-script = { workspace = true, features = ["valkey-client"] }

--- a/crates/ff-script/Cargo.toml
+++ b/crates/ff-script/Cargo.toml
@@ -49,7 +49,7 @@ valkey-client = ["dep:ferriskey"]
 # always-on surface (`contracts`, `keys`, `types`, `error`, `state`,
 # `partition`, `engine_error`); `core` is requested explicitly so the
 # dep stays correct if gates migrate onto those modules.
-ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.15.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: optional so `--no-default-features` drops the transport edge.
 ferriskey = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ff-sdk/Cargo.toml
+++ b/crates/ff-sdk/Cargo.toml
@@ -84,7 +84,7 @@ layer-circuit-breaker = ["dep:async-trait"]
 # future tranches will add trait methods + types requiring the Valkey
 # backend). The `valkey-default` feature re-enables them below for the
 # default build.
-ff-core = { version = "0.14.1", path = "../ff-core", default-features = false, features = ["core"] }
+ff-core = { version = "0.15.0", path = "../ff-core", default-features = false, features = ["core"] }
 # Issue #171: ff-script's defaults are empty — the `valkey-client`
 # feature (which owns the `ferriskey` dep edge) is activated below by
 # the `valkey-default` feature, NOT here. This keeps
@@ -102,7 +102,7 @@ ferriskey = { workspace = true, optional = true }
 # RFC-023 Phase 1a: optional SQLite backend edge, activated by the
 # `sqlite` feature above. Off by default so Valkey consumers pay no
 # sqlx compile cost.
-ff-backend-sqlite = { version = "0.14.1", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
+ff-backend-sqlite = { version = "0.15.0", path = "../ff-backend-sqlite", optional = true, default-features = false, features = ["core"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/crates/flowfabric/Cargo.toml
+++ b/crates/flowfabric/Cargo.toml
@@ -53,7 +53,7 @@ ff-core = { workspace = true }
 # dep's default-features at the consumer site. Pinning version +
 # path here matches the workspace.dependencies entry; `cargo release`
 # keeps both in lockstep via `shared-version = true`.
-ff-sdk = { version = "0.14.1", path = "../ff-sdk", default-features = false }
+ff-sdk = { version = "0.15.0", path = "../ff-sdk", default-features = false }
 
 ff-backend-valkey = { workspace = true, optional = true }
 ff-backend-postgres = { workspace = true, optional = true }

--- a/ferriskey/Cargo.toml
+++ b/ferriskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriskey"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["FlowFabric Contributors"]


### PR DESCRIPTION
## Summary

Phase 1 of the FF #511 plan — add the one scheduler primitive that's still a raw Valkey FCALL in `ff_scheduler::Scheduler`, so Phase 2 can trait-route the scheduler.

### What lands

- `EngineBackend::release_admission(args) -> ReleaseAdmissionResult` gated `core`.
- `ReleaseAdmissionArgs` extended with `quota_policy_id` (non-breaking — was unused, is `#[non_exhaustive]`). Now `{ quota_policy_id, execution_id }`.
- Valkey body wraps the existing `ff_release_admission` FCALL via the existing typed wrapper.
- PG body: `DELETE ff_quota_admitted` + `UPDATE ff_quota_policy SET active_concurrency = GREATEST(c - 1, 0)` in one tx. Idempotent on replay.
- SQLite body: mirrors PG with `MAX(c - 1, 0)` + flat `partition_key = 0` per RFC-023 §4.1 A3.
- `Supports.release_admission` flag, `true` on all three in-tree backends.

### Regression test

`crates/ff-backend-postgres/tests/release_admission.rs` exercises the idempotency contract against a live PG:
- First release → `Released`, concurrency decremented, admitted row gone.
- Second release → `Released` (idempotent), concurrency clamped at 0 (no underflow).

Local PG 16.13: PASS.

### Next

Phase 2 (Scheduler trait migration) can start — now that the last missing primitive exists, `Scheduler::release_admission` can be rewritten against `Arc<dyn EngineBackend>`. Still under issue #511.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo run -p non-exhaustive-lint` clean
- [x] `cargo test -p ff-core --all-features` — 243 passed
- [x] New PG regression test PASS on 16.13
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)