### PR TITLE
chore(release): v0.15.0 — FF #511 scheduler backend-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-03
+
 ### Added
 
 - **FF #511 scheduler backend-agnostic.** `ff_scheduler::Scheduler` no

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-postgres"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-sqlite"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ff-core",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "ff-backend-valkey"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "ff-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",
@@ -802,11 +802,11 @@ dependencies = [
 
 [[package]]
 name = "ff-observability"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ff-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "ff-script"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-core",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-valkey",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ff-server"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "ferriskey",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ff-test"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ferriskey",
  "ff-backend-postgres",

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -620,6 +620,13 @@ apply_env() {
             export FF_DEMO_VALKEY_PORT="$VALKEY_PORT" ;;
         v011-wave9-postgres|v015-ff511-scheduler-agnostic)
             # Route the URL the preflight verified to the example.
+            # NOTE: when running multiple PG examples in one sweep,
+            # point each at its own db (each calls apply_migrations at
+            # boot; sharing one db triggers "relation already exists"
+            # on the second example). For release-gate runs, run PG
+            # examples individually via FF_EXAMPLES_ONLY against fresh
+            # per-example dbs. A per-example drop+recreate is queued as
+            # a v0.16 harness-hygiene fix.
             export FF_PG_TEST_URL="$POSTGRES_URL" ;;
         retry-and-cancel|v010-read-side-ergonomics|token-budget|deploy-approval)
             # All four examples default to http://localhost:9090 but


### PR DESCRIPTION
## Summary

Cuts v0.15.0 (closing FF #511). CHANGELOG section finalized from [Unreleased]; workspace already at 0.15.0 (bumped during Phase 2a for the semver-major `#[non_exhaustive]` additions).

## Contents (since v0.14.1, PRs #512–#518)

- **FF #511 Phase 1** (#512): `release_admission` trait method + 3 backends
- **FF #511 Phase 2a** (#513): `read_quota_policy_limits` trait method + 3 backends
- **FF #511 Phase 2b** (#514): `block_execution_for_admission` Valkey body (PG/SQLite `Unavailable` per RFC-023)
- **FF #511 Phase 2c** (#515): `read_budget_usage_and_limits` Valkey body
- **FF #511 Phase 3** (#516): Scheduler refactor — `client: Option<Client>`, `backend: Weak<dyn EngineBackend>`, `new_with_backend`, `SchedulerError::EngineContext`, `ValkeyBackend::install_scheduler_cyclic`
- **FF #511 Phase 4** (#517): docs — parity matrix + consumer migration guide
- **v0.15 headline example** (#518): `v015-ff511-scheduler-agnostic` — PG-only `Scheduler::new_with_backend(..)` demo + fix for PG capability surface gap

## Release-gate evidence (CLAUDE.md §5)

- **§5.1 Smoke** (`scripts/smoke-v0.7.sh`): PASS on Valkey + PG. Every scenario `Pass`, no `Skip`, parity clean.
- **§5.2 All examples build clean**: PASS via `scripts/run-all-examples.sh` (14 reachable; coding-agent / llm-race / media-pipeline SKIP as LLM-key-required per harness convention).
- **§5.3 Every example live-runs**: PASS. 10 examples in harness sweep (deploy-approval, external-callback, ff-dev, grafana, incident-remediation, retry-and-cancel, token-budget, v010-read-side-ergonomics, v013-cairn-454-budget-ledger, v014-rfc025-worker-registry) + v011-wave9-postgres + v015-ff511-scheduler-agnostic validated individually on fresh per-example dbs.
- **§5.4 New release example**: v015-ff511-scheduler-agnostic live-run transcript in PR #518.
- **§5.5 README/migration sweep**: landed in #517 + #518.
- **§5.6 CHANGELOG**: `[Unreleased]` → `[0.15.0] - 2026-05-03` in this PR.
- **§5.7 POSTGRES_PARITY_MATRIX**: v0.15 section shipped in #517.
- **§5.8 Pre-publish smoke in release.yml**: unchanged from v0.14.1 (gates the tag workflow Verify→Smoke→Publish→Release).

## Follow-ups queued

- **arm-cluster FUNCTION LOAD flake** — root-caused (stale ferriskey slot map at client-init during cluster mid-gossip); fix hypothesis list saved to memory. Not a v0.15 blocker (x86 cluster + PG + standalone all green; arm-cluster flake identical class to what CI reruns clear).
- **PG examples shared-db collision** — v0.16 harness-hygiene fix noted in `scripts/run-all-examples.sh`.

## Test plan

- [x] Full release gate (§5) — all 8 items clean
- [ ] CI green on this PR
- [ ] Tag push triggers release workflow

## Next

After merge: `git tag v0.15.0` → push tag → release workflow handles Verify → Smoke → Publish → GitHub Release.