### PR TITLE
feat(#511) Phase 3: new_with_backend constructor + read_budget_usage_and_limits

### DIFF
--- a/crates/ff-backend-valkey/src/lib.rs
+++ b/crates/ff-backend-valkey/src/lib.rs
@@ -179,6 +179,7 @@ fn valkey_supports_base() -> ff_core::capability::Supports {
     s.release_admission = true;
     s.read_quota_policy_limits = true;
     s.block_execution_for_admission = true;
+    s.read_budget_usage_and_limits = true;
     s.prepare = true;
     s.subscribe_lease_history = true;
     s.subscribe_completion = true;
@@ -567,7 +568,7 @@ impl ValkeyBackend {
         let backend_arc = Arc::new_cyclic(move |weak_self: &std::sync::Weak<Self>| {
             let weak_trait: std::sync::Weak<dyn EngineBackend> = weak_self.clone();
             let scheduler = Arc::new(ff_scheduler::Scheduler::with_metrics(
-                client_for_sched,
+                Some(client_for_sched),
                 weak_trait,
                 partition_config_clone,
                 metrics_clone.clone(),
@@ -6197,6 +6198,61 @@ impl EngineBackend for ValkeyBackend {
                 message: e.to_string(),
             }),
         }
+    }
+
+    /// FF #511 Phase 3 — typed snapshot of a budget's usage + limits
+    /// hashes. Replaces the scheduler's Valkey-shaped HGETALL/HGET
+    /// pattern. Missing limits hash → empty snapshot (not an error;
+    /// "no limits configured").
+    async fn read_budget_usage_and_limits(
+        &self,
+        budget_id: &ff_core::types::BudgetId,
+    ) -> Result<ff_core::contracts::BudgetUsageAndLimits, EngineError> {
+        use ff_core::partition::budget_partition;
+        let partition = budget_partition(budget_id, &self.partition_config);
+        let tag = partition.hash_tag();
+        let usage_key = format!("ff:budget:{}:{}:usage", tag, budget_id);
+        let limits_key = format!("ff:budget:{}:{}:limits", tag, budget_id);
+
+        let limits_map: std::collections::HashMap<String, String> = self
+            .client
+            .hgetall(limits_key.as_str())
+            .await
+            .map_err(|e| ff_core::engine_error::backend_context(
+                transport_fk(e),
+                "read_budget_usage_and_limits: HGETALL limits",
+            ))?;
+
+        if limits_map.is_empty() {
+            return Ok(ff_core::contracts::BudgetUsageAndLimits::empty());
+        }
+
+        let mut limits: std::collections::BTreeMap<String, String> =
+            std::collections::BTreeMap::new();
+        let mut usage: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
+        for (field, val) in limits_map {
+            if let Some(dim) = field.strip_prefix("hard:") {
+                let raw: Option<String> = self
+                    .client
+                    .cmd("HGET")
+                    .arg(usage_key.as_str())
+                    .arg(dim)
+                    .execute()
+                    .await
+                    .map_err(|e| ff_core::engine_error::backend_context(
+                        transport_fk(e),
+                        "read_budget_usage_and_limits: HGET usage",
+                    ))?;
+                let used: u64 = raw
+                    .as_deref()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                usage.insert(dim.to_owned(), used);
+            }
+            limits.insert(field, val);
+        }
+        Ok(ff_core::contracts::BudgetUsageAndLimits::new(limits, usage))
     }
 
     /// FF #511 Phase 2a — typed snapshot of the admission fields on a

--- a/crates/ff-core/src/capability.rs
+++ b/crates/ff-core/src/capability.rs
@@ -169,6 +169,10 @@ pub struct Supports {
     /// covering budget / quota / capability reason codes
     /// (FF #511 Phase 2b).
     pub block_execution_for_admission: bool,
+    /// `read_budget_usage_and_limits` — typed snapshot of a budget's
+    /// usage + limits hashes (FF #511 Phase 3). Replaces the
+    /// scheduler's Valkey-shaped HGETALL/HGET pattern.
+    pub read_budget_usage_and_limits: bool,
     // Add new fields here, preserving parity-matrix order.
 }
 
@@ -221,6 +225,7 @@ impl Supports {
             release_admission: false,
             read_quota_policy_limits: false,
             block_execution_for_admission: false,
+            read_budget_usage_and_limits: false,
         }
     }
 }

--- a/crates/ff-core/src/contracts/mod.rs
+++ b/crates/ff-core/src/contracts/mod.rs
@@ -2070,6 +2070,54 @@ pub enum ReleaseAdmissionResult {
     Released,
 }
 
+// ─── read_budget_usage_and_limits (FF #511 Phase 3) ───
+
+/// Typed snapshot of one budget's usage + limits map. Returned by
+/// [`crate::engine_backend::EngineBackend::read_budget_usage_and_limits`]
+/// so the scheduler's `BudgetChecker` can evaluate hard-limit
+/// breaches without reaching at Valkey-shaped HGETs.
+///
+/// `limits` keys are full field names written by the control-plane
+/// (`hard:<dimension>`, `soft:<dimension>`, etc.); the scheduler
+/// filters on the `hard:` prefix itself. `usage` keys are raw
+/// dimension names (no prefix) — one entry per dimension currently
+/// counting.
+///
+/// Missing limits hash ⇒ both maps empty (return `Ok(Self::empty())`).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct BudgetUsageAndLimits {
+    pub limits: std::collections::BTreeMap<String, String>,
+    pub usage: std::collections::BTreeMap<String, u64>,
+}
+
+impl BudgetUsageAndLimits {
+    pub fn new(
+        limits: std::collections::BTreeMap<String, String>,
+        usage: std::collections::BTreeMap<String, u64>,
+    ) -> Self {
+        Self { limits, usage }
+    }
+
+    /// Empty snapshot — returned when the budget's limits hash is
+    /// absent. Scheduler treats this as "no limits configured".
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Iterator over `hard:<dimension>` limits paired with the
+    /// current usage for that dimension. Usage defaults to 0 for
+    /// dimensions present in `limits` but missing from `usage`.
+    pub fn hard_limits_with_usage(&self) -> impl Iterator<Item = (&str, u64, u64)> {
+        self.limits.iter().filter_map(|(field, v)| {
+            let dim = field.strip_prefix("hard:")?;
+            let limit: u64 = v.parse().ok().filter(|&n: &u64| n > 0)?;
+            let used = *self.usage.get(dim).unwrap_or(&0);
+            Some((dim, used, limit))
+        })
+    }
+}
+
 // ─── read_quota_policy_limits (FF #511 Phase 2a) ───
 
 /// Typed snapshot of the admission-relevant fields on a quota policy.

--- a/crates/ff-core/src/engine_backend.rs
+++ b/crates/ff-core/src/engine_backend.rs
@@ -81,7 +81,8 @@ use crate::contracts::{
     EvaluateFlowEligibilityArgs, EvaluateFlowEligibilityResult, ExecutionInfo,
     FailExecutionArgs, FailExecutionResult,
     IssueClaimGrantArgs, IssueClaimGrantOutcome, IssueGrantAndClaimArgs,
-    QuotaPolicyLimits, RecordSpendArgs, ReleaseAdmissionArgs, ReleaseAdmissionResult,
+    BudgetUsageAndLimits, QuotaPolicyLimits, RecordSpendArgs, ReleaseAdmissionArgs,
+    ReleaseAdmissionResult,
     ReleaseBudgetArgs, ScanEligibleArgs,
     ListExecutionsPage, ListFlowsPage, ListLanesPage, ListPendingWaitpointsArgs,
     ListPendingWaitpointsResult, ListSuspendedPage, RenewLeaseArgs, RenewLeaseResult,
@@ -1709,6 +1710,21 @@ pub trait EngineBackend: Send + Sync + 'static {
     ) -> Result<BlockExecutionForAdmissionOutcome, EngineError> {
         Err(EngineError::Unavailable {
             op: "block_execution_for_admission",
+        })
+    }
+
+    /// FF #511 Phase 3 — typed snapshot of a budget's usage + limits
+    /// hashes. Replaces the scheduler's Valkey-shaped HGETALL/HGET
+    /// pattern on `ff:budget:{K}:{id}:limits` + `ff:budget:{K}:{id}:usage`.
+    /// Returns [`BudgetUsageAndLimits::empty`] when the limits hash
+    /// is absent ("no limits configured" — not an error).
+    #[cfg(feature = "core")]
+    async fn read_budget_usage_and_limits(
+        &self,
+        _budget_id: &BudgetId,
+    ) -> Result<BudgetUsageAndLimits, EngineError> {
+        Err(EngineError::Unavailable {
+            op: "read_budget_usage_and_limits",
         })
     }
 

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -20,7 +20,7 @@
 //! pipeline + isolation notes.
 
 use ff_core::keys::{ExecKeyContext, IndexKeys};
-use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, budget_partition, quota_partition};
+use ff_core::partition::{Partition, PartitionConfig, PartitionFamily, quota_partition};
 use ff_core::types::{BudgetId, ExecutionId, LaneId, QuotaPolicyId, WorkerId, WorkerInstanceId};
 use ff_script::retry::is_retryable_kind;
 use std::collections::BTreeSet;
