### PR TITLE
feat(#511) Phase 2a: read_quota_policy_limits trait method + 3 backend bodies

### DIFF
--- a/crates/ff-backend-postgres/src/lib.rs
+++ b/crates/ff-backend-postgres/src/lib.rs
@@ -1248,6 +1248,20 @@ impl EngineBackend for PostgresBackend {
         crate::typed_ops::release_admission(&self.pool, &self.partition_config, args).await
     }
 
+    #[cfg(feature = "core")]
+    #[tracing::instrument(name = "pg.read_quota_policy_limits", skip_all)]
+    async fn read_quota_policy_limits(
+        &self,
+        quota_policy_id: &ff_core::types::QuotaPolicyId,
+    ) -> Result<Option<ff_core::contracts::QuotaPolicyLimits>, EngineError> {
+        crate::typed_ops::read_quota_policy_limits(
+            &self.pool,
+            &self.partition_config,
+            quota_policy_id,
+        )
+        .await
+    }
+
     // ── HMAC secret rotation (v0.7 migration-master Q4) ──
     //
     // Wave 4 replaces this stub with a single INSERT into

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -1925,6 +1925,42 @@ pub(crate) async fn release_admission(
     Ok(ff_core::contracts::ReleaseAdmissionResult::Released)
 }
 
+/// PG body for [`ff_core::engine_backend::EngineBackend::read_quota_policy_limits`].
+///
+/// Returns `None` if the policy row is absent. PG schema has no
+/// `jitter_ms` column; the caller gets 0 (disabled jitter), which
+/// matches the scheduler's documented zero-default. FF #511 Phase 2a.
+pub(crate) async fn read_quota_policy_limits(
+    pool: &PgPool,
+    partition_config: &PartitionConfig,
+    quota_policy_id: &QuotaPolicyId,
+) -> Result<Option<ff_core::contracts::QuotaPolicyLimits>, EngineError> {
+    let part = quota_partition(quota_policy_id, partition_config).index as i16;
+    let row = sqlx::query(
+        "SELECT max_requests_per_window, requests_per_window_seconds, active_concurrency_cap \
+           FROM ff_quota_policy \
+          WHERE partition_key = $1 AND quota_policy_id = $2",
+    )
+    .bind(part)
+    .bind(quota_policy_id.to_string())
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else { return Ok(None); };
+
+    let max_requests_per_window: i64 = row.try_get("max_requests_per_window").map_err(map_sqlx_error)?;
+    let requests_per_window_seconds: i64 = row.try_get("requests_per_window_seconds").map_err(map_sqlx_error)?;
+    let active_concurrency_cap: i64 = row.try_get("active_concurrency_cap").map_err(map_sqlx_error)?;
+
+    Ok(Some(ff_core::contracts::QuotaPolicyLimits::new(
+        u64::try_from(max_requests_per_window.max(0)).unwrap_or(0),
+        u64::try_from(requests_per_window_seconds.max(0)).unwrap_or(0),
+        u64::try_from(active_concurrency_cap.max(0)).unwrap_or(0),
+        0, // PG has no jitter_ms column; scheduler treats 0 as disabled.
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     // Integration tests live in `tests/typed_renew_lease.rs` +

--- a/crates/ff-backend-postgres/src/typed_ops.rs
+++ b/crates/ff-backend-postgres/src/typed_ops.rs
@@ -1949,14 +1949,32 @@ pub(crate) async fn read_quota_policy_limits(
 
     let Some(row) = row else { return Ok(None); };
 
-    let max_requests_per_window: i64 = row.try_get("max_requests_per_window").map_err(map_sqlx_error)?;
-    let requests_per_window_seconds: i64 = row.try_get("requests_per_window_seconds").map_err(map_sqlx_error)?;
-    let active_concurrency_cap: i64 = row.try_get("active_concurrency_cap").map_err(map_sqlx_error)?;
+    let max_requests_per_window: i64 =
+        row.try_get("max_requests_per_window").map_err(map_sqlx_error)?;
+    let requests_per_window_seconds: i64 = row
+        .try_get("requests_per_window_seconds")
+        .map_err(map_sqlx_error)?;
+    let active_concurrency_cap: i64 =
+        row.try_get("active_concurrency_cap").map_err(map_sqlx_error)?;
+
+    // Stored as non-negative bigint per 0012_quota_policy.sql; a
+    // negative value here means the row was corrupted out-of-band.
+    // Surface as Corruption so callers don't silently degrade to
+    // "unlimited".
+    let to_u64 = |field: &str, v: i64| -> Result<u64, EngineError> {
+        u64::try_from(v).map_err(|_| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!(
+                "read_quota_policy_limits: quota_policy={} field={} value={} (negative)",
+                quota_policy_id, field, v
+            ),
+        })
+    };
 
     Ok(Some(ff_core::contracts::QuotaPolicyLimits::new(
-        u64::try_from(max_requests_per_window.max(0)).unwrap_or(0),
-        u64::try_from(requests_per_window_seconds.max(0)).unwrap_or(0),
-        u64::try_from(active_concurrency_cap.max(0)).unwrap_or(0),
+        to_u64("max_requests_per_window", max_requests_per_window)?,
+        to_u64("requests_per_window_seconds", requests_per_window_seconds)?,
+        to_u64("active_concurrency_cap", active_concurrency_cap)?,
         0, // PG has no jitter_ms column; scheduler treats 0 as disabled.
     )))
 }

--- a/crates/ff-backend-postgres/tests/read_quota_policy_limits.rs
+++ b/crates/ff-backend-postgres/tests/read_quota_policy_limits.rs
@@ -1,0 +1,76 @@
+//! FF #511 Phase 2a — PG `read_quota_policy_limits` trait-method
+//! regression test.
+//!
+//! ```bash
+//! FF_PG_TEST_URL=postgres://postgres:postgres@localhost:5432/ff_511a \
+//!   cargo test -p ff-backend-postgres --test read_quota_policy_limits -- --ignored
+//! ```
+
+use sqlx::postgres::PgPoolOptions;
+
+use ff_backend_postgres::PostgresBackend;
+use ff_core::engine_backend::EngineBackend;
+use ff_core::partition::PartitionConfig;
+use ff_core::types::QuotaPolicyId;
+
+#[tokio::test]
+#[ignore = "requires a live Postgres; set FF_PG_TEST_URL"]
+async fn read_quota_policy_limits_roundtrip() {
+    let url = std::env::var("FF_PG_TEST_URL").expect("FF_PG_TEST_URL");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("connect");
+    ff_backend_postgres::apply_migrations(&pool)
+        .await
+        .expect("apply_migrations");
+
+    let config = PartitionConfig::default();
+    let backend = PostgresBackend::from_pool(pool.clone(), config.clone());
+
+    let qid = QuotaPolicyId::new();
+    let part = ff_core::partition::quota_partition(&qid, &config).index as i16;
+
+    // Absent policy → None.
+    let absent = backend
+        .read_quota_policy_limits(&qid)
+        .await
+        .expect("read absent");
+    assert!(absent.is_none(), "absent policy must read as None");
+
+    // Seed a policy.
+    sqlx::query(
+        "INSERT INTO ff_quota_policy \
+             (partition_key, quota_policy_id, \
+              requests_per_window_seconds, max_requests_per_window, \
+              active_concurrency_cap, active_concurrency, \
+              created_at_ms, updated_at_ms) \
+         VALUES ($1, $2, 60, 100, 5, 0, 1_000_000, 1_000_000)",
+    )
+    .bind(part)
+    .bind(qid.to_string())
+    .execute(&pool)
+    .await
+    .expect("seed policy");
+
+    let limits = backend
+        .read_quota_policy_limits(&qid)
+        .await
+        .expect("read present")
+        .expect("present policy");
+
+    assert_eq!(limits.max_requests_per_window, 100);
+    assert_eq!(limits.requests_per_window_seconds, 60);
+    assert_eq!(limits.active_concurrency_cap, 5);
+    assert_eq!(limits.jitter_ms, 0, "PG schema has no jitter_ms; must default to 0");
+    assert!(!limits.is_unlimited());
+
+    // Cleanup.
+    sqlx::query("DELETE FROM ff_quota_policy WHERE partition_key = $1 AND quota_policy_id = $2")
+        .bind(part)
+        .bind(qid.to_string())
+        .execute(&pool)
+        .await
+        .ok();
+}

--- a/crates/ff-backend-sqlite/src/backend.rs
+++ b/crates/ff-backend-sqlite/src/backend.rs
@@ -2318,6 +2318,8 @@ fn sqlite_supports_base() -> Supports {
 
     // ── FF #511 Phase 1 scheduler primitive ──
     s.release_admission = true;
+    // ── FF #511 Phase 2a scheduler primitive ──
+    s.read_quota_policy_limits = true;
 
     // ── Stay `false` (see struct-level rustdoc above) ──
     // s.claim_for_worker — RFC-023 §5 non-goal
@@ -3092,6 +3094,15 @@ impl EngineBackend for SqliteBackend {
     ) -> Result<ff_core::contracts::ReleaseAdmissionResult, EngineError> {
         let pool = &self.inner.pool;
         retry_serializable(|| crate::typed_ops::release_admission(pool, args.clone())).await
+    }
+
+    #[cfg(feature = "core")]
+    async fn read_quota_policy_limits(
+        &self,
+        quota_policy_id: &ff_core::types::QuotaPolicyId,
+    ) -> Result<Option<ff_core::contracts::QuotaPolicyLimits>, EngineError> {
+        let pool = &self.inner.pool;
+        crate::typed_ops::read_quota_policy_limits(pool, quota_policy_id).await
     }
 
     #[cfg(feature = "core")]

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -2221,3 +2221,37 @@ pub(crate) async fn release_admission(
     commit_or_rollback(&mut conn).await?;
     Ok(ff_core::contracts::ReleaseAdmissionResult::Released)
 }
+
+/// SQLite body for [`ff_core::engine_backend::EngineBackend::read_quota_policy_limits`].
+///
+/// Mirror of the PG body (same schema columns, no `jitter_ms`).
+/// FF #511 Phase 2a.
+pub(crate) async fn read_quota_policy_limits(
+    pool: &SqlitePool,
+    quota_policy_id: &QuotaPolicyId,
+) -> Result<Option<ff_core::contracts::QuotaPolicyLimits>, EngineError> {
+    let part: i64 = 0;
+    let row = sqlx::query(
+        "SELECT max_requests_per_window, requests_per_window_seconds, active_concurrency_cap \
+           FROM ff_quota_policy \
+          WHERE partition_key = ?1 AND quota_policy_id = ?2",
+    )
+    .bind(part)
+    .bind(quota_policy_id.to_string())
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    let Some(row) = row else { return Ok(None); };
+
+    let max_requests_per_window: i64 = row.try_get("max_requests_per_window").map_err(map_sqlx_error)?;
+    let requests_per_window_seconds: i64 = row.try_get("requests_per_window_seconds").map_err(map_sqlx_error)?;
+    let active_concurrency_cap: i64 = row.try_get("active_concurrency_cap").map_err(map_sqlx_error)?;
+
+    Ok(Some(ff_core::contracts::QuotaPolicyLimits::new(
+        u64::try_from(max_requests_per_window.max(0)).unwrap_or(0),
+        u64::try_from(requests_per_window_seconds.max(0)).unwrap_or(0),
+        u64::try_from(active_concurrency_cap.max(0)).unwrap_or(0),
+        0,
+    )))
+}

--- a/crates/ff-backend-sqlite/src/typed_ops.rs
+++ b/crates/ff-backend-sqlite/src/typed_ops.rs
@@ -2244,14 +2244,28 @@ pub(crate) async fn read_quota_policy_limits(
 
     let Some(row) = row else { return Ok(None); };
 
-    let max_requests_per_window: i64 = row.try_get("max_requests_per_window").map_err(map_sqlx_error)?;
-    let requests_per_window_seconds: i64 = row.try_get("requests_per_window_seconds").map_err(map_sqlx_error)?;
-    let active_concurrency_cap: i64 = row.try_get("active_concurrency_cap").map_err(map_sqlx_error)?;
+    let max_requests_per_window: i64 =
+        row.try_get("max_requests_per_window").map_err(map_sqlx_error)?;
+    let requests_per_window_seconds: i64 = row
+        .try_get("requests_per_window_seconds")
+        .map_err(map_sqlx_error)?;
+    let active_concurrency_cap: i64 =
+        row.try_get("active_concurrency_cap").map_err(map_sqlx_error)?;
+
+    let to_u64 = |field: &str, v: i64| -> Result<u64, EngineError> {
+        u64::try_from(v).map_err(|_| EngineError::Validation {
+            kind: ValidationKind::Corruption,
+            detail: format!(
+                "read_quota_policy_limits: quota_policy={} field={} value={} (negative)",
+                quota_policy_id, field, v
+            ),
+        })
+    };
 
     Ok(Some(ff_core::contracts::QuotaPolicyLimits::new(
-        u64::try_from(max_requests_per_window.max(0)).unwrap_or(0),
-        u64::try_from(requests_per_window_seconds.max(0)).unwrap_or(0),
-        u64::try_from(active_concurrency_cap.max(0)).unwrap_or(0),
+        to_u64("max_requests_per_window", max_requests_per_window)?,
+        to_u64("requests_per_window_seconds", requests_per_window_seconds)?,
+        to_u64("active_concurrency_cap", active_concurrency_cap)?,
         0,
     )))
 }

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -6127,18 +6127,29 @@ impl EngineBackend for ValkeyBackend {
             return Ok(None);
         }
 
-        let parse_u64 = |i: usize, default: u64| -> u64 {
-            fields
-                .get(i)
-                .and_then(|f| f.as_deref())
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(default)
+        // Fields written by `ff_create_quota_policy` Lua; any that's
+        // present-but-unparseable means the hash was corrupted
+        // out-of-band. Absent fields are treated as 0 (disabled)
+        // because the policy hash historically didn't carry every
+        // field — the scheduler's is_unlimited() short-circuit
+        // handles the all-zero case cleanly.
+        let parse_field = |i: usize, name: &str| -> Result<u64, EngineError> {
+            match fields.get(i).and_then(|f| f.as_deref()) {
+                None => Ok(0),
+                Some(s) => s.parse::<u64>().map_err(|e| EngineError::Validation {
+                    kind: ValidationKind::Corruption,
+                    detail: format!(
+                        "read_quota_policy_limits: quota_policy={} field={} value={:?}: {}",
+                        quota_policy_id, name, s, e
+                    ),
+                }),
+            }
         };
         Ok(Some(ff_core::contracts::QuotaPolicyLimits::new(
-            parse_u64(0, 0),
-            parse_u64(1, 60),
-            parse_u64(2, 0),
-            parse_u64(3, 0),
+            parse_field(0, "max_requests_per_window")?,
+            parse_field(1, "requests_per_window_seconds")?,
+            parse_field(2, "active_concurrency_cap")?,
+            parse_field(3, "jitter_ms")?,
         )))
     }
 

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -177,6 +177,7 @@ fn valkey_supports_base() -> ff_core::capability::Supports {
     s.list_expired_leases = true;
     s.list_workers = true;
     s.release_admission = true;
+    s.read_quota_policy_limits = true;
     s.prepare = true;
     s.subscribe_lease_history = true;
     s.subscribe_completion = true;
@@ -6090,6 +6091,55 @@ impl EngineBackend for ValkeyBackend {
                     "release_budget: FCALL ff_release_budget",
                 )
             })
+    }
+
+    /// FF #511 Phase 2a — typed snapshot of the admission fields on a
+    /// quota policy. Replaces the Valkey-shaped 4-HGET pattern
+    /// `ff_scheduler` used pre-#511.
+    async fn read_quota_policy_limits(
+        &self,
+        quota_policy_id: &ff_core::types::QuotaPolicyId,
+    ) -> Result<Option<ff_core::contracts::QuotaPolicyLimits>, EngineError> {
+        use ff_core::keys::QuotaKeyContext;
+        use ff_core::partition::quota_partition;
+        let partition = quota_partition(quota_policy_id, &self.partition_config);
+        let ctx = QuotaKeyContext::new(&partition, quota_policy_id);
+        let def_key = ctx.definition();
+
+        // HMGET the 4 fields in one round-trip. Missing key (no policy
+        // row) → vec of `None`s; caller-visible as `Ok(None)`.
+        let fields: Vec<Option<String>> = self
+            .client
+            .cmd("HMGET")
+            .arg(def_key.as_str())
+            .arg("max_requests_per_window")
+            .arg("requests_per_window_seconds")
+            .arg("active_concurrency_cap")
+            .arg("jitter_ms")
+            .execute()
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "read_quota_policy_limits: HMGET",
+            ))?;
+
+        if fields.iter().all(Option::is_none) {
+            return Ok(None);
+        }
+
+        let parse_u64 = |i: usize, default: u64| -> u64 {
+            fields
+                .get(i)
+                .and_then(|f| f.as_deref())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(default)
+        };
+        Ok(Some(ff_core::contracts::QuotaPolicyLimits::new(
+            parse_u64(0, 0),
+            parse_u64(1, 60),
+            parse_u64(2, 0),
+            parse_u64(3, 0),
+        )))
     }
 
     /// FF #511 Phase 1 — idempotent quota-admission slot release.

--- a/crates/ff-core/src/capability.rs
+++ b/crates/ff-core/src/capability.rs
@@ -161,6 +161,10 @@ pub struct Supports {
     /// used by `ff_scheduler` on the claim-fail rollback path. `true`
     /// on every in-tree backend post-FF-#511.
     pub release_admission: bool,
+    /// `read_quota_policy_limits` — typed snapshot of the admission
+    /// fields on a quota policy (FF #511 Phase 2a). Replaces the
+    /// Valkey-shaped 4-HGET pattern.
+    pub read_quota_policy_limits: bool,
     // Add new fields here, preserving parity-matrix order.
 }
 
@@ -211,6 +215,7 @@ impl Supports {
             list_expired_leases: false,
             list_workers: false,
             release_admission: false,
+            read_quota_policy_limits: false,
         }
     }
 }

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2070,6 +2070,47 @@ pub enum ReleaseAdmissionResult {
     Released,
 }
 
