### PR TITLE
diag(ff-script): instrument FUNCTION LOAD READONLY flake for arm-cluster

### DIFF
--- a/crates/ff-script/src/loader.rs
+++ b/crates/ff-script/src/loader.rs
@@ -77,15 +77,60 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
     let backoff_ms: [u64; 5] = [500, 1_000, 2_000, 4_000, 7_000];
     let mut last_err = None;
     for attempt in 1..=MAX_ATTEMPTS {
+        let attempt_start = std::time::Instant::now();
         match client.function_load_replace(LIBRARY_SOURCE).await {
             Ok(_name) => {
                 last_err = None;
                 break;
             }
             Err(e) => {
+                let attempt_ms = attempt_start.elapsed().as_millis() as u64;
                 if is_permanent_load_error(&e) {
-                    tracing::error!(attempt, error = %e, "FUNCTION LOAD failed with permanent error");
+                    tracing::error!(attempt, attempt_ms, error = %e, "FUNCTION LOAD failed with permanent error");
                     return Err(LoadError::Valkey(e));
+                }
+                // Diagnostic instrumentation for the arm-cluster
+                // FUNCTION LOAD READONLY flake (memory note:
+                // project_arm_cluster_function_load_flake.md). On
+                // ferriskey::ErrorKind::ReadOnly from a cluster client,
+                // dump the canonical gossip-aggregated topology view
+                // via CLUSTER NODES alongside the per-attempt
+                // wall-clock so the next repro ships enough signal to
+                // disambiguate: (a) client-side stale slot map vs
+                // (b) cluster genuinely mid-gossip-convergence vs
+                // (c) ferriskey's retry budget getting cut short at
+                // 3 instead of the default 16.
+                //
+                // Gate: only runs on `ReadOnly`, so standalone dev
+                // loops and permanent-syntax-error paths stay clean.
+                // CLUSTER NODES is routed by ferriskey to a single
+                // node (whichever served the last request); on arm
+                // that's one of 7000-7005. A single-node answer is
+                // enough — gossip-converged clusters agree; a
+                // disagreement between that answer and ferriskey's
+                // fan-out targets IS the signal we're looking for.
+                if e.kind() == ferriskey::ErrorKind::ReadOnly {
+                    let cluster_nodes: Result<String, ferriskey::Error> = client
+                        .cmd("CLUSTER")
+                        .arg("NODES")
+                        .execute()
+                        .await;
+                    match cluster_nodes {
+                        Ok(view) => tracing::warn!(
+                            attempt,
+                            attempt_ms,
+                            error = %e,
+                            cluster_nodes = %view,
+                            "FUNCTION LOAD READONLY — canonical topology view (CLUSTER NODES) at failure"
+                        ),
+                        Err(probe_err) => tracing::warn!(
+                            attempt,
+                            attempt_ms,
+                            error = %e,
+                            probe_error = %probe_err,
+                            "FUNCTION LOAD READONLY — CLUSTER NODES probe also failed"
+                        ),
+                    }
                 }
                 if attempt < MAX_ATTEMPTS {
                     // Log the transient error's Display before moving
@@ -111,6 +156,7 @@ pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
                     }
                     tracing::warn!(
                         attempt,
+                        attempt_ms,
                         max_attempts = MAX_ATTEMPTS,
                         backoff_ms = backoff,
                         error = %e,


### PR DESCRIPTION
## Why

The arm-cluster CI cell has a recurring flake: the very first `FUNCTION LOAD flowfabric lib` during `Server::start_with_metrics` returns `-READONLY` even though bootstrap gates on `cluster_state:ok` + 3-master/3-replica convergence on every node. See memory note `project_arm_cluster_function_load_flake.md` for the full analysis.

Two open questions we can't answer without more data:

1. Is ferriskey's **cached slot map stale** at client-init, routing the fan-out to current-replicas while the real cluster is converged? Or is the cluster **itself mid-gossip** at that moment?
2. Why do we observe only **3 aggregate retries** before panic when `RetryParams.number_of_retries` defaults to 16 and `request_timeout=5s` would return `TimedOut`, not `ReadOnly`?

Pattern-matching a fix now risks masking whichever of the two is real. Saving the verify-read-path-premises feedback lesson: evidence first.

## What this PR does

No behaviour change; pure diagnostics. On every retry / final error in `ff_script::loader::ensure_library`:

- Always log `attempt_ms` (wall-clock per attempt). 3 attempts × ~1.28s = 3.85s confirms default retry-budget arithmetic; anything shorter points at a ferriskey regression.
- On `ErrorKind::ReadOnly` specifically, probe `CLUSTER NODES` and emit its canonical gossip-aggregated view inline with the error. Cross-check: if the view agrees the routed-to node is a replica → client-cache-stale (fix in ferriskey). If it disagrees → Valkey/gossip-propagation window worth upstream reporting.

Gated on `ReadOnly` kind — standalone dev loops, permanent syntax errors, and non-cluster transient errors incur no extra probe cost. Probe failure is logged but doesn't abort the retry loop.

## Test plan

- [x] `cargo check -p ff-script` clean
- [x] `cargo clippy -p ff-script --all-targets -- -D warnings` clean
- [x] `cargo test -p ff-script --lib` — 25 passed, 0 failed (no regressions on the permanent-error classification tests)
- [ ] CI green (this PR)
- [ ] Next arm-cluster flake reproduction carries the diagnostic payload — triage PR will follow with an evidence-driven fix

## Follow-ups

Next time the flake reproduces, the log surface will show:
```
WARN: FUNCTION LOAD READONLY — canonical topology view (CLUSTER NODES) at failure
      attempt=1 attempt_ms=<N> error="READONLY..."
      cluster_nodes="<id1> 127.0.0.1:7000@17000 master - ... slots
                     <id2> 127.0.0.1:7003@17003 slave <id1> ..."
```

with enough signal to either:
- **Fix in ferriskey** (cached slot map) — `ferriskey/src/cluster/container.rs:600-607` warm refresh on first AllMasters dispatch, or
- **Fix in bootstrap** (CI gossip gate) — `.github/cluster/bootstrap.sh:60-123` add cross-node CLUSTER SLOTS stability probe.