### PR TITLE
feat(ff-script): FF_FORCE_LUA_RELOAD dev-only env override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`FF_FORCE_LUA_RELOAD` dev-only env override** (ff-script). When
+  set to `1` / `true` / `yes`, `ff_script::loader::ensure_library`
+  bypasses the version-check fast-path and always issues
+  `FUNCTION LOAD REPLACE`. Closes the dev/test footgun where local
+  Lua edits without a `flowfabric_lua_version` bump leave a
+  long-lived dev Valkey serving the stale cached library (silent
+  stale FCALLs). The PR-level CI guard (`ff-script lua drift`)
+  already catches un-bumped edits before merge; this env covers the
+  inner dev loop where the change isn't pushed yet. Production
+  deployments leave the env unset — the version-guard prevents
+  accidental reloads under concurrent deploys.
+
 ## [0.15.0] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ For production deployments, use the Scheduler (`ff-scheduler`) which enforces ad
   | `FF_SQLITE_PATH` | `:memory:` | SQLite path or URI (required shape under `FF_BACKEND=sqlite`). File path (`/tmp/ff-dev.db`) or URI (`file:name?mode=memory&cache=shared`). Dev-only per RFC-023. |
   | `FF_SQLITE_POOL_SIZE` | `4` | SQLite pool size (1 writer + N–1 readers); ignored on non-SQLite paths. |
   | `FF_DEV_MODE` | *(unset)* | **Required** when `FF_BACKEND=sqlite` or when constructing `SqliteBackend::new` directly; server + backend refuse to start without it. Orthogonal to `FF_ENV=development` / `FF_BACKEND_ACCEPT_UNREADY=1`. No effect on Valkey / Postgres paths. See [`docs/dev-harness.md`](docs/dev-harness.md). |
+  | `FF_FORCE_LUA_RELOAD` | *(unset)* | **Dev-only.** When set to `1`/`true`/`yes`, `ff_script::loader::ensure_library` bypasses the version-check fast-path and always issues `FUNCTION LOAD REPLACE`. Use locally when iterating on Lua sources without bumping `crates/ff-script/src/flowfabric_lua_version` — otherwise a long-lived dev Valkey keeps serving the stale cached library. The PR-level CI guard (`ff-script lua drift`) catches un-bumped edits before merge; this env covers the inner dev loop. Leave unset in production — the version-guard prevents accidental reloads under concurrent deploys. |
   | `FF_LISTEN_ADDR` | `0.0.0.0:9090` | API listen address |
   | `FF_LANES` | `default` | Comma-separated lane names |
   | `FF_FLOW_PARTITIONS` | `256` | Flow partition count (exec keys co-locate under RFC-011) |

--- a/crates/ff-script/src/loader.rs
+++ b/crates/ff-script/src/loader.rs
@@ -38,16 +38,41 @@ impl LoadError {
 /// 2. If missing or version mismatch → `FUNCTION LOAD REPLACE` (with retry)
 /// 3. Verify by calling `ff_version` again
 pub async fn ensure_library(client: &Client) -> Result<(), LoadError> {
-    match check_version(client).await {
-        Ok(true) => {
-            tracing::debug!("flowfabric library already loaded at version {LIBRARY_VERSION}");
-            return Ok(());
-        }
-        Ok(false) => {
-            tracing::info!("flowfabric library version mismatch, reloading");
-        }
-        Err(_) => {
-            tracing::info!("flowfabric library not loaded, loading");
+    // Dev-only override: `FF_FORCE_LUA_RELOAD=1` forces FUNCTION LOAD
+    // REPLACE on every ensure_library call, skipping the version fast-
+    // path. Addresses the dev/test footgun where local Lua edits
+    // without a `flowfabric_lua_version` bump leave the cached library
+    // stale (silent stale FCALLs — cost the PR-F cap-exceeded
+    // investigation a session of red herrings before root-causing).
+    //
+    // The PR-level CI guardrail (`.github/workflows/matrix.yml` ff-
+    // script lua drift) catches the same shape before merge; this
+    // override covers the inner loop where a dev iterates locally
+    // without pushing. Production deployments leave the env unset, so
+    // the version-guard stays intact under concurrent deploys.
+    //
+    // Any truthy value (`1`, `true`, `yes`, case-insensitive) enables
+    // the force-reload. Empty or unset is a no-op.
+    let force_reload = std::env::var("FF_FORCE_LUA_RELOAD")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+    if force_reload {
+        tracing::info!(
+            "FF_FORCE_LUA_RELOAD set — bypassing version check, forcing FUNCTION LOAD REPLACE"
+        );
+    } else {
+        match check_version(client).await {
+            Ok(true) => {
+                tracing::debug!("flowfabric library already loaded at version {LIBRARY_VERSION}");
+                return Ok(());
+            }
+            Ok(false) => {
+                tracing::info!("flowfabric library version mismatch, reloading");
+            }
+            Err(_) => {
+                tracing::info!("flowfabric library not loaded, loading");
+            }
         }
     }
 


### PR DESCRIPTION
## Why

Closes the dev/test footgun from memory note `project_ff_script_stale_lua_in_dev.md`. `ensure_library` only re-loads Lua when `flowfabric_lua_version` disagrees between client and server. If a dev edits Lua sources locally without bumping the version sentinel, a long-lived dev Valkey keeps serving the stale cached `FUNCTION LIBRARY`. Symptoms: silent stale FCALLs. Cost the PR-F cap-exceeded investigation a session of red herrings before we root-caused it.

The PR-level CI guard (`ff-script lua drift` in `.github/workflows/matrix.yml`) already catches un-bumped Lua edits before merge. This env covers the inner dev loop — the iteration where the change isn't pushed yet.

## What

- Adds `FF_FORCE_LUA_RELOAD` env. Truthy values (`1`/`true`/`yes`, case-insensitive) make `ensure_library` skip the version fast-path and always `FUNCTION LOAD REPLACE`.
- README env-var table + CHANGELOG `[Unreleased]` entry.
- Production deploys leave it unset; the version-guard stays intact under concurrent deploys.

## Test plan

- [x] `cargo check -p ff-script` clean
- [x] `cargo clippy -p ff-script --all-targets -- -D warnings` clean
- [x] `cargo test -p ff-script --lib` — 25 passed, no regressions on existing classification tests
- [ ] CI green on this PR

## Tradeoff

Considered a dev/test `cfg` flag instead of an env var. Rejected: consumers run the loader in their own tests + dev harnesses, so flipping via env is more portable than recompiling a workspace feature. Env also matches the pattern of `FF_DEV_MODE` already in use.

No behaviour change on unset; the existing version-guard path is untouched.