@@ -77,14 +77,16 @@ pub struct BudgetChecker {
     /// Cached budget status: budget_id → BudgetCheckResult.
     /// Reset at the start of each scheduler cycle.
     cache: std::collections::HashMap<String, BudgetCheckResult>,
-    config: PartitionConfig,
 }
 
 impl BudgetChecker {
-    pub fn new(config: PartitionConfig) -> Self {
+    pub fn new(_config: PartitionConfig) -> Self {
+        // `_config` retained in the signature for backward-compat —
+        // pre-#511 BudgetChecker computed Valkey key tags from it.
+        // Phase 3 routes through `backend.read_budget_usage_and_limits`
+        // which computes its own partition internally.
         Self {
             cache: std::collections::HashMap::new(),
-            config,
         }
     }
 
@@ -99,91 +101,47 @@ impl BudgetChecker {
     /// candidates sharing a budget do one read per cycle, not 50K.
     pub async fn check_budget(
         &mut self,
-        client: &ferriskey::Client,
+        backend: &dyn ff_core::engine_backend::EngineBackend,
         budget_id: &str,
     ) -> Result<&BudgetCheckResult, SchedulerError> {
         if self.cache.contains_key(budget_id) {
             return Ok(&self.cache[budget_id]);
         }
 
-        // Compute real {b:M} partition tag from budget_id
-        let (usage_key, limits_key) = match BudgetId::parse(budget_id) {
-            Ok(bid) => {
-                let partition = budget_partition(&bid, &self.config);
-                let tag = partition.hash_tag();
-                (
-                    format!("ff:budget:{}:{}:usage", tag, budget_id),
-                    format!("ff:budget:{}:{}:limits", tag, budget_id),
-                )
-            }
-            Err(_) => {
-                // Fallback for non-UUID budget IDs (test compat)
-                (
-                    format!("ff:budget:{{b:0}}:{}:usage", budget_id),
-                    format!("ff:budget:{{b:0}}:{}:limits", budget_id),
-                )
-            }
+        // Parse the budget id; fall through to "no limits" on
+        // non-UUID inputs (test-fixture compat, matches pre-#511).
+        let Ok(bid) = BudgetId::parse(budget_id) else {
+            self.cache
+                .insert(budget_id.to_owned(), BudgetCheckResult::Ok);
+            return Ok(&self.cache[budget_id]);
         };
 
-        let result =
-            Self::read_and_check(client, &usage_key, &limits_key)
-                .await
-                .map_err(|source| SchedulerError::ValkeyContext {
-                    source,
-                    context: format!("budget_checker read {budget_id}"),
-                })?;
+        let snapshot = backend
+            .read_budget_usage_and_limits(&bid)
+            .await
+            .map_err(|source| SchedulerError::EngineContext {
+                source: Box::new(source),
+                context: format!("budget_checker read {budget_id}"),
+            })?;
 
-        self.cache.insert(budget_id.to_owned(), result);
-        Ok(&self.cache[budget_id])
-    }
-
-    /// Read budget usage and limits, compare each dimension.
-    async fn read_and_check(
-        client: &ferriskey::Client,
-        usage_key: &str,
-        limits_key: &str,
-    ) -> Result<BudgetCheckResult, ferriskey::Error> {
-        // Read all limit dimensions via hgetall (returns HashMap, not flat pairs)
-        let limits: std::collections::HashMap<String, String> = client
-            .hgetall(limits_key)
-            .await?;
-
-        // Parse hard limits
-        for (field, limit_val) in &limits {
-            if !field.starts_with("hard:") {
-                continue;
-            }
-            let dimension = &field[5..]; // strip "hard:" prefix
-            let limit: u64 = match limit_val.parse() {
-                Ok(v) if v > 0 => v,
-                _ => continue,
-            };
-
-            // Read current usage for this dimension. Fail-closed: a
-            // transport error must NOT silently default the usage to 0
-            // (which would make every breach invisible).  Absence is
-            // still treated as 0 — the caller is expected to HSET
-            // usage_key on every increment.
-            let usage_str: Option<String> = client
-                .cmd("HGET")
-                .arg(usage_key)
-                .arg(dimension)
-                .execute()
-                .await?;
-            let usage: u64 = usage_str
-                .as_deref()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0);
-
-            if usage >= limit {
-                return Ok(BudgetCheckResult::HardBreach {
-                    dimension: dimension.to_owned(),
-                    detail: format!("budget {}: {} {}/{}", usage_key, dimension, usage, limit),
-                });
+        // Fail-closed on hard-limit breach; matches the pre-#511 logic
+        // byte-for-byte (strip "hard:" prefix, >0 sentinel, usage>=limit).
+        let mut result = BudgetCheckResult::Ok;
+        for (dim, used, limit) in snapshot.hard_limits_with_usage() {
+            if used >= limit {
+                result = BudgetCheckResult::HardBreach {
+                    dimension: dim.to_owned(),
+                    detail: format!(
+                        "budget ff:budget:{}:usage: {} {}/{}",
+                        budget_id, dim, used, limit
+                    ),
+                };
+                break;
             }
         }
 
-        Ok(BudgetCheckResult::Ok)
+        self.cache.insert(budget_id.to_owned(), result);
+        Ok(&self.cache[budget_id])
     }
 
     /// Clear the cache at the start of a new scheduler cycle.
@@ -274,7 +232,13 @@ fn iter_partitions(total: u16, start: u16, count: u16) -> impl Iterator<Item = u
 /// [`SchedulerConfig::rotation_window_ms`]. The per-worker FNV jitter is
 /// applied on top so different workers diverge within any given window.
 pub struct Scheduler {
-    client: ferriskey::Client,
+    /// FF #511 Phase 3: optional ferriskey client. `Some` on Valkey
+    /// deployments (used for the scanner ZRANGEBYSCORE + a handful of
+    /// exec_core HGETs that have no trait primitive yet). `None` on
+    /// backend-only deployments (PG / SQLite) — the scheduler's
+    /// `claim_for_worker` returns `Ok(None)` when no client is
+    /// present, matching the "scanner unavailable" posture.
+    client: Option<ferriskey::Client>,
     /// FF #511 Phase 2c: backend-agnostic routing for the 6 scheduler
     /// primitives that have trait coverage (`server_time_ms`,
     /// `read_quota_policy_limits`, `check_admission`,
@@ -330,7 +294,7 @@ impl Scheduler {
     /// `ferriskey::Client` can wrap it in a `ValkeyBackend` via
     /// `ValkeyBackend::from_client_and_partitions` + `Arc::downgrade`.
     pub fn new(
-        client: ferriskey::Client,
+        client: Option<ferriskey::Client>,
         backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
         config: PartitionConfig,
     ) -> Self {
@@ -339,7 +303,7 @@ impl Scheduler {
 
     /// Construct a scheduler with an explicit [`SchedulerConfig`].
     pub fn with_config(
-        client: ferriskey::Client,
+        client: Option<ferriskey::Client>,
         backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
         config: PartitionConfig,
         scheduler_config: SchedulerConfig,
@@ -355,7 +319,7 @@ impl Scheduler {
 
     /// PR-94: construct a scheduler with a shared observability registry.
     pub fn with_metrics(
-        client: ferriskey::Client,
+        client: Option<ferriskey::Client>,
         backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
         config: PartitionConfig,
         metrics: std::sync::Arc<ff_observability::Metrics>,
@@ -366,7 +330,7 @@ impl Scheduler {
     /// Construct a scheduler with an explicit
     /// [`SchedulerConfig`] AND a shared observability registry.
     pub fn with_config_and_metrics(
-        client: ferriskey::Client,
+        client: Option<ferriskey::Client>,
         backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
         config: PartitionConfig,
         scheduler_config: SchedulerConfig,
@@ -380,6 +344,30 @@ impl Scheduler {
             rotation_state: AtomicU64::new(0),
             metrics,
         }
+    }
+
+    /// FF #511 Phase 3 — backend-only constructor. Drops the
+    /// `ferriskey::Client` requirement for consumers that don't run
+    /// on Valkey. Admission primitives route through the trait;
+    /// however the ZRANGEBYSCORE + exec_core HGET scanner path has
+    /// no trait primitive yet, so a clientless scheduler's
+    /// `claim_for_worker` returns `Ok(None)` — "no hit, scanner
+    /// unavailable on this backend". PG / SQLite deployments can
+    /// still wire their own native claim path
+    /// (`PostgresScheduler`, `SqliteBackend::claim_for_worker`);
+    /// this constructor is for generic trait-only consumers that
+    /// accept the degraded scanner.
+    pub fn new_with_backend(
+        backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend>,
+        config: PartitionConfig,
+    ) -> Self {
+        Self::with_config_and_metrics(
+            None,
+            backend,
+            config,
+            SchedulerConfig::default(),
+            std::sync::Arc::new(ff_observability::Metrics::new()),
+        )
     }
 
     /// Return the current cursor for this call, advancing it if we're the
@@ -491,6 +479,19 @@ impl Scheduler {
                 "num_flow_partitions must be > 0".to_owned(),
             ));
         }
+        // FF #511 Phase 3: backend-only schedulers have no Valkey
+        // client, and this scanner path still needs ZRANGEBYSCORE /
+        // exec_core HGETs that have no trait primitive yet. Degrade
+        // gracefully to "no hit" instead of panicking; consumers
+        // running on non-Valkey backends should wire their own
+        // native claim path (PostgresScheduler, SqliteBackend).
+        let Some(client) = self.client.as_ref() else {
+            tracing::debug!(
+                worker_instance_id = worker_instance_id.as_str(),
+                "scheduler: no client configured (backend-only); returning Ok(None)"
+            );
+            return Ok(None);
+        };
         let mut budget_checker = BudgetChecker::new(self.config);
 
         // Jitter the partition scan start to avoid thundering-herd on
@@ -631,8 +632,7 @@ impl Scheduler {
 
             // ZRANGEBYSCORE eligible -inf +inf LIMIT 0 1
             // Lowest score = highest priority candidate
-            let candidates: Vec<String> = match self
-                .client
+            let candidates: Vec<String> = match client
                 .cmd("ZRANGEBYSCORE")
                 .arg(&eligible_key)
                 .arg("-inf")
@@ -705,8 +705,7 @@ impl Scheduler {
             // A narrow race exists where `required_capabilities` is
             // updated between our HGET and the FCALL — the FCALL is still
             // atomic and correct.
-            let required_caps_csv: Option<String> = match self
-                .client
+            let required_caps_csv: Option<String> = match client
                 .cmd("HGET")
                 .arg(&core_key)
                 .arg("required_capabilities")
@@ -753,7 +752,7 @@ impl Scheduler {
 
             // ── Budget pre-check (cross-partition, cached per cycle) ──
             if let Some(block_detail) = self
-                .check_budgets(&mut budget_checker, &exec_ctx, &core_key, &eid_s)
+                .check_budgets(client, &mut budget_checker, &exec_ctx, &core_key, &eid_s)
                 .await?
             {
                 // Budget breached — block candidate and try next
@@ -766,7 +765,7 @@ impl Scheduler {
 
             // ── Quota pre-check (cross-partition FCALL on {q:K}) ──
             let quota_admission = self
-                .check_quota(&exec_ctx, &core_key, &eid, now_ms)
+                .check_quota(client, &exec_ctx, &core_key, &eid, now_ms)
                 .await?;
             match &quota_admission {
                 QuotaCheckOutcome::Blocked(block_detail) => {
@@ -889,14 +888,14 @@ impl Scheduler {
     /// string if any budget is breached, None if all pass.
     async fn check_budgets(
         &self,
+        client: &ferriskey::Client,
         checker: &mut BudgetChecker,
         _exec_ctx: &ExecKeyContext,
         core_key: &str,
         _eid_s: &str,
     ) -> Result<Option<String>, SchedulerError> {
         // Read budget_ids from exec_core (comma-separated or JSON list)
-        let budget_ids_str: Option<String> = self
-            .client
+        let budget_ids_str: Option<String> = client
             .cmd("HGET")
             .arg(core_key)
             .arg("budget_ids")
@@ -917,7 +916,8 @@ impl Scheduler {
             if budget_id.is_empty() {
                 continue;
             }
-            let result = checker.check_budget(&self.client, budget_id).await?;
+            let backend_for_budget = self.upgrade_backend()?;
+            let result = checker.check_budget(&*backend_for_budget, budget_id).await?;
             if let BudgetCheckResult::HardBreach { dimension, detail } = &result {
                 // PR-94: budget hard-breach counter, labelled by
                 // dimension so operators can distinguish "tokens"
@@ -933,6 +933,7 @@ impl Scheduler {
     /// Check quota admission for the candidate.
     async fn check_quota(
         &self,
+        client: &ferriskey::Client,
         _exec_ctx: &ExecKeyContext,
         core_key: &str,
         eid: &ExecutionId,
@@ -941,8 +942,7 @@ impl Scheduler {
         let eid_s = eid.to_string();
         let eid_s = eid_s.as_str();
         // Read quota_policy_id from exec_core
-        let quota_id_str: Option<String> = self
-            .client
+        let quota_id_str: Option<String> = client
             .cmd("HGET")
             .arg(core_key)
             .arg("quota_policy_id")

--- a/crates/ff-scheduler/src/claim.rs
+++ b/crates/ff-scheduler/src/claim.rs
@@ -108,8 +108,17 @@ impl BudgetChecker {
             return Ok(&self.cache[budget_id]);
         }
 
-        // Parse the budget id; fall through to "no limits" on
-        // non-UUID inputs (test-fixture compat, matches pre-#511).
+        // Parse the budget id. Pre-FF #511 the scheduler fell back
+        // to hardcoded `ff:budget:{b:0}:<raw_string>` keys for
+        // non-UUID IDs — a test-only shortcut that relied on Valkey
+        // HGETALL's tolerance for arbitrary-string IDs. The trait
+        // surface requires a typed `BudgetId` (UUID), so non-UUID
+        // inputs now resolve to "no limits" (cache Ok). Breaking
+        // this fallback is intentional: the in-workspace fixtures
+        // use `BudgetId::new()` (UUID), and out-of-tree consumers
+        // that hand-rolled non-UUID budget IDs should migrate —
+        // budget-row lookups stop working anyway once the trait
+        // surface is the sole admission path.
         let Ok(bid) = BudgetId::parse(budget_id) else {
             self.cache
                 .insert(budget_id.to_owned(), BudgetCheckResult::Ok);

--- a/crates/ff-server/src/server.rs
+++ b/crates/ff-server/src/server.rs
@@ -577,7 +577,7 @@ impl Server {
             valkey_backend,
             |weak_trait| {
                 Arc::new(ff_scheduler::Scheduler::with_metrics(
-                    client.clone(),
+                    Some(client.clone()),
                     weak_trait,
                     config.partition_config,
                     metrics.clone(),

--- a/crates/ff-test/tests/e2e_lifecycle.rs
+++ b/crates/ff-test/tests/e2e_lifecycle.rs
@@ -4779,7 +4779,7 @@ async fn test_scheduler_claim_priority_ordering() {
     let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
         std::sync::Arc::downgrade(&_sched_backend_keepalive);
     let scheduler = ff_scheduler::claim::Scheduler::new(
-        tc.client().clone(),
+        Some(tc.client().clone()),
         _sched_weak,
         config,
     );
@@ -4872,7 +4872,7 @@ async fn test_claim_from_grant_via_scheduler() {
     let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
         std::sync::Arc::downgrade(&_sched_backend_keepalive);
     let scheduler = ff_scheduler::claim::Scheduler::new(
-        tc.client().clone(),
+        Some(tc.client().clone()),
         _sched_weak,
         test_config(),
     );
@@ -4981,7 +4981,7 @@ async fn test_claim_from_grant_rejects_at_capacity() {
     let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
         std::sync::Arc::downgrade(&_sched_backend_keepalive);
     let scheduler = ff_scheduler::claim::Scheduler::new(
-        tc.client().clone(),
+        Some(tc.client().clone()),
         _sched_weak,
         test_config(),
     );
@@ -8548,7 +8548,7 @@ async fn test_capability_mismatch_blocks_to_route_zset() {
     let _sched_backend_keepalive = tc.backend();
     let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
         std::sync::Arc::downgrade(&_sched_backend_keepalive);
-    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), _sched_weak, config);
+    let scheduler = ff_scheduler::claim::Scheduler::new(Some(tc.client().clone()), _sched_weak, config);
 
     // Worker has only {cpu}; execution requires {gpu} → mismatch.
     let cpu_only: std::collections::BTreeSet<String> =
@@ -8642,7 +8642,7 @@ async fn test_capable_worker_unblocks_route_blocked() {
     let _sched_backend_keepalive = tc.backend();
     let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
         std::sync::Arc::downgrade(&_sched_backend_keepalive);
-    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), _sched_weak, config);
+    let scheduler = ff_scheduler::claim::Scheduler::new(Some(tc.client().clone()), _sched_weak, config);
     let cpu_only: std::collections::BTreeSet<String> =
         ["cpu".to_owned()].into_iter().collect();
     scheduler
@@ -8793,7 +8793,7 @@ async fn test_capable_worker_unblocks_on_get_error_failopen() {
     let _sched_backend_keepalive = tc.backend();
     let _sched_weak: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
         std::sync::Arc::downgrade(&_sched_backend_keepalive);
-    let scheduler = ff_scheduler::claim::Scheduler::new(tc.client().clone(), _sched_weak, config);
+    let scheduler = ff_scheduler::claim::Scheduler::new(Some(tc.client().clone()), _sched_weak, config);
     let cpu_only: std::collections::BTreeSet<String> =
         ["cpu".to_owned()].into_iter().collect();
     scheduler

--- a/crates/ff-test/tests/pr_c1_admission_fail_closed.rs
+++ b/crates/ff-test/tests/pr_c1_admission_fail_closed.rs
@@ -131,7 +131,7 @@ async fn scheduler_fails_closed_on_corrupted_budget_limits() {
     let weak_backend: std::sync::Weak<dyn ff_core::engine_backend::EngineBackend> =
         std::sync::Arc::downgrade(&_backend_keepalive);
     let scheduler = ff_scheduler::claim::Scheduler::new(
-        tc.client().clone(),
+        Some(tc.client().clone()),
         weak_backend,
         config,
     );
@@ -145,12 +145,20 @@ async fn scheduler_fails_closed_on_corrupted_budget_limits() {
 
     match result {
         Err(e) => {
-            // Expected: transport error surfaces. Any Valkey-kind error is
-            // acceptable (ResponseError for WRONGTYPE is the usual shape).
-            let kind = e.valkey_kind();
+            // Expected: transport error surfaces. Pre-FF #511 the
+            // scheduler returned a Valkey-kind error directly; post-
+            // Phase-2c the trait routes it through EngineContext, so
+            // valkey_kind() returns None. Accept either shape — the
+            // critical invariant is that admission failed CLOSED
+            // (not Ok(grant)).
+            let is_engine_context = matches!(
+                &e,
+                ff_scheduler::SchedulerError::EngineContext { .. }
+            );
+            let valkey_kind = e.valkey_kind();
             assert!(
-                kind.is_some(),
-                "expected a Valkey-kind error, got {e:?} (kind={kind:?})"
+                valkey_kind.is_some() || is_engine_context,
+                "expected a Valkey-kind or EngineContext error, got {e:?}"
             );
         }
         Ok(grant) => panic!(

--- a/examples/coding-agent/Cargo.lock
+++ b/examples/coding-agent/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -480,11 +480,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/deploy-approval/Cargo.lock
+++ b/examples/deploy-approval/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -480,11 +480,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/external-callback/Cargo.lock
+++ b/examples/external-callback/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -638,11 +638,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-sqlite",

--- a/examples/ff-dev/Cargo.lock
+++ b/examples/ff-dev/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/examples/incident-remediation/Cargo.lock
+++ b/examples/incident-remediation/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -620,11 +620,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-sqlite",

--- a/examples/llm-race/Cargo.lock
+++ b/examples/llm-race/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -464,11 +464,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/media-pipeline/Cargo.lock
+++ b/examples/media-pipeline/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -995,11 +995,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/retry-and-cancel/Cargo.lock
+++ b/examples/retry-and-cancel/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -368,11 +368,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/token-budget/Cargo.lock
+++ b/examples/token-budget/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -368,11 +368,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -419,7 +419,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowfabric"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ff-backend-valkey",
  "ff-core",

--- a/examples/v010-read-side-ergonomics/Cargo.lock
+++ b/examples/v010-read-side-ergonomics/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -368,11 +368,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",

--- a/examples/v011-wave9-postgres/Cargo.lock
+++ b/examples/v011-wave9-postgres/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -337,11 +337,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ff-core",
  "serde_json",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ff-core",
  "ff-script",
@@ -373,7 +373,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowfabric"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ff-backend-postgres",
  "ff-core",

--- a/examples/v013-cairn-454-budget-ledger/Cargo.lock
+++ b/examples/v013-cairn-454-budget-ledger/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -340,11 +340,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",

--- a/examples/v014-rfc025-worker-registry/Cargo.lock
+++ b/examples/v014-rfc025-worker-registry/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -340,11 +340,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",


### PR DESCRIPTION
## Summary

Closes the FF #511 ask: consumers can now construct a `Scheduler` with only an `Arc<dyn EngineBackend>` — no `ferriskey::Client` required. PG deployments unblocked at the trait layer.

### Landed

1. **`EngineBackend::read_budget_usage_and_limits`** + `BudgetUsageAndLimits` contract type. Replaces the scheduler's Valkey-shaped HGETALL/HGET budget pattern. Valkey body ships; PG/SQLite stay at `Unavailable` (scheduler is Valkey-only per RFC-023; PG has its own `PostgresScheduler`).

2. **`BudgetChecker::check_budget`** takes `&dyn EngineBackend` instead of `&ferriskey::Client`. Partition derivation moves inside the backend body.

3. **`Scheduler::client: Option<ferriskey::Client>`**. New `Scheduler::new_with_backend(weak_backend, config)` constructor sets `client = None`. `claim_for_worker` short-circuits to `Ok(None)` when the client is None — "scanner unavailable on this backend". Consumers on PG/SQLite wire their native claim paths (`PostgresScheduler`, `SqliteBackend::claim_for_worker`).

Existing constructors (`new` / `with_config` / `with_metrics` / `with_config_and_metrics`) take `Option<Client>` so Valkey callers pass `Some(client)`.

### Verified

- `cargo check --workspace --all-features` clean
- `cargo clippy` clean on touched crates
- Live: `pr_c1_admission_fail_closed` PASS (admission fail-closed invariant preserved; accepts either old `ValkeyContext` or new `EngineContext` error flavour).
- Live: `admin_rotate_api` 4/4 PASS.

### Next

Phase 4: `POSTGRES_PARITY_MATRIX` row flip + `CONSUMER_MIGRATION_0.15_scheduler_agnostic.md`.

## Test plan

- [x] Workspace check + clippy
- [x] Live Valkey smoke tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)