### PR TITLE
feat(#511) Phase 2c: Scheduler trait-routes 6 ferriskey call-sites

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -480,6 +480,41 @@ impl ValkeyBackend {
         self.scheduler.as_ref()
     }
 
+    /// FF #511 Phase 2c: install a scheduler that holds a
+    /// `Weak<dyn EngineBackend>` into this backend, via `Arc::new_cyclic`.
+    ///
+    /// Takes the already-constructed (but scheduler-less) `Arc<Self>`
+    /// and a closure that produces the scheduler given the final
+    /// backend's `Weak<dyn EngineBackend>`. Returns a new `Arc<Self>`
+    /// with the scheduler installed. Needed because
+    /// [`Self::with_scheduler`] uses `Arc::get_mut`, which fails once
+    /// a `Weak<dyn EngineBackend>` has been minted against the
+    /// backend Arc — exactly the state after constructing the
+    /// scheduler externally.
+    pub fn install_scheduler_cyclic(
+        existing: Arc<Self>,
+        build_scheduler: impl FnOnce(std::sync::Weak<dyn EngineBackend>) -> Arc<ff_scheduler::Scheduler>,
+    ) -> Result<Arc<Self>, &'static str> {
+        // Unpack the fields from the existing Arc. `try_unwrap`
+        // succeeds only if the Arc is unique (which it is at this
+        // boot-path moment).
+        let inner = Arc::try_unwrap(existing).map_err(|_| {
+            "install_scheduler_cyclic: backend Arc has other strong refs; cannot install scheduler"
+        })?;
+
+        // `Arc::new_cyclic` gives `build_scheduler` the Weak pointer
+        // to the final Arc before Arc construction completes.
+        let new_arc = Arc::new_cyclic(move |weak_self: &std::sync::Weak<Self>| {
+            let weak_trait: std::sync::Weak<dyn EngineBackend> = weak_self.clone();
+            let scheduler = build_scheduler(weak_trait);
+            Self {
+                scheduler: Some(scheduler),
+                ..inner
+            }
+        });
+        Ok(new_arc)
+    }
+
     /// Build a `ValkeyBackend` with an embedded scheduler instance, so
     /// [`EngineBackend::claim_for_worker`] works from direct-`Arc<dyn
     /// EngineBackend>` consumers (i.e. outside of `ff-server`'s boot

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -521,24 +521,37 @@ impl ValkeyBackend {
             }
             Err(e) => return Err(e),
         };
-        let scheduler = Arc::new(ff_scheduler::Scheduler::with_metrics(
-            client.clone(),
-            partition_config,
-            metrics.clone(),
-        ));
-        let backend = Arc::new(Self {
-            client,
-            partition_config,
-            subscriber_connection: Some(v),
-            metrics: Some(metrics),
-            stream_semaphore: Arc::new(tokio::sync::Semaphore::new(
-                DEFAULT_STREAM_SEMAPHORE_PERMITS as usize,
-            )),
-            stream_semaphore_max: DEFAULT_STREAM_SEMAPHORE_PERMITS,
-            admin_rotate_fanout_concurrency: DEFAULT_ADMIN_ROTATE_FANOUT_CONCURRENCY,
-            scheduler: Some(scheduler),
+        // FF #511 Phase 2c: Scheduler holds a `Weak<dyn EngineBackend>`
+        // to avoid a cycle with ValkeyBackend.scheduler. Use
+        // `Arc::new_cyclic` so the scheduler can see the final backend
+        // Arc at construction time.
+        let client_for_sched = client.clone();
+        let partition_config_clone = partition_config;
+        let metrics_clone = metrics.clone();
+        let v_clone = v.clone();
+        let backend_arc = Arc::new_cyclic(move |weak_self: &std::sync::Weak<Self>| {
+            let weak_trait: std::sync::Weak<dyn EngineBackend> = weak_self.clone();
+            let scheduler = Arc::new(ff_scheduler::Scheduler::with_metrics(
+                client_for_sched,
+                weak_trait,
+                partition_config_clone,
+                metrics_clone.clone(),
+            ));
+            Self {
+                client,
+                partition_config,
+                subscriber_connection: Some(v_clone),
+                metrics: Some(metrics_clone),
+                stream_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                    DEFAULT_STREAM_SEMAPHORE_PERMITS as usize,
+                )),
+                stream_semaphore_max: DEFAULT_STREAM_SEMAPHORE_PERMITS,
+                admin_rotate_fanout_concurrency: DEFAULT_ADMIN_ROTATE_FANOUT_CONCURRENCY,
+                scheduler: Some(scheduler),
+            }
         });
-        Ok(backend as Arc<dyn EngineBackend>)
+        let _ = v; // original v was consumed by v_clone above via `move`
+        Ok(backend_arc as Arc<dyn EngineBackend>)
     }
 
     /// RFC-017 Wave 8 Stage D (§4 row 12): run the Valkey-specific
@@ -8045,6 +8058,12 @@ impl EngineBackend for ValkeyBackend {
                 ),
                 ff_scheduler::SchedulerError::ValkeyContext { source, context } => {
                     ff_core::engine_error::backend_context(transport_fk(source), context)
+                }
+                ff_scheduler::SchedulerError::EngineContext { source, context } => {
+                    // Already a typed EngineError; just preserve the
+                    // scheduler-site context via backend_context's
+                    // prefix behaviour.
+                    ff_core::engine_error::backend_context(source, context)
                 }
                 ff_scheduler::SchedulerError::Config(msg) => EngineError::Validation {
                     kind: ff_core::engine_error::ValidationKind::InvalidInput,

--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -8060,10 +8060,10 @@ impl EngineBackend for ValkeyBackend {
                     ff_core::engine_error::backend_context(transport_fk(source), context)
                 }
                 ff_scheduler::SchedulerError::EngineContext { source, context } => {
-                    // Already a typed EngineError; just preserve the
-                    // scheduler-site context via backend_context's
-                    // prefix behaviour.
-                    ff_core::engine_error::backend_context(source, context)
+                    // Already a typed EngineError (boxed to keep
+                    // SchedulerError's Result small). Unbox + prefix
+                    // with scheduler-site context.
+                    ff_core::engine_error::backend_context(*source, context)
                 }
                 ff_scheduler::SchedulerError::Config(msg) => EngineError::Validation {
                     kind: ff_core::engine_error::ValidationKind::InvalidInput,

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -563,6 +563,14 @@ impl Scheduler {
                 worker_caps_csv.len()
             )));
         }
+        // FF #511 Phase 2c: build the caps BTreeSet once per claim call
+        // (worker_caps_csv is loop-invariant). Cloned into each
+        // IssueClaimGrantArgs inside the partition loop.
+        let worker_caps_set: std::collections::BTreeSet<String> = worker_caps_csv
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
 
         // ── Bounded scan with rotation cursor ──
         // Prior impl walked all `num_partitions` partitions on every call,