+// ─── read_quota_policy_limits (FF #511 Phase 2a) ───
+
+/// Typed snapshot of the admission-relevant fields on a quota policy.
+/// Returned by [`crate::engine_backend::EngineBackend::read_quota_policy_limits`]
+/// so the scheduler can make admission decisions without reaching
+/// directly at Valkey-shaped HGETs on `ff:quota:{K}:def`.
+///
+/// Fields match the Lua contract for `ff_check_admission_and_record`.
+/// Zero values are the well-defined "no limit" signal (the scheduler
+/// skips admission when both `max_requests_per_window` and
+/// `active_concurrency_cap` are zero).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct QuotaPolicyLimits {
+    pub max_requests_per_window: u64,
+    pub requests_per_window_seconds: u64,
+    pub active_concurrency_cap: u64,
+    pub jitter_ms: u64,
+}
+
+impl QuotaPolicyLimits {
+    pub fn new(
+        max_requests_per_window: u64,
+        requests_per_window_seconds: u64,
+        active_concurrency_cap: u64,
+        jitter_ms: u64,
+    ) -> Self {
+        Self {
+            max_requests_per_window,
+            requests_per_window_seconds,
+            active_concurrency_cap,
+            jitter_ms,
+        }
+    }
+
+    /// Policy declares no admission limits — caller skips admission.
+    pub fn is_unlimited(&self) -> bool {
+        self.max_requests_per_window == 0 && self.active_concurrency_cap == 0
+    }
+}
+
 // ─── block_execution_for_admission ───
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -80,8 +80,8 @@ use crate::contracts::{
     EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult, ExecutionInfo,
     FailExecutionArgs, FailExecutionResult,
     IssueClaimGrantArgs, IssueClaimGrantOutcome, IssueGrantAndClaimArgs,
-    RecordSpendArgs, ReleaseAdmissionArgs, ReleaseAdmissionResult, ReleaseBudgetArgs,
-    ScanEligibleArgs,
+    QuotaPolicyLimits, RecordSpendArgs, ReleaseAdmissionArgs, ReleaseAdmissionResult,
+    ReleaseBudgetArgs, ScanEligibleArgs,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs,
     ListPendingWaitpointsResult, ListSuspendedPage, RenewLeaseArgs, RenewLeaseResult,
     ReplayExecutionArgs, ReplayExecutionResult,
@@ -1687,6 +1687,22 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<CheckAdmissionResult, EngineError> {
         Err(EngineError::Unavailable {
             op: "check_admission",
+        })
+    }
+
+    /// Read the admission-relevant fields of a quota policy
+    /// (rate limit, window, concurrency cap, jitter). Replaces the
+    /// Valkey-shaped 4-HGET pattern on `ff:quota:{K}:def` that
+    /// `ff_scheduler` used pre-FF #511. Returns `None` when the
+    /// policy row is absent; absence is a well-defined "no admission
+    /// configured" signal, not an error.
+    #[cfg(feature = "core")]
+    async fn read_quota_policy_limits(
+        &self,
+        _quota_policy_id: &crate::types::QuotaPolicyId,
+    ) -> Result<Option<QuotaPolicyLimits>, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "read_quota_policy_limits",
         })
     }
 


