### PR TITLE
ci(release): wire published-artifact smoke as pre-release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,9 +490,47 @@ jobs:
             exit 1
           }
 
+  published_smoke:
+    # Published-artifact smoke (v0.9+). Per RELEASING.md §"Published-
+    # artifact smoke (v0.9+)" intended wiring + feedback_smoke_after_
+    # publish.md. `smoke` + `smoke-sqlite` above verify workspace-path
+    # deps (which match the final published trait shape bit-for-bit);
+    # this job verifies a scratch consumer can resolve + compile
+    # against the actual crates.io artifacts. Catches
+    # #[non_exhaustive]-without-constructor (v0.3.2), missing
+    # re-exports, and feature-propagation bugs that only surface
+    # through a downstream resolver.
+    #
+    # Runs AFTER `publish` but BEFORE `release` so a bad publish
+    # blocks the GitHub Release creation (the publish itself cannot
+    # be rolled back beyond `cargo yank`, but preventing the
+    # announcement + notes cut is meaningful belt-and-braces).
+    #
+    # crates.io index propagation can lag tens of seconds past the
+    # `publish` job's completion; `publish` already sleeps 30s
+    # between each crate, but a final 60s wait here covers the
+    # worst-case resolver view on a cold consumer fetch.
+    name: Published-artifact smoke (v0.9+)
+    needs: publish
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch, 2026-03-27
+      - name: wait for crates.io index propagation
+        run: sleep 60
+      - name: Run published-artifact smoke
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # Strip leading `v` — scripts/published-smoke.sh takes a
+          # bare semver (`0.15.0`, not `v0.15.0`).
+          VERSION="${TAG_NAME#v}"
+          bash scripts/published-smoke.sh "${VERSION}"
+
   release:
     name: Create GitHub Release
-    needs: publish
+    needs: [publish, published_smoke]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -174,14 +174,16 @@ scripts/published-smoke.sh 0.9.0
 Exit codes: `0` all clean; `1` build or symbol resolution failed;
 `2` script invocation problem.
 
-**Intended release.yml wiring (follow-up PR):** add a new
-`published_smoke` job to `.github/workflows/release.yml` that
-`needs: publish` and runs `scripts/published-smoke.sh ${{ env.TAG_VERSION }}`.
-The GitHub Release job (`release`) then moves to
-`needs: [publish, published_smoke]` so a failed published-artifact
-smoke blocks the release-notes-cut step (the publish itself cannot
-be rolled back beyond `cargo yank`). This enforces CLAUDE.md §5
-item 8 for the external-consumer dimension.
+**release.yml wiring (shipped v0.16+):** the `published_smoke` job
+in `.github/workflows/release.yml` runs after `publish` and before
+`release`. It waits 60s for crates.io index propagation, then
+invokes `scripts/published-smoke.sh "${TAG_NAME#v}"` against the
+freshly-published artifacts. The `release` job (GitHub Release
+creation) depends on `[publish, published_smoke]`, so a failed
+published-artifact smoke blocks the release-notes cut — the
+publish itself cannot be rolled back beyond `cargo yank`, but
+preventing the announcement is meaningful belt-and-braces. Enforces
+CLAUDE.md §5 item 8 for the external-consumer dimension.
 
 Scenarios covered (see `benches/smoke/README.md` for details):
 


### PR DESCRIPTION
## Summary

Adds a `published_smoke` job to `.github/workflows/release.yml` between `publish` and `release`. Waits 60s for crates.io index propagation, then runs `scripts/published-smoke.sh "${TAG_NAME#v}"` — a scratch consumer build against the freshly-published crates.io artifacts in both the Valkey-default and `--no-default-features --features=postgres` variants.

The `release` job (GitHub Release creation) now needs both `publish` and `published_smoke`. A failing published-artifact smoke blocks the release-notes cut. The publish itself cannot be rolled back beyond `cargo yank`, but preventing the announcement is meaningful belt-and-braces against v0.3.2 / v0.6.0-class regressions (`#[non_exhaustive]` without constructor, missing re-exports, feature-propagation bugs that only surface through a downstream resolver).

Matches the "intended wiring" already documented in `docs/RELEASING.md §"Published-artifact smoke (v0.9+)"`; this PR flips that paragraph from "follow-up PR" to "shipped".

## Safety

- **No change to publish ordering or dependencies.** Purely additive gate between publish and release.
- **Script is battle-tested.** Ran clean on v0.15.0 manual post-publish verification 2026-05-03 (both Valkey + Postgres variants PASS). This PR automates what was already running by hand.
- **Worst case:** crates.io index lag causes a false-negative → release-notes cut blocked → operator runs `gh release create` manually after confirming the publish uploaded cleanly. No rollback of publish needed.

## Test plan

- [x] YAML reads cleanly (syntactic review)
- [x] Script invocation matches the manual v0.15.0 form (bare semver, no leading `v`)
- [ ] First real tag push after merge is the acceptance test — dry-run of release.yml via `workflow_dispatch` doesn't exercise the `publish` + `published_smoke` path since both are `if: !inputs.dry_run`-gated.

## Touches

- `.github/workflows/release.yml` — new `published_smoke` job; `release.needs` → `[publish, published_smoke]`
- `docs/RELEASING.md` — "Intended wiring" → "shipped v0.16+"