@@ -758,7 +766,7 @@ impl Scheduler {
 
             // ── Quota pre-check (cross-partition FCALL on {q:K}) ──
             let quota_admission = self
-                .check_quota(&exec_ctx, &core_key, &eid_s, now_ms)
+                .check_quota(&exec_ctx, &core_key, &eid, now_ms)
                 .await?;
             match &quota_admission {
                 QuotaCheckOutcome::Blocked(block_detail) => {
@@ -776,18 +784,13 @@ impl Scheduler {
             let _ = &core_key; // kept for any future direct read; unused post-trait-route
 
             // FF #511 Phase 2c: route through `backend.issue_claim_grant`.
-            let caps_set: std::collections::BTreeSet<String> = worker_caps_csv
-                .split(',')
-                .filter(|s| !s.is_empty())
-                .map(str::to_owned)
-                .collect();
             let args = ff_core::contracts::IssueClaimGrantArgs::new(
                 eid.clone(),
                 lane.clone(),
                 worker_id.clone(),
                 worker_instance_id.clone(),
                 partition,
-                caps_set,
+                worker_caps_set.clone(),
                 grant_ttl_ms,
                 ff_core::types::TimestampMs(now_ms as i64),
             );
@@ -796,12 +799,48 @@ impl Scheduler {
             let outcome = match backend.issue_claim_grant(args).await {
                 Ok(o) => o,
                 Err(e) => {
-                    tracing::warn!(
-                        partition = p_idx,
-                        execution_id = eid_s.as_str(),
-                        error = %e,
-                        "scheduler: issue_claim_grant transport error, trying next"
+                    // Classify the error. EngineError::Validation with
+                    // CapabilityMismatch is the Lua-race variant — it
+                    // means required_capabilities mutated between our
+                    // HGET pre-check and the trait body's re-check.
+                    // Must fail-closed by blocking (old behaviour);
+                    // otherwise the next tick re-picks the same
+                    // candidate in a tight loop.
+                    //
+                    // Any other error (transport, other validation,
+                    // logical rejects) is best-effort: log + rollback
+                    // admission + try next partition, matching the
+                    // pre-refactor path.
+                    let is_capability_mismatch = matches!(
+                        &e,
+                        ff_core::engine_error::EngineError::Validation {
+                            kind: ff_core::engine_error::ValidationKind::CapabilityMismatch,
+                            ..
+                        }
                     );
+                    if is_capability_mismatch {
+                        tracing::info!(
+                            partition = p_idx,
+                            execution_id = eid_s.as_str(),
+                            worker_id = %worker_id,
+                            worker_caps_hash = worker_caps_hash.as_str(),
+                            error = %e,
+                            "scheduler: capability mismatch via trait (race), blocking execution"
+                        );
+                        self.block_candidate(
+                            &partition, &idx, lane, &eid, &eligible_key,
+                            "waiting_for_capable_worker",
+                            "no connected worker satisfies required_capabilities",
+                            now_ms,
+                        ).await;
+                    } else {
+                        tracing::warn!(
+                            partition = p_idx,
+                            execution_id = eid_s.as_str(),
+                            error = %e,
+                            "scheduler: issue_claim_grant rejected, trying next"
+                        );
+                    }
                     if let QuotaCheckOutcome::Admitted { tag, quota_id, eid } = &quota_admission {
                         self.release_admission(tag, quota_id, eid).await;
                     }
@@ -809,11 +848,9 @@ impl Scheduler {
                 }
             };
 
-            // Trait's `IssueClaimGrantOutcome` only surfaces `Granted`
-            // as success today; Lua-level rejects (capability mismatch,
-            // grant_already_exists, etc.) come back on the outer `Err`
-            // branch above. Pattern-match with a wildcard to stay
-            // #[non_exhaustive]-robust without dropping into dead-code.
+            // `IssueClaimGrantOutcome` only surfaces `Granted` as
+            // success today; keep the wildcard to stay non_exhaustive-
+            // robust.
             let _ = outcome;
 
             partitions_hit += 1;
@@ -898,9 +935,11 @@ impl Scheduler {
         &self,
         _exec_ctx: &ExecKeyContext,
         core_key: &str,
-        eid_s: &str,
+        eid: &ExecutionId,
         now_ms: u64,
     ) -> Result<QuotaCheckOutcome, SchedulerError> {
+        let eid_s = eid.to_string();
+        let eid_s = eid_s.as_str();
         // Read quota_policy_id from exec_core
         let quota_id_str: Option<String> = self
             .client
@@ -927,16 +966,15 @@ impl Scheduler {
             Err(_) => "{q:0}".to_owned(), // fallback for non-UUID test IDs
         };
 
-        let quota_def_key = format!("ff:quota:{}:{}", tag, quota_id_str);
-        let window_key = format!("ff:quota:{}:{}:window:requests_per_window", tag, quota_id_str);
-        let concurrency_key = format!("ff:quota:{}:{}:concurrency", tag, quota_id_str);
-        let admitted_key = format!("ff:quota:{}:{}:admitted:{}", tag, quota_id_str, eid_s);
-        let admitted_set_key = format!("ff:quota:{}:{}:admitted_set", tag, quota_id_str);
-
-        // FF #511 Phase 2c: route the policy-limits read through the
-        // trait. Parse failure on `quota_id_str` → treat as no-quota
-        // (matches pre-#511 behaviour where invalid IDs fell through
-        // to the unlimited branch).
+        // FF #511 Phase 2c: Valkey-shaped quota_def_key / window_key /
+        // concurrency_key / admitted_key / admitted_set_key used to
+        // be built here for the pre-#511 FCALL KEYS array. The trait
+        // primitives now compute their own keys from `quota_policy_id`
+        // + `execution_id`. No need to build them scheduler-side.
+        //
+        // Parse failure on `quota_id_str` → treat as no-quota (matches
+        // pre-#511 behaviour where invalid IDs fell through to the
+        // unlimited branch).
         let Ok(qid) = QuotaPolicyId::parse(&quota_id_str) else {
             return Ok(QuotaCheckOutcome::NoQuota);
         };
@@ -964,24 +1002,12 @@ impl Scheduler {
         }
 
         // FF #511 Phase 2c: route through `backend.check_admission`.
-        // The trait result enum maps 1:1 onto the pre-#511 Lua status
-        // strings: Admitted/AlreadyAdmitted → QuotaCheckOutcome::Admitted,
-        // RateExceeded → Blocked (rate), ConcurrencyExceeded → Blocked.
-        // Unused inline keys stay in scope as dead references only —
-        // remove them since the FCALL path is gone.
-        let _ = (&window_key, &concurrency_key, &quota_def_key,
-                 &admitted_key, &admitted_set_key);
-
-        let eid_typed = match ExecutionId::parse(eid_s) {
-            Ok(e) => e,
-            Err(_) => {
-                return Err(SchedulerError::Config(format!(
-                    "check_quota: invalid execution_id {eid_s:?}"
-                )));
-            }
-        };
+        // Trait's CheckAdmissionResult enum maps 1:1 onto the pre-#511
+        // Lua status strings: Admitted/AlreadyAdmitted →
+        // QuotaCheckOutcome::Admitted, RateExceeded → Blocked (rate),
+        // ConcurrencyExceeded → Blocked.
         let args = ff_core::contracts::CheckAdmissionArgs {
-            execution_id: eid_typed,
+            execution_id: eid.clone(),
             now: ff_core::types::TimestampMs(now_ms as i64),
             window_seconds: window_secs,
             rate_limit,

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -584,8 +584,7 @@ impl Scheduler {
         let scan_now_ms = match backend.server_time_ms().await {
             Ok(t) => t,
             Err(e) => {
-                return Err(SchedulerError::EngineContext {
-                    source: e,
+                return Err(SchedulerError::EngineContext { source: Box::new(e),
                     context: "scheduler: server_time_ms for rotation cursor".to_owned(),
                 });
             }
@@ -787,7 +786,7 @@ impl Scheduler {
                 lane.clone(),
                 worker_id.clone(),
                 worker_instance_id.clone(),
-                partition.clone(),
+                partition,
                 caps_set,
                 grant_ttl_ms,
                 ff_core::types::TimestampMs(now_ms as i64),
@@ -946,8 +945,7 @@ impl Scheduler {
             Ok(Some(l)) => l,
             Ok(None) => return Ok(QuotaCheckOutcome::NoQuota),
             Err(e) => {
-                return Err(SchedulerError::EngineContext {
-                    source: e,
+                return Err(SchedulerError::EngineContext { source: Box::new(e),
                     context: format!("check_quota: read_quota_policy_limits {qid}"),
                 });
             }
@@ -1024,8 +1022,7 @@ impl Scheduler {
                     error = %e,
                     "scheduler: check_admission failed, denying (fail-closed)"
                 );
-                Err(SchedulerError::EngineContext {
-                    source: e,
+                Err(SchedulerError::EngineContext { source: Box::new(e),
                     context: format!("check_admission {quota_id_str}"),
                 })
             }
@@ -1066,7 +1063,7 @@ impl Scheduler {
         let args = ff_core::contracts::BlockExecutionForAdmissionArgs::new(
             eid.clone(),
             lane.clone(),
-            partition.clone(),
+            *partition,
             reason,
             if blocking_detail.is_empty() {
                 None
@@ -1188,11 +1185,12 @@ pub enum SchedulerError {
     },
     /// FF #511 Phase 2c: trait-routed backend error (backend-agnostic).
     /// Carries the original `EngineError` so callers can classify by
-    /// kind via `EngineError::kind`-ish matchers.
+    /// kind via `EngineError::kind`-ish matchers. Boxed because
+    /// `EngineError` is large (clippy::result_large_err).
     #[error("engine ({context}): {source}")]
     EngineContext {
         #[source]
-        source: ff_core::engine_error::EngineError,
+        source: Box<ff_core::engine_error::EngineError>,
         context: String,
     },
     /// Caller-supplied value failed ingress validation. NOT retryable — the

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -22,8 +22,6 @@
 use ff_core::keys::{ExecKeyContext, IndexKeys};
 use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, budget_partition, quota_partition};
 use ff_core::types::{BudgetId, ExecutionId, LaneId, QuotaPolicyId, WorkerId, WorkerInstanceId};
-use ff_script::error::ScriptError;
-use ff_script::result::FcallResult;
 use ff_script::retry::is_retryable_kind;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -277,6 +275,21 @@ fn iter_partitions(total: u16, start: u16, count: u16) -> impl Iterator<Item = u
 /// applied on top so different workers diverge within any given window.
 pub struct Scheduler {
     client: ferriskey::Client,
+    /// FF #511 Phase 2c: backend-agnostic routing for the 6 scheduler
+    /// primitives that have trait coverage (`server_time_ms`,
+    /// `read_quota_policy_limits`, `check_admission`,
+    /// `block_execution_for_admission`, `release_admission`,
+    /// `issue_claim_grant`). Budget HGETs stay on `client` for now —
+    /// no trait primitive exists yet; Phase 2d or a future refactor
+    /// can lift them.
+    ///
+    /// Held as `Weak` because Valkey/Postgres backends embed the
+    /// Scheduler inside the backend `Arc`; a strong reference here
+    /// would make an Arc-cycle and leak the backend. Every call-site
+    /// upgrades to `Arc` for the duration of the await; upgrade
+    /// failure (backend dropped mid-scheduler-tick) surfaces as a
+    /// `SchedulerError::Config`.
+    backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
     config: PartitionConfig,
     scheduler_config: SchedulerConfig,
     /// Packed rotation state: high 48 bits = last window epoch seen
@@ -295,54 +308,73 @@ pub struct Scheduler {
 }
 
 impl Scheduler {
-    pub fn new(client: ferriskey::Client, config: PartitionConfig) -> Self {
-        Self::with_config(client, config, SchedulerConfig::default())
+    /// Upgrade the `Weak` backend ref to `Arc` for a single call.
+    /// Returns `Err(SchedulerError::Config)` if the backend was
+    /// dropped — mirrors a transport fault for caller-retry purposes.
+    fn upgrade_backend(
+        &self,
+    ) -> Result<std::sync::Arc<dyn ff_core::engine_backend::EngineBackend>, SchedulerError> {
+        self.backend.upgrade().ok_or_else(|| {
+            SchedulerError::Config(
+                "scheduler: backend Arc dropped (Weak upgrade failed); \
+                 caller must rebuild the scheduler"
+                    .to_owned(),
+            )
+        })
+    }
+
+    /// FF #511 Phase 2c: all constructors now require a trait-object
+    /// backend alongside the client. The backend routes admission
+    /// primitives; the client remains for Valkey-specific calls that
+    /// have no trait coverage yet (budget HGETs). Callers with only a
+    /// `ferriskey::Client` can wrap it in a `ValkeyBackend` via
+    /// `ValkeyBackend::from_client_and_partitions` + `Arc::downgrade`.
+    pub fn new(
+        client: ferriskey::Client,
+        backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
+        config: PartitionConfig,
+    ) -> Self {
+        Self::with_config(client, backend, config, SchedulerConfig::default())
     }
 
     /// Construct a scheduler with an explicit [`SchedulerConfig`].
-    /// Use this when you need non-default scan bounds (e.g., in tests that
-    /// want to walk every partition in one call, or deployments with
-    /// non-default polling cadence). Most callers should use
-    /// [`Self::new`].
     pub fn with_config(
         client: ferriskey::Client,
+        backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
         config: PartitionConfig,
         scheduler_config: SchedulerConfig,
     ) -> Self {
         Self::with_config_and_metrics(
             client,
+            backend,
             config,
             scheduler_config,
             std::sync::Arc::new(ff_observability::Metrics::new()),
         )
     }
 
-    /// PR-94: construct a scheduler with a shared observability
-    /// registry and default [`SchedulerConfig`]. Used by `ff-server`
-    /// so claim/budget/quota metrics land in the same registry
-    /// exposed at `/metrics`. For test harnesses that need both a
-    /// custom `SchedulerConfig` AND observability, use
-    /// [`Self::with_config_and_metrics`].
+    /// PR-94: construct a scheduler with a shared observability registry.
     pub fn with_metrics(
         client: ferriskey::Client,
+        backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
         config: PartitionConfig,
         metrics: std::sync::Arc<ff_observability::Metrics>,
     ) -> Self {
-        Self::with_config_and_metrics(client, config, SchedulerConfig::default(), metrics)
+        Self::with_config_and_metrics(client, backend, config, SchedulerConfig::default(), metrics)
     }
 
-    /// PR-94: construct a scheduler with an explicit
+    /// Construct a scheduler with an explicit
     /// [`SchedulerConfig`] AND a shared observability registry.
-    /// Convenience constructor so callers don't have to thread
-    /// both concerns through separate builders.
     pub fn with_config_and_metrics(
         client: ferriskey::Client,
+        backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
         config: PartitionConfig,
         scheduler_config: SchedulerConfig,
         metrics: std::sync::Arc<ff_observability::Metrics>,
     ) -> Self {
         Self {
             client,
+            backend,
             config,
             scheduler_config,
             rotation_state: AtomicU64::new(0),
@@ -544,16 +576,17 @@ impl Scheduler {
         // time up front. One extra TIME round-trip for quiet-cluster no-hit
         // calls, but on hit paths the existing inner-loop `server_time_ms`
         // call is now redundant — we reuse this value.
-        let scan_now_ms = match server_time_ms(&self.client).await {
+        // FF #511 Phase 2c: route through the backend trait instead of
+        // the raw ferriskey TIME. Transport-level failures surface as
+        // `EngineError`; we map to `EngineContext` so callers backoff +
+        // retry the same way they did pre-#511.
+        let backend = self.upgrade_backend()?;
+        let scan_now_ms = match backend.server_time_ms().await {
             Ok(t) => t,
             Err(e) => {
-                // Transport error talking to Valkey; surface via the same
-                // `ValkeyContext` channel the admission checks use so the
-                // caller retries after backoff instead of silently hitting
-                // partition 0 with a zero cursor.
-                return Err(SchedulerError::ValkeyContext {
+                return Err(SchedulerError::EngineContext {
                     source: e,
-                    context: "scheduler: TIME for rotation cursor".to_owned(),
+                    context: "scheduler: server_time_ms for rotation cursor".to_owned(),
                 });
             }
         };
@@ -741,43 +774,34 @@ impl Scheduler {
 
             // ── All checks passed — issue claim grant ──
             let grant_key = exec_ctx.claim_grant();
-            let keys: [&str; 3] = [&core_key, &grant_key, &eligible_key];
+            let _ = &core_key; // kept for any future direct read; unused post-trait-route
 
-            let ttl_str = grant_ttl_ms.to_string();
-            let wid_s = worker_id.to_string();
-            let wiid_s = worker_instance_id.to_string();
-            let lane_s = lane.to_string();
+            // FF #511 Phase 2c: route through `backend.issue_claim_grant`.
+            let caps_set: std::collections::BTreeSet<String> = worker_caps_csv
+                .split(',')
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect();
+            let args = ff_core::contracts::IssueClaimGrantArgs::new(
+                eid.clone(),
+                lane.clone(),
+                worker_id.clone(),
+                worker_instance_id.clone(),
+                partition.clone(),
+                caps_set,
+                grant_ttl_ms,
+                ff_core::types::TimestampMs(now_ms as i64),
+            );
 
-            let argv: [&str; 9] = [
-                &eid_s,
-                &wid_s,
-                &wiid_s,
-                &lane_s,
-                "",   // capability_hash
-                &ttl_str,
-                "",   // route_snapshot_json
-                "",   // admission_summary
-                &worker_caps_csv, // sorted CSV; empty → matches only empty-required execs
-            ];
-
-            let raw = match self
-                .client
-                .fcall::<ferriskey::Value>("ff_issue_claim_grant", &keys, &argv)
-                .await
-            {
-                Ok(v) => v,
+            let backend = self.upgrade_backend()?;
+            let outcome = match backend.issue_claim_grant(args).await {
+                Ok(o) => o,
                 Err(e) => {
-                    // Transport failure on the FCALL — NOSCRIPT, IoError,
-                    // ClusterDown, etc. This is NOT a normal soft-reject;
-                    // persistent transport errors mean the scheduler is
-                    // effectively idle even though it looks like it's
-                    // running. WARN so ops dashboards (WARN+ aggregators)
-                    // fire instead of burying it at DEBUG.
                     tracing::warn!(
                         partition = p_idx,
                         execution_id = eid_s.as_str(),
                         error = %e,
-                        "scheduler: ff_issue_claim_grant transport error, trying next"
+                        "scheduler: issue_claim_grant transport error, trying next"
                     );
                     if let QuotaCheckOutcome::Admitted { tag, quota_id, eid } = &quota_admission {
                         self.release_admission(tag, quota_id, eid).await;
@@ -786,77 +810,31 @@ impl Scheduler {
                 }
             };
 
-            match FcallResult::parse(&raw).and_then(|r| r.into_success()) {
-                Ok(_) => {
-                    partitions_hit += 1;
-                    tracing::debug!(
-                        partition = p_idx,
-                        execution_id = eid_s.as_str(),
-                        worker_instance_id = worker_instance_id.as_str(),
-                        start_p = scan_start,
-                        partitions_visited,
-                        partitions_skipped,
-                        partitions_hit,
-                        elapsed_ms = call_start.elapsed().as_millis() as u64,
-                        "scheduler: claim call completed (hit)"
-                    );
-                    return Ok(Some(ClaimGrant::new(
-                        eid,
-                        ff_core::partition::PartitionKey::from(&partition),
-                        grant_key.clone(),
-                        now_ms + grant_ttl_ms,
-                    )));
-                }
-                Err(script_err) => {
-                    if matches!(script_err, ScriptError::CapabilityMismatch(_)) {
-                        // Should be rare: the Rust pre-check above
-                        // normally catches this and blocks the execution
-                        // off eligible. Reaching here means the
-                        // required_capabilities field mutated between our
-                        // HGET and the Lua atomic check (narrow race).
-                        // Block here too so the next tick doesn't loop.
-                        //
-                        // Log uses worker_caps_hash (8-hex digest), not
-                        // the full 4KB CSV, to keep per-mismatch log
-                        // volume bounded. Full CSV is logged once at
-                        // worker connect under "worker caps" WARN.
-                        tracing::info!(
-                            partition = p_idx,
-                            execution_id = eid_s.as_str(),
-                            worker_id = wid_s.as_str(),
-                            worker_caps_hash = worker_caps_hash.as_str(),
-                            error = %script_err,
-                            "scheduler: capability mismatch via Lua (race), blocking execution"
-                        );
-                        self.block_candidate(
-                            &partition, &idx, lane, &eid, &eligible_key,
-                            "waiting_for_capable_worker",
-                            "no connected worker satisfies required_capabilities",
-                            now_ms,
-                        ).await;
-                        if let QuotaCheckOutcome::Admitted { tag, quota_id, eid } = &quota_admission {
-                            self.release_admission(tag, quota_id, eid).await;
-                        }
-                        continue;
-                    } else {
-                        // Any other logical reject (grant_already_exists,
-                        // execution_not_in_eligible_set, execution_not_eligible,
-                        // invalid_capabilities, etc.). These are rare and each
-                        // indicates either a race or a config problem — in
-                        // either case ops need to see it, so WARN, not DEBUG.
-                        tracing::warn!(
-                            partition = p_idx,
-                            execution_id = eid_s.as_str(),
-                            error = %script_err,
-                            "scheduler: ff_issue_claim_grant rejected, trying next"
-                        );
-                    }
-                    if let QuotaCheckOutcome::Admitted { tag, quota_id, eid } = &quota_admission {
-                        self.release_admission(tag, quota_id, eid).await;
-                    }
-                    continue;
-                }
-            }
+            // Trait's `IssueClaimGrantOutcome` only surfaces `Granted`
+            // as success today; Lua-level rejects (capability mismatch,
+            // grant_already_exists, etc.) come back on the outer `Err`
+            // branch above. Pattern-match with a wildcard to stay
+            // #[non_exhaustive]-robust without dropping into dead-code.
+            let _ = outcome;
+
+            partitions_hit += 1;
+            tracing::debug!(
+                partition = p_idx,
+                execution_id = eid_s.as_str(),
+                worker_instance_id = worker_instance_id.as_str(),
+                start_p = scan_start,
+                partitions_visited,
+                partitions_skipped,
+                partitions_hit,
+                elapsed_ms = call_start.elapsed().as_millis() as u64,
+                "scheduler: claim call completed (hit)"
+            );
+            return Ok(Some(ClaimGrant::new(
+                eid,
+                ff_core::partition::PartitionKey::from(&partition),
+                grant_key.clone(),
+                now_ms + grant_ttl_ms,
+            )));
         }
 
         tracing::debug!(
@@ -956,119 +934,101 @@ impl Scheduler {
         let admitted_key = format!("ff:quota:{}:{}:admitted:{}", tag, quota_id_str, eid_s);
         let admitted_set_key = format!("ff:quota:{}:{}:admitted_set", tag, quota_id_str);
 
-        // Read quota limits from policy hash
-        let rate_limit: Option<String> = self.client
-            .cmd("HGET").arg(&quota_def_key).arg("max_requests_per_window")
-            .execute().await?;
-        let window_secs: Option<String> = self.client
-            .cmd("HGET").arg(&quota_def_key).arg("requests_per_window_seconds")
-            .execute().await?;
-        let concurrency_cap: Option<String> = self.client
-            .cmd("HGET").arg(&quota_def_key).arg("active_concurrency_cap")
-            .execute().await?;
-        let jitter: Option<String> = self.client
-            .cmd("HGET").arg(&quota_def_key).arg("jitter_ms")
-            .execute().await?;
+        // FF #511 Phase 2c: route the policy-limits read through the
+        // trait. Parse failure on `quota_id_str` → treat as no-quota
+        // (matches pre-#511 behaviour where invalid IDs fell through
+        // to the unlimited branch).
+        let Ok(qid) = QuotaPolicyId::parse(&quota_id_str) else {
+            return Ok(QuotaCheckOutcome::NoQuota);
+        };
+        let backend = self.upgrade_backend()?;
+        let limits = match backend.read_quota_policy_limits(&qid).await {
+            Ok(Some(l)) => l,
+            Ok(None) => return Ok(QuotaCheckOutcome::NoQuota),
+            Err(e) => {
+                return Err(SchedulerError::EngineContext {
+                    source: e,
+                    context: format!("check_quota: read_quota_policy_limits {qid}"),
+                });
+            }
+        };
+        let rate_limit = limits.max_requests_per_window;
+        let window_secs = if limits.requests_per_window_seconds == 0 {
+            60
+        } else {
+            limits.requests_per_window_seconds
+        };
+        let concurrency_cap = limits.active_concurrency_cap;
+        let jitter_ms = limits.jitter_ms;
 
-        let rate_limit = rate_limit.as_deref().and_then(|s| s.parse().ok()).unwrap_or(0u64);
-        let window_secs = window_secs.as_deref().and_then(|s| s.parse().ok()).unwrap_or(60u64);
-        let concurrency_cap = concurrency_cap.as_deref().and_then(|s| s.parse().ok()).unwrap_or(0u64);
-        let jitter_ms = jitter.as_deref().and_then(|s| s.parse().ok()).unwrap_or(0u64);
-
-        // No limits configured — admit without recording
-        if rate_limit == 0 && concurrency_cap == 0 {
+        if limits.is_unlimited() {
             return Ok(QuotaCheckOutcome::NoQuota);
         }
 
-        // FCALL ff_check_admission_and_record on {q:K}
-        let keys: [&str; 5] = [&window_key, &concurrency_key, &quota_def_key, &admitted_key, &admitted_set_key];
-        let now_s = now_ms.to_string();
-        let ws = window_secs.to_string();
-        let rl = rate_limit.to_string();
-        let cc = concurrency_cap.to_string();
-        let jt = jitter_ms.to_string();
-        let argv: [&str; 6] = [&now_s, &ws, &rl, &cc, eid_s, &jt];
+        // FF #511 Phase 2c: route through `backend.check_admission`.
+        // The trait result enum maps 1:1 onto the pre-#511 Lua status
+        // strings: Admitted/AlreadyAdmitted → QuotaCheckOutcome::Admitted,
+        // RateExceeded → Blocked (rate), ConcurrencyExceeded → Blocked.
+        // Unused inline keys stay in scope as dead references only —
+        // remove them since the FCALL path is gone.
+        let _ = (&window_key, &concurrency_key, &quota_def_key,
+                 &admitted_key, &admitted_set_key);
 
-        match self.client
-            .fcall::<ferriskey::Value>("ff_check_admission_and_record", &keys, &argv)
-            .await
-        {
+        let eid_typed = match ExecutionId::parse(eid_s) {
+            Ok(e) => e,
+            Err(_) => {
+                return Err(SchedulerError::Config(format!(
+                    "check_quota: invalid execution_id {eid_s:?}"
+                )));
+            }
+        };
+        let args = ff_core::contracts::CheckAdmissionArgs {
+            execution_id: eid_typed,
+            now: ff_core::types::TimestampMs(now_ms as i64),
+            window_seconds: window_secs,
+            rate_limit,
+            concurrency_cap,
+            jitter_ms: if jitter_ms == 0 { None } else { Some(jitter_ms) },
+        };
+
+        match backend.check_admission(&qid, "default", args).await {
             Ok(result) => {
-                // Parse domain-specific result: {"ADMITTED"}, {"RATE_EXCEEDED", retry_after},
-                // {"CONCURRENCY_EXCEEDED"}, {"ALREADY_ADMITTED"}
-                let status = Self::parse_admission_status(&result);
-                match status.as_str() {
-                    "ADMITTED" | "ALREADY_ADMITTED" => Ok(QuotaCheckOutcome::Admitted {
-                        tag: tag.clone(),
-                        quota_id: quota_id_str.clone(),
-                        eid: eid_s.to_owned(),
-                    }),
-                    "RATE_EXCEEDED" => {
-                        // PR-94: quota admission block, labelled by
-                        // reason so rate-vs-concurrency waves are
-                        // distinguishable in a dashboard.
+                use ff_core::contracts::CheckAdmissionResult;
+                match result {
+                    CheckAdmissionResult::Admitted | CheckAdmissionResult::AlreadyAdmitted => {
+                        Ok(QuotaCheckOutcome::Admitted {
+                            tag: tag.clone(),
+                            quota_id: quota_id_str.clone(),
+                            eid: eid_s.to_owned(),
+                        })
+                    }
+                    CheckAdmissionResult::RateExceeded { .. } => {
                         self.metrics.inc_quota_hit("rate");
                         Ok(QuotaCheckOutcome::Blocked(format!(
                             "quota {}: rate limit {}/{} per {}s window",
                             quota_id_str, rate_limit, rate_limit, window_secs
                         )))
                     }
-                    "CONCURRENCY_EXCEEDED" => {
+                    CheckAdmissionResult::ConcurrencyExceeded => {
                         self.metrics.inc_quota_hit("concurrency");
                         Ok(QuotaCheckOutcome::Blocked(format!(
                             "quota {}: concurrency cap {}",
                             quota_id_str, concurrency_cap
                         )))
                     }
-                    other => {
-                        // Fail-closed: an unrecognised status is the Lua
-                        // telling us a contract we don't understand. Do
-                        // NOT default to admit — surface it so the
-                        // scheduler retries next cycle and ops sees the
-                        // event.
-                        tracing::warn!(
-                            quota_id = quota_id_str.as_str(),
-                            status = other,
-                            "scheduler: unexpected admission result, denying (fail-closed)"
-                        );
-                        Err(SchedulerError::Config(format!(
-                            "quota {quota_id_str}: unexpected admission status \"{other}\""
-                        )))
-                    }
                 }
             }
             Err(e) => {
-                // Fail-closed: transport fault on the admission FCALL
-                // must NOT silently admit the candidate. Propagate so
-                // the outer cycle returns the error and the worker
-                // retries after the usual backoff; the next cycle will
-                // re-run the admission check against fresh state.
                 tracing::warn!(
                     quota_id = quota_id_str.as_str(),
                     error = %e,
-                    "scheduler: quota FCALL failed, denying (fail-closed)"
+                    "scheduler: check_admission failed, denying (fail-closed)"
                 );
-                Err(SchedulerError::ValkeyContext {
+                Err(SchedulerError::EngineContext {
                     source: e,
-                    context: format!("ff_check_admission_and_record {quota_id_str}"),
+                    context: format!("check_admission {quota_id_str}"),
                 })
             }
-        }
-    }
-
-    /// Parse the first element of a Valkey array result as a status string.
-    fn parse_admission_status(result: &ferriskey::Value) -> String {
-        match result {
-            ferriskey::Value::Array(arr) => {
-                match arr.first() {
-                    Some(Ok(ferriskey::Value::BulkString(b))) => {
-                        String::from_utf8_lossy(b).into_owned()
-                    }
-                    Some(Ok(ferriskey::Value::SimpleString(s))) => s.clone(),
-                    _ => "UNKNOWN".to_owned(),
-                }
-            }
-            _ => "UNKNOWN".to_owned(),
         }
     }
 
@@ -1078,148 +1038,139 @@ impl Scheduler {
     async fn block_candidate(
         &self,
         partition: &Partition,
-        idx: &IndexKeys,
+        _idx: &IndexKeys,
         lane: &LaneId,
         eid: &ExecutionId,
-        eligible_key: &str,
+        _eligible_key: &str,
         block_reason: &str,
         blocking_detail: &str,
         now_ms: u64,
     ) {
-        let exec_ctx = ExecKeyContext::new(partition, eid);
-        let core_key = exec_ctx.core();
         let eid_s = eid.to_string();
-        let blocked_key = match block_reason {
-            "waiting_for_budget" => idx.lane_blocked_budget(lane),
-            "waiting_for_quota" => idx.lane_blocked_quota(lane),
-            "waiting_for_capable_worker" => idx.lane_blocked_route(lane),
-            _ => idx.lane_blocked_budget(lane),
+        let reason = match block_reason {
+            "waiting_for_budget" => ff_core::contracts::BlockingReason::WaitingForBudget,
+            "waiting_for_quota" => ff_core::contracts::BlockingReason::WaitingForQuota,
+            "waiting_for_capable_worker" => {
+                ff_core::contracts::BlockingReason::WaitingForCapableWorker
+            }
+            other => {
+                tracing::warn!(
+                    execution_id = eid_s,
+                    reason = other,
+                    "scheduler: unrecognised block reason, defaulting to WaitingForBudget"
+                );
+                ff_core::contracts::BlockingReason::WaitingForBudget
+            }
         };
 
-        let keys: [&str; 3] = [&core_key, eligible_key, &blocked_key];
-        let now_s = now_ms.to_string();
-        let argv: [&str; 4] = [&eid_s, block_reason, blocking_detail, &now_s];
-
-        // Parse FcallResult so we distinguish Lua-level rejections (e.g.
-        // execution_not_active because the execution went terminal between
-        // our HGET and the FCALL) from a real block. Previously `Ok(_)`
-        // treated an err-tuple as success → INFO log "candidate blocked"
-        // while nothing actually changed on exec_core, then the next tick
-        // re-picked the same candidate and looped. Mirrors the
-        // release_admission parse fix.
-        match self.client
-            .fcall::<ferriskey::Value>("ff_block_execution_for_admission", &keys, &argv)
-            .await
-        {
-            Ok(v) => match FcallResult::parse(&v).and_then(|r| r.into_success()) {
-                Ok(_) => {
-                    tracing::info!(
-                        execution_id = eid_s,
-                        reason = block_reason,
-                        "scheduler: candidate blocked by admission check"
-                    );
-                }
-                Err(script_err) => {
-                    // Logical reject from Lua (e.g. execution_not_active
-                    // — the execution went terminal between the scheduler
-                    // pick and the block FCALL; the candidate loop will
-                    // naturally move on). WARN so ops dashboards surface
-                    // actual block failures, but not so loud that a common
-                    // race spams alerts.
-                    tracing::warn!(
-                        execution_id = eid_s,
-                        reason = block_reason,
-                        error = %script_err,
-                        "scheduler: ff_block_execution_for_admission rejected by Lua"
-                    );
-                }
+        let args = ff_core::contracts::BlockExecutionForAdmissionArgs::new(
+            eid.clone(),
+            lane.clone(),
+            partition.clone(),
+            reason,
+            if blocking_detail.is_empty() {
+                None
+            } else {
+                Some(blocking_detail.to_owned())
             },
+            ff_core::types::TimestampMs(now_ms as i64),
+        );
+
+        let Some(backend) = self.backend.upgrade() else {
+            tracing::warn!(
+                execution_id = eid_s,
+                "scheduler: block_execution_for_admission skipped — backend dropped"
+            );
+            return;
+        };
+        match backend.block_execution_for_admission(args).await {
+            Ok(ff_core::contracts::BlockExecutionForAdmissionOutcome::Blocked { .. }) => {
+                tracing::info!(
+                    execution_id = eid_s,
+                    reason = block_reason,
+                    "scheduler: candidate blocked by admission check"
+                );
+            }
+            Ok(ff_core::contracts::BlockExecutionForAdmissionOutcome::LuaRejected { message }) => {
+                // Logical reject (e.g. execution went terminal between
+                // scheduler pick and block call); candidate loop moves on.
+                tracing::warn!(
+                    execution_id = eid_s,
+                    reason = block_reason,
+                    error = %message,
+                    "scheduler: block_execution_for_admission rejected"
+                );
+            }
+            Ok(_) => {
+                // #[non_exhaustive] fallback.
+                tracing::warn!(
+                    execution_id = eid_s,
+                    "scheduler: unknown BlockExecutionForAdmissionOutcome variant"
+                );
+            }
             Err(e) => {
                 tracing::warn!(
                     execution_id = eid_s,
                     error = %e,
-                    "scheduler: ff_block_execution_for_admission transport failed"
+                    "scheduler: block_execution_for_admission transport failed"
                 );
             }
         }
     }
 
     /// Release a previously-recorded quota admission slot.
-    /// Called when ff_issue_claim_grant fails after admission was recorded.
+    /// Called when issue_claim_grant fails after admission was
+    /// recorded. FF #511 Phase 2c: trait-routed.
     async fn release_admission(
         &self,
-        tag: &str,
+        _tag: &str,
         quota_id: &str,
         eid_s: &str,
     ) {
-        let admitted_key = format!("ff:quota:{}:{}:admitted:{}", tag, quota_id, eid_s);
-        let admitted_set_key = format!("ff:quota:{}:{}:admitted_set", tag, quota_id);
-        let concurrency_key = format!("ff:quota:{}:{}:concurrency", tag, quota_id);
-
-        let keys: [&str; 3] = [&admitted_key, &admitted_set_key, &concurrency_key];
-        let argv: [&str; 1] = [eid_s];
-
-        // Parse the Lua response properly: FCALL returns `Ok(Value)` for
-        // BOTH success and logical-error paths. Treating Ok(_) blindly as
-        // "released" logs a false positive when the Lua returns
-        // `{0, "quota_not_found"}` (or any other script-level err) — the
-        // slot in fact remains pinned until its TTL expires, which is
-        // minutes to hours. Surface the real outcome so on-call sees
-        // actual release failures instead of clean "released" events.
-        match self.client
-            .fcall::<ferriskey::Value>("ff_release_admission", &keys, &argv)
-            .await
-        {
-            Ok(v) => match FcallResult::parse(&v).and_then(|r| r.into_success()) {
-                Ok(_) => {
-                    tracing::info!(
-                        execution_id = eid_s,
-                        quota_id,
-                        "scheduler: released admission after claim failure"
-                    );
-                }
-                Err(script_err) => {
-                    tracing::warn!(
-                        execution_id = eid_s,
-                        quota_id,
-                        error = %script_err,
-                        "scheduler: ff_release_admission rejected by Lua \
-                         (slot will expire via TTL)"
-                    );
-                }
-            },
+        let Ok(qid) = QuotaPolicyId::parse(quota_id) else {
+            tracing::warn!(
+                execution_id = eid_s,
+                quota_id,
+                "scheduler: release_admission skipped — invalid quota_policy_id"
+            );
+            return;
+        };
+        let Ok(eid) = ExecutionId::parse(eid_s) else {
+            tracing::warn!(
+                execution_id = eid_s,
+                quota_id,
+                "scheduler: release_admission skipped — invalid execution_id"
+            );
+            return;
+        };
+        let args = ff_core::contracts::ReleaseAdmissionArgs::new(qid, eid);
+        let Some(backend) = self.backend.upgrade() else {
+            tracing::warn!(
+                execution_id = eid_s,
+                quota_id,
+                "scheduler: release_admission skipped — backend dropped"
+            );
+            return;
+        };
+        match backend.release_admission(args).await {
+            Ok(_) => {
+                tracing::info!(
+                    execution_id = eid_s,
+                    quota_id,
+                    "scheduler: released admission after claim failure"
+                );
+            }
             Err(e) => {
                 tracing::warn!(
                     execution_id = eid_s,
                     quota_id,
                     error = %e,
-                    "scheduler: ff_release_admission transport failed \
+                    "scheduler: release_admission failed \
                      (slot will expire via TTL)"
                 );
             }
         }
     }
-}
-
-/// Get server time in milliseconds via the TIME command.
-async fn server_time_ms(client: &ferriskey::Client) -> Result<u64, ferriskey::Error> {
-    let result: Vec<String> = client
-        .cmd("TIME")
-        .execute()
-        .await?;
-    if result.len() < 2 {
-        return Err(ferriskey::Error::from((
-            ferriskey::ErrorKind::ClientError,
-            "TIME returned fewer than 2 elements",
-        )));
-    }
-    let secs: u64 = result[0].parse().map_err(|_| {
-        ferriskey::Error::from((ferriskey::ErrorKind::ClientError, "TIME: invalid seconds"))
-    })?;
-    let micros: u64 = result[1].parse().map_err(|_| {
-        ferriskey::Error::from((ferriskey::ErrorKind::ClientError, "TIME: invalid microseconds"))
-    })?;
-    Ok(secs * 1000 + micros / 1000)
 }
 
 /// Errors from the scheduler.
@@ -1233,6 +1184,15 @@ pub enum SchedulerError {
     ValkeyContext {
         #[source]
         source: ferriskey::Error,
+        context: String,
+    },
+    /// FF #511 Phase 2c: trait-routed backend error (backend-agnostic).
+    /// Carries the original `EngineError` so callers can classify by
+    /// kind via `EngineError::kind`-ish matchers.
+    #[error("engine ({context}): {source}")]
+    EngineContext {
+        #[source]
+        source: ff_core::engine_error::EngineError,
         context: String,
     },
     /// Caller-supplied value failed ingress validation. NOT retryable — the
@@ -1251,6 +1211,11 @@ impl SchedulerError {
     pub fn valkey_kind(&self) -> Option<ferriskey::ErrorKind> {
         match self {
             Self::Valkey(e) | Self::ValkeyContext { source: e, .. } => Some(e.kind()),
+            // EngineContext wraps a higher-level error that's already
+            // classified (transport vs validation vs contention) —
+            // callers that need retry-ability consult
+            // `EngineError::is_retryable` instead. Return None here.
+            Self::EngineContext { .. } => None,
             Self::Config(_) => None,
         }
     }

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -531,11 +531,11 @@ impl Server {
             config.partition_config.num_quota_partitions,
         );
 
-        let scheduler = Arc::new(ff_scheduler::Scheduler::with_metrics(
-            client.clone(),
-            config.partition_config,
-            metrics.clone(),
-        ));
+        // FF #511 Phase 2c: Scheduler now needs an `Arc<dyn
+        // EngineBackend>` — which we don't have until the ValkeyBackend
+        // below exists. Deferred to after the backend is constructed;
+        // the scheduler is installed via `with_scheduler` at the same
+        // point as before.
 
         // RFC-017 Stage A: synthesise an `Arc<ValkeyBackend>` around the
         // already-dialed client. Zero additional round-trips; the
@@ -565,11 +565,22 @@ impl Server {
                 "ValkeyBackend stream semaphore sizing failed (unexpected Arc sharing)".into(),
             ));
         }
-        // RFC-017 Stage C: install the scheduler handle so the
-        // backend's `claim_for_worker` trait impl dispatches through
-        // it. Stage E3 removed the redundant `Server::scheduler`
-        // field — the backend is the sole owner of the scheduler
-        // after this install.
+        // FF #511 Phase 2c: Scheduler holds a Weak<dyn EngineBackend>
+        // so we must construct it AFTER the backend Arc exists.
+        // `Arc::downgrade` yields the Weak; the backend-as-Arc<dyn>
+        // coercion happens after the scheduler install.
+        let backend_arc_concrete = valkey_backend;
+        let weak_trait: std::sync::Weak<dyn EngineBackend> =
+            Arc::downgrade(&backend_arc_concrete) as std::sync::Weak<dyn EngineBackend>;
+        let scheduler = Arc::new(ff_scheduler::Scheduler::with_metrics(
+            client.clone(),
+            weak_trait,
+            config.partition_config,
+            metrics.clone(),
+        ));
+        // Re-acquire a &mut via a local rebind — `Arc::get_mut`
+        // succeeds because no other Arc clones exist yet.
+        let mut valkey_backend = backend_arc_concrete;
         if !valkey_backend.with_scheduler(scheduler) {
             return Err(ServerError::OperationFailed(
                 "ValkeyBackend scheduler wiring failed (unexpected Arc sharing)".into(),

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -543,6 +543,9 @@ impl Server {
         // path so migrated + legacy handlers observe identical state.
         // Stage B relocates `tail_client` / `stream_semaphore` into
         // the backend; Stage E retires the Client fields entirely.
+        // Step 1: build the backend with stream-semaphore sized but
+        // without the scheduler yet (scheduler needs a Weak<dyn
+        // EngineBackend> we can only mint once the Arc exists).
         let mut valkey_backend = ff_backend_valkey::ValkeyBackend::from_client_partitions_and_connection(
             client.clone(),
             config.partition_config,
@@ -556,37 +559,33 @@ impl Server {
                 c
             },
         );
-        // RFC-017 Stage B: size the backend's stream-op semaphore
-        // before handing out the `Arc`. `get_mut` succeeds here
-        // because `valkey_backend` is the sole `Arc` owner at this
-        // point.
         if !valkey_backend.with_stream_semaphore_permits(config.max_concurrent_stream_ops) {
             return Err(ServerError::OperationFailed(
                 "ValkeyBackend stream semaphore sizing failed (unexpected Arc sharing)".into(),
             ));
         }
-        // FF #511 Phase 2c: Scheduler holds a Weak<dyn EngineBackend>
-        // so we must construct it AFTER the backend Arc exists.
-        // `Arc::downgrade` yields the Weak; the backend-as-Arc<dyn>
-        // coercion happens after the scheduler install.
-        let backend_arc_concrete = valkey_backend;
-        let weak_trait: std::sync::Weak<dyn EngineBackend> =
-            Arc::downgrade(&backend_arc_concrete) as std::sync::Weak<dyn EngineBackend>;
-        let scheduler = Arc::new(ff_scheduler::Scheduler::with_metrics(
-            client.clone(),
-            weak_trait,
-            config.partition_config,
-            metrics.clone(),
-        ));
-        // Re-acquire a &mut via a local rebind — `Arc::get_mut`
-        // succeeds because no other Arc clones exist yet.
-        let mut valkey_backend = backend_arc_concrete;
-        if !valkey_backend.with_scheduler(scheduler) {
-            return Err(ServerError::OperationFailed(
-                "ValkeyBackend scheduler wiring failed (unexpected Arc sharing)".into(),
-            ));
-        }
-        let backend: Arc<dyn EngineBackend> = valkey_backend as Arc<dyn EngineBackend>;
+
+        // Step 2: materialise the final trait-object Arc first so the
+        // scheduler's Weak<dyn> can be minted against it. Mutating
+        // the backend AFTER this would fail (strong or weak count
+        // > 0); we must defer the scheduler install to `with_scheduler_via_weak`
+        // which accepts a Weak producer.
+        // FF #511 Phase 2c: install via Arc::new_cyclic pattern —
+        // Scheduler is built inside the backend's cyclic closure and
+        // installed into the backend struct in one go.
+        let valkey_backend_with_sched = ff_backend_valkey::ValkeyBackend::install_scheduler_cyclic(
+            valkey_backend,
+            |weak_trait| {
+                Arc::new(ff_scheduler::Scheduler::with_metrics(
+                    client.clone(),
+                    weak_trait,
+                    config.partition_config,
+                    metrics.clone(),
+                ))
+            },
+        )
+        .map_err(|e| ServerError::OperationFailed(e.into()))?;
+        let backend: Arc<dyn EngineBackend> = valkey_backend_with_sched as Arc<dyn EngineBackend>;
 
         Ok(Self {
             // Single-permit semaphore: only one rotate-waitpoint-secret can

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4775,8 +4775,12 @@ async fn test_scheduler_claim_priority_ordering() {
     fcall_create_execution(&tc, &eid_high, NS, LANE, "sched_test", 1000).await;
 
     // Use the Scheduler to issue claim grants
+    let _sched_backend_keepalive = tc.backend();
+    let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
+        std::sync::Arc::downgrade(&_sched_backend_keepalive);
     let scheduler = ff_scheduler::claim::Scheduler::new(
         tc.client().clone(),
+        _sched_weak,
         config,
     );
     let no_caps = std::collections::BTreeSet::<String>::new();
@@ -4864,8 +4868,12 @@ async fn test_claim_from_grant_via_scheduler() {
 
     // Issue grant via the Scheduler — not via raw FCALL — so the
     // test exercises the scheduler-to-SDK handoff shape.
+    let _sched_backend_keepalive = tc.backend();
+    let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
+        std::sync::Arc::downgrade(&_sched_backend_keepalive);
     let scheduler = ff_scheduler::claim::Scheduler::new(
         tc.client().clone(),
+        _sched_weak,
         test_config(),
     );
     let lane_id = LaneId::new(LANE);
@@ -4969,8 +4977,12 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     };
     let worker = ff_sdk::FlowFabricWorker::connect(worker_config).await.unwrap();
 
+    let _sched_backend_keepalive = tc.backend();
+    let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
+        std::sync::Arc::downgrade(&_sched_backend_keepalive);
     let scheduler = ff_scheduler::claim::Scheduler::new(
         tc.client().clone(),
+        _sched_weak,
         test_config(),
     );
     let lane_id = LaneId::new(LANE);
@@ -8533,7 +8545,10 @@ async fn test_capability_mismatch_blocks_to_route_zset() {
     let lane_id = LaneId::new(LANE);
     let worker_id = ff_core::types::WorkerId::new(WORKER);
     let wiid = ff_core::types::WorkerInstanceId::new(WORKER_INST);
-    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), config);
+    let _sched_backend_keepalive = tc.backend();
+    let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
+        std::sync::Arc::downgrade(&_sched_backend_keepalive);
+    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), _sched_weak, config);
 
     // Worker has only {cpu}; execution requires {gpu} → mismatch.
     let cpu_only: std::collections::BTreeSet<String> =
@@ -8624,7 +8639,10 @@ async fn test_capable_worker_unblocks_route_blocked() {
     create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
     let worker_id = ff_core::types::WorkerId::new(WORKER);
     let wiid = ff_core::types::WorkerInstanceId::new(WORKER_INST);
-    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), config);
+    let _sched_backend_keepalive = tc.backend();
+    let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
+        std::sync::Arc::downgrade(&_sched_backend_keepalive);
+    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), _sched_weak, config);
     let cpu_only: std::collections::BTreeSet<String> =
         ["cpu".to_owned()].into_iter().collect();
     scheduler
@@ -8772,7 +8790,10 @@ async fn test_capable_worker_unblocks_on_get_error_failopen() {
     create_execution_with_caps(&tc, &eid, LANE, &["gpu"]).await;
     let worker_id = ff_core::types::WorkerId::new(WORKER);
     let wiid = ff_core::types::WorkerInstanceId::new(WORKER_INST);
-    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), config);
+    let _sched_backend_keepalive = tc.backend();
+    let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
+        std::sync::Arc::downgrade(&_sched_backend_keepalive);
+    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), _sched_weak, config);
     let cpu_only: std::collections::BTreeSet<String> =
         ["cpu".to_owned()].into_iter().collect();
     scheduler

--- a/crates/ff-test/tests/pr_c1_admission_fail_closed.rs
+++ b/crates/ff-test/tests/pr_c1_admission_fail_closed.rs
@@ -127,7 +127,14 @@ async fn scheduler_fails_closed_on_corrupted_budget_limits() {
     // 4. Call the scheduler. Post-fix: returns Err(SchedulerError::Valkey)
     //    carrying the WRONGTYPE. Pre-fix: silently returns Ok(Some(grant))
     //    because the budget checker swallowed the error and cached Ok.
-    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), config);
+    let _backend_keepalive = tc.backend();
+    let weak_backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
+        std::sync::Arc::downgrade(&_backend_keepalive);
+    let scheduler = ff_scheduler::claim::Scheduler::new(
+        tc.client().clone(),
+        weak_backend,
+        config,
+    );
     let worker_id = WorkerId::new(WORKER);
     let wiid = WorkerInstanceId::new(WORKER_INST);
     let no_caps: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();


### PR DESCRIPTION
## Summary

The `ff_scheduler::Scheduler` now routes admission primitives through `Arc<dyn EngineBackend>`. Sites migrated:

1. `server_time_ms(&self.client)` → `backend.server_time_ms()`
2. 4 quota-policy HGETs → `backend.read_quota_policy_limits()` (Phase 2a)
3. `ff_check_admission_and_record` FCALL → `backend.check_admission()` with typed `CheckAdmissionResult`
4. `ff_block_execution_for_admission` FCALL → `backend.block_execution_for_admission()` via new `BlockingReason` enum (Phase 2b)
5. `ff_release_admission` FCALL → `backend.release_admission()` (Phase 1)
6. `ff_issue_claim_grant` FCALL → `backend.issue_claim_grant()`

`ferriskey::Client` stays on the Scheduler for the one remaining site that has no trait primitive yet — the budget HGETs. Phase 2d candidate.

### Struct change

`Scheduler.backend: Weak<dyn EngineBackend>` — Weak, not Arc, to avoid a cycle with `ValkeyBackend.scheduler`. Every call-site upgrades via `Arc::downgrade(...)` for the await window; upgrade failure surfaces as `SchedulerError::Config`.

New `SchedulerError::EngineContext { source: EngineError, context: String }` variant. The ValkeyBackend's `claim_for_worker` trait wrapper maps it via `backend_context(source, context)`.

### Caller changes

All `Scheduler::new` / `with_config` / `with_metrics` / `with_config_and_metrics` constructors take `Weak<dyn EngineBackend>` as the 2nd argument. 9 in-workspace call sites updated:
- `ff-backend-valkey::connect_inner` — uses `Arc::new_cyclic` so the scheduler sees the final backend Arc.
- `ff-server::Server::start_with_metrics` — constructs the scheduler AFTER the concrete ValkeyBackend Arc exists, uses `Arc::downgrade`.
- 7 test sites in `ff-test` — simple `tc.backend()` + `Arc::downgrade` pattern.

### Verification

- `cargo check --workspace --all-features` clean
- `cargo test --workspace --all-features --no-run` compiles
- `cargo test -p ff-core --all-features` — 243 pass
- `cargo test -p ff-scheduler --all-features` — 10 pass
- `cargo run -p non-exhaustive-lint` clean
- **Live-run**: `pr_c1_admission_fail_closed` (budget-checker WRONGTYPE repro) PASS against local Valkey

### Next

Phase 3: `Scheduler::new_with_backend(backend, config)` drops the `ferriskey::Client` argument entirely once budget HGETs lift to a trait method. Phase 4 docs.

## Test plan

- [x] Workspace cargo check + clippy
- [x] ff-core / ff-scheduler unit tests
- [x] Live scheduler test PASS (Valkey)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)