### PR DESCRIPTION
## Summary

Phase 2a of FF #511. Adds `EngineBackend::read_quota_policy_limits` — typed snapshot of the 4 admission fields on a quota policy (`max_requests_per_window`, `requests_per_window_seconds`, `active_concurrency_cap`, `jitter_ms`). Replaces the Valkey-shaped 4-HGET pattern `ff_scheduler` used pre-#511.

### Landed

- `ff_core::contracts::QuotaPolicyLimits` (`#[non_exhaustive]`, `new()` ctor, `is_unlimited()` helper).
- Trait method returns `Option<limits>` — `None` when the policy row is absent.
- Valkey: single HMGET round-trip on `ff:quota:{q:K}:<id>`.
- PG: SELECT from `ff_quota_policy`. Schema has no `jitter_ms` column; defaults to 0 (scheduler treats as disabled).
- SQLite: mirror of PG.
- `Supports.read_quota_policy_limits` flag, `true` on all three backends.

### Regression test

`tests/read_quota_policy_limits.rs` — absent → `None`, present → populated limits. Local PG 16.13: PASS.

### Next

Phase 2b: `block_execution_for_admission` trait method (budget / quota / capability reason codes). Then Phase 2c: Scheduler refactor.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo run -p non-exhaustive-lint` clean
- [x] `cargo test -p ff-core --all-features` — 243 passed
- [x] New PG regression test PASS on 16.13
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)